### PR TITLE
fix(ai/rsc): Fix types for `createStreamableValue` and `createStreamableUI`

### DIFF
--- a/.changeset/kind-islands-watch.md
+++ b/.changeset/kind-islands-watch.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai/rsc): Fix types for createStreamableValue and createStreamableUI

--- a/packages/core/rsc/streamable.ui.test.tsx
+++ b/packages/core/rsc/streamable.ui.test.tsx
@@ -103,7 +103,7 @@ async function recursiveResolve(val: any): Promise<any> {
   return val;
 }
 
-async function simulateFlightServerRender(node: React.ReactElement) {
+async function simulateFlightServerRender(node: React.ReactNode) {
   async function traverse(node: any): Promise<any> {
     if (!node) return {};
 
@@ -318,7 +318,8 @@ describe('rsc - createStreamableUI()', () => {
     ui.append(<div>2</div>);
     ui.append(<div>3</div>);
 
-    const currentRsolved = ui.value.props.children.props.n;
+    const currentRsolved = (ui.value as React.ReactElement).props.children.props
+      .n;
     const tryResolve1 = await Promise.race([currentRsolved, nextTick()]);
     expect(tryResolve1).toBeDefined();
     const tryResolve2 = await Promise.race([tryResolve1.next, nextTick()]);

--- a/packages/core/rsc/utils.tsx
+++ b/packages/core/rsc/utils.tsx
@@ -57,7 +57,7 @@ export function createSuspensedChunk(initialValue: React.ReactNode) {
       <Suspense fallback={initialValue}>
         <R c={initialValue} n={promise} />
       </Suspense>
-    ),
+    ) as React.ReactNode,
     resolve,
     reject,
   };


### PR DESCRIPTION
TSC can't automatically generate circular types:

https://www.typescriptlang.org/play/?#code/GYVwdgxgLglg9mABMOcAUBKRBvAUIxCBAZykWMQF4d8DEQAHAEwEMoBTALkUyoD5ytAL60ATuyghRSYrhFA

Note that `update: () => any` is not great, which is why `createStreamableValue` and `createStreamableUI` don't have correct types inferred. 
