### PR TITLE
feat (ai/core): add onFinish callback to streamText.

### DIFF
--- a/.changeset/eight-falcons-exercise.md
+++ b/.changeset/eight-falcons-exercise.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): add onFinish callback to streamText

--- a/.changeset/old-hotels-attack.md
+++ b/.changeset/old-hotels-attack.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): add text, toolCalls, and toolResults promises to StreamTextResult (matching the generateText result API with async methods)

--- a/.changeset/sour-drinks-judge.md
+++ b/.changeset/sour-drinks-judge.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+feat (ai/provider): add "unknown" finish reason (for models that don't provide a finish reason)

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -3,10 +3,19 @@ title: Generating Text
 description: Learn how to generate text with the Vercel AI SDK.
 ---
 
-# Generating Text
+# Generating and Streaming Text
 
 Large language models (LLMs) can generate text in response to a prompt, which can contain instructions and information to process.
 For example, you can ask a model to come up with a recipe, draft an email, or summarize a document.
+
+The Vercel AI SDK Core provides two functions to generate text and stream it from LLMs:
+
+- [`generateText`](#generatetext): Generates text for a given prompt and model.
+- [`streamText`](#streamtext): Streams text from a given prompt and model.
+
+Advanced LLM features such as [tool calling](./tools-and-tool-calling) and [structured data generation](./generating-structured-data) are built on top of text generation.
+
+## `generateText`
 
 You can generate text using the [`generateText`](/docs/reference/ai-sdk-core/generate-text) function. This function is ideal for non-interactive use cases where you need to write text (e.g. drafting email or summarizing web pages) and for agents that use tools.
 
@@ -32,7 +41,7 @@ const { text } = await generateText({
 });
 ```
 
-## Streaming Text
+## `streamText`
 
 Depending on your model and prompt, it can take a large language model (LLM) up to a minute to finish generating it's response. This delay can be unacceptable for interactive use cases such as chatbots or real-time applications, where users expect immediate responses.
 
@@ -73,4 +82,38 @@ while (true) {
 }
 ```
 
-Advanced LLM features such as [tool calling](./tools-and-tool-calling) and [structured data generation](./generating-structured-data) are built on top of text generation.
+### `onFinish` callback
+
+When using `streamText`, you can provide an `onFinish` callback that is triggered when the model finishes generating the response and all tool executions.
+
+```tsx
+import { streamText } from 'ai';
+
+const result = await streamText({
+  model,
+  prompt: 'Invent a new holiday and describe its traditions.',
+  onFinish({ text, toolCalls, toolResults, finishReason, usage }) {
+    // your own logic, e.g. for saving the chat history or recording usage
+  },
+});
+```
+
+### Result helper functions
+
+The result object of `streamText` contains several helper functions to make the integration into [AI SDK UI](/docs/ai-sdk-ui) easier:
+
+- `result.toAIStream()`: Creates an AI stream object (with tool calls etc.) that can be used with `StreamingTextResponse()` and `StreamData`.
+- `result.toAIStreamResponse()`: Creates an AI stream response (with tool calls etc.).
+- `result.toTextStreamResponse()`: Creates a simple text stream response.
+- `result.pipeTextStreamToResponse()`: Writes text delta output to a Node.js response-like object.
+- `result.pipeAIStreamToResponse()`: Writes AI stream delta output to a Node.js response-like object.
+
+### Result promises
+
+The result object of `streamText` contains several promises that resolve when all required data is available:
+
+- `result.text`: The generated text.
+- `result.toolCalls`: The tool calls made during text generation.
+- `result.toolResults`: The tool results from the tool calls.
+- `result.finishReason`: The reason the model finished generating text.
+- `result.usage`: The usage of the model during text generation.

--- a/content/docs/05-ai-sdk-ui/15-storing-messages.mdx
+++ b/content/docs/05-ai-sdk-ui/15-storing-messages.mdx
@@ -6,33 +6,30 @@ description: Welcome to the Vercel AI SDK documentation!
 # Storing Messages
 
 The ability to store message history is essential for chatbot use cases.
-
-The Vercel AI SDK simplifies the process of storing chat history through the `toAIStream` method, which is designed to manage stream life cycles with ease. This method supports various lifecycle callbacks such as `onFinal`.
+The Vercel AI SDK simplifies the process of storing chat history through the `onFinish` callback of the `streamText` function.
 
 ## Implementing Persistent Chat History
 
-To implement persistent chat storage, you can utilize the `onFinal` callback on the `toAIStream` method. This callback is triggered upon the completion of the model's response, making it an ideal place to handle the storage of each interaction.
+To implement persistent chat storage, you can utilize the `onFinish` callback on the `streamText` function.
+This callback is triggered upon the completion of the model's response and all tool executions,
+making it an ideal place to handle the storage of each interaction.
 
-```tsx highlight="14-18"
+```tsx highlight="10-13"
 'use server';
 
-import { Message, StreamingTextResponse, streamText } from 'ai';
+import { CoreMessage, streamText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
-export async function continueConversation(messages: Message[]) {
-  'use server';
-
+export async function continueConversation(messages: CoreMessage[]) {
   const result = await streamText({
     model: openai('gpt-4-turbo'),
     messages,
-  });
-
-  const stream = result.toAIStream({
-    async onFinal(completion) {
-      await saveChat(completion);
+    async onFinish({ text, toolCalls, toolResults, finishReason, usage }) {
+      // implement your own storage logic:
+      await saveChat({ text, toolCalls, toolResults });
     },
   });
 
-  return new StreamingTextResponse(stream);
+  return result.toAIStreamResponse();
 }
 ```

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -13,7 +13,640 @@ You can use the streamText function for interactive use cases such as chat bots 
 
 <Snippet text={`import { streamText } from "ai"`} prompt={false} />
 
-<ReferenceTable packageName="core" functionName="streamText" />
+<ObjectTableList
+  content={{
+    Parameters: [
+      {
+        name: 'model',
+        type: 'LanguageModel',
+        description: `The language model to use. Example: openai('gpt-4-turbo')`
+      },
+      {
+        name: 'system',
+        type: 'string',
+        description:
+          'The system prompt to use that specifies the behavior of the model.'
+      },
+      {
+        name: 'prompt',
+        type: 'string',
+        description: 'The input prompt to generate the text from.'
+      },
+      {
+        name: 'messages',
+        type: 'Array<CoreSystemMessage | CoreUserMessage | CoreAssistantMessage | CoreToolMessage>',
+        description: 'A list of messages that represent a conversation.',
+        properties: [
+          {
+            type: 'CoreSystemMessage',
+            parameters: [
+              {
+                name: 'role',
+                type: "'system'",
+                description: 'The role for the system message.'
+              },
+              {
+                name: 'content',
+                type: 'string',
+                description: 'The content of the message.'
+              }
+            ]
+          },
+          {
+            type: 'CoreUserMessage',
+            parameters: [
+              {
+                name: 'role',
+                type: "'user'",
+                description: 'The role for the user message.'
+              },
+              {
+                name: 'content',
+                type: 'string | Array<TextPart | ImagePart>',
+                description: 'The content of the message.',
+                properties: [
+                  {
+                    type: 'TextPart',
+                    parameters: [
+                      {
+                        name: 'type',
+                        type: "'text'",
+                        description: 'The type of the message part.'
+                      },
+                      {
+                        name: 'text',
+                        type: 'string',
+                        description: 'The text content of the message part.'
+                      }
+                    ]
+                  },
+                  {
+                    type: 'ImagePart',
+                    parameters: [
+                      {
+                        name: 'type',
+                        type: "'image'",
+                        description: 'The type of the message part.'
+                      },
+                      {
+                        name: 'image',
+                        type: 'string | Uint8Array | Buffer | ArrayBuffer | URL',
+                        description:
+                          'The image content of the message part. String are base64 encoded content. URLs need to be represented with a URL object'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            type: 'CoreAssistantMessage',
+            parameters: [
+              {
+                name: 'role',
+                type: "'assistant'",
+                description: 'The role for the assistant message.'
+              },
+              {
+                name: 'content',
+                type: 'string | Array<TextPart | ToolCallPart>',
+                description: 'The content of the message.',
+                properties: [
+                  {
+                    type: 'TextPart',
+                    parameters: [
+                      {
+                        name: 'type',
+                        type: "'text'",
+                        description: 'The type of the message part.'
+                      },
+                      {
+                        name: 'text',
+                        type: 'string',
+                        description: 'The text content of the message part.'
+                      }
+                    ]
+                  },
+                  {
+                    type: 'ToolCallPart',
+                    parameters: [
+                      {
+                        name: 'type',
+                        type: "'tool-call'",
+                        description: 'The type of the message part.'
+                      },
+                      {
+                        name: 'toolCallId',
+                        type: 'string',
+                        description: 'The id of the tool call.'
+                      },
+                      {
+                        name: 'toolName',
+                        type: 'string',
+                        description:
+                          'The name of the tool, which typically would be the name of the function.'
+                      },
+                      {
+                        name: 'args',
+                        type: 'object based on zod schema',
+                        description:
+                          'Parameters generated by the model to be used by the tool.'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            type: 'CoreToolMessage',
+            parameters: [
+              {
+                name: 'role',
+                type: "'tool'",
+                description: 'The role for the assistant message.'
+              },
+              {
+                name: 'content',
+                type: 'Array<ToolResultPart>',
+                description: 'The content of the message.',
+                properties: [
+                  {
+                    type: 'ToolResultPart',
+                    parameters: [
+                      {
+                        name: 'type',
+                        type: "'tool-result'",
+                        description: 'The type of the message part.'
+                      },
+                      {
+                        name: 'toolCallId',
+                        type: 'string',
+                        description:
+                          'The id of the tool call the result corresponds to.'
+                      },
+                      {
+                        name: 'toolName',
+                        type: 'string',
+                        description:
+                          'The name of the tool the result corresponds to.'
+                      },
+                      {
+                        name: 'result',
+                        type: 'unknown',
+                        description:
+                          'The result returned by the tool after execution.'
+                      },
+                      {
+                        name: 'isError',
+                        type: 'boolean',
+                        isOptional: true,
+                        description:
+                          'Whether the result is an error or an error message.'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        name: 'tools',
+        type: 'Record<string, CoreTool>',
+        description:
+          'Tools that are accessible to and can be called by the model. The model needs to support calling tools.',
+        properties: [
+          {
+            type: 'CoreTool',
+            parameters: [
+              {
+                name: 'description',
+                isOptional: true,
+                type: 'string',
+                description:
+                  'Information about the purpose of the tool including details on how and when it can be used by the model.'
+              },
+              {
+                name: 'parameters',
+                type: 'zod schema',
+                description:
+                  'The schema of the input that the tool expects. The language model will use this to generate the input. It is also used to validate the output of the language model. Use descriptions to make the input understandable for the language model.'
+              },
+              {
+                name: 'execute',
+                isOptional: true,
+                type: 'async (parameters) => any',
+                description:
+                  'An async function that is called with the arguments from the tool call and produces a result. If not provided, the tool will not be executed automatically.'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        name: 'maxTokens',
+        type: 'number',
+        isOptional: true,
+        description: 'Maximum number of tokens to generate.'
+      },
+      {
+        name: 'temperature',
+        type: 'number',
+        isOptional: true,
+        description:
+          'Temperature setting. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.'
+      },
+      {
+        name: 'topP',
+        type: 'number',
+        isOptional: true,
+        description:
+          'Nucleus sampling. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.'
+      },
+      {
+        name: 'presencePenalty',
+        type: 'number',
+        isOptional: true,
+        description:
+          'Presence penalty setting. It affects the likelihood of the model to repeat information that is already in the prompt. The value is passed through to the provider. The range depends on the provider and model.'
+      },
+      {
+        name: 'frequencyPenalty',
+        type: 'number',
+        isOptional: true,
+        description:
+          'Frequency penalty setting. It affects the likelihood of the model to repeatedly use the same words or phrases. The value is passed through to the provider. The range depends on the provider and model.'
+      },
+      {
+        name: 'seed',
+        type: 'number',
+        isOptional: true,
+        description:
+          'The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results.'
+      },
+      {
+        name: 'maxRetries',
+        type: 'number',
+        isOptional: true,
+        description:
+          'Maximum number of retries. Set to 0 to disable retries. Default: 2.'
+      },
+      {
+        name: 'abortSignal',
+        type: 'AbortSignal',
+        isOptional: true,
+        description:
+          'An optional abort signal that can be used to cancel the call.'
+      },
+      {
+        name: "onFinish",
+        type: "(result: OnFinishResult) => void",
+        isOptional: true,
+        description: "Callback that is called when the LLM response and all request tool executions (for tools that have an `execute` function) are finished.",
+        properties: [
+          {
+            type: 'OnFinishResult',
+            parameters: [
+              {
+                name: 'finishReason',
+                type: '"stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown"',
+                description: 'The reason the model finished generating the text.'
+              },
+              {
+                name: 'usage',
+                type: 'TokenUsage',
+                description: 'The token usage of the generated text.',
+                properties: [
+                    {
+                        type: 'TokenUsage',
+                        parameters: [
+                            {
+                            name: 'promptTokens',
+                            type: 'number',
+                            description: 'The total number of tokens in the prompt.'
+                            },
+                            {
+                            name: 'completionTokens',
+                            type: 'number',
+                            description: 'The total number of tokens in the completion.'
+                            },
+                            {
+                            name: 'totalTokens',
+                            type: 'number',
+                            description: 'The total number of tokens generated.'
+                            }
+                        ]
+                    }
+                ]
+              },
+              {
+                name: 'text',
+                type: 'string',
+                description: 'The full text that has been generated.'
+              },
+                {
+                    name: 'toolCalls',
+                    type: 'ToolCall[]',
+                    description: 'The tool calls that have been executed.'
+                },
+                {
+                    name: 'toolResults',
+                    type: 'ToolResult[]',
+                    description: 'The tool results that have been generated.'
+                },
+                {
+                    name: 'warnings',
+                    type: 'Warning[] | undefined',
+                    description: 'Warnings from the model provider (e.g. unsupported settings).'
+                },
+                {
+                    name: 'rawResponse',
+                    type: 'RawResponse',
+                    description: 'Optional raw response data.',
+                    properties: [
+                        {
+                            type: 'RawResponse',
+                            parameters: [
+                                {
+                                    name: 'header',
+                                    optional: true,
+                                    type: 'Record<string, string>',
+                                    description: 'Response headers.'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+          }
+        ]
+      }
+    ],
+    'Result Object': [
+      {
+        name: 'finishReason',
+        type: "Promise<'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other' | 'unknown'>",
+        description:
+          'The reason why the generation finished. Resolved when the response is finished.'
+      },
+      {
+        name: 'usage',
+        type: 'Promise<TokenUsage>',
+        description:
+          'The token usage of the generated text. Resolved when the response is finished.',
+        properties: [
+          {
+            type: 'TokenUsage',
+            parameters: [
+              {
+                name: 'promptTokens',
+                type: 'number',
+                description: 'The total number of tokens in the prompt.'
+              },
+              {
+                name: 'completionTokens',
+                type: 'number',
+                description: 'The total number of tokens in the completion.'
+              },
+              {
+                name: 'totalTokens',
+                type: 'number',
+                description: 'The total number of tokens generated.'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        name: 'text',
+        type: 'Promise<string>',
+        description:
+          'The full text that has been generated. Resolved when the response is finished.'
+      },
+      {
+        name: 'toolCalls',
+        type: 'Promise<ToolCall[]>',
+        description:
+          'The tool calls that have been executed. Resolved when the response is finished.'
+      },
+      {
+        name: 'toolResults',
+        type: 'Promise<ToolResult[]>',
+        description:
+          'The tool results that have been generated. Resolved when the all tool executions are finished.'
+      },
+      {
+        name: 'rawResponse',
+        type: 'RawResponse',
+        optional: true,
+        description: 'Optional raw response data.',
+        properties: [
+          {
+            type: 'RawResponse',
+            parameters: [
+              {
+                name: 'header',
+                optional: true,
+                type: 'Record<string, string>',
+                description: 'Response headers.'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        name: 'warnings',
+        type: 'Warning[] | undefined',
+        description:
+          'Warnings from the model provider (e.g. unsupported settings).'
+      },
+      {
+        name: 'textStream',
+        type: 'AsyncIterable<string> & ReadableStream<string>',
+        description:
+          'A text stream that returns only the generated text deltas. You can use it as either an AsyncIterable or a ReadableStream. When an error occurs, the stream will throw the error.'
+      },
+      {
+        name: 'fullStream',
+        type: 'AsyncIterable<TextStreamPart> & ReadableStream<TextStreamPart>',
+        description:
+          'A stream with all events, including text deltas, tool calls, tool results, and errors. You can use it as either an AsyncIterable or a ReadableStream. When an error occurs, the stream will throw the error.',
+        properties: [
+          {
+            type: 'TextStreamPart',
+            parameters: [
+              {
+                name: 'type',
+                type: "'text-delta'",
+                description: 'The type to identify the object as text delta.'
+              },
+              {
+                name: 'textDelta',
+                type: 'string',
+                description: 'The text delta.'
+              }
+            ]
+          },
+          {
+            type: 'TextStreamPart',
+            parameters: [
+              {
+                name: 'type',
+                type: "'tool-call'",
+                description: 'The type to identify the object as tool call.'
+              },
+              {
+                name: 'toolCallId',
+                type: 'string',
+                description: 'The id of the tool call.'
+              },
+              {
+                name: 'toolName',
+                type: 'string',
+                description:
+                  'The name of the tool, which typically would be the name of the function.'
+              },
+              {
+                name: 'args',
+                type: 'object based on zod schema',
+                description:
+                  'Parameters generated by the model to be used by the tool.'
+              }
+            ]
+          },
+          {
+            type: 'TextStreamPart',
+            description: 'The result of a tool call execution.',
+            parameters: [
+              {
+                name: 'type',
+                type: "'tool-result'",
+                description: 'The type to identify the object as tool result.'
+              },
+              {
+                name: 'toolCallId',
+                type: 'string',
+                description: 'The id of the tool call.'
+              },
+              {
+                name: 'toolName',
+                type: 'string',
+                description:
+                  'The name of the tool, which typically would be the name of the function.'
+              },
+              {
+                name: 'args',
+                type: 'object based on zod schema',
+                description:
+                  'Parameters generated by the model to be used by the tool.'
+              },
+              {
+                name: 'result',
+                type: 'any',
+                description:
+                  'The result returned by the tool after execution has completed.'
+              }
+            ]
+          },
+          {
+            type: 'TextStreamPart',
+            parameters: [
+              {
+                name: 'type',
+                type: "'error'",
+                description: 'The type to identify the object as error.'
+              },
+              {
+                name: 'error',
+                type: 'Error',
+                description:
+                  'Describes the error that may have occurred during execution.'
+              }
+            ]
+          },
+          {
+            type: 'TextStreamPart',
+            parameters: [
+              {
+                name: 'type',
+                type: "'finish'",
+                description: 'The type to identify the object as finish.'
+              },
+              {
+                name: 'finishReason',
+                type: "'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other' | 'unknown'",
+                description:
+                  'The reason the model finished generating the text.'
+              },
+              {
+                name: 'usage',
+                type: 'TokenUsage',
+                description: 'The token usage of the generated text.',
+                properties: [
+                  {
+                    type: 'TokenUsage',
+                    parameters: [
+                      {
+                        name: 'promptTokens',
+                        type: 'number',
+                        description: 'The total number of tokens in the prompt.'
+                      },
+                      {
+                        name: 'completionTokens',
+                        type: 'number',
+                        description:
+                          'The total number of tokens in the completion.'
+                      },
+                      {
+                        name: 'totalTokens',
+                        type: 'number',
+                        description: 'The total number of tokens generated.'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        name: 'toAIStream',
+        type: '(callbacks?: AIStreamCallbacksAndOptions) => AIStream',
+        description:
+          'Converts the result to an `AIStream` object that is compatible with `StreamingTextResponse`. It can be used with the `useChat` and `useCompletion` hooks.'
+      },
+      {
+        name: 'pipeAIStreamToResponse',
+        type: '(response: ServerResponse, init?: { headers?: Record<string, string>; status?: number } => void',
+        description:
+          'Writes stream data output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each stream data part as a separate chunk.'
+      },
+      {
+        name: 'pipeTextStreamToResponse',
+        type: '(response: ServerResponse, init?: { headers?: Record<string, string>; status?: number } => void',
+        description:
+          'Writes text delta output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each text delta as a separate chunk.'
+      },
+      {
+        name: 'toAIStreamResponse',
+        type: '(init?: ResponseInit) => Response',
+        description:
+          'Converts the result to a streamed response object with a stream data part stream. It can be used with the `useChat` and `useCompletion` hooks.'
+      },
+      {
+        name: 'toTextStreamResponse',
+        type: '(init?: ResponseInit) => Response',
+        description:
+          'Creates a simple text stream response. Each text delta is encoded as UTF-8 and sent as a separate chunk. Non-text-delta events are ignored.'
+      }
+    ]
+
+}}
+/>
 
 ## Examples
 

--- a/examples/ai-core/src/stream-text/openai-on-finish.ts
+++ b/examples/ai-core/src/stream-text/openai-on-finish.ts
@@ -1,0 +1,27 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const result = await streamText({
+    model: openai('gpt-4-turbo'),
+    maxTokens: 128,
+    temperature: 0.3,
+    maxRetries: 5,
+    prompt: 'Invent a new holiday and describe its traditions.',
+    onFinish({ usage, finishReason }) {
+      console.log();
+      console.log('onFinish');
+      console.log('Token usage:', usage);
+      console.log('Finish reason:', finishReason);
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-on-finish.ts
+++ b/examples/ai-core/src/stream-text/openai-on-finish.ts
@@ -1,6 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import { streamText } from 'ai';
 import dotenv from 'dotenv';
+import { weatherTool } from '../tools/weather-tool';
 
 dotenv.config();
 
@@ -11,11 +12,20 @@ async function main() {
     temperature: 0.3,
     maxRetries: 5,
     prompt: 'Invent a new holiday and describe its traditions.',
-    onFinish({ usage, finishReason }) {
+    onFinish({
+      usage,
+      finishReason,
+      text,
+      toolCalls,
+      toolResults,
+      rawResponse,
+      warnings,
+    }) {
       console.log();
       console.log('onFinish');
       console.log('Token usage:', usage);
       console.log('Finish reason:', finishReason);
+      console.log('Text:', text);
     },
   });
 

--- a/packages/core/core/generate-text/stream-text.test.ts
+++ b/packages/core/core/generate-text/stream-text.test.ts
@@ -698,6 +698,10 @@ describe('result.finishReason', () => {
   });
 });
 
+// TODO test result.text
+// TODO test result.toolCalls
+// TODO test result.toolResults
+
 describe('onFinish callback', () => {
   let result: Parameters<
     Required<Parameters<typeof streamText>[0]>['onFinish']
@@ -759,7 +763,7 @@ describe('onFinish callback', () => {
       },
       prompt: 'test-input',
       onFinish: async event => {
-        result = event;
+        result = event as unknown as typeof result;
       },
     });
 
@@ -777,5 +781,32 @@ describe('onFinish callback', () => {
 
   it('should contain finish reason', async () => {
     assert.strictEqual(result.finishReason, 'stop');
+  });
+
+  it('should contain full text', async () => {
+    assert.strictEqual(result.text, 'Hello, world!');
+  });
+
+  it('should contain tool calls', async () => {
+    assert.deepStrictEqual(result.toolCalls, [
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'tool1',
+        args: { value: 'value' },
+      },
+    ]);
+  });
+
+  it('should contain tool results', async () => {
+    assert.deepStrictEqual(result.toolResults, [
+      {
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'tool1',
+        args: { value: 'value' },
+        result: 'value-result',
+      },
+    ]);
   });
 });

--- a/packages/core/core/generate-text/stream-text.test.ts
+++ b/packages/core/core/generate-text/stream-text.test.ts
@@ -623,7 +623,7 @@ describe('multiple stream consumption', () => {
 });
 
 describe('result.usage', () => {
-  it('should send token usage', async () => {
+  it('should resolve with token usage', async () => {
     const result = await streamText({
       model: new MockLanguageModelV1({
         doStream: async ({ prompt, mode }) => {
@@ -663,7 +663,7 @@ describe('result.usage', () => {
 });
 
 describe('result.finishReason', () => {
-  it('should send finish reason', async () => {
+  it('should resolve with finish reason', async () => {
     const result = await streamText({
       model: new MockLanguageModelV1({
         doStream: async ({ prompt, mode }) => {
@@ -698,8 +698,110 @@ describe('result.finishReason', () => {
   });
 });
 
-// TODO test result.text
-// TODO test result.toolCalls
+describe('result.text', () => {
+  it('should resolve with full text', async () => {
+    const result = await streamText({
+      model: new MockLanguageModelV1({
+        doStream: async ({ prompt, mode }) => {
+          assert.deepStrictEqual(mode, { type: 'regular', tools: undefined });
+          assert.deepStrictEqual(prompt, [
+            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+          ]);
+
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'text-delta', textDelta: 'Hello' },
+              { type: 'text-delta', textDelta: ', ' },
+              { type: 'text-delta', textDelta: `world!` },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                logprobs: undefined,
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          };
+        },
+      }),
+      prompt: 'test-input',
+    });
+
+    // consume stream (runs in parallel)
+    convertAsyncIterableToArray(result.textStream);
+
+    assert.strictEqual(await result.text, 'Hello, world!');
+  });
+});
+
+describe('result.toolCalls', () => {
+  it('should resolve with tool calls', async () => {
+    const result = await streamText({
+      model: new MockLanguageModelV1({
+        doStream: async ({ prompt, mode }) => {
+          assert.deepStrictEqual(mode, {
+            type: 'regular',
+            tools: [
+              {
+                type: 'function',
+                name: 'tool1',
+                description: undefined,
+                parameters: {
+                  $schema: 'http://json-schema.org/draft-07/schema#',
+                  additionalProperties: false,
+                  properties: { value: { type: 'string' } },
+                  required: ['value'],
+                  type: 'object',
+                },
+              },
+            ],
+          });
+          assert.deepStrictEqual(prompt, [
+            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+          ]);
+
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'call-1',
+                toolName: 'tool1',
+                args: `{ "value": "value" }`,
+              },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                logprobs: undefined,
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          };
+        },
+      }),
+      tools: {
+        tool1: {
+          parameters: z.object({ value: z.string() }),
+        },
+      },
+      prompt: 'test-input',
+    });
+
+    // consume stream (runs in parallel)
+    convertAsyncIterableToArray(result.textStream);
+
+    assert.deepStrictEqual(await result.toolCalls, [
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'tool1',
+        args: { value: 'value' },
+      },
+    ]);
+  });
+});
+
 // TODO test result.toolResults
 
 describe('onFinish callback', () => {

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -53,6 +53,9 @@ If set and supported by the model, calls will generate deterministic results.
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
 
+@param onFinish - Callback that is called when the LLM response and all request tool executions 
+(for tools that have an `execute` function) are finished.
+
 @return
 A result object for accessing different stream types and additional information.
  */

--- a/packages/provider/src/language-model/v1/language-model-v1-finish-reason.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-finish-reason.ts
@@ -8,6 +8,7 @@ Can be one of the following:
 - `tool-calls`: model triggered tool calls
 - `error`: model stopped because of an error
 - `other`: model stopped for other reasons
+- `unknown`: the model has not transmitted a finish reason
  */
 export type LanguageModelV1FinishReason =
   | 'stop' // model generated stop sequence
@@ -15,4 +16,5 @@ export type LanguageModelV1FinishReason =
   | 'content-filter' // content filter violation stopped the model
   | 'tool-calls' // model triggered tool calls
   | 'error' // model stopped because of an error
-  | 'other'; // model stopped for other reasons
+  | 'other' // model stopped for other reasons
+  | 'unknown'; // the model has not transmitted a finish reason


### PR DESCRIPTION
## Summary
- add `onFinish` callback to `streamText`
- add `text`, `toolCalls`, and `toolResults` promises to `StreamTextResult` (matching the `generateText` result API with async methods)
- add `unknown` finish reason (for models that don't provide a finish reason)

## Tasks

- [x] implementation
- [x] examples
- [x] tests
  - [x] onFinish
  - [x] result promises
- [x] documentation
   - [x] reference docs
   - [x] storage example
   - [x] streamText docs
- [x] changeset

## Future Work
- add similar support to `streamObject` and `streamUI`