### PR TITLE
Expose extra fetch options in useAssistant

### DIFF
--- a/.changeset/green-grapes-attend.md
+++ b/.changeset/green-grapes-attend.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+experimental_useAssistant: Expose extra fetch options

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -51,8 +51,8 @@ export function experimental_useAssistant({
   api,
   threadId: threadIdParam,
   credentials,
-  headers = {},
-  body = {},
+  headers,
+  body,
 }: UseAssistantOptions): UseAssistantHelpers {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -39,13 +39,21 @@ export type UseAssistantHelpers = {
   error: undefined | unknown;
 };
 
+export type UseAssistantOptions = {
+  api: string;
+  threadId?: string | undefined;
+  credentials?: RequestCredentials;
+  headers?: Record<string, string> | Headers;
+  body?: object;
+};
+
 export function experimental_useAssistant({
   api,
   threadId: threadIdParam,
-}: {
-  api: string;
-  threadId?: string | undefined;
-}): UseAssistantHelpers {
+  credentials,
+  headers = {},
+  body = {},
+}: UseAssistantOptions): UseAssistantHelpers {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [threadId, setThreadId] = useState<string | undefined>(undefined);
@@ -83,8 +91,10 @@ export function experimental_useAssistant({
 
     const result = await fetch(api, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      credentials,
+      headers: { ...headers, 'Content-Type': 'application/json' },
       body: JSON.stringify({
+        ...body,
         // always use user-provided threadId when available:
         threadId: threadIdParam ?? threadId ?? null,
         message: input,

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -92,7 +92,7 @@ export function experimental_useAssistant({
     const result = await fetch(api, {
       method: 'POST',
       credentials,
-      headers: { ...headers, 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
         ...body,
         // always use user-provided threadId when available:


### PR DESCRIPTION
Similar to `useChat` allow setting `body`, `headers` and `credentials` from the hook call. Required to implement authentication for the assistants API endpoint.