### PR TITLE
Fix a Tailwind class not rendered in examples/next-ai-rsc

### DIFF
--- a/examples/next-ai-rsc/tailwind.config.ts
+++ b/examples/next-ai-rsc/tailwind.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx}',
     './ai_hooks/**/*.{js,ts,jsx,tsx}',
+    './lib/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
`<ChatScrollAnchor />` is used in `examples/next-ai-rsc`.
It is located in `./lib/hooks` directory but that directory is not included in Tailwind's config
preventing the inclusion of the `'h-px'` class, the html element to have 0 height.

