### PR TITLE
fix (docs): fix provider name on anthropic sdk provider page

### DIFF
--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -41,7 +41,7 @@ const anthropic = createAnthropic({
 });
 ```
 
-You can use the following optional settings to customize the Google Generative AI provider instance:
+You can use the following optional settings to customize the Anthropic provider instance:
 
 - **baseURL** _string_
 


### PR DESCRIPTION

Fix provider name on anthropic sdk [page](https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic)

![image](https://github.com/user-attachments/assets/efcee4f0-4516-40f8-a73b-8755d10b520c)
