### PR TITLE
Fix links on `/docs/ai-sdk-core` page

### DIFF
--- a/content/docs/03-ai-sdk-core/index.mdx
+++ b/content/docs/03-ai-sdk-core/index.mdx
@@ -28,33 +28,33 @@ description: Learn about the Vercel AI SDK Core.
     {
       title: 'Generating Text',
       description: 'Learn how to generate text.',
-      href: '/docs/ai-sdk-core/ai-sdk-core/generating-text',
+      href: '/docs/ai-sdk-core/generating-text',
     },
     {
       title: 'Generating Structured Data',
       description: 'Learn how to generate structured data.',
-      href: '/docs/ai-sdk-core/ai-sdk-core/generating-structured-data',
+      href: '/docs/ai-sdk-core/generating-structured-data',
     },
     {
       title: 'Tools and Tool Calling',
       description: 'Learn how to use tools.',
-      href: '/docs/ai-sdk-core/ai-sdk-core/tools-and-tool-calling',
+      href: '/docs/ai-sdk-core/tools-and-tool-calling',
     },
     {
       title: 'Schemas and Zod',
       description: 'Learn how to use schemas and zod.',
-      href: '/docs/ai-sdk-core/ai-sdk-core/schemas-and-zod',
+      href: '/docs/ai-sdk-core/schemas-and-zod',
     },
     {
       title: 'Settings',
       description:
         'Learn how to set up settings for language models generations.',
-      href: '/docs/ai-sdk-core/ai-sdk-core/settings',
+      href: '/docs/ai-sdk-core/settings',
     },
     {
       title: 'Embeddings',
       description: 'Learn how to use embeddings.',
-      href: '/docs/ai-sdk-core/ai-sdk-core/embeddings',
+      href: '/docs/ai-sdk-core/embeddings',
     },
   ]}
 />


### PR DESCRIPTION
A bunch of the links on https://sdk.vercel.ai/docs/ai-sdk-core have an extra `/ai-sdk-core` part to them, making the links lead to nowhere. This PR fixes the hrefs.