### PR TITLE
Store initial messages (or empty array) in state to avoid re-rendering when using memo.

### DIFF
--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -280,6 +280,22 @@ const getStreamedResponse = async (
   }
 };
 
+const allMessages = new Map<Message[], number>();
+
+function traceMessages(trace: string, messages?: Message[]) {
+  if (messages === undefined) {
+    console.log(trace, 'undefined');
+    return;
+  }
+
+  if (!allMessages.has(messages)) {
+    allMessages.set(messages, allMessages.size);
+  }
+
+  const id = allMessages.get(messages);
+  console.log(trace, id, messages);
+}
+
 export function useChat({
   api = '/api/chat',
   id,
@@ -317,8 +333,10 @@ export function useChat({
   );
 
   // Keep the latest messages in a ref.
+  traceMessages('T1', messages);
   const messagesRef = useRef<Message[]>(messages || []);
   useEffect(() => {
+    traceMessages('T2', messages);
     messagesRef.current = messages || [];
   }, [messages]);
 
@@ -571,8 +589,10 @@ export function useChat({
     setInput(e.target.value);
   };
 
+  traceMessages('T3', messages);
+
   return {
-    messages: messages || [],
+    messages: messages ?? [],
     error,
     append,
     reload,

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -299,7 +299,7 @@ function traceMessages(trace: string, messages?: Message[]) {
 export function useChat({
   api = '/api/chat',
   id,
-  initialMessages = [],
+  initialMessages: initialMessagesParam,
   initialInput = '',
   sendExtraMessageFields,
   experimental_onFunctionCall,
@@ -315,6 +315,9 @@ export function useChat({
   // Generate a unique id for the chat if not provided.
   const hookId = useId();
   const chatId = id || hookId;
+
+  // Store initial messages as a state to avoid re-rendering when using memo:
+  const [initialMessages] = useState(initialMessagesParam);
 
   // Store the chat state in SWR, using the chatId as the key to share states.
   const { data: messages, mutate } = useSWR<Message[]>([api, chatId], null, {

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -280,22 +280,6 @@ const getStreamedResponse = async (
   }
 };
 
-const allMessages = new Map<Message[], number>();
-
-function traceMessages(trace: string, messages?: Message[]) {
-  if (messages === undefined) {
-    console.log(trace, 'undefined');
-    return;
-  }
-
-  if (!allMessages.has(messages)) {
-    allMessages.set(messages, allMessages.size);
-  }
-
-  const id = allMessages.get(messages);
-  console.log(trace, id, messages);
-}
-
 export function useChat({
   api = '/api/chat',
   id,
@@ -336,10 +320,8 @@ export function useChat({
   );
 
   // Keep the latest messages in a ref.
-  traceMessages('T1', messages);
   const messagesRef = useRef<Message[]>(messages || []);
   useEffect(() => {
-    traceMessages('T2', messages);
     messagesRef.current = messages || [];
   }, [messages]);
 
@@ -592,10 +574,8 @@ export function useChat({
     setInput(e.target.value);
   };
 
-  traceMessages('T3', messages);
-
   return {
-    messages: messages ?? [],
+    messages: messages || [],
     error,
     append,
     reload,

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -301,7 +301,7 @@ export function useChat({
   const chatId = id || hookId;
 
   // Store initial messages as a state to avoid re-rendering when using memo:
-  const [initialMessages] = useState(initialMessagesParam);
+  const [initialMessages] = useState(initialMessagesParam ?? []);
 
   // Store the chat state in SWR, using the chatId as the key to share states.
   const { data: messages, mutate } = useSWR<Message[]>([api, chatId], null, {


### PR DESCRIPTION
Resolves #615

Please let me know if `useState` is the preferred solution here. It means keeping state per hook, which may not be desired. However, `fallbackData` is SWR is already per hook from what I understand, so this may not be an issue.