### PR TITLE
Fixed mismatched function name in demo

### DIFF
--- a/examples/next-ai-rsc/app/action.tsx
+++ b/examples/next-ai-rsc/app/action.tsx
@@ -258,7 +258,7 @@ Besides that, you can also chat with users and do some calculations if needed.`,
       ...aiState.get(),
       {
         role: 'function',
-        name: 'list_stocks',
+        name: 'get_events',
         content: JSON.stringify(events),
       },
     ]);


### PR DESCRIPTION
I don't think this is integral to this working because GPT is smart enough to use the data regardless but it might make it slightly more reliable.