### PR TITLE
Allow for message history to be omitted when making request to llm

### DIFF
--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -355,6 +355,7 @@ export function useChat({
         tools,
         tool_choice,
         data,
+        include_only_last_message
       }: ChatRequestOptions = {},
     ) => {
       if (!message.id) {
@@ -362,7 +363,7 @@ export function useChat({
       }
 
       const chatRequest: ChatRequest = {
-        messages: messagesRef.current.concat(message as Message),
+        messages: !include_only_last_message ? messagesRef.current.concat(message as Message) : [message as Message],
         options,
         data,
         ...(functions !== undefined && { functions }),

--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -155,6 +155,7 @@ export type ChatRequestOptions = {
   tools?: Array<Tool>;
   tool_choice?: ToolChoice;
   data?: Record<string, string>;
+  include_only_last_message?: boolean;
 };
 
 export type UseChatOptions = {


### PR DESCRIPTION
**Feature:** Add support for appending messages to existing conversations while providing the option to include only the latest message in the conversation history.

**Change:** Introduces an optional boolean flag, exclude_history. When set to true, only the most recent message in the conversation is passed instead of the complete history.

**Benefits:**

1. Reduced Payload Size: Enables compliance with services that have payload size limits (e.g., AWS CloudFront).
2. Optimized Performance: Can potentially improve request processing speed and efficiency by reducing data transmission overhead.
3. Developer Flexibility: Offers developers the choice to manage conversation history as needed in their backend systems.

**Use Case**

In scenarios where back-end services impose payload size restrictions, this flag allows developers to selectively exclude potentially large conversation histories. A typical use case is sending inference requests containing only the latest user prompt, while managing a more extensive conversation history in the backend.

**Important Note:** Developers will still need to implement their own backend persistence mechanisms if they require LLM access to the complete conversation history beyond the latest user message.

