### PR TITLE
feat (ai/core): add roundtrips property to generateText result

### DIFF
--- a/.changeset/two-rules-know.md
+++ b/.changeset/two-rules-know.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): add roundtrips property to generateText result

--- a/content/docs/03-ai-sdk-core/17-agents.mdx
+++ b/content/docs/03-ai-sdk-core/17-agents.mdx
@@ -12,7 +12,7 @@ One approach to implementing agents is to allow the LLM to choose the next step 
 With `generateText`, you can combine [tools](/docs/ai-sdk-core/tools-and-tool-calling) with `maxToolRoundtrips`.
 This makes it possible to implement basic agents that reason at each step and make decisions based on the context.
 
-## Example
+### Example
 
 This example demonstrates how to create an agent that solves math problems.
 It has a calculator tool (using [math.js](https://mathjs.org/)) that it can call to evaluate mathematical expressions.
@@ -54,4 +54,20 @@ const { text: answer } = await generateText({
 });
 
 console.log(`ANSWER: ${answer}`);
+```
+
+## Accessing information from all roundtrips
+
+Calling `generateText` with `maxToolRoundtrips` can result in several calls to the LLM (roundtrips).
+You can access information from all roundtrips by using the `roundtrips` property of the response.
+
+```ts
+const { roundtrips } = await generateText({
+  model: openai('gpt-4-turbo'),
+  maxToolRoundtrips: 10,
+  // ...
+});
+
+// extract all tool calls from the roundtrips:
+const allToolCalls = roundtrips.flatMap(roundtrip => roundtrip.toolCalls);
 ```

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -457,6 +457,93 @@ console.log(text);
       description:
         'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
     },
+    {
+      name: 'roundtrips',
+      type: 'Array<Roundtrip>',
+      description:
+        'Response information for every roundtrip. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
+      properties: [
+        {
+          type: 'Roundtrip',
+          parameters: [
+            {
+              name: 'text',
+              type: 'string',
+              description: 'The generated text by the model.',
+            },
+            {
+              name: 'toolCalls',
+              type: 'array',
+              description: 'A list of tool calls made by the model.',
+            },
+            {
+              name: 'toolResults',
+              type: 'array',
+              description:
+                'A list of tool results returned as responses to earlier tool calls.',
+            },
+            {
+              name: 'finishReason',
+              type: "'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other' | 'unknown'",
+              description: 'The reason the model finished generating the text.',
+            },
+            {
+              name: 'usage',
+              type: 'CompletionTokenUsage',
+              description: 'The token usage of the generated text.',
+              properties: [
+                {
+                  type: 'CompletionTokenUsage',
+                  parameters: [
+                    {
+                      name: 'promptTokens',
+                      type: 'number',
+                      description: 'The total number of tokens in the prompt.',
+                    },
+                    {
+                      name: 'completionTokens',
+                      type: 'number',
+                      description:
+                        'The total number of tokens in the completion.',
+                    },
+                    {
+                      name: 'totalTokens',
+                      type: 'number',
+                      description: 'The total number of tokens generated.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'rawResponse',
+              type: 'RawResponse',
+              optional: true,
+              description: 'Optional raw response data.',
+              properties: [
+                {
+                  type: 'RawResponse',
+                  parameters: [
+                    {
+                      name: 'headers',
+                      optional: true,
+                      type: 'Record<string, string>',
+                      description: 'Response headers.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'warnings',
+              type: 'Warning[] | undefined',
+              description:
+                'Warnings from the model provider (e.g. unsupported settings).',
+            },
+          ],
+        },
+      ],
+    },
   ]}
 />
 

--- a/packages/core/core/generate-text/generate-text.ts
+++ b/packages/core/core/generate-text/generate-text.ts
@@ -260,6 +260,7 @@ By default, it's set to 0, which will disable the feature.
         rawResponse: currentModelResponse.rawResponse,
         logprobs: currentModelResponse.logprobs,
         responseMessages,
+        roundtrips: [], // TODO implement
       });
     },
   });
@@ -367,33 +368,84 @@ need to be added separately.
   readonly responseMessages: Array<CoreAssistantMessage | CoreToolMessage>;
 
   /**
+Response information for every roundtrip.
+You can use this to get information about intermediate steps, such as the tool calls or the response headers.
+   */
+  readonly roundtrips: Array<{
+    /**
+The generated text.
+   */
+    readonly text: string;
+
+    /**
+The tool calls that were made during the generation.
+ */
+    readonly toolCalls: ToToolCallArray<TOOLS>;
+
+    /**
+The results of the tool calls.
+ */
+    readonly toolResults: ToToolResultArray<TOOLS>;
+
+    /**
+The reason why the generation finished.
+   */
+    readonly finishReason: FinishReason;
+
+    /**
+The token usage of the generated text.
+ */
+    readonly usage: CompletionTokenUsage;
+
+    /**
+Warnings from the model provider (e.g. unsupported settings)
+   */
+    readonly warnings: CallWarning[] | undefined;
+
+    /**
+Logprobs for the completion.
+`undefined` if the mode does not support logprobs or if was not enabled.
+   */
+    readonly logprobs: LogProbs | undefined;
+
+    /**
+  Optional raw response data.
+     */
+    readonly rawResponse?: {
+      /**
+  Response headers.
+     */
+      readonly headers?: Record<string, string>;
+    };
+  }>;
+
+  /**
 Optional raw response data.
    */
-  rawResponse?: {
+  readonly rawResponse?: {
     /**
 Response headers.
    */
-    headers?: Record<string, string>;
+    readonly headers?: Record<string, string>;
   };
 
   /**
-Logprobs for the completion. 
-`undefined` if the mode does not support logprobs or if was not enabled
+Logprobs for the completion.
+`undefined` if the mode does not support logprobs or if was not enabled.
    */
   readonly logprobs: LogProbs | undefined;
 
   constructor(options: {
-    text: string;
-    toolCalls: ToToolCallArray<TOOLS>;
-    toolResults: ToToolResultArray<TOOLS>;
-    finishReason: FinishReason;
-    usage: CompletionTokenUsage;
-    warnings: CallWarning[] | undefined;
-    rawResponse?: {
-      headers?: Record<string, string>;
-    };
-    logprobs: LogProbs | undefined;
-    responseMessages: Array<CoreAssistantMessage | CoreToolMessage>;
+    text: GenerateTextResult<TOOLS>['text'];
+    toolCalls: GenerateTextResult<TOOLS>['toolCalls'];
+    toolResults: GenerateTextResult<TOOLS>['toolResults'];
+    finishReason: GenerateTextResult<TOOLS>['finishReason'];
+    usage: GenerateTextResult<TOOLS>['usage'];
+    warnings: GenerateTextResult<TOOLS>['warnings'];
+    rawResponse?: GenerateTextResult<TOOLS>['rawResponse'];
+    logprobs: GenerateTextResult<TOOLS>['logprobs'];
+    responseMessages: GenerateTextResult<TOOLS>['responseMessages'];
+    roundtrips: GenerateTextResult<TOOLS>['roundtrips'];
   }) {
     this.text = options.text;
     this.toolCalls = options.toolCalls;
@@ -404,6 +456,7 @@ Logprobs for the completion.
     this.rawResponse = options.rawResponse;
     this.logprobs = options.logprobs;
     this.responseMessages = options.responseMessages;
+    this.roundtrips = options.roundtrips;
   }
 }
 


### PR DESCRIPTION
## Summary
Adds a `roundtrips` property to the `generateText` result that contains information about all roundtrips in sequential order.

## Background
It was not possible to access information about intermediate steps (e.g. tool calls) when `maxToolRoundtrips` is > 0 (see 2176 ).

## Tasks

- [x] implement
- [x] test
- [x] docs
   - [x] reference docs
   - [x] add to agents guide
- [x] changeset