### PR TITLE
documentation: Fix-documentation-sentence

### DIFF
--- a/docs/pages/docs/concepts/backpressure-and-cancellation.mdx
+++ b/docs/pages/docs/concepts/backpressure-and-cancellation.mdx
@@ -37,7 +37,7 @@ function createStream(iterator) {
 
 // Collect data from stream
 async function run() {
-  // Set up a stream that of integers
+  // Set up a stream of integers
   const stream = createStream(integers());
 
   // Read values from our stream


### PR DESCRIPTION
## What this PR does:
Changes the sentence "Set up a stream that of integers" to "Set up a stream of integers" which is more clear.