### PR TITLE
fix (core): filter out empty assistant text messages

### DIFF
--- a/.changeset/eleven-maps-yawn.md
+++ b/.changeset/eleven-maps-yawn.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (core): filter out empty assistant text messages

--- a/packages/core/core/generate-text/generate-text.test.ts
+++ b/packages/core/core/generate-text/generate-text.test.ts
@@ -428,7 +428,6 @@ describe('maxToolRoundtrips', () => {
                 {
                   role: 'assistant',
                   content: [
-                    { type: 'text', text: '' },
                     {
                       type: 'tool-call',
                       toolCallId: 'call-1',

--- a/packages/core/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/core/core/prompt/convert-to-language-model-prompt.test.ts
@@ -1,0 +1,35 @@
+import { convertToLanguageModelMessage } from './convert-to-language-model-prompt';
+
+describe('convertToLanguageModelMessage', () => {
+  describe('assistant message', () => {
+    it('should ignore empty text parts', async () => {
+      const result = convertToLanguageModelMessage({
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: '',
+          },
+          {
+            type: 'tool-call',
+            toolName: 'toolName',
+            toolCallId: 'toolCallId',
+            args: {},
+          },
+        ],
+      });
+
+      expect(result).toEqual({
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            args: {},
+            toolCallId: 'toolCallId',
+            toolName: 'toolName',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/packages/core/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/core/core/prompt/convert-to-language-model-prompt.ts
@@ -100,7 +100,13 @@ export function convertToLanguageModelMessage(
         };
       }
 
-      return { role: 'assistant', content: message.content };
+      return {
+        role: 'assistant',
+        content: message.content.filter(
+          // remove empty text parts:
+          part => part.type !== 'text' || part.text !== '',
+        ),
+      };
     }
 
     case 'tool': {


### PR DESCRIPTION
## Summary
Empty assistant text messages when using tools caused issues with some models. Since empty text messages don't provide value and are a cause of errors, we filter them out.