### PR TITLE
Fix: add correct ai version

### DIFF
--- a/examples/next-huggingface/package.json
+++ b/examples/next-huggingface/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@huggingface/inference": "^2.5.1",
-    "ai": "2.0.1",
+    "ai": "2.0.0",
     "next": "13.4.4-canary.11",
     "openai-edge": "^0.5.1",
     "react": "18.2.0",

--- a/examples/next-langchain/package.json
+++ b/examples/next-langchain/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "ai": "2.0.1",
+    "ai": "2.0.0",
     "next": "13.4.4-canary.11",
     "langchain": "^0.0.86",
     "react": "18.2.0",

--- a/examples/next-openai/package.json
+++ b/examples/next-openai/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "ai": "2.0.1",
+    "ai": "2.0.0",
     "next": "13.4.4-canary.11",
     "openai-edge": "^0.5.1",
     "react": "18.2.0",

--- a/examples/sveltekit-openai/package.json
+++ b/examples/sveltekit-openai/package.json
@@ -9,7 +9,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "dependencies": {
-    "ai": "2.0.1",
+    "ai": "2.0.0",
     "openai-edge": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Running the `npm i` with any of the provided examples from `/examples` fails due to the `package.json` faulty version.

```
➜  next-langchain git:(main) ✗ npm i
npm ERR! code ETARGET
npm ERR! notarget No matching version found for ai@2.0.1.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/fertostado/.npm/_logs/2023-06-15T21_57_28_736Z-debug-0.log
➜  next-langchain git:(main) ✗ yarn install
yarn install v1.22.19
info No lockfile found.
[1/4] 🔍  Resolving packages...
Couldn't find any versions for "ai" that matches "2.0.1"
? Please choose a version of "ai" from this list: 2.0.0
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "ai > sswr@1.10.0" has unmet peer dependency "svelte@^3.29.0".
[4/4] 🔨  Building fresh packages...

success Saved lockfile.
✨  Done in 15.89s.
```

Using `2.0.0` should fix this

resolves #82 