### PR TITLE
Document useAssistant helpers & add data request option to submit.

### DIFF
--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -7,24 +7,55 @@ import { parseStreamPart } from '../shared/stream-parts';
 
 export type AssistantStatus = 'in_progress' | 'awaiting_message';
 
+export type UseAssistantHelpers = {
+  /** Current messages in the chat */
+  messages: Message[];
+
+  /** Current thread ID */
+  threadId: string | undefined;
+
+  /** The current value of the input */
+  input: string;
+
+  /** An input/textarea-ready onChange handler to control the value of the input */
+  handleInputChange: (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => void;
+
+  /** Form submission handler to automatically reset input and append a user message  */
+  submitMessage: (event?: React.FormEvent<HTMLFormElement>) => Promise<void>;
+
+  /** Current status of the assistant */
+  status: AssistantStatus;
+
+  /** Current error, if any */
+  error: undefined | unknown;
+};
+
 export function experimental_useAssistant({
   api,
   threadId: threadIdParam,
 }: {
   api: string;
   threadId?: string | undefined;
-}) {
+}): UseAssistantHelpers {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [threadId, setThreadId] = useState<string | undefined>(undefined);
   const [status, setStatus] = useState<AssistantStatus>('awaiting_message');
   const [error, setError] = useState<unknown | undefined>(undefined);
 
-  const handleInputChange = (e: any) => {
-    setInput(e.target.value);
+  const handleInputChange = (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    setInput(event.target.value);
   };
 
-  const submitMessage = async (event?: any) => {
+  const submitMessage = async (event?: React.FormEvent<HTMLFormElement>) => {
     event?.preventDefault?.();
 
     if (input === '') {

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -25,7 +25,12 @@ export type UseAssistantHelpers = {
   ) => void;
 
   /** Form submission handler to automatically reset input and append a user message  */
-  submitMessage: (event?: React.FormEvent<HTMLFormElement>) => Promise<void>;
+  submitMessage: (
+    event?: React.FormEvent<HTMLFormElement>,
+    requestOptions?: {
+      data?: Record<string, string>;
+    },
+  ) => Promise<void>;
 
   /** Current status of the assistant */
   status: AssistantStatus;
@@ -55,7 +60,12 @@ export function experimental_useAssistant({
     setInput(event.target.value);
   };
 
-  const submitMessage = async (event?: React.FormEvent<HTMLFormElement>) => {
+  const submitMessage = async (
+    event?: React.FormEvent<HTMLFormElement>,
+    requestOptions?: {
+      data?: Record<string, string>;
+    },
+  ) => {
     event?.preventDefault?.();
 
     if (input === '') {
@@ -78,6 +88,9 @@ export function experimental_useAssistant({
         // always use user-provided threadId when available:
         threadId: threadIdParam ?? threadId ?? null,
         message: input,
+
+        // optional request data:
+        data: requestOptions?.data,
       }),
     });
 


### PR DESCRIPTION
Addresses #784 

## Usage example

**page.tsx**
```tsx
export default function Chat() {
  const { status, messages, input, submitMessage, handleInputChange, error } =
    useAssistant({
      api: '/api/assistant',
    });

  // When status changes to accepting messages, focus the input:
  const inputRef = useRef<HTMLInputElement>(null);
  useEffect(() => {
    if (status === 'awaiting_message') {
      inputRef.current?.focus();
    }
  }, [status]);

  return (
    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
      {error != null && (
        <div className="relative bg-red-500 text-white px-6 py-4 rounded-md">
          <span className="block sm:inline">
            Error: {(error as any).toString()}
          </span>
        </div>
      )}

      {messages.map((m: Message) => (
        <div
          key={m.id}
          className="whitespace-pre-wrap"
          style={{ color: roleToColorMap[m.role] }}
        >
          <strong>{`${m.role}: `}</strong>
          {m.content}
          <br />
          <br />
        </div>
      ))}

      {status === 'in_progress' && (
        <div className="h-8 w-full max-w-md p-2 mb-8 bg-gray-300 dark:bg-gray-600 rounded-lg animate-pulse" />
      )}

      <form onSubmit={e => submitMessage(e, { data: { assistantId: '123' } })}>
        <input
          ref={inputRef}
          disabled={status !== 'awaiting_message'}
          className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
          value={input}
          placeholder="What is the temperature in the living room?"
          onChange={handleInputChange}
        />
      </form>
    </div>
  );
}
```

**route.ts**
```ts
export async function POST(req: Request) {
  // Parse the request body
  const input: {
    threadId: string | null;
    message: string;
    data: { assistantId: string };
  } = await req.json();

  // Create a thread if needed
  const threadId = input.threadId ?? (await openai.beta.threads.create({})).id;

  // Add a message to the thread
  const createdMessage = await openai.beta.threads.messages.create(threadId, {
    role: 'user',
    content: input.message,
  });

  return experimental_AssistantResponse(
    { threadId, messageId: createdMessage.id },
    async ({ threadId, sendMessage }) => {
      // Run the assistant on the thread
      const run = await openai.beta.threads.runs.create(threadId, {
        assistant_id: input.data.assistantId,
      });

// ...
```
