### PR TITLE
react/use-chat: stream data doc updates, fix aborting clientside function calls too early

### DIFF
--- a/.changeset/gorgeous-hats-sort.md
+++ b/.changeset/gorgeous-hats-sort.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+react/use-chat: fix aborting clientside function calls too early

--- a/docs/pages/docs/guides/providers/openai-functions.mdx
+++ b/docs/pages/docs/guides/providers/openai-functions.mdx
@@ -214,3 +214,9 @@ if (m.function_call) {
   return m.content
 }
 ```
+
+<Callout>
+  When using the `experimental_StreamData` API, the assistant message containing
+  the `function_call` has no `content`. Previously, it contained the stringified
+  function_call contents.
+</Callout>

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -451,8 +451,9 @@ export function useChat({
             chatRequest = functionCallResponse
           }
         }
-        abortControllerRef.current = null
       }
+
+      abortControllerRef.current = null
     } catch (err) {
       // Ignore abort errors as they are expected.
       if ((err as any).name === 'AbortError') {


### PR DESCRIPTION
As seen in https://github.com/vercel/ai/pull/484#issuecomment-1685484796