### PR TITLE
chore: fix borked links

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -474,6 +474,6 @@ The `ai/rsc` library is designed to give you complete control over streamable va
 
 ## Where to Next?
 
-You've built an AI chatbot using the Vercel AI SDK! Experiment and extend the functionality of this application further by exploring [tool calling](/ai-sdk-core/tools-and-tool-calling) or introducing more granular control over [AI and UI states](/docs/ai-sdk-rsc/ai-ui-states).
+You've built an AI chatbot using the Vercel AI SDK! Experiment and extend the functionality of this application further by exploring [tool calling](/docs/ai-sdk-core/tools-and-tool-calling) or introducing more granular control over [AI and UI states](/docs/ai-sdk-rsc/ai-ui-states).
 
 If you are looking to leverage the broader capabilities of LLMs, Vercel [ AI SDK Core ](/docs/ai-sdk-core) provides a comprehensive set of lower-level tools and APIs that will help you unlock a wider range of AI functionalities beyond the chatbot paradigm.

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -124,7 +124,7 @@ Let's take a look at what is happening in this code:
 
 ## Wire up the UI
 
-Now that you have an API route that can query an LLM, it's time to setup your frontend. Vercel AI SDK's [ UI ](docs/building-applications) package abstract the complexity of a chat interface into one hook, [`useChat`](/docs/reference/ai-sdk-ui/use-chat).
+Now that you have an API route that can query an LLM, it's time to setup your frontend. Vercel AI SDK's [ UI ](/docs/ai-sdk-ui/overview) package abstract the complexity of a chat interface into one hook, [`useChat`](/docs/reference/ai-sdk-ui/use-chat).
 
 Update your root page (`pages/index.vue`) with the following code to show a list of chat messages and provide a user message input:
 

--- a/content/docs/03-ai-sdk-core/01-overview.mdx
+++ b/content/docs/03-ai-sdk-core/01-overview.mdx
@@ -16,8 +16,8 @@ For example, here’s how you can generate text with various models using the Ve
 
 ## AI SDK Core Functions
 
-AI SDK Core has various functions designed for [text generation](./ai-sdk-core/generating-text), [structured data generation](./ai-sdk-core/generating-structured-data), and [tool usage](./ai-sdk-core/tools-and-tool-calling).
-These functions take a standardized approach to setting up [prompts](./ai-sdk-core/prompts) and [settings](./ai-sdk-core/settings), making it easier to work with different models.
+AI SDK Core has various functions designed for [text generation](./generating-text), [structured data generation](./generating-structured-data), and [tool usage](./tools-and-tool-calling).
+These functions take a standardized approach to setting up [prompts](./prompts) and [settings](./settings), making it easier to work with different models.
 
 - [`generateText`](/docs/reference/ai-sdk-core/generate-text): Generates text and [tool calls](./ai-sdk-core/tools-and-tool-calling).
   This function is ideal for non-interactive use cases such as automation tasks where you need to write text (e.g. drafting email or summarizing web pages) and for agents that use tools.

--- a/content/docs/07-reference/ai-sdk-rsc/09-use-actions.mdx
+++ b/content/docs/07-reference/ai-sdk-rsc/09-use-actions.mdx
@@ -7,7 +7,7 @@ description: Reference for the useActions function from the AI SDK RSC
 
 It is a hook to help you access your Server Actions from the client. This is particularly useful for building interfaces that require user interactions with the server.
 
-It is required to access these server actions via this hook because they are patched when passed through the context. Accessing them directly may result in a [Cannot find Client Component error](/docs/troubleshooting/server-actions-in-client-components).
+It is required to access these server actions via this hook because they are patched when passed through the context. Accessing them directly may result in a [Cannot find Client Component error](/docs/troubleshooting/common-issues/server-actions-in-client-components).
 
 ## Import
 

--- a/content/docs/07-reference/stream-helpers/index.mdx
+++ b/content/docs/07-reference/stream-helpers/index.mdx
@@ -113,7 +113,7 @@ description: Learn to use help functions that help stream generations from diffe
       title: 'InkeepsStream',
       description:
         "Transforms the response from Inkeeps's language models into a readable stream.",
-      href: '/docs/reference/stream-helpers/inkeeps-stream',
+      href: '/docs/reference/stream-helpers/inkeep-stream',
     },
   ]}
 />

--- a/content/docs/08-troubleshooting/01-common-issues/20-nan-token-counts-openai-streaming.mdx
+++ b/content/docs/08-troubleshooting/01-common-issues/20-nan-token-counts-openai-streaming.mdx
@@ -7,7 +7,7 @@ description: Troubleshooting errors related to NaN token counts in OpenAI stream
 
 ## Issue
 
