### PR TITLE
chore: specify the minimum `react` version to 18

### DIFF
--- a/.changeset/hip-points-suffer.md
+++ b/.changeset/hip-points-suffer.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore: specify the minimum react version to 18

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -5,6 +5,6 @@
   "exports": "./dist/index.mjs",
   "private": true,
   "peerDependencies": {
-    "react": "^18"
+    "react": ">=18"
   }
 }

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -5,6 +5,6 @@
   "exports": "./dist/index.mjs",
   "private": true,
   "peerDependencies": {
-    "react": "*"
+    "react": "^18"
   }
 }


### PR DESCRIPTION
`useId` is the new API since https://github.com/facebook/react/releases/tag/v18.0.0.

https://github.com/vercel/ai/blob/70bd2ac68262185cd0ad70be9f3646bcf09240e3/packages/core/react/use-chat.ts#L1