### PR TITLE
add support for LlamaIndex

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@ The Vercel AI SDK is **a library for building AI-powered streaming text and chat
 ## Features
 
 - [SWR](https://swr.vercel.app)-powered React, Svelte, Vue and Solid helpers for streaming text responses and building chat and completion UIs
-- First-class support for [LangChain](https://js.langchain.com/docs) and [OpenAI](https://openai.com), [Anthropic](https://www.anthropic.com), [Cohere](https://cohere.com), [Hugging Face](https://huggingface.co), [Fireworks](https://app.fireworks.ai) and [Replicate](https://replicate.com)
+- First-class support for [LangChain](https://js.langchain.com/docs) and [OpenAI](https://openai.com), [Anthropic](https://www.anthropic.com), [Cohere](https://cohere.com), [Hugging Face](https://huggingface.co), [Fireworks](https://app.fireworks.ai), [Replicate](https://replicate.com) and [LlamaIndex](https://ts.llamaindex.ai/)
 - Node.js, Serverless, and [Edge Runtime](https://edge-runtime.vercel.app/) support
 - Callbacks for saving completed streaming responses to a database (in the same request)
 

--- a/packages/core/streams/llamaindex-stream.test.ts
+++ b/packages/core/streams/llamaindex-stream.test.ts
@@ -1,0 +1,25 @@
+import { LlamaIndexStream } from './llamaindex-stream';
+
+describe('LlamaIndexStream function', () => {
+  it('should create a ReadableStream', async () => {
+    const mockGenerator = jest.fn(async function* () {
+      yield '   Hello'; // Note the leading whitespace, which should be trimmed by LlamaIndexStream
+      yield 'World';
+    })();
+
+    const stream = LlamaIndexStream(mockGenerator);
+
+    const reader = stream.getReader();
+
+    const decoder = new TextDecoder();
+
+    const result1 = await reader.read();
+    expect(decoder.decode(result1.value)).toEqual('Hello');
+
+    const result2 = await reader.read();
+    expect(decoder.decode(result2.value)).toEqual('World');
+
+    const result3 = await reader.read();
+    expect(result3.done).toEqual(true);
+  });
+});

--- a/packages/core/streams/llamaindex-stream.ts
+++ b/packages/core/streams/llamaindex-stream.ts
@@ -1,0 +1,35 @@
+import {
+  createCallbacksTransformer,
+  trimStartOfStreamHelper,
+  type AIStreamCallbacksAndOptions,
+} from './ai-stream';
+import { createStreamDataTransformer } from './stream-data';
+
+function createParser(res: AsyncGenerator<any>) {
+  const trimStartOfStream = trimStartOfStreamHelper();
+  return new ReadableStream<string>({
+    async pull(controller): Promise<void> {
+      const { value, done } = await res.next();
+      if (done) {
+        controller.close();
+        return;
+      }
+
+      const text = trimStartOfStream(value ?? '');
+      if (text) {
+        controller.enqueue(text);
+      }
+    },
+  });
+}
+
+export function LlamaIndexStream(
+  res: AsyncGenerator<any>,
+  callbacks?: AIStreamCallbacksAndOptions,
+): ReadableStream {
+  return createParser(res)
+    .pipeThrough(createCallbacksTransformer(callbacks))
+    .pipeThrough(
+      createStreamDataTransformer(callbacks?.experimental_streamData),
+    );
+}


### PR DESCRIPTION
adds support for using LlamaIndex's [`ChatEngine`](https://ts.llamaindex.ai/api/interfaces/ChatEngine)

Usage:
```
export async function POST(request: NextRequest) {
    const { messages } = await request.json();
    const lastMessage = messages.pop();

    const llm = new OpenAI({
      model: "gpt-3.5-turbo",
    });

    const chatEngine = new SimpleChatEngine({
      llm,
    });

    const response = await chatEngine.chat(lastMessage.content, messages, true);

    const stream = LlamaIndexStream(response);
    return new StreamingTextResponse(stream);
}
```
