### PR TITLE
Implement `usage` response for `embed` and `embedMany` 

### DIFF
--- a/packages/core/core/embed/embed-many.ts
+++ b/packages/core/core/embed/embed-many.ts
@@ -66,6 +66,12 @@ Only applicable for HTTP-based providers.
     return new EmbedManyResult({
       values,
       embeddings: modelResponse.embeddings,
+      usage: modelResponse.usage
+        ? {
+            promptTokens: modelResponse.usage.promptTokens,
+            totalTokens: modelResponse.usage.totalTokens,
+          }
+        : undefined,
     });
   }
 
@@ -74,14 +80,22 @@ Only applicable for HTTP-based providers.
 
   // serially embed the chunks:
   const embeddings = [];
+  const usage: { promptTokens: number; totalTokens: number } = {
+    promptTokens: 0,
+    totalTokens: 0,
+  };
   for (const chunk of valueChunks) {
     const modelResponse = await retry(() =>
       model.doEmbed({ values: chunk, abortSignal, headers }),
     );
     embeddings.push(...modelResponse.embeddings);
+    if (modelResponse.usage) {
+      usage.promptTokens += modelResponse.usage.promptTokens;
+      usage.totalTokens += modelResponse.usage.totalTokens;
+    }
   }
 
-  return new EmbedManyResult({ values, embeddings });
+  return new EmbedManyResult({ values, embeddings, usage });
 }
 
 /**
@@ -99,8 +113,24 @@ The embeddings. They are in the same order as the values.
   */
   readonly embeddings: Array<Embedding>;
 
-  constructor(options: { values: Array<VALUE>; embeddings: Array<Embedding> }) {
+  /**
+The embedding token usage.
+  */
+  readonly usage?: {
+    promptTokens: number;
+    totalTokens: number;
+  };
+
+  constructor(options: {
+    values: Array<VALUE>;
+    embeddings: Array<Embedding>;
+    usage?: {
+      promptTokens: number;
+      totalTokens: number;
+    };
+  }) {
     this.values = options.values;
     this.embeddings = options.embeddings;
+    this.usage = options.usage;
   }
 }

--- a/packages/core/core/embed/embed.ts
+++ b/packages/core/core/embed/embed.ts
@@ -57,6 +57,12 @@ Only applicable for HTTP-based providers.
   return new EmbedResult({
     value,
     embedding: modelResponse.embeddings[0],
+    usage: modelResponse.usage
+      ? {
+          promptTokens: modelResponse.usage.promptTokens,
+          totalTokens: modelResponse.usage.totalTokens,
+        }
+      : undefined,
     rawResponse: modelResponse.rawResponse,
   });
 }
@@ -77,6 +83,14 @@ The embedding of the value.
   readonly embedding: Embedding;
 
   /**
+The embedding token usage.
+  */
+  readonly usage?: {
+    promptTokens: number;
+    totalTokens: number;
+  };
+
+  /**
 Optional raw response data.
    */
   readonly rawResponse?: {
@@ -89,12 +103,17 @@ Response headers.
   constructor(options: {
     value: VALUE;
     embedding: Embedding;
+    usage?: {
+      promptTokens: number;
+      totalTokens: number;
+    };
     rawResponse?: {
       headers?: Record<string, string>;
     };
   }) {
     this.value = options.value;
     this.embedding = options.embedding;
+    this.usage = options.usage;
     this.rawResponse = options.rawResponse;
   }
 }

--- a/packages/openai/src/openai-embedding-model.ts
+++ b/packages/openai/src/openai-embedding-model.ts
@@ -89,6 +89,12 @@ export class OpenAIEmbeddingModel implements EmbeddingModelV1<string> {
 
     return {
       embeddings: response.data.map(item => item.embedding),
+      usage: response.usage
+        ? {
+            promptTokens: response.usage.prompt_tokens,
+            totalTokens: response.usage.total_tokens,
+          }
+        : undefined,
       rawResponse: { headers: responseHeaders },
     };
   }
@@ -102,4 +108,10 @@ const openaiTextEmbeddingResponseSchema = z.object({
       embedding: z.array(z.number()),
     }),
   ),
+  usage: z
+    .object({
+      prompt_tokens: z.number(),
+      total_tokens: z.number(),
+    })
+    .nullish(),
 });

--- a/packages/provider/src/embedding-model/v1/embedding-model-v1.ts
+++ b/packages/provider/src/embedding-model/v1/embedding-model-v1.ts
@@ -67,6 +67,14 @@ Generated embeddings. They are in the same order as the input values.
     embeddings: Array<EmbeddingModelV1Embedding>;
 
     /**
+Token Usage.
+    */
+    usage?: {
+      promptTokens: number;
+      totalTokens: number;
+    };
+
+    /**
 Optional raw response information for debugging purposes.
      */
     rawResponse?: {


### PR DESCRIPTION
Currently, the `usage` response provided by OpenAI on Embedding is not available when calling `embed` or `embedMany`.

* This PR adds `usage` as an optional response property for `embed` and `embedMany` calls.
* This has been added to the `openai` sdk (not yet any others)
* Due to `usage` being optional in `core`, it serves as an optinal additional, without breaking any other providers or examples. Additinal providers can be updated in the future to expose the `usage` property.