### PR TITLE
Fix docs for sendExtraMessageFields on useCompletion

### DIFF
--- a/docs/pages/docs/api-reference/use-completion.mdx
+++ b/docs/pages/docs/api-reference/use-completion.mdx
@@ -106,12 +106,7 @@ export default function Completion() {
       'credentials',
       '"omit" | "same-origin" | "include"',
       'An optional literal that sets the mode of credentials to be used on the request. Defaults to "same-origin".',
-    ],
-    [
-      'sendExtraMessageFields',
-      'boolean',
-      "An optional boolean that determines whether to send extra fields you've added to `messages`. Defaults to `false` and only the `content` and `role` fields will be sent to the API endpoint.",
-    ],
+    ]
   ]}
 />
 


### PR DESCRIPTION
`sendExtraMessageFields` doesn't exist for `useCompletion` but was mentioned in the docs.