### PR TITLE
[Draft] Feature: Expose onCompletion/onFinal events to client

### DIFF
--- a/examples/next-openai/app/api/chat-with-data/route.ts
+++ b/examples/next-openai/app/api/chat-with-data/route.ts
@@ -1,0 +1,44 @@
+// ./app/api/chat/route.ts
+import OpenAI from 'openai';
+import {
+  OpenAIStream,
+  StreamingTextResponse,
+  experimental_StreamData,
+} from 'ai';
+
+// Create an OpenAI API client (that's edge friendly!)
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY || '',
+});
+
+// IMPORTANT! Set the runtime to edge
+export const runtime = 'edge';
+
+export async function POST(req: Request) {
+  // Extract the `prompt` from the body of the request
+  const { messages } = await req.json();
+
+  // Ask OpenAI for a streaming chat completion given the prompt
+  const response = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    stream: true,
+    messages: messages,
+  });
+
+  // Convert the response into a friendly text-stream
+  const data = new experimental_StreamData();
+  const stream = OpenAIStream(response, {
+    onFinal: message => {
+      setTimeout(() => {
+        data.append('moreData');
+        data.close();
+      }, 2000);
+    },
+    experimental_streamData: true,
+  });
+
+  data.append('someData');
+
+  // Respond with the stream
+  return new StreamingTextResponse(stream, {}, data);
+}

--- a/examples/next-openai/app/stream-data/page.tsx
+++ b/examples/next-openai/app/stream-data/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useChat } from 'ai/react';
+
+export default function Chat() {
+  const { messages, input, handleInputChange, handleSubmit } = useChat({
+    api: '/api/chat-with-data',
+    onCompletion: message => {
+      console.log('onCompletion');
+      console.log(message);
+    },
+    onFinal: message => {
+      console.log('onFinal');
+      console.log(message);
+    },
+    onFinish: message => {
+      console.log('onFinish');
+      console.log(message);
+    },
+  });
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      {messages.length > 0
+        ? messages.map(m => (
+            <div key={m.id} className="whitespace-pre-wrap">
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.content}
+            </div>
+          ))
+        : null}
+
+      <form onSubmit={handleSubmit}>
+        <input
+          className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          value={input}
+          placeholder="Say something..."
+          onChange={handleInputChange}
+        />
+      </form>
+    </div>
+  );
+}

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -76,6 +76,8 @@ const getStreamedResponse = async (
   extraMetadataRef: React.MutableRefObject<any>,
   messagesRef: React.MutableRefObject<Message[]>,
   abortControllerRef: React.MutableRefObject<AbortController | null>,
+  onCompletion?: (message: Message) => void,
+  onFinal?: (message: Message) => void,
   onFinish?: (message: Message) => void,
   onResponse?: (response: Response) => void | Promise<void>,
   sendExtraMessageFields?: boolean,
@@ -246,6 +248,14 @@ const getStreamedResponse = async (
           }
         }
 
+        if (type === 'completion') {
+          onCompletion?.(value as Message);
+        }
+
+        if (type === 'final') {
+          onFinal?.(value as Message);
+        }
+
         const data = prefixMap['data'];
         const responseMessage = prefixMap['text'];
 
