### PR TITLE
Refactor HuggingFaceStream

### DIFF
--- a/packages/core/src/huggingface-stream.ts
+++ b/packages/core/src/huggingface-stream.ts
@@ -1,64 +1,43 @@
-// import { type TextGenerationStreamOutput } from "@huggingface/inference";
-import type { AIStreamCallbacks } from './ai-stream'
+import { type AIStreamCallbacks, createCallbacksTransformer } from './ai-stream'
+
+function createParser(res: AsyncGenerator<any>) {
+  let counter = 0
+  return new ReadableStream<string>({
+    async pull(controller): Promise<void> {
+      const { value, done } = await res.next()
+      if (done) {
+        controller.close()
+        return
+      }
+
+      const text: string = value.token?.text ?? ''
+
+      // some HF models return generated_text instead of a real ending token
+      if (value.generated_text != null && value.generated_text.length > 0) {
+        controller.close()
+        return
+      }
+
+      // <|endoftext|> is for https://huggingface.co/OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5
+      // </s> is also often last token in the stream depending on the model
+      if (text !== '</s>' && text !== '<|endoftext|>') {
+        // TODO: Is this needed?
+        if (counter < 2 && (text.match(/\n/) || []).length) {
+          return
+        }
+
+        controller.enqueue(text)
+        counter++
+      } else {
+        controller.close()
+      }
+    }
+  })
+}
 
 export function HuggingFaceStream(
   res: AsyncGenerator<any>,
   callbacks?: AIStreamCallbacks
 ): ReadableStream {
-  const encoder = new TextEncoder()
-  const decoder = new TextDecoder()
-  let counter = 0
-  const stream = new ReadableStream({
-    async start(controller): Promise<void> {
-      for await (const chunk of res) {
-        const text = chunk.token?.text ?? ''
-        // some HF models return generated_text instead of a real ending token
-
-        if (chunk.generated_text != null && chunk.generated_text.length > 0) {
-          controller.close()
-          return
-        }
-
-        // <|endoftext|> is for https://huggingface.co/OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5
-        // </s> is also often last token in the stream depending on the model
-        if (text !== '</s>' && text !== '<|endoftext|>') {
-          if (counter < 2 && (text.match(/\n/) || []).length) {
-            return
-          }
-
-          const queue = encoder.encode(`${JSON.stringify(text)}\n`)
-          controller.enqueue(queue)
-          counter++
-        } else {
-          controller.close()
-          return
-        }
-      }
-    }
-  })
-
-  let fullResponse = ''
-  const forkedStream = new TransformStream({
-    start: async (): Promise<void> => {
-      if (callbacks?.onStart) {
-        await callbacks.onStart()
-      }
-    },
-    transform: async (chunk, controller): Promise<void> => {
-      controller.enqueue(chunk)
-      const item = decoder.decode(chunk)
-      const value = JSON.parse(item.split('\n')[0])
-      if (callbacks?.onToken) {
-        await callbacks.onToken(value as string)
-      }
-      fullResponse += value
-    },
-    flush: async (controller): Promise<void> => {
-      if (callbacks?.onCompletion) {
-        await callbacks.onCompletion(fullResponse)
-      }
-      controller.terminate()
-    }
-  })
-  return stream.pipeThrough(forkedStream)
+  return createParser(res).pipeThrough(createCallbacksTransformer(callbacks))
 }

--- a/packages/core/src/huggingface-stream.ts
+++ b/packages/core/src/huggingface-stream.ts
@@ -22,7 +22,7 @@ function createParser(res: AsyncGenerator<any>) {
       // </s> is also often last token in the stream depending on the model
       if (text !== '</s>' && text !== '<|endoftext|>') {
         // TODO: Is this needed?
-        if (counter < 2 && (text.match(/\n/) || []).length) {
+        if (counter < 2 && text.includes('\n')) {
           return
         }
 


### PR DESCRIPTION
After #27, we can significantly simplify our `HuggingFaceStream` impl. There's now a reusable `createCallbacksTransformer` to handle calling the callbacks with our stream data. This also changes the `ReadableStream` to use `pull`, so that the consumer can signal back-pressure without us eagerly filling all data into the stream.