### PR TITLE
feat (ai/core): custom request headers

### DIFF
--- a/.changeset/brown-flowers-smell.md
+++ b/.changeset/brown-flowers-smell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+feat (provider): add headers support to language and embedding model spec

--- a/.changeset/fast-peas-applaud.md
+++ b/.changeset/fast-peas-applaud.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+'ai': patch
+---
+
+feat (ai/core): add custom request header support

--- a/.changeset/stupid-deers-brush.md
+++ b/.changeset/stupid-deers-brush.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': major
+---
+
+feat (provider-utils): change getRequestHeader() test helper to return Record (breaking change)

--- a/.changeset/ten-plants-tease.md
+++ b/.changeset/ten-plants-tease.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+feat (provider-utils): add combineHeaders helper

--- a/content/docs/03-ai-sdk-core/25-settings.mdx
+++ b/content/docs/03-ai-sdk-core/25-settings.mdx
@@ -74,3 +74,7 @@ Maximum number of retries. Set to 0 to disable retries. Default: `2`.
 ### `abortSignal`
 
 An optional abort signal that can be used to cancel the call.
+
+### `headers`
+
+Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -324,6 +324,13 @@ console.log(text);
         'An optional abort signal that can be used to cancel the call.',
     },
     {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
+    },
+    {
       name: 'maxAutomaticRoundtrips',
       type: 'number',
       isOptional: true,

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -326,6 +326,13 @@ for await (const textPart of textStream) {
         'An optional abort signal that can be used to cancel the call.',
     },
     {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
+    },
+    {
       name: 'onFinish',
       type: '(result: OnFinishResult) => void',
       isOptional: true,

--- a/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
@@ -42,29 +42,30 @@ console.log(JSON.stringify(object, null, 2));
     {
       name: 'model',
       type: 'LanguageModel',
-      description: `The language model to use. Example: openai('gpt-4-turbo')`
+      description: `The language model to use. Example: openai('gpt-4-turbo')`,
     },
     {
       name: 'mode',
       type: "'auto' | 'json' | 'grammar' | 'tool'",
       description:
-        "The mode to use for object generation. Not every model supports all modes. Defaults to 'auto'."
+        "The mode to use for object generation. Not every model supports all modes. Defaults to 'auto'.",
     },
     {
-        name: 'schema',
-        type: 'Zod Schema',
-        description: 'The schema that describes the shape of the object to generate. It is sent to the model to generate the object and used to validate the output.'
+      name: 'schema',
+      type: 'Zod Schema',
+      description:
+        'The schema that describes the shape of the object to generate. It is sent to the model to generate the object and used to validate the output.',
     },
     {
       name: 'system',
       type: 'string',
       description:
-        'The system prompt to use that specifies the behavior of the model.'
+        'The system prompt to use that specifies the behavior of the model.',
     },
     {
       name: 'prompt',
       type: 'string',
-      description: 'The input prompt to generate the text from.'
+      description: 'The input prompt to generate the text from.',
     },
     {
       name: 'messages',
@@ -77,14 +78,14 @@ console.log(JSON.stringify(object, null, 2));
             {
               name: 'role',
               type: "'system'",
-              description: 'The role for the system message.'
+              description: 'The role for the system message.',
             },
             {
               name: 'content',
               type: 'string',
-              description: 'The content of the message.'
-            }
-          ]
+              description: 'The content of the message.',
+            },
+          ],
         },
         {
           type: 'CoreUserMessage',
@@ -92,7 +93,7 @@ console.log(JSON.stringify(object, null, 2));
             {
               name: 'role',
               type: "'user'",
-              description: 'The role for the user message.'
+              description: 'The role for the user message.',
             },
             {
               name: 'content',
@@ -105,14 +106,14 @@ console.log(JSON.stringify(object, null, 2));
                     {
                       name: 'type',
                       type: "'text'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'text',
                       type: 'string',
-                      description: 'The text content of the message part.'
-                    }
-                  ]
+                      description: 'The text content of the message part.',
+                    },
+                  ],
                 },
                 {
                   type: 'ImagePart',
@@ -120,19 +121,19 @@ console.log(JSON.stringify(object, null, 2));
                     {
                       name: 'type',
                       type: "'image'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'image',
                       type: 'string | Uint8Array | Buffer | ArrayBuffer | URL',
                       description:
-                        'The image content of the message part. String are either base64 encoded content, base64 data URLs, or http(s) URLs.'
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+                        'The image content of the message part. String are either base64 encoded content, base64 data URLs, or http(s) URLs.',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         },
         {
           type: 'CoreAssistantMessage',
@@ -140,7 +141,7 @@ console.log(JSON.stringify(object, null, 2));
             {
               name: 'role',
               type: "'assistant'",
-              description: 'The role for the assistant message.'
+              description: 'The role for the assistant message.',
             },
             {
               name: 'content',
@@ -153,14 +154,14 @@ console.log(JSON.stringify(object, null, 2));
                     {
                       name: 'type',
                       type: "'text'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'text',
                       type: 'string',
-                      description: 'The text content of the message part.'
-                    }
-                  ]
+                      description: 'The text content of the message part.',
+                    },
+                  ],
                 },
                 {
                   type: 'ToolCallPart',
@@ -168,30 +169,30 @@ console.log(JSON.stringify(object, null, 2));
                     {
                       name: 'type',
                       type: "'tool-call'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'toolCallId',
                       type: 'string',
-                      description: 'The id of the tool call.'
+                      description: 'The id of the tool call.',
                     },
                     {
                       name: 'toolName',
                       type: 'string',
                       description:
-                        'The name of the tool, which typically would be the name of the function.'
+                        'The name of the tool, which typically would be the name of the function.',
                     },
                     {
                       name: 'args',
                       type: 'object based on zod schema',
                       description:
-                        'Parameters generated by the model to be used by the tool.'
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+                        'Parameters generated by the model to be used by the tool.',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         },
         {
           type: 'CoreToolMessage',
@@ -199,7 +200,7 @@ console.log(JSON.stringify(object, null, 2));
             {
               name: 'role',
               type: "'tool'",
-              description: 'The role for the assistant message.'
+              description: 'The role for the assistant message.',
             },
             {
               name: 'content',
@@ -212,99 +213,104 @@ console.log(JSON.stringify(object, null, 2));
                     {
                       name: 'type',
                       type: "'tool-result'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'toolCallId',
                       type: 'string',
                       description:
-                        'The id of the tool call the result corresponds to.'
+                        'The id of the tool call the result corresponds to.',
                     },
                     {
                       name: 'toolName',
                       type: 'string',
                       description:
-                        'The name of the tool the result corresponds to.'
+                        'The name of the tool the result corresponds to.',
                     },
                     {
                       name: 'result',
                       type: 'unknown',
                       description:
-                        'The result returned by the tool after execution.'
+                        'The result returned by the tool after execution.',
                     },
                     {
                       name: 'isError',
                       type: 'boolean',
                       isOptional: true,
                       description:
-                        'Whether the result is an error or an error message.'
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                        'Whether the result is an error or an error message.',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
-
     {
       name: 'maxTokens',
       type: 'number',
       isOptional: true,
-      description: 'Maximum number of tokens to generate.'
+      description: 'Maximum number of tokens to generate.',
     },
     {
       name: 'temperature',
       type: 'number',
       isOptional: true,
       description:
-        'Temperature setting. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.'
+        'Temperature setting. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.',
     },
     {
       name: 'topP',
       type: 'number',
       isOptional: true,
       description:
-        'Nucleus sampling. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.'
+        'Nucleus sampling. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.',
     },
     {
       name: 'presencePenalty',
       type: 'number',
       isOptional: true,
       description:
-        'Presence penalty setting. It affects the likelihood of the model to repeat information that is already in the prompt. The value is passed through to the provider. The range depends on the provider and model.'
+        'Presence penalty setting. It affects the likelihood of the model to repeat information that is already in the prompt. The value is passed through to the provider. The range depends on the provider and model.',
     },
     {
       name: 'frequencyPenalty',
       type: 'number',
       isOptional: true,
       description:
-        'Frequency penalty setting. It affects the likelihood of the model to repeatedly use the same words or phrases. The value is passed through to the provider. The range depends on the provider and model.'
+        'Frequency penalty setting. It affects the likelihood of the model to repeatedly use the same words or phrases. The value is passed through to the provider. The range depends on the provider and model.',
     },
     {
       name: 'seed',
       type: 'number',
       isOptional: true,
       description:
-        'The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results.'
+        'The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results.',
     },
     {
       name: 'maxRetries',
       type: 'number',
       isOptional: true,
       description:
-        'Maximum number of retries. Set to 0 to disable retries. Default: 2.'
+        'Maximum number of retries. Set to 0 to disable retries. Default: 2.',
     },
     {
       name: 'abortSignal',
       type: 'AbortSignal',
       isOptional: true,
       description:
-        'An optional abort signal that can be used to cancel the call.'
-    }
-
-]}
+        'An optional abort signal that can be used to cancel the call.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
+    },
+  ]}
 />
 
 ### Returns

