### PR TITLE
Use mock service worker in replicate-stream test. 

### DIFF
--- a/packages/core/tests/utils/mock-server.ts
+++ b/packages/core/tests/utils/mock-server.ts
@@ -1,0 +1,33 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+
+export const DEFAULT_TEST_URL = 'http://localhost/';
+
+export function createMockServer<CHUNK>({
+  chunks,
+  formatChunk,
+  url,
+}: {
+  chunks: Array<CHUNK>;
+  formatChunk: (value: CHUNK) => string;
+  url: string;
+}) {
+  const encoder = new TextEncoder();
+  return setupServer(
+    http.get(url, () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(encoder.encode(formatChunk(chunk)));
+          }
+
+          controller.close();
+        },
+      });
+
+      return new HttpResponse(stream, {
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }),
+  );
+}

--- a/packages/core/tests/utils/mock-service.ts
+++ b/packages/core/tests/utils/mock-service.ts
@@ -6,7 +6,6 @@ import {
   chatCompletionChunksWithFunctionCall,
   chatCompletionChunksWithSpecifiedFunctionCall,
 } from '../snapshots/openai-chat';
-import { replicateTextChunks } from '../snapshots/replicate';
 
 async function flushDataToResponse(
   res: ServerResponse,
@@ -202,35 +201,6 @@ export const setup = (port = 3030) => {
               flushDelayInMs,
             );
             break;
-
-          case 'replicate': {
-            res.writeHead(200, {
-              'Content-Type': 'text/event-stream',
-              'Cache-Control': 'no-cache',
-              Connection: 'keep-alive',
-            });
-            res.flushHeaders();
-            recentFlushed = [];
-            flushDataToResponse(
-              res,
-              replicateTextChunks.map(
-                value =>
-                  new Proxy(
-                    { value },
-                    {
-                      get(target) {
-                        recentFlushed.push(target.value);
-                        return target.value;
-                      },
-                    },
-                  ),
-              ),
-              value => value.toString(),
-              undefined,
-              flushDelayInMs,
-            );
-            break;
-          }
 
           default:
             throw new Error(`Unknown service: ${service}`);


### PR DESCRIPTION
## Summary
- Extract mock server from cohere test
- Use mock service worker in replicate-stream test

## Note
Replicate tests were slow before MSW (5s), now they are fast (not hanging any longer).