### PR TITLE
Fix highlighted code in StreamData documentation

### DIFF
--- a/docs/pages/docs/api-reference/stream-data.mdx
+++ b/docs/pages/docs/api-reference/stream-data.mdx
@@ -15,7 +15,7 @@ For information on the implementation, see the associated [pull request](https:/
 
 ### On the Server
 
-```jsx filename="app/api/chat/route.ts" {24-25,39-40,58-59,62-63,66-67}
+```jsx filename="app/api/chat/route.ts" {1,20-21,35-37,50-53,56-58,60-62}
 import { OpenAIStream, StreamingTextResponse, StreamData } from 'ai';
 import OpenAI from 'openai';
 import type { ChatCompletionCreateParams } from 'openai/resources/chat';


### PR DESCRIPTION
The highlights in the StreamData documentation do not highlight the actual changes required to begin using StreamData (they highlight unrelated lines of code).

This updates the highlights to showcase which lines are new and required for using `StreamData`

<img width="907" alt="Screenshot 2024-04-15 at 6 07 49 PM" src="https://github.com/vercel/ai/assets/540442/efec3c7d-dc29-4e34-bb98-5c7161cd2c2e">
