### PR TITLE
chore: Update deprecated Langchain types

### DIFF
--- a/examples/next-langchain/app/api/chat/route.ts
+++ b/examples/next-langchain/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { StreamingTextResponse, LangChainStream, Message } from 'ai'
 import { ChatOpenAI } from 'langchain/chat_models/openai'
-import { AIChatMessage, HumanChatMessage } from 'langchain/schema'
+import { AIMessage, HumanMessage } from 'langchain/schema'
 
 export const runtime = 'edge'
 
@@ -17,8 +17,8 @@ export async function POST(req: Request) {
     .call(
       (messages as Message[]).map(m =>
         m.role == 'user'
-          ? new HumanChatMessage(m.content)
-          : new AIChatMessage(m.content)
+          ? new HumanMessage(m.content)
+          : new AIMessage(m.content)
       ),
       {},
       [handlers]

--- a/examples/nuxt-langchain/server/api/chat.ts
+++ b/examples/nuxt-langchain/server/api/chat.ts
@@ -1,6 +1,6 @@
 import { LangChainStream, Message, streamToResponse } from 'ai'
 import { ChatOpenAI } from 'langchain/chat_models/openai'
-import { AIChatMessage, HumanChatMessage } from 'langchain/schema'
+import { AIMessage, HumanMessage } from 'langchain/schema'
 
 export const runtime = 'edge'
 
@@ -23,8 +23,8 @@ export default defineEventHandler(async (event: any) => {
       .call(
         (messages as Message[]).map(message =>
           message.role === 'user'
-            ? new HumanChatMessage(message.content)
-            : new AIChatMessage(message.content)
+            ? new HumanMessage(message.content)
+            : new AIMessage(message.content)
         ),
         {},
         [handlers]


### PR DESCRIPTION
Langchain schema types `AIChatMessage` and `HumanChatMessage` have been deprecated and `AIMessage` , `HumanMessage` are used instead. Updated types in Nuxt and Next langchain examples.

Docs: [AIChatMessage](url) , [HumanChatMessage](https://js.langchain.com/docs/api/schema/variables/HumanChatMessage)
Code: [AIMessage](https://github.com/hwchase17/langchainjs/blob/46e1734/langchain/src/schema/index.ts#L172) ,[HumanMessage](https://github.com/hwchase17/langchainjs/blob/46e1734/langchain/src/schema/index.ts#L166) 