### PR TITLE
Fix potential race condition of renderer

### DIFF
--- a/.changeset/hot-birds-develop.md
+++ b/.changeset/hot-birds-develop.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix potential race conditions

--- a/packages/core/rsc/__snapshots__/streamable.ui.test.tsx.snap
+++ b/packages/core/rsc/__snapshots__/streamable.ui.test.tsx.snap
@@ -1,0 +1,91 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`rsc - streamable > should emit React Nodes with async render function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "current": undefined,
+      "next": {
+        "done": false,
+        "next": {
+          "done": true,
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Weather
+        </div>,
+      },
+    },
+    "type": "Row",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
+exports[`rsc - streamable > should emit React Nodes with generator render function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "current": undefined,
+      "next": {
+        "done": false,
+        "next": {
+          "done": false,
+          "next": {
+            "done": true,
+            "value": <div>
+              Weather
+            </div>,
+          },
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Loading...
+        </div>,
+      },
+    },
+    "type": "Row",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
+exports[`rsc - streamable > should emit React Nodes with sync render function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "current": undefined,
+      "next": {
+        "done": false,
+        "next": {
+          "done": true,
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Weather
+        </div>,
+      },
+    },
+    "type": "Row",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;

--- a/packages/core/rsc/__snapshots__/streamable.ui.test.tsx.snap
+++ b/packages/core/rsc/__snapshots__/streamable.ui.test.tsx.snap
@@ -1,5 +1,95 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`rsc - render() > should emit React Nodes with async render function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "current": undefined,
+      "next": {
+        "done": false,
+        "next": {
+          "done": true,
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Weather
+        </div>,
+      },
+    },
+    "type": "Row",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
+exports[`rsc - render() > should emit React Nodes with generator render function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "current": undefined,
+      "next": {
+        "done": false,
+        "next": {
+          "done": false,
+          "next": {
+            "done": true,
+            "value": <div>
+              Weather
+            </div>,
+          },
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Loading...
+        </div>,
+      },
+    },
+    "type": "Row",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
+exports[`rsc - render() > should emit React Nodes with sync render function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "current": undefined,
+      "next": {
+        "done": false,
+        "next": {
+          "done": true,
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Weather
+        </div>,
+      },
+    },
+    "type": "Row",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
 exports[`rsc - streamable > should emit React Nodes with async render function 1`] = `
 {
   "children": {

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -247,7 +247,7 @@ export function render<
   ) {
     if (!renderer) return;
 
-    const resolvable = createResolvablePromise();
+    const resolvable = createResolvablePromise<void>();
 
     if (finished) {
       finished = finished.then(() => resolvable.promise);

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -197,6 +197,11 @@ export function render<
 }): ReactNode {
   const ui = createStreamableUI(options.initial);
 
+  // The default text renderer just returns the content as string.
+  const text = options.text
+    ? options.text
+    : ({ content }: { content: string }) => content;
+
   const functions = options.functions
     ? Object.entries(options.functions).map(
         ([name, { description, parameters }]) => {
@@ -233,7 +238,7 @@ export function render<
     );
   }
 
-  let finished: ReturnType<typeof createResolvablePromise> | undefined;
+  let finished: Promise<void> | undefined;
 
   async function handleRender(
     args: any,
@@ -242,8 +247,14 @@ export function render<
   ) {
     if (!renderer) return;
 
-    if (finished) await finished.promise;
-    finished = createResolvablePromise();
+    const resolvable = createResolvablePromise();
+
+    if (finished) {
+      finished = finished.then(() => resolvable.promise);
+    } else {
+      finished = resolvable.promise;
+    }
+
     const value = renderer(args);
     if (
       value instanceof Promise ||
@@ -254,7 +265,7 @@ export function render<
     ) {
       const node = await (value as Promise<React.ReactNode>);
       res.update(node);
-      finished?.resolve(void 0);
+      resolvable.resolve(void 0);
     } else if (
       value &&
       typeof value === 'object' &&
@@ -270,7 +281,7 @@ export function render<
         res.update(value);
         if (done) break;
       }
-      finished?.resolve(void 0);
+      resolvable.resolve(void 0);
     } else if (value && typeof value === 'object' && Symbol.iterator in value) {
       const it = value as Generator<React.ReactNode, React.ReactNode, void>;
       while (true) {
@@ -278,16 +289,16 @@ export function render<
         res.update(value);
         if (done) break;
       }
-      finished?.resolve(void 0);
+      resolvable.resolve(void 0);
     } else {
       res.update(value);
-      finished?.resolve(void 0);
+      resolvable.resolve(void 0);
     }
   }
 
   (async () => {
     let hasFunction = false;
-    let text = '';
+    let content = '';
 
     const parseFunctionCallArguments = (fn: {
       type: 'functions' | 'tools';
@@ -365,18 +376,18 @@ export function render<
               }
             : {}),
           onText(chunk) {
-            text += chunk;
-            handleRender({ content: text, done: false }, options.text, ui);
+            content += chunk;
+            handleRender({ content, done: false }, text, ui);
           },
           async onFinal() {
             if (hasFunction) {
-              await finished?.promise;
+              await finished;
               ui.done();
               return;
             }
 
-            handleRender({ content: text, done: true }, options.text, ui);
-            await finished?.promise;
+            handleRender({ content, done: true }, text, ui);
+            await finished;
             ui.done();
           },
         },

--- a/packages/core/rsc/streamable.ui.test.tsx
+++ b/packages/core/rsc/streamable.ui.test.tsx
@@ -93,7 +93,7 @@ function createMockUpProvider() {
   } as any;
 }
 
-describe('rsc - streamable', () => {
+describe('rsc - render()', () => {
   it('should emit React Nodes with sync render function', async () => {
     const ui = render({
       model: 'gpt-3.5-turbo',

--- a/packages/core/rsc/streamable.ui.test.tsx
+++ b/packages/core/rsc/streamable.ui.test.tsx
@@ -1,0 +1,159 @@
+import {
+  openaiChatCompletionChunks,
+  openaiFunctionCallChunks,
+} from '../tests/snapshots/openai-chat';
+import { DEFAULT_TEST_URL, createMockServer } from '../tests/utils/mock-server';
+import { render } from './streamable';
+import { z } from 'zod';
+
+const FUNCTION_CALL_TEST_URL = DEFAULT_TEST_URL + 'mock-func-call';
+
+const server = createMockServer([
+  {
+    url: DEFAULT_TEST_URL,
+    chunks: openaiChatCompletionChunks,
+    formatChunk: chunk => `data: ${JSON.stringify(chunk)}\n\n`,
+    suffix: 'data: [DONE]',
+  },
+  {
+    url: FUNCTION_CALL_TEST_URL,
+    chunks: openaiFunctionCallChunks,
+    formatChunk: chunk => `data: ${JSON.stringify(chunk)}\n\n`,
+    suffix: 'data: [DONE]',
+  },
+]);
+
+beforeAll(() => {
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+async function recursiveResolve(val: any): Promise<any> {
+  if (val && typeof val === 'object' && typeof val.then === 'function') {
+    return await recursiveResolve(await val);
+  }
+
+  if (Array.isArray(val)) {
+    return await Promise.all(val.map(recursiveResolve));
+  }
+
+  if (val && typeof val === 'object') {
+    const result: any = {};
+    for (const key in val) {
+      result[key] = await recursiveResolve(val[key]);
+    }
+    return result;
+  }
+
+  return val;
+}
+
+async function simulateFlightServerRender(node: React.ReactElement) {
+  async function traverse(node: any): Promise<any> {
+    if (!node) return {};
+
+    // Let's only do one level of promise resolution here. As it's only for testing purposes.
+    const props = await recursiveResolve({ ...node.props } || {});
+
+    const { type } = node;
+    const { children, ...otherProps } = props;
+    const typeName = typeof type === 'function' ? type.name : String(type);
+
+    return {
+      type: typeName,
+      props: otherProps,
+      children:
+        typeof children === 'string'
+          ? children
+          : Array.isArray(children)
+          ? children.map(traverse)
+          : await traverse(children),
+    };
+  }
+
+  return traverse(node);
+}
+
+function createMockUpProvider() {
+  return {
+    chat: {
+      completions: {
+        create: async () => {
+          return await fetch(FUNCTION_CALL_TEST_URL);
+        },
+      },
+    },
+  } as any;
+}
+
+describe('rsc - streamable', () => {
+  it('should emit React Nodes with sync render function', async () => {
+    const ui = render({
+      model: 'gpt-3.5-turbo',
+      messages: [],
+      provider: createMockUpProvider(),
+      functions: {
+        get_current_weather: {
+          description: 'Get the current weather',
+          parameters: z.object({}),
+          render: () => {
+            return <div>Weather</div>;
+          },
+        },
+      },
+    });
+
+    const rendered = await simulateFlightServerRender(ui as any);
+    expect(rendered).toMatchSnapshot();
+  });
+
+  it('should emit React Nodes with async render function', async () => {
+    const ui = render({
+      model: 'gpt-3.5-turbo',
+      messages: [],
+      provider: createMockUpProvider(),
+      functions: {
+        get_current_weather: {
+          description: 'Get the current weather',
+          parameters: z.object({}),
+          render: async () => {
+            await new Promise(resolve => setTimeout(resolve, 100));
+            return <div>Weather</div>;
+          },
+        },
+      },
+    });
+
+    const rendered = await simulateFlightServerRender(ui as any);
+    expect(rendered).toMatchSnapshot();
+  });
+
+  it('should emit React Nodes with generator render function', async () => {
+    const ui = render({
+      model: 'gpt-3.5-turbo',
+      messages: [],
+      provider: createMockUpProvider(),
+      functions: {
+        get_current_weather: {
+          description: 'Get the current weather',
+          parameters: z.object({}),
+          render: async function* () {
+            yield <div>Loading...</div>;
+            await new Promise(resolve => setTimeout(resolve, 100));
+            return <div>Weather</div>;
+          },
+        },
+      },
+    });
+
+    const rendered = await simulateFlightServerRender(ui as any);
+    expect(rendered).toMatchSnapshot();
+  });
+});

--- a/packages/core/rsc/utils.tsx
+++ b/packages/core/rsc/utils.tsx
@@ -1,8 +1,8 @@
 import React, { Suspense } from 'react';
 
-export function createResolvablePromise() {
-  let resolve: (value: any) => void, reject: (error: any) => void;
-  const promise = new Promise((res, rej) => {
+export function createResolvablePromise<T = any>() {
+  let resolve: (value: T) => void, reject: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;
   });

--- a/packages/core/rsc/utils.tsx
+++ b/packages/core/rsc/utils.tsx
@@ -14,13 +14,14 @@ export function createResolvablePromise<T = any>() {
 }
 
 export function createSuspensedChunk(initialValue: React.ReactNode) {
-  const Row = (async ({
-    current,
-    next,
-  }: {
+  const Row = (async (props: {
     current: React.ReactNode;
     next: Promise<any>;
   }) => {
+    if (!props) console.trace(props);
+
+    const { current, next } = props;
+
     const chunk = await next;
     if (chunk.done) {
       return chunk.value;

--- a/packages/core/rsc/utils.tsx
+++ b/packages/core/rsc/utils.tsx
@@ -14,14 +14,13 @@ export function createResolvablePromise<T = any>() {
 }
 
 export function createSuspensedChunk(initialValue: React.ReactNode) {
-  const Row = (async (props: {
+  const Row = (async ({
+    current,
+    next,
+  }: {
     current: React.ReactNode;
     next: Promise<any>;
   }) => {
-    if (!props) console.trace(props);
-
-    const { current, next } = props;
-
     const chunk = await next;
     if (chunk.done) {
       return chunk.value;

--- a/packages/core/vitest.ui.react.config.js
+++ b/packages/core/vitest.ui.react.config.js
@@ -7,6 +7,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['react/**/*.ui.test.ts', 'react/**/*.ui.test.tsx'],
+    include: [
+      'react/**/*.ui.test.ts',
+      'react/**/*.ui.test.tsx',
+      'rsc/**/*.ui.test.ts',
+      'rsc/**/*.ui.test.tsx',
+    ],
   },
 });


### PR DESCRIPTION
If there're multiple pending `await`s (when the LLM streams very quickly), they'll be resolved together and override `finished` on the next line hence one of them will be lost and untracked:

```ts
if (finished) await finished.promise;
finished = createResolvablePromise();
```

This PR fixes that.

Also adds some tests for basic `render()` cases.