### PR TITLE
Add pnpm auth token to release-snapshot workflow

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           node-version: 18.x
 
+      - name: Add npm auth token to pnpm
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN_ELEVATED}"
+        env:
+          NPM_TOKEN_ELEVATED: ${{secrets.NPM_TOKEN_ELEVATED}}
+
       - name: Install Dependencies
         run: pnpm i
 


### PR DESCRIPTION
Fixes broken release: https://github.com/vercel/ai/actions/runs/8759107644/job/24041406214