### PR TITLE
ai/core: align setting ranges with OpenAI.

### DIFF
--- a/.changeset/shy-boats-rescue.md
+++ b/.changeset/shy-boats-rescue.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/openai': patch
+'ai': patch
+---
+
+ai/core: change setting ranges for experimental temperature, presencePenalty, frequencyPenalty to match OpenAI configuration (breaking change). If you use these settings, you need to update the provider packages and adjust your values.

--- a/docs/pages/docs/ai-core/settings.mdx
+++ b/docs/pages/docs/ai-core/settings.mdx
@@ -10,18 +10,18 @@ All AI functions (`generateText`, `streamText`, `generateObject`, `streamObject`
 
 - **maxTokens** - Maximum number of tokens to generate.
 - **temperature** - Temperature setting.
-  This is a number between 0 (almost no randomness) and 1 (very random).
+  This is a number between 0 (almost no randomness) and 2 (very random).
   It is recommended to set either `temperature` or `topP`, but not both.
 - **topP** - Nucleus sampling. This is a number between 0 and 1.
   E.g. 0.1 would mean that only tokens with the top 10% probability mass are considered.
   It is recommended to set either `temperature` or `topP`, but not both.
 - **presencePenalty** - Presence penalty setting.
   It affects the likelihood of the model to repeat information that is already in the prompt.
-  The presence penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition).
+  The presence penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition).
   0 means no penalty.
 - **frequencyPenalty** - Frequency penalty setting.
   It affects the likelihood of the model to repeatedly use the same words or phrases.
-  The frequency penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition).
+  The frequency penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition).
   0 means no penalty.
 - **seed** - The seed (integer) to use for random sampling.
   If set and supported by the model, calls will generate deterministic results.

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -296,6 +296,19 @@ describe('doStream', () => {
     });
   });
 
+  it('should scale the temperature', async () => {
+    prepareStreamResponse({ content: [] });
+
+    await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+      temperature: 2,
+    });
+
+    expect((await server.getRequestBodyJson()).temperature).toEqual(1);
+  });
+
   it('should pass custom headers', async () => {
     prepareStreamResponse({ content: [] });
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -11,6 +11,7 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   postJsonToApi,
+  scale,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import { anthropicFailedResponseHandler } from './anthropic-error';
@@ -96,7 +97,14 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
 
       // standardized settings:
       max_tokens: maxTokens ?? 4096, // 4096: max model output tokens
-      temperature, // uses 0..1 scale
+      temperature: scale({
+        // anthropic uses 0..1 scale:
+        value: temperature,
+        inputMin: 0,
+        inputMax: 2,
+        outputMin: 0,
+        outputMax: 1,
+      }),
       top_p: topP,
 
       // prompt:

--- a/packages/core/core/generate-object/generate-object.ts
+++ b/packages/core/core/generate-object/generate-object.ts
@@ -32,18 +32,18 @@ This function does not stream the output. If you want to stream the output, use 
 
 @param maxTokens - Maximum number of tokens to generate.
 @param temperature - Temperature setting. 
-This is a number between 0 (almost no randomness) and 1 (very random).
+This is a number between 0 (almost no randomness) and 2 (very random).
 It is recommended to set either `temperature` or `topP`, but not both.
 @param topP - Nucleus sampling. This is a number between 0 and 1.
 E.g. 0.1 would mean that only tokens with the top 10% probability mass are considered.
 It is recommended to set either `temperature` or `topP`, but not both.
 @param presencePenalty - Presence penalty setting. 
 It affects the likelihood of the model to repeat information that is already in the prompt.
-The presence penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition). 
+The presence penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition). 
 0 means no penalty.
 @param frequencyPenalty - Frequency penalty setting.
 It affects the likelihood of the model to repeatedly use the same words or phrases.
