### PR TITLE
fix (core): pass settings correctly for generateObject and streamObject

### DIFF
--- a/.changeset/dry-wasps-sit.md
+++ b/.changeset/dry-wasps-sit.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (core): pass settings correctly for generateObject and streamObject

--- a/packages/core/core/generate-object/generate-object.ts
+++ b/packages/core/core/generate-object/generate-object.ts
@@ -143,7 +143,7 @@ Default and recommended: 'auto' (best mode for the model).
       const generateResult = await retry(() =>
         model.doGenerate({
           mode: { type: 'object-grammar', schema: jsonSchema },
-          ...settings,
+          ...prepareCallSettings(settings),
           inputFormat: validatedPrompt.type,
           prompt: convertToLanguageModelPrompt(validatedPrompt),
           abortSignal,
@@ -182,7 +182,7 @@ Default and recommended: 'auto' (best mode for the model).
               parameters: jsonSchema,
             },
           },
-          ...settings,
+          ...prepareCallSettings(settings),
           inputFormat: validatedPrompt.type,
           prompt: convertToLanguageModelPrompt(validatedPrompt),
           abortSignal,

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -185,7 +185,7 @@ Warnings from the model provider (e.g. unsupported settings).
 
       callOptions = {
         mode: { type: 'object-grammar', schema: jsonSchema },
-        ...settings,
+        ...prepareCallSettings(settings),
         inputFormat: validatedPrompt.type,
         prompt: convertToLanguageModelPrompt(validatedPrompt),
         abortSignal,
@@ -225,7 +225,7 @@ Warnings from the model provider (e.g. unsupported settings).
             parameters: jsonSchema,
           },
         },
-        ...settings,
+        ...prepareCallSettings(settings),
         inputFormat: validatedPrompt.type,
         prompt: convertToLanguageModelPrompt(validatedPrompt),
         abortSignal,


### PR DESCRIPTION
## Summary
The temperature was not automatically set to `0`, leading to unstable results.