### PR TITLE
Expansion to `ai/prompts` System with Base Types and Implementations

### DIFF
--- a/.changeset/three-gifts-listen.md
+++ b/.changeset/three-gifts-listen.md
@@ -1,0 +1,5 @@
+---
+'ai': minor
+---
+
+Adding Prompt Construction with New Base Types and Functions

--- a/packages/core/prompts/ai-prompt.ts
+++ b/packages/core/prompts/ai-prompt.ts
@@ -1,0 +1,35 @@
+import type { SimpleMessage } from '../shared/types';
+
+// A simple interface for the AIInput object that is required for the Llama2 API
+export interface ReplicateAIInput {
+  prompt: string;
+  system_prompt?: string;
+}
+
+// this signature is expected by OpenAI's Node Library; we include it for convenience in calling the library
+export interface ChatCompletionMessageParam {
+  role: 'system' | 'user' | 'assistant' | 'function';
+  content: string | null;
+  function_call?: any;
+  name?: string;
+}
+
+export interface AIPrompt {
+  buildPrompt(messages: SimpleMessage[]): string;
+  addMessage(
+    content: string, // parameter ordering is due to role being optional
+    role?: 'user' | 'assistant' | 'system' | 'function',
+    location?: 'before' | 'after',
+  ): void;
+
+  // We overload toPrompt because different AI APIs expect differently-typed prompts.
+  // Our goal is for the calling application to be able to call toPrompt on the AIPrompt object and
+  // receive a return that can just be plugged into the AI service's library-defined call to the API.
+  // Implementing functions will have the responsibility of converting the prompt to the appropriate type.
+
+  toPrompt():
+    | string
+    | ChatCompletionMessageParam[]
+    | ReplicateAIInput
+    | undefined;
+}

