### PR TITLE
fix(ai/rsc): Improve typings for `StreamableValue`

### DIFF
--- a/.changeset/eight-points-dress.md
+++ b/.changeset/eight-points-dress.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai/rsc): improve typings for `StreamableValue`

--- a/packages/core/rsc/shared-client/streamable.ui.test.tsx
+++ b/packages/core/rsc/shared-client/streamable.ui.test.tsx
@@ -1,5 +1,8 @@
-import { createStreamableValue } from '../streamable';
-import { readStreamableValue } from './streamable';
+// import { createStreamableValue } from '../streamable';
+// import { readStreamableValue } from './streamable';
+
+import { createStreamableValue } from '../dist';
+import { readStreamableValue } from '../dist';
 
 function nextTick() {
   return Promise.resolve();

--- a/packages/core/rsc/shared-client/streamable.ui.test.tsx
+++ b/packages/core/rsc/shared-client/streamable.ui.test.tsx
@@ -1,8 +1,5 @@
-// import { createStreamableValue } from '../streamable';
-// import { readStreamableValue } from './streamable';
-
-import { createStreamableValue } from '../dist';
-import { readStreamableValue } from '../dist';
+import { createStreamableValue } from '../streamable';
+import { readStreamableValue } from './streamable';
 
 function nextTick() {
   return Promise.resolve();

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -213,7 +213,9 @@ export function createStreamableValue<T = any, E = any>(initialValue?: T) {
 
   return {
     /**
-     * The value of the streamable. This can be returned from a Server Action and received by the client.
+     * The value of the streamable. This can be returned from a Server Action and
+     * received by the client. To read the streamed values, use the
+     * `readStreamableValue` API.
      */
     get value() {
       return createWrapped(true);

--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -89,6 +89,10 @@ export type MutableAIState<AIState> = {
 
 export type StreamablePatch = undefined | [0, string]; // Append string.
 
+/**
+ * StreamableValue is a value that can be streamed over the network via AI Actions.
+ * To read the streamed values, use the `readStreamableValue` API.
+ */
 export type StreamableValue<T = any, E = any> = {
   type?: typeof STREAMABLE_VALUE_TYPE;
   curr?: T;

--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -94,9 +94,24 @@ export type StreamablePatch = undefined | [0, string]; // Append string.
  * To read the streamed values, use the `readStreamableValue` API.
  */
 export type StreamableValue<T = any, E = any> = {
+  /**
+   * @internal Use `readStreamableValue` to read the values.
+   */
   type?: typeof STREAMABLE_VALUE_TYPE;
+  /**
+   * @internal Use `readStreamableValue` to read the values.
+   */
   curr?: T;
+  /**
+   * @internal Use `readStreamableValue` to read the values.
+   */
   error?: E;
+  /**
+   * @internal Use `readStreamableValue` to read the values.
+   */
   diff?: StreamablePatch;
+  /**
+   * @internal Use `readStreamableValue` to read the values.
+   */
   next?: Promise<StreamableValue<T, E>>;
 };

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/@vercel/ai-tsconfig/react-library.json",
   "compilerOptions": {
-    "target": "ES2018"
+    "target": "ES2018",
+    "stripInternal": true
   },
   "include": ["."],
   "exclude": ["dist", "build", "node_modules"]


### PR DESCRIPTION
Adds proper JSDoc to mention about `readStreamableValue` in the `.value` property of streamable values, and marks properties of streamable values as internal only. This ensures that users can't access to them:

![CleanShot-2024-03-25-Z1H8N4zW@2x](https://github.com/vercel/ai/assets/3676859/957b1e78-be88-4b13-8fc5-c9e7a3e9d61b)
