### PR TITLE
fix: Update link to PromptTemplate in langchain.mdx

### DIFF
--- a/docs/pages/docs/guides/providers/langchain.mdx
+++ b/docs/pages/docs/guides/providers/langchain.mdx
@@ -11,7 +11,7 @@ However, LangChain does not provide a way to easily build UIs or a standard way 
 ## Example
 
 Here is an example implementation of a chat application that uses both Vercel AI SDK and a composed LangChain chain together with the
-[Next.js](https://nextjs.org/docs) App Router. It includes a LangChain [`PromptTemplate`](https://js.langchain.com/docs/modules/model_io/prompts/prompt_templates/)
+[Next.js](https://nextjs.org/docs) App Router. It includes a LangChain [`PromptTemplate`](https://js.langchain.com/docs/modules/model_io/prompts/quick_start/)
 to pass input into a [`ChatOpenAI`](https://js.langchain.com/docs/modules/model_io/models/chat/integrations/openai) model wrapper,
 then streams the result through an encoding output parser.
 


### PR DESCRIPTION
The [current PromptTemplate link](https://js.langchain.com/docs/modules/model_io/prompts/prompt_templates/) is not valid anymore and takes users to a 404 page. I have updated the url to instead take users to LangChain's ['Quick Start'](https://js.langchain.com/docs/modules/model_io/prompts/quick_start) on prompts, where both prompts and prompt templates are explained.