### PR TITLE
feat (ai/react): add setThreadId helper to switch between threads for useAssistant

### DIFF
--- a/.changeset/plenty-ties-remember.md
+++ b/.changeset/plenty-ties-remember.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+add setThreadId helper to switch between threads for useAssistant

--- a/content/docs/07-reference/ai-sdk-ui/20-use-assistant.mdx
+++ b/content/docs/07-reference/ai-sdk-ui/20-use-assistant.mdx
@@ -108,6 +108,12 @@ This works in conjunction with [`AssistantResponse`](./assistant-response) in th
       description: 'The current thread ID.',
     },
     {
+      name: 'setThreadId',
+      type: '(threadId: string | undefined) => void',
+      description:
+        "Set the current thread ID. Specifying a thread ID will switch to that thread, if it exists. If set to 'undefined', a new thread will be created. For both cases, `threadId` will be updated with the new value and `messages` will be cleared.",
+    },
+    {
       name: 'input',
       type: 'string',
       description: 'The current value of the input field.',

--- a/packages/react/src/use-assistant.ts
+++ b/packages/react/src/use-assistant.ts
@@ -29,6 +29,11 @@ export type UseAssistantHelpers = {
   threadId: string | undefined;
 
   /**
+   * Set the current thread ID. Specifying a thread ID will switch to that thread, if it exists. If set to 'undefined', a new thread will be created. For both cases, the thread ID will be updated with the new value and messages will be cleared.
+   */
+  setThreadId: (threadId: string | undefined) => void;
+
+  /**
    * The current value of the input field.
    */
   input: string;
@@ -97,7 +102,9 @@ export function useAssistant({
 }: UseAssistantOptions): UseAssistantHelpers {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
-  const [threadId, setThreadId] = useState<string | undefined>(undefined);
+  const [currentThreadId, setCurrentThreadId] = useState<string | undefined>(
+    undefined,
+  );
   const [status, setStatus] = useState<AssistantStatus>('awaiting_message');
   const [error, setError] = useState<undefined | Error>(undefined);
 
@@ -151,7 +158,7 @@ export function useAssistant({
         body: JSON.stringify({
           ...body,
           // always use user-provided threadId when available:
-          threadId: threadIdParam ?? threadId ?? null,
+          threadId: threadIdParam ?? currentThreadId ?? null,
           message: message.content,
 
           // optional request data:
@@ -216,7 +223,7 @@ export function useAssistant({
           }
 
           case 'assistant_control_data': {
-            setThreadId(value.threadId);
+            setCurrentThreadId(value.threadId);
 
             // set id of last message:
             setMessages(messages => {
@@ -267,11 +274,17 @@ export function useAssistant({
     append({ role: 'user', content: input }, requestOptions);
   };
 
+  const setThreadId = (threadId: string | undefined) => {
+    setCurrentThreadId(threadId);
+    setMessages([]);
+  };
+
   return {
     append,
     messages,
     setMessages,
-    threadId,
+    threadId: currentThreadId,
+    setThreadId,
     input,
     setInput,
     handleInputChange,

--- a/packages/react/src/use-assistant.ts
+++ b/packages/react/src/use-assistant.ts
@@ -29,7 +29,7 @@ export type UseAssistantHelpers = {
   threadId: string | undefined;
 
   /**
-   * Set the current thread ID. Specifying a thread ID will switch to that thread, if it exists. If set to 'undefined', a new thread will be created. For both cases, the thread ID will be updated with the new value and messages will be cleared.
+   * Set the current thread ID. Specifying a thread ID will switch to that thread, if it exists. If set to 'undefined', a new thread will be created. For both cases, `threadId` will be updated with the new value and `messages` will be cleared.
    */
   setThreadId: (threadId: string | undefined) => void;
 

--- a/packages/react/src/use-assistant.ui.test.tsx
+++ b/packages/react/src/use-assistant.ui.test.tsx
@@ -143,3 +143,195 @@ describe('stream data stream', () => {
     });
   });
 });
+
+describe('thread management', () => {
+  const TestComponent = () => {
+    const { status, messages, error, append, setThreadId, threadId } =
+      useAssistant({
+        api: '/api/assistant',
+      });
+
+    return (
+      <div>
+        <div data-testid="status">{status}</div>
+        <div data-testid="thread-id">{threadId || 'undefined'}</div>
+        {error && <div data-testid="error">{error.toString()}</div>}
+        {messages.map((m, idx) => (
+          <div data-testid={`message-${idx}`} key={idx}>
+            {m.role === 'user' ? 'User: ' : 'AI: '}
+            {m.content}
+          </div>
+        ))}
+
+        <button
+          data-testid="do-append"
+          onClick={() => {
+            append({ role: 'user', content: 'hi' });
+          }}
+        />
+        <button
+          data-testid="do-new-thread"
+          onClick={() => {
+            setThreadId(undefined);
+          }}
+        />
+        <button
+          data-testid="do-thread-3"
+          onClick={() => {
+            setThreadId('t3');
+          }}
+        />
+      </div>
+    );
+  };
+
+  beforeEach(() => {
+    render(<TestComponent />);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('create new thread', async () => {
+    await screen.findByTestId('thread-id');
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('undefined');
+  });
+
+  it('should show streamed response', async () => {
+    const { requestBody } = mockFetchDataStream({
+      url: 'https://example.com/api/assistant',
+      chunks: [
+        formatStreamPart('assistant_control_data', {
+          threadId: 't0',
+          messageId: 'm0',
+        }),
+        formatStreamPart('assistant_message', {
+          id: 'm0',
+          role: 'assistant',
+          content: [{ type: 'text', text: { value: '' } }],
+        }),
+        // text parts:
+        '0:"Hello"\n',
+        '0:","\n',
+        '0:" world"\n',
+        '0:"."\n',
+      ],
+    });
+
+    await userEvent.click(screen.getByTestId('do-append'));
+
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('t0');
+
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent(
+      'AI: Hello, world.',
+    );
+
+    // check that correct information was sent to the server:
+    expect(await requestBody).toStrictEqual(
+      JSON.stringify({
+        threadId: null,
+        message: 'hi',
+      }),
+    );
+  });
+
+  it('should switch to new thread on setting undefined threadId', async () => {
+    await userEvent.click(screen.getByTestId('do-new-thread'));
+
+    expect(screen.queryByTestId('message-0')).toBeNull();
+    expect(screen.queryByTestId('message-1')).toBeNull();
+
+    const { requestBody } = mockFetchDataStream({
+      url: 'https://example.com/api/assistant',
+      chunks: [
+        formatStreamPart('assistant_control_data', {
+          threadId: 't1',
+          messageId: 'm0',
+        }),
+        formatStreamPart('assistant_message', {
+          id: 'm0',
+          role: 'assistant',
+          content: [{ type: 'text', text: { value: '' } }],
+        }),
+        // text parts:
+        '0:"Hello"\n',
+        '0:","\n',
+        '0:" world"\n',
+        '0:"."\n',
+      ],
+    });
+
+    await userEvent.click(screen.getByTestId('do-append'));
+
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('t1');
+
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent(
+      'AI: Hello, world.',
+    );
+
+    // check that correct information was sent to the server:
+    expect(await requestBody).toStrictEqual(
+      JSON.stringify({
+        threadId: null,
+        message: 'hi',
+      }),
+    );
+  });
+
+  it('should switch to thread on setting previously created threadId', async () => {
+    await userEvent.click(screen.getByTestId('do-thread-3'));
+
+    expect(screen.queryByTestId('message-0')).toBeNull();
+    expect(screen.queryByTestId('message-1')).toBeNull();
+
+    const { requestBody } = mockFetchDataStream({
+      url: 'https://example.com/api/assistant',
+      chunks: [
+        formatStreamPart('assistant_control_data', {
+          threadId: 't3',
+          messageId: 'm0',
+        }),
+        formatStreamPart('assistant_message', {
+          id: 'm0',
+          role: 'assistant',
+          content: [{ type: 'text', text: { value: '' } }],
+        }),
+        // text parts:
+        '0:"Hello"\n',
+        '0:","\n',
+        '0:" world"\n',
+        '0:"."\n',
+      ],
+    });
+
+    await userEvent.click(screen.getByTestId('do-append'));
+
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('t3');
+
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent(
+      'AI: Hello, world.',
+    );
+
+    // check that correct information was sent to the server:
+    expect(await requestBody).toStrictEqual(
+      JSON.stringify({
+        threadId: 't3',
+        message: 'hi',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Addresses #1673 

- [x] add `setThreadId(threadId: string | undefined)` helper function to useAssistant
  - `setThreadId("thread_abc123")` sets the assistant to that specific thread
  - `setThreadId(undefined)` creates a new thread
  - both actions will reset messages and update threadId
- [x] add tests for thread management
- [x] update reference to include `setThreadId`