### PR TITLE
Fix streaming for function calls

### DIFF
--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -10,6 +10,92 @@ function parseOpenAIStream(): (data: string) => string | void {
     // TODO: Needs a type
     const json = JSON.parse(data)
 
+    /*
+       If the response is a function call, the first streaming chunk from OpenAI returns the name of the function like so
+
+          {
+            ...
+            "choices": [{
+              "index": 0,
+              "delta": {
+                "role": "assistant",
+                "content": null,
+                "function_call": {
+                  "name": "get_current_weather",
+                  "arguments": ""
+                }
+              },
+              "finish_reason": null
+            }]
+          }
+
+       Then, it begins streaming the arguments for the function call.
+       The second chunk looks like:
+
+          {
+            ...
+            "choices": [{
+              "index": 0,
+              "delta": {
+                "function_call": {
+                  "arguments": "{\n"
+                }
+              },
+              "finish_reason": null
+            }]
+          }
+
+        Third chunk:
+
+          {
+            ...
+            "choices": [{
+              "index": 0,
+              "delta": {
+                "function_call": {
+                  "arguments": "\"location"
+                }
+              },
+              "finish_reason": null
+            }]
+          }
+
+        ...
+
+        Finally, the last chunk has a `finish_reason` of `function_call`:
+
+          {
+            ...
+            "choices": [{
+              "index": 0,
+              "delta": {},
+              "finish_reason": "function_call"
+            }]
+          }
+
+
+        With the implementation below, the client will end up getting a
+        response like the one below streamed to them whenever a function call
+        response is returned (but without newline formatting):
+
+          {
+            "function_call": {
+              "name": "get_current_weather",
+              "arguments": {
+                "location": "San Francisco, CA",
+                "format": "celsius"
+              }
+            }
+          }
+     */
+    if (json.choices[0]?.delta?.function_call?.name) {
+      return `{"function_call": {"name": "${json.choices[0]?.delta?.function_call.name}", "arguments": `
+    } else if (json.choices[0]?.delta?.function_call?.arguments) {
+      return `${json.choices[0]?.delta?.function_call.arguments}`
+    } else if (json.choices[0]?.finish_reason === 'function_call') {
+      return '}}'
+    }
+
     // this can be used for either chat or completion models
     const text = trimStartOfStream(
       json.choices[0]?.delta?.content ?? json.choices[0]?.text ?? ''


### PR DESCRIPTION
# Context
I'm trying to build an LLM agent that operates primarily on the client side that users can interact with from a chat interface.

With OpenAI's new function-calling capabilities, it's up to the model to decide whether or not it will call a function (if functions are provided to it). If using an Edge Runtime route handler similar to the Vercel AI SDK [example here](https://sdk.vercel.ai/docs/guides/openai#create-a-route-handler), the route handler should be able to support streaming back a function call in addition to normal chat completion responses from the assistant role. Without this PR, Vercel's streaming utils simply return an empty stream if OpenAI responds with a function call.

# Testing
I've only manually tested this change so far, but if maintainers would like to move forward with the approach, I can write a unit test as well.

To see how the streamed response chunks from OpenAI are broken up, Postman is a great tool.

Since the Vercel AI SDK does not yet support function-calling in its `useChat()` hook or any other method, I've got my own custom logic calling the Edge route handler for now that's passing functions in the request (See below). I also am using an updated version of `openai-edge` [(PR here)](https://github.com/dan-kwiat/openai-edge/pull/7) in order to use function calling in the Next Edge Runtime.

Here's the rudimentary code I hacked together to test this. Note that the code below does not render the stream chunk by chunk on the client side yet (though that would probably be trivial to add).



```typescript
'use client';

import { useState } from 'react';

// This type comes from the updated version of openai-edge that I copied over into my repo.
import { CreateChatCompletionRequest } from '@/openai-edge-function-calling';

export default function ChatWithFunctionCall() {
  const [input, setInput] = useState('');
  const [response, setResponse] = useState('');

  const functions = [
    {
      'name': 'get_current_weather',
      'description': 'Get the current weather',
      'parameters': {
        'type': 'object',
        'properties': {
          'location': {
            'type': 'string',
            'description': 'The city and state, e.g. San Francisco, CA'
          },
          'format': {
            'type': 'string',
            'enum': ['celsius', 'fahrenheit'],
            'description': 'The temperature unit to use. Infer this from the users location.'
          }
        },
        'required': ['location', 'format']
      }
    }];

  const decoder = new TextDecoder();

  function decodeAIStreamChunk(chunk: Uint8Array): string {
    return decoder.decode(chunk);
  }

  const handleSubmit = async (e: any) => {
    e.preventDefault()

    const createChatCompletionRequest: CreateChatCompletionRequest = {
      model: 'gpt-3.5-turbo',
      messages: [{ role: 'user', content: input }],
      functions: functions
    };

    const res = await fetch('/api/chat/', {
      method: 'POST',
      body: JSON.stringify(createChatCompletionRequest)
    });

    if (!res.body) {
      throw new Error('No response body');
    }
    let result = '';
    const reader = res.body.getReader();

    while (true) {
      const { done, value } = await reader.read();
      if (done) {
        break;
      }
      result += decodeAIStreamChunk(value);
    }

    setResponse(result);
  };


  return (
    <div className='mx-auto w-full max-w-md py-24 flex flex-col stretch'>
      <form onSubmit={(e) => handleSubmit(e)}>
        <input
          className='w-full max-w-md bottom-0 border border-gray-300 rounded mb-8 shadow-xl p-2'
          value={input}
          placeholder='Say something...'
          onChange={(e) => setInput(e.target.value)}
          style={{ color: 'black' }}
        />
      </form>

      {<div>
        {response}
      </div>}
    </div>
  );
}
```

The route handler code I tested is also very similar to the example given in the Vercel AI SDK docs. It looks something like this:

```typescript
...

const config = new Configuration({
  apiKey: process.env.OPENAI_API_KEY
});
const openai = new OpenAIApi(config);

export const runtime = 'edge';

export async function POST(req: Request) {
  const { messages, functions } = await req.json();

  // Note that gpt-3.5-turbo-0613 MUST be used if functions are being passed in the request.
  const response = await openai.createChatCompletion({
    model: 'gpt-3.5-turbo-0613',
    stream: true,
    messages,
    functions
  });

  const stream = OpenAIStream(response);
  return new StreamingTextResponse(stream);
}
```