### PR TITLE
docs: fix sveltekit `edge` runtime config

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -142,7 +142,9 @@ We've written some code to get you started — follow the instructions below to 
     const openai = new OpenAIApi(config);
 
     // Set the runtime to edge for best performance
-    export const runtime = 'edge'
+    export const config = {
+      runtime: 'edge'
+    };
 
     export async function POST({ request }) {
       const { prompt } = await request.json();


### PR DESCRIPTION
Updated Sveltekit runtime config according to docs: [Sveltekit docs page](https://kit.svelte.dev/docs/adapter-vercel#deployment-configuration) 