### PR TITLE
fix: types for onChange event on input/textarea on react lib added

### DIFF
--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -39,7 +39,7 @@ export type UseChatHelpers = {
   /** setState-powered method to update the input value */
   setInput: React.Dispatch<React.SetStateAction<string>>
   /** An input/textarea-ready onChange handler to control the value of the input */
-  handleInputChange: (e: any) => void
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => void
   /** Form submission handler to automattically reset input and append a user message  */
   handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void
   /** Whether the API request is in progress */

--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -32,7 +32,7 @@ export type UseCompletionHelpers = {
    * <input onChange={handleInputChange} value={input} />
    * ```
    */
-  handleInputChange: (e: any) => void
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => void
   /**
    * Form submission handler to automattically reset input and append a user message
    * @example


### PR DESCRIPTION
Types for onChange event added on react useChat and useCompletion lib.

Before:
```ts
/** An input/textarea-ready onChange handler to control the value of the input */
  handleInputChange: (e: any) => void
```

After:
```ts
/** An input/textarea-ready onChange handler to control the value of the input */
  handleInputChange: (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => void
```