### PR TITLE
fix: fix missing tool_call_id

### DIFF
--- a/packages/core/core/generate-text/generate-text.ts
+++ b/packages/core/core/generate-text/generate-text.ts
@@ -325,6 +325,7 @@ function toResponseMessages<TOOLS extends Record<string, CoreTool>>({
       content: toolResults.map(result => ({
         type: 'tool-result',
         toolCallId: result.toolCallId,
+        tool_call_id: result.toolCallId,
         toolName: result.toolName,
         result: result.result,
       })),


### PR DESCRIPTION
```typescript
  let tmp = convertToCoreMessages(messages);
  const result = await streamText({
    model: openai(realConfig.model),
    system: realConfig.prompt ? realConfig.prompt : undefined,
    temperature: realConfig.temperature,
    messages: tmp,
    tools: {
      searchDB: {
        description: 'xxx',
        parameters: z.object({
          query: z.string().describe('xxx'),
        }),
        execute: async ({ query }) => {
          let querys = [query];
          if (realConfig.baseConfig.queryExtension)
            querys = await qusetionOptimization({ query, histories: messages, model: realConfig.model });
          let recallData = await newRecall(querys, realConfig.baseIds, realConfig.baseConfig);
          console.log('recallData', recallData);
          return JSON.stringify(recallData);
        },
      },
    },
  });
```


responseBody: `{"error":{"message":"Missing parameter 'tool_call_id': messages with role 'tool' must have a 'tool_call_id'. (request id: 2024070404235161549043036070944) (request id: 20240704122351578408206S36xl1ry)","type":"invalid_request_error","param":"messages.[3].tool_call_id","code":null}}`,