### PR TITLE
Fix(docs): Fix broken links in `api-reference`

### DIFF
--- a/docs/pages/docs/guides/openai.mdx
+++ b/docs/pages/docs/guides/openai.mdx
@@ -65,10 +65,10 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from OpenAI to
-  [`OpenAIStream`](/api-reference#openaistream). This method decodes/extracts
+  [`OpenAIStream`](/api-reference/openai-stream). This method decodes/extracts
   the text tokens in the response and then re-encodes them properly for simple
   consumption. We can then pass that new stream directly to
-  [`StreamingTextResponse`](/api-reference#streamingtextresponse). This is
+  [`StreamingTextResponse`](/api-reference/streaming-text-response). This is
   another utility class that extends the normal Node/Edge Runtime `Response`
   class with the default headers you probably want (hint: `'Content-Type':
   'text/plain; charset=utf-8'` is already set for you).


### PR DESCRIPTION
This PR fixes #56 
Update links to utilize slashes instead of hashtags and use Kababcase instead of lower case