### PR TITLE
ai/core: export language model types

### DIFF
--- a/.changeset/afraid-panthers-sing.md
+++ b/.changeset/afraid-panthers-sing.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+ai/core: re-expose language model types.

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -1,17 +1,15 @@
 import {
-  LanguageModelV1,
   LanguageModelV1CallOptions,
-  LanguageModelV1CallWarning,
-  LanguageModelV1FinishReason,
-  LanguageModelV1LogProbs,
   LanguageModelV1StreamPart,
 } from '@ai-sdk/provider';
 import { z } from 'zod';
+import { calculateTokenUsage } from '../generate-text/token-usage';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { getValidatedPrompt } from '../prompt/get-validated-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { Prompt } from '../prompt/prompt';
+import { CallWarning, FinishReason, LanguageModel, LogProbs } from '../types';
 import {
   AsyncIterableStream,
   createAsyncIterableStream,
@@ -22,7 +20,6 @@ import { isDeepEqualData } from '../util/is-deep-equal-data';
 import { parsePartialJson } from '../util/parse-partial-json';
 import { retryWithExponentialBackoff } from '../util/retry-with-exponential-backoff';
 import { injectJsonSchemaIntoSystem } from './inject-json-schema-into-system';
-import { calculateTokenUsage } from '../generate-text/token-usage';
 
 /**
 Generate a structured, typed object for a given prompt and schema using a language model.
@@ -75,7 +72,7 @@ export async function experimental_streamObject<T>({
     /**
 The language model to use.
      */
-    model: LanguageModelV1;
+    model: LanguageModel;
 
     /**
 The schema of the object that the model should generate.
@@ -231,8 +228,8 @@ export type ObjectStreamPartInput =
     }
   | {
       type: 'finish';
-      finishReason: LanguageModelV1FinishReason;
-      logprobs?: LanguageModelV1LogProbs;
+      finishReason: FinishReason;
+      logprobs?: LogProbs;
       usage: {
         promptTokens: number;
         completionTokens: number;
@@ -258,7 +255,7 @@ export class StreamObjectResult<T> {
   /**
 Warnings from the model provider (e.g. unsupported settings)
    */
-  readonly warnings: LanguageModelV1CallWarning[] | undefined;
+  readonly warnings: CallWarning[] | undefined;
 
   /**
 Optional raw response data.
@@ -276,7 +273,7 @@ Response headers.
     rawResponse,
   }: {
     stream: ReadableStream<string | ObjectStreamPartInput>;
-    warnings: LanguageModelV1CallWarning[] | undefined;
+    warnings: CallWarning[] | undefined;
     rawResponse?: {
       headers?: Record<string, string>;
     };

--- a/packages/core/core/generate-text/generate-text.ts
+++ b/packages/core/core/generate-text/generate-text.ts
@@ -1,15 +1,10 @@
-import {
-  LanguageModelV1,
-  LanguageModelV1CallWarning,
-  LanguageModelV1FinishReason,
-  LanguageModelV1LogProbs,
-} from '@ai-sdk/provider';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { getValidatedPrompt } from '../prompt/get-validated-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { Prompt } from '../prompt/prompt';
 import { ExperimentalTool } from '../tool/tool';
+import { CallWarning, FinishReason, LanguageModel, LogProbs } from '../types';
 import { convertZodToJSONSchema } from '../util/convert-zod-to-json-schema';
 import { retryWithExponentialBackoff } from '../util/retry-with-exponential-backoff';
 import { TokenUsage, calculateTokenUsage } from './token-usage';
@@ -66,7 +61,7 @@ export async function experimental_generateText<
     /**
 The language model to use.
      */
-    model: LanguageModelV1;
+    model: LanguageModel;
 
     /**
 The tools that the model can call. The model needs to support calling tools.
@@ -177,7 +172,7 @@ The results of the tool calls.
   /**
 The reason why the generation finished.
    */
-  readonly finishReason: LanguageModelV1FinishReason;
+  readonly finishReason: FinishReason;
 
   /**
 The token usage of the generated text.
@@ -187,7 +182,7 @@ The token usage of the generated text.
   /**
 Warnings from the model provider (e.g. unsupported settings)
    */
-  readonly warnings: LanguageModelV1CallWarning[] | undefined;
+  readonly warnings: CallWarning[] | undefined;
 
   /**
 Optional raw response data.
@@ -203,19 +198,19 @@ Response headers.
 Logprobs for the completion. 
 `undefined` if the mode does not support logprobs or if was not enabled
    */
-  readonly logprobs: LanguageModelV1LogProbs | undefined;
+  readonly logprobs: LogProbs | undefined;
 
   constructor(options: {
     text: string;
     toolCalls: ToToolCallArray<TOOLS>;
     toolResults: ToToolResultArray<TOOLS>;
-    finishReason: LanguageModelV1FinishReason;
+    finishReason: FinishReason;
     usage: TokenUsage;
-    warnings: LanguageModelV1CallWarning[] | undefined;
+    warnings: CallWarning[] | undefined;
     rawResponse?: {
       headers?: Record<string, string>;
     };
-    logprobs: LanguageModelV1LogProbs | undefined;
+    logprobs: LogProbs | undefined;
   }) {
     this.text = options.text;
     this.toolCalls = options.toolCalls;

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -1,9 +1,3 @@
-import {
-  LanguageModelV1,
-  LanguageModelV1CallWarning,
-  LanguageModelV1FinishReason,
-  LanguageModelV1LogProbs,
-} from '@ai-sdk/provider';
 import { ServerResponse } from 'node:http';
 import {
   AIStreamCallbacksAndOptions,
@@ -17,6 +11,7 @@ import { getValidatedPrompt } from '../prompt/get-validated-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { Prompt } from '../prompt/prompt';
 import { ExperimentalTool } from '../tool';
+import { CallWarning, FinishReason, LanguageModel, LogProbs } from '../types';
 import {
   AsyncIterableStream,
   createAsyncIterableStream,
@@ -77,7 +72,7 @@ export async function experimental_streamText<
     /**
 The language model to use.
      */
-    model: LanguageModelV1;
+    model: LanguageModel;
 
     /**
 The tools that the model can call. The model needs to support calling tools.
@@ -134,8 +129,8 @@ export type TextStreamPart<TOOLS extends Record<string, ExperimentalTool>> =
     } & ToToolResult<TOOLS>)
   | {
       type: 'finish';
-      finishReason: LanguageModelV1FinishReason;
-      logprobs?: LanguageModelV1LogProbs;
+      finishReason: FinishReason;
+      logprobs?: LogProbs;
       usage: {
         promptTokens: number;
         completionTokens: number;
@@ -152,7 +147,7 @@ export class StreamTextResult<TOOLS extends Record<string, ExperimentalTool>> {
   /**
 Warnings from the model provider (e.g. unsupported settings)
    */
-  readonly warnings: LanguageModelV1CallWarning[] | undefined;
+  readonly warnings: CallWarning[] | undefined;
 
   /**
 Optional raw response data.
@@ -170,7 +165,7 @@ Response headers.
     rawResponse,
   }: {
     stream: ReadableStream<TextStreamPart<TOOLS>>;
-    warnings: LanguageModelV1CallWarning[] | undefined;
+    warnings: CallWarning[] | undefined;
     rawResponse?: {
       headers?: Record<string, string>;
     };

--- a/packages/core/core/index.ts
+++ b/packages/core/core/index.ts
@@ -2,4 +2,5 @@ export * from './generate-object';
 export * from './generate-text';
 export * from './prompt';
 export * from './tool';
+export * from './types';
 export * from './util/deep-partial';

--- a/packages/core/core/types/errors.ts
+++ b/packages/core/core/types/errors.ts
@@ -1,0 +1,18 @@
+export {
+  APICallError,
+  EmptyResponseBodyError,
+  InvalidArgumentError,
+  InvalidDataContentError,
+  InvalidPromptError,
+  InvalidResponseDataError,
+  InvalidToolArgumentsError,
+  JSONParseError,
+  LoadAPIKeyError,
+  NoObjectGeneratedError,
+  NoSuchToolError,
+  RetryError,
+  ToolCallParseError,
+  TypeValidationError,
+  UnsupportedFunctionalityError,
+  UnsupportedJSONSchemaError,
+} from '@ai-sdk/provider';

--- a/packages/core/core/types/index.ts
+++ b/packages/core/core/types/index.ts
@@ -1,0 +1,2 @@
+export * from './errors';
+export * from './language-model';

--- a/packages/core/core/types/language-model.ts
+++ b/packages/core/core/types/language-model.ts
@@ -1,0 +1,35 @@
+import {
+  LanguageModelV1,
+  LanguageModelV1CallWarning,
+  LanguageModelV1FinishReason,
+  LanguageModelV1LogProbs,
+} from '@ai-sdk/provider';
+
+/**
+Language model that is used by the AI SDK Core functions.
+*/
+export type LanguageModel = LanguageModelV1;
+
+/**
+Reason why a language model finished generating a response.
+
+Can be one of the following:
+- `stop`: model generated stop sequence
+- `length`: model generated maximum number of tokens
+- `content-filter`: content filter violation stopped the model
+- `tool-calls`: model triggered tool calls
+- `error`: model stopped because of an error
+- `other`: model stopped for other reasons
+*/
+export type FinishReason = LanguageModelV1FinishReason;
+
+/**
+Log probabilities for each token and its top log probabilities.
+ */
+export type LogProbs = LanguageModelV1LogProbs;
+
+/**
+Warning from the model provider for this call. The call will proceed, but e.g.
+some settings might not be supported, which can lead to suboptimal results.
+*/
+export type CallWarning = LanguageModelV1CallWarning;

--- a/packages/provider/src/errors/no-object-generated-error.ts
+++ b/packages/provider/src/errors/no-object-generated-error.ts
@@ -1,14 +1,16 @@
-export class NoTextGeneratedError extends Error {
+export class NoObjectGeneratedError extends Error {
   readonly cause: unknown;
 
   constructor() {
-    super(`No text generated.`);
+    super(`No object generated.`);
 
-    this.name = 'AI_NoTextGeneratedError';
+    this.name = 'AI_NoObjectGeneratedError';
   }
 
-  static isNoTextGeneratedError(error: unknown): error is NoTextGeneratedError {
-    return error instanceof Error && error.name === 'AI_NoTextGeneratedError';
+  static isNoTextGeneratedError(
+    error: unknown,
+  ): error is NoObjectGeneratedError {
+    return error instanceof Error && error.name === 'AI_NoObjectGeneratedError';
   }
 
   toJSON() {

--- a/packages/provider/src/language-model/v1/language-model-v1-finish-reason.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-finish-reason.ts
@@ -1,3 +1,14 @@
+/**
+Reason why a language model finished generating a response.
+
+Can be one of the following:
+- `stop`: model generated stop sequence
+- `length`: model generated maximum number of tokens
+- `content-filter`: content filter violation stopped the model
+- `tool-calls`: model triggered tool calls
+- `error`: model stopped because of an error
+- `other`: model stopped for other reasons
+ */
 export type LanguageModelV1FinishReason =
   | 'stop' // model generated stop sequence
   | 'length' // model generated maximum number of tokens

--- a/packages/provider/src/language-model/v1/language-model-v1-logprobs.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-logprobs.ts
@@ -1,3 +1,6 @@
+/**
+Log probabilities for each token and its top log probabilities.
+ */
 export type LanguageModelV1LogProbs = Array<{
   token: string;
   logprob: number;


### PR DESCRIPTION
## Summary
- exports the necessary language model types (shielded to decouple the evolution) from the `ai` package
- exports the error types from the `ai` package
- rename `NoTextGeneratedError` to `NoObjectGeneratedError`