### PR TITLE
ai/react: don't throw error if onError is passed

### DIFF
--- a/.changeset/good-pumas-hang.md
+++ b/.changeset/good-pumas-hang.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+ai/react: don't throw error if onError is passed

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -8,14 +8,9 @@ import type {
   CreateMessage,
   Message,
   UseChatOptions,
-  RequestOptions,
   ChatRequestOptions
 } from '../shared/types'
-import {
-  ChatCompletionRequestMessageFunctionCall,
-  CreateChatCompletionRequestFunctionCall
-} from 'openai-edge'
-import { ChatCompletionFunctions } from 'openai-edge/types/api'
+import { ChatCompletionRequestMessageFunctionCall } from 'openai-edge'
 export type { Message, CreateMessage, UseChatOptions }
 
 export type UseChatHelpers = {
@@ -320,7 +315,9 @@ export function useChat({
     },
     {
       populateCache: false,
-      revalidate: false
+      revalidate: false,
+      // @ts-expect-error - SWR tries to be clever with the throwOnError type
+      throwOnError: Boolean(!onError)
     }
   )
 

--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -194,7 +194,9 @@ export function useCompletion({
     },
     {
       populateCache: false,
-      revalidate: false
+      revalidate: false,
+      // @ts-expect-error - SWR tries to be clever with the throwOnError type
+      throwOnError: Boolean(onError)
     }
   )
 


### PR DESCRIPTION
The vue, solid, and svelte utils do not use an equivalent to `useSWRMutation` and always return the caught error in the `error` returned from our client hooks. This more closely aligns the react package by having SWR not throw the error if an `onError` is passed. 

x-ref: [slack](https://vercel.slack.com/archives/C050WU03V3N/p1689962301840149)