### PR TITLE
feat (ai/react): add experimental_maxAutomaticRoundtrips to useChat

### DIFF
--- a/.changeset/great-bottles-burn.md
+++ b/.changeset/great-bottles-burn.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/react): add experimental_maxAutomaticRoundtrips to useChat

--- a/examples/next-openai/app/api/use-chat-tool-result-roundtrip/route.ts
+++ b/examples/next-openai/app/api/use-chat-tool-result-roundtrip/route.ts
@@ -8,8 +8,6 @@ export const maxDuration = 60;
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
-  console.log('messages:', JSON.stringify(messages, null, 2));
-
   const result = await streamText({
     model: openai('gpt-4-turbo'),
     system:

--- a/examples/next-openai/app/api/use-chat-tool-result-roundtrip/route.ts
+++ b/examples/next-openai/app/api/use-chat-tool-result-roundtrip/route.ts
@@ -1,0 +1,39 @@
+import { openai } from '@ai-sdk/openai';
+import { convertToCoreMessages, streamText } from 'ai';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  console.log('messages:', JSON.stringify(messages, null, 2));
+
+  const result = await streamText({
+    model: openai('gpt-4-turbo'),
+    system:
+      'You are a weather bot that can use the weather tool to get the weather in a given city. ' +
+      'Respond to the user with weather information in a friendly and helpful manner.',
+    messages: convertToCoreMessages(messages),
+    tools: {
+      weather: {
+        description: 'show the weather in a given city to the user',
+        parameters: z.object({ city: z.string() }),
+        execute: async ({}: { city: string }) => {
+          // Random delay between 1000ms (1s) and 3000ms (3s):
+          const delay = Math.floor(Math.random() * (3000 - 1000 + 1)) + 1000;
+          await new Promise(resolve => setTimeout(resolve, delay));
+
+          // Random weather:
+          const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
+          return weatherOptions[
+            Math.floor(Math.random() * weatherOptions.length)
+          ];
+        },
+      },
+    },
+  });
+
+  return result.toAIStreamResponse();
+}

--- a/examples/next-openai/app/use-chat-tool-result-roundtrip/page.tsx
+++ b/examples/next-openai/app/use-chat-tool-result-roundtrip/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useChat } from 'ai/react';
+
+export default function Chat() {
+  const { messages, input, handleInputChange, handleSubmit } = useChat({
+    api: '/api/use-chat-tool-result-roundtrip',
+    experimental_maxAutomaticRoundtrips: 2,
+  });
+
+  console.log(messages);
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      {messages
+        .filter(m => m.content) // filter out empty messages
+        .map(m => (
+          <div key={m.id} className="whitespace-pre-wrap">
+            <strong>{`${m.role}: `}</strong>
+            {m.content}
+            <br />
+            <br />
+          </div>
+        ))}
+
+      <form onSubmit={handleSubmit}>
+        <input
+          className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          value={input}
+          placeholder="Say something..."
+          onChange={handleInputChange}
+        />
+      </form>
+    </div>
+  );
+}

--- a/examples/next-openai/app/use-chat-tool-result-roundtrip/page.tsx
+++ b/examples/next-openai/app/use-chat-tool-result-roundtrip/page.tsx
@@ -8,8 +8,6 @@ export default function Chat() {
     experimental_maxAutomaticRoundtrips: 2,
   });
 
