### PR TITLE
fix (docs): Add missing content for nuxt example

### DIFF
--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -61,7 +61,7 @@ Edit the `.env.local` file:
 OPENAI_API_KEY=xxxxxxxxx
 ```
 
-Replace `xxxxxxxxx` with your actual OpenAI API key and configure the environment variable in `nuxt.config.ts`: 
+Replace `xxxxxxxxx` with your actual OpenAI API key and configure the environment variable in `nuxt.config.ts`:
 
 ```ts filename="nuxt.config.ts"
 export default defineNuxtConfig({
@@ -70,7 +70,6 @@ export default defineNuxtConfig({
   },
 });
 ```
-
 
 ## Create an API route
 

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -63,7 +63,7 @@ OPENAI_API_KEY=xxxxxxxxx
 
 Replace `xxxxxxxxx` with your actual OpenAI API key and configure the environment variable in `nuxt.config.ts`: 
 
-```ts
+```ts filename="nuxt.config.ts"
 export default defineNuxtConfig({
   runtimeConfig: {
     openaiApiKey: process.env.OPENAI_API_KEY,

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -61,7 +61,16 @@ Edit the `.env.local` file:
 OPENAI_API_KEY=xxxxxxxxx
 ```
 
-Replace `xxxxxxxxx` with your actual OpenAI API key.
+Replace `xxxxxxxxx` with your actual OpenAI API key and configurate the environment variable in `nuxt.config.ts`: 
+
+```ts
+export default defineNuxtConfig({
+  runtimeConfig: {
+    openaiApiKey: process.env.OPENAI_API_KEY,
+  },
+});
+```
+
 
 ## Create an API route
 

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -61,7 +61,7 @@ Edit the `.env.local` file:
 OPENAI_API_KEY=xxxxxxxxx
 ```
 
-Replace `xxxxxxxxx` with your actual OpenAI API key and configurate the environment variable in `nuxt.config.ts`: 
+Replace `xxxxxxxxx` with your actual OpenAI API key and configure the environment variable in `nuxt.config.ts`: 
 
 ```ts
 export default defineNuxtConfig({


### PR DESCRIPTION
As [the documentation](https://nuxt.com/docs/api/composables/use-runtime-config#define-runtime-config) points out, we should configure the environment variables in `nuxt.config.ts` before using `useRuntimeConfig`.

If we don't do that, the environment variables aren't accessible.