-I am using `streamText` with the [OpenAI provider for the AI SDK](/docs/ai-sdk/providers/openai) and OpenAI models.
+I am using `streamText` with the [OpenAI provider for the AI SDK](/providers/ai-sdk-providers/openai) and OpenAI models.
 I use `createOpenAI` to create the provider instance.
 When I try to get the token counts, I get `NaN` values.
 

--- a/content/examples/01-next-app/03-tools/index.mdx
+++ b/content/examples/01-next-app/03-tools/index.mdx
@@ -19,7 +19,7 @@ You will also briefly explore rendering React components as part of a function's
     },
     {
       title: 'Call Tools in Parallel',
-      href: '/examples/next-app/tools/call-functions-in-parallel',
+      href: '/examples/next-app/tools/call-tools-in-parallel',
     },
     {
       title: 'Render Interface during Tool Call',

--- a/content/examples/03-node/03-tools/index.mdx
+++ b/content/examples/03-node/03-tools/index.mdx
@@ -19,7 +19,7 @@ The following sections will guide you through tool use with Node.js and the Verc
     },
     {
       title: 'Call Tools in Parallel',
-      href: '/examples/node/tools/call-tool-in-parallel',
+      href: '/examples/node/tools/call-tools-in-parallel',
     },
     {
       title: 'Call Tools with Automatic Roundtrips',

--- a/content/providers/04-adapters/index.mdx
+++ b/content/providers/04-adapters/index.mdx
@@ -11,4 +11,4 @@ with 3rd party libraries.
 
 The following adapters are currently available:
 
-- [LangChain](./langchain)
+- [LangChain](/providers/adapters/langchain)

--- a/content/providers/05-legacy-providers/azure-openai.mdx
+++ b/content/providers/05-legacy-providers/azure-openai.mdx
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
 <Note>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Azure OpenAI library to
-  [`OpenAIStream`](/docs/reference/stream-helpers/open-ai-stream). This method
+  [`OpenAIStream`](/docs/reference/stream-helpers/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/reference/stream-helpers/streaming-text-response).

--- a/content/providers/05-legacy-providers/fireworks-ai.mdx
+++ b/content/providers/05-legacy-providers/fireworks-ai.mdx
@@ -81,7 +81,7 @@ export async function POST(req: Request) {
 <Note>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Fireworks to
-  [`OpenAIStream`](/docs/reference/stream-helpers/open-ai-stream). This method
+  [`OpenAIStream`](/docs/reference/stream-helpers/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/reference/stream-helpers/streaming-text-response).

--- a/content/providers/05-legacy-providers/langchain.mdx
+++ b/content/providers/05-legacy-providers/langchain.mdx
@@ -137,4 +137,4 @@ For streaming with legacy or more complex chains or agents that don't support st
 Under the hood it is a wrapper over LangChain's [`callbacks`](https://js.langchain.com/docs/production/callbacks/).
 We wrap over these methods to provide which then write to the `stream` which can then be passed directly to [`StreamingTextResponse`](/docs/reference/stream-helpers/streaming-text-response).
 
-You can see an example of how this looks from the [`LangChainStream` docs page](/docs/reference/stream-helpers/lang-chain-stream).
+You can see an example of how this looks from the [`LangChainStream` docs page](/docs/reference/stream-helpers/langchain-stream).

--- a/content/providers/05-legacy-providers/openai.mdx
+++ b/content/providers/05-legacy-providers/openai.mdx
@@ -70,7 +70,7 @@ export async function POST(req: Request) {
 <Note>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from OpenAI to
-  [`OpenAIStream`](/docs/reference/stream-helpers/open-ai-stream). This method
+  [`OpenAIStream`](/docs/reference/stream-helpers/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/reference/stream-helpers/streaming-text-response).

--- a/content/providers/05-legacy-providers/perplexity.mdx
+++ b/content/providers/05-legacy-providers/perplexity.mdx
@@ -82,7 +82,7 @@ export async function POST(req: Request) {
 <Note>
   Vercel AI SDK provides 2 utility helpers to make the above seamless: First, we
   pass the streaming `response` we receive from Perplexity to
-  [`OpenAIStream`](/docs/reference/stream-helpers/open-ai-stream). This method
+  [`OpenAIStream`](/docs/reference/stream-helpers/openai-stream). This method
   decodes/extracts the text tokens in the response and then re-encodes them
   properly for simple consumption. We can then pass that new stream directly to
   [`StreamingTextResponse`](/docs/reference/stream-helpers/streaming-text-response).


### PR DESCRIPTION
Addresses most broken links from https://crawl-analysis.vercel.sh/sdk.vercel.ai

Footer links will be addressed in a separate `ai-studio` PR