### PR TITLE
Fix type inference for tool parameters in `streamUI`

### DIFF
--- a/packages/core/rsc/stream-ui/stream-ui.tsx
+++ b/packages/core/rsc/stream-ui/stream-ui.tsx
@@ -71,7 +71,7 @@ const defaultTextRenderer: RenderText = ({ content }: { content: string }) =>
  * `experimental_streamUI` is a helper function to create a streamable UI from LLMs.
  */
 export async function experimental_streamUI<
-  TOOLS extends Record<string, RenderTool>,
+  TOOLS extends { [name: string]: z.ZodTypeAny } = {},
 >({
   model,
   tools,
@@ -93,7 +93,9 @@ export async function experimental_streamUI<
     /**
      * The tools that the model can call. The model needs to support calling tools.
      */
-    tools?: TOOLS;
+    tools?: {
+      [name in keyof TOOLS]: RenderTool<TOOLS[name]>;
+    };
 
     text?: RenderText;
     initial?: ReactNode;

--- a/packages/core/rsc/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/core/rsc/stream-ui/stream-ui.ui.test.tsx
@@ -160,6 +160,7 @@ describe('result.value', () => {
             parameters: z.object({
               value: z.string(),
             }),
+            // @ts-expect-error
             render: async function* () {},
           },
         },


### PR DESCRIPTION
The first argument of the tool `generate` functions was implicitly `any`. By using the same trick as in the `render` function, we can fix the type inference based on the provided `parameters`.