### PR TITLE
fix (@ai-sdk/vue): use-chat-handleSubmit event optional

### DIFF
--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -51,7 +51,7 @@ export type UseChatHelpers = {
   /** The current value of the input */
   input: Ref<string>;
   /** Form submission handler to automatically reset input and append a user message  */
-  handleSubmit: (e: any, chatRequestOptions?: ChatRequestOptions) => void;
+  handleSubmit: (chatRequestOptions?: ChatRequestOptions, e?: any) => void;
   /** Whether the API request is in progress */
   isLoading: Ref<boolean | undefined>;
 
@@ -246,8 +246,10 @@ export function useChat({
 
   const input = ref(initialInput);
 
-  const handleSubmit = (e: any, options: ChatRequestOptions = {}) => {
-    e.preventDefault();
+  const handleSubmit = (options: ChatRequestOptions = {}, e: any) => {
+    if(e){
+      e.preventDefault();
+    }
     const inputValue = input.value;
     if (!inputValue) return;
     append(


### PR DESCRIPTION
I think the `event` of the `handleSubmit` method should not be used as the first parameter. It is very convenient to handle `event` in `vue` and does not need to be passed at all. Let me give two examples:

#### The first point:
If you just want to handle its default behavior, you can use modifiers to write like this:
```
<form @submit.prevent="handleSubmit">
    <input data-testid="input" v-model="input" />
 </form>
```
Or if you want to pass `event`:
```
<form @submit="e => handleSubmit(_, e)">
    <input data-testid="input" v-model="input" />
 </form>
```

#### Second point:
For example, additional information may need to be processed when sending a message.
before fixing:
```vue
<script setup>
function sendMessage(e: Event) {
    const [provider, model] = modelSelectValue.value.split(' ')
    handleSubmit(e, {
      options: {
        headers: {
          'Test-keys': JSON.stringify(modelSetting.value)
        },
        body: { text: content.value, provider, model }
      }
    })
  }
</script>
<template>
  <form @submit="e => sendMessage(e)">
      <input v-model="inputtest" border="~ gray-200" data-testid="input" @keydown.enter="e => sendMessage(e)">
   </form>
</template>
```
It can be seen here that `event` is not the best choice as a parameter, and it is a bit awkward to use. Let’s look at the modified one:
```vue
<script setup>
function sendMessage() {
    const [provider, model] = modelSelectValue.value.split(' ')
    handleSubmit({
      options: {
        headers: {
          'Test-keys': JSON.stringify(modelSetting.value)
        },
        body: { text: content.value, provider, model }
      }
    })
}
</script>
<template>
  <form @submit.prevent="sendMessage">
      <input v-model="inputtest" border="~ gray-200" data-testid="input" @keydown.enter="sendMessage">
   </form>
</template>
```
Written this way, it is clear that it is concise and easy to use. Moreover, more attention is put on the logic, and there is no need to pass `event` everywhere.

This is what I personally find difficult to use. The design of the `handleSubmit` api parameter feels like it was copied from `react`, or it is for the sake of the uniformity of `api`. I think this is an area that can be improved. What I said may not be correct. You may have your own understanding.