### PR TITLE
fix: handle ping and error events from anthropic

### DIFF
--- a/.changeset/fast-dryers-compare.md
+++ b/.changeset/fast-dryers-compare.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+anthropic-stream: handle ping and error events from anthropic

--- a/packages/core/streams/anthropic-stream.ts
+++ b/packages/core/streams/anthropic-stream.ts
@@ -1,17 +1,54 @@
 import { AIStream, type AIStreamCallbacks } from './ai-stream'
 
+/**
+ * Parses the anthropic stream data.
+ * @returns A function that accepts a string `data` and returns a parsed string or `void`.
+ */
 function parseAnthropicStream(): (data: string) => string | void {
   let previous = ''
 
-  return data => {
-    const json = JSON.parse(data as string) as {
-      completion: string
-      stop: string | null
-      stop_reason: string | null
-      truncated: boolean
-      log_id: string
-      model: string
-      exception: string | null
+  /**
+   * @param data - The input data string to parse.
+   * @throws An error if the data contains an error event.
+   * @returns The parsed delta or `void`.
+   */
+  return function (data: string): string | void {
+    const json = JSON.parse(data as string) as
+      | {
+          completion: string
+          stop: string | null
+          stop_reason: string | null
+          truncated: boolean
+          log_id: string
+          model: string
+          exception: string | null
+        }
+      | {
+          error: {
+            type: string
+            message: string
+          }
+        }
+
+    /**
+     * Handles the error event.
+     * @event
+     * @property data - The data for the error event.
+     * @property data.error - The error details.
+     * @property data.error.type - The type of the error (e.g., "overloaded_error").
+     * @property data.error.message - The message for the error (e.g., "Overloaded").
+     */
+    if ('error' in json) {
+      throw new Error(json.error.message)
+    }
+
+    /**
+     * Handles the ping event.
+     * @event
+     * @property data - The data for the ping event (empty object).
+     */
+    if (!json.completion) {
+      return
     }
 
     // Anthropic's `completion` field is cumulative unlike OpenAI's


### PR DESCRIPTION
This PR fixes  #383 

Currently, when the stream encounters a ping or an error event during the stream it breaks down entirely. Sort of expected for Error if errors aren't properly handled but this should not break on ping. 

The main reason for this is the line 

` const text = json.completion`

According to the documentation from Anthrophic, neither the ping nor the error object have completion as a key: 

https://docs.anthropic.com/claude/reference/streaming#events

Thus text is going to be `undefined` in those occasions and JS throws an error saying it caannot find slide of undefined

This PR handles both error and ping events from the Anthrophic stream. 

There is probably a better way to do this upstream but this fixes a bug on the SDK for major Anthrophic use cases. 