### PR TITLE
Fix onFinal callback argument when a string is returned from tool call.

### DIFF
--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -656,6 +656,7 @@ function createFunctionCallTransformer(
                 ? textEncoder.encode(formatStreamPart('text', functionResponse))
                 : textEncoder.encode(functionResponse),
             );
+            aggregatedFinalCompletionResponse = functionResponse;
             return;
           }
 


### PR DESCRIPTION
There is an inconsistent behaviour of `onFinal` callback when different types are returned from `experimental_onToolCall`.

When `experimental_onToolCall` callback returns a stream, `onFinal` gets called with a complete response of the returned stream. However, when `experimental_onToolCall` returns a string, `onFinal` callback is called with the tool call instead of the returned string. 

This PR makes the behaviour consistent - `onFinal` is called with the string returned from `experimental_onToolCall`. 