### PR TITLE
Revert #1065

### DIFF
--- a/.changeset/khaki-starfishes-fold.md
+++ b/.changeset/khaki-starfishes-fold.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Revert "fix(render): parse the args based on the zod schema"


### PR DESCRIPTION
```
Error calling experimental_onToolCall: [Error: Invalid function call arguments in message. [
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "string",
    "path": [],
    "message": "Expected object, received string"
  }
]]

```

cc @IdoPesok 