-  console.log(messages);
-
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {messages

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -219,6 +219,7 @@ export function useChat({
   sendExtraMessageFields,
   experimental_onFunctionCall,
   experimental_onToolCall,
+  experimental_maxAutomaticRoundtrips = 0,
   streamMode,
   onResponse,
   onFinish,
@@ -230,6 +231,19 @@ export function useChat({
 }: Omit<UseChatOptions, 'api'> & {
   api?: string | StreamingReactResponseAction;
   key?: string;
+  /**
+Maximal number of automatic roundtrips for tool calls.
+
+An automatic tool call roundtrip is a call to the server with the 
+tool call results when all tool calls in the last assistant 
+message have results.
+
+A maximum number is required to prevent infinite loops in the
+case of misconfigured tools.
+
+By default, it's set to 0, which will disable the feature.
+   */
+  experimental_maxAutomaticRoundtrips?: number;
 } = {}): UseChatHelpers & {
   experimental_addToolResult: ({
     toolCallId,
@@ -342,6 +356,20 @@ export function useChat({
         setError(err as Error);
       } finally {
         mutateLoading(false);
+      }
+
+      // auto-submit when all tool calls in the last assistant message have results:
+      const lastMessage = messagesRef.current[messagesRef.current.length - 1];
+      if (
+        // check if the feature is enabled:
+        experimental_maxAutomaticRoundtrips > 0 &&
+        // check that roundtrip is possible:
+        isAssistantMessageWithCompletedToolCalls(lastMessage) &&
+        // limit the number of automatic roundtrips:
+        countTrailingAssistantMessages(messagesRef.current) <=
+          experimental_maxAutomaticRoundtrips
+      ) {
+        await triggerRequest({ messages: messagesRef.current });
       }
     },
     [
@@ -526,16 +554,38 @@ export function useChat({
 
       // auto-submit when all tool calls in the last assistant message have results:
       const lastMessage = updatedMessages[updatedMessages.length - 1];
-      if (
-        lastMessage.role === 'assistant' &&
-        lastMessage.toolInvocations &&
-        lastMessage.toolInvocations.length > 0 &&
-        lastMessage.toolInvocations.every(
-          toolInvocation => 'result' in toolInvocation,
-        )
-      ) {
+      if (isAssistantMessageWithCompletedToolCalls(lastMessage)) {
         triggerRequest({ messages: updatedMessages });
       }
     },
   };
+}
+
+/**
+Check if the message is an assistant message with completed tool calls. 
+The message must have at least one tool invocation and all tool invocations
+must have a result.
+ */
+function isAssistantMessageWithCompletedToolCalls(message: Message) {
+  return (
+    message.role === 'assistant' &&
+    message.toolInvocations &&
+    message.toolInvocations.length > 0 &&
+    message.toolInvocations.every(toolInvocation => 'result' in toolInvocation)
+  );
+}
+
+/**
+Returns the number of trailing assistant messages in the array.
+ */
+function countTrailingAssistantMessages(messages: Message[]) {
+  let count = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'assistant') {
+      count++;
+    } else {
+      break;
+    }
+  }
+  return count;
 }

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -359,17 +359,20 @@ By default, it's set to 0, which will disable the feature.
       }
 
       // auto-submit when all tool calls in the last assistant message have results:
-      const lastMessage = messagesRef.current[messagesRef.current.length - 1];
+      const messages = messagesRef.current;
+      const lastMessage = messages[messages.length - 1];
       if (
+        // ensure there is a last message:
+        lastMessage != null &&
         // check if the feature is enabled:
         experimental_maxAutomaticRoundtrips > 0 &&
         // check that roundtrip is possible:
         isAssistantMessageWithCompletedToolCalls(lastMessage) &&
         // limit the number of automatic roundtrips:
-        countTrailingAssistantMessages(messagesRef.current) <=
+        countTrailingAssistantMessages(messages) <=
           experimental_maxAutomaticRoundtrips
       ) {
-        await triggerRequest({ messages: messagesRef.current });
+        await triggerRequest({ messages });
       }
     },
     [

--- a/packages/core/react/use-chat.ts
+++ b/packages/core/react/use-chat.ts
@@ -387,6 +387,7 @@ By default, it's set to 0, which will disable the feature.
       sendExtraMessageFields,
       experimental_onFunctionCall,
       experimental_onToolCall,
+      experimental_maxAutomaticRoundtrips,
       messagesRef,
       abortControllerRef,
       generateId,

--- a/packages/core/shared/parse-complex-response.ts
+++ b/packages/core/shared/parse-complex-response.ts
@@ -52,8 +52,6 @@ export async function parseComplexResponse({
   for await (const { type, value } of readDataStream(reader, {
     isAborted: () => abortControllerRef?.current === null,
   })) {
-    console.log('type:', type, 'value:', value);
-
     if (type === 'text') {
       if (prefixMap['text']) {
         prefixMap['text'] = {
@@ -192,8 +190,6 @@ export async function parseComplexResponse({
       .map(message => ({
         ...assignAnnotationsToMessage(message, message_annotations),
       })) as Message[];
-
-    console.log('merged:', merged);
 
     update(merged, [...prefixMap['data']]); // make a copy of the data array
   }

--- a/packages/core/shared/parse-complex-response.ts
+++ b/packages/core/shared/parse-complex-response.ts
@@ -52,6 +52,8 @@ export async function parseComplexResponse({
   for await (const { type, value } of readDataStream(reader, {
     isAborted: () => abortControllerRef?.current === null,
   })) {
+    console.log('type:', type, 'value:', value);
+
     if (type === 'text') {
       if (prefixMap['text']) {
         prefixMap['text'] = {
@@ -190,6 +192,8 @@ export async function parseComplexResponse({
       .map(message => ({
         ...assignAnnotationsToMessage(message, message_annotations),
       })) as Message[];
+
+    console.log('merged:', merged);
 
     update(merged, [...prefixMap['data']]); // make a copy of the data array
   }


### PR DESCRIPTION
## Summary
This PR enables automatic roundtrips from client to server for tool calling. When all tool results are available, a new server call is initiated to call the language model with the tool results.

This architecture (going through the client) enables the unification of client tool calls and server tool calls.

## Tasks

- [x] implement experimental feature
- [x] add example
- [x] changeset

## Future Work
- optimize server side tool calls (roundtrip fully on server when there are no client side tool calls)
- Svelte, Vue support
- update docs (reference docs, dedicated tutorial page)