### PR TITLE
feat (providers): support custom fetch implementations

### DIFF
--- a/.changeset/nasty-goats-hammer.md
+++ b/.changeset/nasty-goats-hammer.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+---
+
+feat (providers): support custom fetch implementations

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -67,6 +67,13 @@ You can use the following optional settings to customize the OpenAI provider ins
 
   Custom headers to include in the requests.
 
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
 - **compatibility** _"strict" | "compatible"_
 
   OpenAI compatibility mode. Should be set to `strict` when using the OpenAI API,

--- a/content/providers/01-ai-sdk-providers/02-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/02-azure.mdx
@@ -54,6 +54,13 @@ You can use the following optional settings to customize the OpenAI provider ins
   API key that is being send using the `api-key` header.
   It defaults to the `AZURE_API_KEY` environment variable.
 
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
 ## Language Models
 
 The Azure OpenAI provider instance is a function that you can invoke to create a language model:

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -57,6 +57,13 @@ You can use the following optional settings to customize the Google Generative A
 
   Custom headers to include in the requests.
 
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
 ## Language Models
 
 You can create models that call the [Anthropic Messages API](https://docs.anthropic.com/claude/reference/messages_post) using the provider instance.

--- a/content/providers/01-ai-sdk-providers/10-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/10-google-generative-ai.mdx
@@ -57,6 +57,13 @@ You can use the following optional settings to customize the Google Generative A
 
   Custom headers to include in the requests.
 
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
 ## Language Models
 
 You can create models that call the [Google Generative AI API](https://ai.google.dev/api/rest) using the provider instance.

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -58,6 +58,13 @@ You can use the following optional settings to customize the Mistral provider in
 
   Custom headers to include in the requests.
 
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
 ## Language Models
 
 You can create models that call the [Mistral chat API](https://docs.mistral.ai/api/#operation/createChatCompletion) using provider instance.

--- a/examples/ai-core/src/generate-text/anthropic-custom-fetch.ts
+++ b/examples/ai-core/src/generate-text/anthropic-custom-fetch.ts
@@ -1,0 +1,27 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const anthropic = createAnthropic({
+  // example fetch wrapper that logs the URL:
+  fetch: async (url, options) => {
+    console.log(`Fetching ${url}`);
+    const result = await fetch(url, options);
+    console.log(`Fetched ${url}`);
+    console.log();
+    return result;
+  },
+});
+
+async function main() {
+  const result = await generateText({
+    model: anthropic('claude-3-haiku-20240307'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/azure-custom-fetch.ts
+++ b/examples/ai-core/src/generate-text/azure-custom-fetch.ts
@@ -1,0 +1,27 @@
+import { createAzure } from '@ai-sdk/azure';
+import { generateText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const azure = createAzure({
+  // example fetch wrapper that logs the URL:
+  fetch: async (url, options) => {
+    console.log(`Fetching ${url}`);
+    const result = await fetch(url, options);
+    console.log(`Fetched ${url}`);
+    console.log();
+    return result;
+  },
+});
+
+async function main() {
+  const result = await generateText({
+    model: azure('v0-gpt-35-turbo'), // use your own deployment
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/google-custom-fetch.ts
+++ b/examples/ai-core/src/generate-text/google-custom-fetch.ts
@@ -1,0 +1,27 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const google = createGoogleGenerativeAI({
+  // example fetch wrapper that logs the URL:
+  fetch: async (url, options) => {
+    console.log(`Fetching ${url}`);
+    const result = await fetch(url, options);
+    console.log(`Fetched ${url}`);
+    console.log();
+    return result;
+  },
+});
+
+async function main() {
+  const result = await generateText({
+    model: google('models/gemini-pro'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/mistral-custom-fetch.ts
+++ b/examples/ai-core/src/generate-text/mistral-custom-fetch.ts
@@ -1,0 +1,27 @@
+import { createMistral } from '@ai-sdk/mistral';
+import { generateText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const mistral = createMistral({
+  // example fetch wrapper that logs the URL:
+  fetch: async (url, options) => {
+    console.log(`Fetching ${url}`);
+    const result = await fetch(url, options);
+    console.log(`Fetched ${url}`);
+    console.log();
+    return result;
+  },
+});
+
+async function main() {
+  const result = await generateText({
+    model: mistral('open-mistral-7b'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-custom-fetch.ts
+++ b/examples/ai-core/src/generate-text/openai-custom-fetch.ts
@@ -1,0 +1,27 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const openai = createOpenAI({
+  // example fetch wrapper that logs the URL:
+  fetch: async (url, options) => {
+    console.log(`Fetching ${url}`);
+    const result = await fetch(url, options);
+    console.log(`Fetched ${url}`);
+    console.log();
+    return result;
+  },
+});
+
+async function main() {
+  const result = await generateText({
+    model: openai('gpt-3.5-turbo'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -25,6 +25,7 @@ type AnthropicMessagesConfig = {
   provider: string;
   baseURL: string;
   headers: () => Record<string, string | undefined>;
+  fetch?: typeof fetch;
 };
 
 export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
@@ -163,6 +164,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
         anthropicMessagesResponseSchema,
       ),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { messages: rawPrompt, ...rawSettings } = args;
@@ -222,6 +224,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
         anthropicMessagesChunkSchema,
       ),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { messages: rawPrompt, ...rawSettings } = args;

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -54,6 +54,12 @@ Custom headers to include in the requests.
      */
   headers?: Record<string, string>;
 
+  /**
+Custom fetch implementation. You can use it as a middleware to intercept requests,
+or to provide a custom fetch implementation for e.g. testing.
+    */
+  fetch?: typeof fetch;
+
   generateId?: () => string;
 }
 
@@ -86,6 +92,7 @@ export function createAnthropic(
       provider: 'anthropic.messages',
       baseURL,
       headers: getHeaders,
+      fetch: options.fetch,
     });
 
   const provider = function (

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -29,6 +29,12 @@ Name of the Azure OpenAI resource.
 API key for authenticating requests.
      */
   apiKey?: string;
+
+  /**
+Custom fetch implementation. You can use it as a middleware to intercept requests,
+or to provide a custom fetch implementation for e.g. testing.
+    */
+  fetch?: typeof fetch;
 }
 
 /**
@@ -63,6 +69,7 @@ export function createAzure(
       url: ({ path, modelId }) =>
         `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=2024-05-01-preview`,
       compatibility: 'compatible',
+      fetch: options.fetch,
     });
 
   const provider = function (

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -26,6 +26,7 @@ type GoogleGenerativeAIConfig = {
   baseURL: string;
   headers: () => Record<string, string | undefined>;
   generateId: () => string;
+  fetch?: typeof fetch;
 };
 
 export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
@@ -156,6 +157,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       failedResponseHandler: googleFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(responseSchema),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { contents: rawPrompt, ...rawSettings } = args;
@@ -197,6 +199,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       failedResponseHandler: googleFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(chunkSchema),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { contents: rawPrompt, ...rawSettings } = args;

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -1,4 +1,8 @@
-import { Google } from './google-facade';
+import {
+  generateId,
+  loadApiKey,
+  withoutTrailingSlash,
+} from '@ai-sdk/provider-utils';
 import { GoogleGenerativeAILanguageModel } from './google-generative-ai-language-model';
 import {
   GoogleGenerativeAIModelId,
@@ -48,6 +52,12 @@ Custom headers to include in the requests.
      */
   headers?: Record<string, string>;
 
+  /**
+Custom fetch implementation. You can use it as a middleware to intercept requests,
+or to provide a custom fetch implementation for e.g. testing.
+    */
+  fetch?: typeof fetch;
+
   generateId?: () => string;
 }
 
@@ -57,7 +67,30 @@ Create a Google Generative AI provider instance.
 export function createGoogleGenerativeAI(
   options: GoogleGenerativeAIProviderSettings = {},
 ): GoogleGenerativeAIProvider {
-  const google = new Google(options);
+  const baseURL =
+    withoutTrailingSlash(options.baseURL ?? options.baseUrl) ??
+    'https://generativelanguage.googleapis.com/v1beta';
+
+  const getHeaders = () => ({
+    'x-goog-api-key': loadApiKey({
+      apiKey: options.apiKey,
+      environmentVariableName: 'GOOGLE_GENERATIVE_AI_API_KEY',
+      description: 'Google Generative AI',
+    }),
+    ...options.headers,
+  });
+
+  const createChatModel = (
+    modelId: GoogleGenerativeAIModelId,
+    settings: GoogleGenerativeAISettings = {},
+  ) =>
+    new GoogleGenerativeAILanguageModel(modelId, settings, {
+      provider: 'google.generative-ai',
+      baseURL,
+      headers: getHeaders,
+      generateId: options.generateId ?? generateId,
+      fetch: options.fetch,
+    });
 
   const provider = function (
     modelId: GoogleGenerativeAIModelId,
@@ -69,11 +102,11 @@ export function createGoogleGenerativeAI(
       );
     }
 
-    return google.chat(modelId, settings);
+    return createChatModel(modelId, settings);
   };
 
-  provider.chat = google.chat.bind(google);
-  provider.generativeAI = google.generativeAI.bind(google);
+  provider.chat = createChatModel;
+  provider.generativeAI = createChatModel;
 
   return provider as GoogleGenerativeAIProvider;
 }

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -25,6 +25,7 @@ type MistralChatConfig = {
   baseURL: string;
   headers: () => Record<string, string | undefined>;
   generateId: () => string;
+  fetch?: typeof fetch;
 };
 
 export class MistralChatLanguageModel implements LanguageModelV1 {
@@ -151,6 +152,7 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
         mistralChatResponseSchema,
       ),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { messages: rawPrompt, ...rawSettings } = args;
@@ -192,6 +194,7 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
         mistralChatChunkSchema,
       ),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { messages: rawPrompt, ...rawSettings } = args;

--- a/packages/mistral/src/mistral-embedding-model.ts
+++ b/packages/mistral/src/mistral-embedding-model.ts
@@ -17,6 +17,7 @@ type MistralEmbeddingConfig = {
   provider: string;
   baseURL: string;
   headers: () => Record<string, string | undefined>;
+  fetch?: typeof fetch;
 };
 
 export class MistralEmbeddingModel implements EmbeddingModelV1<string> {
@@ -78,6 +79,7 @@ export class MistralEmbeddingModel implements EmbeddingModelV1<string> {
         MistralTextEmbeddingResponseSchema,
       ),
       abortSignal,
+      fetch: this.config.fetch,
     });
 
     return {

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -60,6 +60,12 @@ Custom headers to include in the requests.
      */
   headers?: Record<string, string>;
 
+  /**
+Custom fetch implementation. You can use it as a middleware to intercept requests,
+or to provide a custom fetch implementation for e.g. testing.
+    */
+  fetch?: typeof fetch;
+
   generateId?: () => string;
 }
 
@@ -91,6 +97,7 @@ export function createMistral(
       baseURL,
       headers: getHeaders,
       generateId: options.generateId ?? generateId,
+      fetch: options.fetch,
     });
 
   const createEmbeddingModel = (
@@ -101,6 +108,7 @@ export function createMistral(
       provider: 'mistral.embedding',
       baseURL,
       headers: getHeaders,
+      fetch: options.fetch,
     });
 
   const provider = function (

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -29,6 +29,7 @@ type OpenAIChatConfig = {
   compatibility: 'strict' | 'compatible';
   headers: () => Record<string, string | undefined>;
   url: (options: { modelId: string; path: string }) => string;
+  fetch?: typeof fetch;
 };
 
 export class OpenAIChatLanguageModel implements LanguageModelV1 {
@@ -157,6 +158,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
         openAIChatResponseSchema,
       ),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { messages: rawPrompt, ...rawSettings } = args;
@@ -208,6 +210,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
         openaiChatChunkSchema,
       ),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { messages: rawPrompt, ...rawSettings } = args;

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -29,6 +29,7 @@ type OpenAICompletionConfig = {
   baseURL: string;
   compatibility: 'strict' | 'compatible';
   headers: () => Record<string, string | undefined>;
+  fetch?: typeof fetch;
 };
 
 export class OpenAICompletionLanguageModel implements LanguageModelV1 {
@@ -159,6 +160,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
         openAICompletionResponseSchema,
       ),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { prompt: rawPrompt, ...rawSettings } = args;
@@ -201,6 +203,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
         openaiCompletionChunkSchema,
       ),
       abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
     });
 
     const { prompt: rawPrompt, ...rawSettings } = args;

--- a/packages/openai/src/openai-embedding-model.ts
+++ b/packages/openai/src/openai-embedding-model.ts
@@ -17,6 +17,7 @@ type OpenAIEmbeddingConfig = {
   provider: string;
   baseURL: string;
   headers: () => Record<string, string | undefined>;
+  fetch?: typeof fetch;
 };
 
 export class OpenAIEmbeddingModel implements EmbeddingModelV1<string> {
@@ -78,6 +79,7 @@ export class OpenAIEmbeddingModel implements EmbeddingModelV1<string> {
         openaiTextEmbeddingResponseSchema,
       ),
       abortSignal,
+      fetch: this.config.fetch,
     });
 
     return {

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -84,6 +84,12 @@ and `compatible` when using 3rd party providers. In `compatible` mode, newer
 information such as streamOptions are not being sent. Defaults to 'compatible'.
    */
   compatibility?: 'strict' | 'compatible';
+
+  /**
+Custom fetch implementation. You can use it as a middleware to intercept requests,
+or to provide a custom fetch implementation for e.g. testing.
+    */
+  fetch?: typeof fetch;
 }
 
 /**
@@ -119,6 +125,7 @@ export function createOpenAI(
       url: ({ path }) => `${baseURL}${path}`,
       headers: getHeaders,
       compatibility,
+      fetch: options.fetch,
     });
 
   const createCompletionModel = (
@@ -130,6 +137,7 @@ export function createOpenAI(
       baseURL,
       headers: getHeaders,
       compatibility,
+      fetch: options.fetch,
     });
 
   const createEmbeddingModel = (
@@ -140,6 +148,7 @@ export function createOpenAI(
       provider: 'openai.embedding',
       baseURL,
       headers: getHeaders,
+      fetch: options.fetch,
     });
 
   const provider = function (

--- a/packages/provider-utils/src/post-to-api.ts
+++ b/packages/provider-utils/src/post-to-api.ts
@@ -3,6 +3,8 @@ import { extractResponseHeaders } from './extract-response-headers';
 import { isAbortError } from './is-abort-error';
 import { ResponseHandler } from './response-handler';
 
+const originalFetch = fetch;
+
 export const postJsonToApi = async <T>({
   url,
   headers,
@@ -10,6 +12,7 @@ export const postJsonToApi = async <T>({
   failedResponseHandler,
   successfulResponseHandler,
   abortSignal,
+  fetch,
 }: {
   url: string;
   headers?: Record<string, string | undefined>;
@@ -17,6 +20,7 @@ export const postJsonToApi = async <T>({
   failedResponseHandler: ResponseHandler<APICallError>;
   successfulResponseHandler: ResponseHandler<T>;
   abortSignal?: AbortSignal;
+  fetch?: typeof originalFetch;
 }) =>
   postToApi({
     url,
@@ -31,6 +35,7 @@ export const postJsonToApi = async <T>({
     failedResponseHandler,
     successfulResponseHandler,
     abortSignal,
+    fetch,
   });
 
 export const postToApi = async <T>({
@@ -40,6 +45,7 @@ export const postToApi = async <T>({
   successfulResponseHandler,
   failedResponseHandler,
   abortSignal,
+  fetch = originalFetch,
 }: {
   url: string;
   headers?: Record<string, string | undefined>;
@@ -50,6 +56,7 @@ export const postToApi = async <T>({
   failedResponseHandler: ResponseHandler<Error>;
   successfulResponseHandler: ResponseHandler<T>;
   abortSignal?: AbortSignal;
+  fetch?: typeof originalFetch;
 }) => {
   try {
     // remove undefined headers:

--- a/packages/provider-utils/src/post-to-api.ts
+++ b/packages/provider-utils/src/post-to-api.ts
@@ -3,7 +3,8 @@ import { extractResponseHeaders } from './extract-response-headers';
 import { isAbortError } from './is-abort-error';
 import { ResponseHandler } from './response-handler';
 
-const originalFetch = fetch;
+// use function to allow for mocking in tests:
+const getOriginalFetch = () => fetch;
 
 export const postJsonToApi = async <T>({
   url,
@@ -20,7 +21,7 @@ export const postJsonToApi = async <T>({
   failedResponseHandler: ResponseHandler<APICallError>;
   successfulResponseHandler: ResponseHandler<T>;
   abortSignal?: AbortSignal;
-  fetch?: typeof originalFetch;
+  fetch?: ReturnType<typeof getOriginalFetch>;
 }) =>
   postToApi({
     url,
@@ -45,7 +46,7 @@ export const postToApi = async <T>({
   successfulResponseHandler,
   failedResponseHandler,
   abortSignal,
-  fetch = originalFetch,
+  fetch = getOriginalFetch(),
 }: {
   url: string;
   headers?: Record<string, string | undefined>;
@@ -56,7 +57,7 @@ export const postToApi = async <T>({
   failedResponseHandler: ResponseHandler<Error>;
   successfulResponseHandler: ResponseHandler<T>;
   abortSignal?: AbortSignal;
-  fetch?: typeof originalFetch;
+  fetch?: ReturnType<typeof getOriginalFetch>;
 }) => {
   try {
     // remove undefined headers:


### PR DESCRIPTION
## Summary

Add `fetch` option on the providers that use `fetch` to call APIs. Overriding fetch can be useful for logging, testing, and VPNs. 

## Tasks

- [x] implementation
   - [x] openai
   - [x] mistral
   - [x] azure
   - [x] google gemini
   - [x] anthropic
- [x] examples
   - [x] openai
   - [x] mistral
   - [x] azure
   - [x] google gemini
   - [x] anthropic
- [x] docs
   - [x] openai
   - [x] mistral
   - [x] azure
   - [x] google gemini
   - [x] anthropic
- [x] changeset