### PR TITLE
Fixes toolCallStreamPart in stream-parts.ts

### DIFF
--- a/packages/core/shared/stream-parts.ts
+++ b/packages/core/shared/stream-parts.ts
@@ -194,8 +194,9 @@ const toolCallStreamPart: StreamPart<
       typeof value.tool_calls !== 'object' ||
       value.tool_calls == null ||
       !Array.isArray(value.tool_calls) ||
-      value.tool_calls.some(tc => {
-        tc == null ||
+      value.tool_calls.some(
+        tc => 
+          tc == null ||
           typeof tc !== 'object' ||
           !('id' in tc) ||
           typeof tc.id !== 'string' ||
@@ -206,8 +207,8 @@ const toolCallStreamPart: StreamPart<
           typeof tc.function !== 'object' ||
           !('arguments' in tc.function) ||
           typeof tc.function.name !== 'string' ||
-          typeof tc.function.arguments !== 'string';
-      })
+          typeof tc.function.arguments !== 'string',
+      )
     ) {
       throw new Error(
         '"tool_calls" parts expect an object with a ToolCallPayload.',


### PR DESCRIPTION
The `.some()` check was not returning a value. This PR fixes that. 