### PR TITLE
experimental_ChatFunctionHandler API

### DIFF
--- a/.changeset/chilled-kids-float.md
+++ b/.changeset/chilled-kids-float.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Introduce experimental_ChatFunctionHandler API

--- a/examples/next-openai/app/api/chat-with-functions/route.ts
+++ b/examples/next-openai/app/api/chat-with-functions/route.ts
@@ -1,50 +1,73 @@
 import { Configuration, OpenAIApi } from 'openai-edge'
 import { OpenAIStream, StreamingTextResponse } from 'ai'
-import { ChatCompletionFunctions } from 'openai-edge/types/api'
+import { experimental_ChatFunctionHandler } from 'ai/functions'
 
-// Create an OpenAI API client (that's edge friendly!)
 const config = new Configuration({
   apiKey: process.env.OPENAI_API_KEY
 })
 const openai = new OpenAIApi(config)
 
-// IMPORTANT! Set the runtime to edge
 export const runtime = 'edge'
 
-const functions: ChatCompletionFunctions[] = [
-  {
-    name: 'get_current_weather',
-    description: 'Get the current weather',
-    parameters: {
-      type: 'object',
-      properties: {
-        format: {
-          type: 'string',
-          enum: ['celsius', 'fahrenheit'],
-          description:
-            'The temperature unit to use. Infer this from the users location.'
+const functions: experimental_ChatFunctionHandler =
+  new experimental_ChatFunctionHandler([
+    {
+      function: {
+        name: 'get_current_weather',
+        description: 'Get the current weather in a given location',
+        parameters: {
+          type: 'object',
+          properties: {
+            location: {
+              type: 'string',
+              description: 'The location to get the weather for'
+            },
+            format: {
+              type: 'string',
+              enum: ['celsius', 'fahrenheit']
+            }
+          },
+          required: ['location', 'format']
         }
       },
-      required: ['format']
-    }
-  },
-  {
-    name: 'eval_code_in_browser',
-    description: 'Execute javascript code in the browser with eval().',
-    parameters: {
-      type: 'object',
-      properties: {
-        code: {
-          type: 'string',
-          description: `Javascript code that will be directly executed via eval(). Do not use backticks in your response.
-           DO NOT include any newlines in your response, and be sure to provide only valid JSON when providing the arguments object.
-           The output of the eval() will be returned directly by the function.`
+      handler: async (
+        { location, format },
+        createFunctionCallMessages,
+        messages = []
+      ) => {
+        // Call a weather API here
+        const weatherData = {
+          temperature: 20,
+          unit: format === 'celsius' ? 'C' : 'F'
         }
-      },
-      required: ['code']
+
+        return openai.createChatCompletion({
+          model: 'gpt-3.5-turbo-0613',
+          stream: true,
+          messages: [
+            ...messages,
+            ...(createFunctionCallMessages(weatherData) as any)
+          ],
+          functions: functions.schemas
+        })
+      }
+    },
+    {
+      function: {
+        name: 'eval_code_in_browser',
+        description: 'Execute javascript code in the browser with eval().',
+        parameters: {
+          type: 'object',
+          properties: {
+            code: {
+              type: 'string',
+              description: `Javascript code that will be directly executed via eval(). Do not use backticks in your response.`
+            }
+          }
+        }
+      }
     }
-  }
-]
+  ])
 
 export async function POST(req: Request) {
   const { messages } = await req.json()
@@ -53,29 +76,11 @@ export async function POST(req: Request) {
     model: 'gpt-3.5-turbo-0613',
     stream: true,
     messages,
-    functions
+    functions: functions.schemas
   })
 
   const stream = OpenAIStream(response, {
-    experimental_onFunctionCall: async (
-      { name, arguments: args },
-      createFunctionCallMessages
-    ) => {
-      if (name === 'get_current_weather') {
-        // Call a weather API here
-        const weatherData = {
-          temperature: 20,
-          unit: args.format === 'celsius' ? 'C' : 'F'
-        }
-        const newMessages = createFunctionCallMessages(weatherData)
-        return openai.createChatCompletion({
-          messages: [...messages, ...newMessages],
-          stream: true,
-          model: 'gpt-3.5-turbo-0613',
-          functions
-        })
-      }
-    }
+    experimental_onFunctionCall: functions.onFunctionCallHandler(messages)
   })
 
   return new StreamingTextResponse(stream)

--- a/examples/next-openai/app/api/chat-with-functions/route.ts
+++ b/examples/next-openai/app/api/chat-with-functions/route.ts
@@ -30,11 +30,7 @@ const functions: experimental_ChatFunctionHandler =
           required: ['location', 'format']
         }
       },
-      handler: async (
-        { location, format },
-        createFunctionCallMessages,
-        messages = []
-      ) => {
+      handler: async ({ location, format }, createFunctionCallMessages) => {
         // Call a weather API here
         const weatherData = {
           temperature: 20,
@@ -44,10 +40,7 @@ const functions: experimental_ChatFunctionHandler =
         return openai.createChatCompletion({
           model: 'gpt-3.5-turbo-0613',
           stream: true,
-          messages: [
-            ...messages,
-            ...(createFunctionCallMessages(weatherData) as any)
-          ],
+          messages: createFunctionCallMessages(weatherData),
           functions: functions.schemas
         })
       }

--- a/examples/next-openai/app/api/chat-with-functions/route.ts
+++ b/examples/next-openai/app/api/chat-with-functions/route.ts
@@ -40,6 +40,8 @@ const functions: experimental_ChatFunctionHandler =
         return openai.createChatCompletion({
           model: 'gpt-3.5-turbo-0613',
           stream: true,
+          // Messages from the `onFunctionCallHandler` are automatically appended to the messages array.
+          // Further messages can be added as a second argument below:
           messages: createFunctionCallMessages(weatherData),
           functions: functions.schemas
         })

--- a/examples/next-openai/app/function-calling/page.tsx
+++ b/examples/next-openai/app/function-calling/page.tsx
@@ -2,7 +2,7 @@
 
 import { Message } from 'ai/react'
 import { useChat } from 'ai/react'
-import { ChatRequest, FunctionCallHandler, nanoid } from 'ai'
+import { ChatRequest, ClientMessage, FunctionCallHandler, nanoid } from 'ai'
 
 export default function Chat() {
   const functionCallHandler: FunctionCallHandler = async (
@@ -49,7 +49,7 @@ export default function Chat() {
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {messages.length > 0
-        ? messages.map((m: Message) => (
+        ? messages.map((m: ClientMessage) => (
             <div
               key={m.id}
               className="whitespace-pre-wrap"

--- a/examples/next-openai/package.json
+++ b/examples/next-openai/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "ai": "^2.1.31",
+    "ai": "workspace:*",
     "next": "13.4.4-canary.11",
     "openai-edge": "^1.1.0",
     "react": "18.2.0",

--- a/packages/core/functions/functions.ts
+++ b/packages/core/functions/functions.ts
@@ -1,0 +1,156 @@
+import type { ChatCompletionFunctions } from 'openai-edge'
+import type { OpenAIStreamCallbacks } from '../streams'
+import type { Message } from '../shared/types'
+
+type FunctionSchema = ChatCompletionFunctions
+
+type ExperimentalOnFunctionCall = NonNullable<
+  OpenAIStreamCallbacks['experimental_onFunctionCall']
+>
+
+type CreateFunctionCallMessages = Parameters<ExperimentalOnFunctionCall>[1]
+
+type FunctionResponse = ReturnType<ExperimentalOnFunctionCall>
+
+/**
+ * A server-side function handler is a wrapper around an OpenAI function schema and it's corresponding handler.
+ * The handler is optional. If it is not provided, the function will be sent to the client.
+ * @experimental This API is experimental and may change at any time.
+ */
+export class experimental_ChatFunction {
+  name: string
+  private description?: string
+  private parameters: FunctionSchema['parameters']
+  /**
+   * If the handler is undefined, the function will be sent to the client.
+   */
+  private handler?: (
+    args: any,
+    createFunctionCallMessages: CreateFunctionCallMessages,
+    messages: Message[]
+  ) => FunctionResponse
+
+  constructor({
+    function: functionSchema,
+    handler
+  }: {
+    function: FunctionSchema
+    handler?: (
+      args: any,
+      createFunctionCallMessages: CreateFunctionCallMessages,
+      messages: Message[]
+    ) => FunctionResponse
+  }) {
+    this.name = functionSchema.name
+    this.description = functionSchema.description
+    this.parameters = functionSchema.parameters
+    this.handler = handler
+  }
+
+  private validate(args: any): any {
+    if (!this.parameters) return args
+
+    for (const key of Object.keys(this.parameters.properties)) {
+      if (!(key in args)) {
+        throw new Error(`Missing required parameter: ${key}`)
+      }
+    }
+
+    return args
+  }
+
+  /**
+   * Execute the function handler with the given arguments.
+   * The first argument is passed to the function handler.
+   * The second should be the function callback from `experimental_onFunctionCall`.
+   */
+  execute(
+    /**
+     * Arguments passed to the function handler.
+     */
+    args: any,
+    /**
+     * This should be the function from the `experimental_onFunctionCall` callback.
+     */
+    createFunctionCallMessages: CreateFunctionCallMessages,
+    /**
+     *  Any messages to be included in the context.
+     */
+    messages: Message[]
+  ): Promise<any> {
+    if (!this.handler) return Promise.resolve(undefined)
+    const validatedArgs = this.validate(args)
+    return this.handler(validatedArgs, createFunctionCallMessages, messages)
+  }
+
+  get schema(): FunctionSchema {
+    return {
+      name: this.name,
+      description: this.description,
+      parameters: this.parameters
+    }
+  }
+}
+
+type FunctionInput =
+  | experimental_ChatFunction
+  | { function: FunctionSchema; handler?: FunctionHandlerType }
+  | (
+      | experimental_ChatFunction
+      | { function: FunctionSchema; handler?: FunctionHandlerType }
+    )[]
+
+type FunctionHandlerType = (
+  args: any,
+  createFunctionCallMessages: CreateFunctionCallMessages,
+  messages: Message[]
+) => FunctionResponse
+
+export class experimental_ChatFunctionHandler extends Array<experimental_ChatFunction> {
+  constructor(functions: FunctionInput) {
+    super()
+
+    if (Array.isArray(functions)) {
+      for (const func of functions) {
+        this.add(func)
+      }
+    } else {
+      this.add(functions)
+    }
+  }
+
+  add(
+    func:
+      | experimental_ChatFunction
+      | { function: FunctionSchema; handler?: FunctionHandlerType }
+  ) {
+    if (func instanceof experimental_ChatFunction) {
+      this.push(func)
+    } else {
+      // If it's not an instance of experimental_ChatFunction, we assume it's a FunctionSchema
+      // and create a new experimental_ChatFunction from it
+      const { function: functionSchema, handler } = func
+      this.push(
+        new experimental_ChatFunction({
+          function: functionSchema,
+          handler
+        })
+      )
+    }
+  }
+
+  onFunctionCallHandler(messages: Message[]): ExperimentalOnFunctionCall {
+    return async ({ name, arguments: args }, createFunctionCallMessages) => {
+      const functionHandler = this.find(f => f.name === name)
+      if (!functionHandler) {
+        throw new Error(`Function ${name} not found`)
+      }
+
+      return functionHandler.execute(args, createFunctionCallMessages, messages)
+    }
+  }
+
+  get schemas(): FunctionSchema[] {
+    return this.map(f => f.schema)
+  }
+}

--- a/packages/core/functions/functions.ts
+++ b/packages/core/functions/functions.ts
@@ -39,6 +39,7 @@ export class experimental_ChatFunction {
       createFunctionCallMessages: CreateFunctionCallMessages
     ) => FunctionResponse
   }) {
+    if (!functionSchema?.name) console.trace('Function name is required')
     this.name = functionSchema.name
     this.description = functionSchema.description
     this.parameters = functionSchema.parameters
@@ -99,8 +100,14 @@ type FunctionHandlerType = (
   createFunctionCallMessages: CreateFunctionCallMessages
 ) => FunctionResponse
 
+type Options = {
+  debug?: boolean
+}
+
 export class experimental_ChatFunctionHandler extends Array<experimental_ChatFunction> {
-  constructor(functions: FunctionInput) {
+  private options: Options = {}
+
+  constructor(functions: FunctionInput, options?: Options) {
     super()
 
     if (Array.isArray(functions)) {
@@ -110,6 +117,10 @@ export class experimental_ChatFunctionHandler extends Array<experimental_ChatFun
     } else {
       this.add(functions)
     }
+
+    if (options) {
+      this.options = options
+    }
   }
 
   add(
@@ -117,9 +128,11 @@ export class experimental_ChatFunctionHandler extends Array<experimental_ChatFun
       | experimental_ChatFunction
       | { function: FunctionSchema; handler?: FunctionHandlerType }
   ) {
+    if (this.options.debug) console.debug('Adding function', func)
     if (func instanceof experimental_ChatFunction) {
       this.push(func)
     } else {
+      if (!func?.function) return
       // If it's not an instance of experimental_ChatFunction, we assume it's a FunctionSchema
       // and create a new experimental_ChatFunction from it
       const { function: functionSchema, handler } = func
@@ -149,6 +162,7 @@ export class experimental_ChatFunctionHandler extends Array<experimental_ChatFun
         ])
       }
 
+      if (this.options.debug) console.debug('Executing function', name, args)
       return functionHandler.execute(
         args,
         createFunctionCallMessagesWithMessages

--- a/packages/core/functions/index.ts
+++ b/packages/core/functions/index.ts
@@ -1,0 +1,1 @@
+export * from './functions'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,8 @@
     "sswr": "2.0.0",
     "swr": "2.2.0",
     "swr-store": "0.10.6",
-    "swrv": "1.0.4"
+    "swrv": "1.0.4",
+    "zod": "3.21.4"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "1.1.0-beta.31",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,12 @@
       "module": "./prompts/dist/index.mjs",
       "require": "./prompts/dist/index.js"
     },
+    "./functions": {
+      "types": "./functions/dist/index.d.ts",
+      "import": "./functions/dist/index.mjs",
+      "module": "./functions/dist/index.mjs",
+      "require": "./functions/dist/index.js"
+    },
     "./react": {
       "types": "./react/dist/index.d.ts",
       "react-server": "./react/dist/index.server.mjs",

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -43,7 +43,7 @@ export type ChatRequest = {
   function_call?: CreateChatCompletionRequestFunctionCall
 }
 
-export type ClientFunctionCallHandler = (
+export type FunctionCallHandler = (
   chatMessages: ClientMessage[],
   functionCall: ChatCompletionRequestMessageFunctionCall
 ) => Promise<ChatRequest | void>
@@ -88,7 +88,7 @@ export type UseChatOptions = {
    * If the function returns a `ChatRequest` object, the request will be sent
    * automatically to the API and will be used to update the chat.
    */
-  experimental_onFunctionCall?: ClientFunctionCallHandler
+  experimental_onFunctionCall?: FunctionCallHandler
 
   /**
    * Callback function to be called when the API response is received.

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -22,6 +22,13 @@ export type Message = {
    * contains the function call name and arguments. Otherwise, the field should
    * not be set.
    */
+  function_call?: ChatCompletionRequestMessageFunctionCall
+}
+
+/**
+ * Identical to Message except `function_call` may be a string when streaming in.
+ */
+export type ClientMessage = Omit<Message, 'function_call'> & {
   function_call?: string | ChatCompletionRequestMessageFunctionCall
 }
 
@@ -30,14 +37,14 @@ export type CreateMessage = Omit<Message, 'id'> & {
 }
 
 export type ChatRequest = {
-  messages: Message[]
+  messages: ClientMessage[]
   options?: RequestOptions
   functions?: Array<ChatCompletionFunctions>
   function_call?: CreateChatCompletionRequestFunctionCall
 }
 
-export type FunctionCallHandler = (
-  chatMessages: Message[],
+export type ClientFunctionCallHandler = (
+  chatMessages: ClientMessage[],
   functionCall: ChatCompletionRequestMessageFunctionCall
 ) => Promise<ChatRequest | void>
 
@@ -69,7 +76,7 @@ export type UseChatOptions = {
   /**
    * Initial messages of the chat. Useful to load an existing chat history.
    */
-  initialMessages?: Message[]
+  initialMessages?: ClientMessage[]
 
   /**
    * Initial input of the chat.
@@ -81,7 +88,7 @@ export type UseChatOptions = {
    * If the function returns a `ChatRequest` object, the request will be sent
    * automatically to the API and will be used to update the chat.
    */
-  experimental_onFunctionCall?: FunctionCallHandler
+  experimental_onFunctionCall?: ClientFunctionCallHandler
 
   /**
    * Callback function to be called when the API response is received.
@@ -91,7 +98,7 @@ export type UseChatOptions = {
   /**
    * Callback function to be called when the chat is finished streaming.
    */
-  onFinish?: (message: Message) => void
+  onFinish?: (message: ClientMessage) => void
 
   /**
    * Callback function to be called when an error is encountered.
@@ -196,3 +203,11 @@ export type UseCompletionOptions = {
    */
   body?: object
 }
+
+export type JSONValue =
+  | null
+  | string
+  | number
+  | boolean
+  | { [x: string]: JSONValue }
+  | Array<JSONValue>

--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -352,7 +352,10 @@ function createFunctionCallTransformer(
             ]
 
             // Return it to the user
-            return [...(messages || []), ...newFunctionCallMessages] as ChatCompletionRequestMessage[]
+            return [
+              ...(messages || []),
+              ...newFunctionCallMessages
+            ] as ChatCompletionRequestMessage[]
           }
         )
 

--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -362,7 +362,7 @@ function createFunctionCallTransformer(
           }
         )
 
-        if (!functionResponse) {
+        if (functionResponse === undefined) {
           // The user didn't do anything with the function call on the server and wants
           // to either do nothing or run it on the client
           // so we just return the function call as a message

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -6,7 +6,14 @@ export default defineConfig([
     entry: ['streams/index.ts'],
     format: ['cjs', 'esm'],
     external: ['react', 'svelte', 'vue'],
-    dts: true
+    dts: true,
+  },
+  {
+    entry: ['functions/index.ts'],
+    outDir: 'functions/dist',
+    format: ['cjs', 'esm'],
+    external: ['react', 'svelte', 'vue'],
+    dts: true,
   },
   {
     entry: ['prompts/index.ts'],

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -6,14 +6,14 @@ export default defineConfig([
     entry: ['streams/index.ts'],
     format: ['cjs', 'esm'],
     external: ['react', 'svelte', 'vue'],
-    dts: true,
+    dts: true
   },
   {
     entry: ['functions/index.ts'],
     outDir: 'functions/dist',
     format: ['cjs', 'esm'],
     external: ['react', 'svelte', 'vue'],
-    dts: true,
+    dts: true
   },
   {
     entry: ['prompts/index.ts'],

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -214,7 +214,10 @@ export function useChat({
     if (!message.id) {
       message.id = nanoid()
     }
-    return triggerRequest(messages.value.concat(message as ClientMessage), options)
+    return triggerRequest(
+      messages.value.concat(message as ClientMessage),
+      options
+    )
   }
 
   const reload: UseChatHelpers['reload'] = async options => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
   examples/next-openai:
     dependencies:
       ai:
-        specifier: ^2.1.31
+        specifier: workspace:*
         version: link:../../packages/core
       next:
         specifier: 13.4.4-canary.11
@@ -507,7 +507,7 @@ importers:
     dependencies:
       eslint-config-next:
         specifier: ^13.4.1
-        version: 13.4.1(eslint@8.42.0)(typescript@4.9.4)
+        version: 13.4.12(eslint@8.42.0)(typescript@4.9.4)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.8.0(eslint@8.42.0)
@@ -620,7 +620,7 @@ packages:
       '@babel/helper-validator-option': 7.22.5
       browserslist: 4.21.9
       lru-cache: 5.1.1
-      semver: 6.3.0
+      semver: 6.3.1
 
   /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.5):
     resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
@@ -2684,8 +2684,8 @@ packages:
     resolution: {integrity: sha512-0rFr8hcDkuIqlPdkHmIbk+VcJRHm4X4cx8bc78pE8g/CHSFZCviUE7AxEXBPFPB1q1cdiEChG8yb+ceIBHrg9w==}
     dev: false
 
-  /@next/eslint-plugin-next@13.4.1:
-    resolution: {integrity: sha512-tVPS/2FKlA3ANCRCYZVT5jdbUKasBU8LG6bYqcNhyORDFTlDYa4cAWQJjZ7msIgLwMQIbL8CAsxrOL8maa/4Lg==}
+  /@next/eslint-plugin-next@13.4.12:
+    resolution: {integrity: sha512-6rhK9CdxEgj/j1qvXIyLTWEaeFv7zOK8yJMulz3Owel0uek0U9MJCGzmKgYxM3aAUBo3gKeywCZKyQnJKto60A==}
     dependencies:
       glob: 7.1.7
     dev: false
@@ -6358,8 +6358,8 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  /eslint-config-next@13.4.1(eslint@8.42.0)(typescript@4.9.4):
-    resolution: {integrity: sha512-ajuxjCkW1hvirr0EQZb3/B/bFH52Z7CT89uCtTcICFL9l30i5c8hN4p0LXvTjdOXNPV5fEDcxBgGHgXdzTj1/A==}
+  /eslint-config-next@13.4.12(eslint@8.42.0)(typescript@4.9.4):
+    resolution: {integrity: sha512-ZF0r5vxKaVazyZH/37Au/XItiG7qUOBw+HaH3PeyXltIMwXorsn6bdrl0Nn9N5v5v9spc+6GM2ryjugbjF6X2g==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
       typescript: '>=3.3.1'
@@ -6367,7 +6367,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@next/eslint-plugin-next': 13.4.1
+      '@next/eslint-plugin-next': 13.4.12
       '@rushstack/eslint-patch': 1.3.2
       '@typescript-eslint/parser': 5.59.11(eslint@8.42.0)(typescript@4.9.4)
       eslint: 8.42.0
@@ -6376,7 +6376,7 @@ packages:
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-typescript@3.5.5)(eslint@8.42.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.42.0)
       eslint-plugin-react: 7.32.2(eslint@8.42.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.42.0)
+      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.42.0)
       typescript: 4.9.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -6836,7 +6836,7 @@ packages:
       ignore: 5.2.4
       minimatch: 3.1.2
       resolve: 1.22.2
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /eslint-plugin-nuxt@4.0.0(eslint@8.42.0):
@@ -6885,8 +6885,8 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.42.0):
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+  /eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.42.0):
+    resolution: {integrity: sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
@@ -12324,6 +12324,7 @@ packages:
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
+    dev: false
 
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,9 @@ importers:
       vue:
         specifier: ^3.3.4
         version: 3.3.4
+      zod:
+        specifier: 3.21.4
+        version: 3.21.4
     devDependencies:
       '@edge-runtime/jest-environment':
         specifier: 1.1.0-beta.31


### PR DESCRIPTION
- Made a new `ClientMessage` type that supports `function_call` being JSON (whereas server-handled functions halt until the function is completely streamed in)
	- Removes some type casting from the example
	- This is officially a breaking change but it _should_ just affect types
- Created new `experimental_ChatFunction` and `experimental_ChatFunctionHandler` classes. User's shouldn't need to interact with `experimental_ChatFunction` if they don't want to (they can pass the handler an array of objects)
- Basic argument validation
	- 	In the future we should investigate using zod 

[View the example route](https://github.com/vercel-labs/ai/blob/max/function-utils/examples/next-openai/app/api/chat-with-functions/route.ts) to see it in action
