### PR TITLE
Add DataStream support to streamToResponse

### DIFF
--- a/docs/pages/docs/api-reference/stream-to-response.mdx
+++ b/docs/pages/docs/api-reference/stream-to-response.mdx
@@ -8,7 +8,7 @@ import { OptionTable } from '@/components/table';
   [`web-streams-polyfill`](https://www.npmjs.com/package/web-streams-polyfill).
 </Callout>
 
-## `streamToResponse(stream: ReadableStream, response: ServerResponse, options?: Options)`
+## `streamToResponse(stream: ReadableStream, response: ServerResponse, options?: Options, data?: DataStream)`
 
 This method will pipe a `ReadableStream` to a Node.js `ServerResponse` object. It can be helpful to combine this with other AI stream utilities, such as [`OpenAIStream`](/docs/api-reference/providers/openai-stream), in Node.js environments.
 
@@ -42,6 +42,10 @@ Optional object to configure the response, with the following properties:
     ],
   ]}
 />
+
+### `data?: DataStream`
+
+Similar to example in [`StreamData`](docs/api-reference/stream-data#on-the-server), you can provide additional data here.
 
 ## Example: Node.js HTTP Server
 

--- a/packages/core/streams/streaming-text-response.ts
+++ b/packages/core/streams/streaming-text-response.ts
@@ -45,16 +45,14 @@ export function streamToResponse(
 
   const reader = processedStream.getReader();
   function read() {
-    reader
-      .read()
-      .then(({ done, value }: { done: boolean; value?: any }) => {
-        if (done) {
-          response.end();
-          return;
-        }
-        response.write(value);
-        read();
-      });
+    reader.read().then(({ done, value }: { done: boolean; value?: any }) => {
+      if (done) {
+        response.end();
+        return;
+      }
+      response.write(value);
+      read();
+    });
   }
   read();
 }


### PR DESCRIPTION
This PR adds DataStream support to `streamToResponse`. Should fix #1285.