### PR TITLE
chore (ai/core): use interfaces for core function results

### DIFF
--- a/.changeset/purple-laws-bake.md
+++ b/.changeset/purple-laws-bake.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore (ai/core): use interfaces for core function results

--- a/packages/core/core/embed/embed-many-result.ts
+++ b/packages/core/core/embed/embed-many-result.ts
@@ -1,0 +1,23 @@
+import { Embedding } from '../types';
+import { EmbeddingTokenUsage } from '../types/token-usage';
+
+/**
+The result of a `embedMany` call.
+It contains the embeddings, the values, and additional information.
+ */
+export interface EmbedManyResult<VALUE> {
+  /**
+  The values that were embedded.
+     */
+  readonly values: Array<VALUE>;
+
+  /**
+  The embeddings. They are in the same order as the values.
+    */
+  readonly embeddings: Array<Embedding>;
+
+  /**
+  The embedding token usage.
+    */
+  readonly usage: EmbeddingTokenUsage;
+}

--- a/packages/core/core/embed/embed-many.ts
+++ b/packages/core/core/embed/embed-many.ts
@@ -1,10 +1,10 @@
-import { Embedding, EmbeddingModel } from '../types';
-import { EmbeddingTokenUsage } from '../types/token-usage';
+import { EmbeddingModel } from '../types';
 import { retryWithExponentialBackoff } from '../util/retry-with-exponential-backoff';
 import { splitArray } from '../util/split-array';
