### PR TITLE
Update docs to ChatCompletionCreateParams

### DIFF
--- a/docs/pages/docs/guides/providers/openai-functions.mdx
+++ b/docs/pages/docs/guides/providers/openai-functions.mdx
@@ -19,9 +19,9 @@ The `functions` object is an array containing the schema for each function you w
 Here is an example:
 
 ```ts {3, 34}
-import type { CompletionCreateParams } from 'openai/resources/chat';
+import type { ChatCompletionCreateParams } from 'openai/resources/chat';
 
-const functions: CompletionCreateParams.Function[] = [
+const functions: ChatCompletionCreateParams.Function[] = [
   {
     name: 'get_current_weather',
     description: 'Get the current weather',


### PR DESCRIPTION
Per deprecation here: [src/resources/chat/completions.ts](https://github.com/openai/openai-node/blob/45fad1ba633214b89f2c35fd01867e30b90985a4/src/resources/chat/completions.ts#L470).

This is already reflected in [examples/next-openai/app/api/chat-with-functions/route.ts](https://github.com/vercel/ai/blob/703e9ec55832c6da6fd5f253ee8331f4b5510188/examples/next-openai/app/api/chat-with-functions/route.ts#L7) and [examples/sveltekit-openai/src/routes/api/chat-with-functions/+server.ts](https://github.com/vercel/ai/blob/703e9ec55832c6da6fd5f253ee8331f4b5510188/examples/sveltekit-openai/src/routes/api/chat-with-functions/%2Bserver.ts#L3), but not yet here: https://sdk.vercel.ai/docs/guides/providers/openai-functions.

It's not a particularly important fix because your IDE can call out the deprecation, but I noticed when mine was being slow enough to cause a temporary issue. Amazing docs overall — thanks!