### PR TITLE
Executed tool calls handling

### DIFF
--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -100,19 +100,19 @@ const getStreamedResponse = async (
   const constructedMessagesPayload = sendExtraMessageFields
     ? chatRequest.messages
     : chatRequest.messages.map(
-        ({ role, content, name, function_call, tool_calls, tool_call_id }) => ({
-          role,
-          content,
-          tool_call_id,
-          ...(name !== undefined && { name }),
-          ...(function_call !== undefined && {
-            function_call: function_call,
-          }),
-          ...(tool_calls !== undefined && {
-            tool_calls: tool_calls,
-          }),
+      ({ role, content, name, function_call, tool_calls, tool_call_id }) => ({
+        role,
+        content,
+        tool_call_id,
+        ...(name !== undefined && { name }),
+        ...(function_call !== undefined && {
+          function_call: function_call,
         }),
-      );
+        ...(tool_calls !== undefined && {
+          tool_calls: tool_calls,
+        }),
+      }),
+    );
 
   if (typeof api !== 'string') {
     // In this case, we are handling a Server Action. No complex mode handling needed.
@@ -209,6 +209,7 @@ export function useChat({
   sendExtraMessageFields,
   experimental_onFunctionCall,
   experimental_onToolCall,
+  experimental_onToolExecution,
   onResponse,
   onFinish,
   onError,
@@ -301,6 +302,7 @@ export function useChat({
             ),
           experimental_onFunctionCall,
           experimental_onToolCall,
+          experimental_onToolExecution,
           updateChatRequest: chatRequestParam => {
             chatRequest = chatRequestParam;
           },

--- a/packages/core/shared/parse-complex-response.ts
+++ b/packages/core/shared/parse-complex-response.ts
@@ -139,6 +139,10 @@ export async function parseComplexResponse({
         prefixMap['tool_calls'],
         message_annotations,
       );
+      toolExecutionMessage = assignAnnotationsToMessage(
+        prefixMap['tool_execution_message'],
+        message_annotations,
+      );
       responseMessage = assignAnnotationsToMessage(
         prefixMap['text'],
         message_annotations,
@@ -151,6 +155,7 @@ export async function parseComplexResponse({
         'text',
         'function_call',
         'tool_calls',
+        'tool_execution_message',
       ];
       messagePrefixKeys.forEach(key => {
         if (prefixMap[key]) {

--- a/packages/core/shared/stream-parts.ts
+++ b/packages/core/shared/stream-parts.ts
@@ -259,20 +259,8 @@ const toolExecutionMessageStreamPart: StreamPart<
       typeof value.role !== 'string' ||
       typeof value.tool_call_id !== 'string' ||
       typeof value.name !== 'string' ||
-      value.role !== 'tool' ||
-      !Array.isArray(value.content) ||
-      !value.content.every(
-        item =>
-          item != null &&
-          typeof item === 'object' &&
-          'type' in item &&
-          item.type === 'text' &&
-          'text' in item &&
-          item.text != null &&
-          typeof item.text === 'object' &&
-          'value' in item.text &&
-          typeof item.text.value === 'string',
-      )
+      typeof value.content !== 'string' || // Check if content is a string
+      value.role !== 'tool'
     ) {
       throw new Error(
         '"tool_execution_message" parts expect an object with an "id", "role", "name" and "content" property.',
@@ -285,7 +273,6 @@ const toolExecutionMessageStreamPart: StreamPart<
     };
   },
 };
-
 
 const streamParts = [
   textStreamPart,

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -334,6 +334,14 @@ export type AssistantMessage = {
   }>;
 };
 
+export type ToolExecutionMessage = {
+  id: string;
+  role: 'tool';
+  name: string;
+  tool_call_id: string;
+  content: string;
+};
+
 /*
  * A data message is an application-specific message from the assistant
  * that should be shown in order with the other messages.

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -143,6 +143,11 @@ export type ToolCallHandler = (
   toolCalls: ToolCall[],
 ) => Promise<ChatRequest | void>;
 
+export type ToolExecutionMessageHandler = (
+  chatMessages: Message[],
+  toolExecutionMessage: ToolExecutionMessage,
+) => Promise<ChatRequest | void>;
+
 export type RequestOptions = {
   headers?: Record<string, string> | Headers;
   body?: object;
@@ -194,6 +199,14 @@ export type UseChatOptions = {
    * automatically to the API and will be used to update the chat.
    */
   experimental_onToolCall?: ToolCallHandler;
+
+  /**
+   * Callback function to be called when the API response is received that
+   * contains an executed tool call.
+   * If the function returns a `ChatRequest` object, the request will be sent
+   * automatically to the API and will be used to update the chat.
+   */
+  experimental_onToolExecution?: ToolExecutionMessageHandler;
 
   /**
    * Callback function to be called when the API response is received.


### PR DESCRIPTION
My own implementation to cover the lack of #983. Basically, being able to receive the results of an executed tool_call from the server, so that the executed_tool call can stay in the chat history. Would be great if we can get this to merged.