### PR TITLE
fix(ai/rsc): Improve type inference of states

### DIFF
--- a/packages/core/rsc/ai-state.tsx
+++ b/packages/core/rsc/ai-state.tsx
@@ -64,14 +64,12 @@ export function sealMutableAIState() {
  * @example const state = getAIState() // Get the entire AI state
  * @example const field = getAIState('key') // Get the value of the key
  */
-function getAIState<AI extends AIProvider = any>(): Readonly<
-  InferAIState<AI, any>
->;
+function getAIState<AI extends AIProvider = any>(): Readonly<InferAIState<AI>>;
 function getAIState<AI extends AIProvider = any>(
-  key: keyof InferAIState<AI, any>,
-): Readonly<InferAIState<AI, any>[typeof key]>;
+  key: keyof InferAIState<AI>,
+): Readonly<InferAIState<AI>[typeof key]>;
 function getAIState<AI extends AIProvider = any>(
-  ...args: [] | [key: keyof InferAIState<AI, any>]
+  ...args: [] | [key: keyof InferAIState<AI>]
 ) {
   const store = getAIStateStoreOrThrow(
     '`getAIState` must be called within an AI Action.',
@@ -110,16 +108,19 @@ function getAIState<AI extends AIProvider = any>(
  * state.done({ ...state.get(), key: 'value' }) // Done with a new state
  * ```
  */
-function getMutableAIState<AI extends AIProvider = any>(): MutableAIState<
-  InferAIState<AI, any>
->;
-function getMutableAIState<AI extends AIProvider = any>(
-  key: keyof InferAIState<AI, any>,
-): MutableAIState<InferAIState<AI, any>[typeof key]>;
-function getMutableAIState<AI extends AIProvider = any>(
-  ...args: [] | [key: keyof InferAIState<AI, any>]
-) {
-  type AIState = InferAIState<AI, any>;
+function getMutableAIState<
+  AI extends AIProvider = any,
+  _AIState = InferAIState<AI>,
+>(): MutableAIState<_AIState>;
+function getMutableAIState<
+  AI extends AIProvider = any,
+  _AIState = InferAIState<AI>,
+>(key: keyof _AIState): MutableAIState<_AIState[typeof key]>;
+function getMutableAIState<
+  AI extends AIProvider = any,
+  _AIState = InferAIState<AI>,
+>(...args: [] | [key: keyof _AIState]) {
+  type AIState = _AIState;
   type AIStateWithKey = typeof args extends [key: keyof AIState]
     ? AIState[(typeof args)[0]]
     : AIState;

--- a/packages/core/rsc/index.ts
+++ b/packages/core/rsc/index.ts
@@ -17,4 +17,4 @@ export type {
   useSyncUIState,
 } from './rsc-client';
 
-export type { StreamableValue } from './types';
+export type { StreamableValue, AIProvider } from './types';

--- a/packages/core/rsc/shared-client/context.tsx
+++ b/packages/core/rsc/shared-client/context.tsx
@@ -126,7 +126,7 @@ export function InternalAIProvider({
 }
 
 export function useUIState<AI extends AIProvider = any>() {
-  type T = InferUIState<AI, any>;
+  type T = InferUIState<AI>;
 
   const state = React.useContext<
     [T, (v: T | ((v_: T) => T)) => void] | null | undefined
@@ -147,20 +147,20 @@ export function useUIState<AI extends AIProvider = any>() {
 
 // TODO: How do we avoid causing a re-render when the AI state changes but you
 // are only listening to a specific key? We need useSES perhaps?
-function useAIState<AI extends AIProvider = any>(): [
-  InferAIState<AI, any>,
-  (newState: ValueOrUpdater<InferAIState<AI, any>>) => void,
-];
-function useAIState<AI extends AIProvider = any>(
-  key: keyof InferAIState<AI, any>,
+function useAIState<
+  AI extends AIProvider = any,
+  _AIState = InferAIState<AI>,
+>(): [_AIState, (newState: ValueOrUpdater<_AIState>) => void];
+function useAIState<AI extends AIProvider = any, _AIState = InferAIState<AI>>(
+  key: keyof _AIState,
 ): [
-  InferAIState<AI, any>[typeof key],
-  (newState: ValueOrUpdater<InferAIState<AI, any>[typeof key]>) => void,
+  _AIState[typeof key],
+  (newState: ValueOrUpdater<_AIState[typeof key]>) => void,
 ];
-function useAIState<AI extends AIProvider = any>(
-  ...args: [] | [keyof InferAIState<AI, any>]
+function useAIState<AI extends AIProvider = any, _AIState = InferAIState<AI>>(
+  ...args: [] | [keyof _AIState]
 ) {
-  type T = InferAIState<AI, any>;
+  type T = InferAIState<AI>;
 
   const state = React.useContext<
     [T, (newState: ValueOrUpdater<T>) => void] | null | undefined
@@ -206,7 +206,7 @@ function useAIState<AI extends AIProvider = any>(
 }
 
 export function useActions<AI extends AIProvider = any>() {
-  type T = InferActions<AI, any>;
+  type T = InferActions<AI>;
 
   const actions = React.useContext<T>(InternalActionProvider);
   return actions;

--- a/packages/core/rsc/types.test-d.ts
+++ b/packages/core/rsc/types.test-d.ts
@@ -1,6 +1,14 @@
 import { expectTypeOf } from 'vitest';
 
-import type { StreamableValue } from './dist';
+import {
+  createAI,
+  useActions,
+  useAIState,
+  useUIState,
+  getAIState,
+  type StreamableValue,
+  type AIProvider,
+} from './dist';
 
 describe('StreamableValue type', () => {
   it('should not contain types marked with @internal after compilation', () => {
@@ -21,5 +29,88 @@ describe('StreamableValue type', () => {
     expectTypeOf<
       StreamableValue<string>
     >().not.toEqualTypeOf<'THIS IS NOT A STREAMABLE VALUE'>();
+  });
+});
+
+describe('createAI type', () => {
+  it('should be inferred by useAIState()', () => {
+    function testType() {
+      const AI = createAI({
+        actions: {},
+        initialAIState: [1, 2, 3],
+      });
+      const [aiState] = useAIState<typeof AI>();
+      return aiState;
+    }
+
+    type AIStateType = ReturnType<typeof testType>;
+    expectTypeOf<AIStateType>().toEqualTypeOf<number[]>();
+  });
+
+  it('should be inferred by useUIState()', () => {
+    function testType() {
+      const AI = createAI({
+        actions: {},
+        initialUIState: [true, 'hi'],
+      });
+      const [uiState] = useUIState<typeof AI>();
+      return uiState;
+    }
+
+    type UIStateType = ReturnType<typeof testType>;
+    expectTypeOf<UIStateType>().toEqualTypeOf<(boolean | string)[]>();
+  });
+
+  it('should be inferred by useActions()', () => {
+    function testType() {
+      const AI = createAI({
+        actions: {
+          foo: async () => 123,
+          bar: async () => 'hello',
+        },
+      });
+      return useActions<typeof AI>();
+    }
+
+    type ActionsType = ReturnType<typeof testType>;
+
+    expectTypeOf<ActionsType['foo']>().toEqualTypeOf<() => Promise<number>>();
+    expectTypeOf<ActionsType['bar']>().toEqualTypeOf<() => Promise<string>>();
+  });
+
+  it('should workaround recursive type definitions using AIProvider type', () => {
+    function testType() {
+      type T_AIProvider = AIProvider<{
+        str: string;
+        num: number;
+      }>;
+
+      const AI = createAI({
+        initialAIState: {
+          str: 'hello',
+          num: 123,
+        },
+        actions: {
+          foo: async () => {
+            const aiState = getAIState<T_AIProvider>();
+            return [aiState];
+          },
+          bar: async () => 'hello',
+        },
+      });
+      return useActions<typeof AI>();
+    }
+
+    type ActionsType = ReturnType<typeof testType>;
+
+    expectTypeOf<ActionsType['foo']>().toEqualTypeOf<
+      () => Promise<
+        Readonly<{
+          str: string;
+          num: number;
+        }>[]
+      >
+    >();
+    expectTypeOf<ActionsType['bar']>().toEqualTypeOf<() => Promise<string>>();
   });
 });

--- a/packages/core/rsc/types.ts
+++ b/packages/core/rsc/types.ts
@@ -29,39 +29,33 @@ export type InternalAIProviderProps<AIState = any, UIState = any> = {
   wrappedSyncUIState?: ServerWrappedAction<AIState>;
 };
 
+declare const __internal_actions: unique symbol;
+declare const __internal_ai_state: unique symbol;
+declare const __internal_ui_state: unique symbol;
+
 export type AIProviderProps<AIState = any, UIState = any, Actions = any> = {
   children: React.ReactNode;
   initialAIState?: AIState;
   initialUIState?: UIState;
-  /** $ActionTypes is only added for type inference and is never used at runtime **/
-  $ActionTypes?: Actions;
+
+  /** Internals are only added for type inference and is never used at runtime **/
+  [__internal_actions]: Actions;
+  [__internal_ai_state]: AIState;
+  [__internal_ui_state]: UIState;
 };
 
 export type AIProvider<AIState = any, UIState = any, Actions = any> = (
   props: AIProviderProps<AIState, UIState, Actions>,
 ) => Promise<React.ReactElement>;
 
-export type InferAIState<T, Fallback> = T extends AIProvider<
-  infer AIState,
-  any,
-  any
->
-  ? AIState
-  : Fallback;
-export type InferUIState<T, Fallback> = T extends AIProvider<
-  any,
-  infer UIState,
-  any
->
-  ? UIState
-  : Fallback;
-export type InferActions<T, Fallback> = T extends AIProvider<
-  any,
-  any,
-  infer Actions
->
-  ? Actions
-  : Fallback;
+export type InferAIState<
+  T extends AIProvider,
+  S = Parameters<T>[0][typeof __internal_ai_state],
+> = S extends undefined ? any : S;
+export type InferUIState<T extends AIProvider> =
+  Parameters<T>[0][typeof __internal_ui_state];
+export type InferActions<T extends AIProvider> =
+  Parameters<T>[0][typeof __internal_actions];
 
 export type InternalAIStateStorageOptions = {
   onSetAIState?: OnSetAIState<any>;


### PR DESCRIPTION
Similar to #1786, this PR simplifies `infer`-based implementation of `InferUIState`, `InferAIState` and `InferActions`, to be unique symbol based.

Also, this PR adds a new `AIProvider` generic helper so circular type references can be implemented correctly:

```ts
const AI = createAI({
  initialAIState: 'hi',
  actions: {
    foo: async () => {
      const aiState = getAIState<typeof AI>();
      return aiState;
    },
  },
})
```

This currently fails on type checking because `AI`'s type depends on the `foo` action's type, which has the return value of `aiState` that again relies on `typeof AI`.

By using the new generic, `getAIState<...>`, `useAIState<...>`, `useUIState<...>`, don't have to accept `typeof AI` only:

```ts
type T = AIProvider<string>
getAIState<T>
```