### PR TITLE
docs: Update function name from AWSBedrockCohereStream to AWSBedrockLlama2Stream 🌱

### DIFF
--- a/docs/pages/docs/api-reference/aws-bedrock-stream.mdx
+++ b/docs/pages/docs/api-reference/aws-bedrock-stream.mdx
@@ -183,4 +183,4 @@ export async function POST(req: Request) {
 }
 ```
 
-In this example, the `AWSBedrockCohereStream` function transforms the text generation stream from the Bedrock into a ReadableStream of parsed result. This allows clients to consume AI outputs in real-time as they're generated, instead of waiting for the complete response.
+In this example, the `AWSBedrockLlama2Stream` function transforms the text generation stream from the Bedrock into a ReadableStream of parsed result. This allows clients to consume AI outputs in real-time as they're generated, instead of waiting for the complete response.


### PR DESCRIPTION
## Summary:
This pull request updates the function name in the documentation from `AWSBedrockCohereStream` to `AWSBedrockLlama2Stream`.

## Changes Made:

Corrected function name in the documentation to reflect `AWSBedrockLlama2Stream`.

## Context:
The modification addresses an issue where the documentation had an incorrect function name, which was copied from a previous example. The accurate function name, AWSBedrockLlama2Stream, has now been incorporated into the documentation. This adjustment ensures that the documentation aligns with the correct implementation, enhancing clarity and preventing potential confusion for users relying on the provided examples.