### PR TITLE
ai/core type improvements

### DIFF
--- a/examples/ai-core/src/stream-object/mistral-json.ts
+++ b/examples/ai-core/src/stream-object/mistral-json.ts
@@ -27,7 +27,7 @@ async function main() {
       'Generate 3 character descriptions for a fantasy role playing game.',
   });
 
-  for await (const partialObject of result.objectStream) {
+  for await (const partialObject of result.partialObjectStream) {
     console.clear();
     console.log(partialObject);
   }

--- a/examples/ai-core/src/stream-object/mistral-tool.ts
+++ b/examples/ai-core/src/stream-object/mistral-tool.ts
@@ -27,7 +27,7 @@ async function main() {
       'Generate 3 character descriptions for a fantasy role playing game.',
   });
 
-  for await (const partialObject of result.objectStream) {
+  for await (const partialObject of result.partialObjectStream) {
     console.clear();
     console.log(partialObject);
   }

--- a/examples/ai-core/src/stream-object/mistral.ts
+++ b/examples/ai-core/src/stream-object/mistral.ts
@@ -26,7 +26,7 @@ async function main() {
       'Generate 3 character descriptions for a fantasy role playing game.',
   });
 
-  for await (const partialObject of result.objectStream) {
+  for await (const partialObject of result.partialObjectStream) {
     console.clear();
     console.log(partialObject);
   }

--- a/examples/ai-core/src/stream-object/openai-json.ts
+++ b/examples/ai-core/src/stream-object/openai-json.ts
@@ -27,7 +27,7 @@ async function main() {
       'Generate 3 character descriptions for a fantasy role playing game.',
   });
 
-  for await (const partialObject of result.objectStream) {
+  for await (const partialObject of result.partialObjectStream) {
     console.clear();
     console.log(partialObject);
   }

--- a/examples/ai-core/src/stream-object/openai-tool.ts
+++ b/examples/ai-core/src/stream-object/openai-tool.ts
@@ -27,7 +27,7 @@ async function main() {
       'Generate 3 character descriptions for a fantasy role playing game.',
   });
 
-  for await (const partialObject of result.objectStream) {
+  for await (const partialObject of result.partialObjectStream) {
     console.clear();
     console.log(partialObject);
   }

--- a/examples/ai-core/src/stream-object/openai.ts
+++ b/examples/ai-core/src/stream-object/openai.ts
@@ -26,7 +26,7 @@ async function main() {
       'Generate 3 character descriptions for a fantasy role playing game.',
   });
 
