### PR TITLE
Added `baseURL` to the Azure OpenAI Provider

### DIFF
--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -62,25 +62,6 @@ describe('chat', () => {
       );
     });
 
-    it('should update the api version correctly', async () => {
-      prepareJsonResponse();
-
-      const provider = createAzure({
-        resourceName: 'test-resource',
-        apiVersion: '2024-05-01-preview',
-        apiKey: 'test-api-key',
-      });
-
-      await provider('test-deployment').doGenerate({
-        inputFormat: 'prompt',
-        mode: { type: 'regular' },
-        prompt: TEST_PROMPT,
-      });
-
-      const searchParams = await server.getRequestUrlSearchParams();
-      expect(searchParams.get('api-version')).toStrictEqual('2024-05-01');
-    });
-
     it('should pass headers', async () => {
       prepareJsonResponse();
 

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -68,11 +68,6 @@ The default prefix is ``https://{resourceName}.openai.azure.com/openai/deploymen
   baseURL?: string;
 
   /**
-Use API version. The default API version is ``2024-05-01-preview``.
-   */
-  apiVersion?: string;
-
-  /**
 API key for authenticating requests.
      */
   apiKey?: string;
@@ -118,7 +113,6 @@ export function createAzure(
       settingName: 'baseURL',
       environmentVariableName: 'AZURE_BASE_URL',
       description: 'Azure OpenAI base URL',
-      defaultValue: undefined,
       failOnMissing: false,
     });
 
@@ -130,19 +124,10 @@ export function createAzure(
       description: 'Azure OpenAI base URL',
     });
 
-  const getApiVersion = () =>
-    loadSetting({
-      settingValue: options.apiVersion,
-      settingName: 'apiVersion',
-      environmentVariableName: 'AZURE_API_VERSION',
-      description: 'Azure OpenAI API version',
-      defaultValue: '2024-05-01-preview',
-    });
-
   const url = ({ path, modelId }: { path: string; modelId: string }) =>
     checkIfBaseUrlIsProvided()
-      ? `${getBaseUrl()}/${modelId}${path}?api-version=${getApiVersion()}`
-      : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=${getApiVersion()}`;
+      ? `${getBaseUrl()}/${modelId}${path}?api-version=2024-05-01-preview`
+      : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=2024-05-01-preview`;
 
   const createChatModel = (
     deploymentName: string,

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -107,26 +107,9 @@ export function createAzure(
       description: 'Azure OpenAI resource name',
     });
 
-  const checkIfBaseUrlIsProvided = () =>
-    loadSetting({
-      settingValue: options.baseURL,
-      settingName: 'baseURL',
-      environmentVariableName: 'AZURE_BASE_URL',
-      description: 'Azure OpenAI base URL',
-      failOnMissing: false,
-    });
-
-  const getBaseUrl = () =>
-    loadSetting({
-      settingValue: options.baseURL,
-      settingName: 'baseURL',
-      environmentVariableName: 'AZURE_BASE_URL',
-      description: 'Azure OpenAI base URL',
-    });
-
   const url = ({ path, modelId }: { path: string; modelId: string }) =>
