### PR TITLE
fix(examples): promisify nuxt streaming response

### DIFF
--- a/examples/nuxt-openai/server/api/chat.ts
+++ b/examples/nuxt-openai/server/api/chat.ts
@@ -26,5 +26,18 @@ export default defineEventHandler(async event => {
   // Convert the response into a friendly text-stream
   const stream = OpenAIStream(response)
   // Respond with the stream
-  streamToResponse(stream, event.node.res)
+  const reader = stream.getReader()
+  return new Promise((resolve, reject) => {
+    function read() {
+      reader.read().then(({ done, value }) => {
+        if (done) {
+          event.node.res.end();
+          return
+        }
+        event.node.res.write(value);
+        read()
+      })
+    }
+    read()
+  })
 })

--- a/examples/nuxt-openai/server/api/chat.ts
+++ b/examples/nuxt-openai/server/api/chat.ts
@@ -31,10 +31,10 @@ export default defineEventHandler(async event => {
     function read() {
       reader.read().then(({ done, value }) => {
         if (done) {
-          event.node.res.end();
+          event.node.res.end()
           return
         }
-        event.node.res.write(value);
+        event.node.res.write(value)
         read()
       })
     }


### PR DESCRIPTION
This fixes an issue when deploying Nuxt example to Vercel. We need to return a promise to prevent the Nitro server from setting headers after the stream ends. This mirrors the implementation of `sendStream` in h3: https://github.com/unjs/h3/pull/68.