### PR TITLE
fixes (docs): add warnings & links to provider pages

### DIFF
--- a/content/docs/01-introduction/index.mdx
+++ b/content/docs/01-introduction/index.mdx
@@ -13,9 +13,9 @@ Despite the hype around AI, integrating LLMs into applications is complicated an
 
 The Vercel AI SDK simplifies this process by abstracting away the differences between model providers, eliminating boilerplate code for building chatbots, and allowing you to go beyond text output to generate rich, interactive components.
 
-- **AI SDK Core:** A unified API for generating text, structured objects, and tool calls with large language models (LLMs).
-- **AI SDK UI:** A set of framework-agnostic hooks for quickly building chat interfaces.
-- **AI SDK RSC:** A library to stream generative user interfaces with React Server Components (RSC).
+- **[AI SDK Core](/docs/ai-sdk-core):** A unified API for generating text, structured objects, and tool calls with large language models (LLMs).
+- **[AI SDK UI](/docs/ai-sdk-ui):** A set of framework-agnostic hooks for quickly building chat interfaces.
+- **[AI SDK RSC](/docs/ai-sdk-rsc):** A library to stream generative user interfaces with React Server Components (RSC).
 
 ## Model Providers
 

--- a/content/docs/07-reference/stream-helpers/03-streaming-react-response.mdx
+++ b/content/docs/07-reference/stream-helpers/03-streaming-react-response.mdx
@@ -3,7 +3,12 @@ title: StreamingReactResponse
 description: Learn to use StreamingReactResponse helper function in your application.
 ---
 
-# `StreamingReactResponse`
+# `experimental_StreamingReactResponse`
+
+<Note type="warning">
+  This experimental feature has been deprecated. Please use [AI SDK
+  RSC](/docs/ai-sdk-rsc) instead.
+</Note>
 
 The StreamingReactResponse class is designed to facilitate streaming React responses in a server action environment. It can handle and stream both raw content and data payloads, including special UI payloads, through nested promises.
 

--- a/content/docs/07-reference/stream-helpers/07-openai-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/07-openai-stream.mdx
@@ -5,6 +5,13 @@ description: Learn to use OpenAIStream helper function in your application.
 
 # `OpenAIStream`
 
+<Note type="warning">
+  OpenAIStream is part of the [legacy OpenAI
+  integration](/providers/legacy-providers/openai). It is not compatible with
+  the AI SDK 3.1 functions. It is recommended to use the [AI SDK OpenAI
+  Provider](/providers/ai-sdk-providers/openai) instead.
+</Note>
+
 Transforms the response from OpenAI's language models into a ReadableStream.
 
 Note: Prior to v4, the official OpenAI API SDK does not support the Edge Runtime and only works in serverless environments. The openai-edge package is based on fetch instead of axios (and thus works in the Edge Runtime) so we recommend using openai v4+ or openai-edge.

--- a/content/docs/07-reference/stream-helpers/08-anthropic-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/08-anthropic-stream.mdx
@@ -5,6 +5,13 @@ description: Learn to use AnthropicStream helper function in your application.
 
 # `AnthropicStream`
 
+<Note type="warning">
+  AnthropicStream is part of the [legacy Anthropic
+  integration](/providers/legacy-providers/anthropic). It is not compatible with
+  the AI SDK 3.1 functions. It is recommended to use the [AI SDK Anthropic
+  Provider](/providers/ai-sdk-providers/anthropic) instead.
+</Note>
+
 It is a utility function that transforms the output from Anthropic's SDK into a ReadableStream. It uses AIStream under the hood, applying a specific parser for the Anthropic's response data structure.
 
 ## Import

--- a/content/docs/07-reference/stream-helpers/09-aws-bedrock-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/09-aws-bedrock-stream.mdx
@@ -5,6 +5,12 @@ description: Learn to use AWSBedrockStream helper function in your application.
 
 # `AWSBedrockStream`
 
+<Note type="warning">
+  AWSBedrockStream is part of the [legacy AWS Bedrock
+  integration](/providers/legacy-providers/aws-bedrock). It is not compatible
+  with the AI SDK 3.1 functions.
+</Note>
+
 The AWS Bedrock stream functions are utilties that transform the outputs from the AWS Bedrock API into a ReadableStream. It uses AIStream under the hood and handle parsing Bedrock's response.
 
 ## Import

--- a/content/docs/07-reference/stream-helpers/10-aws-bedrock-anthropic-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/10-aws-bedrock-anthropic-stream.mdx
@@ -1,12 +1,12 @@
 ---
-title: AWSBedrockAnthropicMessagesStream
-description: Learn to use AWSBedrockAnthropicMessagesStream helper function in your application.
+title: AWSBedrockAnthropicStream
+description: Learn to use AWSBedrockAnthropicStream helper function in your application.
 ---
 
