### PR TITLE
[next-ai-rsc] Prevent Infinite Loop in Stock Component useEffect

### DIFF
--- a/examples/next-ai-rsc/components/llm-stocks/stock.tsx
+++ b/examples/next-ai-rsc/components/llm-stocks/stock.tsx
@@ -49,12 +49,12 @@ export function Stock({ name = 'DOGE', price = 12.34, delta = 1 }) {
       };
 
       if (history[history.length - 1]?.id === id) {
-        setHistory([...history.slice(0, -1), message]);
+        setHistory(prevHistory => [...prevHistory.slice(0, -1), message]);
       } else {
-        setHistory([...history, message]);
+        setHistory(prevHistory => [...prevHistory, message]);
       }
     }
-  }, [startHighlight, endHighlight, history, id, setHistory, xToDate]);
+  }, [startHighlight, endHighlight]);
 
   return (
     <div className="p-4 text-green-400 border rounded-xl bg-zinc-950">


### PR DESCRIPTION
In the next-ai-rsc example if you select a date range you get an infinte loop with useEffect.

- Refactored useEffect to depend solely on start and end highlight states.
- Switched to functional state updates for history state to ensure correct dependency tracking.
- Improved state management by adopting functional updates and immutability principles.