### PR TITLE
Remove error checking for huggingface example in documentation

### DIFF
--- a/docs/pages/docs/guides/providers/hugging-face.mdx
+++ b/docs/pages/docs/guides/providers/hugging-face.mdx
@@ -68,13 +68,6 @@ export async function POST(req: Request) {
     },
   });
 
-  // Check for errors
-  if (!response.ok) {
-    return new Response(await response.text(), {
-      status: response.status,
-    });
-  }
-
   // Convert the async generator into a friendly text-stream
   const stream = HuggingFaceStream(response);
 


### PR DESCRIPTION
In the documentation the lines:
```
// Check for errors
  if (!response.ok) {
    return new Response(await response.text(), {
      status: response.status,
    });
  }
```
were not working (response is a stream which does not contain ok, and text. so it crashed on `await response.text()`). 

This led to a frustrating experience as there was not a lot of information about this issue.

This is the only place where the error checking is present (not present in the `api-reference` and the `example`).

I propose to remove it to be more consistent as well as avoiding having a not working guide.