### PR TITLE
Add support for Anthropic SDK and newer Anthropic API Version(s)

### DIFF
--- a/.changeset/odd-coins-matter.md
+++ b/.changeset/odd-coins-matter.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add support for the Anthropic SDK, newer Anthropic API versions, and improve Anthropic error handling

--- a/packages/core/streams/anthropic-stream.ts
+++ b/packages/core/streams/anthropic-stream.ts
@@ -32,7 +32,7 @@ interface CompletionChunk {
 /**
  * Intended for API versions before 2023-06-01
  */
-function parseAnthropicStreamLegacy(): (data: string) => string | void {
+function parseAnthropicStream(): (data: string) => string | void {
   let previous = ''
 
   return data => {
@@ -46,19 +46,6 @@ function parseAnthropicStreamLegacy(): (data: string) => string | void {
     const delta = text.slice(previous.length)
     previous = text
 
-    return delta
-  }
-}
-
-/**
- * Intended for v2023-06-01 and greater,
- * but may need to be adjusted for future versions.
- * https://docs.anthropic.com/claude/reference/versioning#version-history
- */
-function parseAnthropicStream(): (data: string) => string | void {
-  return data => {
-    const json = JSON.parse(data as string) as CompletionChunk
-    const delta = json.completion
     return delta
   }
 }
@@ -84,9 +71,6 @@ export function AnthropicStream(
       createCallbacksTransformer(cb)
     )
   } else {
-    if (res.headers.get('anthropic-version') === '2023-01-01') {
-      return AIStream(res, parseAnthropicStreamLegacy(), cb)
-    }
     return AIStream(res, parseAnthropicStream(), cb)
   }
 }

--- a/packages/core/streams/anthropic-stream.ts
+++ b/packages/core/streams/anthropic-stream.ts
@@ -84,9 +84,14 @@ export function AnthropicStream(
       createCallbacksTransformer(cb)
     )
   } else {
-    if (res.headers.get('anthropic-version') === '2023-01-01') {
+    const apiVersion = res.headers.get('anthropic-version')
+
+    // TODO(2023-12-01): after this version has been out for a while,
+    // assume a missing version header means the newer version.
+    if (!apiVersion || apiVersion === '2023-01-01') {
       return AIStream(res, parseAnthropicStreamLegacy(), cb)
     }
+
     return AIStream(res, parseAnthropicStream(), cb)
   }
 }

--- a/packages/core/streams/anthropic-stream.ts
+++ b/packages/core/streams/anthropic-stream.ts
@@ -1,19 +1,44 @@
-import { AIStream, type AIStreamCallbacks } from './ai-stream'
+import {
+  AIStream,
+  readableFromAsyncIterable,
+  type AIStreamCallbacks,
+  createCallbacksTransformer
+} from './ai-stream'
 
