### PR TITLE
feat: add createdAt on user input message

### DIFF
--- a/.changeset/modern-cameras-shave.md
+++ b/.changeset/modern-cameras-shave.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Add `createdAt` on `user` input message in `useChat` (it was already present in `assistant` messages)

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -253,7 +253,8 @@ export function useChat({
       if (!input) return
       append({
         content: input,
-        role: 'user'
+        role: 'user',
+        createdAt: new Date()
       })
       setInput('')
     },

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -224,7 +224,8 @@ export function useChat({
     if (!inputValue) return
     append({
       content: inputValue,
-      role: 'user'
+      role: 'user',
+      createdAt: new Date()
     })
     input.set('')
   }


### PR DESCRIPTION
Currently createdAt only available on message from role `assistant`.