### PR TITLE
feat (docs): add chrome built-in ai provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -37,6 +37,7 @@ The open-source community has created the following providers:
 
 - [LLamaCpp Provider](/providers/community-providers/llama-cpp) (`nnance/llamacpp-ai-provider `)
 - [Ollama Provider](/providers/community-providers/ollama) (`sgomez/ollama-ai-provider`)
+- [ChromeAI Provider](/providers/community-providers/chrome-ai) (`jeasonstudio/chrome-ai`)
 
 ## Model Capabilities
 

--- a/content/providers/03-community-providers/04-chrome-ai.mdx
+++ b/content/providers/03-community-providers/04-chrome-ai.mdx
@@ -1,0 +1,143 @@
+---
+title: Chrome AI
+description: Learn how to use the Chrome built-in Language Model.
+---
+
+# ChromeAI
+
+[jeasonstudio/chrome-ai](https://github.com/jeasonstudio/chrome-ai) is a community provider that uses [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in) to provide language model support for the Vercel AI SDK.
+
+## Setup
+
+The ChromeAI provider is available in the `chrome-ai` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn']}>
+  <Tab>
+    <Snippet text="pnpm install chrome-ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install chrome-ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add chrome-ai" dark />
+  </Tab>
+</Tabs>
+
+> ⚠️ Note:
+> * This module is under development and may contain errors and frequent incompatible changes.
+> * Chrome's implementation of [built-in AI with Gemini Nano](https://developer.chrome.com/docs/ai/built-in) is an experiment and will change as they test and address feedback.
+> * If you've never heard of it before, [follow these steps](#enable-ai-in-chrome) to turn on Chrome's built-in AI.
+
+
+## Language Models
+
+The `chromeai` provider instance is a function that you can invoke to create a language model:
+
+```ts
+import { chromeai } from 'chrome-ai';
+
+const model = chromeai();
+```
+
+It automatically selects the correct model id. You can also pass additional settings in the second argument:
+
+```ts
+import { chromeai } from 'chrome-ai';
+
+const model = chromeai('generic', {
+  // additional settings
+  temperature: 0.5,
+  topK: 5,
+});
+```
+
+You can use the following optional settings to customize:
+
+- **modelId** _'text' | 'generic'_
+
+  Used to distinguish models of Gemini Nano, there is no difference in the current version.
+
+- **temperature** _number_
+
+  The value is passed through to the provider. The range depends on the provider and model.
+  For most providers, `0` means almost deterministic results, and higher values mean more randomness.
+
+- **topK** _number_
+
+  Only sample from the top K options for each subsequent token.
+
+  Used to remove "long tail" low probability responses.
+  Recommended for advanced use cases only. You usually only need to use temperature.
+
+## Examples
+
+You can use Chrome built-in language models to generate text with the `generateText` or `streamText` function:
+
+```javascript
+import { generateText } from 'ai';
+import { chromeai } from 'chrome-ai';
+
+const { text } = await generateText({
+  model: chromeai(),
+  prompt: 'Who are you?',
+});
+
+console.log(text); //  I am a large language model, trained by Google.
+```
+
+```javascript
+import { streamText } from 'ai';
+import { chromeai } from 'chrome-ai';
+
+const { textStream } = await streamText({
+  model: chromeai(),
+  prompt: 'Who are you?',
+});
+
+let result = '';
+for await (const textPart of textStream) {
+  result = textPart;
+}
+
+console.log(result);
+//  I am a large language model, trained by Google.
+```
+
+Chrome built-in language models can also be used in the generateObject function:
+
+```javascript
+import { generateObject } from 'ai';
+import { chromeai } from 'chrome-ai';
+import { z } from 'zod';
+
+const { object } = await generateObject({
+  model: chromeai('text'),
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(
+        z.object({
+          name: z.string(),
+          amount: z.string(),
+        })
+      ),
+      steps: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate a lasagna recipe.',
+});
+
+console.log(object);
+// { recipe: {...} }
+```
+
+> Due to model reasons, `toolCall` and `streamObject` are not supported. We are making an effort to implement these functions by prompt engineering.
+
+## Enable AI in Chrome
+
+Chrome built-in AI is a preview feature, you need to use chrome version 127 or greater, now in [dev](https://www.google.com/chrome/dev/?extra=devchannel) or [canary](https://www.google.com/chrome/canary/) channel, [may release on stable chanel at Jul 17, 2024](https://chromestatus.com/roadmap).
+
+After then, you should turn on these flags:
+* [chrome://flags/#prompt-api-for-gemini-nano](chrome://flags/#prompt-api-for-gemini-nano): `Enabled`
+* [chrome://flags/#optimization-guide-on-device-model](chrome://flags/#optimization-guide-on-device-model): `Enabled BypassPrefRequirement`
+* [chrome://components/](chrome://components/): Click `Optimization Guide On Device Model` to download the model.

--- a/content/providers/03-community-providers/04-chrome-ai.mdx
+++ b/content/providers/03-community-providers/04-chrome-ai.mdx
@@ -103,7 +103,7 @@ console.log(result);
 //  I am a large language model, trained by Google.
 ```
 
-Chrome built-in language models can also be used in the generateObject function:
+Chrome built-in language models can also be used in the `generateObject` function:
 
 ```javascript
 import { generateObject } from 'ai';


### PR DESCRIPTION
`chrome-ai` is a community provider that uses [Chrome Built-in AI](https://developer.chrome.com/docs/ai/built-in) to provide language model support for the Vercel AI SDK.

See more detail: https://github.com/jeasonstudio/chrome-ai