-The frequency penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition).
+The frequency penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition).
 0 means no penalty.
 @param seed - The seed (integer) to use for random sampling.
 If set and supported by the model, calls will generate deterministic results.

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -37,18 +37,18 @@ This function streams the output. If you do not want to stream the output, use `
 
 @param maxTokens - Maximum number of tokens to generate.
 @param temperature - Temperature setting. 
-This is a number between 0 (almost no randomness) and 1 (very random).
+This is a number between 0 (almost no randomness) and 2 (very random).
 It is recommended to set either `temperature` or `topP`, but not both.
 @param topP - Nucleus sampling. This is a number between 0 and 1.
 E.g. 0.1 would mean that only tokens with the top 10% probability mass are considered.
 It is recommended to set either `temperature` or `topP`, but not both.
 @param presencePenalty - Presence penalty setting. 
 It affects the likelihood of the model to repeat information that is already in the prompt.
-The presence penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition). 
+The presence penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition). 
 0 means no penalty.
 @param frequencyPenalty - Frequency penalty setting.
 It affects the likelihood of the model to repeatedly use the same words or phrases.
-The frequency penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition).
+The frequency penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition).
 0 means no penalty.
 @param seed - The seed (integer) to use for random sampling.
 If set and supported by the model, calls will generate deterministic results.

--- a/packages/core/core/generate-text/generate-text.ts
+++ b/packages/core/core/generate-text/generate-text.ts
@@ -29,18 +29,18 @@ This function does not stream the output. If you want to stream the output, use 
 
 @param maxTokens - Maximum number of tokens to generate.
 @param temperature - Temperature setting. 
-This is a number between 0 (almost no randomness) and 1 (very random).
+This is a number between 0 (almost no randomness) and 2 (very random).
 It is recommended to set either `temperature` or `topP`, but not both.
 @param topP - Nucleus sampling. This is a number between 0 and 1.
 E.g. 0.1 would mean that only tokens with the top 10% probability mass are considered.
 It is recommended to set either `temperature` or `topP`, but not both.
 @param presencePenalty - Presence penalty setting. 
 It affects the likelihood of the model to repeat information that is already in the prompt.
-The presence penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition). 
+The presence penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition). 
 0 means no penalty.
 @param frequencyPenalty - Frequency penalty setting.
 It affects the likelihood of the model to repeatedly use the same words or phrases.
-The frequency penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition).
+The frequency penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition).
 0 means no penalty.
 @param seed - The seed (integer) to use for random sampling.
 If set and supported by the model, calls will generate deterministic results.

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -38,18 +38,18 @@ This function streams the output. If you do not want to stream the output, use `
 
 @param maxTokens - Maximum number of tokens to generate.
 @param temperature - Temperature setting. 
-This is a number between 0 (almost no randomness) and 1 (very random).
+This is a number between 0 (almost no randomness) and 2 (very random).
 It is recommended to set either `temperature` or `topP`, but not both.
 @param topP - Nucleus sampling. This is a number between 0 and 1.
 E.g. 0.1 would mean that only tokens with the top 10% probability mass are considered.
 It is recommended to set either `temperature` or `topP`, but not both.
 @param presencePenalty - Presence penalty setting. 
 It affects the likelihood of the model to repeat information that is already in the prompt.
-The presence penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition). 
+The presence penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition). 
 0 means no penalty.
 @param frequencyPenalty - Frequency penalty setting.
 It affects the likelihood of the model to repeatedly use the same words or phrases.
-The frequency penalty is a number between -1 (increase repetition) and 1 (maximum penalty, decrease repetition).
+The frequency penalty is a number between -2 (increase repetition) and 2 (maximum penalty, decrease repetition).
 0 means no penalty.
 @param seed - The seed (integer) to use for random sampling.
 If set and supported by the model, calls will generate deterministic results.

--- a/packages/core/core/prompt/prepare-call-settings.ts
+++ b/packages/core/core/prompt/prepare-call-settings.ts
@@ -2,7 +2,7 @@ import { InvalidArgumentError } from '@ai-sdk/provider';
 import { CallSettings } from './call-settings';
 
 /**
- * Validates call settings and sets default values.
+Validates call settings and sets default values.
  */
 export function prepareCallSettings({
   maxTokens,
@@ -40,11 +40,11 @@ export function prepareCallSettings({
       });
     }
 
-    if (temperature < 0 || temperature > 1) {
+    if (temperature < 0 || temperature > 2) {
       throw new InvalidArgumentError({
         parameter: 'temperature',
         value: temperature,
-        message: 'temperature must be between 0 and 1 (inclusive)',
+        message: 'temperature must be between 0 and 2 (inclusive)',
       });
     }
   }
@@ -76,11 +76,11 @@ export function prepareCallSettings({
       });
     }
 
-    if (presencePenalty < -1 || presencePenalty > 1) {
+    if (presencePenalty < -2 || presencePenalty > 2) {
       throw new InvalidArgumentError({
         parameter: 'presencePenalty',
         value: presencePenalty,
-        message: 'presencePenalty must be between -1 and 1 (inclusive)',
+        message: 'presencePenalty must be between -2 and 2 (inclusive)',
       });
     }
   }
@@ -94,11 +94,11 @@ export function prepareCallSettings({
       });
     }
 
