### PR TITLE
Update docs: Update imports for LangChain provider

### DIFF
--- a/docs/pages/docs/guides/providers/langchain.mdx
+++ b/docs/pages/docs/guides/providers/langchain.mdx
@@ -29,9 +29,9 @@ pnpm install @langchain/openai
 import { NextRequest } from 'next/server';
 import { Message as VercelChatMessage, StreamingTextResponse } from 'ai';
 
-import { ChatOpenAI } from "@langchain/openai";
-import { BytesOutputParser } from "@langchain/core/output_parsers";
-import { PromptTemplate } from "@langchain/core/prompts";
+import { ChatOpenAI } from '@langchain/openai';
+import { BytesOutputParser } from '@langchain/core/output_parsers';
+import { PromptTemplate } from '@langchain/core/prompts';
 
 export const runtime = 'edge';
 

--- a/docs/pages/docs/guides/providers/langchain.mdx
+++ b/docs/pages/docs/guides/providers/langchain.mdx
@@ -18,13 +18,20 @@ then streams the result through an encoding output parser.
 It takes this stream and uses Vercel AI SDK's [`StreamingTextResponse`](/docs/api-reference/streaming-text-response)
 to pipe text to the client (from the edge) and then Vercel AI SDK's `useChat` to handle the chat UI.
 
+Install the LangChain package:
+
+```shell
+pnpm install @langchain/openai   
+```
+
+
 ```tsx filename="app/api/chat/route.ts"
 import { NextRequest } from 'next/server';
 import { Message as VercelChatMessage, StreamingTextResponse } from 'ai';
 
-import { ChatOpenAI } from 'langchain/chat_models/openai';
-import { BytesOutputParser } from 'langchain/schema/output_parser';
-import { PromptTemplate } from 'langchain/prompts';
+import { ChatOpenAI } from "@langchain/openai";
+import { BytesOutputParser } from "@langchain/core/output_parsers";
+import { PromptTemplate } from "@langchain/core/prompts";
 
 export const runtime = 'edge';
 


### PR DESCRIPTION
Update imports for LangChain provider. The current ones are deprecated and result in those warnings:

```shell
[WARNING]: Importing from "langchain/chat_models/openai" is deprecated.

Instead, please add the "@langchain/openai" package to your project with e.g.

    $ npm install @langchain/openai

and import from "@langchain/openai".

This will be mandatory after the next "langchain" minor version bump to 0.2.
[WARNING]: Importing from "langchain/schema/output_parser" is deprecated.

Instead, please import from "@langchain/core/output_parsers".

This will be mandatory after the next "langchain" minor version bump to 0.2.
[WARNING]: Importing from "langchain/prompts" is deprecated.

Instead, please import from "@langchain/core/prompts".

This will be mandatory after the next "langchain" minor version bump to 0.2.
```
