### PR TITLE
feat: add options for zod-to-json-schema usage

### DIFF
--- a/packages/core/core/generate-object/generate-object.ts
+++ b/packages/core/core/generate-object/generate-object.ts
@@ -1,6 +1,7 @@
 import { NoObjectGeneratedError } from '@ai-sdk/provider';
 import { safeParseJSON } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
+import zodToJsonSchema from 'zod-to-json-schema';
 import { TokenUsage, calculateTokenUsage } from '../generate-text/token-usage';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
@@ -60,6 +61,7 @@ export async function generateObject<T>({
   maxRetries,
   abortSignal,
   headers,
+  zodToJsonSchemaOptions,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -88,9 +90,14 @@ Please note that most providers do not support all modes.
 Default and recommended: 'auto' (best mode for the model).
      */
     mode?: 'auto' | 'json' | 'tool' | 'grammar';
+
+    /**
+     * Options for zodToJsonSchema.
+     */
+    zodToJsonSchemaOptions?: Parameters<typeof zodToJsonSchema>[1];
   }): Promise<GenerateObjectResult<T>> {
   const retry = retryWithExponentialBackoff({ maxRetries });
-  const jsonSchema = convertZodToJSONSchema(schema);
+  const jsonSchema = convertZodToJSONSchema(schema, zodToJsonSchemaOptions);
 
   // use the default provider mode when the mode is set to 'auto' or unspecified
   if (mode === 'auto' || mode == null) {

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -9,6 +9,7 @@ import {
   parsePartialJson,
 } from '@ai-sdk/ui-utils';
 import { z } from 'zod';
+import zodToJsonSchema from 'zod-to-json-schema';
 import { TokenUsage, calculateTokenUsage } from '../generate-text/token-usage';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
@@ -74,6 +75,7 @@ export async function streamObject<T>({
   abortSignal,
   headers,
   onFinish,
+  zodToJsonSchemaOptions,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -103,6 +105,11 @@ Default and recommended: 'auto' (best mode for the model).
      */
     mode?: 'auto' | 'json' | 'tool' | 'grammar';
 
+    /**
+     * Options for zodToJsonSchema.
+     */
+    zodToJsonSchemaOptions?: Parameters<typeof zodToJsonSchema>[1];
+    
     /**
 Callback that is called when the LLM response and the final object validation are finished.
      */
@@ -139,7 +146,7 @@ Warnings from the model provider (e.g. unsupported settings).
     }) => Promise<void> | void;
   }): Promise<StreamObjectResult<T>> {
   const retry = retryWithExponentialBackoff({ maxRetries });
-  const jsonSchema = convertZodToJSONSchema(schema);
+  const jsonSchema = convertZodToJSONSchema(schema, zodToJsonSchemaOptions);
 
   // use the default provider mode when the mode is set to 'auto' or unspecified
   if (mode === 'auto' || mode == null) {

--- a/packages/core/core/generate-text/generate-text.ts
+++ b/packages/core/core/generate-text/generate-text.ts
@@ -1,3 +1,4 @@
+import zodToJsonSchema from 'zod-to-json-schema';
 import { CoreAssistantMessage, CoreToolMessage } from '../prompt';
 import { CallSettings } from '../prompt/call-settings';
 import {
@@ -72,6 +73,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   headers,
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
+  zodToJsonSchemaOptions,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -108,13 +110,17 @@ case of misconfigured tools.
 By default, it's set to 0, which will disable the feature.
      */
     maxToolRoundtrips?: number;
+    /**
+     * Options for zodToJsonSchema.
+     */
+    zodToJsonSchemaOptions?: Parameters<typeof zodToJsonSchema>[1];
   }): Promise<GenerateTextResult<TOOLS>> {
   const retry = retryWithExponentialBackoff({ maxRetries });
   const validatedPrompt = getValidatedPrompt({ system, prompt, messages });
 
   const mode = {
     type: 'regular' as const,
-    ...prepareToolsAndToolChoice({ tools, toolChoice }),
+    ...prepareToolsAndToolChoice({ tools, toolChoice, zodToJsonSchemaOptions }),
   };
   const callSettings = prepareCallSettings(settings);
   const promptMessages = convertToLanguageModelPrompt(validatedPrompt);

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -1,4 +1,5 @@
 import { ServerResponse } from 'node:http';
+import zodToJsonSchema from 'zod-to-json-schema';
 import {
   AIStreamCallbacksAndOptions,
   StreamingTextResponse,
@@ -78,6 +79,7 @@ export async function streamText<TOOLS extends Record<string, CoreTool>>({
   abortSignal,
   headers,
   onFinish,
+  zodToJsonSchemaOptions,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -96,6 +98,10 @@ The tool choice strategy. Default: 'auto'.
      */
     toolChoice?: CoreToolChoice<TOOLS>;
 
+    /**
+     * Options for zodToJsonSchema.
+     */
+    zodToJsonSchemaOptions?: Parameters<typeof zodToJsonSchema>[1];
     /**
 Callback that is called when the LLM response and all request tool executions 
 (for tools that have an `execute` function) are finished.
@@ -148,7 +154,7 @@ Warnings from the model provider (e.g. unsupported settings).
     model.doStream({
       mode: {
         type: 'regular',
-        ...prepareToolsAndToolChoice({ tools, toolChoice }),
+        ...prepareToolsAndToolChoice({ tools, toolChoice, zodToJsonSchemaOptions }),
       },
       ...prepareCallSettings(settings),
       inputFormat: validatedPrompt.type,

--- a/packages/core/core/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/core/core/prompt/prepare-tools-and-tool-choice.test.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { prepareToolsAndToolChoice } from './prepare-tools-and-tool-choice';
+import { CoreTool } from '../tool/tool';
+
+describe('prepareToolsAndToolChoice', () => {
+  it('should correctly use zodToJsonSchemaOptions when provided', () => {
+    const mockTool: CoreTool = {
+      description: 'Test tool',
+      parameters: z.object({
+        param1: z.string().min(5),
+      }),
+    };
+
+    const mockTools = {
+      testTool: mockTool,
+    };
+
+    const zodToJsonSchemaOptions = {
+      $refStrategy: 'none',
+    } as const;
+
+    const result = prepareToolsAndToolChoice({
+      tools: mockTools,
+      toolChoice: undefined,
+      zodToJsonSchemaOptions,
+    });
+
+    expect(result).toEqual({
+      tools: [
+        {
+          description: 'Test tool',
+          name: 'testTool',
+          parameters: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            additionalProperties: false,
+            properties: {
+              param1: {
+                minLength: 5,
+                type: 'string',
+              },
+            },
+            required: ['param1'],
+            type: 'object',
+          },
+          type: 'function',
+        },
+      ],
+      toolChoice: { type: 'auto' },
+    });
+  });
+});

--- a/packages/core/core/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/core/core/prompt/prepare-tools-and-tool-choice.ts
@@ -2,6 +2,7 @@ import {
   LanguageModelV1FunctionTool,
   LanguageModelV1ToolChoice,
 } from '@ai-sdk/provider';
+import zodToJsonSchema from 'zod-to-json-schema';
 import { CoreTool } from '../tool/tool';
 import { CoreToolChoice } from '../types/language-model';
 import { convertZodToJSONSchema } from '../util/convert-zod-to-json-schema';
@@ -12,9 +13,11 @@ export function prepareToolsAndToolChoice<
 >({
   tools,
   toolChoice,
+  zodToJsonSchemaOptions,
 }: {
   tools: TOOLS | undefined;
   toolChoice: CoreToolChoice<TOOLS> | undefined;
+  zodToJsonSchemaOptions?: Parameters<typeof zodToJsonSchema>[1];
 }): {
   tools: LanguageModelV1FunctionTool[] | undefined;
   toolChoice: LanguageModelV1ToolChoice | undefined;
@@ -31,7 +34,10 @@ export function prepareToolsAndToolChoice<
       type: 'function' as const,
       name,
       description: tool.description,
-      parameters: convertZodToJSONSchema(tool.parameters),
+      parameters: convertZodToJSONSchema(
+        tool.parameters,
+        zodToJsonSchemaOptions,
+      ),
     })),
     toolChoice:
       toolChoice == null

--- a/packages/core/core/util/convert-zod-to-json-schema.ts
+++ b/packages/core/core/util/convert-zod-to-json-schema.ts
@@ -4,7 +4,8 @@ import zodToJsonSchema from 'zod-to-json-schema';
 
 export function convertZodToJSONSchema(
   zodSchema: z.Schema<unknown>,
+  options?: Parameters<typeof zodToJsonSchema>[1]
 ): JSONSchema7 {
   // we assume that zodToJsonSchema will return a valid JSONSchema7
-  return zodToJsonSchema(zodSchema) as JSONSchema7;
+  return zodToJsonSchema(zodSchema, options) as JSONSchema7;
 }

--- a/packages/core/rsc/stream-ui/stream-ui.tsx
+++ b/packages/core/rsc/stream-ui/stream-ui.tsx
@@ -5,6 +5,7 @@ import {
 } from '@ai-sdk/provider';
 import { ReactNode } from 'react';
 import { z } from 'zod';
+import zodToJsonSchema from 'zod-to-json-schema';
 
 import { safeParseJSON } from '@ai-sdk/provider-utils';
 import { CallSettings } from '../../core/prompt/call-settings';
@@ -21,6 +22,7 @@ import {
   TokenUsage,
   calculateTokenUsage,
 } from '../../core/generate-text/token-usage';
+
 
 type Streamable = ReactNode | Promise<ReactNode>;
 
@@ -90,6 +92,7 @@ export async function streamUI<
   initial,
   text,
   onFinish,
+  zodToJsonSchemaOptions,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -112,6 +115,10 @@ export async function streamUI<
 
     text?: RenderText;
     initial?: ReactNode;
+    /**
+     * Options for zodToJsonSchema.
+     */
+    zodToJsonSchemaOptions?: Parameters<typeof zodToJsonSchema>[1];
     /**
      * Callback that is called when the LLM response and the final object validation are finished.
      */
@@ -258,7 +265,7 @@ export async function streamUI<
     model.doStream({
       mode: {
         type: 'regular',
-        ...prepareToolsAndToolChoice({ tools, toolChoice }),
+        ...prepareToolsAndToolChoice({ tools, toolChoice, zodToJsonSchemaOptions }),
       },
       ...prepareCallSettings(settings),
       inputFormat: validatedPrompt.type,

--- a/packages/core/rsc/streamable.tsx
+++ b/packages/core/rsc/streamable.tsx
@@ -519,6 +519,7 @@ export function render<
   };
   initial?: ReactNode;
   temperature?: number;
+  zodToJsonSchemaOptions?: Parameters<typeof zodToJsonSchema>[1];
 }): ReactNode {
   const ui = createStreamableUI(options.initial);
 
@@ -533,7 +534,7 @@ export function render<
           return {
             name,
             description,
-            parameters: zodToJsonSchema(parameters) as Record<string, unknown>,
+            parameters: zodToJsonSchema(parameters, options.zodToJsonSchemaOptions) as Record<string, unknown>,
           };
         },
       )
@@ -547,7 +548,7 @@ export function render<
             function: {
               name,
               description,
-              parameters: zodToJsonSchema(parameters) as Record<
+              parameters: zodToJsonSchema(parameters, options.zodToJsonSchemaOptions) as Record<
                 string,
                 unknown
               >,


### PR DESCRIPTION
Adds an option to `streamUI`, `generateObject`, `streamObject`, `streamText` and `generateText` to control the output of tools paramter send to external llm provider. This could be useful when certain provider does not accept certain schema output such as '$schema' property