### PR TITLE
Move bedrock init outside of request handler.

### DIFF
--- a/docs/pages/docs/api-reference/aws-bedrock-stream.mdx
+++ b/docs/pages/docs/api-reference/aws-bedrock-stream.mdx
@@ -39,17 +39,17 @@ import { experimental_buildAnthropicPrompt } from 'ai/prompts';
 // IMPORTANT! Set the runtime to edge
 export const runtime = 'edge';
 
+const bedrockClient = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? 'us-east-1',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+  },
+});
+
 export async function POST(req: Request) {
   // Extract the `prompt` from the body of the request
   const { messages } = await req.json();
-
-  const bedrockClient = new BedrockRuntimeClient({
-    region: process.env.AWS_REGION ?? '',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
-    },
-  });
 
   // Ask Claude for a streaming chat completion given the prompt
   const bedrockResponse = await bedrockClient.send(
@@ -87,6 +87,14 @@ import {
 } from '@aws-sdk/client-bedrock-runtime';
 import { AWSBedrockCohereStream, StreamingTextResponse } from 'ai';
 
+const bedrockClient = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? 'us-east-1',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+  },
+});
+
 function buildPrompt(
   messages: { content: string, role: 'system' | 'user' | 'assistant' }[],
 ) {
@@ -104,14 +112,6 @@ function buildPrompt(
 export async function POST(req: Request) {
   // Extract the `prompt` from the body of the request
   const { messages } = await req.json();
-
-  const bedrockClient = new BedrockRuntimeClient({
-    region: process.env.AWS_REGION ?? '',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
-    },
-  });
 
   // Ask Claude for a streaming chat completion given the prompt
   const bedrockResponse = await bedrockClient.send(
@@ -150,17 +150,17 @@ import {
 import { AWSBedrockLlama2Stream, StreamingTextResponse } from 'ai';
 import { experimental_buildLlama2Prompt } from 'ai/prompts';
 
+const bedrockClient = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? 'us-east-1',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+  },
+});
+
 export async function POST(req: Request) {
   // Extract the `prompt` from the body of the request
   const { messages } = await req.json();
-
-  const bedrockClient = new BedrockRuntimeClient({
-    region: process.env.AWS_REGION ?? '',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
-    },
-  });
 
   // Ask Claude for a streaming chat completion given the prompt
   const bedrockResponse = await bedrockClient.send(

--- a/docs/pages/docs/guides/providers/aws-bedrock.mdx
+++ b/docs/pages/docs/guides/providers/aws-bedrock.mdx
@@ -45,17 +45,17 @@ import { experimental_buildAnthropicPrompt } from 'ai/prompts';
 // IMPORTANT! Set the runtime to edge
 export const runtime = 'edge';
 
+const bedrockClient = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? 'us-east-1',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+  },
+});
+
 export async function POST(req: Request) {
   // Extract the `prompt` from the body of the request
   const { messages } = await req.json();
-
-  const bedrockClient = new BedrockRuntimeClient({
-    region: process.env.AWS_REGION ?? '',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
-    },
-  });
 
   // Ask Claude for a streaming chat completion given the prompt
   const bedrockResponse = await bedrockClient.send(

--- a/examples/next-aws-bedrock/app/api/chat-anthropic/route.ts
+++ b/examples/next-aws-bedrock/app/api/chat-anthropic/route.ts
@@ -9,7 +9,7 @@ import { experimental_buildAnthropicPrompt } from 'ai/prompts';
 export const runtime = 'edge';
 
 const bedrockClient = new BedrockRuntimeClient({
-  region: process.env.AWS_REGION ?? '',
+  region: process.env.AWS_REGION ?? 'us-east-1',
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',

--- a/examples/next-aws-bedrock/app/api/chat-anthropic/route.ts
+++ b/examples/next-aws-bedrock/app/api/chat-anthropic/route.ts
@@ -8,17 +8,17 @@ import { experimental_buildAnthropicPrompt } from 'ai/prompts';
 // IMPORTANT! Set the runtime to edge
 export const runtime = 'edge';
 
+const bedrockClient = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? '',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+  },
+});
+
 export async function POST(req: Request) {
   // Extract the `prompt` from the body of the request
   const { messages } = await req.json();
-
-  const bedrockClient = new BedrockRuntimeClient({
-    region: process.env.AWS_REGION ?? '',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
-    },
-  });
 
   // Ask Claude for a streaming chat completion given the prompt
   const bedrockResponse = await bedrockClient.send(

--- a/examples/next-aws-bedrock/app/api/chat-cohere/route.ts
+++ b/examples/next-aws-bedrock/app/api/chat-cohere/route.ts
@@ -22,7 +22,7 @@ function buildPrompt(
 }
 
 const bedrockClient = new BedrockRuntimeClient({
-  region: process.env.AWS_REGION ?? '',
+  region: process.env.AWS_REGION ?? 'us-east-1',
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',

--- a/examples/next-aws-bedrock/app/api/chat-cohere/route.ts
+++ b/examples/next-aws-bedrock/app/api/chat-cohere/route.ts
@@ -21,17 +21,17 @@ function buildPrompt(
   );
 }
 
+const bedrockClient = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? '',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+  },
+});
+
 export async function POST(req: Request) {
   // Extract the `prompt` from the body of the request
   const { messages } = await req.json();
-
-  const bedrockClient = new BedrockRuntimeClient({
-    region: process.env.AWS_REGION ?? '',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
-    },
-  });
 
   // Ask Claude for a streaming chat completion given the prompt
   const bedrockResponse = await bedrockClient.send(

--- a/examples/next-aws-bedrock/app/api/chat-llama2/route.ts
+++ b/examples/next-aws-bedrock/app/api/chat-llama2/route.ts
@@ -9,7 +9,7 @@ import { experimental_buildLlama2Prompt } from 'ai/prompts';
 export const runtime = 'edge';
 
 const bedrockClient = new BedrockRuntimeClient({
-  region: process.env.AWS_REGION ?? '',
+  region: process.env.AWS_REGION ?? 'us-east-1',
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',

--- a/examples/next-aws-bedrock/app/api/chat-llama2/route.ts
+++ b/examples/next-aws-bedrock/app/api/chat-llama2/route.ts
@@ -8,17 +8,17 @@ import { experimental_buildLlama2Prompt } from 'ai/prompts';
 // IMPORTANT! Set the runtime to edge
 export const runtime = 'edge';
 
+const bedrockClient = new BedrockRuntimeClient({
+  region: process.env.AWS_REGION ?? '',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+  },
+});
+
 export async function POST(req: Request) {
   // Extract the `prompt` from the body of the request
   const { messages } = await req.json();
-
-  const bedrockClient = new BedrockRuntimeClient({
-    region: process.env.AWS_REGION ?? '',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
-    },
-  });
 
   // Ask Claude for a streaming chat completion given the prompt
   const bedrockResponse = await bedrockClient.send(


### PR DESCRIPTION
Provide default region to work around CI failure.