### PR TITLE
fixes prettier formatting and reverts to CompletionCreateParams

### DIFF
--- a/docs/pages/docs/guides/providers/openai-functions.mdx
+++ b/docs/pages/docs/guides/providers/openai-functions.mdx
@@ -19,8 +19,8 @@ The `functions` object is an array containing the schema for each function you w
 Here is an example:
 
 ```ts {3, 34}
-import type { ChatCompletionCreateParams } from 'openai/resources/chat';
- 
+import type { CompletionCreateParams } from 'openai/resources/chat';
+
 const functions: CompletionCreateParams.Function[] = [
   {
     name: 'get_current_weather',


### PR DESCRIPTION
Fixes a prettier formatting issue currently breaking CI.

Also it looks like `ChatCompletionCreateParams` isn't available in `openai` at `4.2.0` (it was introduced in `4.4.x`).

Since `openai` is frozen at `4.2.0`, this should be reverted to `CompletionCreateParams`. Alternatively, `openai` should be upgraded.