### PR TITLE
fix (docs): Fix wrong default port for nuxt example

### DIFF
--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -166,7 +166,7 @@ With that, you have built everything you need for your chatbot! To start your ap
 
 <Snippet text="pnpm run dev" />
 
-Head to your browser and open http://localhost:5173. You should see an input field. Test it out by entering a message and see the AI chatbot respond in real-time! Vercel AI SDK makes it fast and easy to build AI chat interfaces with Nuxt.
+Head to your browser and open http://localhost:3000. You should see an input field. Test it out by entering a message and see the AI chatbot respond in real-time! Vercel AI SDK makes it fast and easy to build AI chat interfaces with Nuxt.
 
 ## Stream Data Alongside Response
 
@@ -248,7 +248,7 @@ const { messages, input, handleSubmit, data } = useChat();
 </template>
 ```
 
-Head back to your browser (http://localhost:5173) and enter a new message. You should see a JSON object appear with the value you sent from your API route!
+Head back to your browser (http://localhost:3000) and enter a new message. You should see a JSON object appear with the value you sent from your API route!
 
 ## Where to Next?
 


### PR DESCRIPTION
The vite default port is 5173, but not nuxt. The right [default port](https://nuxt.com/docs/api/nuxt-config#port) for nuxt is 3000.