--- a/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
@@ -45,29 +45,30 @@ for await (const partialObject of partialObjectStream) {
     {
       name: 'model',
       type: 'LanguageModel',
-      description: `The language model to use. Example: openai('gpt-4-turbo')`
+      description: `The language model to use. Example: openai('gpt-4-turbo')`,
     },
     {
       name: 'mode',
       type: "'auto' | 'json' | 'grammar' | 'tool'",
       description:
-        "The mode to use for object generation. Not every model supports all modes. Defaults to 'auto'."
+        "The mode to use for object generation. Not every model supports all modes. Defaults to 'auto'.",
     },
     {
-        name: 'schema',
-        type: 'Zod Schema',
-        description: 'The schema that describes the shape of the object to generate. It is sent to the model to generate the object and used to validate the output.'
+      name: 'schema',
+      type: 'Zod Schema',
+      description:
+        'The schema that describes the shape of the object to generate. It is sent to the model to generate the object and used to validate the output.',
     },
     {
       name: 'system',
       type: 'string',
       description:
-        'The system prompt to use that specifies the behavior of the model.'
+        'The system prompt to use that specifies the behavior of the model.',
     },
     {
       name: 'prompt',
       type: 'string',
-      description: 'The input prompt to generate the text from.'
+      description: 'The input prompt to generate the text from.',
     },
     {
       name: 'messages',
@@ -80,14 +81,14 @@ for await (const partialObject of partialObjectStream) {
             {
               name: 'role',
               type: "'system'",
-              description: 'The role for the system message.'
+              description: 'The role for the system message.',
             },
             {
               name: 'content',
               type: 'string',
-              description: 'The content of the message.'
-            }
-          ]
+              description: 'The content of the message.',
+            },
+          ],
         },
         {
           type: 'CoreUserMessage',
@@ -95,7 +96,7 @@ for await (const partialObject of partialObjectStream) {
             {
               name: 'role',
               type: "'user'",
-              description: 'The role for the user message.'
+              description: 'The role for the user message.',
             },
             {
               name: 'content',
@@ -108,14 +109,14 @@ for await (const partialObject of partialObjectStream) {
                     {
                       name: 'type',
                       type: "'text'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'text',
                       type: 'string',
-                      description: 'The text content of the message part.'
-                    }
-                  ]
+                      description: 'The text content of the message part.',
+                    },
+                  ],
                 },
                 {
                   type: 'ImagePart',
@@ -123,19 +124,19 @@ for await (const partialObject of partialObjectStream) {
                     {
                       name: 'type',
                       type: "'image'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'image',
                       type: 'string | Uint8Array | Buffer | ArrayBuffer | URL',
                       description:
-                        'The image content of the message part. String are either base64 encoded content, base64 data URLs, or http(s) URLs.'
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+                        'The image content of the message part. String are either base64 encoded content, base64 data URLs, or http(s) URLs.',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         },
         {
           type: 'CoreAssistantMessage',
@@ -143,7 +144,7 @@ for await (const partialObject of partialObjectStream) {
             {
               name: 'role',
               type: "'assistant'",
-              description: 'The role for the assistant message.'
+              description: 'The role for the assistant message.',
             },
             {
               name: 'content',
@@ -156,14 +157,14 @@ for await (const partialObject of partialObjectStream) {
                     {
                       name: 'type',
                       type: "'text'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'text',
                       type: 'string',
-                      description: 'The text content of the message part.'
-                    }
-                  ]
+                      description: 'The text content of the message part.',
+                    },
+                  ],
                 },
                 {
                   type: 'ToolCallPart',
@@ -171,30 +172,30 @@ for await (const partialObject of partialObjectStream) {
                     {
                       name: 'type',
                       type: "'tool-call'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'toolCallId',
                       type: 'string',
-                      description: 'The id of the tool call.'
+                      description: 'The id of the tool call.',
                     },
                     {
                       name: 'toolName',
                       type: 'string',
                       description:
-                        'The name of the tool, which typically would be the name of the function.'
+                        'The name of the tool, which typically would be the name of the function.',
                     },
                     {
                       name: 'args',
                       type: 'object based on zod schema',
                       description:
-                        'Parameters generated by the model to be used by the tool.'
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+                        'Parameters generated by the model to be used by the tool.',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         },
         {
           type: 'CoreToolMessage',
@@ -202,7 +203,7 @@ for await (const partialObject of partialObjectStream) {
             {
               name: 'role',
               type: "'tool'",
-              description: 'The role for the assistant message.'
+              description: 'The role for the assistant message.',
             },
             {
               name: 'content',
@@ -215,96 +216,102 @@ for await (const partialObject of partialObjectStream) {
                     {
                       name: 'type',
                       type: "'tool-result'",
-                      description: 'The type of the message part.'
+                      description: 'The type of the message part.',
                     },
                     {
                       name: 'toolCallId',
                       type: 'string',
                       description:
-                        'The id of the tool call the result corresponds to.'
+                        'The id of the tool call the result corresponds to.',
                     },
                     {
                       name: 'toolName',
                       type: 'string',
                       description:
-                        'The name of the tool the result corresponds to.'
+                        'The name of the tool the result corresponds to.',
                     },
                     {
                       name: 'result',
                       type: 'unknown',
                       description:
-                        'The result returned by the tool after execution.'
+                        'The result returned by the tool after execution.',
                     },
                     {
                       name: 'isError',
                       type: 'boolean',
                       isOptional: true,
                       description:
-                        'Whether the result is an error or an error message.'
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                        'Whether the result is an error or an error message.',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
-
     {
       name: 'maxTokens',
       type: 'number',
       isOptional: true,
-      description: 'Maximum number of tokens to generate.'
+      description: 'Maximum number of tokens to generate.',
     },
     {
       name: 'temperature',
       type: 'number',
       isOptional: true,
       description:
-        'Temperature setting. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.'
+        'Temperature setting. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.',
     },
     {
       name: 'topP',
       type: 'number',
       isOptional: true,
       description:
-        'Nucleus sampling. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.'
+        'Nucleus sampling. The value is passed through to the provider. The range depends on the provider and model. It is recommended to set either `temperature` or `topP`, but not both.',
     },
     {
       name: 'presencePenalty',
       type: 'number',
       isOptional: true,
       description:
-        'Presence penalty setting. It affects the likelihood of the model to repeat information that is already in the prompt. The value is passed through to the provider. The range depends on the provider and model.'
+        'Presence penalty setting. It affects the likelihood of the model to repeat information that is already in the prompt. The value is passed through to the provider. The range depends on the provider and model.',
     },
     {
       name: 'frequencyPenalty',
       type: 'number',
       isOptional: true,
       description:
-        'Frequency penalty setting. It affects the likelihood of the model to repeatedly use the same words or phrases. The value is passed through to the provider. The range depends on the provider and model.'
+        'Frequency penalty setting. It affects the likelihood of the model to repeatedly use the same words or phrases. The value is passed through to the provider. The range depends on the provider and model.',
     },
     {
       name: 'seed',
       type: 'number',
       isOptional: true,
       description:
-        'The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results.'
+        'The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results.',
     },
     {
       name: 'maxRetries',
       type: 'number',
       isOptional: true,
       description:
-        'Maximum number of retries. Set to 0 to disable retries. Default: 2.'
+        'Maximum number of retries. Set to 0 to disable retries. Default: 2.',
     },
     {
       name: 'abortSignal',
       type: 'AbortSignal',
       isOptional: true,
       description:
-        'An optional abort signal that can be used to cancel the call.'
+        'An optional abort signal that can be used to cancel the call.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
     },
     {
       name: 'onFinish',
@@ -351,9 +358,10 @@ for await (const partialObject of partialObjectStream) {
                 'The generated object (typed according to the schema). Can be undefined if the final object does not match the schema.',
             },
             {
-              name:"error",
-              type:"unknown | undefined",
-              description:"Optional error object. This is e.g. a TypeValidationError when the final object does not match the schema."
+              name: 'error',
+              type: 'unknown | undefined',
+              description:
+                'Optional error object. This is e.g. a TypeValidationError when the final object does not match the schema.',
             },
             {
               name: 'warnings',
@@ -383,8 +391,7 @@ for await (const partialObject of partialObjectStream) {
         },
       ],
     },
-
-]}
+  ]}
 />
 
 ### Returns

--- a/content/docs/07-reference/ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/ai-sdk-core/05-embed.mdx
@@ -53,6 +53,13 @@ const { embedding } = await embed({
       description:
         'An optional abort signal that can be used to cancel the call.',
     },
+    {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
+    },
   ]}
 />
 

--- a/content/docs/07-reference/ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/ai-sdk-core/06-embed-many.mdx
@@ -59,6 +59,13 @@ const { embeddings } = await embedMany({
       description:
         'An optional abort signal that can be used to cancel the call.',
     },
+    {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
+    },
   ]}
 />
 

--- a/content/docs/07-reference/ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/ai-sdk-rsc/01-stream-ui.mdx
@@ -274,6 +274,13 @@ A helper function to create a streamable UI from LLM providers. This function is
         'An optional abort signal that can be used to cancel the call.',
     },
     {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
+    },
+    {
       name: 'tools',
       type: 'Record<string, Tool>',
       description:

--- a/content/providers/01-ai-sdk-providers/02-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/02-azure.mdx
@@ -54,6 +54,10 @@ You can use the following optional settings to customize the OpenAI provider ins
   API key that is being send using the `api-key` header.
   It defaults to the `AZURE_API_KEY` environment variable.
 
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
 - **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
 
   Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.

--- a/examples/ai-core/src/generate-text/openai-custom-headers.ts
+++ b/examples/ai-core/src/generate-text/openai-custom-headers.ts
@@ -7,7 +7,12 @@ dotenv.config();
 const openai = createOpenAI({
   apiKey: process.env.OPENAI_API_KEY!,
   headers: {
-    'X-My-Header': 'something',
+    'custom-provider-header': 'value-1',
+  },
+  // fetch wrapper to log the headers:
+  fetch: async (url, options) => {
+    console.log('Headers', options?.headers);
+    return fetch(url, options);
   },
 });
 
@@ -15,6 +20,10 @@ async function main() {
   const result = await generateText({
     model: openai('gpt-3.5-turbo'),
     prompt: 'Invent a new holiday and describe its traditions.',
+    maxTokens: 50,
+    headers: {
+      'custom-request-header': 'value-2',
+    },
   });
 
   console.log(result.text);

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -56,6 +56,7 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
     frequencyPenalty,
     presencePenalty,
     seed,
+    headers,
   }: Parameters<LanguageModelV1['doGenerate']>[0]) {
     const type = mode.type;
 
@@ -79,6 +80,13 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'seed',
+      });
+    }
+
+    if (headers != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'headers',
       });
     }
 

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -267,13 +267,13 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareJsonResponse({ content: [] });
 
     const provider = createAnthropic({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -281,28 +281,20 @@ describe('doGenerate', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
 
-  it('should pass the api key as Authorization header', async () => {
-    prepareJsonResponse({});
-
-    const provider = createAnthropic({
-      apiKey: 'test-api-key',
+    expect(requestHeaders).toStrictEqual({
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'x-api-key': 'test-api-key',
     });
-
-    await provider.chat('claude-3-haiku-20240307').doGenerate({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-    });
-
-    expect((await server.getRequestHeaders()).get('x-api-key')).toStrictEqual(
-      'test-api-key',
-    );
   });
 });
 
@@ -497,13 +489,13 @@ describe('doStream', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareStreamResponse({ content: [] });
 
     const provider = createAnthropic({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -511,27 +503,19 @@ describe('doStream', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
 
-  it('should pass the api key as Authorization header', async () => {
-    prepareStreamResponse({ content: [] });
-
-    const provider = createAnthropic({
-      apiKey: 'test-api-key',
+    expect(requestHeaders).toStrictEqual({
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'x-api-key': 'test-api-key',
     });
-
-    await provider.chat('claude-3-haiku-2024').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-    });
-
-    expect((await server.getRequestHeaders()).get('x-api-key')).toStrictEqual(
-      'test-api-key',
-    );
   });
 });

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -8,6 +8,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   ParseResult,
+  combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   postJsonToApi,
@@ -157,7 +158,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/messages`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
@@ -214,7 +215,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/messages`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: {
         ...args,
         stream: true,

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -42,23 +42,34 @@ describe('chat', () => {
       };
     }
 
-    it('should pass the api key as api-key header', async () => {
+    it('should pass headers', async () => {
       prepareJsonResponse();
 
       const provider = createAzure({
         resourceName: 'test-resource',
         apiKey: 'test-api-key',
+        headers: {
+          'Custom-Provider-Header': 'provider-header-value',
+        },
       });
 
       await provider('test-deployment').doGenerate({
         inputFormat: 'prompt',
         mode: { type: 'regular' },
         prompt: TEST_PROMPT,
+        headers: {
+          'Custom-Request-Header': 'request-header-value',
+        },
       });
 
-      expect((await server.getRequestHeaders()).get('api-key')).toStrictEqual(
-        'test-api-key',
-      );
+      const requestHeaders = await server.getRequestHeaders();
+
+      expect(requestHeaders).toStrictEqual({
+        'api-key': 'test-api-key',
+        'content-type': 'application/json',
+        'custom-provider-header': 'provider-header-value',
+        'custom-request-header': 'request-header-value',
+      });
     });
   });
 });
@@ -111,23 +122,34 @@ describe('completion', () => {
       };
     }
 
-    it('should pass the api key as Authorization header', async () => {
+    it('should pass headers', async () => {
       prepareJsonCompletionResponse({ content: 'Hello World!' });
 
       const provider = createAzure({
         resourceName: 'test-resource',
         apiKey: 'test-api-key',
+        headers: {
+          'Custom-Provider-Header': 'provider-header-value',
+        },
       });
 
       await provider.completion('gpt-35-turbo-instruct').doGenerate({
         inputFormat: 'prompt',
         mode: { type: 'regular' },
         prompt: TEST_PROMPT,
+        headers: {
+          'Custom-Request-Header': 'request-header-value',
+        },
       });
 
-      expect((await server.getRequestHeaders()).get('api-key')).toStrictEqual(
-        'test-api-key',
-      );
+      const requestHeaders = await server.getRequestHeaders();
+
+      expect(requestHeaders).toStrictEqual({
+        'api-key': 'test-api-key',
+        'content-type': 'application/json',
+        'custom-provider-header': 'provider-header-value',
+        'custom-request-header': 'request-header-value',
+      });
     });
   });
 });
@@ -223,21 +245,32 @@ describe('embedding', () => {
       });
     });
 
