### PR TITLE
fix(useActions): return typed object

### DIFF
--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -27,14 +27,14 @@ export type InternalAIProviderProps<AIState = any, UIState = any> = {
   wrappedSyncUIState?: ServerWrappedAction<AIState>;
 };
 
-export type AIProviderProps<AIState = any, UIState = any> = {
+export type AIProviderProps<AIState = any, UIState = any, Actions = any> = {
   children: React.ReactNode;
   initialAIState?: AIState;
   initialUIState?: UIState;
 };
 
 export type AIProvider<AIState = any, UIState = any, Actions = any> = (
-  props: AIProviderProps<AIState, UIState>,
+  props: AIProviderProps<AIState, UIState, Actions>,
 ) => Promise<React.ReactElement>;
 
 export type InferAIState<T, Fallback> = T extends AIProvider<


### PR DESCRIPTION
`useActions` is not inferring the AIActions type correctly since it seems like the Actions generic isn't being used in `AIProvider`. If we just pipe it to `AIProviderProps` it is now being used and can be inferred.

Before:

![Screen Shot 2024-03-01 at 4 19 45 PM](https://github.com/vercel/ai/assets/43461847/4c73da05-7596-4f29-b9ee-62dd3554eedc)


After:

![Screen Shot 2024-03-01 at 4 36 56 PM](https://github.com/vercel/ai/assets/43461847/389b7dba-3ff5-4e41-8e5d-0f6fc6b1f67b)
