### PR TITLE
feat (ai/core): add response format option to streamText / generateText

### DIFF
--- a/examples/ai-core/src/generate-text/openai-json.ts
+++ b/examples/ai-core/src/generate-text/openai-json.ts
@@ -1,0 +1,20 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const { text, usage } = await generateText({
+    model: openai('gpt-3.5-turbo'),
+    experimental_responseFormat: { type: 'json' },
+    prompt:
+      'Invent a new holiday and describe its traditions. Response with JSON.',
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Usage:', usage);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/mistral-json.ts
+++ b/examples/ai-core/src/stream-text/mistral-json.ts
@@ -1,0 +1,27 @@
+import { mistral } from '@ai-sdk/mistral';
+import { streamText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const result = await streamText({
+    model: mistral('open-mistral-7b'),
+    maxTokens: 512,
+    temperature: 0.3,
+    maxRetries: 5,
+    experimental_responseFormat: { type: 'json' },
+    prompt:
+      'Invent a new holiday and describe its traditions. Response with JSON.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-json.ts
+++ b/examples/ai-core/src/stream-text/openai-json.ts
@@ -1,0 +1,27 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const result = await streamText({
+    model: openai('gpt-3.5-turbo'),
+    maxTokens: 512,
+    temperature: 0.3,
+    maxRetries: 5,
+    experimental_responseFormat: { type: 'json' },
+    prompt:
+      'Invent a new holiday and describe its traditions. Response with JSON.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/core/core/generate-text/generate-text.ts
+++ b/packages/core/core/generate-text/generate-text.ts
@@ -81,6 +81,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
   experimental_telemetry: telemetry,
+  experimental_responseFormat: responseFormat,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -117,6 +118,11 @@ case of misconfigured tools.
 By default, it's set to 0, which will disable the feature.
      */
     maxToolRoundtrips?: number;
+
+    /**
+The response format. Can be either text or json.
+     */
+    experimental_responseFormat?: { type: 'text' } | { type: 'json' };
 
     /**
      * Optional telemetry configuration (experimental).
@@ -189,6 +195,7 @@ By default, it's set to 0, which will disable the feature.
               const result = await model.doGenerate({
                 mode,
                 ...callSettings,
+                responseFormat,
                 inputFormat: currentInputFormat,
                 prompt: promptMessages,
                 abortSignal,

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -91,6 +91,7 @@ export async function streamText<TOOLS extends Record<string, CoreTool>>({
   headers,
   experimental_telemetry: telemetry,
   experimental_toolCallStreaming: toolCallStreaming = false,
+  experimental_responseFormat: responseFormat,
   onFinish,
   ...settings
 }: CallSettings &
@@ -109,6 +110,11 @@ The tools that the model can call. The model needs to support calling tools.
 The tool choice strategy. Default: 'auto'.
      */
     toolChoice?: CoreToolChoice<TOOLS>;
+
+    /**
+The response format. Can be either text or json.
+     */
+    experimental_responseFormat?: { type: 'text' } | { type: 'json' };
 
     /**
 Optional telemetry configuration (experimental).
@@ -210,6 +216,7 @@ Warnings from the model provider (e.g. unsupported settings).
                   ...prepareToolsAndToolChoice({ tools, toolChoice }),
                 },
                 ...prepareCallSettings(settings),
+                responseFormat,
                 inputFormat: validatedPrompt.type,
                 prompt: promptMessages,
                 abortSignal,


### PR DESCRIPTION
## Status
On hold. Unclear if this is desired, vs changing / adjusting generateObject.