### PR TITLE
Unref body for useCompletion calls to support reactive data on Vue

### DIFF
--- a/.changeset/eleven-books-matter.md
+++ b/.changeset/eleven-books-matter.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+ai/vue: wrap body with unref to support reactivity

--- a/packages/core/vue/use-completion.ts
+++ b/packages/core/vue/use-completion.ts
@@ -1,5 +1,5 @@
 import swrv from 'swrv';
-import { ref } from 'vue';
+import { ref, unref } from 'vue';
 import type { Ref } from 'vue';
 
 import type { UseCompletionOptions, RequestOptions } from '../shared/types';
@@ -101,7 +101,7 @@ export function useCompletion({
         method: 'POST',
         body: JSON.stringify({
           prompt,
-          ...body,
+          ...unref(body),
           ...options?.body,
         }),
         headers: {


### PR DESCRIPTION
Same implementation as https://github.com/vercel/ai/pull/511 but for `useCompletion` in the Vue-package. 

Makes the body-parameter reactive.

Example usage:
````ts
const body = ref({
  username: "itzaks"
})

const { completion, input, complete } = useCompletion({
  headers: { 'Content-Type': 'application/json' },
  body
})
````