### PR TITLE
add Replicate to README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@ The Vercel AI SDK is **a library for building AI-powered streaming text and chat
 ## Features
 
 - [SWR](https://swr.vercel.app)-powered React, Svelte, Vue and Solid helpers for streaming text responses and building chat and completion UIs
-- First-class support for [LangChain](https://js.langchain.com/docs) and [OpenAI](https://openai.com), [Anthropic](https://www.anthropic.com), [Cohere](https://cohere.com) and [Hugging Face](https://huggingface.co)
+- First-class support for [LangChain](https://js.langchain.com/docs) and [OpenAI](https://openai.com), [Anthropic](https://www.anthropic.com), [Cohere](https://cohere.com), [Hugging Face](https://huggingface.co), and [Replicate](https://replicate.com)
 - Node.js, Serverless, and [Edge Runtime](https://edge-runtime.vercel.app/) support
 - Callbacks for saving completed streaming responses to a database (in the same request)
 


### PR DESCRIPTION
Thanks to the hard work of @mattt, @evilstreak, @jaredpalmer, @MaxLeiter, @satpalsr, and others, Replicate is now properly integrated into Vercel's AI SDK. 🎉 

This PR adds us to the README, alongside big shots like OpenAI and HuggingFace. 🙌🏼 

<img width="1115" alt="Screenshot 2023-08-03 at 5 26 52 PM" src="https://github.com/zeke/ai/assets/2289/4017f8cb-0695-4e1d-8e3b-d22ed209c109">
