### PR TITLE
Support extra request options in chat and completion

### DIFF
--- a/.changeset/tender-knives-sing.md
+++ b/.changeset/tender-knives-sing.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Support extra request options in chat and completion hooks

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -16,7 +16,8 @@ export type UseChatHelpers = {
    * the assistant's response.
    */
   append: (
-    message: Message | CreateMessage
+    message: Message | CreateMessage,
+    metadata?: Object
   ) => Promise<string | null | undefined>
   /**
    * Reload the last AI chat response for the given chat history. If the last
@@ -215,7 +216,13 @@ export function useChat({
   )
 
   const append = useCallback(
-    async (message: Message | CreateMessage) => {
+    async (message: Message | CreateMessage, metadata?: Object) => {
+      if (metadata) {
+        extraMetadataRef.current = {
+          ...extraMetadataRef.current,
+          ...metadata
+        }
+      }
       if (!message.id) {
         message.id = nanoid()
       }
@@ -253,7 +260,14 @@ export function useChat({
   const [input, setInput] = useState(initialInput)
 
   const handleSubmit = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
+    (e: React.FormEvent<HTMLFormElement>, metadata?: Object) => {
+      if (metadata) {
+        extraMetadataRef.current = {
+          ...extraMetadataRef.current,
+          ...metadata
+        }
+      }
+
       e.preventDefault()
       if (!input) return
       append({

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -3,13 +3,13 @@ import useSWRMutation from 'swr/mutation'
 import useSWR from 'swr'
 import { nanoid, createChunkDecoder } from '../shared/utils'
 
-import type { Message, CreateMessage, UseChatOptions } from '../shared/types'
+import type {
+  Message,
+  CreateMessage,
+  UseChatOptions,
+  RequestOptions
+} from '../shared/types'
 export type { Message, CreateMessage, UseChatOptions }
-
-type RequestOptions = {
-  headers?: Record<string, string> | Headers
-  body?: object
-}
 
 export type UseChatHelpers = {
   /** Current messages in the chat */

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -15,6 +15,11 @@ export type CreateMessage = {
   role: 'system' | 'user' | 'assistant'
 }
 
+export type RequestOptions = {
+  headers?: Record<string, string> | Headers
+  body?: object
+}
+
 export type UseChatOptions = {
   /**
    * The API endpoint that accepts a `{ messages: Message[] }` object and returns

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -1,8 +1,14 @@
 import { useSWR } from 'sswr'
 import { Readable, get, writable } from 'svelte/store'
 
-import type { Message, CreateMessage, UseChatOptions } from '../shared/types'
 import { Writable } from 'svelte/store'
+
+import type {
+  Message,
+  CreateMessage,
+  UseChatOptions,
+  RequestOptions
+} from '../shared/types'
 import { nanoid, createChunkDecoder } from '../shared/utils'
 
 export type { Message, CreateMessage, UseChatOptions }
@@ -17,14 +23,15 @@ export type UseChatHelpers = {
    * the assistant's response.
    */
   append: (
-    message: Message | CreateMessage
+    message: Message | CreateMessage,
+    options?: RequestOptions
   ) => Promise<string | null | undefined>
   /**
    * Reload the last AI chat response for the given chat history. If the last
    * message isn't from the assistant, it will request the API to generate a
    * new response.
    */
-  reload: () => Promise<string | null | undefined>
+  reload: (options?: RequestOptions) => Promise<string | null | undefined>
   /**
    * Abort the current request immediately, keep the generated tokens if any.
    */
@@ -82,7 +89,10 @@ export function useChat({
   const isLoading = writable(false)
 
   let abortController: AbortController | null = null
-  async function triggerRequest(messagesSnapshot: Message[]) {
+  async function triggerRequest(
+    messagesSnapshot: Message[],
+    options?: RequestOptions
+  ) {
     try {
       isLoading.set(true)
       abortController = new AbortController()
@@ -101,9 +111,13 @@ export function useChat({
                 role,
                 content
               })),
-          ...body
+          ...body,
+          ...options?.body
         }),
-        headers: headers || {},
+        headers: {
+          ...headers,
+          ...options?.headers
+        },
         signal: abortController.signal
       }).catch(err => {
         // Restore the previous messages if the request fails.
@@ -188,22 +202,22 @@ export function useChat({
     }
   }
 
-  const append = async (message: Message | CreateMessage) => {
+  const append: UseChatHelpers['append'] = async (message, options) => {
     if (!message.id) {
       message.id = nanoid()
     }
-    return triggerRequest(get(messages).concat(message as Message))
+    return triggerRequest(get(messages).concat(message as Message), options)
   }
 
-  const reload = async () => {
+  const reload: UseChatHelpers['reload'] = async options => {
     const messagesSnapshot = get(messages)
     if (messagesSnapshot.length === 0) return null
 
     const lastMessage = messagesSnapshot[messagesSnapshot.length - 1]
     if (lastMessage.role === 'assistant') {
-      return triggerRequest(messagesSnapshot.slice(0, -1))
+      return triggerRequest(messagesSnapshot.slice(0, -1), options)
     }
-    return triggerRequest(messagesSnapshot)
+    return triggerRequest(messagesSnapshot, options)
   }
 
   const stop = () => {


### PR DESCRIPTION
Attempts to solve #189 by adding a way to update the extraMetadataRef headers and body in useChat. The same might apply to useCompletion, but that is outside my use case and I did not want to overcommit my assumptions of what was acceptable before getting feedback on this contribution. Looking forward to thoughts and feedback, thanks for the support!

Closes #141, closes #131, closes #189.