### PR TITLE
fix (ai): Make public conversion CoreMessage to Provider messages

### DIFF
--- a/packages/core/core/prompt/index.ts
+++ b/packages/core/core/prompt/index.ts
@@ -3,3 +3,6 @@ export * from './convert-to-core-messages';
 export * from './data-content';
 export * from './invalid-message-role-error';
 export * from './message';
+export * from './prompt';
+export * from './get-validated-prompt';
+export * from './convert-to-language-model-prompt';


### PR DESCRIPTION
These APIs were previously private, which made using the `doGenerate` and `doStream` APIs cumbersome from outside the AI SDK.

Fixes #2196