### PR TITLE
use JSONValue for ChatRequest data

### DIFF
--- a/packages/ui-utils/src/types.ts
+++ b/packages/ui-utils/src/types.ts
@@ -184,7 +184,7 @@ export type ChatRequest = {
   functions?: Array<Function>;
   // @deprecated
   function_call?: FunctionCall;
-  data?: Record<string, string>;
+  data?: JSONValue;
   // @deprecated
   tools?: Array<Tool>;
   // @deprecated
@@ -248,7 +248,7 @@ The options to be passed to the fetch call.
   /**
 Additional data to be sent to the server.
    */
-  data?: Record<string, string>;
+  data?: JSONValue;
 };
 
 export type UseChatOptions = {


### PR DESCRIPTION
Functionality wise the data field can include `JSONValue`, which is more expressive than `Record<string, string>`. One of my use cases is appending additional metadata

```ts
handleSubmit(e, {
	data: {
		messages: [
			{
				role: 'user',
				content: `User selection is `gridSelectionToString`,
			},
			{
				role: 'user',
				content: `The user has edited the spreadsheet. Here is a list of changes: ${JSON.stringify(appState.changes)}`,
			},
		],
	},
});
```

```ts
export async function POST(req: Request) {
	const { messages = [], data = {} } = await req.json();

        const result = await streamText({
	        model: model,
	        system: SPREADSHEET_ASSISTANT_SYSTEM_PROMPT,
	        messages: convertToCoreMessages(messages).concat(data.messages || []),
```