-    it('should pass the api key as api-key header', async () => {
+    it('should pass headers', async () => {
       prepareJsonResponse();
 
       const provider = createAzure({
         resourceName: 'test-resource',
         apiKey: 'test-api-key',
+        headers: {
+          'Custom-Provider-Header': 'provider-header-value',
+        },
       });
 
       await provider.embedding('my-embedding').doEmbed({
         values: testValues,
+        headers: {
+          'Custom-Request-Header': 'request-header-value',
+        },
       });
 
-      expect((await server.getRequestHeaders()).get('api-key')).toStrictEqual(
-        'test-api-key',
-      );
+      const requestHeaders = await server.getRequestHeaders();
+
+      expect(requestHeaders).toStrictEqual({
+        'api-key': 'test-api-key',
+        'content-type': 'application/json',
+        'custom-provider-header': 'provider-header-value',
+        'custom-request-header': 'request-header-value',
+      });
     });
   });
 });

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -67,6 +67,11 @@ API key for authenticating requests.
   apiKey?: string;
 
   /**
+Custom headers to include in the requests.
+     */
+  headers?: Record<string, string>;
+
+  /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
     */
@@ -85,6 +90,7 @@ export function createAzure(
       environmentVariableName: 'AZURE_API_KEY',
       description: 'Azure OpenAI',
     }),
