### PR TITLE
Return writer for lang-chain stream.

### DIFF
--- a/.changeset/quick-shrimps-smash.md
+++ b/.changeset/quick-shrimps-smash.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+langchain-stream: return langchain `writer` from LangChainStream

--- a/docs/pages/docs/api-reference/langchain-stream.mdx
+++ b/docs/pages/docs/api-reference/langchain-stream.mdx
@@ -37,7 +37,7 @@ export const runtime = 'edge'
 
 export async function POST(req: Request) {
   const { messages } = await req.json()
-  const { stream, handlers } = LangChainStream()
+  const { stream, handlers, writer } = LangChainStream()
 
   const llm = new ChatOpenAI({
     streaming: true

--- a/packages/core/streams/langchain-stream.ts
+++ b/packages/core/streams/langchain-stream.ts
@@ -35,6 +35,7 @@ export function LangChainStream(callbacks?: AIStreamCallbacksAndOptions) {
       .pipeThrough(
         createStreamDataTransformer(callbacks?.experimental_streamData)
       ),
+    writer,
     handlers: {
       handleLLMNewToken: async (token: string) => {
         await writer.ready


### PR DESCRIPTION
Allows writing content other than the callback handlers.
This may be required where content other than LLM tokens needs to be written.

I have faced such situations as writing additional data like sources in the response stream.