### PR TITLE
chore (test): introduce test server

### DIFF
--- a/packages/provider-utils/src/test/convert-array-to-readable-stream.ts
+++ b/packages/provider-utils/src/test/convert-array-to-readable-stream.ts
@@ -3,10 +3,13 @@ export function convertArrayToReadableStream<T>(
 ): ReadableStream<T> {
   return new ReadableStream({
     start(controller) {
-      for (const value of values) {
-        controller.enqueue(value);
+      try {
+        for (const value of values) {
+          controller.enqueue(value);
+        }
+      } finally {
+        controller.close();
       }
-      controller.close();
     },
   });
 }

--- a/packages/provider-utils/src/test/index.ts
+++ b/packages/provider-utils/src/test/index.ts
@@ -1,9 +1,10 @@
-export * from './convert-array-to-readable-stream';
 export * from './convert-array-to-async-iterable';
+export * from './convert-array-to-readable-stream';
 export * from './convert-async-iterable-to-array';
 export * from './convert-readable-stream-to-array';
 export * from './json-test-server';
 export * from './streaming-test-server';
+export * from './test-server';
 
 import { convertReadableStreamToArray } from './convert-readable-stream-to-array';
 

--- a/packages/provider-utils/src/test/test-server.ts
+++ b/packages/provider-utils/src/test/test-server.ts
@@ -1,0 +1,74 @@
+import { HttpResponse, JsonBodyType, http } from 'msw';
+import { setupServer } from 'msw/node';
+
+export type TestServerJsonBodyType = JsonBodyType;
+
+export type TestServerResponse = {
+  url: string;
+  type: 'json-value';
+  content: TestServerJsonBodyType;
+  headers?: Record<string, string>;
+};
+
+class TestServerCall {
+  constructor(private request: Request) {}
+
+  async getRequestBodyJson() {
+    expect(this.request).toBeDefined();
+    return JSON.parse(await this.request!.text());
+  }
+
+  async getRequestHeaders() {
+    expect(this.request).toBeDefined();
+    const requestHeaders = this.request!.headers;
+
+    // convert headers to object for easier comparison
+    const headersObject: Record<string, string> = {};
+    requestHeaders.forEach((value, key) => {
+      headersObject[key] = value;
+    });
+
+    return headersObject;
+  }
+
+  async getRequestUrlSearchParams() {
+    expect(this.request).toBeDefined();
+    return new URL(this.request!.url).searchParams;
+  }
+}
+
+export function withTestServer(
+  responses: Array<TestServerResponse>,
+  testFunction: (options: {
+    calls: () => Array<TestServerCall>;
+    call: (index: number) => TestServerCall;
+  }) => Promise<void>,
+) {
+  return async () => {
+    const calls: Array<TestServerCall> = [];
+    const server = setupServer(
+      ...responses.map(response => {
+        return http.post(response.url, ({ request }) => {
+          calls.push(new TestServerCall(request));
+
+          return HttpResponse.json(response.content, {
+            headers: {
+              'Content-Type': 'application/json',
+              ...response.headers,
+            },
+          });
+        });
+      }),
+    );
+
+    try {
+      server.listen;
+      testFunction({
+        calls: () => calls,
+        call: (index: number) => calls[index],
+      });
+    } finally {
+      server.close();
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- introduces a new `withTestServer` abstraction to unify json and streaming testing
  - can cover json, error, streaming value, and controlled stream cases
- use in react / useObject test
- use in google provider test