+    ...options.headers,
   });
 
   const getResourceName = () =>

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -133,13 +133,13 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareJsonResponse({});
 
     const provider = createCohere({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -147,26 +147,19 @@ describe('doGenerate', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
 
-  it('should pass the api key as Authorization header', async () => {
-    prepareJsonResponse({});
-
-    const provider = createCohere({ apiKey: 'test-api-key' });
-
-    await provider('command-r-plus').doGenerate({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
     });
-
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
   });
 });
 
@@ -303,13 +296,13 @@ describe('doStream', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareStreamResponse({ content: [] });
 
     const provider = createCohere({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -317,26 +310,18 @@ describe('doStream', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
 
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
-
-  it('should pass the api key as Authorization header', async () => {
-    prepareStreamResponse({ content: [] });
-
-    const provider = createCohere({ apiKey: 'test-api-key' });
-
-    await provider('command-r-plus').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
     });
-
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
   });
 });

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -6,6 +6,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   ParseResult,
+  combineHeaders,
   createJsonResponseHandler,
   createJsonStreamResponseHandler,
   postJsonToApi,
@@ -120,7 +121,7 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/chat`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
       failedResponseHandler: cohereFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
@@ -158,7 +159,7 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/chat`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: {
         ...args,
         stream: true,

--- a/packages/core/core/embed/embed-many.test.ts
+++ b/packages/core/core/embed/embed-many.test.ts
@@ -72,3 +72,24 @@ describe('result.values', () => {
     assert.deepStrictEqual(result.values, testValues);
   });
 });
+
+describe('options.headers', () => {
+  it('should set headers', async () => {
+    const result = await embedMany({
+      model: new MockEmbeddingModelV1({
+        maxEmbeddingsPerCall: 5,
+        doEmbed: async ({ headers }) => {
+          assert.deepStrictEqual(headers, {
+            'custom-request-header': 'request-header-value',
+          });
+
+          return { embeddings: dummyEmbeddings };
+        },
+      }),
+      values: testValues,
+      headers: { 'custom-request-header': 'request-header-value' },
+    });
+
+    assert.deepStrictEqual(result.embeddings, dummyEmbeddings);
+  });
+});

--- a/packages/core/core/embed/embed.test.ts
+++ b/packages/core/core/embed/embed.test.ts
@@ -33,3 +33,23 @@ describe('result.value', () => {
     assert.deepStrictEqual(result.value, testValue);
   });
 });
+
+describe('options.headers', () => {
+  it('should set headers', async () => {
+    const result = await embed({
+      model: new MockEmbeddingModelV1({
+        doEmbed: async ({ headers }) => {
+          assert.deepStrictEqual(headers, {
+            'custom-request-header': 'request-header-value',
+          });
+
+          return { embeddings: [dummyEmbedding] };
+        },
+      }),
+      value: testValue,
+      headers: { 'custom-request-header': 'request-header-value' },
+    });
+
+    assert.deepStrictEqual(result.embedding, dummyEmbedding);
+  });
+});

--- a/packages/core/core/embed/embed.ts
+++ b/packages/core/core/embed/embed.ts
@@ -9,6 +9,7 @@ Embed a value using an embedding model. The type of the value is defined by the 
 
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
+@param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
 @returns A result object that contains the embedding, the value, and additional information.
  */
