### PR TITLE
Fix: Issue #94 CallbackManager is deprecated

### DIFF
--- a/.changeset/blue-rice-remember.md
+++ b/.changeset/blue-rice-remember.md
@@ -1,5 +1,5 @@
 ---
-"ai": patch
+'ai': patch
 ---
 
 Provider direct callback handlers in LangChain now that `CallbackManager` is deprecated.

--- a/.changeset/blue-rice-remember.md
+++ b/.changeset/blue-rice-remember.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Provider direct callback handlers in LangChain now that `CallbackManager` is deprecated.

--- a/docs/pages/docs/api-reference/langchain-stream.mdx
+++ b/docs/pages/docs/api-reference/langchain-stream.mdx
@@ -35,7 +35,6 @@ The `LangChainCallbacks` object has the following properties which are compatibl
 import { StreamingTextResponse, LangChainStream } from 'ai'
 import { ChatOpenAI } from 'langchain/chat_models/openai'
 import { AIChatMessage, HumanChatMessage } from 'langchain/schema'
-import { CallbackManager } from 'langchain/callbacks'
 
 export const runtime = 'edge'
 
@@ -45,7 +44,7 @@ export async function POST(req: Request) {
 
   const llm = new ChatOpenAI({
     streaming: true,
-    callbackManager: CallbackManager.fromHandlers(handlers)
+    callbacks: [handlers]
   })
 
   llm

--- a/docs/pages/docs/guides/langchain.mdx
+++ b/docs/pages/docs/guides/langchain.mdx
@@ -13,7 +13,6 @@ Here is an example implementation of a chat application that uses both Vercel AI
 
 ```tsx filename="app/api/chat/route.ts" {1,11,15,28}
 import { StreamingTextResponse, LangChainStream, Message } from 'ai'
-import { CallbackManager } from 'langchain/callbacks'
 import { ChatOpenAI } from 'langchain/chat_models/openai'
 import { AIChatMessage, HumanChatMessage } from 'langchain/schema'
 
@@ -26,7 +25,7 @@ export async function POST(req: Request) {
 
   const llm = new ChatOpenAI({
     streaming: true,
-    callbackManager: CallbackManager.fromHandlers(handlers)
+    callbacks: [handlers]
   })
 
   llm

--- a/examples/next-langchain/app/api/chat/route.ts
+++ b/examples/next-langchain/app/api/chat/route.ts
@@ -1,5 +1,4 @@
 import { StreamingTextResponse, LangChainStream, Message } from 'ai'
-import { CallbackManager } from 'langchain/callbacks'
 import { ChatOpenAI } from 'langchain/chat_models/openai'
 import { AIChatMessage, HumanChatMessage } from 'langchain/schema'
 
@@ -12,7 +11,7 @@ export async function POST(req: Request) {
 
   const llm = new ChatOpenAI({
     streaming: true,
-    callbackManager: CallbackManager.fromHandlers(handlers)
+    callbacks: [handlers]
   })
 
   llm

--- a/examples/nuxt-langchain/server/api/chat.ts
+++ b/examples/nuxt-langchain/server/api/chat.ts
@@ -1,5 +1,4 @@
 import { LangChainStream, Message, streamToResponse } from 'ai'
-import { CallbackManager } from 'langchain/callbacks'
 import { ChatOpenAI } from 'langchain/chat_models/openai'
 import { AIChatMessage, HumanChatMessage } from 'langchain/schema'
 
@@ -18,7 +17,7 @@ export default defineEventHandler(async (event: any) => {
     const llm = new ChatOpenAI({
       openAIApiKey: process.env.OPENAI_API_KEY,
       streaming: true,
-      callbackManager: CallbackManager.fromHandlers(handlers)
+      callbacks: [handlers]
     })
 
     llm

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -45,7 +45,7 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       ai:
-        specifier: 2.1.3
+        specifier: 2.1.4
         version: link:../../packages/core
       next:
         specifier: 13.4.4-canary.11
@@ -91,7 +91,7 @@ importers:
   examples/next-langchain:
     dependencies:
       ai:
-        specifier: 2.1.3
+        specifier: 2.1.4
         version: link:../../packages/core
       langchain:
         specifier: ^0.0.86
@@ -137,7 +137,7 @@ importers:
   examples/next-openai:
     dependencies:
       ai:
-        specifier: 2.1.3
+        specifier: 2.1.4
         version: link:../../packages/core
       next:
         specifier: 13.4.4-canary.11
@@ -277,7 +277,7 @@ importers:
         specifier: ^3.3.4
         version: 3.3.4
       ai:
-        specifier: 2.1.3
+        specifier: 2.1.4
         version: link:../../packages/core
       nuxt:
         specifier: ^3.5.2
@@ -298,7 +298,7 @@ importers:
   examples/sveltekit-openai:
     dependencies:
       ai:
-        specifier: 2.1.3
+        specifier: 2.1.4
         version: link:../../packages/core
       openai-edge:
         specifier: ^0.5.1


### PR DESCRIPTION
Fix #94 . Do not use `callbackManager` in LangChain examples, but `callbacks` key. 