### PR TITLE
chore (ai/core): remove grammar mode

### DIFF
--- a/.changeset/violet-tips-brake.md
+++ b/.changeset/violet-tips-brake.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'ai': patch
+---
+
+chore (ai/core): remove grammar mode

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -39,8 +39,7 @@ While some models (like OpenAI) natively support object generation, others requi
 
 - `auto`: The provider will choose the best mode for the model. This recommended mode is used by default.
 - `tool`: A tool with the JSON schema as parameters is provided and the provider is instructed to use it.
-- `json`: The JSON schema and an instruction is injected into the prompt. If the provider supports JSON mode, it is enabled.
-- `grammar`: The provider is instructed to convert the JSON schema into a provider specific grammar and use it to select the output tokens.
+- `json`: The JSON schema and an instruction is injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
 
 <Note>Please note that not every provider supports all generation modes.</Note>
 

--- a/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
@@ -46,7 +46,7 @@ console.log(JSON.stringify(object, null, 2));
     },
     {
       name: 'mode',
-      type: "'auto' | 'json' | 'grammar' | 'tool'",
+      type: "'auto' | 'json' | 'tool'",
       description:
         "The mode to use for object generation. Not every model supports all modes. Defaults to 'auto'.",
     },

--- a/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
@@ -49,7 +49,7 @@ for await (const partialObject of partialObjectStream) {
     },
     {
       name: 'mode',
-      type: "'auto' | 'json' | 'grammar' | 'tool'",
+      type: "'auto' | 'json' | 'tool'",
       description:
         "The mode to use for object generation. Not every model supports all modes. Defaults to 'auto'.",
     },

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -141,12 +141,6 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
         } satisfies ConverseCommandInput;
       }
 
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'grammar-mode object generation',
-        });
-      }
-
       default: {
         const _exhaustiveCheck: never = type;
         throw new Error(`Unsupported type: ${_exhaustiveCheck}`);

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -133,12 +133,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
         };
       }
 
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'grammar-mode object generation',
-        });
-      }
-
       default: {
         const _exhaustiveCheck: never = type;
         throw new Error(`Unsupported type: ${_exhaustiveCheck}`);

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -101,12 +101,6 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
         });
       }
 
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'object-grammar mode',
-        });
-      }
-
       default: {
         const _exhaustiveCheck: never = type;
         throw new Error(`Unsupported type: ${_exhaustiveCheck}`);

--- a/packages/core/core/generate-object/generate-object.ts
+++ b/packages/core/core/generate-object/generate-object.ts
@@ -83,7 +83,7 @@ The Zod schema is converted in a JSON schema and used in one of the following wa
 
 - 'auto': The provider will choose the best mode for the model.
 - 'tool': A tool with the JSON schema as parameters is is provided and the provider is instructed to use it.
-- 'json': The JSON schema and a instruction is injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
+- 'json': The JSON schema and an instruction is injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
 
 Please note that most providers do not support all modes.
 

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -98,7 +98,7 @@ The Zod schema is converted in a JSON schema and used in one of the following wa
 
 - 'auto': The provider will choose the best mode for the model.
 - 'tool': A tool with the JSON schema as parameters is is provided and the provider is instructed to use it.
-- 'json': The JSON schema and a instruction is injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
+- 'json': The JSON schema and an instruction is injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
 
 Please note that most providers do not support all modes.
 

--- a/packages/core/core/generate-object/stream-object.ts
+++ b/packages/core/core/generate-object/stream-object.ts
@@ -98,14 +98,13 @@ The Zod schema is converted in a JSON schema and used in one of the following wa
 
 - 'auto': The provider will choose the best mode for the model.
 - 'tool': A tool with the JSON schema as parameters is is provided and the provider is instructed to use it.
-- 'json': The JSON schema and a instruction is injected into the prompt. If the provider supports JSON mode, it is enabled.
-- 'grammar': The provider is instructed to converted the JSON schema into a provider specific grammar and use it to select the output tokens.
+- 'json': The JSON schema and a instruction is injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
 
 Please note that most providers do not support all modes.
 
 Default and recommended: 'auto' (best mode for the model).
      */
-    mode?: 'auto' | 'json' | 'tool' | 'grammar';
+    mode?: 'auto' | 'json' | 'tool';
 
     /**
 Callback that is called when the LLM response and the final object validation are finished.
@@ -166,39 +165,6 @@ Warnings from the model provider (e.g. unsupported settings).
 
       callOptions = {
         mode: { type: 'object-json' },
-        ...prepareCallSettings(settings),
-        inputFormat: validatedPrompt.type,
-        prompt: convertToLanguageModelPrompt(validatedPrompt),
-        abortSignal,
-        headers,
-      };
-
-      transformer = {
-        transform: (chunk, controller) => {
-          switch (chunk.type) {
-            case 'text-delta':
-              controller.enqueue(chunk.textDelta);
-              break;
-            case 'finish':
-            case 'error':
-              controller.enqueue(chunk);
-              break;
-          }
-        },
-      };
-
-      break;
-    }
-
-    case 'grammar': {
-      const validatedPrompt = getValidatedPrompt({
-        system: injectJsonSchemaIntoSystem({ system, schema: jsonSchema }),
-        prompt,
-        messages,
-      });
-
-      callOptions = {
-        mode: { type: 'object-grammar', schema: jsonSchema },
         ...prepareCallSettings(settings),
         inputFormat: validatedPrompt.type,
         prompt: convertToLanguageModelPrompt(validatedPrompt),

--- a/packages/google-vertex/src/google-vertex-language-model.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.ts
@@ -129,12 +129,6 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
         });
       }
 
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'object-grammar mode',
-        });
-      }
-
       default: {
         const _exhaustiveCheck: never = type;
         throw new Error(`Unsupported type: ${_exhaustiveCheck}`);

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -154,12 +154,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
         };
       }
 
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'object-grammar mode',
-        });
-      }
-
       default: {
         const _exhaustiveCheck: never = type;
         throw new Error(`Unsupported type: ${_exhaustiveCheck}`);

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -126,12 +126,6 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
         };
       }
 
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'object-grammar mode',
-        });
-      }
-
       default: {
         const _exhaustiveCheck: never = type;
         throw new Error(`Unsupported type: ${_exhaustiveCheck}`);

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -131,12 +131,6 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
         };
       }
 
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'object-grammar mode',
-        });
-      }
-
       default: {
         const _exhaustiveCheck: never = type;
         throw new Error(`Unsupported type: ${_exhaustiveCheck}`);

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -134,12 +134,6 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
         });
       }
 
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'object-grammar mode',
-        });
-      }
-
       default: {
         const _exhaustiveCheck: never = type;
         throw new Error(`Unsupported type: ${_exhaustiveCheck}`);

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -1,4 +1,3 @@
-import { JSONSchema7 } from 'json-schema';
 import { LanguageModelV1CallSettings } from './language-model-v1-call-settings';
 import { LanguageModelV1FunctionTool } from './language-model-v1-function-tool';
 import { LanguageModelV1Prompt } from './language-model-v1-prompt';
@@ -41,11 +40,6 @@ Specifies how the tool should be selected. Defaults to 'auto'.
     | {
         // object generation with json mode enabled (streaming: text delta)
         type: 'object-json';
-      }
-    | {
-        // object generation with grammar enabled (streaming: text delta)
-        type: 'object-grammar';
-        schema: JSONSchema7;
       }
     | {
         // object generation with tool mode enabled (streaming: tool call deltas)

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -35,7 +35,7 @@ model. `undefined` can be returned if object generation is not supported.
 This is needed to generate the best objects possible w/o requiring the
 user to explicitly specify the object generation mode.
    */
-  readonly defaultObjectGenerationMode: 'json' | 'tool' | 'grammar' | undefined;
+  readonly defaultObjectGenerationMode: 'json' | 'tool' | undefined;
 
   /**
 Generates a language model output (non-streaming).


### PR DESCRIPTION
Removes grammar mode.

## Background
Grammar mode was never supported in any provider. It can be included under JSON mode, where grammar should automatically be used when the provider supports them. Thus, the grammar mode only adds unnecessary complexity.