-    checkIfBaseUrlIsProvided()
-      ? `${getBaseUrl()}/${modelId}${path}?api-version=2024-05-01-preview`
+    options.baseURL
+      ? `${options.baseURL}/${modelId}${path}?api-version=2024-05-01-preview`
       : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=2024-05-01-preview`;
 
   const createChatModel = (

--- a/packages/provider-utils/src/load-setting.ts
+++ b/packages/provider-utils/src/load-setting.ts
@@ -10,7 +10,7 @@ export function loadSetting({
   environmentVariableName: string;
   settingName: string;
   description: string;
-}) {
+}): string {
   if (typeof settingValue === 'string') {
     return settingValue;
   }

--- a/packages/provider-utils/src/load-setting.ts
+++ b/packages/provider-utils/src/load-setting.ts
@@ -12,7 +12,7 @@ export function loadSetting({
   environmentVariableName: string;
   settingName: string;
   description: string;
-  failOnMissing: true;
+  failOnMissing?: true;
 }): string;
 
 // Added an overload for the `failOnMissing` parameter to be `false`.
@@ -27,7 +27,7 @@ export function loadSetting({
   environmentVariableName: string;
   settingName: string;
   description: string;
-  failOnMissing: false;
+  failOnMissing?: false;
 }): string | undefined;
 
 export function loadSetting({
@@ -41,7 +41,7 @@ export function loadSetting({
   environmentVariableName: string;
   settingName: string;
   description: string;
-  failOnMissing: boolean;
+  failOnMissing?: boolean;
 }) {
   if (typeof settingValue === 'string') {
     return settingValue;

--- a/packages/provider-utils/src/load-setting.ts
+++ b/packages/provider-utils/src/load-setting.ts
@@ -6,14 +6,12 @@ export function loadSetting({
   environmentVariableName,
   settingName,
   description,
-  defaultValue,
   failOnMissing,
 }: {
   settingValue: string | undefined;
   environmentVariableName: string;
   settingName: string;
   description: string;
-  defaultValue: string | undefined;
   failOnMissing: true;
 }): string;
 
@@ -23,14 +21,12 @@ export function loadSetting({
   environmentVariableName,
   settingName,
   description,
-  defaultValue,
   failOnMissing,
 }: {
   settingValue: string | undefined;
   environmentVariableName: string;
   settingName: string;
   description: string;
-  defaultValue: string | undefined;
   failOnMissing: false;
 }): string | undefined;
 
@@ -39,14 +35,12 @@ export function loadSetting({
   environmentVariableName,
   settingName,
   description,
-  defaultValue,
   failOnMissing,
 }: {
   settingValue: string | undefined;
   environmentVariableName: string;
   settingName: string;
   description: string;
-  defaultValue: string | undefined;
   failOnMissing: boolean;
 }) {
   if (typeof settingValue === 'string') {
@@ -79,5 +73,5 @@ export function loadSetting({
     });
   }
 
-  return settingValue ?? defaultValue ?? undefined;
+  return settingValue ?? undefined;
 }

--- a/packages/provider-utils/src/load-setting.ts
+++ b/packages/provider-utils/src/load-setting.ts
@@ -1,41 +1,10 @@
 import { LoadSettingError } from '@ai-sdk/provider';
 
-// Added an overload for the `failOnMissing` parameter to be `true` by default.
 export function loadSetting({
   settingValue,
   environmentVariableName,
   settingName,
   description,
-  failOnMissing,
-}: {
-  settingValue: string | undefined;
-  environmentVariableName: string;
-  settingName: string;
-  description: string;
-  failOnMissing?: true;
-}): string;
-
-// Added an overload for the `failOnMissing` parameter to be `false`.
-export function loadSetting({
-  settingValue,
-  environmentVariableName,
-  settingName,
-  description,
-  failOnMissing,
-}: {
-  settingValue: string | undefined;
-  environmentVariableName: string;
-  settingName: string;
-  description: string;
-  failOnMissing?: false;
-}): string | undefined;
-
-export function loadSetting({
-  settingValue,
-  environmentVariableName,
-  settingName,
-  description,
-  failOnMissing,
 }: {
   settingValue: string | undefined;
   environmentVariableName: string;
@@ -53,7 +22,7 @@ export function loadSetting({
     });
   }
 
-  if (typeof process === 'undefined' && failOnMissing) {
+  if (typeof process === 'undefined') {
     throw new LoadSettingError({
       message: `${description} setting is missing. Pass it using the '${settingName}' parameter. Environment variables is not supported in this environment.`,
     });
@@ -61,17 +30,17 @@ export function loadSetting({
 
   settingValue = process.env[environmentVariableName];
 
-  if (settingValue == null && failOnMissing) {
+  if (settingValue == null) {
     throw new LoadSettingError({
       message: `${description} setting is missing. Pass it using the '${settingName}' parameter or the ${environmentVariableName} environment variable.`,
     });
   }
 
-  if (typeof settingValue !== 'string' && failOnMissing) {
+  if (typeof settingValue !== 'string') {
     throw new LoadSettingError({
       message: `${description} setting must be a string. The value of the ${environmentVariableName} environment variable is not a string.`,
     });
   }
 
-  return settingValue ?? undefined;
+  return settingValue;
 }

--- a/packages/provider-utils/src/load-setting.ts
+++ b/packages/provider-utils/src/load-setting.ts
@@ -10,7 +10,6 @@ export function loadSetting({
   environmentVariableName: string;
   settingName: string;
   description: string;
-  failOnMissing?: boolean;
 }) {
   if (typeof settingValue === 'string') {
     return settingValue;

--- a/packages/provider-utils/src/load-setting.ts
+++ b/packages/provider-utils/src/load-setting.ts
@@ -1,16 +1,54 @@
 import { LoadSettingError } from '@ai-sdk/provider';
 
+// Added an overload for the `failOnMissing` parameter to be `true` by default.
 export function loadSetting({
   settingValue,
   environmentVariableName,
   settingName,
   description,
+  defaultValue,
+  failOnMissing,
 }: {
   settingValue: string | undefined;
   environmentVariableName: string;
   settingName: string;
   description: string;
-}): string {
+  defaultValue: string | undefined;
+  failOnMissing: true;
+}): string;
+
+// Added an overload for the `failOnMissing` parameter to be `false`.
+export function loadSetting({
+  settingValue,
+  environmentVariableName,
+  settingName,
+  description,
+  defaultValue,
+  failOnMissing,
+}: {
+  settingValue: string | undefined;
+  environmentVariableName: string;
+  settingName: string;
+  description: string;
+  defaultValue: string | undefined;
+  failOnMissing: false;
+}): string | undefined;
+
+export function loadSetting({
+  settingValue,
+  environmentVariableName,
+  settingName,
+  description,
+  defaultValue,
+  failOnMissing,
+}: {
+  settingValue: string | undefined;
+  environmentVariableName: string;
+  settingName: string;
+  description: string;
+  defaultValue: string | undefined;
+  failOnMissing: boolean;
+}) {
   if (typeof settingValue === 'string') {
     return settingValue;
   }
@@ -21,7 +59,7 @@ export function loadSetting({
     });
   }
 
-  if (typeof process === 'undefined') {
+  if (typeof process === 'undefined' && failOnMissing) {
     throw new LoadSettingError({
       message: `${description} setting is missing. Pass it using the '${settingName}' parameter. Environment variables is not supported in this environment.`,
     });
@@ -29,17 +67,17 @@ export function loadSetting({
 
   settingValue = process.env[environmentVariableName];
 
-  if (settingValue == null) {
+  if (settingValue == null && failOnMissing) {
     throw new LoadSettingError({
       message: `${description} setting is missing. Pass it using the '${settingName}' parameter or the ${environmentVariableName} environment variable.`,
     });
   }
 
-  if (typeof settingValue !== 'string') {
+  if (typeof settingValue !== 'string' && failOnMissing) {
     throw new LoadSettingError({
       message: `${description} setting must be a string. The value of the ${environmentVariableName} environment variable is not a string.`,
     });
   }
 
-  return settingValue;
+  return settingValue ?? defaultValue ?? undefined;
 }

--- a/packages/provider-utils/src/test/json-test-server.ts
+++ b/packages/provider-utils/src/test/json-test-server.ts
@@ -49,6 +49,11 @@ export class JsonTestServer {
     return new URL(this.request!.url).searchParams;
   }
 
+  async getRequestUrl() {
+    expect(this.request).toBeDefined();
+    return new URL(this.request!.url).toString();
+  }
+
   setupTestEnvironment() {
     beforeAll(() => this.server.listen());
     beforeEach(() => {


### PR DESCRIPTION
Implementation of #2312 

### Main Changes
- Added `baseURL` ~~and `apiVersion`~~ as optional parameters to `AzureOpenAIProviderSettings`
- Added two test cases for the change

### Secondary Changes
~~- Added two parameters to the `loadSetting` function in `provider-utils`. The `defaultValue` param is needed to handle the fallback value for the `apiVersion` parameter. The `failOnMissing` param is needed to handle optional parameters in the Provider. It is used to check whether a `baseURL` is provided.~~
- Added a `getRequestUrl` function to the `JsonTestServer`. This is needed in the provider test to ensure that the `baseURL` is properly set.