### PR TITLE
Throw error when provided AI response doesn't have the 2xx status code

### DIFF
--- a/.changeset/tidy-onions-camp.md
+++ b/.changeset/tidy-onions-camp.md
@@ -1,0 +1,5 @@
+---
+'ai-connector': patch
+---
+
+Throw error when provided AI response isn't valid

--- a/packages/core/streams/ai-stream.ts
+++ b/packages/core/streams/ai-stream.ts
@@ -90,11 +90,11 @@ export function AIStream(
   customParser: AIStreamParser,
   callbacks?: AIStreamCallbacks
 ): ReadableStream {
-  // If the response is not 200, we want to throw an error to indicate that
+  // If the response is not OK, we want to throw an error to indicate that
   // the AI service is not available.
   // When catching this error, we can check the status code and return a handled
   // error response to the client.
-  if (res.status !== 200) {
+  if (!res.ok) {
     throw new Error(
       `Failed to convert the response to stream. Received status code: ${res.status}.`
     )

--- a/packages/core/streams/ai-stream.ts
+++ b/packages/core/streams/ai-stream.ts
@@ -90,6 +90,16 @@ export function AIStream(
   customParser: AIStreamParser,
   callbacks?: AIStreamCallbacks
 ): ReadableStream {
+  // If the response is not 200, we want to throw an error to indicate that
+  // the AI service is not available.
+  // When catching this error, we can check the status code and return a handled
+  // error response to the client.
+  if (res.status !== 200) {
+    throw new Error(
+      `Failed to convert the response to stream. Received status code: ${res.status}.`
+    )
+  }
+
   const stream =
     res.body ||
     new ReadableStream({


### PR DESCRIPTION
This is necessary when the response returned by another AI service, e.g. `const response = await openai.createCompletion(...)`, isn't considered as a good response that is ready to pass through a SSE parser. We detect that based on whether the response has a non-200 status code or not.

This is very common when the service is not available, or a wrong parameter is passed (e.g. model name). Even if it's not wrapped with `try-catch`, Next.js' API route will still return 500 so it's easier to catch and debug locally. Without this, `AIStream` will create an empty stream without any error message.