### PR TITLE
Fix(docs): Missing word and typo

### DIFF
--- a/docs/pages/docs/concepts/backpressure-and-cancellation.mdx
+++ b/docs/pages/docs/concepts/backpressure-and-cancellation.mdx
@@ -56,7 +56,7 @@ If you were to run this program, you'd notice something funny. We'll see roughly
 
 The problem stems from the way we wrap our generator into a stream. Notice the use of `for await (…)` inside our `start` handler. This is an **eager** for-loop, and it is constantly running to get the next value from our generator to be enqueued in our stream. This means our stream does not respect back-pressure, the signal from the consumer to the producer that more values aren't needed _yet_. We've essentially spawned a thread that will perpetually push more data into the stream, one that runs as fast as possible to push new data immediately. Worse, there's no way to signal to this thread to stop running when we don't need additional data.
 
-To fix this, `ReadableStream` allows a `pull` handler. `pull` is called every time the consumer attempts to read more data from our stream (if there's no data already queued internally). But it's not enough to just move the `for await(…)` into `pull`, we also need to convert from an eager enqueuing to a **lazy** one. By making these 2 changes, we'll be able to react to consumer. If they need more data, we can easily produce it, and it they don't, then we don't need to spend any time doing unnecessary work.
+To fix this, `ReadableStream` allows a `pull` handler. `pull` is called every time the consumer attempts to read more data from our stream (if there's no data already queued internally). But it's not enough to just move the `for await(…)` into `pull`, we also need to convert from an eager enqueuing to a **lazy** one. By making these 2 changes, we'll be able to react to consumer. If they need more data, we can easily produce it, and if they don't, then we don't need to spend any time doing unnecessary work.
 
 ```jsx
 function createStream(iterator) {
@@ -152,7 +152,7 @@ Now let's imagine you're integrating AIBot service into your product. Users will
 
 After a few seconds, the user gets bored and navigates away. Or maybe you're doing local development and a hot-module reload refreshes your page. The browser will have ended its connection to the API endpoint, but will your server end its connection with AIBot?
 
-If you used the eager `for await (...)` approach, then the connection is still running and your server is asking for more and more data from AIBot. Our server spawned a "thread" and there's no signal when we can end the eager pulls. Eventually, the server is going to run of memory (remember, there's no active fetch connection to read the buffering responses and free them).
+If you used the eager `for await (...)` approach, then the connection is still running and your server is asking for more and more data from AIBot. Our server spawned a "thread" and there's no signal when we can end the eager pulls. Eventually, the server is going to run out of memory (remember, there's no active fetch connection to read the buffering responses and free them).
 
 {/* When we started writing the streaming code for the Vercel AI SDK, we confirm aborting a fetch will end a streamed response from Next.js */}
 


### PR DESCRIPTION
Add missing word and fix typo in the docs `docs/pages/docs/concepts/backpressure-and-cancellation.mdx` file.