### PR TITLE
ai/core: add instruction to call specific tool to anthropic provider for generate object

### DIFF
--- a/packages/core/anthropic/anthropic-messages-language-model.test.ts
+++ b/packages/core/anthropic/anthropic-messages-language-model.test.ts
@@ -149,6 +149,17 @@ describe('doGenerate', () => {
       },
     ]);
     expect(finishReason).toStrictEqual('tool-calls');
+
+    // check injection of tool use instruction:
+    expect((await server.getRequestBodyJson()).messages).toStrictEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          { type: 'text', text: `\n\nUse the 'json' tool.` },
+        ],
+      },
+    ]);
   });
 
   it('should extract usage', async () => {

--- a/packages/core/anthropic/anthropic-messages-language-model.ts
+++ b/packages/core/anthropic/anthropic-messages-language-model.ts
@@ -131,16 +131,18 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
       }
 
       case 'object-tool': {
+        const { name, description, parameters } = mode.tool;
+
+        // add instruction to use tool:
+        baseArgs.messages[baseArgs.messages.length - 1].content.push({
+          type: 'text',
+          text: `\n\nUse the '${name}' tool.`,
+        });
+
         return {
           args: {
             ...baseArgs,
-            tools: [
-              {
-                name: mode.tool.name,
-                description: mode.tool.description,
-                input_schema: mode.tool.parameters,
-              },
-            ],
+            tools: [{ name, description, input_schema: parameters }],
           },
           warnings,
         };


### PR DESCRIPTION
Following this example: https://github.com/anthropics/anthropic-cookbook/blob/main/tool_use/extracting_structured_json.ipynb

This should increase robustness.