### PR TITLE
examples: And missing .env.example

### DIFF
--- a/examples/next-ai-rsc/.env.example
+++ b/examples/next-ai-rsc/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY="xxxxxxxxxxxx"

--- a/examples/next-ai-rsc/.gitignore
+++ b/examples/next-ai-rsc/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+node_modules
+.turbo
+*.log
+.next
+*.local
+.env
+.cache
+.turbo

--- a/examples/next-ai-rsc/next.config.mjs
+++ b/examples/next-ai-rsc/next.config.mjs
@@ -1,4 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-export default nextConfig;


### PR DESCRIPTION
Also removed the Next.js config as it's empty.