### PR TITLE
Implement Zephyr prompt helper

### DIFF
--- a/docs/pages/docs/api-reference/prompts.mdx
+++ b/docs/pages/docs/api-reference/prompts.mdx
@@ -28,6 +28,20 @@ const response = Hf.textGenerationStream({
 });
 ```
 
+## `experiment_buildZephyrPrompt`
+
+Uses `<|user|>`, `<|assistant|>`, `<|system|>`, and `</s>` tokens. If a `Message` with an unsupported `role` is passed, an error will be thrown.
+
+```ts filename="route.ts" {6}
+import { experimental_buildZephyrPrompt } from 'ai/prompts';
+
+const { messages } = await req.json();
+const response = Hf.textGenerationStream({
+  model: 'HuggingFaceH4/zephyr-7b-beta',
+  inputs: experimental_buildStarChatBetaPrompt(messages),
+});
+```
+
 ## `experimental_buildStarChatBetaPrompt`
 
 Uses `<|user|>`, `<|end|>`, `<|system|>`, and `<|assistant>` tokens. If a `Message` with an unsupported `role` is passed, an error will be thrown.

--- a/packages/core/prompts/huggingface.test.ts
+++ b/packages/core/prompts/huggingface.test.ts
@@ -3,7 +3,29 @@ import {
   experimental_buildLlama2Prompt,
   experimental_buildOpenAssistantPrompt,
   experimental_buildStarChatBetaPrompt,
+  experimental_buildZephyrPrompt,
 } from './huggingface';
+
+describe('buildZephyrPrompt', () => {
+  it('should return a string with user, assistant, and system messages', () => {
+    const messages: Pick<Message, 'content' | 'role'>[] = [
+      { content: 'You are a chat bot.', role: 'system' },
+      { content: 'Hello!', role: 'user' },
+      { content: 'Hi there!', role: 'assistant' },
+    ];
+
+    const expectedPrompt = `<|system|>\nYou are a chat bot.<\s>\n<|user|>\nHello!<\s>\n<|assistant|>\nHi there!<\s>\n<|assistant|>\n`;
+    const prompt = experimental_buildZephyrPrompt(messages);
+    expect(prompt).toEqual(expectedPrompt);
+  });
+
+  it('should throw an error if a function message is included', () => {
+    const messages: Pick<Message, 'content' | 'role'>[] = [
+      { content: 'someFunction()', role: 'function' },
+    ];
+    expect(() => experimental_buildZephyrPrompt(messages)).toThrow();
+  });
+});
 
 describe('buildStarChatBetaPrompt', () => {
   it('should return a string with user, assistant, and system messages', () => {

--- a/packages/core/prompts/huggingface.ts
+++ b/packages/core/prompts/huggingface.ts
@@ -1,6 +1,32 @@
 import { Message } from '../shared/types';
 
 /**
+ * A prompt constructor for the HuggingFace Zephyr model.
+ *
+ * Does not support `function` messages.
+ * @see https://huggingface.co/HuggingFaceH4/zephyr-7b-beta
+ */
+export function experimental_buildZephyrPrompt(
+  messages: Pick<Message, 'content' | 'role'>[],
+) {
+  return (
+    messages
+      .map(({ content, role }, index) => {
+        if (role == 'user') {
+          return `<|user|>\n${content}<\s>\n`;
+        } else if (role == 'assistant') {
+          return `<|assistant|>\n${content}<\s>\n`;
+        } else if (role == 'system' && index == 0) {
+          return `<|system|>\n${content}<\s>\n`;
+        } else if (role == 'function') {
+          throw new Error('Zephyr does not support function calls.');
+        }
+      })
+      .join('') + `<|assistant|>\n`
+  );
+}
+
+/**
  * A prompt constructor for the HuggingFace StarChat Beta model.
  * Does not support `function` messages.
  * @see https://huggingface.co/HuggingFaceH4/starchat-beta


### PR DESCRIPTION
We add a prompt helper for the [Zephyr series of models](https://huggingface.co/HuggingFaceH4/zephyr-7b-alpha).

Helper logic is pulled from [the chat template in the Zephyr model files themselves](https://huggingface.co/HuggingFaceH4/zephyr-7b-alpha/blob/main/tokenizer_config.json#L34).