### PR TITLE
handle partial chunks in react getStreamedResponse

### DIFF
--- a/.changeset/popular-badgers-applaud.md
+++ b/.changeset/popular-badgers-applaud.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+ai/react: fix: handle partial chunks in react getStreamedResponse

--- a/docs/pages/docs/api-reference/use-chat.mdx
+++ b/docs/pages/docs/api-reference/use-chat.mdx
@@ -109,7 +109,7 @@ Options passed to `useChat`:
     [
       'sendExtraMessageFields',
       'boolean',
-      'An optional boolean that determines whether to send extra fields you\'ve added to `messages`. Defaults to `false` and only the `content` and `role` fields will be sent to the API endpoint.'
+      "An optional boolean that determines whether to send extra fields you've added to `messages`. Defaults to `false` and only the `content` and `role` fields will be sent to the API endpoint."
     ]
   ]}
 />

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -186,7 +186,7 @@ const getStreamedResponse = async (
       }
 
       // Update the chat state with the new message tokens.
-      const lines = decode(value)
+      const lines = decode(concatenatedChunks)
       if (typeof lines === 'string') {
         throw new Error(
           'Invalid response format. Complex mode was set but the response is a string. This should never happen.'

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -184,6 +184,8 @@ const getStreamedResponse = async (
         concatenatedChunks.set(chunk, offset)
         offset += chunk.length
       }
+      chunks.length = 0;
+      totalLength = 0;
 
       // Update the chat state with the new message tokens.
       const lines = decode(concatenatedChunks)

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -184,8 +184,8 @@ const getStreamedResponse = async (
         concatenatedChunks.set(chunk, offset)
         offset += chunk.length
       }
-      chunks.length = 0;
-      totalLength = 0;
+      chunks.length = 0
+      totalLength = 0
 
       // Update the chat state with the new message tokens.
       const lines = decode(concatenatedChunks)

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -156,7 +156,7 @@ const getStreamedResponse = async (
   }
 
   const prefixMap: PrefixMap = {}
-  const NEWLINE = '\n'.charCodeAt(0);
+  const NEWLINE = '\n'.charCodeAt(0)
 
   if (isComplexMode) {
     while (true) {

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -159,10 +159,21 @@ const getStreamedResponse = async (
 
   if (isComplexMode) {
     while (true) {
-      const { done, value } = await reader.read()
+      const { done, value: partialValue } = await reader.read()
       if (done) {
         break
       }
+
+      let value = partialValue
+      // while last character of value is not a newline, keep reading
+      while (value[value.length - 1] !== 10) {
+        const { done, value: partialValue } = await reader.read()
+        if (done) {
+          break
+        }
+        value = new Uint8Array([...value, ...partialValue])
+      }
+
       // Update the chat state with the new message tokens.
       const lines = decode(value)
       if (typeof lines === 'string') {


### PR DESCRIPTION
I have noticed that for extra (still experimental) 'data' (the one with prefix "2:") in a streamed response, I get occasional `JSON.parse` errors, when the stream reader returns a chunk that ends in the middle of a line.

I propose to keep reading until the end of a full line or the end of the stream, whichever comes first.