### PR TITLE
Implement new start-of-stream newline trimming

### DIFF
--- a/.changeset/flat-garlics-knock.md
+++ b/.changeset/flat-garlics-knock.md
@@ -1,0 +1,5 @@
+---
+"ai-connector": patch
+---
+
+Implement new start-of-stream newline trimming

--- a/packages/core/src/anthropic-stream.ts
+++ b/packages/core/src/anthropic-stream.ts
@@ -1,15 +1,9 @@
-import {
-  AIStream,
-  type AIStreamCallbacks,
-  type AIStreamParserOptions
-} from './ai-stream'
+import { AIStream, type AIStreamCallbacks } from './ai-stream'
 
-function parseAnthropicStream(): ({
-  data
-}: AIStreamParserOptions) => string | void {
+function parseAnthropicStream(): (data: string) => string | void {
   let previous = ''
 
-  return ({ data }) => {
+  return data => {
     const json = JSON.parse(data as string) as {
       completion: string
       stop: string | null

--- a/packages/core/src/openai-stream.ts
+++ b/packages/core/src/openai-stream.ts
@@ -1,30 +1,27 @@
 import {
   AIStream,
-  type AIStreamCallbacks,
-  type AIStreamParserOptions
+  trimStartOfStreamHelper,
+  type AIStreamCallbacks
 } from './ai-stream'
 
-function parseOpenAIStream({
-  data,
-  counter
-}: AIStreamParserOptions): string | void {
-  // TODO: Needs a type
-  const json = JSON.parse(data)
+function parseOpenAIStream(): (data: string) => string | void {
+  const trimStartOfStream = trimStartOfStreamHelper()
+  return data => {
+    // TODO: Needs a type
+    const json = JSON.parse(data)
 
-  // this can be used for either chat or completion models
-  const text = json.choices[0]?.delta?.content ?? json.choices[0]?.text ?? ''
+    // this can be used for either chat or completion models
+    const text = trimStartOfStream(
+      json.choices[0]?.delta?.content ?? json.choices[0]?.text ?? ''
+    )
 
-  // TODO: I don't understand the `counter && has newline`. Should this be `counter < 2 || !has newline?`?
-  if (counter < 2 && text.includes('\n')) {
-    return
+    return text
   }
-
-  return text
 }
 
 export function OpenAIStream(
   res: Response,
   cb?: AIStreamCallbacks
 ): ReadableStream {
-  return AIStream(res, parseOpenAIStream, cb)
+  return AIStream(res, parseOpenAIStream(), cb)
 }


### PR DESCRIPTION
This is an attempt to make the removal of the leading `\n\n` a little more correct. What I think the intention is to only trim the leading `\n\n`, but not any other newlines that appear (eg, separating paragraphs of text).

But the old implementation is buggy. Imagine the first response was `"\n\nThe sky is blue because of Rayleigh scattering"`. The old could would have detected `count == 0`, and the response contains a `\n`, so it would have been ignored.