### PR TITLE
packages/react: create separate server component bundle for Tokens

### DIFF
--- a/.changeset/chilled-stingrays-change.md
+++ b/.changeset/chilled-stingrays-change.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+Add <Tokens> RSC to ai/react

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "vue/dist/**/*"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && cat react/dist/index.server.d.ts >> react/dist/index.d.ts",
     "clean": "rm -rf dist && rm -rf react/dist && rm -rf svelte/dist && rm -rf vue/dist",
     "dev": "tsup --watch",
     "lint": "eslint \"./**/*.ts*\"",
@@ -31,15 +31,10 @@
     },
     "./react": {
       "types": "./react/dist/index.d.ts",
+      "react-server": "./react/dist/index.server.mjs",
       "import": "./react/dist/index.mjs",
       "module": "./react/dist/index.mjs",
       "require": "./react/dist/index.js"
-    },
-    "./react/server": {
-      "types": "./react/dist/index.server.d.ts",
-      "import": "./react/dist/index.server.mjs",
-      "module": "./react/dist/index.server.mjs",
-      "require": "./react/dist/index.server.js"
     },
     "./svelte": {
       "types": "./svelte/dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,12 @@
       "module": "./react/dist/index.mjs",
       "require": "./react/dist/index.js"
     },
+    "./react/server": {
+      "types": "./react/dist/index.server.d.ts",
+      "import": "./react/dist/index.server.mjs",
+      "module": "./react/dist/index.server.mjs",
+      "require": "./react/dist/index.server.js"
+    },
     "./svelte": {
       "types": "./svelte/dist/index.d.ts",
       "import": "./svelte/dist/index.mjs",

--- a/packages/core/react/index.server.ts
+++ b/packages/core/react/index.server.ts
@@ -1,0 +1,1 @@
+export * from './tokens'

--- a/packages/core/react/index.ts
+++ b/packages/core/react/index.ts
@@ -1,3 +1,2 @@
 export * from './use-chat'
 export * from './use-completion'
-export * from './tokens'

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -2,7 +2,16 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "exports": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./server": {
+      "import": "./dist/index.server.mjs",
+      "require": "./dist/index.server.js"
+    }
+  },
   "private": true,
   "peerDependencies": {
     "react": "*"

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -2,16 +2,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    },
-    "./server": {
-      "import": "./dist/index.server.mjs",
-      "require": "./dist/index.server.js"
-    }
-  },
+  "exports": "./dist/index.mjs",
   "private": true,
   "peerDependencies": {
     "react": "*"

--- a/packages/core/react/server.ts
+++ b/packages/core/react/server.ts
@@ -1,0 +1,1 @@
+export * from './tokens'

--- a/packages/core/react/tokens.tsx
+++ b/packages/core/react/tokens.tsx
@@ -9,6 +9,7 @@ type Props = {
 
 /**
  * A React Server Component that recursively renders a stream of tokens.
+ * Can only be used inside of server components.
  */
 export async function Tokens(props: Props) {
   const { stream } = props

--- a/packages/core/react/tokens.tsx
+++ b/packages/core/react/tokens.tsx
@@ -24,7 +24,7 @@ export async function Tokens(props: Props) {
 
 type InternalProps = {
   reader: ReadableStreamDefaultReader
-} & Omit<Props, 'stream'>
+}
 
 async function RecursiveTokens({ reader }: InternalProps) {
   const { done, value } = await reader.read()

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -19,6 +19,13 @@ export default defineConfig([
     external: ['react', 'svelte', 'vue'],
     dts: true
   },
+  {
+    entry: ['react/index.server.ts'],
+    outDir: 'react/dist',
+    format: ['cjs', 'esm'],
+    external: ['react', 'svelte', 'vue'],
+    dts: true
+  },
   // Svelte APIs
   {
     entry: ['svelte/index.ts'],


### PR DESCRIPTION
~I feel like this is everything that _should_ be necessary but typescript isn't resolving `ai/react/server`~

To resolve the issues ^, I concat the type files together so it can be imported from the namespace (thanks to the `react-server` condition)