### PR TITLE
Move types to its corresponding file

### DIFF
--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -3,52 +3,13 @@ import useSWRMutation from 'swr/mutation'
 import useSWR from 'swr'
 import { nanoid, createChunkDecoder } from '../shared/utils'
 
-import type { Message, CreateMessage, UseChatOptions } from '../shared/types'
+import type {
+  Message,
+  CreateMessage,
+  UseChatOptions,
+  UseChatHelpersReact
+} from '../shared/types'
 export type { Message, CreateMessage, UseChatOptions }
-
-export type UseChatHelpers = {
-  /** Current messages in the chat */
-  messages: Message[]
-  /** The error object of the API request */
-  error: undefined | Error
-  /**
-   * Append a user message to the chat list. This triggers the API call to fetch
-   * the assistant's response.
-   */
-  append: (
-    message: Message | CreateMessage
-  ) => Promise<string | null | undefined>
-  /**
-   * Reload the last AI chat response for the given chat history. If the last
-   * message isn't from the assistant, it will request the API to generate a
-   * new response.
-   */
-  reload: () => Promise<string | null | undefined>
-  /**
-   * Abort the current request immediately, keep the generated tokens if any.
-   */
-  stop: () => void
-  /**
-   * Update the `messages` state locally. This is useful when you want to
-   * edit the messages on the client, and then trigger the `reload` method
-   * manually to regenerate the AI response.
-   */
-  setMessages: (messages: Message[]) => void
-  /** The current value of the input */
-  input: string
-  /** setState-powered method to update the input value */
-  setInput: React.Dispatch<React.SetStateAction<string>>
-  /** An input/textarea-ready onChange handler to control the value of the input */
-  handleInputChange: (
-    e:
-      | React.ChangeEvent<HTMLInputElement>
-      | React.ChangeEvent<HTMLTextAreaElement>
-  ) => void
-  /** Form submission handler to automattically reset input and append a user message  */
-  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void
-  /** Whether the API request is in progress */
-  isLoading: boolean
-}
 
 export function useChat({
   api = '/api/chat',
@@ -61,7 +22,7 @@ export function useChat({
   onError,
   headers,
   body
-}: UseChatOptions = {}): UseChatHelpers {
+}: UseChatOptions = {}): UseChatHelpersReact {
   // Generate an unique id for the chat if not provided.
   const hookId = useId()
   const chatId = id || hookId

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -1,3 +1,6 @@
+import { Readable, Writable } from 'svelte/store'
+import { Ref } from 'vue'
+
 /**
  * Shared types between the API and UI packages.
  */
@@ -81,6 +84,121 @@ export type UseChatOptions = {
   sendExtraMessageFields?: boolean
 }
 
+export type UseChatHelpersReact = {
+  /** Current messages in the chat */
+  messages: Message[]
+  /** The error object of the API request */
+  error: undefined | Error
+  /**
+   * Append a user message to the chat list. This triggers the API call to fetch
+   * the assistant's response.
+   */
+  append: (
+    message: Message | CreateMessage
+  ) => Promise<string | null | undefined>
+  /**
+   * Reload the last AI chat response for the given chat history. If the last
+   * message isn't from the assistant, it will request the API to generate a
+   * new response.
+   */
+  reload: () => Promise<string | null | undefined>
+  /**
+   * Abort the current request immediately, keep the generated tokens if any.
+   */
+  stop: () => void
+  /**
+   * Update the `messages` state locally. This is useful when you want to
+   * edit the messages on the client, and then trigger the `reload` method
+   * manually to regenerate the AI response.
+   */
+  setMessages: (messages: Message[]) => void
+  /** The current value of the input */
+  input: string
+  /** setState-powered method to update the input value */
+  setInput: React.Dispatch<React.SetStateAction<string>>
+  /** An input/textarea-ready onChange handler to control the value of the input */
+  handleInputChange: (
+    e:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>
+  ) => void
+  /** Form submission handler to automattically reset input and append a user message  */
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void
+  /** Whether the API request is in progress */
+  isLoading: boolean
+}
+
+export type UseChatHelpersVue = {
+  /** Current messages in the chat */
+  messages: Ref<Message[]>
+  /** The error object of the API request */
+  error: Ref<undefined | Error>
+  /**
+   * Append a user message to the chat list. This triggers the API call to fetch
+   * the assistant's response.
+   */
+  append: (
+    message: Message | CreateMessage
+  ) => Promise<string | null | undefined>
+  /**
+   * Reload the last AI chat response for the given chat history. If the last
+   * message isn't from the assistant, it will request the API to generate a
+   * new response.
+   */
+  reload: () => Promise<string | null | undefined>
+  /**
+   * Abort the current request immediately, keep the generated tokens if any.
+   */
+  stop: () => void
+  /**
+   * Update the `messages` state locally. This is useful when you want to
+   * edit the messages on the client, and then trigger the `reload` method
+   * manually to regenerate the AI response.
+   */
+  setMessages: (messages: Message[]) => void
+  /** The current value of the input */
+  input: Ref<string>
+  /** Form submission handler to automattically reset input and append a user message  */
+  handleSubmit: (e: any) => void
+  /** Whether the API request is in progress */
+  isLoading: Ref<boolean>
+}
+
+export type UseChatHelpersSvelte = {
+  /** Current messages in the chat */
+  messages: Readable<Message[]>
+  /** The error object of the API request */
+  error: Readable<undefined | Error>
+  /**
+   * Append a user message to the chat list. This triggers the API call to fetch
+   * the assistant's response.
+   */
+  append: (
+    message: Message | CreateMessage
+  ) => Promise<string | null | undefined>
+  /**
+   * Reload the last AI chat response for the given chat history. If the last
+   * message isn't from the assistant, it will request the API to generate a
+   * new response.
+   */
+  reload: () => Promise<string | null | undefined>
+  /**
+   * Abort the current request immediately, keep the generated tokens if any.
+   */
+  stop: () => void
+  /**
+   * Update the `messages` state locally. This is useful when you want to
+   * edit the messages on the client, and then trigger the `reload` method
+   * manually to regenerate the AI response.
+   */
+  setMessages: (messages: Message[]) => void
+  /** The current value of the input */
+  input: Writable<string>
+  /** Form submission handler to automattically reset input and append a user message  */
+  handleSubmit: (e: any) => void
+  /** Whether the API request is in progress */
+  isLoading: Writable<boolean>
+}
 export type UseCompletionOptions = {
   /**
    * The API endpoint that accepts a `{ prompt: string }` object and returns

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -1,47 +1,16 @@
 import { useSWR } from 'sswr'
 import { Readable, get, writable } from 'svelte/store'
 
-import type { Message, CreateMessage, UseChatOptions } from '../shared/types'
+import type {
+  Message,
+  CreateMessage,
+  UseChatOptions,
+  UseChatHelpersSvelte
+} from '../shared/types'
 import { Writable } from 'svelte/store'
 import { nanoid, createChunkDecoder } from '../shared/utils'
 
 export type { Message, CreateMessage, UseChatOptions }
-
-export type UseChatHelpers = {
-  /** Current messages in the chat */
-  messages: Readable<Message[]>
-  /** The error object of the API request */
-  error: Readable<undefined | Error>
-  /**
-   * Append a user message to the chat list. This triggers the API call to fetch
-   * the assistant's response.
-   */
-  append: (
-    message: Message | CreateMessage
-  ) => Promise<string | null | undefined>
-  /**
-   * Reload the last AI chat response for the given chat history. If the last
-   * message isn't from the assistant, it will request the API to generate a
-   * new response.
-   */
-  reload: () => Promise<string | null | undefined>
-  /**
-   * Abort the current request immediately, keep the generated tokens if any.
-   */
-  stop: () => void
-  /**
-   * Update the `messages` state locally. This is useful when you want to
-   * edit the messages on the client, and then trigger the `reload` method
-   * manually to regenerate the AI response.
-   */
-  setMessages: (messages: Message[]) => void
-  /** The current value of the input */
-  input: Writable<string>
-  /** Form submission handler to automattically reset input and append a user message  */
-  handleSubmit: (e: any) => void
-  /** Whether the API request is in progress */
-  isLoading: Writable<boolean>
-}
 
 let uniqueId = 0
 
@@ -58,7 +27,7 @@ export function useChat({
   onError,
   headers,
   body
-}: UseChatOptions = {}): UseChatHelpers {
+}: UseChatOptions = {}): UseChatHelpersSvelte {
   // Generate a unique ID for the chat if not provided.
   const chatId = id || `chat-${uniqueId++}`
 

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -2,46 +2,15 @@ import swrv from 'swrv'
 import { ref } from 'vue'
 import type { Ref } from 'vue'
 
-import type { Message, CreateMessage, UseChatOptions } from '../shared/types'
+import type {
+  Message,
+  CreateMessage,
+  UseChatOptions,
+  UseChatHelpersVue
+} from '../shared/types'
 import { createChunkDecoder, nanoid } from '../shared/utils'
 
 export type { Message, CreateMessage, UseChatOptions }
-
-export type UseChatHelpers = {
-  /** Current messages in the chat */
-  messages: Ref<Message[]>
-  /** The error object of the API request */
-  error: Ref<undefined | Error>
-  /**
-   * Append a user message to the chat list. This triggers the API call to fetch
-   * the assistant's response.
-   */
-  append: (
-    message: Message | CreateMessage
-  ) => Promise<string | null | undefined>
-  /**
-   * Reload the last AI chat response for the given chat history. If the last
-   * message isn't from the assistant, it will request the API to generate a
-   * new response.
-   */
-  reload: () => Promise<string | null | undefined>
-  /**
-   * Abort the current request immediately, keep the generated tokens if any.
-   */
-  stop: () => void
-  /**
-   * Update the `messages` state locally. This is useful when you want to
-   * edit the messages on the client, and then trigger the `reload` method
-   * manually to regenerate the AI response.
-   */
-  setMessages: (messages: Message[]) => void
-  /** The current value of the input */
-  input: Ref<string>
-  /** Form submission handler to automattically reset input and append a user message  */
-  handleSubmit: (e: any) => void
-  /** Whether the API request is in progress */
-  isLoading: Ref<boolean>
-}
 
 let uniqueId = 0
 
@@ -60,7 +29,7 @@ export function useChat({
   onError,
   headers,
   body
-}: UseChatOptions = {}): UseChatHelpers {
+}: UseChatOptions = {}): UseChatHelpersVue {
   // Generate a unique ID for the chat if not provided.
   const chatId = id || `chat-${uniqueId++}`
 


### PR DESCRIPTION
To make those beautiful hooks even more readable I went ahead and moved those big types definitions on it's own shared file. I re-created the same types adding it's corresponding framework/lib name to make easy to identify. 