### PR TITLE
Handle OpenAI tool calls called after a message

### DIFF
--- a/packages/core/streams/openai-stream.test.ts
+++ b/packages/core/streams/openai-stream.test.ts
@@ -87,7 +87,7 @@ describe('OpenAIStream', () => {
     const chunks = await client.readAll();
 
     const expectedChunks = [
-      '{"function_call": {"name": "get_current_weather", "arguments": "',
+      '\n{"function_call": {"name": "get_current_weather", "arguments": "',
       '{\\n',
       '\\"',
       'location',
@@ -112,7 +112,7 @@ describe('OpenAIStream', () => {
 
     expect(chunks).toEqual(expectedChunks);
     expect(chunks.join('')).toEqual(
-      `{"function_call": {"name": "get_current_weather", "arguments": "{\\n\\"location\\": \\"Charlottesville, Virginia\\",\\n\\"format\\": \\"celsius\\"\\n}"}}`,
+      `\n{"function_call": {"name": "get_current_weather", "arguments": "{\\n\\"location\\": \\"Charlottesville, Virginia\\",\\n\\"format\\": \\"celsius\\"\\n}"}}`,
     );
   });
 
@@ -170,7 +170,7 @@ describe('OpenAIStream', () => {
       const chunks = await client.readAll();
 
       expect(chunks).toEqual([
-        '0:"{\\"function_call\\": {\\"name\\": \\"get_current_weather\\", \\"arguments\\": \\""\n',
+        '0:"\\n{\\"function_call\\": {\\"name\\": \\"get_current_weather\\", \\"arguments\\": \\""\n',
         '0:"{\\\\n"\n',
         '0:"\\\\\\""\n',
         '0:"location"\n',

--- a/packages/core/streams/openai-stream.ts
+++ b/packages/core/streams/openai-stream.ts
@@ -330,7 +330,7 @@ function chunkToText(): (
         isFunctionStreamingIn = true;
         return {
           isText: false,
-          content: `{"function_call": {"name": "${delta.function_call.name}", "arguments": "`,
+          content: `\n{"function_call": {"name": "${delta.function_call.name}", "arguments": "`,
         };
       } else if (delta.tool_calls?.[0]?.function?.name) {
         isFunctionStreamingIn = true;
@@ -338,7 +338,7 @@ function chunkToText(): (
         if (toolCall.index === 0) {
           return {
             isText: false,
-            content: `{"tool_calls":[ {"id": "${toolCall.id}", "type": "function", "function": {"name": "${toolCall.function?.name}", "arguments": "`,
+            content: `\n{"tool_calls":[ {"id": "${toolCall.id}", "type": "function", "function": {"name": "${toolCall.function?.name}", "arguments": "`,
           };
         } else {
           return {
@@ -511,8 +511,8 @@ function createFunctionCallTransformer(
 
       const shouldHandleAsFunction =
         isFirstChunk &&
-        (message.startsWith('{"function_call":') ||
-          message.startsWith('{"tool_calls":'));
+        (message.startsWith('\n{"function_call":') ||
+          message.startsWith('\n{"tool_calls":'));
 
       if (shouldHandleAsFunction) {
         isFunctionStreamingIn = true;


### PR DESCRIPTION
This PR handles the tool calls that appear in the middle of messages. The problem is exactly same as #1134, but the solution is different.

To solve the problem, we add a newline before the function call and tool call message in the stream. Then, in the client, we check for the presence of the lines and construct the objects accordingly.

This will _still_ break in the cases where a wrong message is constructed and `JSON.parse` fails.

Please let me know your thoughts on this. Love the great work!