### PR TITLE
fix(ai/rsc): Improve streamable `.done()` types

### DIFF
--- a/.changeset/early-pants-count.md
+++ b/.changeset/early-pants-count.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai/rsc): improve .done() argument type

--- a/packages/core/rsc/index.ts
+++ b/packages/core/rsc/index.ts
@@ -6,6 +6,7 @@ export type {
   render,
   createAI,
 } from './rsc-server';
+
 export type {
   readStreamableValue,
   useUIState,
@@ -13,3 +14,5 @@ export type {
   useActions,
   useSyncUIState,
 } from './rsc-client';
+
+export type { StreamableValue } from './types';

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -187,7 +187,7 @@ export function createStreamableValue<T = any, E = any>(initialValue?: T) {
 
       resolvable.resolve({ error });
     },
-    done(...args: any) {
+    done(...args: [] | [T]) {
       assertStream('.done()');
 
       if (warningTimeout) {

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -91,7 +91,7 @@ export function createStreamableUI(initialValue?: React.ReactNode) {
       closed = true;
       reject(error);
     },
-    done(...args: any) {
+    done(...args: [] | [React.ReactNode]) {
       assertStream('.done()');
 
       if (warningTimeout) {


### PR DESCRIPTION
This makes sure that TS can do proper type checking for `.done()` arguments.