### PR TITLE
added the additionalParams property to the options object in render function

### DIFF
--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -150,6 +150,10 @@ type Renderer<T> = (
   | Generator<Streamable, Streamable, void>
   | AsyncGenerator<Streamable, Streamable, void>;
 
+  type AdditionalParams = {
+    [key: string]: any;
+  };
+
 /**
  * `render` is a helper function to create a streamable UI from some LLMs.
  * Currently, it only supports OpenAI's GPT models with Function Calling and Assistants Tools.
@@ -194,6 +198,7 @@ export function render<
   };
   initial?: ReactNode;
   temperature?: number;
+  additionalParams?: AdditionalParams;
 }): ReactNode {
   const ui = createStreamableUI(options.initial);
 


### PR DESCRIPTION
This pr fixes #1061

I added the 'additionalParams' property to the options object, allowing users to pass arbitrary parameters when calling the render function.

