### PR TITLE
fix(types): make sure Actions type is bound to prevent `InferActions` returning unknown

### DIFF
--- a/.changeset/fresh-trees-listen.md
+++ b/.changeset/fresh-trees-listen.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix `useActions` type inference

--- a/examples/next-ai-rsc/app/page.tsx
+++ b/examples/next-ai-rsc/app/page.tsx
@@ -23,7 +23,7 @@ import { toast } from '@/components/ui/use-toast';
 
 export default function Page() {
   const [messages, setMessages] = useUIState<typeof AI>();
-  const { submitUserMessage } = useActions();
+  const { submitUserMessage } = useActions<typeof AI>();
   const [inputValue, setInputValue] = useState('');
   const { formRef, onKeyDown } = useEnterSubmit();
   const inputRef = useRef<HTMLTextAreaElement>(null);

--- a/packages/core/rsc/provider.tsx
+++ b/packages/core/rsc/provider.tsx
@@ -15,7 +15,6 @@ import type {
   InternalAIStateStorageOptions,
   OnSetAIState,
   OnGetUIState,
-  AIProviderProps,
 } from './types';
 
 async function innerAction<T>(

--- a/packages/core/rsc/provider.tsx
+++ b/packages/core/rsc/provider.tsx
@@ -116,5 +116,5 @@ export function createAI<
     );
   }
 
-  return AI as AIProvider<AIState, UIState, Actions>;
+  return AI as unknown as AIProvider<AIState, UIState, Actions>;
 }

--- a/packages/core/rsc/provider.tsx
+++ b/packages/core/rsc/provider.tsx
@@ -78,7 +78,7 @@ export function createAI<
     ? wrapAction(onGetUIState, {})
     : undefined;
 
-  async function AI(props: AIProviderProps<AIState, UIState, Actions>) {
+  const AI: AIProvider<AIState, UIState, Actions> = async props => {
     if ('useState' in React) {
       // This file must be running on the React Server layer.
       // Ideally we should be using `import "server-only"` here but we can have a
@@ -111,7 +111,7 @@ export function createAI<
         {props.children}
       </InternalAIProvider>
     );
-  }
+  };
 
-  return AI as AIProvider<AIState, UIState, Actions>;
+  return AI;
 }

--- a/packages/core/rsc/provider.tsx
+++ b/packages/core/rsc/provider.tsx
@@ -15,6 +15,7 @@ import type {
   InternalAIStateStorageOptions,
   OnSetAIState,
   OnGetUIState,
+  AIProviderProps,
 } from './types';
 
 async function innerAction<T>(
@@ -77,11 +78,7 @@ export function createAI<
     ? wrapAction(onGetUIState, {})
     : undefined;
 
-  async function AI(props: {
-    children: React.ReactNode;
-    initialAIState?: AIState;
-    initialUIState?: UIState;
-  }) {
+  async function AI(props: AIProviderProps<AIState, UIState, Actions>) {
     if ('useState' in React) {
       // This file must be running on the React Server layer.
       // Ideally we should be using `import "server-only"` here but we can have a
@@ -116,5 +113,5 @@ export function createAI<
     );
   }
 
-  return AI as unknown as AIProvider<AIState, UIState, Actions>;
+  return AI as AIProvider<AIState, UIState, Actions>;
 }

--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -31,7 +31,7 @@ export type AIProviderProps<AIState = any, UIState = any, Actions = any> = {
   children: React.ReactNode;
   initialAIState?: AIState;
   initialUIState?: UIState;
-  __actions?: Actions;
+  $ActionTypes?: Actions;
 };
 
 export type AIProvider<AIState = any, UIState = any, Actions = any> = (

--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -31,6 +31,7 @@ export type AIProviderProps<AIState = any, UIState = any, Actions = any> = {
   children: React.ReactNode;
   initialAIState?: AIState;
   initialUIState?: UIState;
+  /** $ActionTypes is only added for type inference and is never used at runtime **/
   $ActionTypes?: Actions;
 };
 

--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -31,12 +31,12 @@ export type AIProviderProps<AIState = any, UIState = any, Actions = any> = {
   children: React.ReactNode;
   initialAIState?: AIState;
   initialUIState?: UIState;
+  __actions?: Actions;
 };
 
-export interface AIProvider<AIState = any, UIState = any, Actions = any> {
-  $Actions: Actions;
-  (props: AIProviderProps<AIState, UIState>): Promise<React.ReactElement>;
-}
+export type AIProvider<AIState = any, UIState = any, Actions = any> = (
+  props: AIProviderProps<AIState, UIState, Actions>,
+) => Promise<React.ReactElement>;
 
 export type InferAIState<T, Fallback> = T extends AIProvider<
   infer AIState,

--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -33,9 +33,10 @@ export type AIProviderProps<AIState = any, UIState = any, Actions = any> = {
   initialUIState?: UIState;
 };
 
-export type AIProvider<AIState = any, UIState = any, Actions = any> = (
-  props: AIProviderProps<AIState, UIState, Actions>,
-) => Promise<React.ReactElement>;
+export interface AIProvider<AIState = any, UIState = any, Actions = any> {
+  $Actions: Actions;
+  (props: AIProviderProps<AIState, UIState>): Promise<React.ReactElement>;
+}
 
 export type InferAIState<T, Fallback> = T extends AIProvider<
   infer AIState,


### PR DESCRIPTION
Previously the InferActions didn't work, resulting in `useActions<typeof AI>()` returning `unknown`. I identified the cause for this was that you're not binding the Actions generic to anything so it gets lost:

![CleanShot 2024-03-04 at 00 04 28](https://github.com/vercel/ai/assets/51714798/2bb5adb3-7db4-4187-8e3b-b6d6fe7cf98e)

I added a prop to bind the generic so we get proper type inference. We use the `$Name` naming convention in tRPC to bind types, not sure if you got other preferences there

https://github.com/vercel/ai/assets/51714798/8c44eebd-7f96-4fc6-a45d-8744049d329b