@@ -17,6 +18,7 @@ export async function embed<VALUE>({
   value,
   maxRetries,
   abortSignal,
+  headers,
 }: {
   /**
 The embedding model to use.
@@ -39,6 +41,12 @@ Maximum number of retries per embedding model call. Set to 0 to disable retries.
 Abort signal.
  */
   abortSignal?: AbortSignal;
+
+  /**
+Additional headers to include in the request.
+Only applicable for HTTP-based providers.
+ */
+  headers?: Record<string, string>;
 }): Promise<EmbedResult<VALUE>> {
   const retry = retryWithExponentialBackoff({ maxRetries });
 
@@ -46,6 +54,7 @@ Abort signal.
     model.doEmbed({
       values: [value],
       abortSignal,
+      headers,
     }),
   );
 

--- a/packages/core/core/embed/embed.ts
+++ b/packages/core/core/embed/embed.ts
@@ -51,11 +51,7 @@ Only applicable for HTTP-based providers.
   const retry = retryWithExponentialBackoff({ maxRetries });
 
   const modelResponse = await retry(() =>
-    model.doEmbed({
-      values: [value],
-      abortSignal,
-      headers,
-    }),
+    model.doEmbed({ values: [value], abortSignal, headers }),
   );
 
   return new EmbedResult({

--- a/packages/core/core/generate-object/generate-object.test.ts
+++ b/packages/core/core/generate-object/generate-object.test.ts
@@ -118,3 +118,28 @@ describe('result.toJsonResponse', () => {
     );
   });
 });
+
+describe('options.headers', () => {
+  it('should set headers', async () => {
+    const result = await generateObject({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({ headers }) => {
+          assert.deepStrictEqual(headers, {
+            'custom-request-header': 'request-header-value',
+          });
+
+          return {
+            ...dummyResponseValues,
+            text: `{ "content": "Hello, world!" }`,
+          };
+        },
+      }),
+      schema: z.object({ content: z.string() }),
+      mode: 'json',
+      prompt: 'prompt',
+      headers: { 'custom-request-header': 'request-header-value' },
+    });
+
+    assert.deepStrictEqual(result.object, { content: 'Hello, world!' });
+  });
+});

--- a/packages/core/core/generate-object/generate-object.ts
+++ b/packages/core/core/generate-object/generate-object.ts
@@ -45,6 +45,7 @@ If set and supported by the model, calls will generate deterministic results.
 
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
+@param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
 @returns 
 A result object that contains the generated object, the finish reason, the token usage, and additional information.
@@ -58,6 +59,7 @@ export async function generateObject<T>({
   messages,
   maxRetries,
   abortSignal,
+  headers,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -117,6 +119,7 @@ Default and recommended: 'auto' (best mode for the model).
           inputFormat: validatedPrompt.type,
           prompt: convertToLanguageModelPrompt(validatedPrompt),
           abortSignal,
+          headers,
         });
       });
 

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -58,6 +58,7 @@ If set and supported by the model, calls will generate deterministic results.
 
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
+@param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
 @return
 A result object for accessing the partial object stream and additional information.