+import { EmbedManyResult } from './embed-many-result';
 
 /**
-Embed several values using an embedding model. The type of the value is defined 
+Embed several values using an embedding model. The type of the value is defined
 by the embedding model.
 
 `embedMany` automatically splits large requests into smaller chunks if the model
@@ -64,7 +64,7 @@ Only applicable for HTTP-based providers.
       model.doEmbed({ values, abortSignal, headers }),
     );
 
-    return new EmbedManyResult({
+    return new DefaultEmbedManyResult({
       values,
       embeddings: modelResponse.embeddings,
       usage: modelResponse.usage ?? { tokens: NaN },
@@ -86,33 +86,18 @@ Only applicable for HTTP-based providers.
     tokens += modelResponse.usage?.tokens ?? NaN;
   }
 
-  return new EmbedManyResult({ values, embeddings, usage: { tokens } });
+  return new DefaultEmbedManyResult({ values, embeddings, usage: { tokens } });
 }
 
-/**
-The result of a `embedMany` call.
-It contains the embeddings, the values, and additional information.
- */
-export class EmbedManyResult<VALUE> {
-  /**
-The values that were embedded.
-   */
-  readonly values: Array<VALUE>;
-
-  /**
-The embeddings. They are in the same order as the values.
-  */
-  readonly embeddings: Array<Embedding>;
-
-  /**
-The embedding token usage.
-  */
-  readonly usage: EmbeddingTokenUsage;
+class DefaultEmbedManyResult<VALUE> implements EmbedManyResult<VALUE> {
+  readonly values: EmbedManyResult<VALUE>['values'];
+  readonly embeddings: EmbedManyResult<VALUE>['embeddings'];
+  readonly usage: EmbedManyResult<VALUE>['usage'];
 
   constructor(options: {
-    values: Array<VALUE>;
-    embeddings: Array<Embedding>;
-    usage: EmbeddingTokenUsage;
+    values: EmbedManyResult<VALUE>['values'];
+    embeddings: EmbedManyResult<VALUE>['embeddings'];
+    usage: EmbedManyResult<VALUE>['usage'];
   }) {
     this.values = options.values;
     this.embeddings = options.embeddings;

--- a/packages/core/core/embed/embed-result.ts
+++ b/packages/core/core/embed/embed-result.ts
@@ -1,7 +1,11 @@
 import { Embedding } from '../types';
 import { EmbeddingTokenUsage } from '../types/token-usage';
 
-export type EmbedResult<VALUE> = {
+/**
+The result of a `embed` call.
+It contains the embedding, the value, and additional information.
+ */
+export interface EmbedResult<VALUE> {
   /**
   The value that was embedded.
      */
@@ -26,4 +30,4 @@ export type EmbedResult<VALUE> = {
        */
     headers?: Record<string, string>;
   };
-};
+}

--- a/packages/core/core/embed/embed-result.ts
+++ b/packages/core/core/embed/embed-result.ts
@@ -1,0 +1,29 @@
+import { Embedding } from '../types';
+import { EmbeddingTokenUsage } from '../types/token-usage';
+
+export type EmbedResult<VALUE> = {
+  /**
+  The value that was embedded.
+     */
+  readonly value: VALUE;
+
+  /**
+  The embedding of the value.
+    */
+  readonly embedding: Embedding;
+
+  /**
+  The embedding token usage.
+    */
+  readonly usage: EmbeddingTokenUsage;
+
+  /**
+  Optional raw response data.
+     */
+  readonly rawResponse?: {
+    /**
+  Response headers.
+       */
+    headers?: Record<string, string>;
+  };
+};

--- a/packages/core/core/embed/embed.ts
+++ b/packages/core/core/embed/embed.ts
@@ -1,6 +1,6 @@
-import { Embedding, EmbeddingModel } from '../types';
-import { EmbeddingTokenUsage } from '../types/token-usage';
+import { EmbeddingModel } from '../types';
 import { retryWithExponentialBackoff } from '../util/retry-with-exponential-backoff';
+import { EmbedResult } from './embed-result';
 
 /**
 Embed a value using an embedding model. The type of the value is defined by the embedding model.
@@ -55,7 +55,7 @@ Only applicable for HTTP-based providers.
     model.doEmbed({ values: [value], abortSignal, headers }),
   );
 
-  return new EmbedResult({
+  return new DefaultEmbedResult({
     value,
     embedding: modelResponse.embeddings[0],
     usage: modelResponse.usage ?? { tokens: NaN },
@@ -63,41 +63,17 @@ Only applicable for HTTP-based providers.
   });
 }
 
-/**
-The result of a `embed` call.
-It contains the embedding, the value, and additional information.
- */
-export class EmbedResult<VALUE> {
-  /**
-The value that was embedded.
-   */
-  readonly value: VALUE;
-
-  /**
-The embedding of the value.
-  */
-  readonly embedding: Embedding;
-
-  /**
-The embedding token usage.
-  */
-  readonly usage: EmbeddingTokenUsage;
-
-  /**
-Optional raw response data.
-   */
-  readonly rawResponse?: {
-    /**
-Response headers.
-     */
-    headers?: Record<string, string>;
-  };
+class DefaultEmbedResult<VALUE> implements EmbedResult<VALUE> {
+  readonly value: EmbedResult<VALUE>['value'];
+  readonly embedding: EmbedResult<VALUE>['embedding'];
+  readonly usage: EmbedResult<VALUE>['usage'];
+  readonly rawResponse: EmbedResult<VALUE>['rawResponse'];
 
   constructor(options: {
-    value: VALUE;
-    embedding: Embedding;
-    usage: EmbeddingTokenUsage;
-    rawResponse?: { headers?: Record<string, string> };
+    value: EmbedResult<VALUE>['value'];
+    embedding: EmbedResult<VALUE>['embedding'];
+    usage: EmbedResult<VALUE>['usage'];
+    rawResponse?: EmbedResult<VALUE>['rawResponse'];
   }) {
     this.value = options.value;
     this.embedding = options.embedding;

--- a/packages/core/core/embed/index.ts
+++ b/packages/core/core/embed/index.ts
@@ -1,3 +1,4 @@
 export * from './embed';
 export * from './embed-many';
+export * from './embed-many-result';
 export * from './embed-result';

--- a/packages/core/core/embed/index.ts
+++ b/packages/core/core/embed/index.ts
@@ -1,2 +1,3 @@
 export * from './embed';
 export * from './embed-many';
+export * from './embed-result';

--- a/packages/core/core/generate-object/generate-object-result.ts
+++ b/packages/core/core/generate-object/generate-object-result.ts
@@ -28,7 +28,7 @@ export interface GenerateObjectResult<T> {
   /**
   Optional raw response data.
      */
-  rawResponse?: {
+  readonly rawResponse?: {
     /**
   Response headers.
    */

--- a/packages/core/core/generate-object/generate-object-result.ts
+++ b/packages/core/core/generate-object/generate-object-result.ts
@@ -1,0 +1,49 @@
+import { CallWarning, FinishReason, LogProbs } from '../types';
+import { CompletionTokenUsage } from '../types/token-usage';
+
+/**
+The result of a `generateObject` call.
+ */
+export interface GenerateObjectResult<T> {
+  /**
+  The generated object (typed according to the schema).
+     */
+  readonly object: T;
+
+  /**
+  The reason why the generation finished.
+     */
+  readonly finishReason: FinishReason;
+
+  /**
+  The token usage of the generated text.
+     */
+  readonly usage: CompletionTokenUsage;
+
+  /**
+  Warnings from the model provider (e.g. unsupported settings)
+     */
+  readonly warnings: CallWarning[] | undefined;
+
+  /**
+  Optional raw response data.
+     */
+  rawResponse?: {
+    /**
+  Response headers.
+   */
+    headers?: Record<string, string>;
+  };
+
+  /**
+  Logprobs for the completion.
+  `undefined` if the mode does not support logprobs or if was not enabled
+     */
+  readonly logprobs: LogProbs | undefined;
+
+  /**
+  Converts the object to a JSON response.
+  The response will have a status code of 200 and a content type of `application/json; charset=utf-8`.
+     */
+  toJsonResponse(init?: ResponseInit): Response;
+}

--- a/packages/core/core/generate-object/index.ts
+++ b/packages/core/core/generate-object/index.ts
@@ -1,3 +1,4 @@
 export * from './generate-object';
 export * from './generate-object-result';
 export * from './stream-object';
+export * from './stream-object-result';

--- a/packages/core/core/generate-object/index.ts
+++ b/packages/core/core/generate-object/index.ts
@@ -1,2 +1,3 @@
 export * from './generate-object';
+export * from './generate-object-result';
 export * from './stream-object';

--- a/packages/core/core/generate-object/stream-object-result.ts
+++ b/packages/core/core/generate-object/stream-object-result.ts
@@ -1,0 +1,105 @@
+import { DeepPartial } from '@ai-sdk/ui-utils';
+import { ServerResponse } from 'http';
+import { CallWarning, FinishReason, LogProbs } from '../types';
+import { CompletionTokenUsage } from '../types/token-usage';
+import { AsyncIterableStream } from '../util/async-iterable-stream';
+
+/**
+The result of a `streamObject` call that contains the partial object stream and additional information.
+ */
+export interface StreamObjectResult<T> {
+  /**
+  Warnings from the model provider (e.g. unsupported settings)
+     */
+  readonly warnings: CallWarning[] | undefined;
+
+  /**
+  The token usage of the generated response. Resolved when the response is finished.
+     */
+  readonly usage: Promise<CompletionTokenUsage>;
+
+  /**
+  Optional raw response data.
+     */
+  readonly rawResponse?: {
+    /**
+  Response headers.
+   */
+    headers?: Record<string, string>;
+  };
+
+  /**
+  The generated object (typed according to the schema). Resolved when the response is finished.
+     */
+  readonly object: Promise<T>;
+
+  /**
+  Stream of partial objects. It gets more complete as the stream progresses.
+
+  Note that the partial object is not validated.
+  If you want to be certain that the actual content matches your schema, you need to implement your own validation for partial results.
+     */
+  readonly partialObjectStream: AsyncIterableStream<DeepPartial<T>>;
+
+  /**
+  Text stream of the JSON representation of the generated object. It contains text chunks.
+  When the stream is finished, the object is valid JSON that can be parsed.
+     */
+  readonly textStream: AsyncIterableStream<string>;
+
+  /**
+  Stream of different types of events, including partial objects, errors, and finish events.
+  Only errors that stop the stream, such as network errors, are thrown.
+     */
+  readonly fullStream: AsyncIterableStream<ObjectStreamPart<T>>;
+
+  /**
+  Writes text delta output to a Node.js response-like object.
+  It sets a `Content-Type` header to `text/plain; charset=utf-8` and
+  writes each text delta as a separate chunk.
+
+  @param response A Node.js response-like object (ServerResponse).
+  @param init Optional headers and status code.
+     */
+  pipeTextStreamToResponse(
+    response: ServerResponse,
+    init?: { headers?: Record<string, string>; status?: number },
+  ): void;
+
+  /**
+  Creates a simple text stream response.
+  The response has a `Content-Type` header set to `text/plain; charset=utf-8`.
+  Each text delta is encoded as UTF-8 and sent as a separate chunk.
+  Non-text-delta events are ignored.
+
+  @param init Optional headers and status code.
+     */
+  toTextStreamResponse(init?: ResponseInit): Response;
+}
+
+export type ObjectStreamInputPart =
+  | {
+      type: 'error';
+      error: unknown;
+    }
+  | {
+      type: 'finish';
+      finishReason: FinishReason;
+      logprobs?: LogProbs;
+      usage: {
+        promptTokens: number;
+        completionTokens: number;
+        totalTokens: number;
+      };
+    };
+
+export type ObjectStreamPart<T> =
+  | ObjectStreamInputPart
+  | {
+      type: 'object';
+      object: DeepPartial<T>;
+    }
+  | {
+      type: 'text-delta';
+      textDelta: string;
+    };

--- a/packages/core/core/generate-text/generate-text-result.ts
+++ b/packages/core/core/generate-text/generate-text-result.ts
@@ -1,0 +1,119 @@
+import { CoreAssistantMessage, CoreToolMessage } from '../prompt';
+import { CoreTool } from '../tool/tool';
+import { CallWarning, FinishReason, LogProbs } from '../types';
+import { CompletionTokenUsage } from '../types/token-usage';
+import { ToToolCallArray } from './tool-call';
+import { ToToolResultArray } from './tool-result';
+
+/**
+The result of a `generateText` call.
+It contains the generated text, the tool calls that were made during the generation, and the results of the tool calls.
+ */
+export interface GenerateTextResult<TOOLS extends Record<string, CoreTool>> {
+  /**
+  The generated text.
+     */
+  readonly text: string;
+
+  /**
+  The tool calls that were made during the generation.
+   */
+  readonly toolCalls: ToToolCallArray<TOOLS>;
+
+  /**
+  The results of the tool calls.
+   */
+  readonly toolResults: ToToolResultArray<TOOLS>;
+
+  /**
+  The reason why the generation finished.
+   */
+  readonly finishReason: FinishReason;
+
+  /**
+  The token usage of the generated text.
+   */
+  readonly usage: CompletionTokenUsage;
+
+  /**
+  Warnings from the model provider (e.g. unsupported settings)
+   */
+  readonly warnings: CallWarning[] | undefined;
+
+  /**
+  The response messages that were generated during the call. It consists of an assistant message,
+  potentially containing tool calls.
+  When there are tool results, there is an additional tool message with the tool results that are available.
+  If there are tools that do not have execute functions, they are not included in the tool results and
+  need to be added separately.
+     */
+  readonly responseMessages: Array<CoreAssistantMessage | CoreToolMessage>;
+
+  /**
+  Response information for every roundtrip.
+  You can use this to get information about intermediate steps, such as the tool calls or the response headers.
+   */
+  readonly roundtrips: Array<{
+    /**
+  The generated text.
+   */
+    readonly text: string;
+
+    /**
+  The tool calls that were made during the generation.
+  */
+    readonly toolCalls: ToToolCallArray<TOOLS>;
+
+    /**
+  The results of the tool calls.
+  */
+    readonly toolResults: ToToolResultArray<TOOLS>;
+
+    /**
+  The reason why the generation finished.
+   */
+    readonly finishReason: FinishReason;
+
+    /**
+  The token usage of the generated text.
+  */
+    readonly usage: CompletionTokenUsage;
+
+    /**
+  Warnings from the model provider (e.g. unsupported settings)
+   */
+    readonly warnings: CallWarning[] | undefined;
+
+    /**
+  Logprobs for the completion.
+  `undefined` if the mode does not support logprobs or if was not enabled.
+   */
+    readonly logprobs: LogProbs | undefined;
+
+    /**
+  Optional raw response data.
+     */
+    readonly rawResponse?: {
+      /**
+  Response headers.
+     */
+      readonly headers?: Record<string, string>;
+    };
+  }>;
+
+  /**
+  Optional raw response data.
+   */
+  readonly rawResponse?: {
+    /**
+  Response headers.
+   */
+    readonly headers?: Record<string, string>;
+  };
+
+  /**
+  Logprobs for the completion.
+  `undefined` if the mode does not support logprobs or if was not enabled.
+     */
+  readonly logprobs: LogProbs | undefined;
+}

--- a/packages/core/core/generate-text/generate-text.test.ts
+++ b/packages/core/core/generate-text/generate-text.test.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { setTestTracer } from '../telemetry/get-tracer';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
 import { MockTracer } from '../test/mock-tracer';
-import { GenerateTextResult, generateText } from './generate-text';
+import { generateText } from './generate-text';
+import { GenerateTextResult } from './generate-text-result';
 
 const dummyResponseValues = {
   rawCall: { rawPrompt: 'prompt', rawSettings: {} },

--- a/packages/core/core/generate-text/index.ts
+++ b/packages/core/core/generate-text/index.ts
@@ -1,3 +1,4 @@
 export * from './generate-text';
 export * from './generate-text-result';
 export * from './stream-text';
+export * from './stream-text-result';

--- a/packages/core/core/generate-text/index.ts
+++ b/packages/core/core/generate-text/index.ts
@@ -1,2 +1,3 @@
 export * from './generate-text';
+export * from './generate-text-result';
 export * from './stream-text';

--- a/packages/core/core/generate-text/run-tools-transformation.ts
+++ b/packages/core/core/generate-text/run-tools-transformation.ts
@@ -4,7 +4,7 @@ import { Tracer } from '@opentelemetry/api';
 import { recordSpan } from '../telemetry/record-span';
 import { CoreTool } from '../tool';
 import { calculateCompletionTokenUsage } from '../types/token-usage';
-import { TextStreamPart } from './stream-text';
+import { TextStreamPart } from './stream-text-result';
 import { parseToolCall } from './tool-call';
 
 export function runToolsTransformation<TOOLS extends Record<string, CoreTool>>({

--- a/packages/core/core/generate-text/stream-text-result.ts
+++ b/packages/core/core/generate-text/stream-text-result.ts
@@ -1,0 +1,130 @@
+import { ServerResponse } from 'node:http';
+import { AIStreamCallbacksAndOptions, StreamData } from '../../streams';
+import { CoreTool } from '../tool';
+import { CallWarning, FinishReason } from '../types';
+import { CompletionTokenUsage } from '../types/token-usage';
+import { AsyncIterableStream } from '../util/async-iterable-stream';
+import { TextStreamPart } from './stream-text';
+import { ToToolCall } from './tool-call';
+import { ToToolResult } from './tool-result';
+
+/**
+A result object for accessing different stream types and additional information.
+ */
+export interface StreamTextResult<TOOLS extends Record<string, CoreTool>> {
+  /**
+  Warnings from the model provider (e.g. unsupported settings).
+     */
+  readonly warnings: CallWarning[] | undefined;
+
+  /**
+  The token usage of the generated response. Resolved when the response is finished.
+     */
+  readonly usage: Promise<CompletionTokenUsage>;
+
+  /**
+  The reason why the generation finished. Resolved when the response is finished.
+     */
+  readonly finishReason: Promise<FinishReason>;
+
+  /**
+  The full text that has been generated. Resolved when the response is finished.
+     */
+  readonly text: Promise<string>;
+
+  /**
+  The tool calls that have been executed. Resolved when the response is finished.
+     */
+  readonly toolCalls: Promise<ToToolCall<TOOLS>[]>;
+
+  /**
+  The tool results that have been generated. Resolved when the all tool executions are finished.
+     */
+  readonly toolResults: Promise<ToToolResult<TOOLS>[]>;
+
+  /**
+  Optional raw response data.
+     */
+  readonly rawResponse?: {
+    /**
+  Response headers.
+       */
+    headers?: Record<string, string>;
+  };
+
+  /**
+  A text stream that returns only the generated text deltas. You can use it
+  as either an AsyncIterable or a ReadableStream. When an error occurs, the
+  stream will throw the error.
+     */
+  readonly textStream: AsyncIterableStream<string>;
+
+  /**
+  A stream with all events, including text deltas, tool calls, tool results, and
+  errors.
+  You can use it as either an AsyncIterable or a ReadableStream.
+  Only errors that stop the stream, such as network errors, are thrown.
+     */
+  readonly fullStream: AsyncIterableStream<TextStreamPart<TOOLS>>;
+
+  /**
+  Converts the result to an `AIStream` object that is compatible with `StreamingTextResponse`.
+  It can be used with the `useChat` and `useCompletion` hooks.
+
+  @param callbacks
+  Stream callbacks that will be called when the stream emits events.
+
+  @returns an `AIStream` object.
+     */
+  toAIStream(
+    callbacks?: AIStreamCallbacksAndOptions,
+  ): ReadableStream<Uint8Array>;
+
+  /**
+  Writes stream data output to a Node.js response-like object.
+  It sets a `Content-Type` header to `text/plain; charset=utf-8` and
+  writes each stream data part as a separate chunk.
+
+  @param response A Node.js response-like object (ServerResponse).
+  @param init Optional headers and status code.
+     */
+  pipeAIStreamToResponse(
+    response: ServerResponse,
+    init?: { headers?: Record<string, string>; status?: number },
+  ): void;
+
+  /**
+  Writes text delta output to a Node.js response-like object.
+  It sets a `Content-Type` header to `text/plain; charset=utf-8` and
+  writes each text delta as a separate chunk.
+
+  @param response A Node.js response-like object (ServerResponse).
+  @param init Optional headers and status code.
+     */
+  pipeTextStreamToResponse(
+    response: ServerResponse,
+    init?: { headers?: Record<string, string>; status?: number },
+  ): void;
+
+  /**
+  Converts the result to a streamed response object with a stream data part stream.
+  It can be used with the `useChat` and `useCompletion` hooks.
+
+  @param options An object with an init property (ResponseInit) and a data property.
+  You can also pass in a ResponseInit directly (deprecated).
+
+  @return A response object.
+     */
+  toAIStreamResponse(
+    options?: ResponseInit | { init?: ResponseInit; data?: StreamData },
+  ): Response;
+
+  /**
+  Creates a simple text stream response.
+  Each text delta is encoded as UTF-8 and sent as a separate chunk.
+  Non-text-delta events are ignored.
+
+  @param init Optional headers and status code.
+     */
+  toTextStreamResponse(init?: ResponseInit): Response;
+}

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -3,6 +3,7 @@ import { ServerResponse } from 'node:http';
 import {
   AIStreamCallbacksAndOptions,
   StreamData,
+  TextStreamPart,
   formatStreamPart,
 } from '../../streams';
 import { CallSettings } from '../prompt/call-settings';
@@ -21,7 +22,6 @@ import {
   CoreToolChoice,
   FinishReason,
   LanguageModel,
-  LogProbs,
 } from '../types';
 import { CompletionTokenUsage } from '../types/token-usage';
 import {
@@ -237,43 +237,6 @@ Warnings from the model provider (e.g. unsupported settings).
     },
   });
 }
-
-export type TextStreamPart<TOOLS extends Record<string, CoreTool>> =
-  | {
-      type: 'text-delta';
-      textDelta: string;
-    }
-  | ({
-      type: 'tool-call';
-    } & ToToolCall<TOOLS>)
-  | {
-      type: 'tool-call-streaming-start';
-      toolCallId: string;
-      toolName: string;
-    }
-  | {
-      type: 'tool-call-delta';
-      toolCallId: string;
-      toolName: string;
-      argsTextDelta: string;
-    }
-  | ({
-      type: 'tool-result';
-    } & ToToolResult<TOOLS>)
-  | {
-      type: 'finish';
-      finishReason: FinishReason;
-      logprobs?: LogProbs;
-      usage: {
-        promptTokens: number;
-        completionTokens: number;
-        totalTokens: number;
-      };
-    }
-  | {
-      type: 'error';
-      error: unknown;
-    };
 
 class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
   implements StreamTextResult<TOOLS>

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -32,9 +32,9 @@ import { mergeStreams } from '../util/merge-streams';
 import { prepareResponseHeaders } from '../util/prepare-response-headers';
 import { retryWithExponentialBackoff } from '../util/retry-with-exponential-backoff';
 import { runToolsTransformation } from './run-tools-transformation';
+import { StreamTextResult } from './stream-text-result';
 import { ToToolCall } from './tool-call';
 import { ToToolResult } from './tool-result';
-import { StreamTextResult } from './stream-text-result';
 
 /**
 Generate a text and call tools for a given prompt using a language model.


### PR DESCRIPTION
Separates result interface specification (for external usage) from implementation (internal only) for AI core functions.

## Background
The usage of the result objects as classes (constructor calls) is internal functionality.

## Tasks

- [x] implementation
   - [x] generateText
   - [x] streamText
   - [x] generateObject
   - [x] streamObject
   - [x] embed
   - [x] embedMany
- [x] changeset