### PR TITLE
feat(ai/rsc): Patchable string values

### DIFF
--- a/.changeset/lemon-beans-bathe.md
+++ b/.changeset/lemon-beans-bathe.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai/rsc): support string diff and patch in streamable value

--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -87,9 +87,12 @@ export type MutableAIState<AIState> = {
   done: ((newState: AIState) => void) | (() => void);
 };
 
+export type StreamablePatch = undefined | [0, string]; // Append string.
+
 export type StreamableValue<T = any, E = any> = {
   type?: typeof STREAMABLE_VALUE_TYPE;
   curr?: T;
   error?: E;
+  diff?: StreamablePatch;
   next?: Promise<StreamableValue<T, E>>;
 };


### PR DESCRIPTION
This makes sure that when sending a streamed string over `createStreamableValue` will be optimized so that only the diff gets sent over the wire. This will be a common use case for generated content.

When can also look into a _special_<sup>*</sup> JSON diff-patch protocol for this API, so the shape will no longer matter.

*: We probably don't need fancy and expensive features like full text diff. Append-only is good enough for streaming cases.