### PR TITLE
fix (provider/anthropic): automatically trim trailing whitespace on pre-filled assistant responses

### DIFF
--- a/.changeset/twenty-peaches-roll.md
+++ b/.changeset/twenty-peaches-roll.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix (provider/anthropic): automatically trim trailing whitespace on pre-filled assistant responses

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -254,3 +254,71 @@ describe('tool messages', () => {
     });
   });
 });
+
+describe('assistant messages', () => {
+  it('should remove trailing whitespace from last assistant message when there is no further user message', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'assistant content  ' }],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'assistant content' }],
+        },
+      ],
+      system: undefined,
+    });
+  });
+
+  it('should keep trailing whitespace from assistant message when there is a further user message', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'assistant content  ' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content 2' }],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'assistant content  ' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content 2' }],
+        },
+      ],
+      system: undefined,
+    });
+  });
+});

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -22,7 +22,8 @@ export async function convertToAnthropicMessagesPrompt({
   let system: string | undefined = undefined;
   const messages: AnthropicMessage[] = [];
 
-  for (const block of blocks) {
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
     const type = block.type;
 
     switch (type) {
@@ -118,9 +119,19 @@ export async function convertToAnthropicMessagesPrompt({
 
         messages.push({
           role: 'assistant',
-          content: content.map(part => {
+          content: content.map((part, j) => {
             switch (part.type) {
               case 'text': {
+                // trim the last text part if it's the last message in the block
+                // because Anthropic does not allow trailing whitespace
+                // in pre-filled assistant responses
+                if (
+                  i === blocks.length - 1 &&
+                  j === block.messages.length - 1
+                ) {
+                  return { type: 'text', text: part.text.trim() };
+                }
+
                 return { type: 'text', text: part.text };
               }
               case 'tool-call': {


### PR DESCRIPTION
…re-filled assistant responses