### PR TITLE
Parse function call args

### DIFF
--- a/examples/next-openai/app/api/chat-with-tools/route.ts
+++ b/examples/next-openai/app/api/chat-with-tools/route.ts
@@ -86,7 +86,10 @@ export async function POST(req: Request) {
           // Call a weather API here
           const weatherData = {
             temperature: 20,
-            unit: toolCall.func.arguments.format === 'celsius' ? 'C' : 'F',
+            unit:
+              JSON.parse(toolCall.func.arguments).format === 'celsius'
+                ? 'C'
+                : 'F',
           };
 
           const newMessages = appendToolCallMessage({

--- a/examples/sveltekit-openai/src/routes/api/chat-with-tools/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/chat-with-tools/+server.ts
@@ -84,7 +84,10 @@ export async function POST({ request }) {
           // Call a weather API here
           const weatherData = {
             temperature: 20,
-            unit: toolCall.func.arguments.format === 'celsius' ? 'C' : 'F',
+            unit:
+              JSON.parse(toolCall.func.arguments).format === 'celsius'
+                ? 'C'
+                : 'F',
           };
 
           const newMessages = appendToolCallMessage({

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -292,7 +292,7 @@ export function render<
     const parseFunctionCallArguments = (fn: {
       type: 'functions' | 'tools';
       name: string;
-      arguments: any;
+      arguments: Record<string, unknown>;
     }) => {
       const renderer =
         fn.type === 'functions'
@@ -355,7 +355,8 @@ export function render<
                     handleRender(
                       parseFunctionCallArguments({
                         type: 'tools',
-                        ...tool.func,
+                        name: tool.func.name,
+                        arguments: JSON.parse(tool.func.arguments),
                       }),
                       options.tools?.[tool.func.name as any]?.render,
                       ui,

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -182,14 +182,14 @@ export function render<
     [name in keyof TS]: {
       description?: string;
       parameters: TS[name];
-      render: Renderer<z.infer<TS[name]>>;
+      render: Renderer<z.output<TS[name]>>;
     };
   };
   functions?: {
     [name in keyof FS]: {
       description?: string;
       parameters: FS[name];
-      render: Renderer<z.infer<FS[name]>>;
+      render: Renderer<z.output<FS[name]>>;
     };
   };
   initial?: ReactNode;
@@ -289,6 +289,27 @@ export function render<
     let hasFunction = false;
     let text = '';
 
+    const parseFunctionCallArguments = (fn: {
+      type: 'functions' | 'tools';
+      name: string;
+      arguments: any;
+    }) => {
+      const renderer =
+        fn.type === 'functions'
+          ? options.functions?.[fn.name]
+          : options.tools?.[fn.name];
+
+      const safeParsed = renderer?.parameters.safeParse(fn.arguments);
+
+      if (safeParsed && !safeParsed.success) {
+        throw new Error(
+          `Invalid function call arguments in message. ${safeParsed.error.message}`,
+        );
+      }
+
+      return safeParsed?.data;
+    };
+
     consumeStream(
       OpenAIStream(
         (await options.provider.chat.completions.create({
@@ -313,7 +334,10 @@ export function render<
                 async experimental_onFunctionCall(functionCallPayload) {
                   hasFunction = true;
                   handleRender(
-                    functionCallPayload.arguments,
+                    parseFunctionCallArguments({
+                      ...functionCallPayload,
+                      type: 'functions',
+                    }),
                     options.functions?.[functionCallPayload.name as any]
                       ?.render,
                     ui,
@@ -323,13 +347,16 @@ export function render<
             : {}),
           ...(tools
             ? {
-                async experimental_onToolCall(toolCallPayload: any) {
+                async experimental_onToolCall(toolCallPayload) {
                   hasFunction = true;
 
                   // TODO: We might need Promise.all here?
                   for (const tool of toolCallPayload.tools) {
                     handleRender(
-                      tool.func.arguments,
+                      parseFunctionCallArguments({
+                        type: 'tools',
+                        ...tool.func,
+                      }),
                       options.tools?.[tool.func.name as any]?.render,
                       ui,
                     );

--- a/packages/core/streams/ai-stream.ts
+++ b/packages/core/streams/ai-stream.ts
@@ -16,7 +16,7 @@ export interface ToolCallPayload {
     type: 'function';
     func: {
       name: string;
-      arguments: Record<string, unknown>;
+      arguments: string;
     };
   }[];
 }


### PR DESCRIPTION
#1065 take 2

It seems the `ToolCallPayload` was improperly typed as `{ arguments: Record<string, unknown> }` when it should have extended `{ arguments: string }`.

Per OpenAI docs, you must JSON.parse the tool -> function -> arguments. https://platform.openai.com/docs/guides/function-calling

In this PR, I chose to just fix the type and not parse it in the `OpenAIStream` since this would be a breaking change for many codebases that are already probably doing a `JSON.parse` in their own code without a conditional string check. The bad side is now this diverges from the function call types (which do get parsed in the `OpenAIStream`)

---------

To clarify -- to actually use this handler right using the current SDK version, you need to do:

```typescript
tool.func.arguments = JSON.parse(tool.func.arguments)
```

or in a more safe way

```typescript
tool.func.arguments = typeof tool.func.arguments === "string" ? JSON.parse(tool.func.arguments) : tool.func.arguments
```

The problem is if we change it now to do the parsing in `OpenAIStream`, it will break the code of those from case 1, where they parse in an unsafe way. Even worse, the types won't signal a breakage since it has been incorrectly typed as a Record so it would appear that nothing has changed.