### PR TITLE
Improve `abortController` and callbacks of `useChat`

### DIFF
--- a/.changeset/thirty-buses-beam.md
+++ b/.changeset/thirty-buses-beam.md
@@ -1,0 +1,5 @@
+---
+'ai-connector': patch
+---
+
+Improve abortController and callbacks of `useChat`


### PR DESCRIPTION
- Changing `abortController` to a ref to keep the same reference of `stop()` function
- Make `reload` and `append` async and return the full completion result
- `reload` handles the case where the last message is from user by appending an assistant message