### PR TITLE
Update openai-functions.mdx

### DIFF
--- a/docs/pages/docs/guides/providers/openai-functions.mdx
+++ b/docs/pages/docs/guides/providers/openai-functions.mdx
@@ -19,8 +19,8 @@ The `functions` object is an array containing the schema for each function you w
 Here is an example:
 
 ```ts {3, 34}
-import type { CompletionCreateParams } from 'openai/resources/chat';
-
+import type { ChatCompletionCreateParams } from 'openai/resources/chat';
+ 
 const functions: CompletionCreateParams.Function[] = [
   {
     name: 'get_current_weather',


### PR DESCRIPTION
'CompletionCreateParams' is declared but its value is never read.ts(6133) 'CompletionCreateParams' is deprecated.ts(6385)
completions.d.ts(395, 4): The declaration was marked as deprecated here. (alias) type CompletionCreateParams = API.Chat.Completions.ChatCompletionCreateParamsNonStreaming | API.Chat.Completions.ChatCompletionCreateParamsStreaming import CompletionCreateParams
@deprecated — Use ChatCompletionCreateParams instead