### PR TITLE
fix (examples): typo use-chat-attachments-url (next-openai)

### DIFF
--- a/examples/next-openai/app/use-chat-attachments-url/page.tsx
+++ b/examples/next-openai/app/use-chat-attachments-url/page.tsx
@@ -83,7 +83,7 @@ export default function Page() {
               for (const file of Array.from(event.target.files)) {
                 const blob = await upload(file.name, file, {
                   access: 'public',
-                  handleUploadUrl: '/api/file',
+                  handleUploadUrl: '/api/files',
                 });
 
                 setAttachments(prevAttachments => [


### PR DESCRIPTION
Fix typo in use-chat-attachments-url next-openai example.

- blob upload method was calling a wrong "handleUploadUrl" route. 