### PR TITLE
docs: Fixed misspelled top-level domain for Hugging Face Hub

### DIFF
--- a/docs/pages/docs/api-reference/huggingface-stream.mdx
+++ b/docs/pages/docs/api-reference/huggingface-stream.mdx
@@ -12,13 +12,13 @@ Currently, `</s>` and `<|endoftext|>` are recognized as end-of-stream tokens.
 
 `HuggingFaceStream` is compatible with the following models, as specified through the `model` parameter in the Hugging Face Inference SDK:
 
-- [`OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5`](https://huggingface.com/OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5)
-- [`EleutherAI/gpt-neox-20b`](https://huggingface.com/EleutherAI/gpt-neox-20b)
-- [`google/flan-ul2`](https://huggingface.com/google/flan-ul2)
-- [`google/flan-t5-xxl`](https://huggingface.com/google/flan-t5-xxl)
-- [`bigscience/bloomz`](https://huggingface.com/bigscience/bloomz)
-- [`bigscience/bloom`](https://huggingface.com/bigscience/bloom)
-- [`bigcode/santacoder`](https://huggingface.com/bigcode/santacoder)
+- [`OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5`](https://huggingface.co/OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5)
+- [`EleutherAI/gpt-neox-20b`](https://huggingface.co/EleutherAI/gpt-neox-20b)
+- [`google/flan-ul2`](https://huggingface.co/google/flan-ul2)
+- [`google/flan-t5-xxl`](https://huggingface.co/google/flan-t5-xxl)
+- [`bigscience/bloomz`](https://huggingface.co/bigscience/bloomz)
+- [`bigscience/bloom`](https://huggingface.co/bigscience/bloom)
+- [`bigcode/santacoder`](https://huggingface.co/bigcode/santacoder)
 
 ## Parameters
 


### PR DESCRIPTION
The old links with a `huggingface.com` domain leads to an emoji database, also known as HuggingFace, which results in a 404 error. Therefore, they are replaced by `huggingface.co`.
