### PR TITLE
Use `interface` instead of `type` for Message

### DIFF
--- a/.changeset/eleven-tools-develop.md
+++ b/.changeset/eleven-tools-develop.md
@@ -1,0 +1,5 @@
+---
+'ai': patch 
+---
+
+Use interface instead of type for Message to allow declaration merging

--- a/.changeset/eleven-tools-develop.md
+++ b/.changeset/eleven-tools-develop.md
@@ -1,5 +1,5 @@
 ---
-'ai': patch 
+'ai': patch
 ---
 
 Use interface instead of type for Message to allow declaration merging

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -43,7 +43,7 @@ interface Function {
 /**
  * Shared types between the API and UI packages.
  */
-export type Message = {
+export interface Message {
   id: string;
   createdAt?: Date;
   content: string;
@@ -59,7 +59,7 @@ export type Message = {
    * not be set.
    */
   function_call?: string | FunctionCall;
-};
+}
 
 export type CreateMessage = Omit<Message, 'id'> & {
   id?: Message['id'];


### PR DESCRIPTION
This is a tiny change, but by using an interface rather than a type, developers can use declaration merging to modify this type to suit their needs. 

For example: 

```tsx
declare module 'ai' {
  interface Message {
    additionalProperty?: string
  }
}
```

This would satisfy requests like https://github.com/vercel/ai/issues/551#issuecomment-1744829091

