### PR TITLE
Added include_usage flag for OpenAI's streams

### DIFF
--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -198,6 +198,9 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
       body: {
         ...args,
         stream: true,
+        stream_options: {
+          include_usage: true
+        }
       },
       failedResponseHandler: openaiFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -179,6 +179,9 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
       body: {
         ...this.getArgs(options),
         stream: true,
+        stream_options: {
+          include_usage: true
+        }
       },
       failedResponseHandler: openaiFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(


### PR DESCRIPTION
OpenAI [recently added support for tracking token usage when using streamings](https://community.openai.com/t/usage-stats-now-available-when-using-streaming-with-the-chat-completions-api-or-completions-api/738156). The `include_usage` flag enables the feature.