--- a/packages/core/prompts/anthropic-prompt.ts
+++ b/packages/core/prompts/anthropic-prompt.ts
@@ -56,6 +56,9 @@ export function AnthropicPrompt(messages: SimpleMessage[]): Anthropic_AIPrompt {
     role: 'user' | 'assistant' | 'system' | 'function' = 'system',
     location: 'before' | 'after' = 'after',
   ): void => {
+    //if content is null we'll just skip the message.
+    if (content === null) return;
+
     if (role === 'function') {
       //skip function messages for prompts as of now
     } else if (role === 'system') {

--- a/packages/core/prompts/anthropic-prompt.ts
+++ b/packages/core/prompts/anthropic-prompt.ts
@@ -1,0 +1,121 @@
+import { AIPrompt } from './ai-prompt';
+import type { SimpleMessage } from '../shared/types';
+
+// We extend AIPrompt to get a clean signature on the return for downstream callers.
+export interface Anthropic_AIPrompt extends AIPrompt {
+  toPrompt(): string;
+}
+
+/**
+ * Claude has an interesting way of dealing with prompts. Prompt formatting is discussed briefly at https://docs.anthropic.com/claude/reference/getting-started-with-the-api
+ * However, there is nothing in the Anthropic Documentation that discusses what to do with Chat-type prompting.
+ * We'll go a little "off-book" with a prompt style mirroring a recent publication by Amazon AWS: (https://github.com/aws-samples/amazon-bedrock-workshop/blob/main/04_Chatbot/00_Chatbot_Claude.ipynb)
+ *
+ * Here is their suggested approach:
+ *
+ * Human: The following is a friendly conversation between a human and an AI.
+ * The AI is talkative and provides lots of specific details from its context. If the AI does not know
+ * the answer to a question, it truthfully says it does not know.
+ *
+ * Current conversation:
+ * <conversation_history>
+ * {history}
+ * </conversation_history>
+ *
+ * Here is the human's next reply:
+ * <human_reply>
+ * {input}
+ * </human_reply>
+ *
+ * Assistant:
+ *
+ * Creates an AnthropicPrompt object that can be used to construct a prompt string.
+ * @param messages An array of SimpleMessage objects containing the content and role of each message to be included in the prompt.
+ * @returns An AIPrompt object with methods to build and retrieve the prompt string.
+ */
+export function AnthropicPrompt(messages: SimpleMessage[]): Anthropic_AIPrompt {
+  let promptText = '';
+  let promptStart = `Human:`;
+  let systemContent = '';
+  let conversationHistory = 'No conversation history yet.';
+  let humanReply = '';
+  let promptEnd = '\n\nAssistant:';
+  let isConversationHistoryStarted = false;
+  // So, the prompt will be constructed as follows:
+  //   promptStart + systemsContent + '<conversationHistory>' + conversationHistory + '</conversationHistory>' + '<humanReply>' + humanReply + '</humanReply>' + promptEnd
+  // with some newlines.
+
+  /**
+   * Adds a message to the prompt text.
+   * @param content The content of the message to be added.
+   * @param role The role of the message sender. Defaults to 'system'.
+   * @param location The location of the message in the prompt text. Defaults to 'after'.
+   */
+  const addMessage = (
+    content: string,
+    role: 'user' | 'assistant' | 'system' | 'function' = 'system',
+    location: 'before' | 'after' = 'after',
+  ): void => {
+    if (role === 'function') {
+      //skip function messages for prompts as of now
+    } else if (role === 'system') {
+      systemContent =
+        location === 'before'
+          ? content + systemContent
+          : systemContent + content;
+    } else if (role === 'user') {
+      // this part is a little tricky. The latest role=user message becomes the single humanReply value. Any existing humanReply value needs to be bumped into conversationhistory at its end.
+      if (isConversationHistoryStarted === false) {
+        conversationHistory = '';
+        isConversationHistoryStarted = true;
+      }
+      conversationHistory = conversationHistory + '\n' + humanReply;
+      humanReply = 'Human: ' + content;
+    } else if (role === 'assistant') {
+      if (isConversationHistoryStarted === false) {
+        conversationHistory = '';
+        isConversationHistoryStarted = true;
+      }
+      conversationHistory =
+        conversationHistory + '\n' + 'Assistant: ' + content;
+    }
+    //and now we need to update the promptText
+    promptText =
+      promptStart +
+      systemContent +
+      '\n\n<conversationHistory>\n' +
+      conversationHistory +
+      '\n</conversationHistory>\n\n<humanReply>\n' +
+      humanReply +
+      '\n</humanReply>' +
+      promptEnd;
+  };
+
+  /**
+   * Initializes the `promptText` string by iterating over the array of objects (messages) provided.
+   * @param messages An array of SimpleMessage objects containing the content and role of each message to be included in the prompt.
+   * @returns The initial prompt string for external use, if needed.
+   */
+  const buildPrompt = (messages: SimpleMessage[]): string => {
+    messages.forEach(({ content, role }) => {
+      addMessage(content, role, 'after');
+    });
+    return promptText;
+  };
+
+  buildPrompt(messages);
+
+  /**
+   * Returns the constructed prompt string.
+   * @returns The prompt string.
+   */
+  const toPrompt = (): string => {
+    return promptText;
+  };
+
+  return {
+    buildPrompt,
+    addMessage,
+    toPrompt,
+  };
+}

--- a/packages/core/prompts/huggingface-prompt.ts
+++ b/packages/core/prompts/huggingface-prompt.ts
@@ -45,6 +45,9 @@ export function HuggingfacePrompt(
     role: 'user' | 'assistant' | 'system' | 'function' = 'system',
     location: 'before' | 'after' = 'after',
   ): void => {
+    //if content is null we'll just skip the message.
+    if (content === null) return;
+
     if (role === 'function') {
       //skip function messages for prompts as of now
     } else if (role === 'system') {

--- a/packages/core/prompts/huggingface-prompt.ts
+++ b/packages/core/prompts/huggingface-prompt.ts
@@ -1,0 +1,89 @@
+import { AIPrompt } from './ai-prompt';
+import type { SimpleMessage } from '../shared/types';
+
+// We extend AIPrompt to get a clean signature on the return for downstream callers.
+export interface Huggingface_AIPrompt extends AIPrompt {
+  toPrompt(): string;
+}
+
+/**
+ * Huggingface Prompt is currently intended for OpenAssistant Chat hosted on Huggingface
+ *
+ * Here is the example at https://huggingface.co/OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5
+ *   Two special tokens are used to mark the beginning of user and assistant turns: <|prompter|> and <|assistant|>. Each turn ends with a <|endoftext|> token.
+ *
+ *   Input prompt example:
+ *
+ *   <|prompter|>What is a meme, and what's the history behind this word?<|endoftext|><|assistant|>
+ *
+ *   The input ends with the <|assistant|> token to signal that the model should start generating the assistant reply.
+ *
+ * There is nothing about system prompts so we will skip it for now.
+ *
+ * @param messages An array of SimpleMessage objects containing the content and role of each message to be included in the prompt.
+ * @returns An AIPrompt object with methods to build and retrieve the prompt.
+ */
+export function HuggingfacePrompt(
+  messages: SimpleMessage[],
+): Huggingface_AIPrompt {
+  const userToken = '<|prompter|>';
+  const assistantToken = '<|assistant|>';
+  const endToken = '<|endoftext|>';
+  const endText = '\n<|assistant|>';
+  let promptText = '';
+  let messagesText = '';
+
+  /**
+   * Adds a message to the prompt.
+   * @param content - The content of the message.
+   * @param role - The role of the message. Can be 'user', 'assistant', 'system', or 'function'. Defaults to 'system'.
+   * @param location - The location of the message. Can be 'before' or 'after'. Defaults to 'after'.
+   * @returns void
+   */
+  const addMessage = (
+    content: string,
+    role: 'user' | 'assistant' | 'system' | 'function' = 'system',
+    location: 'before' | 'after' = 'after',
+  ): void => {
+    if (role === 'function') {
+      //skip function messages for prompts as of now
+    } else if (role === 'system') {
+      //skip system messages for prompts as of now
+    } else if (role === 'user') {
+      location === 'before'
+        ? (messagesText = userToken + content + endToken + messagesText)
+        : (messagesText += userToken + content + endToken);
+    } else if (role === 'assistant') {
+      location === 'before'
+        ? (messagesText = assistantToken + content + endToken + messagesText)
+        : (messagesText += assistantToken + content + endToken);
+    }
+    // update promptText
+    promptText = messagesText + endText;
+  };
+
+  /**
+   * Initializes the `promptText` string by iterating over the array of objects (messages) provided.
+   * @param messages An array of SimpleMessage objects containing the content and role of each message to be included in the prompt.
+   * @returns The initial prompt string for external use, if needed.
+   */
+  const buildPrompt = (messages: SimpleMessage[]): string => {
+    messages.forEach(({ content, role }) => {
+      addMessage(content, role, 'after');
+    });
+    return promptText;
+  };
+
+  buildPrompt(messages);
+
+  const toPrompt = (): string => {
+    // here we need to format together our systemPrompt and our promptText to generate output for Huggingface Llama
+    return promptText;
+  };
+
+  return {
+    buildPrompt,
+    addMessage,
+    toPrompt,
+  };
+}

--- a/packages/core/prompts/huggingface.ts
+++ b/packages/core/prompts/huggingface.ts
@@ -1,6 +1,10 @@
 import { Message } from '../shared/types';
 
 /**
+ * This file preceded the advent of AIPrompt, and is now deprecated.
+ */
+
+/**
  * A prompt constructor for the HuggingFace StarChat Beta model.
  * Does not support `function` messages.
  * @see https://huggingface.co/HuggingFaceH4/starchat-beta

--- a/packages/core/prompts/index.ts
+++ b/packages/core/prompts/index.ts
@@ -1,1 +1,7 @@
-export * from './huggingface';
+export * from './huggingface'; // legacy/experimental
+
+export * from './ai-prompt';
+export * from './anthropic-prompt';
+export * from './huggingface-prompt';
+export * from './openai-prompt';
+export * from './replicate-prompt';

--- a/packages/core/prompts/openai-prompt.ts
+++ b/packages/core/prompts/openai-prompt.ts
@@ -39,6 +39,9 @@ export function OpenAIPrompt(messages: SimpleMessage[]): OpenAI_AIPrompt {
     role: 'user' | 'assistant' | 'system' | 'function' = 'system',
     location: 'before' | 'after' = 'after',
   ): void => {
+    //if content is null we'll just skip the message.
+    if (content === null) return;
+
     if (role === 'function') {
       //skip function messages for prompts as of now
     } else {

--- a/packages/core/prompts/openai-prompt.ts
+++ b/packages/core/prompts/openai-prompt.ts
@@ -1,0 +1,91 @@
+import {
+  AIPrompt,
+  ChatCompletionMessageParam,
+  ReplicateAIInput,
+} from './ai-prompt';
+import type { SimpleMessage } from '../shared/types';
+
+// We extend AIPrompt to get a clean signature on the return for downstream callers.
+// The underscore is because the name is a bit of a lark without it.
+export interface OpenAI_AIPrompt extends AIPrompt {
+  toPrompt(): ChatCompletionMessageParam[];
+}
+
+/**
+ * Creates an OpenAI prompt object that can be used to generate prompts for OpenAI's API.
+ * OpenAI prompts mirror the format of SimpleMessage. (Or, vice-versa.)
+ * Here is an example from the OpenAI Cookbook: https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
+ *
+ * {"role": "system", "content": "You are a helpful, pattern-following assistant."},
+ * {"role": "user", "content": "Help me translate the following corporate jargon into plain English."},
+ * {"role": "assistant", "content": "Sure, I'd be happy to!"},
+ * {"role": "user", "content": "New synergies will help drive top-line growth."},
+ *
+ * @param messages An array of SimpleMessage objects containing the content and role of each message to be included in the prompt.
+ * @returns An AIPrompt object with methods to build and retrieve the prompt.
+ */
+export function OpenAIPrompt(messages: SimpleMessage[]): OpenAI_AIPrompt {
+  let simpleMessages = new Array<SimpleMessage>();
+
+  /**
+   * Adds a message to the prompt text.
+   * @param content - The text of the message to add.
+   * @param role - The role of the message sender. Can be 'user', 'assistant', 'system', or 'function'. Defaults to 'system'.
+   * @param location - The location of the message in relation to existing messages. Can be 'before' or 'after'. Defaults to 'after'.
+   * @returns void
+   */
+  const addMessage = (
+    content: string,
+    role: 'user' | 'assistant' | 'system' | 'function' = 'system',
+    location: 'before' | 'after' = 'after',
+  ): void => {
+    if (role === 'function') {
+      //skip function messages for prompts as of now
+    } else {
+      const newMessage: SimpleMessage = { role, content: content };
+      simpleMessages =
+        location === 'before'
+          ? [newMessage, ...simpleMessages]
+          : [...simpleMessages, newMessage];
+    }
+  };
+
+  /**
+   * Initializes the `promptText` string by iterating over the array of objects (messages) provided.
+   * @param messages An array of SimpleMessage objects containing the content and role of each message to be included in the prompt.
+   * @returns The initial prompt string for external use, if needed.
+   */
+  const buildPrompt = (messages: SimpleMessage[]): string => {
+    messages.forEach(({ content, role }) => {
+      addMessage(content, role, 'after');
+    });
+    return JSON.stringify(simpleMessages);
+  };
+
+  /**
+   * Converts our simpleMessages into a ChatCompletionMessageParam array object for return
+   * to the calling application. Using this type allows downstream caller to simply use as follows:
+   *
+   * const prompt = OpenAIPrompt(messages);
+   * //... process prompt to taste
+   * const response = await openai.complete(messages: prompt.toPrompt()); //other params as needed
+   *
+   * @returns The converted prompt as ChatCompletionMessageParam[].
+   */
+  const toPrompt = (): ChatCompletionMessageParam[] => {
+    return simpleMessages.map(({ role, content }) => {
+      return {
+        role,
+        content,
+      };
+    }) as ChatCompletionMessageParam[];
+  };
+
+  buildPrompt(messages);
+
+  return {
+    buildPrompt,
+    addMessage,
+    toPrompt,
+  };
+}

--- a/packages/core/prompts/replicate-prompt.ts
+++ b/packages/core/prompts/replicate-prompt.ts
@@ -37,6 +37,9 @@ export function ReplicatePrompt(messages: SimpleMessage[]): Replicate_AIPrompt {
     role: 'user' | 'assistant' | 'system' | 'function' = 'system',
     location: 'before' | 'after' = 'after',
   ): void => {
+    //if content is null we'll just skip the message.
+    if (content === null) return;
+
     if (role === 'function') {
       //skip function messages for prompts as of now
     } else if (role === 'system') {

--- a/packages/core/prompts/replicate-prompt.ts
+++ b/packages/core/prompts/replicate-prompt.ts
@@ -1,0 +1,87 @@
+import { AIPrompt, ReplicateAIInput } from './ai-prompt';
+import type { SimpleMessage } from '../shared/types';
+
+// We extend AIPrompt to get a clean signature on the return for downstream callers.
+export interface Replicate_AIPrompt extends AIPrompt {
+  toPrompt(): ReplicateAIInput;
+}
+
+/**
+ * ReplicatePrompt is currently intended for Llama2 hosted on Replicate. We can think further about
+ * how to generalize for other Llama2 deployments, as well as for other Replicate-hosted models.
+ * We are working from the Replicate blog post at: https://replicate.com/blog/how-to-prompt-llama#how-to-format-chat-prompts,
+ * Let's see if we can slog through it!
+ *
+ * A prompt example (from a chat) follows:
+ * [INST] Hi! [/INST] (user)
+ * Hello! How are you? (assistant)
+ * [INST] I'm great, thanks for asking. Could you help me with a task? [/INST] (user)
+ * For now:
+ *
+ * @param messages An array of SimpleMessage objects containing the content and role of each message to be included in the prompt.
+ * @returns An AIPrompt object with methods to build and modify the prompt, and to generate AI inputs from the prompt.
+ */
+export function ReplicatePrompt(messages: SimpleMessage[]): Replicate_AIPrompt {
+  let promptText = '';
+  let systemPrompt = '';
+
+  /**
+   * Adds a message to the prompt text.
+   * @param content - The message text to add.
+   * @param role - The role of the message sender. Defaults to 'system'.
+   * @param location - The location of the message in the prompt text. Defaults to 'after'.
+   * @returns void
+   */
+  const addMessage = (
+    content: string,
+    role: 'user' | 'assistant' | 'system' | 'function' = 'system',
+    location: 'before' | 'after' = 'after',
+  ): void => {
+    if (role === 'function') {
+      //skip function messages for prompts as of now
+    } else if (role === 'system') {
+      // use ternary to put this new system message before or after (if systemPrompt is not empty!)
+      systemPrompt =
+        location === 'before' ? content + systemPrompt : systemPrompt + content;
+    } else {
+      const newMessage = `\n${
+        role === 'user' ? '[INST]' + content + '[/INST]' : content
+      }`;
+      promptText =
+        location === 'before'
+          ? newMessage + promptText
+          : promptText + newMessage;
+    }
+  };
+
+  /**
+   * Initializes the `promptText` string by iterating over the array of objects (messages) provided.
+   * @param messages An array of SimpleMessage objects containing the content and role of each message to be included in the prompt.
+   * @returns The initial prompt string for external use, if needed.
+   */
+  const buildPrompt = (messages: SimpleMessage[]): string => {
+    messages.forEach(({ content, role }) => {
+      addMessage(content, role, 'after');
+    });
+    return promptText;
+  };
+
+  buildPrompt(messages);
+
+  /**
+   * Returns the constructed prompt string.
+   * @returns The AIInput object.
+   */
+  const toPrompt = (): ReplicateAIInput => {
+    return {
+      prompt: promptText,
+      system_prompt: systemPrompt,
+    };
+  };
+
+  return {
+    buildPrompt,
+    addMessage,
+    toPrompt,
+  };
+}

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -61,6 +61,15 @@ export interface Message {
   function_call?: string | FunctionCall;
 }
 
+/**
+ * SimpleMessage is intended to be helpful for content that is passed over the wire to the API.
+ * Note that it mirrors the OpenAI API input, as of now. Note also the reorder from the Message type.
+ */
+export type SimpleMessage = {
+  role: 'system' | 'user' | 'assistant' | 'function';
+  content: string;
+};
+
 export type CreateMessage = Omit<Message, 'id'> & {
   id?: Message['id'];
 };


### PR DESCRIPTION
tl/dr:
This is an expansion to `ai/prompts` with the base types in `ai-prompts.ts` and four implementations (OpenAI, Replicate/LLama2, Anthropic, and HuggingFace/OASST).

### Overview
This PR expands ai/prompts by adding base types in ai-prompts.ts and implementing four new providers: OpenAI, Replicate/LLama2, Anthropic, and HuggingFace/OASST. The objective is to make it easy for consuming applications to engineer prompts and then pass their outputs to the respective provider's API calls. I also aimed to stay stylistically consistent with the rest of the SDK where possible.

### Example Uses

A basic example with OpenAI:

```typescript
 const { messages } = await req.json();
 const myPrompt = OpenAIPrompt(messages);
 myPrompt.addMessage('You are a pirate. Speak like one please.', 'system');

  // Ask OpenAI for a streaming chat completion given the prompt
  // note that myPrompt is implemented to send back a matching ChatCompletionArrayParams[] in its return
  const response = await openai.chat.completions.create({
    model: 'gpt-3.5-turbo',
    stream: true,
    messages: myPrompt.toPrompt()
  });
  ```
  
  Another example, using Anthropic SDK:

  ```typescript
  const { messages } = await req.json();
  const myPrompt = AnthropicPrompt(messages);
  myPrompt.addMessage('Please review the prompt and follow the example for output.', 'system'); 
  myPrompt.addMessage('your response should look like what in <example></example> tags.', 'user', 'after');
  myPrompt.addMessage('<example>[...some example]</example>', 'user', 'after');

  const response = await anthropic.completions.create({
    prompt: myPrompt.toPrompt(),
    model: 'claude-2',
    stream: true,
    max_tokens_to_sample: 300,
  });
  ```
  ### Notes
  The approach taken in the Pull Request makes many decisions, but there are still a few that could be discussed. I left the existing typing for `ai/prompts` alone, and that may or may not be preferable. However, it does mean that the consuming application as of now has to import the implementations like this: 
  
  ```typescript
  import { AnthropicStream, StreamingTextResponse } from 'ai';
  import { AnthropicPrompt } from 'ai/prompts'; //currently a dist is being built in ai/prompts
  ```
  
  It might be worth considering whether that clunkiness is desirable. It would be straightforward to change (I think.)
  
  There is also a question of how to implement provider prompts with multiple models, but that would mostly just be a naming question for the implementations. It was the intent of this pull request to try and push all the nitty-gritty onto the implementations in order to try and keep the base approach clean as possible (given a wide array of current and future providers!)
  
 Will be happy to provide docs and tests if the maintainers decide to move this direction.
 
 Opened feature request #654 in case that solicits feedback.