### PR TITLE
feat(types): Export type UseCompletionOptions

### DIFF
--- a/packages/core/react/use-completion.ts
+++ b/packages/core/react/use-completion.ts
@@ -7,6 +7,8 @@ import {
   UseCompletionOptions,
 } from '../shared/types';
 
+export type { UseCompletionOptions };
+
 export type UseCompletionHelpers = {
   /** The current completion result */
   completion: string;

--- a/packages/core/solid/use-completion.ts
+++ b/packages/core/solid/use-completion.ts
@@ -8,6 +8,8 @@ import type {
   UseCompletionOptions,
 } from '../shared/types';
 
+export type { UseCompletionOptions };
+
 export type UseCompletionHelpers = {
   /** The current completion result */
   completion: Resource<string>;

--- a/packages/core/svelte/use-completion.ts
+++ b/packages/core/svelte/use-completion.ts
@@ -7,6 +7,8 @@ import type {
   UseCompletionOptions,
 } from '../shared/types';
 
+export type { UseCompletionOptions };
+
 export type UseCompletionHelpers = {
   /** The current completion result */
   completion: Readable<string>;

--- a/packages/core/vue/use-completion.ts
+++ b/packages/core/vue/use-completion.ts
@@ -8,6 +8,8 @@ import type {
   UseCompletionOptions,
 } from '../shared/types';
 
+export type { UseCompletionOptions };
+
 export type UseCompletionHelpers = {
   /** The current completion result */
   completion: Ref<string>;


### PR DESCRIPTION
Similar to how `UseChatOptions` is exported.

Useful in cases where you want to omit some fields.

```ts
import { useCompletion, UseCompletionOptions } from 'ai/react'

const useMyCompletion = (options: Omit<UseCompletionOptions, 'api' | 'headers'>) => {
  const authToken = useMyToken()

  const completion = useCompletion({
    ...options,
    api: process.env.NEXT_PUBLIC_MY_AI_COMPLETION_URL,
    headers: {
      Authorization: `Bearer ${authToken}`,
    },
  })

  return completion
}
```