### PR TITLE
Exported the Function interface

### DIFF
--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -15,7 +15,7 @@ export interface FunctionCall {
 }
 
 //
-interface Function {
+export interface Function {
   /**
    * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain
    * underscores and dashes, with a maximum length of 64.


### PR DESCRIPTION
it is used by the already exported `ChatRequest` but itself it not exported so it's difficult to create the list of Functions to pass to `ChatRequest` without it being exported.