### PR TITLE
fix: code snippet for `useChat` reference

### DIFF
--- a/content/docs/07-reference/ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/ai-sdk-ui/01-use-chat.mdx
@@ -11,16 +11,16 @@ Allows you to easily create a conversational user interface for your chatbot app
 
 <Tabs items={['React', 'Svelte', 'Vue', 'Solid']}>
   <Tab>
-    <Snippet text="{`import { useChat } from 'ai/react'`}" dark />
+    <Snippet text="import { useChat } from 'ai/react'" dark />
   </Tab>
   <Tab>
-    <Snippet text="{`import { useChat } from 'ai/svelte'`}" dark />
+    <Snippet text="import { useChat } from 'ai/svelte'" dark />
   </Tab>
   <Tab>
-    <Snippet text="{`import { useChat } from 'ai/vue'`}" dark />
+    <Snippet text="`import { useChat } from 'ai/vue'" dark />
   </Tab>
   <Tab>
-    <Snippet text="{`import { useChat } from 'ai/solid'`}" dark />
+    <Snippet text="import { useChat } from 'ai/solid'" dark />
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
resolves https://vercel.live/link/sdk.vercel.ai?page=%2Fdocs%2Freference%2Fai-sdk-ui%2Fuse-chat%3FvercelThreadId%3DxUqUp&via=in-app-copy-link