### PR TITLE
fix: infinite loop for experimental stream data

### DIFF
--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -391,14 +391,15 @@ export function useChat({
 
         // Using experimental stream data
         if ('messages' in messagesAndDataOrJustMessage) {
+          let hasFollowingResponse = false;
           for (const message of messagesAndDataOrJustMessage.messages) {
             if (
               message.function_call === undefined ||
               typeof message.function_call === 'string'
             ) {
-              break
+              continue;
             }
-
+            hasFollowingResponse = true;
             // Streamed response is a function call, invoke the function call handler if it exists.
             if (experimental_onFunctionCall) {
               const functionCall = message.function_call
@@ -420,6 +421,9 @@ export function useChat({
               // The updated chat with function call response will be sent to the API in the next iteration of the loop.
               chatRequest = functionCallResponse
             }
+          }
+          if (!hasFollowingResponse) {
+            break;
           }
         } else {
           const streamedResponseMessage = messagesAndDataOrJustMessage

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -391,15 +391,15 @@ export function useChat({
 
         // Using experimental stream data
         if ('messages' in messagesAndDataOrJustMessage) {
-          let hasFollowingResponse = false;
+          let hasFollowingResponse = false
           for (const message of messagesAndDataOrJustMessage.messages) {
             if (
               message.function_call === undefined ||
               typeof message.function_call === 'string'
             ) {
-              continue;
+              continue
             }
-            hasFollowingResponse = true;
+            hasFollowingResponse = true
             // Streamed response is a function call, invoke the function call handler if it exists.
             if (experimental_onFunctionCall) {
               const functionCall = message.function_call
@@ -423,7 +423,7 @@ export function useChat({
             }
           }
           if (!hasFollowingResponse) {
-            break;
+            break
           }
         } else {
           const streamedResponseMessage = messagesAndDataOrJustMessage


### PR DESCRIPTION
We want to try this new experimental stream data feature, but it is causing our client to infinitely send request.
This diff fixes that. AI SDK has been very helpful, looking forward to the stable version of this feature.