### PR TITLE
add Replicate to guides index

### DIFF
--- a/docs/pages/docs/guides.mdx
+++ b/docs/pages/docs/guides.mdx
@@ -7,6 +7,7 @@ with models and services from these providers:
 - [Hugging Face](./guides/huggingface)
 - [Anthropic](./guides/anthropic)
 - [LangChain](./guides/langchain)
+- [Replicate](./guides/replicate)
 
 We also have guides for using the SDK with these frameworks:
 


### PR DESCRIPTION
This PR updates the guides landing page with a link to the Replicate guide.