### PR TITLE
react/svelte/vue: don't use api as part of loading SWR key

### DIFF
--- a/.changeset/strong-geese-chew.md
+++ b/.changeset/strong-geese-chew.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+react/svelte/vue: don't use api as part of loading SWR key

--- a/docs/pages/docs/guides/providers/huggingface.mdx
+++ b/docs/pages/docs/guides/providers/huggingface.mdx
@@ -74,7 +74,7 @@ export async function POST(req: Request) {
       status: response.status
     })
   }
-  
+
   // Convert the async generator into a friendly text-stream
   const stream = HuggingFaceStream(response)
 

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -215,7 +215,7 @@ export function useChat({
   })
 
   const { data: isLoading = false, mutate: mutateLoading } = useSWR<boolean>(
-    [api, chatId, 'loading'],
+    [chatId, 'loading'],
     null
   )
 

--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -76,7 +76,7 @@ export function useCompletion({
   })
 
   const { data: isLoading = false, mutate: mutateLoading } = useSWR<boolean>(
-    [api, completionId, 'loading'],
+    [completionId, 'loading'],
     null
   )
 

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -51,7 +51,7 @@ export type UseChatHelpers = {
   handleSubmit: (e: any, chatRequestOptions?: ChatRequestOptions) => void
   metadata?: Object
   /** Whether the API request is in progress */
-  isLoading: Writable<boolean | undefined>
+  isLoading: Readable<boolean | undefined>
 }
 const getStreamedResponse = async (
   api: string,
@@ -210,14 +210,16 @@ export function useChat({
   const chatId = id || `chat-${uniqueId++}`
 
   const key = `${api}|${chatId}`
-  const { data, mutate: originalMutate } = useSWR<Message[]>(key, {
+  const {
+    data,
+    mutate: originalMutate,
+    isLoading: isSWRLoading
+  } = useSWR<Message[]>(key, {
     fetcher: () => store[key] || initialMessages,
     fallbackData: initialMessages
   })
 
-  const { data: isLoading, mutate: mutateLoading } = useSWR<boolean>(
-    `${chatId}-loading`
-  )
+  const loading = writable<boolean>(false)
 
   // Force the `data` to be `initialMessages` if it's `undefined`.
   data.set(initialMessages)
@@ -245,7 +247,7 @@ export function useChat({
   // chat state.
   async function triggerRequest(chatRequest: ChatRequest) {
     try {
-      mutateLoading(true)
+      loading.set(true)
       abortController = new AbortController()
 
       while (true) {
@@ -304,7 +306,7 @@ export function useChat({
 
       error.set(err as Error)
     } finally {
-      mutateLoading(false)
+      loading.set(false)
     }
   }
 
@@ -393,6 +395,6 @@ export function useChat({
     setMessages,
     input,
     handleSubmit,
-    isLoading
+    isLoading: isSWRLoading || loading
   }
 }

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -216,7 +216,7 @@ export function useChat({
   })
 
   const { data: isLoading, mutate: mutateLoading } = useSWR<boolean>(
-    `${key}-loading`
+    `${chatId}-loading`
   )
 
   // Force the `data` to be `initialMessages` if it's `undefined`.

--- a/packages/core/svelte/use-completion.ts
+++ b/packages/core/svelte/use-completion.ts
@@ -72,7 +72,7 @@ export function useCompletion({
   })
 
   const { data: isLoading, mutate: mutateLoading } = useSWR<boolean>(
-    `${key}-loading`
+    `${completionId}-loading`
   )
 
   // Force the `data` to be `initialCompletion` if it's `undefined`.

--- a/packages/core/svelte/use-completion.ts
+++ b/packages/core/svelte/use-completion.ts
@@ -39,7 +39,7 @@ export type UseCompletionHelpers = {
    */
   handleSubmit: (e: any) => void
   /** Whether the API request is in progress */
-  isLoading: Writable<boolean | undefined>
+  isLoading: Readable<boolean | undefined>
 }
 
 let uniqueId = 0
@@ -71,9 +71,7 @@ export function useCompletion({
     fallbackData: initialCompletion
   })
 
-  const { data: isLoading, mutate: mutateLoading } = useSWR<boolean>(
-    `${completionId}-loading`
-  )
+  const loading = writable<boolean>(false)
 
   // Force the `data` to be `initialCompletion` if it's `undefined`.
   data.set(initialCompletion)
@@ -91,7 +89,7 @@ export function useCompletion({
   let abortController: AbortController | null = null
   async function triggerRequest(prompt: string, options?: RequestOptions) {
     try {
-      mutateLoading(true)
+      loading.set(true)
       abortController = new AbortController()
 
       // Empty the completion immediately.
@@ -171,7 +169,7 @@ export function useCompletion({
 
       error.set(err as Error)
     } finally {
-      mutateLoading(false)
+      loading.set(false)
     }
   }
 
@@ -210,6 +208,6 @@ export function useCompletion({
     setCompletion,
     input,
     handleSubmit,
-    isLoading
+    isLoading: isSWRLoading || loading
   }
 }

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -78,7 +78,7 @@ export function useChat({
   )
 
   const { data: isLoading, mutate: mutateLoading } = useSWRV<boolean>(
-    `${key}-loading`
+    `${chatId}-loading`
   )
 
   // Force the `data` to be `initialMessages` if it's `undefined`.

--- a/packages/core/vue/use-completion.ts
+++ b/packages/core/vue/use-completion.ts
@@ -69,7 +69,7 @@ export function useCompletion({
   )
 
   const { data: isLoading, mutate: mutateLoading } = useSWRV<boolean>(
-    `${key}-loading`
+    `${completionId}-loading`
   )
 
   // Force the `data` to be `initialCompletion` if it's `undefined`.


### PR DESCRIPTION
Follow-up to https://github.com/vercel-labs/ai/commit/3d2979910847db5cfc0b36780b7017fbf8af5f5b, resolves #395 
 
We used `api` as part of the key for the loading SWR call, but `api` will be a valid URL that the hook tries to fetch in non-react implementations