-function parseAnthropicStream(): (data: string) => string | void {
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/0fc31f4f1ae2976afd0af3236e82d9e2c84c43c9/src/resources/completions.ts#L28-L49
+interface CompletionChunk {
+  /**
+   * The resulting completion up to and excluding the stop sequences.
+   */
+  completion: string
+
+  /**
+   * The model that performed the completion.
+   */
+  model: string
+
+  /**
+   * The reason that we stopped sampling.
+   *
+   * This may be one the following values:
+   *
+   * - `"stop_sequence"`: we reached a stop sequence — either provided by you via the
+   *   `stop_sequences` parameter, or a stop sequence built into the model
+   * - `"max_tokens"`: we exceeded `max_tokens_to_sample` or the model's maximum
+   */
+  stop_reason: string
+}
+
+/**
+ * Intended for API versions before 2023-06-01
+ */
+function parseAnthropicStreamLegacy(): (data: string) => string | void {
   let previous = ''
 
   return data => {
-    const json = JSON.parse(data as string) as {
-      completion: string
-      stop: string | null
-      stop_reason: string | null
-      truncated: boolean
-      log_id: string
-      model: string
-      exception: string | null
-    }
+    const json = JSON.parse(data as string) as CompletionChunk
 
+    // On API versions older than 2023-06-01,
     // Anthropic's `completion` field is cumulative unlike OpenAI's
     // deltas. In order to compute the delta, we must slice out the text
     // we previously received.
@@ -25,9 +50,43 @@ function parseAnthropicStream(): (data: string) => string | void {
   }
 }
 
+/**
+ * Intended for v2023-06-01 and greater,
+ * but may need to be adjusted for future versions.
+ * https://docs.anthropic.com/claude/reference/versioning#version-history
+ */
+function parseAnthropicStream(): (data: string) => string | void {
+  return data => {
+    const json = JSON.parse(data as string) as CompletionChunk
+    const delta = json.completion
+    return delta
+  }
+}
+
+async function* streamable(stream: AsyncIterable<CompletionChunk>) {
+  for await (const chunk of stream) {
+    const text = chunk.completion
+    if (text) yield text
+  }
+}
+
+/**
+ * Accepts either a fetch Response from the Anthropic `POST /v1/complete` endpoint,
+ * or the return value of `await client.completions.create({ stream: true })`
+ * from the `@anthropic-ai/sdk` package.
+ */
 export function AnthropicStream(
-  res: Response,
+  res: Response | AsyncIterable<CompletionChunk>,
   cb?: AIStreamCallbacks
 ): ReadableStream {
-  return AIStream(res, parseAnthropicStream(), cb)
+  if (Symbol.asyncIterator in res) {
+    return readableFromAsyncIterable(streamable(res)).pipeThrough(
+      createCallbacksTransformer(cb)
+    )
+  } else {
+    if (res.headers.get('anthropic-version') === '2023-01-01') {
+      return AIStream(res, parseAnthropicStreamLegacy(), cb)
+    }
+    return AIStream(res, parseAnthropicStream(), cb)
+  }
 }

--- a/packages/core/streams/anthropic-stream.ts
+++ b/packages/core/streams/anthropic-stream.ts
@@ -32,7 +32,7 @@ interface CompletionChunk {
 /**
  * Intended for API versions before 2023-06-01
  */
-function parseAnthropicStream(): (data: string) => string | void {
+function parseAnthropicStreamLegacy(): (data: string) => string | void {
   let previous = ''
 
   return data => {
@@ -46,6 +46,19 @@ function parseAnthropicStream(): (data: string) => string | void {
     const delta = text.slice(previous.length)
     previous = text
 
+    return delta
+  }
+}
+
+/**
+ * Intended for v2023-06-01 and greater,
+ * but may need to be adjusted for future versions.
+ * https://docs.anthropic.com/claude/reference/versioning#version-history
+ */
+function parseAnthropicStream(): (data: string) => string | void {
+  return data => {
+    const json = JSON.parse(data as string) as CompletionChunk
+    const delta = json.completion
     return delta
   }
 }
@@ -71,6 +84,9 @@ export function AnthropicStream(
       createCallbacksTransformer(cb)
     )
   } else {
+    if (res.headers.get('anthropic-version') === '2023-01-01') {
+      return AIStream(res, parseAnthropicStreamLegacy(), cb)
+    }
     return AIStream(res, parseAnthropicStream(), cb)
   }
 }


### PR DESCRIPTION
Mimics https://github.com/vercel-labs/ai/pull/356 for Anthropic, using their SDK: https://github.com/anthropics/anthropic-sdk-typescript

Motivated by an issue on the Anthropic TS SDK repo, in which a user reports that the vercel/ai wasn't working with anthropic for them: https://github.com/anthropics/anthropic-sdk-typescript/issues/112

Example usage:

```ts
import Anthropic from '@anthropic-ai/sdk'
import { AnthropicStream, StreamingTextResponse } from 'ai'

const client = new Anthropic()

export async function POST(req: Request) {
  const result = await client.completions.create({ stream: true, ...params })
  const stream = AnthropicStream(result)
  return new StreamingTextResponse(stream)
}
```

Note that the SDK uses `anthropic-version: 2023-06-01`, which results in `result.completion` being a diff instead of a snapshot. This PR also adds support for this with raw `Response`.

https://docs.anthropic.com/claude/reference/versioning

cc @jridgewell @MaxLeiter 