### PR TITLE
feat (core): add maxAutomaticRoundtrips setting to generateText

### DIFF
--- a/.changeset/sour-eagles-tease.md
+++ b/.changeset/sour-eagles-tease.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (core): add maxAutomaticRoundtrips setting to generateText

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -21,7 +21,9 @@ const result = await generateText({
 });
 ```
 
-## Parameters
+## API Signature
+
+### Parameters
 
 <PropertiesTable
   content={[
@@ -317,10 +319,17 @@ const result = await generateText({
       description:
         'An optional abort signal that can be used to cancel the call.',
     },
+    {
+      name: 'maxAutomaticRoundtrips',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Maximum number of automatic roundtrips for tool calls. An automatic tool call roundtrip is another LLM call with the tool call results when all tool calls of the last assistant message have results. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 0, which will disable the feature.',
+    },
   ]}
 />
 
-## Result Object
+### Returns
 
 <PropertiesTable
   content={[

--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -10,6 +10,7 @@
     "@ai-sdk/openai": "latest",
     "ai": "latest",
     "dotenv": "16.4.5",
+    "mathjs": "12.4.2",
     "zod": "3.23.8",
     "zod-to-json-schema": "3.22.4"
   },

--- a/examples/ai-core/src/complex/math-agent/agent.ts
+++ b/examples/ai-core/src/complex/math-agent/agent.ts
@@ -1,0 +1,48 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import dotenv from 'dotenv';
+import * as mathjs from 'mathjs';
+import { z } from 'zod';
+
+dotenv.config();
+
+const problem =
+  'A taxi driver earns $9461 per 1-hour work. ' +
+  'If he works 12 hours a day and in 1 hour he uses 12-liters petrol with price $134 for 1-liter. ' +
+  'How much money does he earn in one day?';
+
+async function main() {
+  console.log(`PROBLEM: ${problem}\n`);
+
+  await generateText({
+    model: openai('gpt-4-turbo'),
+    system:
+      'You are solving math problems. ' +
+      'Reason step by step. ' +
+      'Use the calculator when necessary. ' +
+      'The calculator can only do simple additions, subtractions, multiplications, and divisions. ' +
+      'When you give the final answer, provide an explanation for how you got it.',
+    prompt: problem,
+    tools: {
+      calculate: tool({
+        description:
+          'A tool for evaluating mathematical expressions. Example expressions: ' +
+          "'1.2 * (2 + 4.5)', '12.7 cm to inch', 'sin(45 deg) ^ 2'.",
+        parameters: z.object({ expression: z.string() }),
+        execute: async ({ expression }) => mathjs.evaluate(expression),
+      }),
+      answer: tool({
+        description: 'A tool for providing the final answer.',
+        parameters: z.object({ answer: z.string() }),
+        execute: async ({ answer }) => {
+          console.log(`ANSWER: ${answer}`);
+          process.exit(0);
+        },
+      }),
+    },
+    toolChoice: 'required',
+    maxAutomaticRoundtrips: 10,
+  });
+}
+
+main().catch(console.error);

--- a/packages/core/core/generate-text/generate-text.test.ts
+++ b/packages/core/core/generate-text/generate-text.test.ts
@@ -349,3 +349,130 @@ describe('result.responseMessages', () => {
     ]);
   });
 });
+
+describe('maxAutomaticRoundtrips', () => {
+  it('should return text, tool calls and tool results from last roundtrip', async () => {
+    let responseCount = 0;
+    const result = await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({ prompt, mode }) => {
+          switch (responseCount++) {
+            case 0:
+              assert.deepStrictEqual(mode, {
+                type: 'regular',
+                toolChoice: { type: 'auto' },
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'tool1',
+                    description: undefined,
+                    parameters: {
+                      $schema: 'http://json-schema.org/draft-07/schema#',
+                      additionalProperties: false,
+                      properties: { value: { type: 'string' } },
+                      required: ['value'],
+                      type: 'object',
+                    },
+                  },
+                ],
+              });
+              assert.deepStrictEqual(prompt, [
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'test-input' }],
+                },
+              ]);
+              return {
+                ...dummyResponseValues,
+                toolCalls: [
+                  {
+                    toolCallType: 'function',
+                    toolCallId: 'call-1',
+                    toolName: 'tool1',
+                    args: `{ "value": "value" }`,
+                  },
+                ],
+                toolResults: [
+                  {
+                    toolCallId: 'call-1',
+                    toolName: 'tool1',
+                    args: { value: 'value' },
+                    result: 'result1',
+                  },
+                ],
+              };
+            case 1:
+              assert.deepStrictEqual(mode, {
+                type: 'regular',
+                toolChoice: { type: 'auto' },
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'tool1',
+                    description: undefined,
+                    parameters: {
+                      $schema: 'http://json-schema.org/draft-07/schema#',
+                      additionalProperties: false,
+                      properties: { value: { type: 'string' } },
+                      required: ['value'],
+                      type: 'object',
+                    },
+                  },
+                ],
+              });
+              assert.deepStrictEqual(prompt, [
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'test-input' }],
+                },
+                {
+                  role: 'assistant',
+                  content: [
+                    { type: 'text', text: '' },
+                    {
+                      type: 'tool-call',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      args: { value: 'value' },
+                    },
+                  ],
+                },
+                {
+                  role: 'tool',
+                  content: [
+                    {
+                      type: 'tool-result',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      result: 'result1',
+                    },
+                  ],
+                },
+              ]);
+              return {
+                ...dummyResponseValues,
+                text: 'Hello, world!',
+              };
+            default:
+              throw new Error(`Unexpected response count: ${responseCount}`);
+          }
+        },
+      }),
+      tools: {
+        tool1: {
+          parameters: z.object({ value: z.string() }),
+          execute: async args => {
+            assert.deepStrictEqual(args, { value: 'value' });
+            return 'result1';
+          },
+        },
+      },
+      prompt: 'test-input',
+      maxAutomaticRoundtrips: 2,
+    });
+
+    assert.deepStrictEqual(result.text, 'Hello, world!');
+    assert.deepStrictEqual(result.toolCalls, []);
+    assert.deepStrictEqual(result.toolResults, []);
+  });
+});

--- a/packages/core/core/generate-text/generate-text.ts
+++ b/packages/core/core/generate-text/generate-text.ts
@@ -1,6 +1,9 @@
 import { CoreAssistantMessage, CoreToolMessage } from '../prompt';
 import { CallSettings } from '../prompt/call-settings';
-import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
+import {
+  convertToLanguageModelMessage,
+  convertToLanguageModelPrompt,
+} from '../prompt/convert-to-language-model-prompt';
 import { getValidatedPrompt } from '../prompt/get-validated-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choice';
@@ -24,7 +27,9 @@ Generate a text and call tools for a given prompt using a language model.
 This function does not stream the output. If you want to stream the output, use `streamText` instead.
 
 @param model - The language model to use.
+
 @param tools - Tools that are accessible to and can be called by the model. The model needs to support calling tools.
+@param toolChoice - The tool choice strategy. Default: 'auto'.
 
 @param system - A system message that will be part of the prompt.
 @param prompt - A simple text prompt. You can either use `prompt` or `messages` but not both.
@@ -49,6 +54,8 @@ If set and supported by the model, calls will generate deterministic results.
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
 
+@param maxAutomaticRoundtrips - Maximal number of automatic roundtrips for tool calls.
+
 @returns
 A result object that contains the generated text, the results of the tool calls, and additional information.
  */
@@ -61,6 +68,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   messages,
   maxRetries,
   abortSignal,
+  maxAutomaticRoundtrips = 0,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -78,44 +86,90 @@ The tools that the model can call. The model needs to support calling tools.
 The tool choice strategy. Default: 'auto'.
      */
     toolChoice?: CoreToolChoice<TOOLS>;
+
+    /**
+Maximal number of automatic roundtrips for tool calls.
+
+An automatic tool call roundtrip is another LLM call with the 
+tool call results when all tool calls of the last assistant 
+message have results.
+
+A maximum number is required to prevent infinite loops in the
+case of misconfigured tools.
+
+By default, it's set to 0, which will disable the feature.
+     */
+    maxAutomaticRoundtrips?: number;
   }): Promise<GenerateTextResult<TOOLS>> {
   const retry = retryWithExponentialBackoff({ maxRetries });
   const validatedPrompt = getValidatedPrompt({ system, prompt, messages });
-  const modelResponse = await retry(() => {
-    return model.doGenerate({
-      mode: {
-        type: 'regular',
-        ...prepareToolsAndToolChoice({ tools, toolChoice }),
-      },
-      ...prepareCallSettings(settings),
-      inputFormat: validatedPrompt.type,
-      prompt: convertToLanguageModelPrompt(validatedPrompt),
-      abortSignal,
-    });
-  });
 
-  // parse tool calls:
+  const mode = {
+    type: 'regular' as const,
+    ...prepareToolsAndToolChoice({ tools, toolChoice }),
+  };
+  const callSettings = prepareCallSettings(settings);
+  const promptMessages = convertToLanguageModelPrompt(validatedPrompt);
+
+  let currentModelResponse: Awaited<ReturnType<LanguageModel['doGenerate']>>;
+  let currentToolCalls: ToToolCallArray<TOOLS> = [];
+  let currentToolResults: ToToolResultArray<TOOLS> = [];
+  let roundtrips = 0;
   const toolCalls: ToToolCallArray<TOOLS> = [];
-  for (const modelToolCall of modelResponse.toolCalls ?? []) {
-    toolCalls.push(parseToolCall({ toolCall: modelToolCall, tools }));
-  }
+  const toolResults: ToToolResultArray<TOOLS> = [];
 
-  // execute tools:
-  const toolResults =
-    tools == null ? [] : await executeTools({ toolCalls, tools });
+  do {
+    currentModelResponse = await retry(() => {
+      return model.doGenerate({
+        mode,
+        ...callSettings,
+        // once we have a roundtrip, we need to switch to messages format:
+        inputFormat: roundtrips === 0 ? validatedPrompt.type : 'messages',
+        prompt: promptMessages,
+        abortSignal,
+      });
+    });
+
+    // parse tool calls:
+    currentToolCalls = (currentModelResponse.toolCalls ?? []).map(
+      modelToolCall => parseToolCall({ toolCall: modelToolCall, tools }),
+    );
+
+    // execute tools:
+    currentToolResults =
+      tools == null
+        ? []
+        : await executeTools({ toolCalls: currentToolCalls, tools });
+
+    // append to messages for potential next roundtrip:
+    promptMessages.push(
+      ...toResponseMessages({
+        text: currentModelResponse.text ?? '',
+        toolCalls: currentToolCalls,
+        toolResults: currentToolResults,
+      }).map(convertToLanguageModelMessage),
+    );
+  } while (
+    // there are tool calls:
+    currentToolCalls.length > 0 &&
+    // all current tool calls have results:
+    currentToolResults.length === currentToolCalls.length &&
+    // the number of roundtrips is less than the maximum:
+    roundtrips++ < maxAutomaticRoundtrips
+  );
 
   return new GenerateTextResult({
     // Always return a string so that the caller doesn't have to check for undefined.
     // If they need to check if the model did not return any text,
     // they can check the length of the string:
-    text: modelResponse.text ?? '',
+    text: currentModelResponse.text ?? '',
     toolCalls,
     toolResults,
-    finishReason: modelResponse.finishReason,
-    usage: calculateTokenUsage(modelResponse.usage),
-    warnings: modelResponse.warnings,
-    rawResponse: modelResponse.rawResponse,
-    logprobs: modelResponse.logprobs,
+    finishReason: currentModelResponse.finishReason,
+    usage: calculateTokenUsage(currentModelResponse.usage),
+    warnings: currentModelResponse.warnings,
+    rawResponse: currentModelResponse.rawResponse,
+    logprobs: currentModelResponse.logprobs,
   });
 }
 

--- a/packages/core/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/core/core/prompt/convert-to-language-model-prompt.ts
@@ -4,6 +4,7 @@ import {
   LanguageModelV1Prompt,
   LanguageModelV1TextPart,
 } from '@ai-sdk/provider';
+import { CoreMessage } from '../prompt/message';
 import { detectImageMimeType } from '../util/detect-image-mimetype';
 import { convertDataContentToUint8Array } from './data-content';
 import { ValidatedPrompt } from './get-validated-prompt';
@@ -17,7 +18,8 @@ export function convertToLanguageModelPrompt(
     languageModelMessages.push({ role: 'system', content: prompt.system });
   }
 
-  switch (prompt.type) {
+  const promptType = prompt.type;
+  switch (promptType) {
     case 'prompt': {
       languageModelMessages.push({
         role: 'user',
@@ -28,82 +30,86 @@ export function convertToLanguageModelPrompt(
 
     case 'messages': {
       languageModelMessages.push(
-        ...prompt.messages.map((message): LanguageModelV1Message => {
-          switch (message.role) {
-            case 'system': {
-              return { role: 'system', content: message.content };
-            }
-
-            case 'user': {
-              if (typeof message.content === 'string') {
-                return {
-                  role: 'user',
-                  content: [{ type: 'text', text: message.content }],
-                };
-              }
-
-              return {
-                role: 'user',
-                content: message.content.map(
-                  (
-                    part,
-                  ): LanguageModelV1TextPart | LanguageModelV1ImagePart => {
-                    switch (part.type) {
-                      case 'text': {
-                        return part;
-                      }
-
-                      case 'image': {
-                        if (part.image instanceof URL) {
-                          return {
-                            type: 'image',
-                            image: part.image,
-                            mimeType: part.mimeType,
-                          };
-                        }
-
-                        const imageUint8 = convertDataContentToUint8Array(
-                          part.image,
-                        );
-
-                        return {
-                          type: 'image',
-                          image: imageUint8,
-                          mimeType:
-                            part.mimeType ?? detectImageMimeType(imageUint8),
-                        };
-                      }
-                    }
-                  },
-                ),
-              };
-            }
-
-            case 'assistant': {
-              if (typeof message.content === 'string') {
-                return {
-                  role: 'assistant',
-                  content: [{ type: 'text', text: message.content }],
-                };
-              }
-
-              return { role: 'assistant', content: message.content };
-            }
-
-            case 'tool': {
-              return message;
-            }
-          }
-        }),
+        ...prompt.messages.map(convertToLanguageModelMessage),
       );
       break;
     }
 
     default: {
-      const _exhaustiveCheck: never = prompt;
+      const _exhaustiveCheck: never = promptType;
       throw new Error(`Unsupported prompt type: ${_exhaustiveCheck}`);
     }
   }
 
   return languageModelMessages;
+}
+
+export function convertToLanguageModelMessage(
+  message: CoreMessage,
+): LanguageModelV1Message {
+  switch (message.role) {
+    case 'system': {
+      return { role: 'system', content: message.content };
+    }
+
+    case 'user': {
+      if (typeof message.content === 'string') {
+        return {
+          role: 'user',
+          content: [{ type: 'text', text: message.content }],
+        };
+      }
+
+      return {
+        role: 'user',
+        content: message.content.map(
+          (part): LanguageModelV1TextPart | LanguageModelV1ImagePart => {
+            switch (part.type) {
+              case 'text': {
+                return part;
+              }
+
+              case 'image': {
+                if (part.image instanceof URL) {
+                  return {
+                    type: 'image',
+                    image: part.image,
+                    mimeType: part.mimeType,
+                  };
+                }
+
+                const imageUint8 = convertDataContentToUint8Array(part.image);
+
+                return {
+                  type: 'image',
+                  image: imageUint8,
+                  mimeType: part.mimeType ?? detectImageMimeType(imageUint8),
+                };
+              }
+            }
+          },
+        ),
+      };
+    }
+
+    case 'assistant': {
+      if (typeof message.content === 'string') {
+        return {
+          role: 'assistant',
+          content: [{ type: 'text', text: message.content }],
+        };
+      }
+
+      return { role: 'assistant', content: message.content };
+    }
+
+    case 'tool': {
+      return message;
+    }
+
+    default: {
+      const _exhaustiveCheck: never = message;
+      throw new Error(`Unsupported message role: ${_exhaustiveCheck}`);
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
+      mathjs:
+        specifier: 12.4.2
+        version: 12.4.2
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -2816,6 +2819,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
+
+  /@babel/runtime@7.24.6:
+    resolution: {integrity: sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+    dev: false
 
   /@babel/standalone@7.23.3:
     resolution: {integrity: sha512-ZfB6wyLVqr9ANl1F0l/0aqoNUE1/kcWlQHmk0wF9OTEKDK1whkXYLruRMt53zY556yS2+84EsOpr1hpjZISTRg==}
@@ -8884,6 +8894,10 @@ packages:
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
+  /complex.js@2.1.1:
+    resolution: {integrity: sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==}
+    dev: false
+
   /compress-commons@5.0.1:
     resolution: {integrity: sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==}
     engines: {node: '>= 12.0.0'}
@@ -10047,6 +10061,10 @@ packages:
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  /escape-latex@1.2.0:
+    resolution: {integrity: sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==}
+    dev: false
+
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -10932,6 +10950,10 @@ packages:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
+
+  /fraction.js@4.3.4:
+    resolution: {integrity: sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==}
+    dev: false
 
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -12112,6 +12134,10 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  /javascript-natural-sort@0.7.1:
+    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+    dev: false
 
   /jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -13478,6 +13504,22 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /mathjs@12.4.2:
+    resolution: {integrity: sha512-lW14EzwAFgbNN7AZikxplmhs7wiXDhMphBOGCA3KS6T29ECEkHJsBtbEW5cnCz7sXtl4nDyvTdR+DqVsZyiiEw==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.24.6
+      complex.js: 2.1.1
+      decimal.js: 10.4.3
+      escape-latex: 1.2.0
+      fraction.js: 4.3.4
+      javascript-natural-sort: 0.7.1
+      seedrandom: 3.0.5
+      tiny-emitter: 2.1.0
+      typed-function: 4.1.1
+    dev: false
 
   /md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
@@ -16183,6 +16225,10 @@ packages:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
     dev: false
 
+  /seedrandom@3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
+    dev: false
+
   /seek-bzip@1.0.6:
     resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
     hasBin: true
@@ -17344,6 +17390,10 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
+  /tiny-emitter@2.1.0:
+    resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
+    dev: false
+
   /tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
     dependencies:
@@ -17767,6 +17817,11 @@ packages:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
+
+  /typed-function@4.1.1:
+    resolution: {integrity: sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ==}
+    engines: {node: '>= 14'}
+    dev: false
 
   /typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}


### PR DESCRIPTION
## Summary
* Adds `maxAutomaticRoundtrips` setting to `generateText`. This enables automatic looping to feed back tool results to the LLM.
* Adds math agent example

## Tasks

- [x] implement
- [x] add example
- [x] add tests
- [x] docs
- [x] changeset

## Future Work
- Implement something similar in `streamText` and `streamUI`