-# `AWSBedrockAnthropicMessagesStream`
+# `AWSBedrockAnthropicStream`
 
 <Note type="warning">
-  AWSBedrockAnthropicMessagesStream is part of the [legacy AWS Bedrock
+  AWSBedrockAnthropicStream is part of the [legacy AWS Bedrock
   integration](/providers/legacy-providers/aws-bedrock). It is not compatible
   with the AI SDK 3.1 functions.
 </Note>
@@ -18,7 +18,7 @@ The AWS Bedrock stream functions are utilties that transform the outputs from th
 ### React
 
 <Snippet
-  text={`import { AWSBedrockAnthropicMessagesStream } from "ai"`}
+  text={`import { AWSBedrockAnthropicStream } from "ai"`}
   prompt={false}
 />
 

--- a/content/docs/07-reference/stream-helpers/11-aws-bedrock-cohere-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/11-aws-bedrock-cohere-stream.mdx
@@ -5,6 +5,12 @@ description: Learn to use AWSBedrockCohereStream helper function in your applica
 
 # `AWSBedrockCohereStream`
 
+<Note type="warning">
+  AWSBedrockCohereStream is part of the [legacy AWS Bedrock
+  integration](/providers/legacy-providers/aws-bedrock). It is not compatible
+  with the AI SDK 3.1 functions.
+</Note>
+
 ## Import
 
 The AWS Bedrock stream functions are utilties that transform the outputs from the AWS Bedrock API into a ReadableStream. It uses AIStream under the hood and handles parsing Bedrock's response.

--- a/content/docs/07-reference/stream-helpers/12-aws-bedrock-llama-2-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/12-aws-bedrock-llama-2-stream.mdx
@@ -5,6 +5,12 @@ description: Learn to use AWSBedrockLlama2Stream helper function in your applica
 
 # `AWSBedrockLlama2Stream`
 
+<Note type="warning">
+  AWSBedrockLlama2Stream is part of the [legacy AWS Bedrock
+  integration](/providers/legacy-providers/aws-bedrock). It is not compatible
+  with the AI SDK 3.1 functions.
+</Note>
+
 The AWS Bedrock stream functions are utilties that transform the outputs from the AWS Bedrock API into a ReadableStream. It uses AIStream under the hood and handle parsing Bedrock's response.
 
 ## Import

--- a/content/docs/07-reference/stream-helpers/13-cohere-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/13-cohere-stream.mdx
@@ -5,6 +5,12 @@ description: Learn to use CohereStream helper function in your application.
 
 # `CohereStream`
 
+<Note type="warning">
+  CohereStream is part of the [legacy Cohere
+  integration](/providers/legacy-providers/cohere). It is not compatible with
+  the AI SDK 3.1 functions.
+</Note>
+
 The CohereStream function is a utility that transforms the output from Cohere's API into a ReadableStream. It uses AIStream under the hood, applying a specific parser for the Cohere's response data structure. This works with the official Cohere API, and it's supported in both Node.js, the Edge Runtime, and browser environments.
 
 ## Import

--- a/content/docs/07-reference/stream-helpers/14-google-generative-ai-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/14-google-generative-ai-stream.mdx
@@ -5,6 +5,14 @@ description: Learn to use GoogleGenerativeAIStream helper function in your appli
 
 # `GoogleGenerativeAIStream`
 
+<Note type="warning">
+  GoogleGenerativeAIStream is part of the [legacy Google
+  integration](/providers/legacy-providers/google). It is not compatible with
+  the AI SDK 3.1 functions. It is recommended to use the [AI SDK Google
+  Generative AI Provider](/providers/ai-sdk-providers/google-generative-ai)
+  instead.
+</Note>
+
 The GoogleGenerativeAIStream function is a utility that transforms the output from Google's Generative AI SDK into a ReadableStream. It uses AIStream under the hood, applying a specific parser for the Google's response data structure. This works with the official Generative AI SDK, and it's supported in both Node.js, Edge Runtime, and browser environments.
 
 ## Import

--- a/content/docs/07-reference/stream-helpers/15-hugging-face-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/15-hugging-face-stream.mdx
@@ -5,6 +5,12 @@ description: Learn to use HuggingFaceStream helper function in your application.
 
 # `HuggingFaceStream`
 
+<Note type="warning">
+  HuggingFaceStream is part of the [legacy HuggingFaceS
+  integration](/providers/legacy-providers/hugging-face). It is not compatible
+  with the AI SDK 3.1 functions.
+</Note>
+
 Converts the output from language models hosted on Hugging Face into a ReadableStream.
 
 While HuggingFaceStream is compatible with most Hugging Face language models, the rapidly evolving landscape of models may result in certain new or niche models not being supported. If you encounter a model that isn't supported, we encourage you to open an issue.

--- a/content/docs/07-reference/stream-helpers/16-langchain-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/16-langchain-stream.mdx
@@ -5,6 +5,12 @@ description: Learn to use LangChainStream helper function in your application.
 
 # `LangChainStream`
 
+<Note type="warning">
+  LangChainStream is part of the [legacy LangChain
+  integration](/providers/legacy-providers/langchain). It is recommended to use
+  the [LangChain Adapter](/providers/adapters/langchain) instead.
+</Note>
+
 Helps with the integration of LangChain. It is compatible with useChat and useCompletion.
 
 ## Import

--- a/content/docs/07-reference/stream-helpers/17-mistral-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/17-mistral-stream.mdx
@@ -5,6 +5,13 @@ description: Learn to use MistralStream helper function in your application.
 
 # `MistralStream`
 
+<Note type="warning">
+  MistralStream is part of the [legacy Mistral
+  integration](/providers/legacy-providers/openai). It is not compatible with
+  the AI SDK 3.1 functions. It is recommended to use the [AI SDK Mistral
+  Provider](/providers/ai-sdk-providers/mistral) instead.
+</Note>
+
 Transforms the output from Mistral's language models into a ReadableStream.
 
 This works with the official Mistral API, and it's supported in both Node.js, the Edge Runtime, and browser environments.

--- a/content/docs/07-reference/stream-helpers/18-replicate-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/18-replicate-stream.mdx
@@ -5,6 +5,12 @@ description: Learn to use ReplicateStream helper function in your application.
 
 # `ReplicateStream`
 
+<Note type="warning">
+  ReplicateStream is part of the [legacy Replicate
+  integration](/providers/legacy-providers/replicate). It is not compatible with
+  the AI SDK 3.1 functions.
+</Note>
+
 The ReplicateStream function is a utility that handles extracting the stream from the output of [Replicate](https://replicate.com)'s API. It expects a Prediction object as returned by the [Replicate JavaScript SDK](https://github.com/replicate/replicate-javascript), and returns a ReadableStream. Unlike other wrappers, ReplicateStream returns a Promise because it makes a fetch call to the [Replicate streaming API](https://github.com/replicate/replicate-javascript#streaming) under the hood.
 
 ## Import

--- a/content/docs/07-reference/stream-helpers/19-inkeep-stream.mdx
+++ b/content/docs/07-reference/stream-helpers/19-inkeep-stream.mdx
@@ -5,6 +5,12 @@ description: Learn to use InkeepStream helper function in your application.
 
 # `InkeepStream`
 
+<Note type="warning">
+  InkeepStream is part of the [legacy Inkeep
+  integration](/providers/legacy-providers/inkeep). It is not compatible with
+  the AI SDK 3.1 functions.
+</Note>
+
 The InkeepStream function is a utility that transforms the output from [Inkeep](https://inkeep.com)'s API into a ReadableStream. It uses AIStream under the hood, applying a specific parser for the Inkeep's response data structure.
 
 This works with the official Inkeep API, and it's supported in both Node.js, the Edge Runtime, and browser environments.

--- a/content/providers/05-legacy-providers/anthropic.mdx
+++ b/content/providers/05-legacy-providers/anthropic.mdx
@@ -5,10 +5,10 @@ description: Learn how to use Anthropic with the Vercel AI SDK.
 
 # Anthropic
 
-<Note>
-  **It is recommended to use the [AI SDK Anthropic
-  Provider](../ai-sdk-providers/anthropic) instead of the legacy Anthropic
-  provider.**
+<Note type="warning">
+  The legacy Anthropic integration is not compatible with the AI SDK 3.1
+  functions. It is recommended to use the [AI SDK Anthropic
+  Provider](../ai-sdk-providers/anthropic) instead.
 </Note>
 
 Vercel AI SDK provides a set of utilities to make it easy to use Anthropic's API. In this guide, we'll walk through how to use the utilities to create a chat bot and a text completion app.

--- a/content/providers/05-legacy-providers/fireworks-ai.mdx
+++ b/content/providers/05-legacy-providers/fireworks-ai.mdx
@@ -5,6 +5,12 @@ description: Learn how to use Fireworks.ai with the Vercel AI SDK.
 
 # Fireworks.ai
 
+<Note type="warning">
+  The legacy Fireworks integration is not compatible with the AI SDK 3.1
+  functions. It is recommended to use the [AI SDK Fireworks
+  Provider](../ai-sdk-providers/fireworks) instead.
+</Note>
+
 Vercel AI SDK provides a set of utilities to make it easy to use [Fireworks.ai](https://app.fireworks.ai)'s APIs and models. In this guide, we'll walk through how to use the utilities to create a chat bot and a text completion app.
 
 <Note>

--- a/content/providers/05-legacy-providers/google.mdx
+++ b/content/providers/05-legacy-providers/google.mdx
@@ -5,10 +5,11 @@ description: Learn how to use Google's Generative AI SDK with the Vercel AI SDK.
 
 # Google
 
-<Note>
-  **It is recommended to use the [AI SDK Google Generative AI
-  Provider](../ai-sdk-providers/google-generative-ai) instead of the legacy
-  Google provider.**
+<Note type="warning">
+  The legacy Google integration is not compatible with the AI SDK 3.1 functions.
+  It is recommended to use the [AI SDK Google Generative AI
+  Provider](../ai-sdk-providers/google-generative-ai) or the [AI SDK Google
+  Vertex Provider](../ai-sdk-providers/google-vertex) instead.
 </Note>
 
 Vercel AI SDK provides a set of utilities to make it easy to use [Google's Generative AI SDK](https://github.com/google/generative-ai-js)

--- a/content/providers/05-legacy-providers/langchain.mdx
+++ b/content/providers/05-legacy-providers/langchain.mdx
@@ -5,10 +5,10 @@ description: Learn how to use LangChain with the Vercel AI SDK.
 
 # LangChain
 
-<Note>
-  **It is recommended to use the [AI SDK Langchain
+<Note type="warning">
+  It is recommended to use the [AI SDK Langchain
   Adapter](/providers/adapters/langchain) instead of the legacy Langchain
-  provider.**
+  provider.
 </Note>
 
 [LangChain](https://js.langchain.com/docs/) is a framework for developing applications powered by language models.

--- a/content/providers/05-legacy-providers/mistral.mdx
+++ b/content/providers/05-legacy-providers/mistral.mdx
@@ -5,10 +5,10 @@ description: Learn how to use Mistral with the Vercel AI SDK.
 
 # Mistral
 
-<Note>
-  **It is recommended to use the [AI SDK Mistral
-  Provider](../ai-sdk-providers/mistral) instead of the legacy Mistral
-  provider.**
+<Note type="warning">
+  The legacy Mistral integration is not compatible with the AI SDK 3.1
+  functions. It is recommended to use the [AI SDK Mistral
+  Provider](../ai-sdk-providers/mistral) instead.
 </Note>
 
 Vercel AI SDK provides a set of utilities to make it easy to use [Mistral](https://mistral.ai/)'s APIs and models. In this guide, we'll walk through how to use the utilities to create a chat bot and a text completion app.

--- a/content/providers/05-legacy-providers/openai-functions.mdx
+++ b/content/providers/05-legacy-providers/openai-functions.mdx
@@ -5,6 +5,12 @@ description: Learn how to use OpenAI functions with the Vercel AI SDK.
 
 # OpenAI Functions
 
+<Note type="warning">
+  The legacy OpenAI integration is not compatible with the AI SDK 3.1 functions.
+  It is recommended to use the [AI SDK OpenAI
+  Provider](../ai-sdk-providers/openai) instead.
+</Note>
+
 The Vercel AI SDK has **experimental support** for [OpenAI functions](https://openai.com/blog/function-calling-and-other-api-updates).
 Any of the content below is subject to change as OpenAI continues to develop their functions API and we iterate on the Vercel AI SDK. You can see our planned roadmap [here](https://twitter.com/jaredpalmer/status/1673350963191508993).
 

--- a/content/providers/05-legacy-providers/openai.mdx
+++ b/content/providers/05-legacy-providers/openai.mdx
@@ -5,6 +5,12 @@ description: Learn how to use OpenAI with the Vercel AI SDK.
 
 # OpenAI
 
+<Note type="warning">
+  The legacy OpenAI integration is not compatible with the AI SDK 3.1 functions.
+  It is recommended to use the [AI SDK OpenAI
+  Provider](../ai-sdk-providers/openai) instead.
+</Note>
+
 Vercel AI SDK provides a set of utilities to make it easy to use OpenAI's API. In this guide, we'll walk through how to use the utilities to create a chat bot and a text completion app.
 
 ## Guide: Chat Bot

--- a/content/providers/05-legacy-providers/perplexity.mdx
+++ b/content/providers/05-legacy-providers/perplexity.mdx
@@ -5,6 +5,12 @@ description: Learn how to use Perplexity with the Vercel AI SDK.
 
 # Perplexity
 
+<Note type="warning">
+  The legacy Perplexity integration is not compatible with the AI SDK 3.1
+  functions. It is recommended to use the [AI SDK Perplexity
+  Provider](../ai-sdk-providers/perplexity) instead.
+</Note>
+
 Vercel AI SDK provides a set of utilities to make it easy to use [Perplexity](https://perplexity.ai)'s APIs and models. In this guide, we'll walk through how to use the utilities to create a chat bot.
 
 <Note>


### PR DESCRIPTION
## Summary
- Add links to overview pages (for mobile)
- Add warnings and links from reference StreamHelper docs to legacy providers
- Add warnings to legacy providers
- Add missing StreamHelper pages and fix errors