### PR TITLE
fix(ai/rsc): Optimize streamable value

### DIFF
--- a/.changeset/large-rivers-tease.md
+++ b/.changeset/large-rivers-tease.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-optimize streamable value
+ai/rsc: optimize streamable value stream size

--- a/.changeset/large-rivers-tease.md
+++ b/.changeset/large-rivers-tease.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+optimize streamable value

--- a/packages/core/rsc/streamable.ui.test.tsx
+++ b/packages/core/rsc/streamable.ui.test.tsx
@@ -3,12 +3,7 @@ import {
   openaiFunctionCallChunks,
 } from '../tests/snapshots/openai-chat';
 import { DEFAULT_TEST_URL, createMockServer } from '../tests/utils/mock-server';
-import { readStreamableValue } from './shared-client';
-import {
-  createStreamableUI,
-  createStreamableValue,
-  render,
-} from './streamable';
+import { createStreamableUI, render } from './streamable';
 import { z } from 'zod';
 
 const FUNCTION_CALL_TEST_URL = DEFAULT_TEST_URL + 'mock-func-call';
@@ -334,89 +329,5 @@ describe('rsc - createStreamableUI()', () => {
     }).toThrowErrorMatchingInlineSnapshot(
       '".update(): UI stream is already closed."',
     );
-  });
-});
-
-describe('rsc - createStreamableValue()', () => {
-  it('should directly emit the final value when reading .value', async () => {
-    const streamable = createStreamableValue('1');
-    streamable.update('2');
-    streamable.update('3');
-
-    expect(streamable.value).toMatchInlineSnapshot(`
-      {
-        "curr": "3",
-        "next": Promise {},
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
-
-    streamable.done('4');
-
-    expect(streamable.value).toMatchInlineSnapshot(`
-      {
-        "curr": "4",
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
-  });
-
-  it('should be able to stream any JSON values', async () => {
-    const streamable = createStreamableValue();
-    streamable.update({ v: 123 });
-
-    expect(streamable.value).toMatchInlineSnapshot(`
-      {
-        "curr": {
-          "v": 123,
-        },
-        "next": Promise {},
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
-
-    streamable.done();
-  });
-
-  it('should support .error()', async () => {
-    const streamable = createStreamableValue();
-    streamable.error('This is an error');
-
-    expect(streamable.value).toMatchInlineSnapshot(`
-      {
-        "error": "This is an error",
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
-  });
-
-  it('should support reading streamed values and errors', async () => {
-    const streamable = createStreamableValue(1);
-    (async () => {
-      await nextTick();
-      streamable.update(2);
-      await nextTick();
-      streamable.update(3);
-      await nextTick();
-      streamable.error('This is an error');
-    })();
-
-    const values = [];
-
-    try {
-      for await (const v of readStreamableValue(streamable.value)) {
-        values.push(v);
-      }
-    } catch (e) {
-      expect(e).toMatchInlineSnapshot(`"This is an error"`);
-    }
-
-    expect(values).toMatchInlineSnapshot(`
-      [
-        1,
-        2,
-        3,
-      ]
-    `);
   });
 });


### PR DESCRIPTION
This PR optimize `createStreamableValue` to return the streamable state starting from the moment when `.value` is read (i.e. `return`), instead of the stack of all previous values. This saves the stream size and simplifies the shape for cases like this:

```js
const streamable = createStreamableValue()

if (some_condition) {
  streamable.error('This is an error')
  return streamable.value
}

const data = await getData()
streamable.done(data)

return streamable.value
```

So the returned streamable will now have the error or data available directly without one or more `.next` ticks. Previously you'll need to `(await res.next).error`.

This makes the streamable more predictable as well because there can be initial checks like auth, before the actual streaming process. And the receiver side can just use `res.error` to tell if the initial checks pass or not on the app shell level.