### PR TITLE
fix (docs): tiny improvements

### DIFF
--- a/content/docs/04-ai-sdk-rsc/01-streaming-user-interfaces.mdx
+++ b/content/docs/04-ai-sdk-rsc/01-streaming-user-interfaces.mdx
@@ -18,21 +18,21 @@ This is useful when you want to go beyond raw data and stream React components t
 
 You can import `createStreamableUI` from `ai/rsc` and use it to create a streamable UI.
 
-```tsx file='app/actions.ts'
-'use server'
+```tsx file='app/actions.tsx'
+'use server';
 
-import { createStreamableUI } from 'ai/rsc'
+import { createStreamableUI } from 'ai/rsc';
 
-export async function getWeather {
-  const weatherUI = createStreamableUI()
+export async function getWeather() {
+  const weatherUI = createStreamableUI();
 
-  weatherUI.update(<div style={{ color: 'gray' }}>Loading...</div>)
+  weatherUI.update(<div style={{ color: 'gray' }}>Loading...</div>);
 
   setTimeout(() => {
-    weatherUI.done(<div>It's a sunny day!</div>)
-  }, 1000)
+    weatherUI.done(<div>It's a sunny day!</div>);
+  }, 1000);
 
-  return weatherUI.value
+  return weatherUI.value;
 }
 ```
 

--- a/content/docs/04-ai-sdk-rsc/03-generative-ui.mdx
+++ b/content/docs/04-ai-sdk-rsc/03-generative-ui.mdx
@@ -21,27 +21,28 @@ When language models are provided with a set of function definitions, and instru
 - Not execute any function if the user query is out of bounds the set of functions available to them.
 
 ```tsx filename='app/actions.ts'
-const sendMessage = (prompt: string) => generateText({
-  model: 'gpt-3.5-turbo',
-  system: "you are a friendly weather assistant!",
-  prompt,
-  tools: {
-    getWeather: {
-      description: 'Get the weather in a location',
-      parameters: z.object({
-        location: z.string().describe('The location to get the weather for')
-      }),
-      execute: async ({ location }: { location: string }) => ({
-        location,
-        temperature: 72 + Math.floor(Math.random() * 21) - 10
-      })
+const sendMessage = (prompt: string) =>
+  generateText({
+    model: 'gpt-3.5-turbo',
+    system: 'you are a friendly weather assistant!',
+    prompt,
+    tools: {
+      getWeather: {
+        description: 'Get the weather in a location',
+        parameters: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        execute: async ({ location }: { location: string }) => ({
+          location,
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+        }),
+      },
     },
-  }
-})
+  });
 
-sendMessage('What is the weather in San Francisco?') // getWeather is called
-sendMessage('What is the weather in New York?')      // getWeather is called
-sendMessage('What events are happening in London?')  // No function is called
+sendMessage('What is the weather in San Francisco?'); // getWeather is called
+sendMessage('What is the weather in New York?'); // getWeather is called
+sendMessage('What events are happening in London?'); // No function is called
 ```
 
 This way, it is possible to ensure that the generations result in deterministic outputs, while the choice a model makes still remains to be probabilistic.

--- a/content/docs/04-ai-sdk-rsc/03-generative-ui.mdx
+++ b/content/docs/04-ai-sdk-rsc/03-generative-ui.mdx
@@ -22,7 +22,7 @@ When language models are provided with a set of function definitions, and instru
 
 ```tsx filename='app/actions.ts'
 const sendMessage = (prompt: string) => generateText({
-  model: 'gpt-3.5-turbo'
+  model: 'gpt-3.5-turbo',
   system: "you are a friendly weather assistant!",
   prompt,
   tools: {

--- a/content/docs/04-ai-sdk-rsc/04-ai-ui-states.mdx
+++ b/content/docs/04-ai-sdk-rsc/04-ai-ui-states.mdx
@@ -177,9 +177,10 @@ To call the `sendMessage` action from the client, you can use the [`useActions`]
 'use client';
 
 import { useActions, useUIState } from 'ai/rsc';
+import { AI } from './actions';
 
 export default function Page() {
-  const { sendMessage } = useActions();
+  const { sendMessage } = useActions<typeof AI>();
   const [messages, setMessages] = useUIState();
 
   const handleSubmit = async event => {

--- a/content/docs/04-ai-sdk-rsc/04-ai-ui-states.mdx
+++ b/content/docs/04-ai-sdk-rsc/04-ai-ui-states.mdx
@@ -104,7 +104,7 @@ The AI state can be accessed in Client Components using the [`useAIState`](/docs
 ```tsx filename='app/page.tsx'
 'use client';
 
-import { useAIAtate } from 'ai/rsc';
+import { useAIState } from 'ai/rsc';
 
 export default function Page() {
   const [messages, setMessages] = useAIState();


### PR DESCRIPTION
- Fixed missing comma in docs for ai-rsc example
- Fixed syntax errors in examples
- Made ai-ui-states `useActions` call typesafe in the example