### PR TITLE
Add OpenAI and Anthropic tests & fix some types

### DIFF
--- a/packages/core/prompts/anthropic.test.ts
+++ b/packages/core/prompts/anthropic.test.ts
@@ -1,0 +1,20 @@
+import { Message } from '../shared/types';
+import { experimental_buildAnthropicPrompt } from './anthropic';
+
+describe('experimental_buildAnthropicPrompt', () => {
+  it('should correctly format messages', () => {
+    const messages = [
+      { content: 'Hello', role: 'user' },
+      { content: 'Hi there', role: 'assistant' },
+      { content: 'How are you?', role: 'user' },
+      { content: 'I am fine, thank you.', role: 'assistant' },
+    ] as Pick<Message, 'content' | 'role'>[];
+
+    const result = experimental_buildAnthropicPrompt(messages);
+
+    const expected =
+      '\n\nHuman: Hello,\n\nAssistant: Hi there,\n\nHuman: How are you?,\n\nAssistant: I am fine, thank you.\n\nAssistant:';
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/core/prompts/openai.test.ts
+++ b/packages/core/prompts/openai.test.ts
@@ -1,0 +1,152 @@
+import { Message } from '../shared/types';
+import {
+  experimental_buildOpenAIMessages,
+  ChatCompletionMessageParam,
+} from './openai';
+
+describe('experimental_buildOpenAIMessages', () => {
+  it('should correctly map messages to ChatCompletionMessageParam', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'system',
+        content: 'System message',
+      },
+      {
+        id: '2',
+        role: 'user',
+        content: 'User message',
+      },
+      {
+        id: '3',
+        role: 'assistant',
+        content: 'Assistant message',
+        function_call: {
+          name: 'functionName',
+          arguments: 'arg1, arg2',
+        },
+      },
+      {
+        id: '4',
+        role: 'function',
+        content: 'Function message',
+        name: 'functionName',
+      },
+      {
+        id: '5',
+        role: 'tool',
+        content: 'Tool message',
+        name: 'toolName',
+        tool_call_id: 'toolCallId',
+      },
+    ];
+
+    const expected: ChatCompletionMessageParam[] = [
+      {
+        role: 'system',
+        content: 'System message',
+      },
+      {
+        role: 'user',
+        content: 'User message',
+      },
+      {
+        role: 'assistant',
+        content: 'Assistant message',
+        function_call: {
+          name: 'functionName',
+          arguments: 'arg1, arg2',
+        },
+      },
+      {
+        role: 'function',
+        content: 'Function message',
+        name: 'functionName',
+      },
+      {
+        role: 'tool',
+        content: 'Tool message',
+        name: 'toolName',
+        tool_call_id: 'toolCallId',
+      },
+    ];
+
+    const result = experimental_buildOpenAIMessages(messages);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should throw an error for invalid function call in assistant message', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        content: 'Assistant message',
+        function_call: 'invalidFunctionCall',
+      },
+    ];
+
+    expect(() => experimental_buildOpenAIMessages(messages)).toThrowError(
+      'Invalid function call in message. Expected a function call object',
+    );
+  });
+
+  it('should throw an error for invalid function call in function message', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'function',
+        content: 'Function message',
+      },
+    ];
+
+    expect(() => experimental_buildOpenAIMessages(messages)).toThrowError(
+      'Invalid function call in message. Expected a name',
+    );
+  });
+
+  it('should throw an error for unsupported message role', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'data',
+        content: 'Data message',
+      },
+    ];
+
+    expect(() => experimental_buildOpenAIMessages(messages)).toThrowError(
+      "unsupported message role 'data'",
+    );
+  });
+
+  it('should throw an error for invalid tool message', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'tool',
+        content: 'Tool message',
+        name: undefined,
+      },
+    ];
+
+    expect(() => experimental_buildOpenAIMessages(messages)).toThrowError(
+      'Invalid tool message. Expected a name',
+    );
+  });
+
+  it('should throw an error for invalid tool message', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        role: 'tool',
+        content: 'Tool message',
+        name: 'toolName',
+        tool_call_id: undefined,
+      },
+    ];
+
+    expect(() => experimental_buildOpenAIMessages(messages)).toThrowError(
+      'Invalid tool message. Expected a tool_call_id',
+    );
+  });
+});

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -69,7 +69,7 @@ export type UseAssistantOptions = {
    * An optional string that represents the ID of an existing thread.
    * If not provided, a new thread will be created.
    */
-  threadId?: string | undefined;
+  threadId?: string;
 
   /**
    * An optional literal that sets the mode of credentials to be used on the request.

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -70,7 +70,7 @@ export type UseChatHelpers = {
   /** Whether the API request is in progress */
   isLoading: boolean;
   /** Additional data added on the server via StreamData */
-  data?: JSONValue[] | undefined;
+  data?: JSONValue[];
 };
 
 type StreamingReactResponseAction = (payload: {


### PR DESCRIPTION
I removed the undefined type from optional types because it's redundant.

For example:
```ts
threadId?: string | undefined;
// -
threadId?: string;
```

Additionally, I added missing tests for `OpenAI` and `Anthropic`, contributing to the package's stability.