### PR TITLE
[issue-567] resets error message on (re)submission

### DIFF
--- a/.changeset/unlucky-zebras-wait.md
+++ b/.changeset/unlucky-zebras-wait.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+all providers: reset error message on (re)submission

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -394,6 +394,8 @@ export function useChat({
     async (chatRequest: ChatRequest) => {
       try {
         mutateLoading(true);
+        setError(undefined);
+
         const abortController = new AbortController();
         abortControllerRef.current = abortController;
 

--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -104,6 +104,7 @@ export function useCompletion({
     async (prompt: string, options?: RequestOptions) => {
       try {
         mutateLoading(true);
+        setError(undefined);
 
         const abortController = new AbortController();
         setAbortController(abortController);

--- a/packages/core/solid/use-chat.ts
+++ b/packages/core/solid/use-chat.ts
@@ -103,7 +103,9 @@ export function useChat({
     options?: RequestOptions,
   ) {
     try {
+      setError(undefined);
       setIsLoading(true);
+
       abortController = new AbortController();
 
       // Do an optimistic update to the chat state to show the updated messages

--- a/packages/core/solid/use-completion.ts
+++ b/packages/core/solid/use-completion.ts
@@ -89,7 +89,9 @@ export function useCompletion({
   let abortController: AbortController | null = null;
   async function triggerRequest(prompt: string, options?: RequestOptions) {
     try {
+      setError(undefined);
       setIsLoading(true);
+
       abortController = new AbortController();
 
       // Empty the completion immediately.

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -248,6 +248,7 @@ export function useChat({
   // chat state.
   async function triggerRequest(chatRequest: ChatRequest) {
     try {
+      error.set(undefined);
       loading.set(true);
       abortController = new AbortController();
 

--- a/packages/core/svelte/use-completion.ts
+++ b/packages/core/svelte/use-completion.ts
@@ -89,6 +89,7 @@ export function useCompletion({
   let abortController: AbortController | null = null;
   async function triggerRequest(prompt: string, options?: RequestOptions) {
     try {
+      error.set(undefined);
       loading.set(true);
       abortController = new AbortController();
 

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -103,6 +103,7 @@ export function useChat({
     options?: RequestOptions,
   ) {
     try {
+      error.value = undefined;
       mutateLoading(() => true);
       abortController = new AbortController();
 

--- a/packages/core/vue/use-completion.ts
+++ b/packages/core/vue/use-completion.ts
@@ -91,6 +91,7 @@ export function useCompletion({
   let abortController: AbortController | null = null;
   async function triggerRequest(prompt: string, options?: RequestOptions) {
     try {
+      error.value = undefined;
       mutateLoading(() => true);
       abortController = new AbortController();
 


### PR DESCRIPTION
Fixes https://github.com/vercel/ai/issues/567

`error` is set to `undefined` for each useChat/useCompletion hook in each framework when `triggerRequest()` is (re)submitted.