### PR TITLE
Second pass at fixing 404 links on AI SDK docs

### DIFF
--- a/docs/pages/docs/api-reference/ai-stream.mdx
+++ b/docs/pages/docs/api-reference/ai-stream.mdx
@@ -8,7 +8,7 @@ import { OptionTable } from '@/components/table';
 
 ## `AIStream(res: Response, customParser: AIStreamParser => void, callbacks?:  AIStreamCallbacksAndOptions): ReadableStream` [#aistream]
 
-`AIStream` is a helper function for creating a readable stream for AI responses. This is based on the responses returned by `fetch` and serves as the basis for the [`OpenAIStream`](./openai-stream) and [`AnthropicStream`](./anthropic-stream). It allows you to handle AI response streams in a controlled and customized manner that will work with [`useChat`](./use-chat) and [`useCompletion`](./use-completion).
+`AIStream` is a helper function for creating a readable stream for AI responses. This is based on the responses returned by `fetch` and serves as the basis for the [`OpenAIStream`](/docs/api-reference/providers/openai-stream) and [`AnthropicStream`](/docs/api-reference/providers/anthropic-stream). It allows you to handle AI response streams in a controlled and customized manner that will work with [`useChat`](./use-chat) and [`useCompletion`](./use-completion).
 
 `AIStream` will throw an error if `res` doesn't have a `2xx` status code. This is to ensure that the stream is only created for successful responses.
 
@@ -65,9 +65,9 @@ This is an object that contains the following properties:
   ]}
 />
 
-## Example: Using `AIStream` to create [`AnthropicStream`](./anthropic-stream)
+## Example: Using `AIStream` to create [`AnthropicStream`](/docs/api-reference/providers/anthropic-stream)
 
-Here is real example of how to use `AIStream` to create a stream that will work with [`useChat`](./use-chat) and [`useCompletion`](./use-completion). Here's is the implementation for [`AnthropicStream`](./anthropic-stream) which expects a response returned by `fetch`. [`AnthropicStream`](./anthropic-stream) is a specific implementation of `AIStream` for the Anthropic AI platform.
+Here is real example of how to use `AIStream` to create a stream that will work with [`useChat`](./use-chat) and [`useCompletion`](./use-completion). Here's is the implementation for [`AnthropicStream`](/docs/api-reference/providers/anthropic-stream) which expects a response returned by `fetch`. [`AnthropicStream`](/docs/api-reference/providers/anthropic-stream) is a specific implementation of `AIStream` for the Anthropic AI platform.
 
 ```tsx
 import {

--- a/docs/pages/docs/api-reference/providers.mdx
+++ b/docs/pages/docs/api-reference/providers.mdx
@@ -6,7 +6,7 @@
 - [GoogleGenerativeAIStream](./providers/google-generative-ai-stream)
 - [HuggingFaceStream](./providers/huggingface-stream)
 - [InkeepStream](./providers/inkeep-stream)
-- [LangChainStream](./providers/lang-chain-stream)
+- [LangChainStream](./providers/langchain-stream)
 - [MistralStream](./providers/mistral-stream)
 - [OpenAIStream](./providers/openai-stream)
 - [ReplicateStream](./providers/replicate-stream)

--- a/docs/pages/docs/api-reference/providers/langchain-stream.mdx
+++ b/docs/pages/docs/api-reference/providers/langchain-stream.mdx
@@ -2,7 +2,7 @@
 
 ## `LangChainStream(callbacks?: AIStreamCallbacks): { stream: ReadableStream, handlers: LangChainCallbacks }` [#langchainstream]
 
-`LangChainStream` is a utility function designed to facilitate the integration of [LangChain](https://js.langchain.com/docs) - a framework for engineering prompts for AI language models - with UI components and data streaming to the client side. Returns a `stream` and bag of [LangChain](js.langchain.com/docs) `BaseCallbackHandlerMethodsClass` that automatically implement streaming in such a way that you can use [`useChat`](./use-chat) and [`useCompletion`](./use-completion).
+`LangChainStream` is a utility function designed to facilitate the integration of [LangChain](https://js.langchain.com/docs) - a framework for engineering prompts for AI language models - with UI components and data streaming to the client side. Returns a `stream` and bag of [LangChain](https://js.langchain.com/docs) `BaseCallbackHandlerMethodsClass` that automatically implement streaming in such a way that you can use [`useChat`](/docs/api-reference/use-chat) and [`useCompletion`](/docs/api-reference/use-completion).
 
 ## Parameters
 


### PR DESCRIPTION
RE: Issue https://github.com/vercel/ai/issues/1058, after https://github.com/vercel/ai/pull/1059 was merged, I ran Screaming Frog again on the prod docs and found some more 404s.

This PR fixes what (hopefully) should be the last of them (for now):

 * https://sdk.vercel.ai/docs/api-reference/anthropic-stream
 * https://sdk.vercel.ai/docs/api-reference/openai-stream
 * https://sdk.vercel.ai/docs/api-reference/providers/js.langchain.com/docs
 * https://sdk.vercel.ai/docs/api-reference/providers/lang-chain-stream
 * https://sdk.vercel.ai/docs/api-reference/providers/use-chat
 * https://sdk.vercel.ai/docs/api-reference/providers/use-completion

I'd be glad to play around with dynamic routing (to avoid future 404s based on moving files around) if you could help me learn how to run these docs locally 😝 