### PR TITLE
ai/rsc: `streamUI`

### DIFF
--- a/.changeset/light-mice-ring.md
+++ b/.changeset/light-mice-ring.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+ai/rsc: remove experimental\_ from streamUI

--- a/packages/core/rsc/index.ts
+++ b/packages/core/rsc/index.ts
@@ -3,7 +3,7 @@ export type {
   getMutableAIState,
   createStreamableUI,
   createStreamableValue,
-  experimental_streamUI,
+  streamUI,
   render,
   createAI,
 } from './rsc-server';

--- a/packages/core/rsc/rsc-server.ts
+++ b/packages/core/rsc/rsc-server.ts
@@ -4,5 +4,5 @@ export {
   createStreamableValue,
   render,
 } from './streamable';
-export { experimental_streamUI } from './stream-ui';
+export { streamUI } from './stream-ui';
 export { createAI } from './provider';

--- a/packages/core/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
+++ b/packages/core/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
@@ -182,4 +182,4 @@ exports[`result.value > should render tool call results with generator render fu
 }
 `;
 
-exports[`result.value > should show better error messages if legacy options are passed 1`] = `[Error: Tool definition in \`experimental_streamUI\` should not have \`render\` property. Use \`generate\` instead. Found in tool: tool1]`;
+exports[`result.value > should show better error messages if legacy options are passed 1`] = `[Error: Tool definition in \`streamUI\` should not have \`render\` property. Use \`generate\` instead. Found in tool: tool1]`;

--- a/packages/core/rsc/stream-ui/index.tsx
+++ b/packages/core/rsc/stream-ui/index.tsx
@@ -1,1 +1,1 @@
-export { experimental_streamUI } from './stream-ui';
+export { streamUI } from './stream-ui';

--- a/packages/core/rsc/stream-ui/stream-ui.tsx
+++ b/packages/core/rsc/stream-ui/stream-ui.tsx
@@ -68,9 +68,9 @@ const defaultTextRenderer: RenderText = ({ content }: { content: string }) =>
   content;
 
 /**
- * `experimental_streamUI` is a helper function to create a streamable UI from LLMs.
+ * `streamUI` is a helper function to create a streamable UI from LLMs.
  */
-export async function experimental_streamUI<
+export async function streamUI<
   TOOLS extends { [name: string]: z.ZodTypeAny } = {},
 >({
   model,
@@ -103,24 +103,24 @@ export async function experimental_streamUI<
   // TODO: Remove these errors after the experimental phase.
   if (typeof model === 'string') {
     throw new Error(
-      '`model` cannot be a string in `experimental_streamUI`. Use the actual model instance instead.',
+      '`model` cannot be a string in `streamUI`. Use the actual model instance instead.',
     );
   }
   if ('functions' in settings) {
     throw new Error(
-      '`functions` is not supported in `experimental_streamUI`, use `tools` instead.',
+      '`functions` is not supported in `streamUI`, use `tools` instead.',
     );
   }
   if ('provider' in settings) {
     throw new Error(
-      '`provider` is no longer needed in `experimental_streamUI`. Use `model` instead.',
+      '`provider` is no longer needed in `streamUI`. Use `model` instead.',
     );
   }
   if (tools) {
     for (const [name, tool] of Object.entries(tools)) {
       if ('render' in tool) {
         throw new Error(
-          'Tool definition in `experimental_streamUI` should not have `render` property. Use `generate` instead. Found in tool: ' +
+          'Tool definition in `streamUI` should not have `render` property. Use `generate` instead. Found in tool: ' +
             name,
         );
       }

--- a/packages/core/rsc/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/core/rsc/stream-ui/stream-ui.ui.test.tsx
@@ -1,6 +1,6 @@
 import { convertArrayToReadableStream } from '../../core/test/convert-array-to-readable-stream';
 import { MockLanguageModelV1 } from '../../core/test/mock-language-model-v1';
-import { experimental_streamUI } from './stream-ui';
+import { streamUI } from './stream-ui';
 import { z } from 'zod';
 
 async function recursiveResolve(val: any): Promise<any> {
@@ -84,7 +84,7 @@ const mockToolModel = new MockLanguageModelV1({
 
 describe('result.value', () => {
   it('should render text', async () => {
-    const result = await experimental_streamUI({
+    const result = await streamUI({
       model: mockTextModel,
       prompt: '',
     });
@@ -94,7 +94,7 @@ describe('result.value', () => {
   });
 
   it('should render text function returned ui', async () => {
-    const result = await experimental_streamUI({
+    const result = await streamUI({
       model: mockTextModel,
       prompt: '',
       text: ({ content }) => <h1>{content}</h1>,
@@ -105,7 +105,7 @@ describe('result.value', () => {
   });
 
   it('should render tool call results', async () => {
-    const result = await experimental_streamUI({
+    const result = await streamUI({
       model: mockToolModel,
       prompt: '',
       tools: {
@@ -127,7 +127,7 @@ describe('result.value', () => {
   });
 
   it('should render tool call results with generator render function', async () => {
-    const result = await experimental_streamUI({
+    const result = await streamUI({
       model: mockToolModel,
       prompt: '',
       tools: {
@@ -151,7 +151,7 @@ describe('result.value', () => {
 
   it('should show better error messages if legacy options are passed', async () => {
     try {
-      await experimental_streamUI({
+      await streamUI({
         model: mockToolModel,
         prompt: '',
         tools: {

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -413,7 +413,7 @@ type Renderer<T> = (
  * please use `streamUI` for compatibility with other providers.
  *
  * @deprecated It's recommended to use the `streamUI` API for compatibility with AI SDK Core APIs
- * and future features. This API will be deprecated in a future release.
+ * and future features. This API will be removed in a future release.
  */
 export function render<
   TS extends {

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -409,9 +409,11 @@ type Renderer<T> = (
 
 /**
  * `render` is a helper function to create a streamable UI from some LLMs.
- * Currently, it only supports OpenAI's GPT models with Function Calling and Assistants Tools.
+ * This API only supports OpenAI's GPT models with Function Calling and Assistants Tools,
+ * please use `streamUI` for compatibility with other providers.
  *
- * @deprecated It's recommended to use the `experimental_streamUI` API for compatibility with the new core APIs.
+ * @deprecated It's recommended to use the `streamUI` API for compatibility with AI SDK Core APIs
+ * and future features. This API will be deprecated in a future release.
  */
 export function render<
   TS extends {


### PR DESCRIPTION
This PR removes the `experimental_` prefix from `streamUI`. There might still be small tweaks in the future but the basic shape should be kept the same.