### PR TITLE
Fix typo in sveltekit-openai example

### DIFF
--- a/examples/sveltekit-openai/package.json
+++ b/examples/sveltekit-openai/package.json
@@ -10,8 +10,8 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "dependencies": {
-    "openai-edge": "^1.1.1"
-    "ai": "2.1.17",
+    "openai-edge": "^1.1.1",
+    "ai": "2.1.17"
   },
   "devDependencies": {
     "@fontsource/fira-mono": "^4.5.10",


### PR DESCRIPTION
Corrected small typo that causes npm install to fail.