### PR TITLE
Break unneeded recursive promise chain

### DIFF
--- a/packages/core/src/streaming-text-response.ts
+++ b/packages/core/src/streaming-text-response.ts
@@ -37,7 +37,7 @@ export function streamToResponse(
         return
       }
       response.write(value)
-      return read()
+      read()
     })
   }
   read()


### PR DESCRIPTION
By returning the `read()` result inside `read()`, we're making every outer promise wait on the resolution of the inner promise. This is unnecessary, the promise chain is never observable, and doing so only keeps items in memory.