### PR TITLE
fix (@ai-sdk/openai): add internal dist to release

### DIFF
--- a/.changeset/long-pears-begin.md
+++ b/.changeset/long-pears-begin.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix (@ai-sdk/openai): add internal dist to bundle

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -7,7 +7,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "internal/dist/**/*"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Summary
Adds missing `internal` dist file to release. Fixes `@ai-sdk/azure` module.