@@ -71,6 +72,7 @@ export async function streamObject<T>({
   messages,
   maxRetries,
   abortSignal,
+  headers,
   onFinish,
   ...settings
 }: CallSettings &
@@ -161,6 +163,7 @@ Warnings from the model provider (e.g. unsupported settings).
         inputFormat: validatedPrompt.type,
         prompt: convertToLanguageModelPrompt(validatedPrompt),
         abortSignal,
+        headers,
       };
 
       transformer = {
@@ -193,6 +196,7 @@ Warnings from the model provider (e.g. unsupported settings).
         inputFormat: validatedPrompt.type,
         prompt: convertToLanguageModelPrompt(validatedPrompt),
         abortSignal,
+        headers,
       };
 
       transformer = {
@@ -233,6 +237,7 @@ Warnings from the model provider (e.g. unsupported settings).
         inputFormat: validatedPrompt.type,
         prompt: convertToLanguageModelPrompt(validatedPrompt),
         abortSignal,
+        headers,
       };
 
       transformer = {

--- a/packages/core/core/generate-text/generate-text.test.ts
+++ b/packages/core/core/generate-text/generate-text.test.ts
@@ -480,7 +480,7 @@ describe('options.headers', () => {
   it('should pass headers to model', async () => {
     const result = await generateText({
       model: new MockLanguageModelV1({
-        doGenerate: async ({ prompt, headers }) => {
+        doGenerate: async ({ headers }) => {
           assert.deepStrictEqual(headers, {
             'custom-request-header': 'request-header-value',
           });

--- a/packages/core/core/generate-text/generate-text.test.ts
+++ b/packages/core/core/generate-text/generate-text.test.ts
@@ -350,7 +350,7 @@ describe('result.responseMessages', () => {
   });
 });
 
-describe('maxToolRoundtrips', () => {
+describe('options.maxToolRoundtrips', () => {
   it('should return text, tool calls and tool results from last roundtrip', async () => {
     let responseCount = 0;
     const result = await generateText({
@@ -473,5 +473,28 @@ describe('maxToolRoundtrips', () => {
     assert.deepStrictEqual(result.text, 'Hello, world!');
     assert.deepStrictEqual(result.toolCalls, []);
     assert.deepStrictEqual(result.toolResults, []);
+  });
+});
+
+describe('options.headers', () => {
+  it('should pass headers to model', async () => {
+    const result = await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({ prompt, headers }) => {
+          assert.deepStrictEqual(headers, {
+            'custom-request-header': 'request-header-value',
+          });
+
+          return {
+            ...dummyResponseValues,
+            text: 'Hello, world!',
+          };
+        },
+      }),
+      prompt: 'test-input',
+      headers: { 'custom-request-header': 'request-header-value' },
+    });
+
+    assert.deepStrictEqual(result.text, 'Hello, world!');
   });
 });

--- a/packages/core/core/generate-text/generate-text.ts
+++ b/packages/core/core/generate-text/generate-text.ts
@@ -53,6 +53,7 @@ If set and supported by the model, calls will generate deterministic results.
 
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
+@param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
 @param maxToolRoundtrips - Maximal number of automatic roundtrips for tool calls.
 
@@ -68,6 +69,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   messages,
   maxRetries,
   abortSignal,
+  headers,
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
   ...settings
@@ -132,6 +134,7 @@ By default, it's set to 0, which will disable the feature.
         inputFormat: roundtrips === 0 ? validatedPrompt.type : 'messages',
         prompt: promptMessages,
         abortSignal,
+        headers,
       });
     });
 

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -59,6 +59,7 @@ If set and supported by the model, calls will generate deterministic results.
 
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
+@param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
 @param onFinish - Callback that is called when the LLM response and all request tool executions 
 (for tools that have an `execute` function) are finished.
@@ -75,6 +76,7 @@ export async function streamText<TOOLS extends Record<string, CoreTool>>({
   messages,
   maxRetries,
   abortSignal,
+  headers,
   onFinish,
   ...settings
 }: CallSettings &
@@ -152,6 +154,7 @@ Warnings from the model provider (e.g. unsupported settings).
       inputFormat: validatedPrompt.type,
       prompt: convertToLanguageModelPrompt(validatedPrompt),
       abortSignal,
+      headers,
     }),
   );
 

--- a/packages/core/core/prompt/call-settings.ts
+++ b/packages/core/core/prompt/call-settings.ts
@@ -63,4 +63,10 @@ Maximum number of retries. Set to 0 to disable retries.
 Abort signal.
    */
   abortSignal?: AbortSignal;
+
+  /**
+Additional HTTP headers to be sent with the request.
+Only applicable for HTTP-based providers.
+   */
+  headers?: Record<string, string | undefined>;
 };

--- a/packages/core/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
+++ b/packages/core/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
@@ -1,5 +1,49 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`options.headers > should set headers 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "c": undefined,
+      "n": {
+        "done": false,
+        "next": {
+          "done": false,
+          "next": {
+            "done": false,
+            "next": {
+              "done": false,
+              "next": {
+                "done": false,
+                "next": {
+                  "done": false,
+                  "next": {
+                    "done": true,
+                    "value": "{ "content": "Hello, world!" }",
+                  },
+                  "value": "{ "content": "Hello, world!" }",
+                },
+                "value": "{ "content": "Hello, world!"",
+              },
+              "value": "{ "content": "Hello, world",
+            },
+            "value": "{ "content": "Hello, ",
+          },
+          "value": "{ "content": ",
+        },
+        "value": "{ ",
+      },
+    },
+    "type": "",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
 exports[`result.value > should render text 1`] = `
 {
   "children": {

--- a/packages/core/rsc/stream-ui/stream-ui.tsx
+++ b/packages/core/rsc/stream-ui/stream-ui.tsx
@@ -86,6 +86,7 @@ export async function streamUI<
   messages,
   maxRetries,
   abortSignal,
+  headers,
   initial,
   text,
   onFinish,
@@ -263,6 +264,7 @@ export async function streamUI<
       inputFormat: validatedPrompt.type,
       prompt: convertToLanguageModelPrompt(validatedPrompt),
       abortSignal,
+      headers,
     }),
   );
 

--- a/packages/google-vertex/src/google-vertex-language-model.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.ts
@@ -57,6 +57,7 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
     maxTokens,
     temperature,
     topP,
+    headers,
   }: LanguageModelV1CallOptions) {
     const warnings: LanguageModelV1CallWarning[] = [];
 
@@ -78,6 +79,13 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'seed',
+      });
+    }
+
+    if (headers != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'headers',
       });
     }
 

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -281,7 +281,7 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareJsonResponse({ content: '' });
 
     const provider = createGoogleGenerativeAI({

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -287,7 +287,7 @@ describe('doGenerate', () => {
     const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -295,27 +295,19 @@ describe('doGenerate', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
 
-  it('should pass the api key as Authorization header', async () => {
-    prepareJsonResponse({ content: '' });
-
-    const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
-    const model = provider.chat('models/gemini-pro');
-
-    await model.doGenerate({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
+    expect(requestHeaders).toStrictEqual({
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'x-goog-api-key': 'test-api-key',
     });
-
-    expect(
-      (await server.getRequestHeaders()).get('x-goog-api-key'),
-    ).toStrictEqual('test-api-key');
   });
 });
 
@@ -404,13 +396,13 @@ describe('doStream', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareStreamResponse({ content: [] });
 
     const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -418,25 +410,18 @@ describe('doStream', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
 
-  it('should pass the api key as Authorization header', async () => {
-    prepareStreamResponse({ content: [''] });
-
-    const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
-
-    await provider.chat('models/gemini-pro').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
+    expect(requestHeaders).toStrictEqual({
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'x-goog-api-key': 'test-api-key',
     });
-
-    expect(
-      (await server.getRequestHeaders()).get('x-goog-api-key'),
-    ).toStrictEqual('test-api-key');
   });
 });

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -7,6 +7,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   ParseResult,
+  combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   postJsonToApi,
@@ -152,7 +153,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/${this.modelId}:generateContent`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
       failedResponseHandler: googleFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(responseSchema),
@@ -194,7 +195,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/${this.modelId}:streamGenerateContent?alt=sse`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
       failedResponseHandler: googleFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(chunkSchema),

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -173,13 +173,13 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareJsonResponse({ content: '' });
 
     const provider = createMistral({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -187,26 +187,19 @@ describe('doGenerate', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
 
-  it('should pass the api key as Authorization header', async () => {
-    prepareJsonResponse({ content: '' });
-
-    const mistral = createMistral({ apiKey: 'test-api-key' });
-
-    await mistral.chat('mistral-small-latest').doGenerate({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
     });
-
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
   });
 });
 
@@ -364,13 +357,13 @@ describe('doStream', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareStreamResponse({ content: [] });
 
     const provider = createMistral({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -378,25 +371,18 @@ describe('doStream', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
 
-  it('should pass the api key as Authorization header', async () => {
-    prepareStreamResponse({ content: [''] });
-
-    const provider = createMistral({ apiKey: 'test-api-key' });
-
-    await provider.chat('mistral-small-latest').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
     });
-
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
   });
 });

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -7,6 +7,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   ParseResult,
+  combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   postJsonToApi,
@@ -145,7 +146,7 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/chat/completions`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
       failedResponseHandler: mistralFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
@@ -184,7 +185,7 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/chat/completions`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: {
         ...args,
         stream: true,

--- a/packages/mistral/src/mistral-embedding-model.test.ts
+++ b/packages/mistral/src/mistral-embedding-model.test.ts
@@ -72,35 +72,30 @@ describe('doEmbed', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareJsonResponse();
 
     const provider = createMistral({
       apiKey: 'test-api-key',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
     await provider.embedding('mistral-embed').doEmbed({
       values: testValues,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
-  });
 
-  it('should pass the api key as Authorization header', async () => {
-    prepareJsonResponse();
-
-    const provider = createMistral({ apiKey: 'test-api-key' });
-
-    await provider.embedding('mistral-embed').doEmbed({
-      values: testValues,
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
     });
-
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
   });
 });

--- a/packages/mistral/src/mistral-embedding-model.ts
+++ b/packages/mistral/src/mistral-embedding-model.ts
@@ -3,6 +3,7 @@ import {
   TooManyEmbeddingValuesForCallError,
 } from '@ai-sdk/provider';
 import {
+  combineHeaders,
   createJsonResponseHandler,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
@@ -54,6 +55,7 @@ export class MistralEmbeddingModel implements EmbeddingModelV1<string> {
   async doEmbed({
     values,
     abortSignal,
+    headers,
   }: Parameters<EmbeddingModelV1<string>['doEmbed']>[0]): Promise<
     Awaited<ReturnType<EmbeddingModelV1<string>['doEmbed']>>
   > {
@@ -68,7 +70,7 @@ export class MistralEmbeddingModel implements EmbeddingModelV1<string> {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/embeddings`,
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), headers),
       body: {
         model: this.modelId,
         input: values,

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -370,7 +370,7 @@ describe('doGenerate', () => {
       organization: 'test-organization',
       project: 'test-project',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -378,15 +378,21 @@ describe('doGenerate', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
 
-    expect(requestHeaders.get('OpenAI-Organization')).toStrictEqual(
-      'test-organization',
-    );
-    expect(requestHeaders.get('OpenAI-Project')).toStrictEqual('test-project');
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'openai-organization': 'test-organization',
+      'openai-project': 'test-project',
+    });
   });
 
   it('should pass the api key as Authorization header', async () => {
@@ -400,9 +406,9 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
+    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
+      'Bearer test-api-key',
+    );
   });
 });
 
@@ -784,7 +790,7 @@ describe('doStream', () => {
       organization: 'test-organization',
       project: 'test-project',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -792,15 +798,21 @@ describe('doStream', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
 
-    expect(requestHeaders.get('OpenAI-Organization')).toStrictEqual(
-      'test-organization',
-    );
-    expect(requestHeaders.get('OpenAI-Project')).toStrictEqual('test-project');
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'openai-organization': 'test-organization',
+      'openai-project': 'test-project',
+    });
   });
 
   it('should pass the api key as Authorization header', async () => {
@@ -814,8 +826,8 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
+    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
+      'Bearer test-api-key',
+    );
   });
 });

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -362,7 +362,7 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareJsonResponse({ content: '' });
 
     const provider = createOpenAI({
@@ -393,22 +393,6 @@ describe('doGenerate', () => {
       'openai-organization': 'test-organization',
       'openai-project': 'test-project',
     });
-  });
-
-  it('should pass the api key as Authorization header', async () => {
-    prepareJsonResponse({ content: '' });
-
-    const provider = createOpenAI({ apiKey: 'test-api-key' });
-
-    await provider.chat('gpt-3.5-turbo').doGenerate({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-    });
-
-    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
-      'Bearer test-api-key',
-    );
   });
 });
 
@@ -782,7 +766,7 @@ describe('doStream', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareStreamResponse({ content: [] });
 
     const provider = createOpenAI({
@@ -813,21 +797,5 @@ describe('doStream', () => {
       'openai-organization': 'test-organization',
       'openai-project': 'test-project',
     });
-  });
-
-  it('should pass the api key as Authorization header', async () => {
-    prepareStreamResponse({ content: [] });
-
-    const provider = createOpenAI({ apiKey: 'test-api-key' });
-
-    await provider.chat('gpt-3.5-turbo').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-    });
-
-    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
-      'Bearer test-api-key',
-    );
   });
 });

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -8,6 +8,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   ParseResult,
+  combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
@@ -153,7 +154,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
         path: '/chat/completions',
         modelId: this.modelId,
       }),
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
       failedResponseHandler: openaiFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
@@ -196,7 +197,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
         path: '/chat/completions',
         modelId: this.modelId,
       }),
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: {
         ...args,
         stream: true,

--- a/packages/openai/src/openai-completion-language-model.test.ts
+++ b/packages/openai/src/openai-completion-language-model.test.ts
@@ -216,7 +216,7 @@ describe('doGenerate', () => {
       organization: 'test-organization',
       project: 'test-project',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -224,15 +224,21 @@ describe('doGenerate', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
 
-    expect(requestHeaders.get('OpenAI-Organization')).toStrictEqual(
-      'test-organization',
-    );
-    expect(requestHeaders.get('OpenAI-Project')).toStrictEqual('test-project');
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'openai-organization': 'test-organization',
+      'openai-project': 'test-project',
+    });
   });
 
   it('should pass the api key as Authorization header', async () => {
@@ -246,9 +252,9 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
+    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
+      'Bearer test-api-key',
+    );
   });
 });
 
@@ -445,7 +451,7 @@ describe('doStream', () => {
       organization: 'test-organization',
       project: 'test-project',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
@@ -453,15 +459,21 @@ describe('doStream', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
 
-    expect(requestHeaders.get('OpenAI-Organization')).toStrictEqual(
-      'test-organization',
-    );
-    expect(requestHeaders.get('OpenAI-Project')).toStrictEqual('test-project');
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'openai-organization': 'test-organization',
+      'openai-project': 'test-project',
+    });
   });
 
   it('should pass the api key as Authorization header', async () => {
@@ -475,8 +487,8 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
+    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
+      'Bearer test-api-key',
+    );
   });
 });

--- a/packages/openai/src/openai-completion-language-model.test.ts
+++ b/packages/openai/src/openai-completion-language-model.test.ts
@@ -208,7 +208,7 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareJsonResponse({ content: '' });
 
     const provider = createOpenAI({
@@ -239,22 +239,6 @@ describe('doGenerate', () => {
       'openai-organization': 'test-organization',
       'openai-project': 'test-project',
     });
-  });
-
-  it('should pass the api key as Authorization header', async () => {
-    prepareJsonResponse({ content: '' });
-
-    const provider = createOpenAI({ apiKey: 'test-api-key' });
-
-    await provider.completion('gpt-3.5-turbo-instruct').doGenerate({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-    });
-
-    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
-      'Bearer test-api-key',
-    );
   });
 });
 
@@ -443,7 +427,7 @@ describe('doStream', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareStreamResponse({ content: [] });
 
     const provider = createOpenAI({
@@ -474,21 +458,5 @@ describe('doStream', () => {
       'openai-organization': 'test-organization',
       'openai-project': 'test-project',
     });
-  });
-
-  it('should pass the api key as Authorization header', async () => {
-    prepareStreamResponse({ content: [] });
-
-    const provider = createOpenAI({ apiKey: 'test-api-key' });
-
-    await provider.completion('gpt-3.5-turbo-instruct').doStream({
-      inputFormat: 'prompt',
-      mode: { type: 'regular' },
-      prompt: TEST_PROMPT,
-    });
-
-    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
-      'Bearer test-api-key',
-    );
   });
 });

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -7,6 +7,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   ParseResult,
+  combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   postJsonToApi,
@@ -156,7 +157,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
         path: '/completions',
         modelId: this.modelId,
       }),
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
       failedResponseHandler: openaiFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
@@ -193,7 +194,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
         path: '/completions',
         modelId: this.modelId,
       }),
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), options.headers),
       body: {
         ...this.getArgs(options),
         stream: true,

--- a/packages/openai/src/openai-embedding-model.test.ts
+++ b/packages/openai/src/openai-embedding-model.test.ts
@@ -86,7 +86,7 @@ describe('doEmbed', () => {
     });
   });
 
-  it('should pass custom headers', async () => {
+  it('should pass headers', async () => {
     prepareJsonResponse();
 
     const provider = createOpenAI({
@@ -115,19 +115,5 @@ describe('doEmbed', () => {
       'openai-organization': 'test-organization',
       'openai-project': 'test-project',
     });
-  });
-
-  it('should pass the api key as Authorization header', async () => {
-    prepareJsonResponse();
-
-    const provider = createOpenAI({ apiKey: 'test-api-key' });
-
-    await provider.embedding('text-embedding-3-large').doEmbed({
-      values: testValues,
-    });
-
-    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
-      'Bearer test-api-key',
-    );
   });
 });

--- a/packages/openai/src/openai-embedding-model.test.ts
+++ b/packages/openai/src/openai-embedding-model.test.ts
@@ -94,21 +94,27 @@ describe('doEmbed', () => {
       organization: 'test-organization',
       project: 'test-project',
       headers: {
-        'Custom-Header': 'test-header',
+        'Custom-Provider-Header': 'provider-header-value',
       },
     });
 
     await provider.embedding('text-embedding-3-large').doEmbed({
       values: testValues,
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
     });
 
     const requestHeaders = await server.getRequestHeaders();
 
-    expect(requestHeaders.get('OpenAI-Organization')).toStrictEqual(
-      'test-organization',
-    );
-    expect(requestHeaders.get('OpenAI-Project')).toStrictEqual('test-project');
-    expect(requestHeaders.get('Custom-Header')).toStrictEqual('test-header');
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'openai-organization': 'test-organization',
+      'openai-project': 'test-project',
+    });
   });
 
   it('should pass the api key as Authorization header', async () => {
@@ -120,8 +126,8 @@ describe('doEmbed', () => {
       values: testValues,
     });
 
-    expect(
-      (await server.getRequestHeaders()).get('Authorization'),
-    ).toStrictEqual('Bearer test-api-key');
+    expect((await server.getRequestHeaders()).authorization).toStrictEqual(
+      'Bearer test-api-key',
+    );
   });
 });

--- a/packages/openai/src/openai-embedding-model.ts
+++ b/packages/openai/src/openai-embedding-model.ts
@@ -3,6 +3,7 @@ import {
   TooManyEmbeddingValuesForCallError,
 } from '@ai-sdk/provider';
 import {
+  combineHeaders,
   createJsonResponseHandler,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
@@ -51,6 +52,7 @@ export class OpenAIEmbeddingModel implements EmbeddingModelV1<string> {
 
   async doEmbed({
     values,
+    headers,
     abortSignal,
   }: Parameters<EmbeddingModelV1<string>['doEmbed']>[0]): Promise<
     Awaited<ReturnType<EmbeddingModelV1<string>['doEmbed']>>
@@ -69,7 +71,7 @@ export class OpenAIEmbeddingModel implements EmbeddingModelV1<string> {
         path: '/embeddings',
         modelId: this.modelId,
       }),
-      headers: this.config.headers(),
+      headers: combineHeaders(this.config.headers(), headers),
       body: {
         model: this.modelId,
         input: values,

--- a/packages/provider-utils/src/combine-headers.ts
+++ b/packages/provider-utils/src/combine-headers.ts
@@ -1,0 +1,11 @@
+export function combineHeaders(
+  ...headers: Array<Record<string, string | undefined> | undefined>
+): Record<string, string | undefined> {
+  return headers.reduce(
+    (combinedHeaders, currentHeaders) => ({
+      ...combinedHeaders,
+      ...(currentHeaders ?? {}),
+    }),
+    {},
+  ) as Record<string, string | undefined>;
+}

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './combine-headers';
 export * from './convert-async-generator-to-readable-stream';
 export * from './download';
 export * from './extract-response-headers';

--- a/packages/provider-utils/src/post-to-api.ts
+++ b/packages/provider-utils/src/post-to-api.ts
@@ -2,6 +2,7 @@ import { APICallError } from '@ai-sdk/provider';
 import { extractResponseHeaders } from './extract-response-headers';
 import { isAbortError } from './is-abort-error';
 import { ResponseHandler } from './response-handler';
+import { removeUndefinedEntries } from './remove-undefined-entries';
 
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => fetch;
@@ -26,8 +27,8 @@ export const postJsonToApi = async <T>({
   postToApi({
     url,
     headers: {
-      ...headers,
       'Content-Type': 'application/json',
+      ...headers,
     },
     body: {
       content: JSON.stringify(body),
@@ -60,14 +61,9 @@ export const postToApi = async <T>({
   fetch?: ReturnType<typeof getOriginalFetch>;
 }) => {
   try {
-    // remove undefined headers:
-    const definedHeaders = Object.fromEntries(
-      Object.entries(headers).filter(([_key, value]) => value != null),
-    ) as Record<string, string>;
-
     const response = await fetch(url, {
       method: 'POST',
-      headers: definedHeaders,
+      headers: removeUndefinedEntries(headers),
       body: body.content,
       signal: abortSignal,
     });

--- a/packages/provider-utils/src/remove-undefined-entries.ts
+++ b/packages/provider-utils/src/remove-undefined-entries.ts
@@ -1,0 +1,7 @@
+export function removeUndefinedEntries<T>(
+  record: Record<string, T | undefined>,
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([_key, value]) => value != null),
+  ) as Record<string, T>;
+}

--- a/packages/provider-utils/src/test/json-test-server.ts
+++ b/packages/provider-utils/src/test/json-test-server.ts
@@ -33,7 +33,15 @@ export class JsonTestServer {
 
   async getRequestHeaders() {
     expect(this.request).toBeDefined();
-    return this.request!.headers;
+    const requestHeaders = this.request!.headers;
+
+    // convert headers to object for easier comparison
+    const headersObject: Record<string, string> = {};
+    requestHeaders.forEach((value, key) => {
+      headersObject[key] = value;
+    });
+
+    return headersObject;
   }
 
   setupTestEnvironment() {

--- a/packages/provider-utils/src/test/streaming-test-server.ts
+++ b/packages/provider-utils/src/test/streaming-test-server.ts
@@ -49,7 +49,15 @@ export class StreamingTestServer {
 
   async getRequestHeaders() {
     expect(this.request).toBeDefined();
-    return this.request!.headers;
+    const requestHeaders = this.request!.headers;
+
+    // convert headers to object for easier comparison
+    const headersObject: Record<string, string> = {};
+    requestHeaders.forEach((value, key) => {
+      headersObject[key] = value;
+    });
+
+    return headersObject;
   }
 
   setupTestEnvironment() {

--- a/packages/provider/src/embedding-model/v1/embedding-model-v1.ts
+++ b/packages/provider/src/embedding-model/v1/embedding-model-v1.ts
@@ -54,6 +54,12 @@ List of values to embed.
 Abort signal for cancelling the operation.
      */
     abortSignal?: AbortSignal;
+
+    /**
+  Additional HTTP headers to be sent with the request.
+  Only applicable for HTTP-based providers.
+     */
+    headers?: Record<string, string | undefined>;
   }): PromiseLike<{
     /**
 Generated embeddings. They are in the same order as the input values.

--- a/packages/provider/src/language-model/v1/language-model-v1-call-settings.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-settings.ts
@@ -40,4 +40,10 @@ by the model, calls will generate deterministic results.
 Abort signal for cancelling the operation.
    */
   abortSignal?: AbortSignal;
+
+  /**
+Additional HTTP headers to be sent with the request.
+Only applicable for HTTP-based providers.
+   */
+  headers?: Record<string, string | undefined>;
 };


### PR DESCRIPTION
## Summary
* add custom request header support to AI functions
* adds "headers" option to `createAzure` factory method (azure openai provider)
* add `combineHeaders` helper to provider utils
* change test helper signature in provider utils

## Tasks

- [x] Implementation
  - [x] providers
     - [x] anthropic
     - [x] azure
     - [x] cohere
     - [x] google gen ai
     - [x] mistral
     - [x] openai
     - [x] amazon (warning)
     - [x] vertex (warning)
  - [x] ai functions
     - [x] generateText
     - [x] streamText
     - [x] generateObject
     - [x] streamObject
     - [x] streamUI
     - [x] embed
     - [x] embedMany
- [x] Examples
- [x] Docs
  - [x] reference
  - [x] ai core settings page
  - [x] azure openai headers option
- [x] Changesets