### PR TITLE
streams/openai-stream: re-add onCompletion when recursing

### DIFF
--- a/.changeset/angry-pots-type.md
+++ b/.changeset/angry-pots-type.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+streams/openai-stream: re-add onCompletion when recursing

--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -376,13 +376,12 @@ function createFunctionCallTransformer(
 
         // Recursively:
 
-        // We don't want to trigger onStart or onComplete recursively
-        // so we remove them from the callbacks
+        // We don't want to trigger onStart recursively
+        // so we remove it from the callbacks
         // see https://github.com/vercel-labs/ai/issues/351
         const filteredCallbacks: OpenAIStreamCallbacks = {
           ...callbacks,
-          onStart: undefined,
-          onCompletion: undefined
+          onStart: undefined
         }
 
         const openAIStream = OpenAIStream(functionResponse, {


### PR DESCRIPTION
# Original Discussion

https://github.com/vercel-labs/ai/pull/357#issuecomment-1669387296

# Issue 
The previous change completely removed the final `onCompletion` call. Meaning `onCompletion` would only be called for the function call, and not for the original request. This prevents users from saving the final response of the bot.

# Solution

This re-adds `onCompletion`. Users that don't want to save the recursive in-between function calls can check for `function_call` in the completion string. It's probably a good idea to add some kind of `isFunctionCompletion` flag to `onCompletion` maybe? Thoughts @MaxLeiter ?