-    if (frequencyPenalty < -1 || frequencyPenalty > 1) {
+    if (frequencyPenalty < -2 || frequencyPenalty > 2) {
       throw new InvalidArgumentError({
         parameter: 'frequencyPenalty',
         value: frequencyPenalty,
-        message: 'frequencyPenalty must be between -1 and 1 (inclusive)',
+        message: 'frequencyPenalty must be between -2 and 2 (inclusive)',
       });
     }
   }

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -11,6 +11,7 @@ const TEST_PROMPT: LanguageModelV1Prompt = [
 ];
 
 const provider = createMistral({ apiKey: 'test-api-key' });
+const model = provider.chat('mistral-small-latest');
 
 describe('doGenerate', () => {
   const server = new JsonTestServer(
@@ -58,7 +59,7 @@ describe('doGenerate', () => {
   it('should extract text response', async () => {
     prepareJsonResponse({ content: 'Hello, World!' });
 
-    const { text } = await provider.chat('mistral-small-latest').doGenerate({
+    const { text } = await model.doGenerate({
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
@@ -73,7 +74,7 @@ describe('doGenerate', () => {
       usage: { prompt_tokens: 20, total_tokens: 25, completion_tokens: 5 },
     });
 
-    const { usage } = await provider.chat('mistral-small-latest').doGenerate({
+    const { usage } = await model.doGenerate({
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
@@ -88,7 +89,7 @@ describe('doGenerate', () => {
   it('should pass the model and the messages', async () => {
     prepareJsonResponse({ content: '' });
 
-    await provider.chat('mistral-small-latest').doGenerate({
+    await model.doGenerate({
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
@@ -167,7 +168,7 @@ describe('doStream', () => {
   it('should stream text deltas', async () => {
     prepareStreamResponse({ content: ['Hello', ', ', 'world!'] });
 
-    const { stream } = await provider.chat('mistral-small-latest').doStream({
+    const { stream } = await model.doStream({
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
@@ -254,7 +255,7 @@ describe('doStream', () => {
   it('should pass the messages', async () => {
     prepareStreamResponse({ content: [''] });
 
-    await provider.chat('mistral-small-latest').doStream({
+    await model.doStream({
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
@@ -265,6 +266,19 @@ describe('doStream', () => {
       model: 'mistral-small-latest',
       messages: [{ role: 'user', content: 'Hello' }],
     });
+  });
+
+  it('should scale the temperature', async () => {
+    prepareStreamResponse({ content: [] });
+
+    await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+      temperature: 2,
+    });
+
+    expect((await server.getRequestBodyJson()).temperature).toEqual(1);
   });
 
   it('should pass custom headers', async () => {

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -10,6 +10,7 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   postJsonToApi,
+  scale,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import { convertToMistralChatMessages } from './convert-to-mistral-chat-messages';
@@ -87,7 +88,14 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
 
       // standardized settings:
       max_tokens: maxTokens,
-      temperature, // uses 0..1 scale
+      temperature: scale({
+        // mistral uses 0..1 scale:
+        value: temperature,
+        inputMin: 0,
+        inputMax: 2,
+        outputMin: 0,
+        outputMax: 1,
+      }),
       top_p: topP,
       random_seed: seed,
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -330,51 +330,6 @@ describe('doStream', () => {
     });
   });
 
-  it('should scale the temperature', async () => {
-    prepareStreamResponse({ content: [] });
-
-    await provider.chat('gpt-3.5-turbo').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-      temperature: 0.5,
-    });
-
-    expect((await server.getRequestBodyJson()).temperature).toBeCloseTo(1, 5);
-  });
-
-  it('should scale the frequency penalty', async () => {
-    prepareStreamResponse({ content: [] });
-
-    await provider.chat('gpt-3.5-turbo').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-      frequencyPenalty: 0.2,
-    });
-
-    expect((await server.getRequestBodyJson()).frequency_penalty).toBeCloseTo(
-      0.4,
-      5,
-    );
-  });
-
-  it('should scale the presence penalty', async () => {
-    prepareStreamResponse({ content: [] });
-
-    await provider.chat('gpt-3.5-turbo').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-      presencePenalty: -0.9,
-    });
-
-    expect((await server.getRequestBodyJson()).presence_penalty).toBeCloseTo(
-      -1.8,
-      5,
-    );
-  });
-
   it('should pass custom headers', async () => {
     prepareStreamResponse({ content: [] });
 

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -12,7 +12,6 @@ import {
   generateId,
   isParseableJson,
   postJsonToApi,
-  scale,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import { convertToOpenAIChatMessages } from './convert-to-openai-chat-messages';
@@ -71,26 +70,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
 
       // standardized settings:
       max_tokens: maxTokens,
-      temperature: scale({
-        value: temperature,
-        outputMin: 0,
-        outputMax: 2,
-      }),
+      temperature,
       top_p: topP,
-      frequency_penalty: scale({
-        value: frequencyPenalty,
-        inputMin: -1,
-        inputMax: 1,
-        outputMin: -2,
-        outputMax: 2,
-      }),
-      presence_penalty: scale({
-        value: presencePenalty,
-        inputMin: -1,
-        inputMax: 1,
-        outputMin: -2,
-        outputMax: 2,
-      }),
+      frequency_penalty: frequencyPenalty,
+      presence_penalty: presencePenalty,
       seed,
 
       // messages:

--- a/packages/openai/src/openai-completion-language-model.test.ts
+++ b/packages/openai/src/openai-completion-language-model.test.ts
@@ -208,51 +208,6 @@ describe('doStream', () => {
     });
   });
 
-  it('should scale the temperature', async () => {
-    prepareStreamResponse({ content: [] });
-
-    await provider.completion('gpt-3.5-turbo-instruct').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-      temperature: 0.5,
-    });
-
-    expect((await server.getRequestBodyJson()).temperature).toBeCloseTo(1, 5);
-  });
-
-  it('should scale the frequency penalty', async () => {
-    prepareStreamResponse({ content: [] });
-
-    await provider.completion('gpt-3.5-turbo-instruct').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-      frequencyPenalty: 0.2,
-    });
-
-    expect((await server.getRequestBodyJson()).frequency_penalty).toBeCloseTo(
-      0.4,
-      5,
-    );
-  });
-
-  it('should scale the presence penalty', async () => {
-    prepareStreamResponse({ content: [] });
-
-    await provider.completion('gpt-3.5-turbo-instruct').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-      presencePenalty: -0.9,
-    });
-
-    expect((await server.getRequestBodyJson()).presence_penalty).toBeCloseTo(
-      -1.8,
-      5,
-    );
-  });
-
   it('should pass custom headers', async () => {
     prepareStreamResponse({ content: [] });
 

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -9,7 +9,6 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   postJsonToApi,
-  scale,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import { convertToOpenAICompletionPrompt } from './convert-to-openai-completion-prompt';
@@ -77,26 +76,10 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
 
       // standardized settings:
       max_tokens: maxTokens,
-      temperature: scale({
-        value: temperature,
-        outputMin: 0,
-        outputMax: 2,
-      }),
+      temperature,
       top_p: topP,
-      frequency_penalty: scale({
-        value: frequencyPenalty,
-        inputMin: -1,
-        inputMax: 1,
-        outputMin: -2,
-        outputMax: 2,
-      }),
-      presence_penalty: scale({
-        value: presencePenalty,
-        inputMin: -1,
-        inputMax: 1,
-        outputMin: -2,
-        outputMax: 2,
-      }),
+      frequency_penalty: frequencyPenalty,
+      presence_penalty: presencePenalty,
       seed,
 
       // prompt:

--- a/packages/provider/src/language-model/v1/language-model-v1-call-settings.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-settings.ts
@@ -6,7 +6,7 @@ export type LanguageModelV1CallSettings = {
 
   /**
    * Temperature setting. This is a number between 0 (almost no randomness) and
-   * 1 (very random).
+   * 2 (very random).
    *
    * Different LLM providers have different temperature
    * scales, so they'd need to map it (without mapping, the same temperature has
@@ -32,8 +32,8 @@ export type LanguageModelV1CallSettings = {
    * Presence penalty setting. It affects the likelihood of the model to
    * repeat information that is already in the prompt.
    *
-   * The presence penalty is a number between -1 (increase repetition)
-   * and 1 (maximum penalty, decrease repetition). 0 means no penalty.
+   * The presence penalty is a number between -2 (increase repetition)
+   * and 2 (maximum penalty, decrease repetition). 0 means no penalty.
    */
   presencePenalty?: number;
 
@@ -41,8 +41,8 @@ export type LanguageModelV1CallSettings = {
    * Frequency penalty setting. It affects the likelihood of the model
    * to repeatedly use the same words or phrases.
    *
-   * The frequency penalty is a number between -1 (increase repetition)
-   * and 1 (maximum penalty, decrease repetition). 0 means no penalty.
+   * The frequency penalty is a number between -2 (increase repetition)
+   * and 2 (maximum penalty, decrease repetition). 0 means no penalty.
    */
   frequencyPenalty?: number;
 


### PR DESCRIPTION
## Summary
* Aligns the ranges for `temperature`, `frequencyPenalty` and `presencePenalty` with the OpenAI API