### PR TITLE
fix: update Sveltekit to newest version

### DIFF
--- a/examples/sveltekit-openai/package.json
+++ b/examples/sveltekit-openai/package.json
@@ -19,7 +19,7 @@
     "@sveltejs/adapter-auto": "^2.0.0",
     "@sveltejs/kit": "^1.5.0",
     "@types/cookie": "^0.5.1",
-    "svelte": "^3.54.0",
+    "svelte": "^4.0.0",
     "svelte-check": "^3.0.1",
     "tslib": "^2.4.1",
     "typescript": "5.1.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "svelte": "^3.29.0",
+    "svelte": "^4.0.0",
     "vue": "^3.3.4"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
fixes: #235 

## The problem
Trying to install the `ai` package on a new Sveltekit project fails, due to the version mismatch.

## The solution
Update the version where necessary in the `ai` library