### PR TITLE
Add GPT-4o to supported OpenAI model types

### DIFF
--- a/packages/openai/src/openai-chat-settings.ts
+++ b/packages/openai/src/openai-chat-settings.ts
@@ -1,5 +1,7 @@
 // https://platform.openai.com/docs/models
 export type OpenAIChatModelId =
+  | 'gpt-4o'
+  | 'gpt-4o-2024-05-13'
   | 'gpt-4-turbo'
   | 'gpt-4-turbo-2024-04-09'
   | 'gpt-4-turbo-preview'


### PR DESCRIPTION
Simple change to add support for new model types released this morning. I believe this is the only required change.