### PR TITLE
Refactor LangChain

### DIFF
--- a/examples/with-openai/app/api/chat/route.ts
+++ b/examples/with-openai/app/api/chat/route.ts
@@ -19,8 +19,12 @@ export async function POST(req: Request) {
   const response = await openai.createChatCompletion({
     model: 'gpt-3.5-turbo',
     stream: true,
-    messages
+    messages: messages.map((message: any) => ({
+      content: message.content,
+      role: message.role
+    }))
   })
+
   // Convert the response into a friendly text-stream
   const stream = OpenAIStream(response)
   // Respond with the stream

--- a/packages/core/src/langchain-stream.ts
+++ b/packages/core/src/langchain-stream.ts
@@ -1,39 +1,14 @@
-import { AIStreamCallbacks } from './ai-stream'
+import { type AIStreamCallbacks, createCallbacksTransformer } from './ai-stream'
 
 export function LangChainStream(callbacks?: AIStreamCallbacks) {
   const stream = new TransformStream()
-  const encoder = new TextEncoder()
   const writer = stream.writable.getWriter()
-  const decoder = new TextDecoder()
-  let fullResponse = ''
-  const forkedStream = new TransformStream({
-    start: async (): Promise<void> => {
-      if (callbacks?.onStart) {
-        await callbacks.onStart()
-      }
-    },
-    transform: async (chunk, controller): Promise<void> => {
-      controller.enqueue(chunk)
-      const item = decoder.decode(chunk)
-      const value = JSON.parse(item.split('\n')[0])
-      if (callbacks?.onToken) {
-        await callbacks.onToken(value as string)
-      }
-      fullResponse += value
-    },
-    flush: async (controller): Promise<void> => {
-      if (callbacks?.onCompletion) {
-        await callbacks.onCompletion(fullResponse)
-      }
-      controller.terminate()
-    }
-  })
   return {
-    stream: stream.readable.pipeThrough(forkedStream),
+    stream: stream.readable.pipeThrough(createCallbacksTransformer(callbacks)),
     handlers: {
       handleLLMNewToken: async (token: string) => {
         await writer.ready
-        await writer.write(encoder.encode(`${JSON.stringify(token)}\n`))
+        await writer.write(token)
       },
       handleLLMEnd: async () => {
         await writer.ready


### PR DESCRIPTION
After #27, we're able to reuse `createCallbacksTransformer` to handle calling the callbacks with our stream data.