### PR TITLE
docs ai/react: fix spellcheck example code for consistency with API route filename

### DIFF
--- a/docs/pages/docs/api-reference/use-completion.mdx
+++ b/docs/pages/docs/api-reference/use-completion.mdx
@@ -458,7 +458,7 @@ export default function PostEditorPage() {
   // Locally store our blog posts content
   const [content, setContent] = useState('')
   const { complete } = useCompletion({
-    api: '/api/complete'
+    api: '/api/completion'
   })
 
   const checkAndPublish = useCallback(


### PR DESCRIPTION
The backend snippet below suggests a location of `api/completion/` but the frontend code here currently points to `/api/complete`