### PR TITLE
ai/core: add toTextStreamResponse to streamText result

### DIFF
--- a/.changeset/pretty-poets-switch.md
+++ b/.changeset/pretty-poets-switch.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+ai/core: add toTextStreamResponse() method to streamText result

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -219,4 +219,30 @@ Stream callbacks that will be called when the stream emits events.
       .pipeThrough(createCallbacksTransformer(callbacks))
       .pipeThrough(createStreamDataTransformer());
   }
+
+  /**
+Creates a simple text stream response.
+Each text delta is encoded as UTF-8 and sent as a separate chunk.
+Non-text-delta events are ignored.
+   */
+  toTextStreamResponse(init?: ResponseInit): Response {
+    const encoder = new TextEncoder();
+    return new Response(
+      this.textStream.pipeThrough(
+        new TransformStream({
+          transform(chunk, controller) {
+            controller.enqueue(encoder.encode(chunk));
+          },
+        }),
+      ),
+      {
+        ...init,
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          ...init?.headers,
+        },
+      },
+    );
+  }
 }


### PR DESCRIPTION
## Use Case
Some users have custom frontend code that consumes simple text streams. They use the AI SDK to standardize different AI providers on the server side and just need a simple text stream that is sent to the client.