### PR TITLE
Add optional metadata to base Message type

### DIFF
--- a/packages/core/shared/types.ts
+++ b/packages/core/shared/types.ts
@@ -115,6 +115,11 @@ export interface Message {
    * Additional message-specific information added on the server via StreamData
    */
   annotations?: JSONValue[] | undefined;
+
+  /**
+   * Attach arbitrary metadata to a message. 
+   */
+  metadata?: { [key: string]: any } | undefined
 }
 
 export type CreateMessage = Omit<Message, 'id'> & {


### PR DESCRIPTION
# Problem

While the base `Message` type is robust, there are cases in which users may want to include additional metadata with a message. For example, adding user attribution to a message if the chat / completion / assistant is being used in a shared context.

# Solution

We update the base `Message` type to include an optional `metadata` field to support this change.