### PR TITLE
Expose setMessages for useAssistant hook

### DIFF
--- a/docs/pages/docs/api-reference/use-assistant.mdx
+++ b/docs/pages/docs/api-reference/use-assistant.mdx
@@ -129,6 +129,11 @@ The `experimental_useAssistant` hook returns an object with several helper metho
 <OptionTable
   options={[
     ['messages', 'Message[]', 'The current array of chat messages.'],
+    [
+      'setMessages',
+      'React.Dispatch<React.SetStateAction<Message>>',
+      'Function to update the `messages` array.',
+    ],
     ['threadId', 'string | undefined', 'The current thread ID.'],
     ['input', 'string', 'The current value of the input field.'],
     [

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -1,9 +1,10 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { useState } from 'react';
+import { nanoid } from 'nanoid';
+import { useEffect, useState } from 'react';
+
 import { readDataStream } from '../shared/read-data-stream';
 import { Message } from '../shared/types';
-import { nanoid } from 'nanoid';
 
 export type AssistantStatus = 'in_progress' | 'awaiting_message';
 
@@ -12,6 +13,11 @@ export type UseAssistantHelpers = {
    * The current array of chat messages.
    */
   messages: Message[];
+
+  /**
+   * setState-powered method to update the messages array.
+   */
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
 
   /**
    * The current thread ID.
@@ -107,6 +113,10 @@ export function experimental_useAssistant({
   const [threadId, setThreadId] = useState<string | undefined>(undefined);
   const [status, setStatus] = useState<AssistantStatus>('awaiting_message');
   const [error, setError] = useState<undefined | Error>(undefined);
+
+  useEffect(() => {
+    setMessages([]);
+  }, [threadIdParam]);
 
   const handleInputChange = (
     event:
@@ -236,6 +246,7 @@ export function experimental_useAssistant({
 
   return {
     messages,
+    setMessages,
     threadId,
     input,
     setInput,

--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import { nanoid } from 'nanoid';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { readDataStream } from '../shared/read-data-stream';
 import { Message } from '../shared/types';
@@ -113,10 +113,6 @@ export function experimental_useAssistant({
   const [threadId, setThreadId] = useState<string | undefined>(undefined);
   const [status, setStatus] = useState<AssistantStatus>('awaiting_message');
   const [error, setError] = useState<undefined | Error>(undefined);
-
-  useEffect(() => {
-    setMessages([]);
-  }, [threadIdParam]);
 
   const handleInputChange = (
     event:


### PR DESCRIPTION
This PR exposes the `setMessages()` function in the `useAssistant` hook.

This solves multiple issues brought up by members of our community:
- https://github.com/vercel/ai/issues/895
- https://github.com/vercel/ai/issues/888
- https://github.com/vercel/ai/issues/767


What this change enables:
- If the thread already has previous messages (eg. the user reloads the page), we need to be able to `setMessages(prevMessages)` upon initialization of the hook.
- If the chatbot has multiple threads and this hook is used in a parent component, then when the `threadId` changes, we need to either reset the `messages` to an empty array or to whatever the existing messages are in that thread.
- If the user requests a regeneration of the last message, we need to be able to remove the last message from the array and then submit it again.
- If the user decides to edit a message, we need to be able to remove all the messages until that edited message and then edit the message and submit it again.