@@ -338,6 +348,8 @@ export function useChat({
   sendExtraMessageFields,
   experimental_onFunctionCall,
   onResponse,
+  onCompletion,
+  onFinal,
   onFinish,
   onError,
   credentials,
@@ -411,6 +423,8 @@ export function useChat({
             extraMetadataRef,
             messagesRef,
             abortControllerRef,
+            onCompletion,
+            onFinal,
             onFinish,
             onResponse,
             sendExtraMessageFields,
@@ -503,6 +517,8 @@ export function useChat({
       api,
       extraMetadataRef,
       onResponse,
+      onCompletion,
+      onFinal,
       onFinish,
       onError,
       setError,

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -89,6 +89,16 @@ export type UseChatOptions = {
   onResponse?: (response: Response) => void | Promise<void>;
 
   /**
+   * Callback function to be called for each tokenized message.
+   */
+  onCompletion?: (message: Message) => void;
+
+  /**
+   * Callback function to be called once after the final tokenized message.
+   */
+  onFinal?: (message: Message) => void;
+
+  /**
    * Callback function to be called when the chat is finished streaming.
    */
   onFinish?: (message: Message) => void;

--- a/packages/core/shared/utils.ts
+++ b/packages/core/shared/utils.ts
@@ -62,6 +62,8 @@ export const StreamStringPrefixes = {
   text: 0,
   function_call: 1,
   data: 2,
+  completion: 3,
+  final: 4,
   // user_err: 3?
 } as const;
 

--- a/packages/core/streams/anthropic-stream.ts
+++ b/packages/core/streams/anthropic-stream.ts
@@ -4,7 +4,6 @@ import {
   type AIStreamCallbacksAndOptions,
   createCallbacksTransformer,
 } from './ai-stream';
-import { createStreamDataTransformer } from './stream-data';
 
 // https://github.com/anthropics/anthropic-sdk-typescript/blob/0fc31f4f1ae2976afd0af3236e82d9e2c84c43c9/src/resources/completions.ts#L28-L49
 interface CompletionChunk {
@@ -94,11 +93,8 @@ export function AnthropicStream(
 ): ReadableStream {
   if (Symbol.asyncIterator in res) {
     return readableFromAsyncIterable(streamable(res))
-      .pipeThrough(createCallbacksTransformer(cb))
-      .pipeThrough(createStreamDataTransformer(cb?.experimental_streamData));
+      .pipeThrough(createCallbacksTransformer(cb));
   } else {
-    return AIStream(res, parseAnthropicStream(), cb).pipeThrough(
-      createStreamDataTransformer(cb?.experimental_streamData),
-    );
+    return AIStream(res, parseAnthropicStream(), cb);
   }
 }

--- a/packages/core/streams/anthropic-stream.ts
+++ b/packages/core/streams/anthropic-stream.ts
@@ -92,8 +92,9 @@ export function AnthropicStream(
   cb?: AIStreamCallbacksAndOptions,
 ): ReadableStream {
   if (Symbol.asyncIterator in res) {
-    return readableFromAsyncIterable(streamable(res))
-      .pipeThrough(createCallbacksTransformer(cb));
+    return readableFromAsyncIterable(streamable(res)).pipeThrough(
+      createCallbacksTransformer(cb),
+    );
   } else {
     return AIStream(res, parseAnthropicStream(), cb);
   }

--- a/packages/core/streams/cohere-stream.ts
+++ b/packages/core/streams/cohere-stream.ts
@@ -67,6 +67,7 @@ export function CohereStream(
   reader: Response,
   callbacks?: AIStreamCallbacksAndOptions,
 ): ReadableStream {
-  return createParser(reader)
-    .pipeThrough(createCallbacksTransformer(callbacks));
+  return createParser(reader).pipeThrough(
+    createCallbacksTransformer(callbacks),
+  );
 }

--- a/packages/core/streams/cohere-stream.ts
+++ b/packages/core/streams/cohere-stream.ts
@@ -2,7 +2,6 @@ import {
   type AIStreamCallbacksAndOptions,
   createCallbacksTransformer,
 } from './ai-stream';
-import { createStreamDataTransformer } from './stream-data';
 
 const utf8Decoder = new TextDecoder('utf-8');
 
@@ -69,8 +68,5 @@ export function CohereStream(
   callbacks?: AIStreamCallbacksAndOptions,
 ): ReadableStream {
   return createParser(reader)
-    .pipeThrough(createCallbacksTransformer(callbacks))
-    .pipeThrough(
-      createStreamDataTransformer(callbacks?.experimental_streamData),
-    );
+    .pipeThrough(createCallbacksTransformer(callbacks));
 }

--- a/packages/core/streams/huggingface-stream.ts
+++ b/packages/core/streams/huggingface-stream.ts
@@ -39,6 +39,5 @@ export function HuggingFaceStream(
   res: AsyncGenerator<any>,
   callbacks?: AIStreamCallbacksAndOptions,
 ): ReadableStream {
-  return createParser(res)
-    .pipeThrough(createCallbacksTransformer(callbacks));
+  return createParser(res).pipeThrough(createCallbacksTransformer(callbacks));
 }

--- a/packages/core/streams/huggingface-stream.ts
+++ b/packages/core/streams/huggingface-stream.ts
@@ -3,7 +3,6 @@ import {
   createCallbacksTransformer,
   trimStartOfStreamHelper,
 } from './ai-stream';
-import { createStreamDataTransformer } from './stream-data';
 
 function createParser(res: AsyncGenerator<any>) {
   const trimStartOfStream = trimStartOfStreamHelper();
@@ -41,8 +40,5 @@ export function HuggingFaceStream(
   callbacks?: AIStreamCallbacksAndOptions,
 ): ReadableStream {
   return createParser(res)
-    .pipeThrough(createCallbacksTransformer(callbacks))
-    .pipeThrough(
-      createStreamDataTransformer(callbacks?.experimental_streamData),
-    );
+    .pipeThrough(createCallbacksTransformer(callbacks));
 }

--- a/packages/core/streams/langchain-stream.ts
+++ b/packages/core/streams/langchain-stream.ts
@@ -2,7 +2,6 @@ import {
   type AIStreamCallbacksAndOptions,
   createCallbacksTransformer,
 } from './ai-stream';
-import { createStreamDataTransformer } from './stream-data';
 
 export function LangChainStream(callbacks?: AIStreamCallbacksAndOptions) {
   const stream = new TransformStream();
@@ -31,10 +30,7 @@ export function LangChainStream(callbacks?: AIStreamCallbacksAndOptions) {
 
   return {
     stream: stream.readable
-      .pipeThrough(createCallbacksTransformer(callbacks))
-      .pipeThrough(
-        createStreamDataTransformer(callbacks?.experimental_streamData),
-      ),
+      .pipeThrough(createCallbacksTransformer(callbacks)),
     writer,
     handlers: {
       handleLLMNewToken: async (token: string) => {

--- a/packages/core/streams/langchain-stream.ts
+++ b/packages/core/streams/langchain-stream.ts
@@ -29,8 +29,7 @@ export function LangChainStream(callbacks?: AIStreamCallbacksAndOptions) {
   };
 
   return {
-    stream: stream.readable
-      .pipeThrough(createCallbacksTransformer(callbacks)),
+    stream: stream.readable.pipeThrough(createCallbacksTransformer(callbacks)),
     writer,
     handlers: {
       handleLLMNewToken: async (token: string) => {

--- a/packages/core/streams/replicate-stream.ts
+++ b/packages/core/streams/replicate-stream.ts
@@ -1,6 +1,5 @@
 import { AIStream, type AIStreamCallbacksAndOptions } from './ai-stream';
 import type { Prediction } from 'replicate';
-import { createStreamDataTransformer } from './stream-data';
 
 /**
  * Stream predictions from Replicate.
@@ -39,7 +38,5 @@ export async function ReplicateStream(
     },
   });
 
-  return AIStream(eventStream, undefined, cb).pipeThrough(
-    createStreamDataTransformer(cb?.experimental_streamData),
-  );
+  return AIStream(eventStream, undefined, cb);
 }

--- a/packages/core/streams/stream-data.ts
+++ b/packages/core/streams/stream-data.ts
@@ -89,27 +89,3 @@ export class experimental_StreamData {
     this.data.push(value);
   }
 }
-
-/**
- * A TransformStream for LLMs that do not have their own transform stream handlers managing encoding (e.g. OpenAIStream has one for function call handling).
- * This assumes every chunk is a 'text' chunk.
- */
-export function createStreamDataTransformer(
-  experimental_streamData: boolean | undefined,
-) {
-  if (!experimental_streamData) {
-    return new TransformStream({
-      transform: async (chunk, controller) => {
-        controller.enqueue(chunk);
-      },
-    });
-  }
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-  return new TransformStream({
-    transform: async (chunk, controller) => {
-      const message = decoder.decode(chunk);
-      controller.enqueue(encoder.encode(getStreamString('text', message)));
-    },
-  });
-}


### PR DESCRIPTION
**This PR is a work-in-progress. Feel free to leave feedback and suggestions 😊**

Per https://github.com/vercel/ai/issues/501: (via @dilanustek)

> The `useChat` hook has an `onFinish` callback which fires when everything is completed. With the new experimental feature to stream additional data, the onFinish callback fires not after the tokens are completed but after any data is also done loading.
> 
> We need to be able to tell when the messages are completed so that we can show a loading state for the additional data that is being calculated based off of the message received. It would be nice to have an `onCompleted` callback added to the `useChat` hook on the client side. It may also look like a `isMessageLoading` added to the `isLoading` boolean to indicate the difference.

Since streams that include additional data use "complex mode", I've added two additional StreamStringPrefixes: `completion` and `final`. This enables the server to inform the client when the `onCompletion` and `onFinal` events occur directly via the stream.

Note: I moved the `getStreamString()` patten from each individual stream to the main AI stream to allow access to the onCompletion/onFinal events. To avoid redundant transformations, I also removed this step from the individual streams. This seems to work so far, but please let me know if there is a preferred approach for this. Thank you!