### PR TITLE
Support returning a stream of unparsed text chunks in `streamObject`

### DIFF
--- a/packages/core/core/generate-object/stream-object.test.ts
+++ b/packages/core/core/generate-object/stream-object.test.ts
@@ -703,3 +703,96 @@ describe('options.headers', () => {
     );
   });
 });
+
+describe('options.asUnparsedParts', () => {
+  it('should send text deltas only', async () => {
+    const result = await streamObject({
+      asUnparsedParts: true,
+      model: new MockLanguageModelV1({
+        doStream: async ({ prompt, mode }) => {
+          assert.deepStrictEqual(mode, {
+            type: 'object-tool',
+            tool: {
+              type: 'function',
+              name: 'json',
+              description: 'Respond with a JSON object.',
+              parameters: {
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                additionalProperties: false,
+                properties: { content: { type: 'string' } },
+                required: ['content'],
+                type: 'object',
+              },
+            },
+          });
+          assert.deepStrictEqual(prompt, [
+            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+          ]);
+
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: '{ ',
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: '"content": ',
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `"Hello, `,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `world`,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `!"`,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: ' }',
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          };
+        },
+      }),
+      schema: z.object({ content: z.string() }),
+      mode: 'tool',
+      prompt: 'prompt',
+    });
+
+    assert.deepStrictEqual(
+      await convertAsyncIterableToArray(result.stream),
+      [
+        "{ ",
+        '"content": ',
+        '"Hello, ',
+        'world',
+        '!"',
+        " }",
+      ],
+    );
+  });
+})


### PR DESCRIPTION
This is an alternative to #1883 and #2036. As `StreamObjectResult` unconditionally parses the input JSON chunks, it's not possible in the current API to make use of incremental parsing without paying the quadratic cost of parsing in `streamObject`.

This PR adds an `asUnparsedParts` option to the `streamObject` call, which allows callers to obtain an unparsed stream of text chunks and implement their own parsing.