### PR TITLE
fix(core): use ref to store loading state

### DIFF
--- a/.changeset/mighty-apricots-play.md
+++ b/.changeset/mighty-apricots-play.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-Use native vue `ref` to track loading state, preventing extraneous network requests
+Prevent `isLoading` in vue integration from triggering extraneous network requests

--- a/.changeset/mighty-apricots-play.md
+++ b/.changeset/mighty-apricots-play.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Use native vue `ref` to track loading state, preventing extraneous network requests

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -79,7 +79,7 @@ export function useChat({
 
   const { data: isLoading, mutate: mutateLoading } = useSWRV<boolean>(
     `${chatId}-loading`,
-    null,
+    null
   )
 
   isLoading.value ??= false

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -77,9 +77,7 @@ export function useChat({
     () => store[key] || initialMessages
   )
 
-  const { data: isLoading, mutate: mutateLoading } = useSWRV<boolean>(
-    `${chatId}-loading`
-  )
+  const isLoading = ref(false)
 
   // Force the `data` to be `initialMessages` if it's `undefined`.
   data.value ||= initialMessages
@@ -100,7 +98,7 @@ export function useChat({
     options?: RequestOptions
   ) {
     try {
-      mutateLoading(() => true)
+      isLoading.value = true
       abortController = new AbortController()
 
       // Do an optimistic update to the chat state to show the updated messages
@@ -205,7 +203,7 @@ export function useChat({
 
       error.value = err as Error
     } finally {
-      mutateLoading(() => false)
+      isLoading.value = false
     }
   }
 

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -77,7 +77,12 @@ export function useChat({
     () => store[key] || initialMessages
   )
 
-  const isLoading = ref(false)
+  const { data: isLoading, mutate: mutateLoading } = useSWRV<boolean>(
+    `${chatId}-loading`,
+    null,
+  )
+
+  isLoading.value ??= false
 
   // Force the `data` to be `initialMessages` if it's `undefined`.
   data.value ||= initialMessages
@@ -98,7 +103,7 @@ export function useChat({
     options?: RequestOptions
   ) {
     try {
-      isLoading.value = true
+      mutateLoading(() => true)
       abortController = new AbortController()
 
       // Do an optimistic update to the chat state to show the updated messages
@@ -203,7 +208,7 @@ export function useChat({
 
       error.value = err as Error
     } finally {
-      isLoading.value = false
+      mutateLoading(() => false)
     }
   }
 


### PR DESCRIPTION
discovered in https://github.com/vercel-labs/ai/pull/295, using `useSWRV` to track a loading state means we actually get a fetch to the loading API key. We can just use a vue `ref` to handle this state, however.