### PR TITLE
ai/rsc: ReadableStream as provider for streamable value; add `.append()` method

### DIFF
--- a/.changeset/clean-planes-reflect.md
+++ b/.changeset/clean-planes-reflect.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+ai/rsc: ReadableStream as provider for createStreamableValue; add .append() method


### PR DESCRIPTION
`createStreamableValue(initialValue)` now accepts a `ReadableStream` type as its `initialValue`. This will be handy when used together with the `textStream` core API, and common Web streams (i.e. from `fetch()`). If the readable stream pipes chunk types other than strings, it will behave like `.update()`.

If a `ReadableStream` is provided, the streamable value will be locked and no longer updatable from the userland.

An `.append()` method is also added to align with the `createStreamableUI()` API. It accepts string values only but in the future we might extend it to allow arrays too.
