### PR TITLE
Ensure response `status` and `statusText` are passed to `onError()`; dedupe code

### DIFF
--- a/packages/core/shared/error.ts
+++ b/packages/core/shared/error.ts
@@ -1,0 +1,22 @@
+export interface ResponseErrorArgs {
+  status?: number;
+  statusText?: string;
+  message: string;
+}
+
+export class ResponseError extends Error {
+  name: string;
+  message: string;
+  status?: number;
+  statusText?: string;
+
+  constructor(response: Response, message: string) {
+    super(message);
+    const { status, statusText } = response;
+
+    this.name = 'ResponseError';
+    this.message = message;
+    this.status = status;
+    this.statusText = statusText;
+  }
+}

--- a/packages/core/shared/response.ts
+++ b/packages/core/shared/response.ts
@@ -1,0 +1,22 @@
+import { ResponseError } from './error';
+
+export function handleResponseError(
+  response: Response,
+  message?: string,
+  onError?: (response: Response) => unknown,
+): asserts response is Response & { body: ReadableStream; ok: true } {
+  if (!response.ok) {
+    if (onError) {
+      onError(response);
+    }
+
+    throw new ResponseError(
+      response,
+      message || 'Failed to fetch the chat response.',
+    );
+  }
+
+  if (!response.body) {
+    throw new Error('The response body is empty.');
+  }
+}

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -1,3 +1,5 @@
+import { ResponseError } from './error';
+
 // https://github.com/openai/openai-node/blob/07b3504e1c40fd929f4aae1651b83afc19e3baf8/src/resources/chat/completions.ts#L146-L159
 export interface FunctionCall {
   /**
@@ -132,7 +134,7 @@ export type UseChatOptions = {
   /**
    * Callback function to be called when an error is encountered.
    */
-  onError?: (error: Error) => void;
+  onError?: (error: ResponseError) => void;
 
   /**
    * The credentials mode to be used for the fetch request.

--- a/packages/core/solid/use-completion.ts
+++ b/packages/core/solid/use-completion.ts
@@ -4,6 +4,8 @@ import { useSWRStore } from 'solid-swr-store';
 
 import type { UseCompletionOptions, RequestOptions } from '../shared/types';
 import { createChunkDecoder } from '../shared/utils';
+import { ResponseError } from '../shared/error';
+import { handleResponseError } from '../shared/response';
 
 export type UseCompletionHelpers = {
   /** The current completion result */
@@ -122,15 +124,8 @@ export function useCompletion({
         }
       }
 
-      if (!res.ok) {
-        throw new Error(
-          (await res.text()) || 'Failed to fetch the chat response.',
-        );
-      }
-
-      if (!res.body) {
-        throw new Error('The response body is empty.');
-      }
+      // Throw an error if the response is not ok.
+      handleResponseError(res, await res.text());
 
       let result = '';
       const reader = res.body.getReader();
@@ -169,7 +164,7 @@ export function useCompletion({
         onError(error);
       }
 
-      setError(err as Error);
+      setError(err as ResponseError);
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
**Edit: This is largely achievable with a combination of `onResponse()` and `onError()`.**