### PR TITLE
enables sending metadata from client and adds example for bidirectional data

### DIFF
--- a/examples/next-openai/app/api/chat-with-data/route.ts
+++ b/examples/next-openai/app/api/chat-with-data/route.ts
@@ -1,0 +1,55 @@
+import {
+  OpenAIStream,
+  StreamingTextResponse,
+  experimental_StreamData,
+} from 'ai';
+import OpenAI from 'openai';
+import { Chat } from 'openai/resources';
+
+// Create an OpenAI API client (that's edge friendly!)
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY || '',
+});
+
+// IMPORTANT! Set the runtime to edge
+export const runtime = 'edge';
+
+export async function POST(req: Request) {
+  // `model` is populated and sent by the client
+  const { messages, model } = (await req.json()) as {
+    messages: Chat.CreateChatCompletionRequestMessage[];
+    model: 'gpt-3.5-turbo' | 'gpt-4';
+  };
+
+  const response = await openai.chat.completions.create({
+    model,
+    stream: true,
+    messages,
+  });
+
+  const data = new experimental_StreamData();
+  const stream = OpenAIStream(response, {
+    async onFinal() {
+      messages.push({
+        content: 'Come up with a title based on the previous response',
+        role: 'system',
+      });
+
+      const res = await openai.chat.completions.create({
+        messages,
+        model,
+      });
+
+      // send data to change title on client
+      data.append({
+        title: res.choices[0].message.content,
+      });
+
+      // IMPORTANT! clone data stream when done
+      data.close();
+    },
+    experimental_streamData: true,
+  });
+
+  return new StreamingTextResponse(stream, {}, data);
+}

--- a/examples/next-openai/app/bidirectional-data/page.tsx
+++ b/examples/next-openai/app/bidirectional-data/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useChat } from 'ai/react';
+import { FormEvent, useEffect, useState } from 'react';
+
+export default function Chat() {
+  const { data, handleSubmit, input, messages, setInput } = useChat({
+    api: '/api/chat-with-data',
+  });
+
+  // populated by client, passed to server
+  const [model, setModel] = useState('gpt-3.5-turbo');
+  // populated by server, passed to client
+  const [title, setTitle] = useState('');
+
+  const handleForm = (e: FormEvent<HTMLFormElement>) =>
+    // override handleSubmit() to send `model` to server
+    handleSubmit(
+      e,
+      {},
+      {
+        body: {
+          model,
+        },
+      },
+    );
+
+  useEffect(() => {
+    // server hasn't sent any data yet
+    if (!data) {
+      setTitle('');
+      return;
+    }
+
+    // data can be an array of anything so be sure to handle/type it based on your needs
+    const newTitle = data.reduce(
+      (result: string, current: any) => current.title || result,
+      '',
+    );
+
+    setTitle(newTitle);
+  }, [data]);
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      <div className="bg-black text-white fixed top-0 left-0 right-0 p-4 text-center font-bold">
+        {title || '(Untitled Chat)'}
+      </div>
+
+      {messages.length > 0
+        ? messages.map(m => (
+            <div key={m.id} className="whitespace-pre-wrap">
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.content}
+            </div>
+          ))
+        : null}
+
+      <form
+        className="flex align-middle justify-center fixed bottom-8 left-6 right-6 gap-2"
+        onSubmit={handleForm}
+      >
+        <input
+          className="w-full max-w-md p-2 border border-gray-300 rounded"
+          value={input}
+          placeholder="Say something..."
+          onChange={e => setInput(e.target.value)}
+        />
+        <select onChange={e => setModel(e.target.value)} value={model}>
+          <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
+          <option value="gpt-4">gpt-4</option>
+        </select>
+      </form>
+    </div>
+  );
+}

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -59,6 +59,7 @@ export type UseChatHelpers = {
   handleSubmit: (
     e: React.FormEvent<HTMLFormElement>,
     chatRequestOptions?: ChatRequestOptions,
+    metadata?: Object,
   ) => void;
   metadata?: Object;
   /** Whether the API request is in progress */


### PR DESCRIPTION
For this PR, I wanted to share what I think might be the way to send metadata back and forth between client/server.

As an example, the client sends which model to use (gpt-3.5-turbo or gpt-4) and the server sends back a relevant title for the chat based on the context of the conversation.

Not sure if `metadata` is meant to be used yet, but if so, this PR exposes it to the client.

It's typed as `Object` currently to be consistent with current codebase.

Happy to make any changes and add the same functionality to the other frameworks if this is the right way to go. Thanks!

<img width="300" alt="image" src="https://github.com/vercel/ai/assets/366502/5144529d-6dac-4952-b6ff-5539a2192946">