### PR TITLE
Feat:add helper to clear returned errors

### DIFF
--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { readDataStream } from '../shared/read-data-stream';
 import { Message } from '../shared/types';
 
@@ -55,6 +55,11 @@ export type UseAssistantHelpers = {
    * The error thrown during the assistant message processing, if any.
    */
   error: undefined | unknown;
+
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 
 export type UseAssistantOptions = {
@@ -205,6 +210,10 @@ export function experimental_useAssistant({
     setStatus('awaiting_message');
   };
 
+  const clearError = useCallback(() => {
+    setError(undefined);
+  }, [setError]);
+
   return {
     messages,
     threadId,
@@ -214,5 +223,6 @@ export function experimental_useAssistant({
     submitMessage,
     status,
     error,
+    clearError,
   };
 }

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -71,6 +71,10 @@ export type UseChatHelpers = {
   isLoading: boolean;
   /** Additional data added on the server via StreamData */
   data?: JSONValue[] | undefined;
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: ()=>void
 };
 
 type StreamingReactResponseAction = (payload: {
@@ -421,6 +425,12 @@ export function useChat({
     }
   }, []);
 
+  const clearError = useCallback(() => { 
+    setError(undefined);
+  }
+  , [setError]);
+
+
   const setMessages = useCallback(
     (messages: Message[]) => {
       mutate(messages, false);
@@ -478,5 +488,6 @@ export function useChat({
     handleSubmit,
     isLoading,
     data: streamData,
+    clearError,
   };
 }

--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -57,6 +57,10 @@ export type UseCompletionHelpers = {
   isLoading: boolean;
   /** Additional data added on the server via StreamData */
   data?: JSONValue[] | undefined;
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 
 export function useCompletion({
@@ -153,6 +157,10 @@ export function useCompletion({
     }
   }, [abortController]);
 
+  const clearError = useCallback(() => {
+    setError(undefined);
+  }, [setError]);
+
   const setCompletion = useCallback(
     (completion: string) => {
       mutate(completion, false);
@@ -194,5 +202,6 @@ export function useCompletion({
     handleSubmit,
     isLoading,
     data: streamData,
+    clearError,
   };
 }

--- a/packages/core/solid/use-chat.ts
+++ b/packages/core/solid/use-chat.ts
@@ -58,6 +58,10 @@ export type UseChatHelpers = {
   isLoading: Accessor<boolean>;
   /** Additional data added on the server via StreamData */
   data: Accessor<JSONValue[] | undefined>;
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 
 let uniqueId = 0;
@@ -235,6 +239,10 @@ export function useChat({
     }
   };
 
+  const clearError = () => {
+    setError(undefined);
+  };
+
   const setMessages = (messages: Message[]) => {
     mutate(messages);
   };
@@ -270,5 +278,6 @@ export function useChat({
     handleSubmit,
     isLoading,
     data: streamData,
+    clearError,
   };
 }

--- a/packages/core/solid/use-completion.ts
+++ b/packages/core/solid/use-completion.ts
@@ -46,6 +46,10 @@ export type UseCompletionHelpers = {
   isLoading: Accessor<boolean>;
   /** Additional data added on the server via StreamData */
   data: Accessor<JSONValue[] | undefined>;
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 
 let uniqueId = 0;
@@ -135,6 +139,10 @@ export function useCompletion({
     }
   };
 
+  const clearError = () => {
+    setError(undefined);
+  };
+
   const setCompletion = (completion: string) => {
     mutate(completion);
   };
@@ -159,5 +167,6 @@ export function useCompletion({
     handleSubmit,
     isLoading,
     data: streamData,
+    clearError,
   };
 }

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -57,6 +57,11 @@ export type UseChatHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Readable<JSONValue[] | undefined>;
+
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 const getStreamedResponse = async (
   api: string,
@@ -319,6 +324,10 @@ export function useChat({
     }
   };
 
+  const clearError = () => {
+    error.set(undefined);
+  };
+
   const setMessages = (messages: Message[]) => {
     mutate(messages);
   };
@@ -359,5 +368,6 @@ export function useChat({
     handleSubmit,
     isLoading,
     data: streamData,
+    clearError,
   };
 }

--- a/packages/core/svelte/use-completion.ts
+++ b/packages/core/svelte/use-completion.ts
@@ -44,6 +44,11 @@ export type UseCompletionHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Readable<JSONValue[] | undefined>;
+
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 
 let uniqueId = 0;
@@ -133,6 +138,10 @@ export function useCompletion({
     }
   };
 
+  const clearError = () => {
+    error.set(undefined);
+  };
+
   const setCompletion = (completion: string) => {
     mutate(completion);
   };
@@ -163,5 +172,6 @@ export function useCompletion({
     handleSubmit,
     isLoading,
     data: streamData,
+    clearError,
   };
 }

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -12,6 +12,7 @@ import type {
   UseChatOptions,
 } from '../shared/types';
 import { nanoid } from '../shared/utils';
+import { c } from 'vitest/dist/reporters-5f784f42';
 
 export type { CreateMessage, Message, UseChatOptions };
 
@@ -55,6 +56,11 @@ export type UseChatHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Ref<JSONValue[] | undefined>;
+
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 
 let uniqueId = 0;
@@ -231,6 +237,10 @@ export function useChat({
     }
   };
 
+  const clearError = () => {
+    error.value = undefined;
+  };
+
   const setMessages = (messages: Message[]) => {
     mutate(messages);
   };
@@ -262,5 +272,6 @@ export function useChat({
     handleSubmit,
     isLoading,
     data: streamData as Ref<undefined | JSONValue[]>,
+    clearError,
   };
 }

--- a/packages/core/vue/use-chat.ts
+++ b/packages/core/vue/use-chat.ts
@@ -55,6 +55,11 @@ export type UseChatHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Ref<JSONValue[] | undefined>;
+
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 
 let uniqueId = 0;
@@ -231,6 +236,10 @@ export function useChat({
     }
   };
 
+  const clearError = () => {
+    error.value = undefined;
+  };
+
   const setMessages = (messages: Message[]) => {
     mutate(messages);
   };
@@ -262,5 +271,6 @@ export function useChat({
     handleSubmit,
     isLoading,
     data: streamData as Ref<undefined | JSONValue[]>,
+    clearError,
   };
 }

--- a/packages/core/vue/use-completion.ts
+++ b/packages/core/vue/use-completion.ts
@@ -45,6 +45,11 @@ export type UseCompletionHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Ref<JSONValue[] | undefined>;
+
+  /**
+   * Clears the error state. This is useful when you want to clear the error manually after it has been returned from the server.
+   */
+  clearError: () => void;
 };
 
 let uniqueId = 0;
@@ -145,6 +150,10 @@ export function useCompletion({
     }
   };
 
+  const clearError = () => {
+    error.value = undefined;
+  };
+
   const setCompletion = (completion: string) => {
     mutate(completion);
   };
@@ -168,5 +177,6 @@ export function useCompletion({
     handleSubmit,
     isLoading,
     data: streamData,
+    clearError,
   };
 }


### PR DESCRIPTION
## Why this PR is needed.
- While using this library, I ran into a situation in which an error was returned from the backend. This library would then return the error to me using the error attribute of the chat helpers.
- However, I had no way of clearing this error to make the current chat + chat messages usable again on the UI.
- It would be helpful if the consumers had a way to clear the error from the state and keep using the chat. This can happen in situations like if the user had sent a message that was beyond the allowed context. We could easily clear the error, notify them to fix this, and then continue the chat

Please take a look @lgrammel , @MaxLeiter:) 