### PR TITLE
Parse tool call arguments for onToolCall callback.

### DIFF
--- a/packages/core/streams/openai-stream.test.ts
+++ b/packages/core/streams/openai-stream.test.ts
@@ -352,14 +352,14 @@ describe('OpenAIStream', () => {
       });
 
       const response = new StreamingTextResponse(stream);
-      const client = createClient(response);
-      const chunks = await client.readAll();
+
+      await createClient(response).readAll(); // consume stream
 
       expect(toolCalls).toEqual({
         tools: [
           {
             func: {
-              arguments: '{}',
+              arguments: {},
               name: 'get_date_time',
             },
             id: 'call_NPkY32jNUOb3Kkm7v9cOgmVg',
@@ -367,7 +367,9 @@ describe('OpenAIStream', () => {
           },
           {
             func: {
-              arguments: '{"url": "https://www.linkedin.com/in/jessepascoe"}',
+              arguments: {
+                url: 'https://www.linkedin.com/in/jessepascoe',
+              },
               name: 'open_webpage',
             },
             id: 'call_pOyOtXFQltSjUGsF7gnLAEcD',

--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -605,7 +605,7 @@ function createFunctionCallTransformer(
                 type: 'function',
                 func: {
                   name: tool.function.name,
-                  arguments: tool.function.arguments,
+                  arguments: JSON.parse(tool.function.arguments),
                 },
               });
             }


### PR DESCRIPTION
## Summary

The implementation did not parse the tool call arguments for the `experimental_onToolCall` callback, despite the types and other parts of the code expecting it to. This diff adds tool args parsing.

> [!WARNING]  
> This is a breaking change for users who ignore the types and just parse the args in onToolCall.
