### PR TITLE
Avoid appending Suspense boundary is the same reference is passed

### DIFF
--- a/.changeset/clever-bottles-do.md
+++ b/.changeset/clever-bottles-do.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai/rsc): avoid appending boundary is the same reference is passed

--- a/.changeset/clever-bottles-do.md
+++ b/.changeset/clever-bottles-do.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-fix(ai/rsc): avoid appending boundary is the same reference is passed
+fix(ai/rsc): avoid appending boundary if the same reference was passed

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -52,6 +52,12 @@ export function createStreamableUI(initialValue?: React.ReactNode) {
     update(value: React.ReactNode) {
       assertStream('.update()');
 
+      // There is no need to update the value if it's referentially equal.
+      if (value === currentValue) {
+        warnUnclosedStream();
+        return;
+      }
+
       const resolvable = createResolvablePromise();
       currentValue = value;
 

--- a/packages/core/rsc/streamable.ui.test.tsx
+++ b/packages/core/rsc/streamable.ui.test.tsx
@@ -423,4 +423,26 @@ describe('rsc - createStreamableUI()', () => {
       '".update(): UI stream is already closed."',
     );
   });
+
+  it('should avoid sending data again if the same UI is passed', async () => {
+    const node = <div>1</div>;
+    const ui = createStreamableUI(node);
+    ui.update(node);
+    ui.update(node);
+    ui.update(node);
+    ui.update(node);
+    ui.update(node);
+    ui.update(node);
+    ui.done();
+
+    expect(await flightRender(ui.value)).toMatchInlineSnapshot(`
+      "1:\\"$Sreact.suspense\\"
+      2:D{\\"name\\":\\"\\",\\"env\\":\\"Server\\"}
+      0:[\\"$\\",\\"$1\\",null,{\\"fallback\\":[\\"$\\",\\"div\\",null,{\\"children\\":\\"1\\"}],\\"children\\":\\"$L2\\"}]
+      4:{\\"children\\":\\"1\\"}
+      3:[\\"$\\",\\"div\\",null,\\"$4\\"]
+      2:\\"$3\\"
+      "
+    `);
+  });
 });


### PR DESCRIPTION
When calling `streamableUI.update()` with the same value, we should just avoid appending another nested Suspense boundary.