### PR TITLE
Prevent `dev` script from creating dts files infinitely

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,5 @@
     "stripInternal": true
   },
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["*/dist", "dist", "build", "node_modules"]
 }


### PR DESCRIPTION
fixes #1074

The files in `packages/core/*/dist` must be excluded from the TS program so that `rollup-plugin-dts` (used by `tsup`) does not include them in the list of watched files.