### PR TITLE
feat(cohere): support AsyncIterable for Cohere

### DIFF
--- a/.changeset/eighty-days-turn.md
+++ b/.changeset/eighty-days-turn.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+cohere-stream: support AsyncIterable

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,6 +101,7 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "@vitejs/plugin-react": "4.2.0",
     "@vitejs/plugin-vue": "4.5.0",
+    "cohere-ai": "^7.6.2",
     "eslint": "^7.32.0",
     "eslint-config-vercel-ai": "workspace:*",
     "jsdom": "^23.0.0",

--- a/packages/core/streams/cohere-stream.test.ts
+++ b/packages/core/streams/cohere-stream.test.ts
@@ -1,3 +1,4 @@
+import { CohereClient } from 'cohere-ai';
 import {
   CohereStream,
   StreamingTextResponse,
@@ -9,7 +10,7 @@ import { DEFAULT_TEST_URL, createMockServer } from '../tests/utils/mock-server';
 
 const server = createMockServer([
   {
-    url: DEFAULT_TEST_URL,
+    url: '/v1/chat',
     chunks: cohereChunks,
     formatChunk: chunk => `${JSON.stringify(chunk)}\n`,
   },
@@ -29,7 +30,15 @@ describe('CohereStream', () => {
   });
 
   it('should be able to parse SSE and receive the streamed response', async () => {
-    const stream = CohereStream(await fetch(DEFAULT_TEST_URL));
+    const co = new CohereClient({
+      token: 'cohere-token',
+    });
+
+    const cohereResponse = await co.chatStream({
+      message: '',
+    });
+
+    const stream = CohereStream(cohereResponse);
 
     const response = new StreamingTextResponse(stream);
 

--- a/packages/core/tests/snapshots/cohere.ts
+++ b/packages/core/tests/snapshots/cohere.ts
@@ -1,3 +1,27 @@
+export const cohereChatChunks = [
+  { text: ' Hello', is_finished: false, event_type: 'text-generation' },
+  { text: ',', is_finished: false, event_type: 'text-generation' },
+  { text: ' world', is_finished: false, event_type: 'text-generation' },
+  { text: '.', is_finished: false, event_type: 'text-generation' },
+  { text: ' ', is_finished: false, event_type: 'text-generation' },
+  {
+    is_finished: true,
+    event_type: 'text-generation',
+    finish_reason: 'COMPLETE',
+    response: {
+      id: 'a15fdf82-758e-4d35-a520-40fbb7308631',
+      generations: [
+        {
+          id: '9700d8ef-a8e5-4eb8-8288-3f0e0a1daed5',
+          text: ' Hello, world. ',
+          finish_reason: 'COMPLETE',
+        },
+      ],
+      prompt: 'Hello',
+    },
+  },
+];
+
 export const cohereChunks = [
   { text: ' Hello', is_finished: false },
   { text: ',', is_finished: false },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,7 +316,7 @@ importers:
         version: link:../../packages/core
       langchain:
         specifier: ^0.0.196
-        version: 0.0.196(@aws-sdk/client-bedrock-runtime@3.451.0)(@huggingface/inference@2.6.4)(axios@1.6.2)(jsdom@23.0.0)
+        version: 0.0.196(@aws-sdk/client-bedrock-runtime@3.451.0)(@huggingface/inference@2.6.4)(axios@1.6.2)(cohere-ai@7.6.2)(jsdom@23.0.0)
       next:
         specifier: 14.0.3
         version: 14.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -741,7 +741,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.1.4
-        version: 4.5.0(@types/node@17.0.45)
+        version: 4.5.0(@types/node@20.9.0)
 
   examples/sveltekit-openai:
     dependencies:
@@ -781,7 +781,7 @@ importers:
         version: 5.1.3
       vite:
         specifier: ^4.3.9
-        version: 4.5.0(@types/node@17.0.45)
+        version: 4.5.0(@types/node@20.9.0)
 
   packages/core:
     dependencies:
@@ -867,6 +867,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.5.0
         version: 4.5.0(vite@4.5.0)(vue@3.3.8)
+      cohere-ai:
+        specifier: ^7.6.2
+        version: 7.6.2
       eslint:
         specifier: ^7.32.0
         version: 7.32.0
@@ -878,7 +881,7 @@ importers:
         version: 23.0.0
       langchain:
         specifier: 0.0.196
-        version: 0.0.196(@aws-sdk/client-bedrock-runtime@3.451.0)(@huggingface/inference@2.6.4)(axios@1.6.2)(jsdom@23.0.0)
+        version: 0.0.196(@aws-sdk/client-bedrock-runtime@3.451.0)(@huggingface/inference@2.6.4)(axios@1.6.2)(cohere-ai@7.6.2)(jsdom@23.0.0)
       msw:
         specifier: 2.0.9
         version: 2.0.9(typescript@5.1.3)
@@ -5030,7 +5033,7 @@ packages:
       svelte: 4.2.3
       tiny-glob: 0.2.9
       undici: 5.26.5
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5046,7 +5049,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.3)(vite@4.5.0)
       debug: 4.3.4
       svelte: 4.2.3
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5065,7 +5068,7 @@ packages:
       magic-string: 0.30.5
       svelte: 4.2.3
       svelte-hmr: 0.15.3(svelte@4.2.3)
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
       vitefu: 0.2.5(vite@4.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -6968,6 +6971,17 @@ packages:
       acorn: 8.11.2
       estree-walker: 3.0.3
       periscopic: 3.1.0
+
+  /cohere-ai@7.6.2:
+    resolution: {integrity: sha512-0cMY8IniquZb7nnQBaLrWacxugNjFNbZQHsn0cJJ5rCZ0LT9OZu0fbKqtoAkcBqkdc9yAFZh5gWnW4ksNhHtpg==}
+    dependencies:
+      form-data: 4.0.0
+      js-base64: 3.7.2
+      node-fetch: 2.7.0
+      qs: 6.11.2
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - encoding
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -9800,6 +9814,9 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /js-base64@3.7.2:
+    resolution: {integrity: sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==}
+
   /js-beautify@1.14.11:
     resolution: {integrity: sha512-rPogWqAfoYh1Ryqqh2agUpVfbxAhbjuN1SmU86dskQUKouRiggUTCO4+2ym9UPXllc2WAp0J+T5qxn7Um3lCdw==}
     engines: {node: '>=14'}
@@ -10304,7 +10321,7 @@ packages:
       - encoding
     dev: false
 
-  /langchain@0.0.196(@aws-sdk/client-bedrock-runtime@3.451.0)(@huggingface/inference@2.6.4)(axios@1.6.2)(jsdom@23.0.0):
+  /langchain@0.0.196(@aws-sdk/client-bedrock-runtime@3.451.0)(@huggingface/inference@2.6.4)(axios@1.6.2)(cohere-ai@7.6.2)(jsdom@23.0.0):
     resolution: {integrity: sha512-kt17GGTDFWHNv3jJOIXymsQxfa+h9UQ6hrHbhur+V2pV6RBKO5E+RRCvnCqBzbnOPtrlkENF6Wl3Ezmsfo21dg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -10609,6 +10626,7 @@ packages:
       '@huggingface/inference': 2.6.4
       axios: 1.6.2
       binary-extensions: 2.2.0
+      cohere-ai: 7.6.2
       expr-eval: 2.0.2
       flat: 5.0.2
       js-tiktoken: 1.0.7
@@ -13159,6 +13177,12 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  /qs@6.11.2:
+    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
@@ -13955,7 +13979,7 @@ packages:
       sirv: 2.0.3
       solid-start: 0.3.10(@solidjs/meta@0.29.3)(@solidjs/router@0.8.2)(solid-js@1.8.7)(solid-start-node@0.3.10)(vite@4.5.0)
       terser: 5.24.0
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14027,7 +14051,7 @@ packages:
       solid-start-node: 0.3.10(solid-start@0.3.10)(vite@4.5.0)
       terser: 5.24.0
       undici: 5.27.2
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
       vite-plugin-inspect: 0.7.42(rollup@3.29.4)(vite@4.5.0)
       vite-plugin-solid: 2.7.2(solid-js@1.8.7)(vite@4.5.0)
       wait-on: 6.0.1(debug@4.3.4)
@@ -15353,6 +15377,9 @@ packages:
     dependencies:
       punycode: 2.3.1
 
+  /url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+
   /url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
     dependencies:
@@ -15561,7 +15588,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.3
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -15691,7 +15718,6 @@ packages:
       rollup: 3.29.4
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitefu@0.2.5(vite@4.5.0):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}


### PR DESCRIPTION
This PR aims to add support for the AsyncIterable in the CohereStream, which is compatible with the response of `co.chatStream` using the official [Cohere SDK](https://github.com/cohere-ai/cohere-typescript). There is [another PR](https://github.com/vercel/ai/pull/870) were we update the Cohere Next.js example as well as the guide.