### PR TITLE
fix (ai/provider): improve request error handling

### DIFF
--- a/.changeset/modern-ligers-dream.md
+++ b/.changeset/modern-ligers-dream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix (ai/provider): improve request error handling


### PR DESCRIPTION
## Summary
* include response headers in error messages
* don't wrap correctly caught errors in another api call error