### PR TITLE
vue/use-completion: fix: don't send network request for loading state

### DIFF
--- a/.changeset/chilly-kangaroos-call.md
+++ b/.changeset/chilly-kangaroos-call.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+vue/use-completion: fix: don't send network request for loading state"

--- a/packages/core/vue/use-completion.ts
+++ b/packages/core/vue/use-completion.ts
@@ -69,8 +69,11 @@ export function useCompletion({
   )
 
   const { data: isLoading, mutate: mutateLoading } = useSWRV<boolean>(
-    `${completionId}-loading`
+    `${completionId}-loading`,
+    null
   )
+
+  isLoading.value ??= false
 
   // Force the `data` to be `initialCompletion` if it's `undefined`.
   data.value ||= initialCompletion


### PR DESCRIPTION
Closes #515 