### PR TITLE
Eliminate JSON stringify/parsing in responses

### DIFF
--- a/packages/core/src/ai-stream.ts
+++ b/packages/core/src/ai-stream.ts
@@ -69,7 +69,7 @@ export function createCallbacksTransformer(
     },
 
     async transform(message, controller): Promise<void> {
-      controller.enqueue(encoder.encode(JSON.stringify(message)))
+      controller.enqueue(encoder.encode(message))
 
       if (callbacks?.onToken) {
         await callbacks.onToken(message)

--- a/packages/core/src/use-chat.ts
+++ b/packages/core/src/use-chat.ts
@@ -25,8 +25,7 @@ export type CreateMessage = {
 
 const decoder = new TextDecoder()
 function decodeAIStreamChunk(chunk: Uint8Array): string {
-  const tokens = decoder.decode(chunk).split('\n')
-  return tokens.map(t => (t ? JSON.parse(t) : '')).join('')
+  return decoder.decode(chunk)
 }
 
 export type UseChatOptions = {

--- a/packages/core/src/use-completion.ts
+++ b/packages/core/src/use-completion.ts
@@ -4,8 +4,7 @@ import useSWR from 'swr'
 
 const decoder = new TextDecoder()
 function decodeAIStreamChunk(chunk: Uint8Array): string {
-  const tokens = decoder.decode(chunk).split('\n')
-  return tokens.map(t => (t ? JSON.parse(t) : '')).join('')
+  return decoder.decode(chunk)
 }
 
 export type UseCompletionOptions = {


### PR DESCRIPTION
Now that everything is using the same `createCallbacksTransformer` to encode their text responses into the final `Response`, we can easily clean up the `JSOn.stringify` and `JSON.parse` round tripping. There's no real reason to use newline-delimited JSON anymore, we're just returning a simple string.