### PR TITLE
fix(@ai-sdk/vue) use-chat-handleSubmit event type  should be optional

### DIFF
--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -51,7 +51,10 @@ export type UseChatHelpers = {
   /** The current value of the input */
   input: Ref<string>;
   /** Form submission handler to automatically reset input and append a user message  */
-  handleSubmit: (e: any, chatRequestOptions?: ChatRequestOptions) => void;
+  handleSubmit: (
+    event?: { preventDefault?: () => void },
+    chatRequestOptions?: ChatRequestOptions
+  ) => void;
   /** Whether the API request is in progress */
   isLoading: Ref<boolean | undefined>;
 


### PR DESCRIPTION
The `handleSubmit` method of the `useChat` function, the first parameter `event` should be optional #2073