### PR TITLE
Refactor AIStream

### DIFF
--- a/.changeset/tough-pans-dance.md
+++ b/.changeset/tough-pans-dance.md
@@ -1,0 +1,14 @@
+---
+"ai-connector": patch
+---
+
+- Splits the `EventSource` parser into a reusable helper
+- Uses a `TransformStream` for this, so the stream respects back-pressure
+- Splits the "forking" stream for callbacks into a reusable helper
+- Changes the signature for `customParser` to avoid Stringify -> Encode -> Decode -> Parse round trip
+- Uses ?.() optional call syntax for callbacks
+- Uses string.includes to perform newline checking
+- Handles the `null` `res.body` case
+- Fixes Anthropic's streaming responses
+   - Anthropic returns cumulative responses, not deltas like OpenAI
+   - https://github.com/hwchase17/langchain/blob/3af36943/langchain/llms/anthropic.py#L190-L193

--- a/packages/core/src/ai-stream.ts
+++ b/packages/core/src/ai-stream.ts
@@ -69,7 +69,7 @@ export function createCallbacksTransformer(
     },
 
     async transform(message, controller): Promise<void> {
-      controller.enqueue(encoder.encode(message))
+      controller.enqueue(encoder.encode(JSON.stringify(message)))
 
       if (callbacks?.onToken) {
         await callbacks.onToken(message)

--- a/packages/core/src/ai-stream.ts
+++ b/packages/core/src/ai-stream.ts
@@ -1,5 +1,6 @@
 import {
   createParser,
+  type EventSourceParser,
   type ParsedEvent,
   type ReconnectInterval
 } from 'eventsource-parser'
@@ -12,64 +13,79 @@ export interface AIStreamCallbacks {
 
 export interface AIStreamParserOptions {
   data: any
-  controller: ReadableStreamDefaultController
   counter: number
-  encoder: TextEncoder
 }
 
-export function AIStream(
-  res: Response,
-  customParser: (opts: AIStreamParserOptions) => void,
-  callbacks?: AIStreamCallbacks
-): ReadableStream {
-  const encoder = new TextEncoder()
+export interface AIStreamParser {
+  (opts: AIStreamParserOptions): string | void
+}
+
+export function createEventStreamTransformer(customParser: AIStreamParser) {
   const decoder = new TextDecoder()
+  let counter = 0
+  let parser: EventSourceParser
 
-  const counter = 0
-
-  const stream = new ReadableStream({
+  return new TransformStream<Uint8Array, string>({
     async start(controller): Promise<void> {
       function onParse(event: ParsedEvent | ReconnectInterval): void {
         if (event.type === 'event') {
           const data = event.data
           if (data === '[DONE]') {
-            controller.close()
+            controller.terminate()
             return
           }
-          return customParser({ data, controller, counter, encoder })
+
+          const message = customParser({ data, counter })
+          counter++
+
+          if (message) controller.enqueue(message)
         }
       }
 
-      const parser = createParser(onParse)
+      parser = createParser(onParse)
+    },
 
-      for await (const chunk of res.body as any) {
-        parser.feed(decoder.decode(chunk))
-      }
+    transform(chunk) {
+      parser.feed(decoder.decode(chunk))
     }
   })
+}
 
+export function createCallbacksTransformer(
+  callbacks: AIStreamCallbacks | undefined
+) {
+  const encoder = new TextEncoder()
   let fullResponse = ''
-  const forkedStream = new TransformStream({
-    start: async (): Promise<void> => {
+
+  return new TransformStream<string, Uint8Array>({
+    async start(): Promise<void> {
       if (callbacks?.onStart) {
         await callbacks.onStart()
       }
     },
-    transform: async (chunk, controller): Promise<void> => {
-      controller.enqueue(chunk)
-      const item = decoder.decode(chunk)
-      const value = JSON.parse(item.split('\n')[0])
+
+    async transform(message, controller): Promise<void> {
+      controller.enqueue(encoder.encode(message))
       if (callbacks?.onToken) {
-        await callbacks.onToken(value as string)
+        await callbacks.onToken(message)
       }
-      fullResponse += value
+      // TODO: If `onCompletion` isn't defined, then we could skip this and save memory.
+      // This is very likely to receive rope-concat optimizations, so at least it's not slow
+      fullResponse += message
     },
-    flush: async (controller): Promise<void> => {
-      if (callbacks?.onCompletion) {
-        await callbacks.onCompletion(fullResponse)
-      }
-      controller.terminate()
+
+    flush() {
+      return callbacks?.onCompletion?.(fullResponse)
     }
   })
-  return stream.pipeThrough(forkedStream)
+}
+
+export function AIStream(
+  res: Response,
+  customParser: AIStreamParser,
+  callbacks?: AIStreamCallbacks
+): ReadableStream {
+  return res.body
+    .pipeThrough(createEventStreamTransformer(customParser))
+    .pipeThrough(createCallbacksTransformer(callbacks))
 }

--- a/packages/core/src/anthropic-stream.ts
+++ b/packages/core/src/anthropic-stream.ts
@@ -6,32 +6,26 @@ import {
 
 function parseAnthropicStream({
   data,
-  controller,
-  counter,
-  encoder
-}: AIStreamParserOptions): void {
-  try {
-    const json = JSON.parse(data as string) as {
-      completion: string
-      stop: string | null
-      stop_reason: string | null
-      truncated: boolean
-      log_id: string
-      model: string
-      exception: string | null
-    }
-    const text = json.completion
-    if (counter < 2 && (/\n/.exec(text) || []).length) {
-      return
-    }
-
-    const queue = encoder.encode(`${JSON.stringify(text)}\n`)
-    controller.enqueue(queue)
-
-    counter++
-  } catch (e) {
-    controller.error(e)
+  counter
+}: AIStreamParserOptions): string | null {
+  const json = JSON.parse(data as string) as {
+    completion: string
+    stop: string | null
+    stop_reason: string | null
+    truncated: boolean
+    log_id: string
+    model: string
+    exception: string | null
   }
+
+  const text = json.completion
+
+  // TODO: I don't understand the `counter && has newline`. Should this be `counter < 2 || !has newline?`?
+  if (counter < 2 && text.includes('\n')) {
+    return
+  }
+
+  return text
 }
 
 export function AnthropicStream(

--- a/packages/core/src/anthropic-stream.ts
+++ b/packages/core/src/anthropic-stream.ts
@@ -7,7 +7,7 @@ import {
 function parseAnthropicStream({
   data,
   counter
-}: AIStreamParserOptions): string | null {
+}: AIStreamParserOptions): string | void {
   const json = JSON.parse(data as string) as {
     completion: string
     stop: string | null

--- a/packages/core/src/openai-stream.ts
+++ b/packages/core/src/openai-stream.ts
@@ -6,27 +6,20 @@ import {
 
 function parseOpenAIStream({
   data,
-  controller,
-  counter,
-  encoder
-}: AIStreamParserOptions): void {
-  try {
-    const json = JSON.parse(data)
-    // this can be used for either chat or completion models
+  counter
+}: AIStreamParserOptions): string | void {
+  // TODO: Needs a type
+  const json = JSON.parse(data)
 
-    const text = json.choices[0]?.delta?.content ?? json.choices[0]?.text ?? ''
+  // this can be used for either chat or completion models
+  const text = json.choices[0]?.delta?.content ?? json.choices[0]?.text ?? ''
 
-    if (counter < 2 && (text.match(/\n/) || []).length) {
-      return
-    }
-
-    const queue = encoder.encode(`${JSON.stringify(text)}\n`)
-    controller.enqueue(queue)
-
-    counter++
-  } catch (e) {
-    controller.error(e)
+  // TODO: I don't understand the `counter && has newline`. Should this be `counter < 2 || !has newline?`?
+  if (counter < 2 && text.includes('\n')) {
+    return
   }
+
+  return text
 }
 
 export function OpenAIStream(


### PR DESCRIPTION
This changes several things in `AIStream`:

- Splits the EventSource parser into a reusable helper
  - Uses a `TransformStream` for this, so the stream respects back-pressure
- Splits the "forking" stream for callbacks into a reusable helper
- Changes the signature for `customParser` to avoid Stringify -> Encode -> Decode -> Parse round trip
- Uses `?.()` optional call syntax for `callbacks`
- Uses `string.includes` to perform newline checking
- Handles the null `res.body` case
- Fixes Anthropic's streaming responses
  - Anthropic returns cumulative responses, not deltas like OpenAI
  - https://github.com/hwchase17/langchain/blob/3af36943/langchain/llms/anthropic.py#L190-L193
