### PR TITLE
Vue and solid: fix passing in function_call and name to subsequent messages

### DIFF
--- a/.changeset/heavy-spies-sneeze.md
+++ b/.changeset/heavy-spies-sneeze.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+vue and solid: fix including `function_call` and `name` fields in subsequent requests

--- a/packages/core/solid/use-chat.ts
+++ b/packages/core/solid/use-chat.ts
@@ -120,10 +120,16 @@ export function useChat({
         body: JSON.stringify({
           messages: sendExtraMessageFields
             ? messagesSnapshot
-            : messagesSnapshot.map(({ role, content }) => ({
-                role,
-                content,
-              })),
+            : messagesSnapshot.map(
+                ({ role, content, name, function_call }) => ({
+                  role,
+                  content,
+                  ...(name !== undefined && { name }),
+                  ...(function_call !== undefined && {
+                    function_call: function_call,
+                  }),
+                }),
+              ),
           ...body,
           ...options?.body,
         }),

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -117,10 +117,16 @@ export function useChat({
         body: JSON.stringify({
           messages: sendExtraMessageFields
             ? messagesSnapshot
-            : messagesSnapshot.map(({ role, content }) => ({
-                role,
-                content,
-              })),
+            : messagesSnapshot.map(
+                ({ role, content, name, function_call }) => ({
+                  role,
+                  content,
+                  ...(name !== undefined && { name }),
+                  ...(function_call !== undefined && {
+                    function_call: function_call,
+                  }),
+                }),
+              ),
           ...unref(body), // Use unref to unwrap the ref value
           ...options?.body,
         }),


### PR DESCRIPTION
Fixes #469

Aligns the vue and solid implementations with react and svelte