### PR TITLE
Update deprecated imports from LangChain

### DIFF
--- a/docs/pages/docs/api-reference/langchain-stream.mdx
+++ b/docs/pages/docs/api-reference/langchain-stream.mdx
@@ -30,7 +30,7 @@ The `LangChainCallbacks` object has properties which are compatible with [LangCh
 ```tsx filename="app/api/chat/route.ts"
 import { StreamingTextResponse, LangChainStream } from 'ai'
 import { ChatOpenAI } from 'langchain/chat_models/openai'
-import { AIChatMessage, HumanChatMessage } from 'langchain/schema'
+import { AIMessage, HumanMessage } from 'langchain/schema'
 
 export const runtime = 'edge'
 
@@ -46,8 +46,8 @@ export async function POST(req: Request) {
     .call(
       messages.map(m =>
         m.role == 'user'
-          ? new HumanChatMessage(m.content)
-          : new AIChatMessage(m.content)
+          ? new HumanMessage(m.content)
+          : new AIMessage(m.content)
       ),
       {},
       [handlers]

--- a/docs/pages/docs/guides/langchain.mdx
+++ b/docs/pages/docs/guides/langchain.mdx
@@ -14,7 +14,7 @@ Here is an example implementation of a chat application that uses both Vercel AI
 ```tsx filename="app/api/chat/route.ts" {1,10,13,28}
 import { StreamingTextResponse, LangChainStream, Message } from 'ai'
 import { ChatOpenAI } from 'langchain/chat_models/openai'
-import { AIChatMessage, HumanChatMessage } from 'langchain/schema'
+import { AIMessage, HumanMessage } from 'langchain/schema'
 
 export const runtime = 'edge'
 
@@ -31,8 +31,8 @@ export async function POST(req: Request) {
     .call(
       (messages as Message[]).map(m =>
         m.role == 'user'
-          ? new HumanChatMessage(m.content)
-          : new AIChatMessage(m.content)
+          ? new HumanMessage(m.content)
+          : new AIMessage(m.content)
       ),
       {},
       [handlers]


### PR DESCRIPTION
Resolves: https://github.com/vercel-labs/ai/issues/332
The `HumanChatMessage` and `AIChatMessage` methods have been deprecated in latest langChain version and it is recommended to use `HumanMessage` and `AIMessage` instead. This pull request aims to update those imports in the usage guide and api reference files.

<img width="2500" alt="image" src="https://github.com/vercel-labs/ai/assets/48244930/5d1159fe-dc55-450c-a840-8087bf36f909">
