### PR TITLE
fix(ai/core): fullStream should throw on error

### DIFF
--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -546,6 +546,8 @@ stream will throw the error.
           if (chunk.textDelta.length > 0) {
             controller.enqueue(chunk);
           }
+        } else if (chunk.type === 'error') {
+          controller.error(chunk.error);
         } else {
           controller.enqueue(chunk);
         }


### PR DESCRIPTION
The doc of fullStream states that _When an error occurs, the stream will throw the error_, but it's missing in the code.