### PR TITLE
fix: Remove dependency on node crypto API

### DIFF
--- a/.changeset/violet-monkeys-float.md
+++ b/.changeset/violet-monkeys-float.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Remove dependency on node crypto API

--- a/packages/core/shared/utils.ts
+++ b/packages/core/shared/utils.ts
@@ -1,4 +1,4 @@
-import { customAlphabet } from 'nanoid'
+import { customAlphabet } from 'nanoid/non-secure'
 
 // 7-character random string
 export const nanoid = customAlphabet(


### PR DESCRIPTION
As seen in #192 , it is currently not possible to use edge functions in SvelteKit because the node crypto API is not available in the edge runtime. The node crypto API requirement is coming from [nanoid](https://github.com/ai/nanoid/blob/main/index.js). Nanoid has an alternative export, [nanoid/non-secure](https://github.com/ai/nanoid/blob/main/non-secure/index.js), which does not depend on the node crypto API.

From their readme r.e. `nanoid/non-secure`:
```
By default, Nano ID uses hardware random bytes generation for security and low collision probability. If you are not so concerned with security, you can use it for environments without hardware random generators.
```

It seems that `ai` is only using nanoid to generate unique IDs for chat messages - IMO this is a situation where non-secure can be used, which would be great for SvelteKit users.