### PR TITLE
fix(render): parse the args based on the zod schema

### DIFF
--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -182,14 +182,14 @@ export function render<
     [name in keyof TS]: {
       description?: string;
       parameters: TS[name];
-      render: Renderer<z.infer<TS[name]>>;
+      render: Renderer<z.output<TS[name]>>;
     };
   };
   functions?: {
     [name in keyof FS]: {
       description?: string;
       parameters: FS[name];
-      render: Renderer<z.infer<FS[name]>>;
+      render: Renderer<z.output<FS[name]>>;
     };
   };
   initial?: ReactNode;
@@ -289,6 +289,27 @@ export function render<
     let hasFunction = false;
     let text = '';
 
+    const parseFunctionCallArguments = (fn: {
+      type: 'functions' | 'tools';
+      name: string;
+      arguments: any;
+    }) => {
+      const renderer =
+        fn.type === 'functions'
+          ? options.functions?.[fn.name]
+          : options.tools?.[fn.name];
+
+      const safeParsed = renderer?.parameters.safeParse(fn.arguments);
+
+      if (safeParsed && !safeParsed.success) {
+        throw new Error(
+          `Invalid function call arguments in message. ${safeParsed.error.message}`,
+        );
+      }
+
+      return safeParsed?.data;
+    };
+
     consumeStream(
       OpenAIStream(
         (await options.provider.chat.completions.create({
@@ -313,7 +334,10 @@ export function render<
                 async experimental_onFunctionCall(functionCallPayload) {
                   hasFunction = true;
                   handleRender(
-                    functionCallPayload.arguments,
+                    parseFunctionCallArguments({
+                      ...functionCallPayload,
+                      type: 'functions',
+                    }),
                     options.functions?.[functionCallPayload.name as any]
                       ?.render,
                     ui,
@@ -323,13 +347,16 @@ export function render<
             : {}),
           ...(tools
             ? {
-                async experimental_onToolCall(toolCallPayload: any) {
+                async experimental_onToolCall(toolCallPayload) {
                   hasFunction = true;
 
                   // TODO: We might need Promise.all here?
                   for (const tool of toolCallPayload.tools) {
                     handleRender(
-                      tool.func.arguments,
+                      parseFunctionCallArguments({
+                        type: 'tools',
+                        ...tool.func,
+                      }),
                       options.tools?.[tool.func.name as any]?.render,
                       ui,
                     );


### PR DESCRIPTION
#1065 Take 3

#1065 was reverted in #1080 due to a bug where the `toolCallPayload.func.arguments` were a string rather than a Record. In #1113 this behavior was fixed so now that bug should be gone since Zod will be parsing the object.