### PR TITLE
[BUGFIX] - useAssistant - Check for empty array

### DIFF
--- a/packages/core/react/use-assistant.ts
+++ b/packages/core/react/use-assistant.ts
@@ -182,6 +182,9 @@ export function experimental_useAssistant({
           case 'text': {
             // text delta - add to last message:
             setMessages(messages => {
+              if (messages.length === 0) {
+                return messages;
+              }
               const lastMessage = messages[messages.length - 1];
               return [
                 ...messages.slice(0, messages.length - 1),
@@ -214,6 +217,9 @@ export function experimental_useAssistant({
 
             // set id of last message:
             setMessages(messages => {
+              if (messages.length === 0) {
+                return messages;
+              }
               const lastMessage = messages[messages.length - 1];
               lastMessage.id = value.messageId;
               return [...messages.slice(0, messages.length - 1), lastMessage];


### PR DESCRIPTION
When I was using the `useAssistant` hook, I noticed this error: `Unhandled Runtime Error
TypeError: Cannot set properties of undefined (setting 'id')`

![image](https://github.com/vercel/ai/assets/46210938/ccf7269f-c4f8-497e-aea9-3e31eff267fa)

This error was kind of cryptic since it doesn't say which element in `useAssistant` is causing this error. However, I figured out that it's due to `lastMessage` being undefined in the following code:
```
const lastMessage = messages[messages.length - 1];
  return [
    ...messages.slice(0, messages.length - 1),
    {
      id: lastMessage.id,
      role: lastMessage.role,
      content: lastMessage.content + value,
    },
  ];
  ```
  
  When `messages` has a length of `0`, then `lastMessage` becomes undefined and then we get a runtime error at `lastMessage.id`.