### PR TITLE
Pass data from stream to the Message in useChat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ node_modules
 .turbo
 *.log
 .next
-dist
-dist-ssr
 *.local
 .env
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 .turbo
 *.log
 .next
+dist
+dist-ssr
 *.local
 .env
 .cache

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "singleQuote": true,
     "arrowParens": "avoid",
     "trailingComma": "all"
+  },
+  "dependencies": {
+    "ai": "^3.0.9"
   }
 }

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -91,6 +91,7 @@ const getStreamedResponse = async (
   onFinish?: (message: Message) => void,
   onResponse?: (response: Response) => void | Promise<void>,
   sendExtraMessageFields?: boolean,
+  passDataToMessage?: boolean,
 ) => {
   // Do an optimistic update to the chat state to show the updated messages
   // immediately.
@@ -198,6 +199,7 @@ const getStreamedResponse = async (
     },
     onFinish,
     generateId,
+    passDataToMessage,
   });
 };
 
@@ -216,6 +218,7 @@ export function useChat({
   headers,
   body,
   generateId = nanoid,
+  passDataToMessage = false,
 }: Omit<UseChatOptions, 'api'> & {
   api?: string | StreamingReactResponseAction;
   key?: string;
@@ -298,6 +301,7 @@ export function useChat({
               onFinish,
               onResponse,
               sendExtraMessageFields,
+              passDataToMessage,
             ),
           experimental_onFunctionCall,
           experimental_onToolCall,

--- a/packages/core/shared/call-chat-api.ts
+++ b/packages/core/shared/call-chat-api.ts
@@ -21,6 +21,7 @@ export async function callChatApi({
   onUpdate,
   onFinish,
   generateId,
+  passDataToMessage,
 }: {
   api: string;
   messages: Omit<Message, 'id'>[];
@@ -34,6 +35,7 @@ export async function callChatApi({
   onUpdate: (merged: Message[], data: JSONValue[] | undefined) => void;
   onFinish?: (message: Message) => void;
   generateId: IdGenerator;
+  passDataToMessage?: boolean;
 }) {
   const response = await fetch(api, {
     method: 'POST',
@@ -86,6 +88,7 @@ export async function callChatApi({
         }
       },
       generateId,
+      passDataToMessage,
     });
   } else {
     const createdAt = new Date();

--- a/packages/core/shared/parse-complex-response.ts
+++ b/packages/core/shared/parse-complex-response.ts
@@ -30,6 +30,7 @@ export async function parseComplexResponse({
   onFinish,
   generateId = nanoid,
   getCurrentDate = () => new Date(),
+  passDataToMessage,
 }: {
   reader: ReadableStreamDefaultReader<Uint8Array>;
   abortControllerRef?: {
@@ -39,6 +40,7 @@ export async function parseComplexResponse({
   onFinish?: (prefixMap: PrefixMap) => void;
   generateId?: () => string;
   getCurrentDate?: () => Date;
+  passDataToMessage?: boolean
 }) {
   const createdAt = getCurrentDate();
   const prefixMap: PrefixMap = {
@@ -65,6 +67,9 @@ export async function parseComplexResponse({
           content: value,
           createdAt,
         };
+        if (prefixMap.data.length > 0 && passDataToMessage) {
+          prefixMap['text'].data = [...prefixMap.data];
+        }
       }
     }
 
@@ -99,6 +104,9 @@ export async function parseComplexResponse({
 
     if (type === 'data') {
       prefixMap['data'].push(...value);
+      if (prefixMap['text'] && passDataToMessage) {
+        prefixMap['text'].data = [...prefixMap['data']];
+      }
     }
 
     let responseMessage = prefixMap['text'];

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -248,6 +248,12 @@ export type UseChatOptions = {
    * handle the extra fields before forwarding the request to the AI service.
    */
   sendExtraMessageFields?: boolean;
+
+  /**
+   * Whether to pass the `data` field from experimental_DataStream to the last message.
+   * Defaults to `false`. When set to `true`, the data will be passed to the message.
+   */
+  passDataToMessage?: boolean;
 };
 
 export type UseCompletionOptions = {


### PR DESCRIPTION
The data prop in useChat allows to recover some data from the stream. Once we receive the data it is not very easy to do something with it. So I added the possibility to add it directly to the message being streamed, allowing to display some extra data with it.