### PR TITLE
fix (ai): Accept `name` on CoreMessage, pass to providers

### DIFF
--- a/packages/core/core/generate-text/generate-text.test.ts
+++ b/packages/core/core/generate-text/generate-text.test.ts
@@ -427,6 +427,7 @@ describe('options.maxToolRoundtrips', () => {
                 },
                 {
                   role: 'assistant',
+                  name: undefined,
                   content: [
                     {
                       type: 'tool-call',

--- a/packages/core/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/core/core/prompt/convert-to-language-model-prompt.test.ts
@@ -6,6 +6,7 @@ describe('convertToLanguageModelMessage', () => {
       it('should convert image string https url to URL object', async () => {
         const result = convertToLanguageModelMessage({
           role: 'user',
+          name: 'admin',
           content: [
             {
               type: 'image',
@@ -16,6 +17,7 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(result).toEqual({
           role: 'user',
+          name: 'admin',
           content: [
             {
               type: 'image',
@@ -28,6 +30,7 @@ describe('convertToLanguageModelMessage', () => {
       it('should convert image string data url to base64 content', async () => {
         const result = convertToLanguageModelMessage({
           role: 'user',
+          name: 'image-submitter',
           content: [
             {
               type: 'image',
@@ -38,6 +41,7 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(result).toEqual({
           role: 'user',
+          name: 'image-submitter',
           content: [
             {
               type: 'image',
@@ -55,6 +59,7 @@ describe('convertToLanguageModelMessage', () => {
       it('should ignore empty text parts', async () => {
         const result = convertToLanguageModelMessage({
           role: 'assistant',
+          name: 'agent-1',
           content: [
             {
               type: 'text',
@@ -71,6 +76,7 @@ describe('convertToLanguageModelMessage', () => {
 
         expect(result).toEqual({
           role: 'assistant',
+          name: 'agent-1',
           content: [
             {
               type: 'tool-call',

--- a/packages/core/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/core/core/prompt/convert-to-language-model-prompt.ts
@@ -52,19 +52,21 @@ export function convertToLanguageModelMessage(
   const role = message.role;
   switch (role) {
     case 'system': {
-      return { role: 'system', content: message.content };
+      return { role: 'system', name: message.name, content: message.content };
     }
 
     case 'user': {
       if (typeof message.content === 'string') {
         return {
           role: 'user',
+          name: message.name,
           content: [{ type: 'text', text: message.content }],
         };
       }
 
       return {
         role: 'user',
+        name: message.name,
         content: message.content.map(
           (part): LanguageModelV1TextPart | LanguageModelV1ImagePart => {
             switch (part.type) {
@@ -147,12 +149,14 @@ export function convertToLanguageModelMessage(
       if (typeof message.content === 'string') {
         return {
           role: 'assistant',
+          name: message.name,
           content: [{ type: 'text', text: message.content }],
         };
       }
 
       return {
         role: 'assistant',
+        name: message.name,
         content: message.content.filter(
           // remove empty text parts:
           part => part.type !== 'text' || part.text !== '',

--- a/packages/core/core/prompt/message.ts
+++ b/packages/core/core/prompt/message.ts
@@ -22,7 +22,15 @@ export type CoreMessage =
  to increase the resilience against prompt injection attacks,
  and because not all providers support several system messages.
  */
-export type CoreSystemMessage = { role: 'system'; content: string };
+export type CoreSystemMessage = {
+  role: 'system';
+  /**
+May be used in place of or in addition to "role" to differentiate between multiple participants with
+the same role. Not supported by all providers.
+   */
+  name?: string;
+  content: string;
+};
 
 /**
  * @deprecated Use `CoreMessage` instead.
@@ -32,7 +40,15 @@ export type ExperimentalMessage = CoreMessage;
 /**
 A user message. It can contain text or a combination of text and images.
  */
-export type CoreUserMessage = { role: 'user'; content: UserContent };
+export type CoreUserMessage = {
+  role: 'user';
+  /**
+May be used in place of or in addition to "role" to differentiate between multiple participants with
+the same role. Not supported by all providers.
+   */
+  name?: string;
+  content: UserContent;
+};
 
 /**
  * @deprecated Use `CoreUserMessage` instead.
@@ -49,6 +65,11 @@ An assistant message. It can contain text, tool calls, or a combination of text 
  */
 export type CoreAssistantMessage = {
   role: 'assistant';
+  /**
+May be used in place of or in addition to "role" to differentiate between multiple participants with
+the same role. Not supported by all providers.
+   */
+  name?: string;
   content: AssistantContent;
 };
 

--- a/packages/openai/src/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.test.ts
@@ -5,6 +5,7 @@ describe('user messages', () => {
     const result = convertToOpenAIChatMessages([
       {
         role: 'user',
+        name: 'anonymous',
         content: [
           { type: 'text', text: 'Hello' },
           {
@@ -19,6 +20,7 @@ describe('user messages', () => {
     expect(result).toEqual([
       {
         role: 'user',
+        name: 'anonymous',
         content: [
           { type: 'text', text: 'Hello' },
           {

--- a/packages/openai/src/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.ts
@@ -7,21 +7,23 @@ export function convertToOpenAIChatMessages(
 ): OpenAIChatPrompt {
   const messages: OpenAIChatPrompt = [];
 
-  for (const { role, content } of prompt) {
-    switch (role) {
+  for (const message of prompt) {
+    switch (message.role) {
       case 'system': {
-        messages.push({ role: 'system', content });
+        messages.push({ role: 'system', name: message.name, content: message.content });
         break;
       }
 
       case 'user': {
+        const { name, content } = message;
         if (content.length === 1 && content[0].type === 'text') {
-          messages.push({ role: 'user', content: content[0].text });
+          messages.push({ role: 'user', name, content: content[0].text });
           break;
         }
 
         messages.push({
           role: 'user',
+          name,
           content: content.map(part => {
             switch (part.type) {
               case 'text': {
@@ -48,6 +50,7 @@ export function convertToOpenAIChatMessages(
       }
 
       case 'assistant': {
+        const { name, content } = message;
         let text = '';
         const toolCalls: Array<{
           id: string;
@@ -89,7 +92,7 @@ export function convertToOpenAIChatMessages(
       }
 
       case 'tool': {
-        for (const toolResponse of content) {
+        for (const toolResponse of message.content) {
           messages.push({
             role: 'tool',
             tool_call_id: toolResponse.toolCallId,
@@ -100,7 +103,7 @@ export function convertToOpenAIChatMessages(
       }
 
       default: {
-        const _exhaustiveCheck: never = role;
+        const _exhaustiveCheck: never = message;
         throw new Error(`Unsupported role: ${_exhaustiveCheck}`);
       }
     }

--- a/packages/openai/src/openai-chat-prompt.ts
+++ b/packages/openai/src/openai-chat-prompt.ts
@@ -8,11 +8,13 @@ export type ChatCompletionMessageParam =
 
 export interface ChatCompletionSystemMessageParam {
   role: 'system';
+  name?: string;
   content: string;
 }
 
 export interface ChatCompletionUserMessageParam {
   role: 'user';
+  name?: string;
   content: string | Array<ChatCompletionContentPart>;
 }
 
@@ -34,6 +36,7 @@ export interface ChatCompletionContentPartText {
 
 export interface ChatCompletionAssistantMessageParam {
   role: 'assistant';
+  name?: string;
   content?: string | null;
   tool_calls?: Array<ChatCompletionMessageToolCall>;
 }

--- a/packages/provider/src/language-model/v1/language-model-v1-prompt.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-prompt.ts
@@ -15,14 +15,17 @@ export type LanguageModelV1Message =
   // such as PDFs.
   | {
       role: 'system';
+      name?: string;
       content: string;
     }
   | {
       role: 'user';
+      name?: string;
       content: Array<LanguageModelV1TextPart | LanguageModelV1ImagePart>;
     }
   | {
       role: 'assistant';
+      name?: string;
       content: Array<LanguageModelV1TextPart | LanguageModelV1ToolCallPart>;
     }
   | {


### PR DESCRIPTION
Adds an optional `name` field to the relevant message types in the core package, provider SDK, and the OpenAI provider. A review of the current providers found no others that accept a `name` field, so no other providers are modified.

OpenAI's API is leading the way here, whether for multi-user or multi-agent interactions, LLM APIs are likely to accept named participants beyond 'user', 'assistant', etc.

As described in #2198, the `name` field may be used with OpenAI's API to provide additional context for system and assistant messages, e.g.: for guardrails and reducing the risks of prompt injection.

Fixes #2198