### PR TITLE
fix (provider-utils): check DOMException existence

### DIFF
--- a/packages/provider-utils/src/is-abort-error.ts
+++ b/packages/provider-utils/src/is-abort-error.ts
@@ -1,5 +1,6 @@
 export function isAbortError(error: unknown): error is DOMException {
   return (
+    typeof DOMException !== 'undefined' &&
     error instanceof DOMException &&
     (error.name === 'AbortError' || error.name === 'TimeoutError')
   );


### PR DESCRIPTION
In Vercel Edge runtime environment, `DOMException` doesn't exist, which causes the `Right-hand side of 'instanceof' is not an object` error. 

```
TypeError: Right-hand side of 'instanceof' is not an object
    at (node_modules/@ai-sdk/provider-utils/dist/index.mjs:102:9)
    at (node_modules/ai/dist/index.mjs:43:21)
    at (node_modules/ai/dist/index.mjs:1427:44)
```

Someone else also reported this issue before ([link](https://github.com/vercel/ai/issues/1333#issuecomment-2147138060)).

This PR fixes the issue by checking the existence of `DOMException`. 