### PR TITLE
Expose setInput for useAssistant hook

### DIFF
--- a/.changeset/slow-scissors-attend.md
+++ b/.changeset/slow-scissors-attend.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+react/use-assistant: Expose setInput

--- a/docs/pages/docs/api-reference/use-assistant.mdx
+++ b/docs/pages/docs/api-reference/use-assistant.mdx
@@ -127,6 +127,11 @@ The `experimental_useAssistant` hook returns an object with several helper metho
     ['threadId', 'string | undefined', 'The current thread ID.'],
     ['input', 'string', 'The current value of the input field.'],
     [
+      'setInput',
+      'React.Dispatch<React.SetStateAction<string>>',
+      'Function to update the `input` value.',
+    ],
+    [
       'handleInputChange',
       '(e: any) => void',
       "Handler for the `onChange` event of the input field to control the input's value.",

--- a/docs/pages/docs/api-reference/use-assistant.mdx
+++ b/docs/pages/docs/api-reference/use-assistant.mdx
@@ -7,7 +7,7 @@ import { FrameworkTabs, Tab } from '@/components/framework-tabs';
 
 # experimental_useAssistant
 
-## `experimental_useAssistant(options: UseAssistantOptions): UseAssistantHelpers` [#useassistant]
+## `experimental_useAssistant(options: UseAssistantOptions): UseAssistantHelpers` [#experimental_useAssistant]
 
 `useAssistant` is a utility designed to handle the UI state of interacting with an OpenAI-compatible assistant API.
 This tool is useful when you need to integrate assistant capabilities into your application,

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -22,11 +22,11 @@ export type UseAssistantHelpers = {
    */
   input: string;
 
-  /** 
+  /**
    * setState-powered method to update the input value.
    */
   setInput: React.Dispatch<React.SetStateAction<string>>;
-  
+
   /**
    * Handler for the `onChange` event of the input field to control the input's value.
    */

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -22,6 +22,11 @@ export type UseAssistantHelpers = {
    */
   input: string;
 
+  /** 
+   * setState-powered method to update the input value.
+   */
+  setInput: React.Dispatch<React.SetStateAction<string>>;
+  
   /**
    * Handler for the `onChange` event of the input field to control the input's value.
    */
@@ -204,6 +209,7 @@ export function experimental_useAssistant({
     messages,
     threadId,
     input,
+    setInput,
     handleInputChange,
     submitMessage,
     status,

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,7 @@
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "lint": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^lint"]
     },
     "type-check": {
       "dependsOn": ["^build", "build"]


### PR DESCRIPTION
This exposes the setInput callback in the `useAssistant` hook, similar to the `useChat` hook. 

This would be helpful to use Assistants with [Vercel's NextJS Chatbot Template](https://github.com/vercel/ai-chatbot).