### PR TITLE
feat (provider/openai): Make compatible with Together AI

### DIFF
--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -415,7 +415,7 @@ const openAIChatResponseSchema = z.object({
               }),
             }),
           )
-          .optional(),
+          .optional().nullable(),
       }),
       index: z.number(),
       logprobs: z
@@ -462,12 +462,12 @@ const openaiChatChunkSchema = z.union([
                 id: z.string().optional().nullable(),
                 type: z.literal('function').optional(),
                 function: z.object({
-                  name: z.string().optional(),
-                  arguments: z.string().optional(),
+                  name: z.string().optional().nullable(),
+                  arguments: z.string().optional().nullable(),
                 }),
               }),
             )
-            .optional(),
+            .optional().nullable(),
         }),
         logprobs: z
           .object({


### PR DESCRIPTION
**Corresponding Issue: https://github.com/vercel/ai/issues/1865**

Together AI is an official partner of Vercel for the integration of AI: https://vercel.com/integrations/together-ai

Unfortunately, the Together AI API cannot currently be used for generating or streaming because Together AI returns `null` for some optional fields, instead of not sending them, resulting in validation errors.

This PR also makes the already optional fields nullable. Streaming and tool calling is fully functional with Together AI with this change.