### PR TITLE
docs: fix path to Streaming Not Working page

### DIFF
--- a/content/docs/08-troubleshooting/01-common-issues/index.mdx
+++ b/content/docs/08-troubleshooting/01-common-issues/index.mdx
@@ -10,6 +10,6 @@ description: Welcome to the Vercel AI SDK documentation!
 - [ Server Actions in Client Components ](/docs/troubleshooting/common-issues/server-actions-in-client-components)
 - [ Strange Stream Output ](/docs/troubleshooting/common-issues/strange-stream-output)
 - [ Streamable UI Errors ](/docs/troubleshooting/common-issues/streamable-ui-errors)
-- [ Streaming Not Working in Production ](/docs/troubleshooting/common-issues/streaming-not-working-in-production)
+- [ Streaming Not Working When Deploying on Vercel ](/docs/troubleshooting/common-issues/streaming-not-working-on-vercel)
 - [ Unclosed Streams ](/docs/troubleshooting/common-issues/unclosed-streams)
 - [ useChat Failed to Parse Stream ](/docs/troubleshooting/common-issues/use-chat-failed-to-parse-stream)


### PR DESCRIPTION
Update title and fix link to docs page for "Streaming Not Working When Deploying on Vercel"

## Background 

On this [page](https://sdk.vercel.ai/docs/troubleshooting/common-issues), current link leads to a page that doesn't exist, and the app returns a 500 error

Broken link:
https://sdk.vercel.ai/docs/troubleshooting/common-issues/streaming-not-working-in-production

Working link: 
https://sdk.vercel.ai/docs/troubleshooting/common-issues/streaming-not-working-on-vercel

<img width="367" alt="image" src="https://github.com/vercel/ai/assets/13279967/30ee8bfc-050d-4eaf-9ef9-c2e6c266b20b">


