### PR TITLE
Improve API typings

### DIFF
--- a/.changeset/clever-ways-shout.md
+++ b/.changeset/clever-ways-shout.md
@@ -1,0 +1,5 @@
+---
+'ai-connector': patch
+---
+
+improve API types

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -67,13 +67,15 @@ export type UseChatHelpers = {
    * Append a user message to the chat list. This triggers the API call to fetch
    * the assistant's response.
    */
-  append: (message: Message | CreateMessage) => void
+  append: (
+    message: Message | CreateMessage
+  ) => Promise<string | null | undefined>
   /**
    * Reload the last AI chat response for the given chat history. If the last
    * message isn't from the assistant, it will request the API to generate a
    * new response.
    */
-  reload: () => void
+  reload: () => Promise<string | null | undefined>
   /**
    * Abort the current request immediately, keep the generated tokens if any.
    */

--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -52,7 +52,7 @@ export type UseCompletionHelpers = {
   /**
    * Send a new prompt to the API endpoint and update the completion state.
    */
-  complete: (prompt: string) => void
+  complete: (prompt: string) => Promise<string | null | undefined>
   /** The error object of the API request */
   error: undefined | Error
   /**
@@ -127,7 +127,7 @@ export function useCompletion({
   // Actual mutation hook to send messages to the API endpoint and update the
   // chat state.
   const { error, trigger, isMutating } = useSWRMutation<
-    null,
+    string | null,
     any,
     [string, string],
     string
@@ -193,7 +193,7 @@ export function useCompletion({
         }
 
         setAbortController(null)
-        return null
+        return result
       } catch (err) {
         // Ignore abort errors as they are expected.
         if ((err as any).name === 'AbortError') {
@@ -240,7 +240,7 @@ export function useCompletion({
   }
 
   const complete = useCallback(
-    (prompt: string) => {
+    async (prompt: string) => {
       return trigger(prompt)
     },
     [trigger]

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -68,13 +68,15 @@ export type UseChatHelpers = {
    * Append a user message to the chat list. This triggers the API call to fetch
    * the assistant's response.
    */
-  append: (message: Message | CreateMessage) => void
+  append: (
+    message: Message | CreateMessage
+  ) => Promise<string | null | undefined>
   /**
    * Reload the last AI chat response for the given chat history. If the last
    * message isn't from the assistant, it will request the API to generate a
    * new response.
    */
-  reload: () => void
+  reload: () => Promise<string | null | undefined>
   /**
    * Abort the current request immediately, keep the generated tokens if any.
    */

--- a/packages/core/svelte/use-completion.ts
+++ b/packages/core/svelte/use-completion.ts
@@ -55,7 +55,7 @@ export type UseCompletionHelpers = {
   /**
    * Send a new prompt to the API endpoint and update the completion state.
    */
-  complete: (prompt: string) => void
+  complete: (prompt: string) => Promise<string | null | undefined>
   /**
    * Abort the current API request but keep the generated tokens.
    */


### PR DESCRIPTION
This PR changes `append`, `reload` and `complete` APIs to return promises instead so it's easier for the user to do tasks after the API call in an imperative way. These are equivalent:

```jsx
const { error, append } = useChat(...)

useEffect(() => {
  if (error) toast.error(error.message)
}, [error])

append()
```

```jsx
const { append } = useChat(...)

append().catch(e => toast.error(e.message))
```