### PR TITLE
add: useChat dynamic body option via function in svelte

### DIFF
--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -87,8 +87,8 @@ const getStreamedResponse = async (
               }),
             }),
           ),
-      ...extraMetadata.body,
-      ...chatRequest.options?.body,
+      ...(extraMetadata?.body instanceof Function ? extraMetadata.body() : extraMetadata?.body),
+      ...(chatRequest?.options?.body instanceof Function ? chatRequest.options.body() : chatRequest?.options?.body),
       ...(chatRequest.functions !== undefined && {
         functions: chatRequest.functions,
       }),


### PR DESCRIPTION
Add support for dynamic body option via function in Svelte.

Example:
```svelte
<script>
     ...
     function getBody() {
          return {};
     }

     let chat = useChat({..., body: getBody})
</script>
```