### PR TITLE
Do not store initialMessages in useState.

### DIFF
--- a/.changeset/dirty-beds-glow.md
+++ b/.changeset/dirty-beds-glow.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+ai/react: Do not store initialMessages in useState

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -283,7 +283,7 @@ const getStreamedResponse = async (
 export function useChat({
   api = '/api/chat',
   id,
-  initialMessages: initialMessagesParam,
+  initialMessages,
   initialInput = '',
   sendExtraMessageFields,
   experimental_onFunctionCall,
@@ -300,12 +300,14 @@ export function useChat({
   const hookId = useId();
   const chatId = id || hookId;
 
-  // Store initial messages as a state to avoid re-rendering when using memo:
-  const [initialMessages] = useState(initialMessagesParam ?? []);
+  // Store a empty array as the initial messages
+  // (instead of using a default parameter value that gets re-created each time)
+  // to avoid re-renders:
+  const [initialMessagesFallback] = useState([]);
 
   // Store the chat state in SWR, using the chatId as the key to share states.
   const { data: messages, mutate } = useSWR<Message[]>([api, chatId], null, {
-    fallbackData: initialMessages,
+    fallbackData: initialMessages ?? initialMessagesFallback,
   });
 
   // We store loading state in another hook to sync loading states across hook invocations


### PR DESCRIPTION
Users want to be able to change the initial messages ( #724 ). Storing `initialMessages` in a `useState` prevents this. It was introduced in https://github.com/vercel/ai/commit/0681baeac2027188f9bac3718ad64e7d194887f0 to prevent double rendering ( #615 ). 

Double rendering is only an issue when using an empty array that comes from a default parameter value, since it's recreated on each call. Therefore now only the empty array is stored in `useState`, and users can pass `initialMessages` like they used to.