### PR TITLE
Fix broken 404 links in docs

### DIFF
--- a/docs/pages/docs/api-reference.mdx
+++ b/docs/pages/docs/api-reference.mdx
@@ -23,10 +23,10 @@ title: API Reference
 
 ## Streaming Helpers
 
-- [`HuggingFaceStream`](./api-reference/huggingface-stream)
-- [`AnthropicStream`](./api-reference/anthropic-stream)
-- [`LangChainStream`](./api-reference/langchain-stream)
-- [`OpenAIStream`](./api-reference/openai-stream)
+- [`HuggingFaceStream`](./api-reference/providers/huggingface-stream)
+- [`AnthropicStream`](./api-reference/providers/anthropic-stream)
+- [`LangChainStream`](./api-reference/providers/langchain-stream)
+- [`OpenAIStream`](./api-reference/providers/openai-stream)
 - [`StreamingTextResponse`](./api-reference/streaming-text-response)
 - [`AIStream`](./api-reference/ai-stream)
 - [`streamToResponse`](./api-reference/stream-to-response)

--- a/docs/pages/docs/api-reference/generative-ui/render.mdx
+++ b/docs/pages/docs/api-reference/generative-ui/render.mdx
@@ -112,7 +112,7 @@ You can also customize the React component streamed for text responses by using 
 The `render` function allows you to map [OpenAI-compatible model/providers with Function Calls and Assistants Tools](https://platform.openai.com/docs/guides/function-calling) to [React Server Components](https://vercel.com/blog/understanding-react-server-components) using the `tools` key.
 Note that both `text` and `render` can be specified at the same time, with `text` being the fallback for when no function is called by the model.
 
-If you use other models, you can [prompt engineer](docs/concepts/prompt-engineering) them
+If you use other models, you can [prompt engineer](/docs/concepts/prompt-engineering) them
 into returning structured data and manually handle the streaming UI with [`createStreamableUI`](./create-streamable-ui) and [`createStreamableValue`](./create-streamable-value).
 
 Tool/Function Schema definitions use [Zod](https://zod.dev/) schemas to specify the function parameters and return values. `render` will automatically validate the schemas and throw an error if the function call is invalid.

--- a/docs/pages/docs/api-reference/stream-to-response.mdx
+++ b/docs/pages/docs/api-reference/stream-to-response.mdx
@@ -10,7 +10,7 @@ import { OptionTable } from '@/components/table';
 
 ## `streamToResponse(stream: ReadableStream, response: ServerResponse, options?: Options)`
 
-This method will pipe a `ReadableStream` to a Node.js `ServerResponse` object. It can be helpful to combine this with other AI stream utilities, such as [`OpenAIStream`](/docs/api-reference/openai-stream#openaistream), in Node.js environments.
+This method will pipe a `ReadableStream` to a Node.js `ServerResponse` object. It can be helpful to combine this with other AI stream utilities, such as [`OpenAIStream`](/docs/api-reference/providers/openai-stream), in Node.js environments.
 
 Similar to [`StreamingTextResponse`](/docs/api-reference/streaming-text-response#streamingtextresponse), it automatically sets the status code to `200` and the `Content-Type` header to `'text/plain; charset=utf-8'`.
 
@@ -18,7 +18,7 @@ Similar to [`StreamingTextResponse`](/docs/api-reference/streaming-text-response
 
 ### `stream: ReadableStream`
 
-The Web Stream to pipe to the response. It can be the return value of [`OpenAIStream`](/docs/api-reference/openai-stream#openaistream), [`HuggingFaceStream`](/docs/api-reference/huggingface-stream#huggingfacestream), [`AnthropicStream`](/docs/api-reference/anthropic-stream#anthropicstream), or an [`AIStream`](/docs/api-reference/ai-stream#aistream) instance.
+The Web Stream to pipe to the response. It can be the return value of [`OpenAIStream`](/docs/api-reference/providers/openai-stream), [`HuggingFaceStream`](/docs/api-reference/providers/huggingface-stream), [`AnthropicStream`](/docs/api-reference/providers/anthropic-stream), or an [`AIStream`](/docs/api-reference/ai-stream) instance.
 
 ### `response: ServerResponse`
 

--- a/docs/pages/docs/api-reference/streaming-react-response.mdx
+++ b/docs/pages/docs/api-reference/streaming-react-response.mdx
@@ -13,8 +13,8 @@ The `experimental_StreamingReactResponse` class allows you to stream React compo
 <Callout>
   <strong>
     This API has been deprecated and will be removed in a future release. See
-    [Generative UI](/docs/concepts/generative-ui) for the recommended approach
-    to streaming React UI.
+    [Generative UI](/docs/concepts/ai-rsc) for the recommended approach to
+    streaming React UI.
   </strong>
 </Callout>
 

--- a/docs/pages/docs/api-reference/use-completion.mdx
+++ b/docs/pages/docs/api-reference/use-completion.mdx
@@ -445,9 +445,9 @@ export default function PostEditorPage() {
 ```
 
 In the code snippet above, we define a React component `PostEditor` that utilizes
-a custom prompt and the [`complete`](docs/api-reference/use-completion#usecompletionhelpers) function to request a JSON string from an AI model.
+a custom prompt and the [`complete`](/docs/api-reference/use-completion#usecompletionhelpers) function to request a JSON string from an AI model.
 
-The server API formats the prompt for the AI model, and then it uses the [OpenAIStream](/docs/api-reference/openai-stream) and [StreamingTextResponse](/docs/api-reference/streaming-text-response) utilities to stream the response back to the client.
+The server API formats the prompt for the AI model, and then it uses the [OpenAIStream](/docs/api-reference/providers/openai-stream) and [StreamingTextResponse](/docs/api-reference/streaming-text-response) utilities to stream the response back to the client.
 
 ```tsx filename="app/api/completion/route.ts"
 import OpenAI from 'openai';

--- a/docs/pages/docs/concepts/ai-rsc.mdx
+++ b/docs/pages/docs/concepts/ai-rsc.mdx
@@ -317,7 +317,7 @@ In many cases, the interface you render will need to request updates from the se
 For example, a weather app might need to request the latest weather data every 5 minutes, or a button press should execute a search.
 To accomplish this, you can pass Server Actions to your UI components and call them as needed.
 
-For example, if you have an `handleUserMessage` action registered in [`createAI`](/docs/api-reference/create-ai), you can define nested Server Actions like this:
+For example, if you have an `handleUserMessage` action registered in [`createAI`](/docs/api-reference/generative-ui/create-ai), you can define nested Server Actions like this:
 
 ```tsx filename="app/action.tsx" {26-29}
 async function handleUserMessage(userInput) {
@@ -376,7 +376,7 @@ And then your `WeatherCard` component can call the `refreshAction` function in a
 
 The AI state represents the context of the conversation provided to the language model and is
 often an array of chat messages. Sometimes, like if the user is filling out a form or interacting with a UI element like a slider,
-you need to update the language models context with the new information. You can mutate the AI state on the client using the [`useAIState`](/docs/api-reference/use-ai-state)
+you need to update the language models context with the new information. You can mutate the AI state on the client using the [`useAIState`](/docs/api-reference/generative-ui/use-ai-state)
 hook.
 
 In the example below, we have a slider that allows the user to purchase a number of shares of a stock. When the user changes the slider, we update the AI state with the new information.

--- a/docs/pages/docs/guides/providers/anthropic.mdx
+++ b/docs/pages/docs/guides/providers/anthropic.mdx
@@ -67,9 +67,10 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Anthropic's TypeScript SDK to
-  [`AnthropicStream`](/docs/api-reference/anthropic-stream). This utility class
-  decodes/extracts the text tokens in the response and then re-encodes them
-  properly for simple consumption. We can then pass that new stream directly to
+  [`AnthropicStream`](/docs/api-reference/providers/anthropic-stream). This
+  utility class decodes/extracts the text tokens in the response and then
+  re-encodes them properly for simple consumption. We can then pass that new
+  stream directly to
   [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This
   is another utility class that extends the normal Node/Edge Runtime `Response`
   class with the default headers you probably want (hint: `'Content-Type':

--- a/docs/pages/docs/guides/providers/azure-openai.mdx
+++ b/docs/pages/docs/guides/providers/azure-openai.mdx
@@ -68,7 +68,7 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Azure OpenAI library to
-  [`OpenAIStream`](/docs/api-reference/openai-stream). This method
+  [`OpenAIStream`](/docs/api-reference/providers/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This

--- a/docs/pages/docs/guides/providers/cohere.mdx
+++ b/docs/pages/docs/guides/providers/cohere.mdx
@@ -93,9 +93,10 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Cohere's TypeScript SDK to
-  [`CohereStream`](/docs/api-reference/cohere-stream). This utility class
-  decodes/extracts the text tokens in the response and then re-encodes them
-  properly for simple consumption. We can then pass that new stream directly to
+  [`CohereStream`](/docs/api-reference/providers/cohere-stream). This utility
+  class decodes/extracts the text tokens in the response and then re-encodes
+  them properly for simple consumption. We can then pass that new stream
+  directly to
   [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This
   is another utility class that extends the normal Node/Edge Runtime `Response`
   class with the default headers you probably want (hint: `'Content-Type':

--- a/docs/pages/docs/guides/providers/fireworks.mdx
+++ b/docs/pages/docs/guides/providers/fireworks.mdx
@@ -77,7 +77,7 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Fireworks to
-  [`OpenAIStream`](/docs/api-reference/openai-stream). This method
+  [`OpenAIStream`](/docs/api-reference/providers/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This

--- a/docs/pages/docs/guides/providers/google.mdx
+++ b/docs/pages/docs/guides/providers/google.mdx
@@ -73,7 +73,7 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Google's Generative AI SDK to
-  [`GoogleGenerativeAIStream`](/docs/api-reference/google-generative-ai-stream).
+  [`GoogleGenerativeAIStream`](/docs/api-reference/providers/google-generative-ai-stream).
   This utility class decodes/extracts the text tokens in the response and then
   re-encodes them properly for simple consumption. We can then pass that new
   stream directly to

--- a/docs/pages/docs/guides/providers/hugging-face.mdx
+++ b/docs/pages/docs/guides/providers/hugging-face.mdx
@@ -78,9 +78,10 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from `Hf.textGenerationStream` to
-  [`HuggingFaceStream`](/docs/api-reference/huggingface-stream). This method
-  decodes/extracts the text tokens in the response and then re-encodes them
-  properly for simple consumption. We can then pass that new stream directly to
+  [`HuggingFaceStream`](/docs/api-reference/providers/huggingface-stream). This
+  method decodes/extracts the text tokens in the response and then re-encodes
+  them properly for simple consumption. We can then pass that new stream
+  directly to
   [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This
   is another utility class that extends the normal Node/Edge Runtime `Response`
   class with the default headers you probably want (hint: `'Content-Type':

--- a/docs/pages/docs/guides/providers/inkeep.mdx
+++ b/docs/pages/docs/guides/providers/inkeep.mdx
@@ -133,7 +133,7 @@ export async function POST(req: Request) {
 This example leverages a few utilities provided by the Vercel AI SDK:
 
 1. First, we pass the streaming `response` we receive from the Inkeep API to the
-   [`InkeepStream`](/docs/api-reference/inkeep-stream). This
+   [`InkeepStream`](/docs/api-reference/providers/inkeep-stream). This
    method decodes/extracts the content of the message from Inkeep's server-side events response and then re-encodes them into a standard [ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream).
 
 2. We then pass that stream directly to the Vercel AI SDK's [`StreamingTextResponse`](/docs/api-reference/streaming-text-response).

--- a/docs/pages/docs/guides/providers/langchain.mdx
+++ b/docs/pages/docs/guides/providers/langchain.mdx
@@ -128,8 +128,8 @@ For more usage examples, including agents and retrieval, you can check out the [
 # Advanced
 
 For streaming with legacy or more complex chains or agents that don't support streaming out of the box, you can use the `LangChainStream` class to handle certain
-[callbacks](https://js.langchain.com/docs/api/callbacks/) provided by LangChain on your behalf.
+[callbacks](https://js.langchain.com/docs/modules/callbacks/) provided by LangChain on your behalf.
 Under the hood it is a wrapper over LangChain's [`callbacks`](https://js.langchain.com/docs/production/callbacks/).
 We wrap over these methods to provide which then write to the `stream` which can then be passed directly to [`StreamingTextResponse`](/docs/api-reference/streaming-text-response).
 
-You can see an example of how this looks from the [`LangChainStream` docs page](/docs/api-reference/langchain-stream).
+You can see an example of how this looks from the [`LangChainStream` docs page](/docs/api-reference/providers/langchain-stream).

--- a/docs/pages/docs/guides/providers/mistral.mdx
+++ b/docs/pages/docs/guides/providers/mistral.mdx
@@ -65,7 +65,7 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Mistral to the
-  [`MistralStream`](/docs/api-reference/mistral-stream). This method
+  [`MistralStream`](/docs/api-reference/providers/mistral-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This

--- a/docs/pages/docs/guides/providers/openai.mdx
+++ b/docs/pages/docs/guides/providers/openai.mdx
@@ -68,7 +68,7 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from OpenAI to
-  [`OpenAIStream`](/docs/api-reference/openai-stream). This method
+  [`OpenAIStream`](/docs/api-reference/providers/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This

--- a/docs/pages/docs/guides/providers/perplexity.mdx
+++ b/docs/pages/docs/guides/providers/perplexity.mdx
@@ -80,7 +80,7 @@ export async function POST(req: Request) {
 <Callout>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Perplexity to
-  [`OpenAIStream`](/docs/api-reference/openai-stream). This method
+  [`OpenAIStream`](/docs/api-reference/providers/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/api-reference/streaming-text-response). This


### PR DESCRIPTION
Fixes #1058 by:

 * [x] Adding the `/providers/` and `/generative-ui/` folders where needed
 * [x] Fixing some places where the links were `docs/` instead of `/docs/` (i.e., missing the leading `/`)
 * [x] Fixing a few just-totally-wrong URLs

Unfortunately I wasn't able to figure out how to run the docs locally 😅  but I manually checked all the ones I changed.