### PR TITLE
(ai/rsc): add renderAzureOpenAI 

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -113,6 +113,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "0.18.0",
     "@aws-sdk/client-bedrock-runtime": "3.451.0",
+    "@azure/openai": "1.0.0-beta.11",
     "@edge-runtime/vm": "^3.1.7",
     "@google/generative-ai": "0.1.1",
     "@huggingface/inference": "2.6.4",

--- a/packages/core/rsc/__snapshots__/streamable.ui.test.tsx.snap
+++ b/packages/core/rsc/__snapshots__/streamable.ui.test.tsx.snap
@@ -89,3 +89,93 @@ exports[`rsc - render() > should emit React Nodes with sync render function 1`] 
   "type": "Symbol(react.suspense)",
 }
 `;
+
+exports[`rsc - renderAzureOpenAI() > should emit React Nodes with async renderAzureOpenAI function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "c": undefined,
+      "n": {
+        "done": false,
+        "next": {
+          "done": true,
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Weather
+        </div>,
+      },
+    },
+    "type": "",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
+exports[`rsc - renderAzureOpenAI() > should emit React Nodes with generator renderAzureOpenAI function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "c": undefined,
+      "n": {
+        "done": false,
+        "next": {
+          "done": false,
+          "next": {
+            "done": true,
+            "value": <div>
+              Weather
+            </div>,
+          },
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Loading...
+        </div>,
+      },
+    },
+    "type": "",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
+exports[`rsc - renderAzureOpenAI() > should emit React Nodes with sync renderAzureOpenAI function 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "c": undefined,
+      "n": {
+        "done": false,
+        "next": {
+          "done": true,
+          "value": <div>
+            Weather
+          </div>,
+        },
+        "value": <div>
+          Weather
+        </div>,
+      },
+    },
+    "type": "",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;

--- a/packages/core/rsc/index.ts
+++ b/packages/core/rsc/index.ts
@@ -4,6 +4,7 @@ export type {
   createStreamableUI,
   createStreamableValue,
   render,
+  renderAzureOpenAI,
   createAI,
 } from './rsc-server';
 

--- a/packages/core/rsc/rsc-server.ts
+++ b/packages/core/rsc/rsc-server.ts
@@ -3,5 +3,6 @@ export {
   createStreamableUI,
   createStreamableValue,
   render,
+  renderAzureOpenAI,
 } from './streamable';
 export { createAI } from './provider';

--- a/packages/core/rsc/streamable.ui.test.tsx
+++ b/packages/core/rsc/streamable.ui.test.tsx
@@ -3,7 +3,7 @@ import {
   openaiFunctionCallChunks,
 } from '../tests/snapshots/openai-chat';
 import { DEFAULT_TEST_URL, createMockServer } from '../tests/utils/mock-server';
-import { createStreamableUI, render } from './streamable';
+import { createStreamableUI, render, renderAzureOpenAI } from './streamable';
 import { z } from 'zod';
 
 const FUNCTION_CALL_TEST_URL = DEFAULT_TEST_URL + 'mock-func-call';
@@ -231,6 +231,79 @@ describe('rsc - render()', () => {
       model: 'gpt-3.5-turbo',
       messages: [],
       provider: createMockUpProvider(),
+      functions: {
+        get_current_weather: {
+          description: 'Get the current weather',
+          parameters: z.object({}),
+          render: async function* () {
+            yield <div>Loading...</div>;
+            await new Promise(resolve => setTimeout(resolve, 100));
+            return <div>Weather</div>;
+          },
+        },
+      },
+    });
+
+    const rendered = await simulateFlightServerRender(ui as any);
+    expect(rendered).toMatchSnapshot();
+  });
+});
+
+function createAzureOpenAIMockUpProvider() {
+  return {
+    streamChatCompletions: async () => {
+      return await fetch(FUNCTION_CALL_TEST_URL);
+    },
+  } as any;
+}
+
+describe('rsc - renderAzureOpenAI()', () => {
+  it('should emit React Nodes with sync renderAzureOpenAI function', async () => {
+    const ui = renderAzureOpenAI({
+      deploymentName: 'gpt-3.5-turbo',
+      messages: [],
+      provider: createAzureOpenAIMockUpProvider(),
+      functions: {
+        get_current_weather: {
+          description: 'Get the current weather',
+          parameters: z.object({}),
+          render: () => {
+            return <div>Weather</div>;
+          },
+        },
+      },
+    });
+
+    const rendered = await simulateFlightServerRender(ui as any);
+    expect(rendered).toMatchSnapshot();
+  });
+
+  it('should emit React Nodes with async renderAzureOpenAI function', async () => {
+    const ui = renderAzureOpenAI({
+      deploymentName: 'gpt-3.5-turbo',
+      messages: [],
+      provider: createAzureOpenAIMockUpProvider(),
+      functions: {
+        get_current_weather: {
+          description: 'Get the current weather',
+          parameters: z.object({}),
+          render: async () => {
+            await new Promise(resolve => setTimeout(resolve, 100));
+            return <div>Weather</div>;
+          },
+        },
+      },
+    });
+
+    const rendered = await simulateFlightServerRender(ui as any);
+    expect(rendered).toMatchSnapshot();
+  });
+
+  it('should emit React Nodes with generator renderAzureOpenAI function', async () => {
+    const ui = renderAzureOpenAI({
+      deploymentName: 'gpt-3.5-turbo',
+      messages: [],
+      provider: createAzureOpenAIMockUpProvider(),
       functions: {
         get_current_weather: {
           description: 'Get the current weather',


### PR DESCRIPTION
Added a function to use ai/rsc's render with Azure OpenAI.

The processing itself is almost the same as `render`, the only difference being the arguments and provider, so I think it would be better to extend `render` to accept multiple types of providers. I think how you write it depends on your policy. Here I wrote it in a separate function.