### PR TITLE
fix: a small typo in docs

### DIFF
--- a/docs/pages/docs/guides/frameworks/nextjs-app.mdx
+++ b/docs/pages/docs/guides/frameworks/nextjs-app.mdx
@@ -82,7 +82,7 @@ export default async function Page({
     stream: true,
     messages: [
       {
-        role: 'system',
+        role: 'user',
         content:
           searchParams['prompt'] ?? 'Give me code for generating a JSX button'
       }


### PR DESCRIPTION
In the Next.js app router guide there is this example: 
```js
  const response = await openai.createChatCompletion({
    model: 'gpt-4',
    stream: true,
    messages: [
      {
        role: 'system',
        content:
          searchParams['prompt'] ?? 'Give me code for generating a JSX button'
      }
    ]
  })
```

But the role should be `user`