### PR TITLE
Resolve function stream parsing error when provided a specific function  

### DIFF
--- a/.changeset/empty-bees-switch.md
+++ b/.changeset/empty-bees-switch.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Providing a function to `function_call` request parameter of the OpenAI Chat Completions API no longer breaks OpenAI function stream parsing.

--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -115,7 +115,7 @@ function parseOpenAIStream(): (data: string) => string | void {
 
         ...
 
-        Finally, the last chunk has a `finish_reason` of `function_call`:
+        Finally, the last chunk has a `finish_reason` of either `function_call`:
 
           {
             ...
@@ -126,6 +126,17 @@ function parseOpenAIStream(): (data: string) => string | void {
             }]
           }
 
+        or `stop`, when the `function_call` request parameter 
+        is specified with a particular function via `{\"name\": \"my_function\"}` 
+
+          {
+            ...
+            "choices": [{
+              "index": 0,
+              "delta": {},
+              "finish_reason": "stop"
+            }]
+          }
 
         With the implementation below, the client will end up getting a
         response like the one below streamed to them whenever a function call

--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -62,7 +62,6 @@ function parseOpenAIStream(): (data: string) => string | void {
   const trimStartOfStream = trimStartOfStreamHelper()
   let isFunctionStreamingIn: boolean
   return data => {
-    const json = JSON.parse(data)
     /*
        If the response is a function call, the first streaming chunk from OpenAI returns the name of the function like so
 
@@ -149,6 +148,7 @@ function parseOpenAIStream(): (data: string) => string | void {
             }
           }
      */
+    const json = JSON.parse(data)
     if (json.choices[0]?.delta?.function_call?.name) {
       isFunctionStreamingIn = true
       return `{"function_call": {"name": "${json.choices[0]?.delta?.function_call.name}", "arguments": "`

--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -167,9 +167,11 @@ function parseOpenAIStream(): (data: string) => string | void {
 
       return `${escapedPartialJson}`
     } else if (
-      json.choices[0]?.finish_reason === 'function_call' ||
-      (isFunctionStreamingIn && json.choices[0]?.finish_reason === 'stop')
+      (json.choices[0]?.finish_reason === 'function_call' ||
+        json.choices[0]?.finish_reason === 'stop') &&
+      isFunctionStreamingIn
     ) {
+      isFunctionStreamingIn = false // Reset the flag
       return '"}}'
     }
 

--- a/packages/core/tests/snapshots/openai-chat.ts
+++ b/packages/core/tests/snapshots/openai-chat.ts
@@ -334,3 +334,14 @@ export const chatCompletionChunksWithFunctionCall = [
     choices: [{ index: 0, delta: {}, finish_reason: 'function_call' }]
   }
 ]
+
+export const chatCompletionChunksWithSpecifiedFunctionCall = [
+  ...chatCompletionChunksWithFunctionCall,
+  {
+    id: 'chatcmpl-7WBy19k4tnzMa0svAIAqkqeIaKZh8',
+    object: 'chat.completion.chunk',
+    created: 1687906853,
+    model: 'gpt-3.5-turbo-0613',
+    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] // finish_reason is 'stop' whenever you provide a function to function_call parameter
+  }
+]

--- a/packages/core/tests/utils/mock-service.ts
+++ b/packages/core/tests/utils/mock-service.ts
@@ -2,7 +2,8 @@ import { ServerResponse, createServer } from 'node:http'
 
 import {
   chatCompletionChunks,
-  chatCompletionChunksWithFunctionCall
+  chatCompletionChunksWithFunctionCall,
+  chatCompletionChunksWithSpecifiedFunctionCall
 } from '../snapshots/openai-chat'
 
 async function flushDataToResponse(
@@ -43,7 +44,8 @@ export const setup = () => {
     const type = req.headers['x-mock-type'] || 'chat' || 'func_call'
 
     switch (type) {
-      case 'func_call': // new case
+      case 'func_call':
+      case 'func_call_with_specified_function':
         switch (service) {
           case 'openai':
             res.writeHead(200, {
@@ -53,9 +55,13 @@ export const setup = () => {
             })
             res.flushHeaders()
             recentFlushed = []
+            const mock =
+              type === 'func_call_with_specified_function'
+                ? chatCompletionChunksWithSpecifiedFunctionCall
+                : chatCompletionChunksWithFunctionCall
             flushDataToResponse(
               res,
-              chatCompletionChunksWithFunctionCall.map(
+              mock.map(
                 value =>
                   new Proxy(
                     { value },


### PR DESCRIPTION
Fixes #329 

The reasoning why this works is similar to why trimStartOfStreamHelper also works. parseOpenAIStream maintains a temporary local state of each complete streamed message from the start chunk to end chunk.


Does this need a changeset? 