### PR TITLE
fix: Fix type resolution when `moduleResolution` is set to `node`

### DIFF
--- a/.changeset/smooth-numbers-whisper.md
+++ b/.changeset/smooth-numbers-whisper.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix type resolution

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,44 +40,37 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "module": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./rsc": {
-      "types": "./rsc/dist/index.d.mts",
+      "types": "./rsc/dist/index.d.ts",
       "react-server": "./rsc/dist/rsc-server.mjs",
-      "import": "./rsc/dist/rsc-client.mjs",
-      "module": "./rsc/dist/rsc-client.mjs"
+      "import": "./rsc/dist/rsc-client.mjs"
     },
     "./prompts": {
       "types": "./prompts/dist/index.d.ts",
       "import": "./prompts/dist/index.mjs",
-      "module": "./prompts/dist/index.mjs",
       "require": "./prompts/dist/index.js"
     },
     "./react": {
       "types": "./react/dist/index.d.ts",
       "react-server": "./react/dist/index.server.mjs",
       "import": "./react/dist/index.mjs",
-      "module": "./react/dist/index.mjs",
       "require": "./react/dist/index.js"
     },
     "./svelte": {
       "types": "./svelte/dist/index.d.ts",
       "import": "./svelte/dist/index.mjs",
-      "module": "./svelte/dist/index.mjs",
       "require": "./svelte/dist/index.js"
     },
     "./vue": {
       "types": "./vue/dist/index.d.ts",
       "import": "./vue/dist/index.mjs",
-      "module": "./vue/dist/index.mjs",
       "require": "./vue/dist/index.js"
     },
     "./solid": {
       "types": "./solid/dist/index.d.ts",
       "import": "./solid/dist/index.mjs",
-      "module": "./solid/dist/index.mjs",
       "require": "./solid/dist/index.js"
     }
   },

--- a/packages/core/rsc/package.json
+++ b/packages/core/rsc/package.json
@@ -1,5 +1,5 @@
 {
-  "types": "./dist/rsc-types.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     "types": "./dist/index.d.ts",
     "react-server": "./dist/rsc-server.mjs",

--- a/packages/core/rsc/package.json
+++ b/packages/core/rsc/package.json
@@ -1,10 +1,9 @@
 {
-  "types": "./dist/rsc-types.d.mts",
+  "types": "./dist/rsc-types.d.ts",
   "exports": {
-    "types": "./dist/index.d.mts",
+    "types": "./dist/index.d.ts",
     "react-server": "./dist/rsc-server.mjs",
-    "import": "./dist/rsc-client.mjs",
-    "module": "./dist/rsc-client.mjs"
+    "import": "./dist/rsc-client.mjs"
   },
   "private": true,
   "peerDependencies": {

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -80,13 +80,27 @@ export default defineConfig([
     dts: true,
     sourcemap: true,
   },
-  // RSC APIs - server, client, types
+  // RSC APIs - server, client
   {
-    entry: ['rsc/rsc-server.ts', 'rsc/rsc-client.ts', 'rsc/index.ts'],
+    entry: ['rsc/rsc-server.ts', 'rsc/rsc-client.ts'],
     outDir: 'rsc/dist',
     format: ['esm'],
     external: ['react', 'zod', /\/rsc-shared/],
     dts: true,
     sourcemap: true,
+  },
+  // RSC APIs - types
+  {
+    entry: ['rsc/index.ts'],
+    outDir: 'rsc/dist',
+    dts: true,
+    outExtension() {
+      return {
+        // It must be `.d.ts` instead of `.d.mts` to support node resolution.
+        // See https://github.com/vercel/ai/issues/1028.
+        dts: '.d.ts',
+        js: '.mjs',
+      };
+    },
   },
 ]);


### PR DESCRIPTION
Closes #1028.

It turns out that when using the `node` resolution, TS will always look for the CJS type definition (`.d.ts`) instead of the ESM one (`.d.mts`).

Also removes the extra `"module"` condition in `exports` as it's the same as `"import"`.

Tested a build locally as well as https://arethetypeswrong.github.io.

`ai@3.0.5`:

![CleanShot-2024-03-06-vKcvdJMq@2x](https://github.com/vercel/ai/assets/3676859/5c307ec3-8967-424d-a52b-4e4f560d24dd)


This PR:

![CleanShot-2024-03-06-29TI1un3@2x](https://github.com/vercel/ai/assets/3676859/442056c1-72e3-4063-9406-e09bdef18886)
