### PR TITLE
Change .env to .env.local in Getting Started guide

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -65,15 +65,15 @@ We've written some code to get you started — follow the instructions below to 
 
     #### Configure OpenAI API Key
 
-    Create a `.env` file in your project root and add your OpenAI API Key. This key is used to authenticate your application with the OpenAI service.
+    Create a `.env.local` file in your project root and add your OpenAI API Key. This key is used to authenticate your application with the OpenAI service.
 
     ```sh
-    touch .env
+    touch .env.local
     ```
 
-    Edit the `.env` file:
+    Edit the `.env.local` file:
 
-    ```env filename=".env"
+    ```env filename=".env.local"
     OPENAI_API_KEY=xxxxxxxxx
     ```
 


### PR DESCRIPTION
After create-next-app which is suggested on this page, out of the box Next.js doesn't gitignore the .env file but does gitignore the .env.local file. Might save a few AI account keys with this change :) 