### PR TITLE
Feature/support credentials on hooks

### DIFF
--- a/docs/pages/docs/api-reference/use-chat.mdx
+++ b/docs/pages/docs/api-reference/use-chat.mdx
@@ -104,6 +104,11 @@ Options passed to `useChat`:
       'body',
       'any',
       'An optional, extra body object to be passed to the API endpoint in addition to the `messages` array'
+    ],
+    [
+      'credentials',
+      '"omit" | "same-origin" | "include"',
+      'An optional literal that sets the mode of credentials to be used on the request. Defaults to "same-origin".'
     ]
   ]}
 />
@@ -234,6 +239,11 @@ Options passed to `useChat`:
       'body',
       'any',
       'An optional, extra body object to be passed to the API endpoint in addition to the `messages` array'
+    ],
+    [
+      'credentials',
+      '"omit" | "same-origin" | "include"',
+      'An optional literal that sets the mode of credentials to be used on the request. Defaults to "same-origin".'
     ]
   ]}
 />

--- a/docs/pages/docs/api-reference/use-completion.mdx
+++ b/docs/pages/docs/api-reference/use-completion.mdx
@@ -144,6 +144,11 @@ export default function Completion() {
       'body',
       'any',
       'An optional, additional body object to be passed to the API endpoint.'
+    ],
+    [
+      'credentials',
+      '"omit" | "same-origin" | "include"',
+      'An optional literal that sets the mode of credentials to be used on the request. Defaults to "same-origin".'
     ]
   ]}
 />
@@ -264,6 +269,11 @@ To use `useCompletion` in Svelte projects, you can import it from the `ai/svelte
       'body',
       'any',
       'An optional, additional body object to be passed to the API endpoint.'
+    ],
+    [
+      'credentials',
+      '"omit" | "same-origin" | "include"',
+      'An optional literal that sets the mode of credentials to be used on the request. Defaults to "same-origin".'
     ]
   ]}
 />

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -67,6 +67,7 @@ export function useChat({
   onResponse,
   onFinish,
   onError,
+  credentials,
   headers,
   body
 }: UseChatOptions = {}): UseChatHelpers {
@@ -89,12 +90,14 @@ export function useChat({
   // Abort controller to cancel the current API call.
   const abortControllerRef = useRef<AbortController | null>(null)
 
-  const extraMetadataRef = useRef<any>({
+  const extraMetadataRef = useRef({
+    credentials,
     headers,
     body
   })
   useEffect(() => {
     extraMetadataRef.current = {
+      credentials,
       headers,
       body
     }
@@ -135,6 +138,7 @@ export function useChat({
             ...extraMetadataRef.current.body,
             ...options?.body
           }),
+          credentials: extraMetadataRef.current.credentials,
           headers: {
             ...extraMetadataRef.current.headers,
             ...options?.headers

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -101,7 +101,7 @@ export function useChat({
       headers,
       body
     }
-  }, [headers, body])
+  }, [credentials, headers, body])
 
   // Actual mutation hook to send messages to the API endpoint and update the
   // chat state.

--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -60,6 +60,7 @@ export function useCompletion({
   id,
   initialCompletion = '',
   initialInput = '',
+  credentials,
   headers,
   body,
   onResponse,
@@ -80,12 +81,14 @@ export function useCompletion({
   const [abortController, setAbortController] =
     useState<AbortController | null>(null)
 
-  const extraMetadataRef = useRef<any>({
+  const extraMetadataRef = useRef({
+    credentials,
     headers,
     body
   })
   useEffect(() => {
     extraMetadataRef.current = {
+      credentials,
       headers,
       body
     }
@@ -120,6 +123,7 @@ export function useCompletion({
             ...extraMetadataRef.current.body,
             ...options?.body
           }),
+          credentials: extraMetadataRef.current.credentials,
           headers: {
             ...extraMetadataRef.current.headers,
             ...options?.headers

--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -92,7 +92,7 @@ export function useCompletion({
       headers,
       body
     }
-  }, [headers, body])
+  }, [credentials, headers, body])
 
   // Actual mutation hook to send messages to the API endpoint and update the
   // chat state.

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -60,6 +60,13 @@ export type UseChatOptions = {
   onError?: (error: Error) => void
 
   /**
+   * The credentials mode to be used for the fetch request.
+   * Possible values are: 'omit', 'same-origin', 'include'.
+   * Defaults to 'same-origin'.
+   */
+  credentials?: RequestCredentials
+
+  /**
    * HTTP headers to be sent with the API request.
    */
   headers?: Record<string, string> | Headers
@@ -123,6 +130,13 @@ export type UseCompletionOptions = {
    * Callback function to be called when an error is encountered.
    */
   onError?: (error: Error) => void
+
+  /**
+   * The credentials mode to be used for the fetch request.
+   * Possible values are: 'omit', 'same-origin', 'include'.
+   * Defaults to 'same-origin'.
+   */
+  credentials?: RequestCredentials
 
   /**
    * HTTP headers to be sent with the API request.

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -63,6 +63,7 @@ export function useChat({
   onResponse,
   onFinish,
   onError,
+  credentials,
   headers,
   body
 }: UseChatOptions = {}): UseChatHelpers {
@@ -118,7 +119,8 @@ export function useChat({
           ...headers,
           ...options?.headers
         },
-        signal: abortController.signal
+        signal: abortController.signal,
+        credentials
       }).catch(err => {
         // Restore the previous messages if the request fails.
         mutate(previousMessages)

--- a/packages/core/svelte/use-completion.ts
+++ b/packages/core/svelte/use-completion.ts
@@ -51,6 +51,7 @@ export function useCompletion({
   id,
   initialCompletion = '',
   initialInput = '',
+  credentials,
   headers,
   body,
   onResponse,
@@ -99,7 +100,8 @@ export function useCompletion({
           ...headers,
           ...options?.headers
         },
-        signal: abortController.signal
+        signal: abortController.signal,
+        credentials
       }).catch(err => {
         throw err
       })

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -64,6 +64,7 @@ export function useChat({
   onResponse,
   onFinish,
   onError,
+  credentials,
   headers,
   body
 }: UseChatOptions = {}): UseChatHelpers {
@@ -119,7 +120,8 @@ export function useChat({
           ...headers,
           ...options?.headers
         },
-        signal: abortController.signal
+        signal: abortController.signal,
+        credentials
       }).catch(err => {
         // Restore the previous messages if the request fails.
         mutate(previousMessages)

--- a/packages/core/vue/use-completion.ts
+++ b/packages/core/vue/use-completion.ts
@@ -52,6 +52,7 @@ export function useCompletion({
   id,
   initialCompletion = '',
   initialInput = '',
+  credentials,
   headers,
   body,
   onResponse,
@@ -101,7 +102,8 @@ export function useCompletion({
           ...headers,
           ...options?.headers
         },
-        signal: abortController.signal
+        signal: abortController.signal,
+        credentials
       }).catch(err => {
         throw err
       })


### PR DESCRIPTION
This PR addresses the issue #159.

This small change just adds the `credentials` parameter to all hooks so that a user can pass it through the hook, then sends it inside the fetch request, as mentioned in the issue.