### PR TITLE
Add warning when streamables are not closed for a while during development

### DIFF
--- a/.changeset/good-masks-suffer.md
+++ b/.changeset/good-masks-suffer.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-improve dev error and warnings
+ai/rsc: improve dev error and warnings by trying to detect hanging streams

--- a/.changeset/good-masks-suffer.md
+++ b/.changeset/good-masks-suffer.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+improve dev error and warnings

--- a/packages/core/rsc/constants.ts
+++ b/packages/core/rsc/constants.ts
@@ -1,1 +1,2 @@
 export const STREAMABLE_VALUE_TYPE = Symbol.for('ui.streamable.value');
+export const DEV_DEFAULT_STREAMABLE_TIMEOUT = 10 * 1000;

--- a/packages/core/rsc/constants.ts
+++ b/packages/core/rsc/constants.ts
@@ -1,2 +1,2 @@
 export const STREAMABLE_VALUE_TYPE = Symbol.for('ui.streamable.value');
-export const DEV_DEFAULT_STREAMABLE_TIMEOUT = 10 * 1000;
+export const DEV_DEFAULT_STREAMABLE_WARNING_TIME = 15 * 1000;

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -8,7 +8,7 @@ import { OpenAIStream } from '../streams';
 
 import {
   STREAMABLE_VALUE_TYPE,
-  DEV_DEFAULT_STREAMABLE_TIMEOUT,
+  DEV_DEFAULT_STREAMABLE_WARNING_TIME,
 } from './constants';
 import {
   createResolvablePromise,
@@ -41,7 +41,7 @@ export function createStreamableUI(initialValue?: React.ReactNode) {
         console.warn(
           'The streamable UI has been slow to update. This may be a bug or a performance issue or you forgot to call `.done()`.',
         );
-      }, DEV_DEFAULT_STREAMABLE_TIMEOUT);
+      }, DEV_DEFAULT_STREAMABLE_WARNING_TIME);
     }
   }
   warnUnclosedStream();
@@ -130,7 +130,7 @@ export function createStreamableValue<T = any>(initialValue?: T) {
         console.warn(
           'The streamable UI has been slow to update. This may be a bug or a performance issue or you forgot to call `.done()`.',
         );
-      }, DEV_DEFAULT_STREAMABLE_TIMEOUT);
+      }, DEV_DEFAULT_STREAMABLE_WARNING_TIME);
     }
   }
   warnUnclosedStream();

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -22,16 +22,16 @@ export function createStreamableUI(initialValue?: React.ReactNode) {
   let closed = false;
   let { row, resolve, reject } = createSuspensedChunk(initialValue);
 
-  function assertStream() {
+  function assertStream(method: string) {
     if (closed) {
-      throw new Error('UI stream is already closed.');
+      throw new Error(method + ': UI stream is already closed.');
     }
   }
 
   return {
     value: row,
     update(value: React.ReactNode) {
-      assertStream();
+      assertStream('.update()');
 
       const resolvable = createResolvablePromise();
       currentValue = value;
@@ -41,7 +41,7 @@ export function createStreamableUI(initialValue?: React.ReactNode) {
       reject = resolvable.reject;
     },
     append(value: React.ReactNode) {
-      assertStream();
+      assertStream('.append()');
 
       const resolvable = createResolvablePromise();
       if (typeof currentValue === 'string' && typeof value === 'string') {
@@ -60,13 +60,13 @@ export function createStreamableUI(initialValue?: React.ReactNode) {
       reject = resolvable.reject;
     },
     error(error: any) {
-      assertStream();
+      assertStream('.error()');
 
       closed = true;
       reject(error);
     },
     done(...args: any) {
-      assertStream();
+      assertStream('.done()');
 
       closed = true;
       if (args.length) {
@@ -87,9 +87,9 @@ export function createStreamableValue<T = any>(initialValue?: T) {
   let closed = false;
   let { promise, resolve, reject } = createResolvablePromise();
 
-  function assertStream() {
+  function assertStream(method: string) {
     if (closed) {
-      throw new Error('Value stream is already closed.');
+      throw new Error(method + ': Value stream is already closed.');
     }
   }
 
@@ -111,7 +111,7 @@ export function createStreamableValue<T = any>(initialValue?: T) {
   return {
     value: createWrapped(initialValue, true),
     update(value: T) {
-      assertStream();
+      assertStream('.update()');
 
       const resolvePrevious = resolve;
       const resolvable = createResolvablePromise();
@@ -124,13 +124,13 @@ export function createStreamableValue<T = any>(initialValue?: T) {
       // currentValue = value
     },
     error(error: any) {
-      assertStream();
+      assertStream('.error()');
 
       closed = true;
       reject(error);
     },
     done(...args: any) {
-      assertStream();
+      assertStream('.done()');
 
       closed = true;
 

--- a/packages/core/rsc/streamable.ui.test.tsx
+++ b/packages/core/rsc/streamable.ui.test.tsx
@@ -319,4 +319,15 @@ describe('rsc - createStreamableUI()', () => {
     );
     expect(final).toMatchInlineSnapshot('"hello world!"');
   });
+
+  it('should error when updating a closed streamable', async () => {
+    const ui = createStreamableUI(<div>1</div>);
+    ui.done(<div>2</div>);
+
+    expect(() => {
+      ui.update(<div>3</div>);
+    }).toThrowErrorMatchingInlineSnapshot(
+      '".update(): UI stream is already closed."',
+    );
+  });
 });


### PR DESCRIPTION
This is an easy mistake to make. For now we can warn during development if there hasn't been any update to the stream for 15 seconds locally.