### PR TITLE
fix(ai/rsc): Remove extra reconciliation of `streamUI`

### DIFF
--- a/.changeset/late-years-share.md
+++ b/.changeset/late-years-share.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai/rsc): Remove extra reconcilation of streamUI

--- a/packages/core/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
+++ b/packages/core/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
@@ -63,13 +63,7 @@ exports[`result.value > should render text function returned ui 1`] = `
                 "next": {
                   "done": false,
                   "next": {
-                    "done": false,
-                    "next": {
-                      "done": true,
-                      "value": <h1>
-                        { "content": "Hello, world!" }
-                      </h1>,
-                    },
+                    "done": true,
                     "value": <h1>
                       { "content": "Hello, world!" }
                     </h1>,
@@ -115,22 +109,11 @@ exports[`result.value > should render tool call results 1`] = `
     "props": {
       "c": undefined,
       "n": {
-        "done": false,
-        "next": {
-          "done": false,
-          "next": {
-            "done": true,
-            "value": <div>
-              tool1: 
-              value
-            </div>,
-          },
-          "value": <div>
-            tool1: 
-            value
-          </div>,
-        },
-        "value": "",
+        "done": true,
+        "value": <div>
+          tool1: 
+          value
+        </div>,
       },
     },
     "type": "",
@@ -151,22 +134,11 @@ exports[`result.value > should render tool call results with generator render fu
       "n": {
         "done": false,
         "next": {
-          "done": false,
-          "next": {
-            "done": false,
-            "next": {
-              "done": true,
-              "value": <div>
-                tool: 
-                value
-              </div>,
-            },
-            "value": <div>
-              tool: 
-              value
-            </div>,
-          },
-          "value": "",
+          "done": true,
+          "value": <div>
+            tool: 
+            value
+          </div>,
         },
         "value": <div>
           Loading...


### PR DESCRIPTION
This PR improves `streamUI` to get rid of the last streamable UI update (`.done()`) so the element won't be re-mounted due to reconciliation of Suspense's fallback and children.

Note that this is a workaround to improve the current experience. In a follow up PR I will refactor it to have even fewer reconciliations.
