### PR TITLE
unwrap body parameter to make it reactive

### DIFF
--- a/.changeset/odd-eggs-check.md
+++ b/.changeset/odd-eggs-check.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+ai/vue: fix: make body parameter reactive

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -1,5 +1,5 @@
 import swrv from 'swrv'
-import { ref } from 'vue'
+import { ref, unref } from 'vue'
 import type { Ref } from 'vue'
 
 import type {
@@ -120,7 +120,7 @@ export function useChat({
                 role,
                 content
               })),
-          ...body,
+          ...unref(body), // Use unref to unwrap the ref value
           ...options?.body
         }),
         headers: {


### PR DESCRIPTION
In Vue, refs should be unwrapped inside the composable to make them reactive. By using the ref pattern, you allow the composable to react to changes in the value. The missing piece here is that the useChat utility should use unref(body) instead of directly accessing the .value property.