### PR TITLE
Fix broken link for StreamingTextResponse in the openai guide

### DIFF
--- a/docs/pages/docs/guides/openai.mdx
+++ b/docs/pages/docs/guides/openai.mdx
@@ -72,7 +72,7 @@ export async function POST(req: Request) {
   [`OpenAIStream`](/docs/api-reference/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
-  [`StreamingTextResponse`](/docs/api-reference/streamingtextresponse). This is
+  [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This is
   another utility class that extends the normal Node/Edge Runtime `Response`
   class with the default headers you probably want (hint: `'Content-Type':
   'text/plain; charset=utf-8'` is already set for you).


### PR DESCRIPTION
The following link(https://sdk.vercel.ai/docs/api-reference/streamingtextresponse) is broken when trying to access it.
Changed it to https://sdk.vercel.ai/docs/api-reference/streaming-text-response