### PR TITLE
Improve docs for RSC APIs

### DIFF
--- a/docs/pages/docs/api-reference/generative-ui/create-streamable-ui.mdx
+++ b/docs/pages/docs/api-reference/generative-ui/create-streamable-ui.mdx
@@ -28,11 +28,13 @@ The `update` method is used to update the UI node. It takes a new UI node and re
 
 ### `append`
 
-The `append` method is used to append a new UI node to the end of the old one.
+The `append` method is used to append a new UI node to the end of the old one. Once appended a new UI node, the previous UI node cannot be updated anymore.
 
 ### `done`
 
-The `done` method is used to replace the UI node with a new one and mark it as done. This is useful for when you want to replace the loading UI with the final result.
+The `done` method marks the UI node as finalized. You can either call it without any parameters or with a new UI node as the final state. Once called, the UI node cannot be updated or appended anymore.
+
+The `done` method is always **required** to be called, otherwise the response will be stuck in a loading state.
 
 ## Example
 
@@ -40,7 +42,7 @@ The `done` method is used to replace the UI node with a new one and mark it as d
   <Tab>
     UI Streams are created on the server and streamed to the client.
 
-    ```tsx filename="app/action.tsx" {8-15, 19-26, 30-37, 41}
+    ```tsx filename="app/action.tsx" {8-15, 23-30, 34-41, 46}
     import { createStreamableUI } from "ai/rsc";
 
     async function confirmPurchase(symbol: string, amount: number) {
@@ -57,27 +59,32 @@ The `done` method is used to replace the UI node with a new one and mark it as d
         </div>
       );
 
-      await sleep(1000);
+      // This async function is immediately invoked but it will not block the
+      // return statement. Because of that, the client will receive the initial
+      // UI immediately and then the updates will be streamed later.
+      (async () => {
+        await sleep(1000);
 
-      uiStream.update(
-        <div className="inline-flex gap-1">
-          {spinner}
-          <p className="mb-2">
-            Purchasing {amount} ${symbol}... working on it...
-          </p>
-        </div>
-      );
+        uiStream.update(
+          <div className="inline-flex gap-1">
+            {spinner}
+            <p className="mb-2">
+              Purchasing {amount} ${symbol}... working on it...
+            </p>
+          </div>
+        );
 
-      await sleep(1000);
+        await sleep(1000);
 
-      uiStream.done(
-        <div>
-          <p className="mb-2">
-            You have successfully purchased {amount} ${symbol}.
-            Total cost: ${amount * price}
-          </p>
-        </div>
-      );
+        uiStream.done(
+          <div>
+            <p className="mb-2">
+              You have successfully purchased {amount} ${symbol}.
+              Total cost: ${amount * price}
+            </p>
+          </div>
+        );
+      })();
 
       return {
         id: Date.now(),

--- a/docs/pages/docs/api-reference/generative-ui/create-streamable-value.mdx
+++ b/docs/pages/docs/api-reference/generative-ui/create-streamable-value.mdx
@@ -28,7 +28,9 @@ The `update` method is used to update the value of the streamable value.
 
 ### `done`
 
-The `done` method is used to replace the old data with a new one and mark it as done. This is useful for when you want to replace the data with the final result.
+The `done` method marks the value as finalized. You can either call it without any parameters or with a new value as the final state. Once called, it cannot be updated or appended anymore.
+
+The `done` method is always **required** to be called, otherwise the response will be stuck in a loading state.
 
 ## Example
 
@@ -36,7 +38,7 @@ The `done` method is used to replace the old data with a new one and mark it as 
   <Tab>
     Value Streams are created on the server and streamed to the client.
 
-    ```tsx filename="app/action.tsx" {6-9, 13-16, 20-23, 27}
+    ```tsx filename="app/action.tsx" {6-9, 14-17, 21-24, 29}
     import { createStreamableValue } from "ai/rsc";
 
     async function getCustomerProfile(id: string) {
@@ -47,19 +49,21 @@ The `done` method is used to replace the old data with a new one and mark it as 
         subscriptions: null,
       })
 
-      const profile = await getProfile(id);
+      (async () => {
+        const profile = await getProfile(id);
 
-      valueStream.update({
-        profile,
-        subscriptions: null,
-      });
+        valueStream.update({
+          profile,
+          subscriptions: null,
+        });
 
-      const subscriptions = await getSubscriptions(profile.customerId);
+        const subscriptions = await getSubscriptions(profile.customerId);
 
-      valueStream.done({
-        profile,
-        subscriptions,
-      });
+        valueStream.done({
+          profile,
+          subscriptions,
+        });
+      })();
 
       return {
         id: Date.now(),

--- a/docs/pages/docs/api-reference/generative-ui/get-ai-state.mdx
+++ b/docs/pages/docs/api-reference/generative-ui/get-ai-state.mdx
@@ -18,5 +18,5 @@ The AI state returned is read-only so if you want to make updates to it, you sho
 
 ```tsx
 const state = getAIState(); // Get the entire AI state
-const field = getAIState('key'); // Get the value of the key
+const field = getAIState('key'); // Get the value of the key. This is equivalent to `getAIState().key`.
 ```

--- a/docs/pages/docs/api-reference/generative-ui/get-mutable-ai-state.mdx
+++ b/docs/pages/docs/api-reference/generative-ui/get-mutable-ai-state.mdx
@@ -40,6 +40,17 @@ const state = getMutableAIState();
 state.done({ ...state.get(), key: 'value' }); // Done with a new state
 ```
 
+It can be called with a specific key as a shorthand for updating a part of the state (if the state is an object):
+
+```tsx
+const state = getMutableAIState('messages');
+state.done([...state.get(), newMessage]);
+
+// is equivalent to:
+const state = getMutableAIState();
+state.update({ ...state.get(), messages: [...state.get().messages, newMessage] });
+```
+
 ## Usage
 
 <Tabs items={['Next.js (App Router)']}>


### PR DESCRIPTION
- Streamable UI and streamable value API examples should not have blocking statements before returning the action. Otherwise streaming isn't helpful.
- Add extra words about `.done()` and mention that it's required.
- Mention the `getMutableAIState` with a key parameter use case.