### PR TITLE
feat (provider/vertex): support googleAuthOptions

### DIFF
--- a/.changeset/perfect-pugs-smash.md
+++ b/.changeset/perfect-pugs-smash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+feat (provider/google): add googleAuthOptions provider configuration setting

--- a/content/providers/01-ai-sdk-providers/03-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/03-google-vertex.mdx
@@ -54,6 +54,34 @@ You can use the following optional settings to customize the Google Generative A
   The Google Cloud location that you want to use for the API calls, e.g. `us-central1`.
   It uses the `GOOGLE_VERTEX_LOCATION` environment variable by default.
 
+- **googleAuthOptions** _object_
+
+  Optional. The Authentication options used by the [Google Auth Library](https://github.com/googleapis/google-auth-library-nodejs/):
+
+  - **authClient** _object_
+    An `AuthClient` to use.
+
+  - **keyFilename** _string_
+    Path to a .json, .pem, or .p12 key file.
+
+  - **keyFile** _string_
+    Path to a .json, .pem, or .p12 key file.
+
+  - **credentials** _object_
+    Object containing client_email and private_key properties, or the external account client options.
+
+  - **clientOptions** _object_
+    Options object passed to the constructor of the client.
+
+  - **scopes** _string | string[]_
+    Required scopes for the desired API request.
+
+  - **projectId** _string_
+    Your project ID.
+
+  - **universeDomain** _string_
+    The default service domain for a given Cloud universe.
+
 ## Language Models
 
 You can create models that call the Vertex API using the provider instance.

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -1,5 +1,5 @@
 import { generateId, loadSetting } from '@ai-sdk/provider-utils';
-import { VertexAI } from '@google-cloud/vertexai';
+import { VertexAI, VertexInit } from '@google-cloud/vertexai';
 import { GoogleVertexLanguageModel } from './google-vertex-language-model';
 import {
   GoogleVertexModelId,
@@ -26,6 +26,14 @@ Your Google Vertex location. Defaults to the environment variable `GOOGLE_VERTEX
 Your Google Vertex project. Defaults to the environment variable `GOOGLE_VERTEX_PROJECT`.
   */
   project?: string;
+
+  /**
+ Optional. The Authentication options provided by google-auth-library.
+Complete list of authentication options is documented in the
+GoogleAuthOptions interface:
+https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/googleauth.ts.
+   */
+  googleAuthOptions?: VertexInit['googleAuthOptions'];
 
   // for testing
   generateId?: () => string;
@@ -60,6 +68,7 @@ export function createVertex(
         environmentVariableName: 'GOOGLE_VERTEX_LOCATION',
         description: 'Google Vertex location',
       }),
+      googleAuthOptions: options.googleAuthOptions,
     };
 
     return options.createVertexAI?.(config) ?? new VertexAI(config);


### PR DESCRIPTION
## Summary

Adds a `googleAuthOptions` setting to the Google Vertex provider.

## Tasks

- [x] implementation
- [x] docs
- [x] changeset