### PR TITLE
Add `streamToResponse`

### DIFF
--- a/.changeset/clever-crabs-train.md
+++ b/.changeset/clever-crabs-train.md
@@ -1,0 +1,5 @@
+---
+'ai-connector': patch
+---
+
+Add streamToResponse

--- a/packages/core/src/streaming-text-response.ts
+++ b/packages/core/src/streaming-text-response.ts
@@ -1,3 +1,5 @@
+import type { ServerResponse } from 'node:http'
+
 /**
  * A utility class for streaming text responses.
  */
@@ -12,4 +14,25 @@ export class StreamingTextResponse extends Response {
       }
     })
   }
+}
+
+/**
+ * A utility function to stream a ReadableStream to a Node.js response-like object.
+ */
+export function streamToResponse(
+  res: ReadableStream,
+  response: ServerResponse
+) {
+  const reader = res.getReader()
+  function read() {
+    reader.read().then(({ done, value }: { done: boolean; value?: any }) => {
+      if (done) {
+        response.end()
+        return
+      }
+      response.write(value)
+      return read()
+    })
+  }
+  read()
 }

--- a/packages/core/src/streaming-text-response.ts
+++ b/packages/core/src/streaming-text-response.ts
@@ -21,8 +21,14 @@ export class StreamingTextResponse extends Response {
  */
 export function streamToResponse(
   res: ReadableStream,
-  response: ServerResponse
+  response: ServerResponse,
+  init?: { headers?: Record<string, string>; status?: number }
 ) {
+  response.writeHead(init?.status || 200, {
+    'Content-Type': 'text/plain; charset=utf-8',
+    ...init?.headers
+  })
+
   const reader = res.getReader()
   function read() {
     reader.read().then(({ done, value }: { done: boolean; value?: any }) => {


### PR DESCRIPTION
This can be used in Node.js (or Next.js pages/ API route) like:

```js
const stream = OpenAIStream(await fetch(...))
streamToResponse(stream, res)
```

Where `res` is a `ServerResponse` instead of a `Response`.

Using the SDK in Node.js requires Node.js 18+.