-  for await (const partialObject of result.objectStream) {
+  for await (const partialObject of result.partialObjectStream) {
     console.clear();
     console.log(partialObject);
   }

--- a/examples/ai-core/src/stream-object/openai.ts
+++ b/examples/ai-core/src/stream-object/openai.ts
@@ -1,4 +1,4 @@
-import { experimental_streamObject } from 'ai';
+import { DeepPartial, experimental_streamObject } from 'ai';
 import { OpenAI } from 'ai/openai';
 import dotenv from 'dotenv';
 import { z } from 'zod';
@@ -8,20 +8,21 @@ dotenv.config();
 const openai = new OpenAI();
 
 async function main() {
+  const schema = z.object({
+    characters: z.array(
+      z.object({
+        name: z.string(),
+        class: z
+          .string()
+          .describe('Character class, e.g. warrior, mage, or thief.'),
+        description: z.string(),
+      }),
+    ),
+  });
   const result = await experimental_streamObject({
     model: openai.chat('gpt-4-turbo-preview'),
     maxTokens: 2000,
-    schema: z.object({
-      characters: z.array(
-        z.object({
-          name: z.string(),
-          class: z
-            .string()
-            .describe('Character class, e.g. warrior, mage, or thief.'),
-          description: z.string(),
-        }),
-      ),
-    }),
+    schema: schema,
     prompt:
       'Generate 3 character descriptions for a fantasy role playing game.',
   });

--- a/packages/core/core/generate-object/stream-object.test.ts
+++ b/packages/core/core/generate-object/stream-object.test.ts
@@ -41,7 +41,7 @@ describe('result.objectStream', () => {
     });
 
     assert.deepStrictEqual(
-      await convertAsyncIterableToArray(result.objectStream),
+      await convertAsyncIterableToArray(result.partialObjectStream),
       [
         {},
         { content: 'Hello, ' },
@@ -129,7 +129,7 @@ describe('result.objectStream', () => {
     });
 
     assert.deepStrictEqual(
-      await convertAsyncIterableToArray(result.objectStream),
+      await convertAsyncIterableToArray(result.partialObjectStream),
       [
         {},
         { content: 'Hello, ' },

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -1,4 +1,3 @@
-import { PartialDeep } from 'type-fest';
 import { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 import {
@@ -16,6 +15,7 @@ import {
   AsyncIterableStream,
   createAsyncIterableStream,
 } from '../util/async-iterable-stream';
+import { DeepPartial } from '../util/deep-partial';
 import { isDeepEqualData } from '../util/is-deep-equal-data';
 import { parsePartialJson } from '../util/parse-partial-json';
 import { retryWithExponentialBackoff } from '../util/retry-with-exponential-backoff';
@@ -177,12 +177,9 @@ export class StreamObjectResult<T> {
     this.warnings = warnings;
   }
 
-  get partialObjectStream(): AsyncIterableStream<
-    PartialDeep<T, { recurseIntoArrays: true }>
-  > {
+  get partialObjectStream(): AsyncIterableStream<DeepPartial<T>> {
     let accumulatedText = '';
-    let latestObject: PartialDeep<T, { recurseIntoArrays: true }> | undefined =
-      undefined;
+    let latestObject: DeepPartial<T> | undefined = undefined;
 
     return createAsyncIterableStream(this.originalStream, {
       transform(chunk, controller) {
@@ -191,7 +188,7 @@ export class StreamObjectResult<T> {
 
           const currentObject = parsePartialJson(
             accumulatedText,
-          ) as PartialDeep<T, { recurseIntoArrays: true }>;
+          ) as DeepPartial<T>;
 
           if (!isDeepEqualData(latestObject, currentObject)) {
             latestObject = currentObject;

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -177,7 +177,7 @@ export class StreamObjectResult<T> {
     this.warnings = warnings;
   }
 
-  get objectStream(): AsyncIterableStream<
+  get partialObjectStream(): AsyncIterableStream<
     PartialDeep<T, { recurseIntoArrays: true }>
   > {
     let accumulatedText = '';

--- a/packages/core/core/generate-text/tool-call.ts
+++ b/packages/core/core/generate-text/tool-call.ts
@@ -1,4 +1,3 @@
-import { ValueOf } from 'type-fest';
 import { z } from 'zod';
 import {
   InvalidToolArgumentsError,
@@ -7,6 +6,7 @@ import {
   safeParseJSON,
 } from '../../ai-model-specification';
 import { ExperimentalTool } from '../tool';
+import { ValueOf } from '../util/value-of';
 
 export interface ToolCall<NAME extends string, ARGS> {
   toolCallId: string;

--- a/packages/core/core/generate-text/tool-result.ts
+++ b/packages/core/core/generate-text/tool-result.ts
@@ -1,6 +1,6 @@
-import { ValueOf } from 'type-fest';
 import { z } from 'zod';
 import { ExperimentalTool } from '../tool';
+import { ValueOf } from '../util/value-of';
 
 export interface ToolResult<NAME extends string, ARGS, RESULT> {
   toolCallId: string;

--- a/packages/core/core/index.ts
+++ b/packages/core/core/index.ts
@@ -2,3 +2,4 @@ export * from './generate-object';
 export * from './generate-text';
 export * from './prompt';
 export * from './tool';
+export * from './util/deep-partial';

--- a/packages/core/core/util/deep-partial.ts
+++ b/packages/core/core/util/deep-partial.ts
@@ -1,0 +1,81 @@
+// License for this File only:
+//
+// MIT License
+//
+// Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+// Copyright (c) Vercel, Inc. (https://vercel.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+import { z } from 'zod';
+
+/**
+Create a type from an object with all keys and nested keys set to optional. 
+The helper supports normal objects and Zod schemas (which are resolved automatically).
+It always recurses into arrays.
+
+Adopted from [type-fest](https://github.com/sindresorhus/type-fest/tree/main) PartialDeep.
+ */
+export type DeepPartial<T> = T extends
+  | null
+  | undefined
+  | string
+  | number
+  | boolean
+  | symbol
+  | bigint
+  | void
+  | Date
+  | RegExp
+  | ((...arguments_: any[]) => unknown)
+  | (new (...arguments_: any[]) => unknown)
+  ? T
+  : T extends Map<infer KeyType, infer ValueType>
+  ? PartialMap<KeyType, ValueType>
+  : T extends Set<infer ItemType>
+  ? PartialSet<ItemType>
+  : T extends ReadonlyMap<infer KeyType, infer ValueType>
+  ? PartialReadonlyMap<KeyType, ValueType>
+  : T extends ReadonlySet<infer ItemType>
+  ? PartialReadonlySet<ItemType>
+  : T extends z.Schema<any>
+  ? DeepPartial<T['_type']>
+  : T extends object
+  ? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
+    ? ItemType[] extends T // Test for arrays (non-tuples) specifically
+      ? readonly ItemType[] extends T // Differentiate readonly and mutable arrays
+        ? ReadonlyArray<DeepPartial<ItemType | undefined>>
+        : Array<DeepPartial<ItemType | undefined>>
+      : PartialObject<T> // Tuples behave properly
+    : PartialObject<T>
+  : unknown;
+
+type PartialMap<KeyType, ValueType> = {} & Map<
+  DeepPartial<KeyType>,
+  DeepPartial<ValueType>
+>;
+
+type PartialSet<T> = {} & Set<DeepPartial<T>>;
+
+type PartialReadonlyMap<KeyType, ValueType> = {} & ReadonlyMap<
+  DeepPartial<KeyType>,
+  DeepPartial<ValueType>
+>;
+
+type PartialReadonlySet<T> = {} & ReadonlySet<DeepPartial<T>>;
+
+type PartialObject<ObjectType extends object> = {
+  [KeyType in keyof ObjectType]?: DeepPartial<ObjectType[KeyType]>;
+};

--- a/packages/core/core/util/value-of.ts
+++ b/packages/core/core/util/value-of.ts
@@ -1,0 +1,65 @@
+// License for this File only:
+//
+// MIT License
+//
+// Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+// Copyright (c) Vercel, Inc. (https://vercel.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+/**
+Create a union of the given object's values, and optionally specify which keys to get the values from.
+
+Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/31438) if you want to have this type as a built-in in TypeScript.
+
+@example
+```
+// data.json
+{
+	'foo': 1,
+	'bar': 2,
+	'biz': 3
+}
+
+// main.ts
+import type {ValueOf} from 'type-fest';
+import data = require('./data.json');
+
+export function getData(name: string): ValueOf<typeof data> {
+	return data[name];
+}
+
+export function onlyBar(name: string): ValueOf<typeof data, 'bar'> {
+	return data[name];
+}
+
+// file.ts
+import {getData, onlyBar} from './main';
+
+getData('foo');
+//=> 1
+
+onlyBar('foo');
+//=> TypeError ...
+
+onlyBar('bar');
+//=> 2
+```
+* @see https://github.com/sindresorhus/type-fest/blob/main/source/value-of.d.ts
+*/
+export type ValueOf<
+  ObjectType,
+  ValueType extends keyof ObjectType = keyof ObjectType,
+> = ObjectType[ValueType];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,8 +108,7 @@
     "swr": "2.2.0",
     "swr-store": "0.10.6",
     "swrv": "1.0.4",
-    "zod-to-json-schema": "^3.22.4",
-    "type-fest": "4.10.3"
+    "zod-to-json-schema": "^3.22.4"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "0.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1105,9 +1105,6 @@ importers:
       swrv:
         specifier: 1.0.4
         version: 1.0.4(vue@3.3.8)
-      type-fest:
-        specifier: 4.10.3
-        version: 4.10.3
       vue:
         specifier: ^3.3.4
         version: 3.3.8(typescript@5.1.3)


### PR DESCRIPTION
## Summary
- rename `objectStream` to `partialObjectStream` (to leave room for future validated streams and to clarify content)
- remove `type-fest` dependency
- simplify `DeepPartial`
- extend `DeepPartial` to support zod schemas (which are automatically resolved)