### PR TITLE
use `$env/static/private` for API key

### DIFF
--- a/examples/sveltekit-openai/src/routes/api/chat/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/chat/+server.ts
@@ -1,11 +1,12 @@
 import { Configuration, OpenAIApi } from 'openai-edge'
 import { OpenAIStream, StreamingTextResponse } from 'ai'
+import { OPENAI_API_KEY } from '$env/static/private'
 
 import type { RequestHandler } from './$types'
 
 // Create an OpenAI API client
 const config = new Configuration({
-  apiKey: process.env.OPENAI_API_KEY
+  apiKey: OPENAI_API_KEY
 })
 const openai = new OpenAIApi(config)
 


### PR DESCRIPTION
This is a more idiomatic approach in SvelteKit than `process.env` — it means e.g. people get a useful build time error if no API key is present, rather than it failing at runtime