### PR TITLE
Fix `.append()` behavior

### DIFF
--- a/.changeset/hungry-moons-drive.md
+++ b/.changeset/hungry-moons-drive.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai/rsc): Fix .append() behavior

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,6 +111,7 @@
     "msw": "2.0.9",
     "openai": "4.28.4",
     "react-dom": "^18.2.0",
+    "react-server-dom-webpack": "18.3.0-canary-eb33bd747-20240312",
     "solid-js": "^1.8.7",
     "tsup": "^7.2.0",
     "typescript": "5.1.3",

--- a/packages/core/rsc/__snapshots__/streamable.ui.test.tsx.snap
+++ b/packages/core/rsc/__snapshots__/streamable.ui.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`rsc - render() > should emit React Nodes with async render function 1`]
   "children": {
     "children": {},
     "props": {
-      "current": undefined,
-      "next": {
+      "c": undefined,
+      "n": {
         "done": false,
         "next": {
           "done": true,
@@ -19,7 +19,7 @@ exports[`rsc - render() > should emit React Nodes with async render function 1`]
         </div>,
       },
     },
-    "type": "Row",
+    "type": "",
   },
   "props": {
     "fallback": undefined,
@@ -33,8 +33,8 @@ exports[`rsc - render() > should emit React Nodes with generator render function
   "children": {
     "children": {},
     "props": {
-      "current": undefined,
-      "next": {
+      "c": undefined,
+      "n": {
         "done": false,
         "next": {
           "done": false,
@@ -53,7 +53,7 @@ exports[`rsc - render() > should emit React Nodes with generator render function
         </div>,
       },
     },
-    "type": "Row",
+    "type": "",
   },
   "props": {
     "fallback": undefined,
@@ -67,8 +67,8 @@ exports[`rsc - render() > should emit React Nodes with sync render function 1`] 
   "children": {
     "children": {},
     "props": {
-      "current": undefined,
-      "next": {
+      "c": undefined,
+      "n": {
         "done": false,
         "next": {
           "done": true,
@@ -81,7 +81,7 @@ exports[`rsc - render() > should emit React Nodes with sync render function 1`] 
         </div>,
       },
     },
-    "type": "Row",
+    "type": "",
   },
   "props": {
     "fallback": undefined,

--- a/packages/core/rsc/shared-client/streamable.tsx
+++ b/packages/core/rsc/shared-client/streamable.tsx
@@ -11,7 +11,7 @@ function assertStreamableValue(
     value.type !== STREAMABLE_VALUE_TYPE
   ) {
     throw new Error(
-      'Invalid value: this hook only accepts values created via `createValueStream` from the server.',
+      'Invalid value: this hook only accepts values created via `createStreamableValue` from the server.',
     );
   }
 }

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -65,18 +65,9 @@ export function createStreamableUI(initialValue?: React.ReactNode) {
       assertStream('.append()');
 
       const resolvable = createResolvablePromise();
-      if (typeof currentValue === 'string' && typeof value === 'string') {
-        currentValue += value;
-      } else {
-        currentValue = (
-          <>
-            {currentValue}
-            {value}
-          </>
-        );
-      }
+      currentValue = value;
 
-      resolve({ value: currentValue, done: false, next: resolvable.promise });
+      resolve({ value, done: false, append: true, next: resolvable.promise });
       resolve = resolvable.resolve;
       reject = resolvable.reject;
 

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -233,7 +233,21 @@ export function render<
   messages: Parameters<
     typeof OpenAI.prototype.chat.completions.create
   >[0]['messages'];
-  text?: Renderer<{ content: string; done: boolean }>;
+  text?: Renderer<{
+    /**
+     * The full text content from the model so far.
+     */
+    content: string;
+    /**
+     * The new appended text content from the model since the last `text` call.
+     */
+    delta: string;
+    /**
+     * Whether the model is done generating text.
+     * If `true`, the `content` will be the final output and this call will be the last.
+     */
+    done: boolean;
+  }>;
   tools?: {
     [name in keyof TS]: {
       description?: string;
@@ -406,7 +420,7 @@ export function render<
             : {}),
           onText(chunk) {
             content += chunk;
-            handleRender({ content, done: false }, text, ui);
+            handleRender({ content, done: false, delta: chunk }, text, ui);
           },
           async onFinal() {
             if (hasFunction) {

--- a/packages/core/rsc/streamable.ui.test.tsx
+++ b/packages/core/rsc/streamable.ui.test.tsx
@@ -8,6 +8,46 @@ import { z } from 'zod';
 
 const FUNCTION_CALL_TEST_URL = DEFAULT_TEST_URL + 'mock-func-call';
 
+// This is a workaround to render the Flight response in a test environment.
+async function flightRender(node: React.ReactNode, byChunk?: boolean) {
+  const ReactDOM = require('react-dom');
+  ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactDOMCurrentDispatcher =
+    { current: {} };
+
+  const React = require('react');
+  React.__SECRET_SERVER_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = {
+    ReactSharedServerInternals: {},
+    ReactCurrentCache: {
+      current: null,
+    },
+  };
+
+  const {
+    renderToReadableStream,
+  } = require('react-server-dom-webpack/server.edge');
+
+  const stream = renderToReadableStream(node);
+  const reader = stream.getReader();
+
+  const chunks = [];
+  let result = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    const decoded = new TextDecoder().decode(value);
+    if (byChunk) {
+      chunks.push(decoded);
+    } else {
+      result += decoded;
+    }
+  }
+
+  return byChunk ? chunks : result;
+}
+
 const server = createMockServer([
   {
     url: DEFAULT_TEST_URL,
@@ -89,14 +129,45 @@ function getFinalValueFromResolved(node: any) {
   if (!node) return node;
   if (node.type === 'Symbol(react.suspense)') {
     return getFinalValueFromResolved(node.children);
-  } else if (node.type === 'Row') {
+  } else if (node.type === '') {
+    let wrapper;
     let value = node.props.value;
-    let next = node.props.next;
+    let next = node.props.n;
+    let current = node.props.c;
+
     while (next) {
+      if (next.append) {
+        if (wrapper === undefined) {
+          wrapper = current;
+        } else if (typeof current === 'string' && typeof wrapper === 'string') {
+          wrapper = wrapper + current;
+        } else {
+          wrapper = (
+            <>
+              {wrapper}
+              {current}
+            </>
+          );
+        }
+      }
+
       value = next.value;
       next = next.next;
+      current = value;
     }
-    return getFinalValueFromResolved(value);
+
+    return getFinalValueFromResolved(
+      wrapper === undefined ? (
+        value
+      ) : typeof value === 'string' && typeof wrapper === 'string' ? (
+        wrapper + value
+      ) : (
+        <>
+          {wrapper}
+          {value}
+        </>
+      ),
+    );
   }
   return node;
 }
@@ -243,25 +314,15 @@ describe('rsc - createStreamableUI()', () => {
     ui.append(<div>2</div>);
     ui.append(<div>3</div>);
 
-    const currentRsolved = ui.value.props.children.props.next;
+    const currentRsolved = ui.value.props.children.props.n;
     const tryResolve1 = await Promise.race([currentRsolved, nextTick()]);
     expect(tryResolve1).toBeDefined();
     const tryResolve2 = await Promise.race([tryResolve1.next, nextTick()]);
     expect(tryResolve2).toBeDefined();
     expect(getFinalValueFromResolved(tryResolve2.value)).toMatchInlineSnapshot(`
-      <React.Fragment>
-        <React.Fragment>
-          <div>
-            1
-          </div>
-          <div>
-            2
-          </div>
-        </React.Fragment>
-        <div>
-          3
-        </div>
-      </React.Fragment>
+      <div>
+        3
+      </div>
     `);
 
     ui.append(<div>4</div>);
@@ -292,7 +353,7 @@ describe('rsc - createStreamableUI()', () => {
     `);
   });
 
-  it('should support updating appended ui', async () => {
+  it('should support updating the appended ui', async () => {
     const ui = createStreamableUI(<div>1</div>);
     ui.update(<div>2</div>);
     ui.append(<div>3</div>);
@@ -302,9 +363,14 @@ describe('rsc - createStreamableUI()', () => {
       await simulateFlightServerRender(ui.value),
     );
     expect(final).toMatchInlineSnapshot(`
-      <div>
-        4
-      </div>
+      <React.Fragment>
+        <div>
+          2
+        </div>
+        <div>
+          4
+        </div>
+      </React.Fragment>
     `);
   });
 
@@ -318,6 +384,33 @@ describe('rsc - createStreamableUI()', () => {
       await simulateFlightServerRender(ui.value),
     );
     expect(final).toMatchInlineSnapshot('"hello world!"');
+  });
+
+  it('should send minimal incremental diffs when appending strings', async () => {
+    const ui = createStreamableUI('hello');
+    ui.append(' world');
+    ui.append(' and');
+    ui.append(' universe');
+    ui.done();
+
+    expect(await flightRender(ui.value)).toMatchInlineSnapshot(`
+      "1:\\"$Sreact.suspense\\"
+      2:D{\\"name\\":\\"\\",\\"env\\":\\"Server\\"}
+      0:[\\"$\\",\\"$1\\",null,{\\"fallback\\":\\"hello\\",\\"children\\":\\"$L2\\"}]
+      3:D{\\"name\\":\\"\\",\\"env\\":\\"Server\\"}
+      2:[\\"hello\\",[\\"$\\",\\"$1\\",null,{\\"fallback\\":\\" world\\",\\"children\\":\\"$L3\\"}]]
+      4:D{\\"name\\":\\"\\",\\"env\\":\\"Server\\"}
+      3:[\\" world\\",[\\"$\\",\\"$1\\",null,{\\"fallback\\":\\" and\\",\\"children\\":\\"$L4\\"}]]
+      5:D{\\"name\\":\\"\\",\\"env\\":\\"Server\\"}
+      4:[\\" and\\",[\\"$\\",\\"$1\\",null,{\\"fallback\\":\\" universe\\",\\"children\\":\\"$L5\\"}]]
+      5:\\" universe\\"
+      "
+    `);
+
+    const final = getFinalValueFromResolved(
+      await simulateFlightServerRender(ui.value),
+    );
+    expect(final).toMatchInlineSnapshot('"hello world and universe"');
   });
 
   it('should error when updating a closed streamable', async () => {

--- a/packages/core/rsc/utils.tsx
+++ b/packages/core/rsc/utils.tsx
@@ -13,15 +13,16 @@ export function createResolvablePromise<T = any>() {
   };
 }
 
-export function createSuspensedChunk(initialValue: React.ReactNode) {
-  const Row = (async ({
-    current,
-    next,
+// Use the name `R` for `Row` as it will be shorter in the RSC payload.
+const R = [
+  (async ({
+    c, // current
+    n, // next
   }: {
-    current: React.ReactNode;
-    next: Promise<any>;
+    c: React.ReactNode;
+    n: Promise<any>;
   }) => {
-    const chunk = await next;
+    const chunk = await n;
     if (chunk.done) {
       return chunk.value;
     }
@@ -29,9 +30,9 @@ export function createSuspensedChunk(initialValue: React.ReactNode) {
     if (chunk.append) {
       return (
         <>
-          {current}
+          {c}
           <Suspense fallback={chunk.value}>
-            <Row current={chunk.value} next={chunk.next} />
+            <R c={chunk.value} n={chunk.next} />
           </Suspense>
         </>
       );
@@ -39,20 +40,22 @@ export function createSuspensedChunk(initialValue: React.ReactNode) {
 
     return (
       <Suspense fallback={chunk.value}>
-        <Row current={chunk.value} next={chunk.next} />
+        <R c={chunk.value} n={chunk.next} />
       </Suspense>
     );
-  }) /* Our React typings don't support async components */ as unknown as React.FC<{
-    current: React.ReactNode;
-    next: Promise<any>;
-  }>;
+  }) as unknown as React.FC<{
+    c: React.ReactNode;
+    n: Promise<any>;
+  }>,
+][0];
 
+export function createSuspensedChunk(initialValue: React.ReactNode) {
   const { promise, resolve, reject } = createResolvablePromise();
 
   return {
     row: (
       <Suspense fallback={initialValue}>
-        <Row current={initialValue} next={promise} />
+        <R c={initialValue} n={promise} />
       </Suspense>
     ),
     resolve,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         version: 1.0.1
       ai:
         specifier: latest
-        version: link:../../packages/core
+        version: 3.0.9(react@18.2.0)(solid-js@1.8.7)(svelte@4.2.3)(vue@3.3.8)(zod@3.22.4)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -762,7 +762,7 @@ importers:
     dependencies:
       ai:
         specifier: ^3.0.0
-        version: link:../../packages/core
+        version: 3.0.9(react@18.2.0)(solid-js@1.8.7)(svelte@4.2.3)(vue@3.3.8)(zod@3.22.4)
       next:
         specifier: 14.1.1
         version: 14.1.1(react-dom@18.2.0)(react@18.2.0)
@@ -808,7 +808,7 @@ importers:
     dependencies:
       ai:
         specifier: ^3.0.0
-        version: link:../../packages/core
+        version: 3.0.9(react@18.2.0)(solid-js@1.8.7)(svelte@4.2.3)(vue@3.3.8)(zod@3.22.4)
       langchain:
         specifier: ^0.0.129
         version: 0.0.129(@mozilla/readability@0.4.4)(jsdom@23.0.0)
@@ -951,7 +951,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.1.4
-        version: 4.5.0(@types/node@17.0.45)
+        version: 4.5.0(@types/node@20.9.0)
 
   examples/sveltekit-openai:
     dependencies:
@@ -991,7 +991,7 @@ importers:
         version: 5.1.3
       vite:
         specifier: ^4.3.9
-        version: 4.5.0(@types/node@17.0.45)
+        version: 4.5.0(@types/node@20.9.0)
 
   packages/core:
     dependencies:
@@ -1061,7 +1061,7 @@ importers:
         version: 6.1.4(vitest@0.34.6)
       '@testing-library/react':
         specifier: ^14.0.0
-        version: 14.1.2(react-dom@18.2.0)(react@18.2.0)
+        version: 14.1.2(react-dom@18.2.0)
       '@testing-library/user-event':
         specifier: ^14.5.1
         version: 14.5.1(@testing-library/dom@9.3.3)
@@ -1110,6 +1110,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-server-dom-webpack:
+        specifier: 18.3.0-canary-eb33bd747-20240312
+        version: 18.3.0-canary-eb33bd747-20240312(react-dom@18.2.0)(webpack@5.89.0)
       solid-js:
         specifier: ^1.8.7
         version: 1.8.7
@@ -5900,7 +5903,7 @@ packages:
       svelte: 4.2.3
       tiny-glob: 0.2.9
       undici: 5.26.5
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5916,7 +5919,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.3)(vite@4.5.0)
       debug: 4.3.4
       svelte: 4.2.3
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5935,7 +5938,7 @@ packages:
       magic-string: 0.30.5
       svelte: 4.2.3
       svelte-hmr: 0.15.3(svelte@4.2.3)
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
       vitefu: 0.2.5(vite@4.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -5990,7 +5993,7 @@ packages:
       vitest: 0.34.6
     dev: true
 
-  /@testing-library/react@14.1.2(react-dom@18.2.0)(react@18.2.0):
+  /@testing-library/react@14.1.2(react-dom@18.2.0):
     resolution: {integrity: sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6000,7 +6003,6 @@ packages:
       '@babel/runtime': 7.23.2
       '@testing-library/dom': 9.3.3
       '@types/react-dom': 18.2.4
-      react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
@@ -6857,6 +6859,13 @@ packages:
       acorn: 8.11.2
     dev: true
 
+  /acorn-loose@8.4.0:
+    resolution: {integrity: sha512-M0EUka6rb+QC4l9Z3T0nJEzNOO7JcoJlYMrBlyBCiFSXRyxjLKayd4TbQs2FDRWQU1h9FR7QVNHt+PEaoNL5rQ==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.11.2
+    dev: true
+
   /acorn-walk@8.3.0:
     resolution: {integrity: sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==}
     engines: {node: '>=0.4.0'}
@@ -6932,6 +6941,43 @@ packages:
       swr-store: 0.10.6
       swrv: 1.0.4(vue@3.3.8)
       vue: 3.3.8(typescript@5.1.3)
+    dev: false
+
+  /ai@3.0.9(react@18.2.0)(solid-js@1.8.7)(svelte@4.2.3)(vue@3.3.8)(zod@3.22.4):
+    resolution: {integrity: sha512-v7y3+bSgGgiA1HkijvXcuHVSqZGljWRnBk/CFp5eJo+rSNFFSt/0s1IoAPZuE8hiWuqPrN9Pz9/cFKB1duh17g==}
+    engines: {node: '>=14.6'}
+    peerDependencies:
+      react: ^18.2.0
+      solid-js: ^1.7.7
+      svelte: ^3.0.0 || ^4.0.0
+      vue: ^3.3.4
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      eventsource-parser: 1.0.0
+      jsondiffpatch: 0.6.0
+      nanoid: 3.3.6
+      react: 18.2.0
+      solid-js: 1.8.7
+      solid-swr-store: 0.10.7(solid-js@1.8.7)(swr-store@0.10.6)
+      sswr: 2.0.0(svelte@4.2.3)
+      svelte: 4.2.3
+      swr: 2.2.0(react@18.2.0)
+      swr-store: 0.10.6
+      swrv: 1.0.4(vue@3.3.8)
+      vue: 3.3.8(typescript@5.1.6)
+      zod: 3.22.4
+      zod-to-json-schema: 3.22.4(zod@3.22.4)
     dev: false
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
@@ -14572,6 +14618,20 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /react-server-dom-webpack@18.3.0-canary-eb33bd747-20240312(react-dom@18.2.0)(webpack@5.89.0):
+    resolution: {integrity: sha512-0Gxe+B42OxoOtmBaUoyWYCOEK5TV8qojK1VT9R+nj6ac9uL99lEg91awPo7Xm8EnLOtJSFK1ILfR77SKzTXiPw==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: 18.3.0-canary-eb33bd747-20240312
+      react-dom: 18.3.0-canary-eb33bd747-20240312
+      webpack: ^5.59.0
+    dependencies:
+      acorn-loose: 8.4.0
+      neo-async: 2.6.2
+      react-dom: 18.2.0(react@18.2.0)
+      webpack: 5.89.0(esbuild@0.18.20)
+    dev: true
+
   /react-textarea-autosize@8.5.3(@types/react@18.2.8)(react@18.2.0):
     resolution: {integrity: sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==}
     engines: {node: '>=10'}
@@ -15323,7 +15383,7 @@ packages:
       sirv: 2.0.3
       solid-start: 0.3.10(@solidjs/meta@0.29.3)(@solidjs/router@0.8.2)(solid-js@1.8.7)(solid-start-node@0.3.10)(vite@4.5.0)
       terser: 5.24.0
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15395,7 +15455,7 @@ packages:
       solid-start-node: 0.3.10(solid-start@0.3.10)(vite@4.5.0)
       terser: 5.24.0
       undici: 5.27.2
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
       vite-plugin-inspect: 0.7.42(rollup@3.29.4)(vite@4.5.0)
       vite-plugin-solid: 2.7.2(solid-js@1.8.7)(vite@4.5.0)
       wait-on: 6.0.1(debug@4.3.4)
@@ -16051,6 +16111,31 @@ packages:
   /term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /terser-webpack-plugin@5.3.9(esbuild@0.18.20)(webpack@5.89.0):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.20
+      esbuild: 0.18.20
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.24.0
+      webpack: 5.89.0(esbuild@0.18.20)
     dev: true
 
   /terser-webpack-plugin@5.3.9(webpack@5.89.0):
@@ -17034,7 +17119,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.3
-      vite: 4.5.0(@types/node@17.0.45)
+      vite: 4.5.0(@types/node@20.9.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -17164,7 +17249,6 @@ packages:
       rollup: 3.29.4
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitefu@0.2.5(vite@4.5.0):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
@@ -17439,6 +17523,46 @@ packages:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.9(webpack@5.89.0)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
+
+  /webpack@5.89.0(esbuild@0.18.20):
+    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.11.2
+      acorn-import-assertions: 1.9.0(acorn@8.11.2)
+      browserslist: 4.22.1
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(esbuild@0.18.20)(webpack@5.89.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
This PR ensures that every `.append()` stashes the current UI and it becomes not updatable (via `.update()`). We're also adding more reliable tests via React Flight to ensure the RSC payload is incremental when calling `.append()`, instead of sending the full row again.

Also renamed some props and function names to minimize the payload size.

Fixes #1129.