### PR TITLE
feat (ui): invoke useChat onFinish with finishReason and tokens

### DIFF
--- a/.changeset/nice-ads-boil.md
+++ b/.changeset/nice-ads-boil.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/ui-utils': patch
+'@ai-sdk/svelte': patch
+'@ai-sdk/react': patch
+'@ai-sdk/solid': patch
+'ai': patch
+'@ai-sdk/vue': patch
+---
+
+feat (ui): invoke useChat onFinish with finishReason and tokens

--- a/content/docs/05-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/05-ai-sdk-ui/02-chatbot.mdx
@@ -263,7 +263,13 @@ When the user clicks the "Regenerate" button, the AI provider will regenerate th
 
 ## Event Callbacks
 
-`useChat` also provides optional event callbacks that you can use to handle different stages of the chatbot lifecycle. These callbacks can be used to trigger additional actions, such as logging, analytics, or custom UI updates.
+`useChat` provides optional event callbacks that you can use to handle different stages of the chatbot lifecycle:
+
+- `onFinish`: Called when the assistant message is completed
+- `onError`: Called when an error occurs during the fetch request.
+- `onResponse`: Called when the response from the API is received.
+
+These callbacks can be used to trigger additional actions, such as logging, analytics, or custom UI updates.
 
 ```tsx
 import { Message } from 'ai/react';
@@ -271,14 +277,16 @@ import { Message } from 'ai/react';
 const {
   /* ... */
 } = useChat({
-  onResponse: (response: Response) => {
-    console.log('Received response from server:', response);
-  },
-  onFinish: (message: Message) => {
+  onFinish: (message, { usage, finishReason }) => {
     console.log('Finished streaming message:', message);
+    console.log('Token usage:', usage);
+    console.log('Finish reason:', finishReason);
   },
-  onError: (error: Error) => {
+  onError: error => {
     console.error('An error occurred:', error);
+  },
+  onResponse: response => {
+    console.log('Received HTTP response from server:', response);
   },
 });
 ```

--- a/content/docs/07-reference/ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/ai-sdk-ui/01-use-chat.mdx
@@ -79,9 +79,49 @@ Allows you to easily create a conversational user interface for your chatbot app
     },
     {
       name: 'onFinish',
-      type: '(message: Message) => void',
+      type: '(message: Message, options: OnFinishOptions) => void',
       description:
         'An optional callback function that is called when the completion stream ends.',
+      properties: [
+        {
+          type: 'OnFinishOptions',
+          parameters: [
+            {
+              name: 'usage',
+              type: 'CompletionTokenUsage',
+              description: 'The token usage for the completion.',
+              properties: [
+                {
+                  type: 'CompletionTokenUsage',
+                  parameters: [
+                    {
+                      name: 'promptTokens',
+                      type: 'number',
+                      description: 'The total number of tokens in the prompt.',
+                    },
+                    {
+                      name: 'completionTokens',
+                      type: 'number',
+                      description:
+                        'The total number of tokens in the completion.',
+                    },
+                    {
+                      name: 'totalTokens',
+                      type: 'number',
+                      description: 'The total number of tokens generated.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'finishReason',
+              type: "'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other' | 'unknown'",
+              description: 'The reason why the generation ended.',
+            },
+          ],
+        },
+      ],
     },
     {
       name: 'onError',

--- a/examples/next-openai/app/page.tsx
+++ b/examples/next-openai/app/page.tsx
@@ -14,6 +14,10 @@ export default function Chat() {
     stop,
   } = useChat({
     keepLastMessageOnError: true,
+    onFinish(message, { usage, finishReason }) {
+      console.log('Usage', usage);
+      console.log('FinishReason', finishReason);
+    },
   });
 
   return (

--- a/examples/nuxt-openai/pages/index.vue
+++ b/examples/nuxt-openai/pages/index.vue
@@ -5,6 +5,10 @@ import { computed } from 'vue';
 const { error, input, isLoading, handleSubmit, messages, reload, stop } =
   useChat({
     keepLastMessageOnError: true,
+    onFinish(message, { usage, finishReason }) {
+      console.log('Usage', usage);
+      console.log('FinishReason', finishReason);
+    },
   });
 const disabled = computed(() => isLoading.value || error.value != null);
 </script>

--- a/examples/solidstart-openai/src/routes/index.tsx
+++ b/examples/solidstart-openai/src/routes/index.tsx
@@ -13,6 +13,10 @@ export default function Chat() {
     stop,
   } = useChat({
     keepLastMessageOnError: true,
+    onFinish(message, { usage, finishReason }) {
+      console.log('Usage', usage);
+      console.log('FinishReason', finishReason);
+    },
   });
 
   return (

--- a/examples/sveltekit-openai/src/routes/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/+page.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
   import { useChat } from '@ai-sdk/svelte';
 
-  const {    
+  const {
      error,
     input,
     isLoading,
     handleSubmit,
     messages,
     reload,
-    stop 
+    stop
   } = useChat({
     keepLastMessageOnError: true,
+    onFinish(message, { usage, finishReason }) {
+      console.log('Usage', usage);
+      console.log('FinishReason', finishReason);
+    },
   });
 </script>
 

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -562,7 +562,13 @@ However, the LLM results are expected to be small enough to not cause issues.
             );
             break;
           case 'finish':
-            break; // ignored
+            controller.enqueue(
+              formatStreamPart('finish_message', {
+                finishReason: chunk.finishReason,
+                usage: chunk.usage,
+              }),
+            );
+            break;
           default: {
             const exhaustiveCheck: never = chunkType;
             throw new Error(`Unknown chunk type: ${exhaustiveCheck}`);

--- a/packages/core/core/types/token-usage.ts
+++ b/packages/core/core/types/token-usage.ts
@@ -3,7 +3,7 @@ Represents the number of tokens used in a prompt and completion.
  */
 export type CompletionTokenUsage = {
   /**
-The number of tokens used in the prompt
+The number of tokens used in the prompt.
    */
   promptTokens: number;
 

--- a/packages/core/svelte/use-chat.ts
+++ b/packages/core/svelte/use-chat.ts
@@ -82,7 +82,7 @@ const getStreamedResponse = async (
   abortControllerRef: AbortController | null,
   generateId: IdGenerator,
   streamMode: 'stream-data' | 'text' | undefined,
-  onFinish: ((message: Message) => void) | undefined,
+  onFinish: UseChatOptions['onFinish'],
   onResponse: ((response: Response) => void | Promise<void>) | undefined,
   sendExtraMessageFields: boolean | undefined,
   fetch: FetchFunction | undefined,

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -87,7 +87,7 @@ const getStreamedResponse = async (
   abortControllerRef: React.MutableRefObject<AbortController | null>,
   generateId: IdGenerator,
   streamMode: 'stream-data' | 'text' | undefined,
-  onFinish: ((message: Message) => void) | undefined,
+  onFinish: UseChatOptions['onFinish'],
   onResponse: ((response: Response) => void | Promise<void>) | undefined,
   onToolCall: UseChatOptions['onToolCall'] | undefined,
   sendExtraMessageFields: boolean | undefined,

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
 import { withTestServer } from '@ai-sdk/provider-utils/test';
-import { formatStreamPart, getTextFromDataUrl } from '@ai-sdk/ui-utils';
+import {
+  formatStreamPart,
+  getTextFromDataUrl,
+  Message,
+} from '@ai-sdk/ui-utils';
 import '@testing-library/jest-dom/vitest';
 import {
   cleanup,
@@ -14,9 +18,26 @@ import React, { useRef, useState } from 'react';
 import { useChat } from './use-chat';
 
 describe('stream data stream', () => {
+  let onFinishCalls: Array<{
+    message: Message;
+    options: {
+      finishReason: string;
+      usage: {
+        completionTokens: number;
+        promptTokens: number;
+        totalTokens: number;
+      };
+    };
+  }> = [];
+
   const TestComponent = () => {
     const [id, setId] = React.useState<string>('first-id');
-    const { messages, append, error, data, isLoading } = useChat({ id });
+    const { messages, append, error, data, isLoading } = useChat({
+      id,
+      onFinish: (message, options) => {
+        onFinishCalls.push({ message, options });
+      },
+    });
 
     return (
       <div>
@@ -48,11 +69,13 @@ describe('stream data stream', () => {
 
   beforeEach(() => {
     render(<TestComponent />);
+    onFinishCalls = [];
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     cleanup();
+    onFinishCalls = [];
   });
 
   it(
@@ -147,6 +170,54 @@ describe('stream data stream', () => {
     );
   });
 
+  it(
+    'should invoke onFinish when the stream finishes',
+    withTestServer(
+      {
+        url: '/api/chat',
+        type: 'stream-values',
+        content: [
+          formatStreamPart('text', 'Hello'),
+          formatStreamPart('text', ','),
+          formatStreamPart('text', ' world'),
+          formatStreamPart('text', '.'),
+          formatStreamPart('finish_message', {
+            finishReason: 'stop',
+            usage: {
+              completionTokens: 1,
+              promptTokens: 3,
+              totalTokens: 4,
+            },
+          }),
+        ],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append'));
+
+        await screen.findByTestId('message-1');
+
+        expect(onFinishCalls).toStrictEqual([
+          {
+            message: {
+              id: expect.any(String),
+              createdAt: expect.any(Date),
+              role: 'assistant',
+              content: 'Hello, world.',
+            },
+            options: {
+              finishReason: 'stop',
+              usage: {
+                completionTokens: 1,
+                promptTokens: 3,
+                totalTokens: 4,
+              },
+            },
+          },
+        ]);
+      },
+    ),
+  );
+
   describe('id', () => {
     it(
       'should clear out messages when the id changes',
@@ -174,8 +245,25 @@ describe('stream data stream', () => {
 });
 
 describe('text stream', () => {
+  let onFinishCalls: Array<{
+    message: Message;
+    options: {
+      finishReason: string;
+      usage: {
+        completionTokens: number;
+        promptTokens: number;
+        totalTokens: number;
+      };
+    };
+  }> = [];
+
   const TestComponent = () => {
-    const { messages, append } = useChat({ streamMode: 'text' });
+    const { messages, append } = useChat({
+      streamMode: 'text',
+      onFinish: (message, options) => {
+        onFinishCalls.push({ message, options });
+      },
+    });
 
     return (
       <div>
@@ -198,11 +286,13 @@ describe('text stream', () => {
 
   beforeEach(() => {
     render(<TestComponent />);
+    onFinishCalls = [];
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     cleanup();
+    onFinishCalls = [];
   });
 
   it(
@@ -225,6 +315,41 @@ describe('text stream', () => {
         expect(screen.getByTestId('message-1-text-stream')).toHaveTextContent(
           'AI: Hello, world.',
         );
+      },
+    ),
+  );
+
+  it(
+    'should invoke onFinish when the stream finishes',
+    withTestServer(
+      {
+        url: '/api/chat',
+        type: 'stream-values',
+        content: ['Hello', ',', ' world', '.'],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append-text-stream'));
+
+        await screen.findByTestId('message-1-text-stream');
+
+        expect(onFinishCalls).toStrictEqual([
+          {
+            message: {
+              id: expect.any(String),
+              createdAt: expect.any(Date),
+              role: 'assistant',
+              content: 'Hello, world.',
+            },
+            options: {
+              finishReason: 'unknown',
+              usage: {
+                completionTokens: NaN,
+                promptTokens: NaN,
+                totalTokens: NaN,
+              },
+            },
+          },
+        ]);
       },
     ),
   );

--- a/packages/solid/src/use-chat.ts
+++ b/packages/solid/src/use-chat.ts
@@ -98,7 +98,7 @@ const getStreamedResponse = async (
   abortController: AbortController | null,
   generateId: IdGenerator,
   streamMode: 'stream-data' | 'text' | undefined,
-  onFinish: UseChatOptions['onFinish'] | undefined,
+  onFinish: UseChatOptions['onFinish'],
   onResponse: UseChatOptions['onResponse'] | undefined,
   onToolCall: UseChatOptions['onToolCall'] | undefined,
   sendExtraMessageFields: boolean | undefined,

--- a/packages/solid/src/use-chat.ui.test.tsx
+++ b/packages/solid/src/use-chat.ui.test.tsx
@@ -1,22 +1,33 @@
 /** @jsxImportSource solid-js */
 import { withTestServer } from '@ai-sdk/provider-utils/test';
-import { formatStreamPart } from '@ai-sdk/ui-utils';
-import {
-  mockFetchDataStream,
-  mockFetchDataStreamWithGenerator,
-  mockFetchError,
-} from '@ai-sdk/ui-utils/test';
+import { formatStreamPart, Message } from '@ai-sdk/ui-utils';
+import { mockFetchDataStream } from '@ai-sdk/ui-utils/test';
 import { cleanup, findByText, render, screen } from '@solidjs/testing-library';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { For, createSignal } from 'solid-js';
+import { createSignal, For } from 'solid-js';
 import { useChat } from './use-chat';
 
 describe('stream data stream', () => {
+  let onFinishCalls: Array<{
+    message: Message;
+    options: {
+      finishReason: string;
+      usage: {
+        completionTokens: number;
+        promptTokens: number;
+        totalTokens: number;
+      };
+    };
+  }> = [];
+
   const TestComponent = () => {
     const [id, setId] = createSignal('first-id');
     const { messages, append, error, data, isLoading } = useChat(() => ({
       id: id(),
+      onFinish: (message, options) => {
+        onFinishCalls.push({ message, options });
+      },
     }));
 
     return (
@@ -50,116 +61,200 @@ describe('stream data stream', () => {
 
   beforeEach(() => {
     render(() => <TestComponent />);
+    onFinishCalls = [];
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     cleanup();
+    onFinishCalls = [];
   });
 
-  it('should show streamed response', async () => {
-    mockFetchDataStream({
-      url: 'https://example.com/api/chat',
-      chunks: ['0:"Hello"\n', '0:","\n', '0:" world"\n', '0:"."\n'],
-    });
+  it(
+    'should show streamed response',
+    withTestServer(
+      {
+        type: 'stream-values',
+        url: '/api/chat',
+        content: ['0:"Hello"\n', '0:","\n', '0:" world"\n', '0:"."\n'],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append'));
 
-    await userEvent.click(screen.getByTestId('do-append'));
+        await screen.findByTestId('message-0');
+        expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
 
-    await screen.findByTestId('message-0');
-    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+        await screen.findByTestId('message-1');
+        expect(screen.getByTestId('message-1')).toHaveTextContent(
+          'AI: Hello, world.',
+        );
+      },
+    ),
+  );
 
-    await screen.findByTestId('message-1');
-    expect(screen.getByTestId('message-1')).toHaveTextContent(
-      'AI: Hello, world.',
+  it(
+    'should show streamed response with data',
+    withTestServer(
+      {
+        type: 'stream-values',
+        url: '/api/chat',
+        content: ['2:[{"t1":"v1"}]\n', '0:"Hello"\n'],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append'));
+
+        await screen.findByTestId('data');
+        expect(screen.getByTestId('data')).toHaveTextContent('[{"t1":"v1"}]');
+
+        await screen.findByTestId('message-1');
+        expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+      },
+    ),
+  );
+
+  it(
+    'should show error response',
+    withTestServer(
+      { type: 'error', url: '/api/chat', status: 404, content: 'Not found' },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append'));
+
+        await screen.findByTestId('error');
+        expect(screen.getByTestId('error')).toHaveTextContent(
+          'Error: Not found',
+        );
+      },
+    ),
+  );
+
+  describe('loading state', () => {
+    it(
+      'should show loading state',
+      withTestServer(
+        { url: '/api/chat', type: 'controlled-stream' },
+        async ({ streamController }) => {
+          streamController.enqueue('0:"Hello"\n');
+
+          await userEvent.click(screen.getByTestId('do-append'));
+
+          await screen.findByTestId('loading');
+          expect(screen.getByTestId('loading')).toHaveTextContent('true');
+
+          streamController.close();
+
+          await findByText(await screen.findByTestId('loading'), 'false');
+          expect(screen.getByTestId('loading')).toHaveTextContent('false');
+        },
+      ),
+    );
+
+    it(
+      'should reset loading state on error',
+      withTestServer(
+        { type: 'error', url: '/api/chat', status: 404, content: 'Not found' },
+        async () => {
+          await userEvent.click(screen.getByTestId('do-append'));
+
+          await screen.findByTestId('loading');
+          expect(screen.getByTestId('loading')).toHaveTextContent('false');
+        },
+      ),
     );
   });
 
-  it('should show streamed response with data', async () => {
-    mockFetchDataStream({
-      url: 'https://example.com/api/chat',
-      chunks: ['2:[{"t1":"v1"}]\n', '0:"Hello"\n'],
-    });
+  it(
+    'should invoke onFinish when the stream finishes',
+    withTestServer(
+      {
+        url: '/api/chat',
+        type: 'stream-values',
+        content: [
+          formatStreamPart('text', 'Hello'),
+          formatStreamPart('text', ','),
+          formatStreamPart('text', ' world'),
+          formatStreamPart('text', '.'),
+          formatStreamPart('finish_message', {
+            finishReason: 'stop',
+            usage: {
+              completionTokens: 1,
+              promptTokens: 3,
+              totalTokens: 4,
+            },
+          }),
+        ],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append'));
 
-    await userEvent.click(screen.getByTestId('do-append'));
+        await screen.findByTestId('message-1');
 
-    await screen.findByTestId('data');
-    expect(screen.getByTestId('data')).toHaveTextContent('[{"t1":"v1"}]');
-
-    await screen.findByTestId('message-1');
-    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
-  });
-
-  it('should show error response', async () => {
-    mockFetchError({ statusCode: 404, errorMessage: 'Not found' });
-
-    await userEvent.click(screen.getByTestId('do-append'));
-
-    await screen.findByTestId('error');
-    expect(screen.getByTestId('error')).toHaveTextContent('Error: Not found');
-  });
-
-  describe('loading state', () => {
-    it('should show loading state', async () => {
-      let finishGeneration: ((value?: unknown) => void) | undefined;
-      const finishGenerationPromise = new Promise(resolve => {
-        finishGeneration = resolve;
-      });
-
-      mockFetchDataStreamWithGenerator({
-        url: 'https://example.com/api/chat',
-        chunkGenerator: (async function* generate() {
-          const encoder = new TextEncoder();
-          yield encoder.encode('0:"Hello"\n');
-          await finishGenerationPromise;
-        })(),
-      });
-
-      await userEvent.click(screen.getByTestId('do-append'));
-
-      await screen.findByTestId('loading');
-      expect(screen.getByTestId('loading')).toHaveTextContent('true');
-
-      finishGeneration?.();
-
-      await findByText(await screen.findByTestId('loading'), 'false');
-      expect(screen.getByTestId('loading')).toHaveTextContent('false');
-    });
-
-    it('should reset loading state on error', async () => {
-      mockFetchError({ statusCode: 404, errorMessage: 'Not found' });
-
-      await userEvent.click(screen.getByTestId('do-append'));
-
-      await screen.findByTestId('loading');
-      expect(screen.getByTestId('loading')).toHaveTextContent('false');
-    });
-  });
+        expect(onFinishCalls).toStrictEqual([
+          {
+            message: {
+              id: expect.any(String),
+              createdAt: expect.any(Date),
+              role: 'assistant',
+              content: 'Hello, world.',
+            },
+            options: {
+              finishReason: 'stop',
+              usage: {
+                completionTokens: 1,
+                promptTokens: 3,
+                totalTokens: 4,
+              },
+            },
+          },
+        ]);
+      },
+    ),
+  );
 
   describe('id', () => {
-    it('should clear out messages when the id changes', async () => {
-      mockFetchDataStream({
-        url: 'https://example.com/api/chat',
-        chunks: ['0:"Hello"\n', '0:","\n', '0:" world"\n', '0:"."\n'],
-      });
+    it(
+      'should clear out messages when the id changes',
+      withTestServer(
+        {
+          url: '/api/chat',
+          type: 'stream-values',
+          content: ['0:"Hello"\n', '0:","\n', '0:" world"\n', '0:"."\n'],
+        },
+        async () => {
+          await userEvent.click(screen.getByTestId('do-append'));
 
-      await userEvent.click(screen.getByTestId('do-append'));
+          await screen.findByTestId('message-1');
+          expect(screen.getByTestId('message-1')).toHaveTextContent(
+            'AI: Hello, world.',
+          );
 
-      await screen.findByTestId('message-1');
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        'AI: Hello, world.',
-      );
+          await userEvent.click(screen.getByTestId('do-change-id'));
 
-      await userEvent.click(screen.getByTestId('do-change-id'));
-
-      expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
-    });
+          expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+        },
+      ),
+    );
   });
 });
 
 describe('text stream', () => {
+  let onFinishCalls: Array<{
+    message: Message;
+    options: {
+      finishReason: string;
+      usage: {
+        completionTokens: number;
+        promptTokens: number;
+        totalTokens: number;
+      };
+    };
+  }> = [];
+
   const TestComponent = () => {
     const { messages, append } = useChat(() => ({
       streamMode: 'text',
+      onFinish: (message, options) => {
+        onFinishCalls.push({ message, options });
+      },
     }));
 
     return (
@@ -185,31 +280,73 @@ describe('text stream', () => {
 
   beforeEach(() => {
     render(() => <TestComponent />);
+    onFinishCalls = [];
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     cleanup();
+    onFinishCalls = [];
   });
 
-  it('should show streamed response', async () => {
-    mockFetchDataStream({
-      url: 'https://example.com/api/chat',
-      chunks: ['Hello', ',', ' world', '.'],
-    });
+  it(
+    'should show streamed response',
+    withTestServer(
+      {
+        url: '/api/chat',
+        type: 'stream-values',
+        content: ['Hello', ',', ' world', '.'],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append-text-stream'));
 
-    await userEvent.click(screen.getByTestId('do-append-text-stream'));
+        await screen.findByTestId('message-0-text-stream');
+        expect(screen.getByTestId('message-0-text-stream')).toHaveTextContent(
+          'User: hi',
+        );
 
-    await screen.findByTestId('message-0-text-stream');
-    expect(screen.getByTestId('message-0-text-stream')).toHaveTextContent(
-      'User: hi',
-    );
+        await screen.findByTestId('message-1-text-stream');
+        expect(screen.getByTestId('message-1-text-stream')).toHaveTextContent(
+          'AI: Hello, world.',
+        );
+      },
+    ),
+  );
 
-    await screen.findByTestId('message-1-text-stream');
-    expect(screen.getByTestId('message-1-text-stream')).toHaveTextContent(
-      'AI: Hello, world.',
-    );
-  });
+  it(
+    'should invoke onFinish when the stream finishes',
+    withTestServer(
+      {
+        url: '/api/chat',
+        type: 'stream-values',
+        content: ['Hello', ',', ' world', '.'],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append-text-stream'));
+
+        await screen.findByTestId('message-1-text-stream');
+
+        expect(onFinishCalls).toStrictEqual([
+          {
+            message: {
+              id: expect.any(String),
+              createdAt: expect.any(Date),
+              role: 'assistant',
+              content: 'Hello, world.',
+            },
+            options: {
+              finishReason: 'unknown',
+              usage: {
+                completionTokens: NaN,
+                promptTokens: NaN,
+                totalTokens: NaN,
+              },
+            },
+          },
+        ]);
+      },
+    ),
+  );
 });
 
 describe('onToolCall', () => {

--- a/packages/svelte/src/use-chat.ts
+++ b/packages/svelte/src/use-chat.ts
@@ -82,7 +82,7 @@ const getStreamedResponse = async (
   abortControllerRef: AbortController | null,
   generateId: IdGenerator,
   streamMode: 'stream-data' | 'text' | undefined,
-  onFinish: ((message: Message) => void) | undefined,
+  onFinish: UseChatOptions['onFinish'],
   onResponse: ((response: Response) => void | Promise<void>) | undefined,
   sendExtraMessageFields: boolean | undefined,
   fetch: FetchFunction | undefined,

--- a/packages/ui-utils/package.json
+++ b/packages/ui-utils/package.json
@@ -36,6 +36,7 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/provider": "0.0.14",
     "@ai-sdk/provider-utils": "1.0.5",
     "secure-json-parse": "2.7.0"
   },

--- a/packages/ui-utils/src/call-chat-api.ts
+++ b/packages/ui-utils/src/call-chat-api.ts
@@ -118,17 +118,9 @@ export async function callChatApi({
           abortController != null ? { current: abortController() } : undefined,
         update: onUpdate,
         onToolCall,
-        onFinish(prefixMap) {
+        onFinish({ prefixMap, finishReason, usage }) {
           if (onFinish && prefixMap.text != null) {
-            // TODO
-            onFinish(prefixMap.text, {
-              usage: {
-                completionTokens: 0,
-                promptTokens: 0,
-                totalTokens: 0,
-              },
-              finishReason: 'stop',
-            });
+            onFinish(prefixMap.text, { usage, finishReason });
           }
         },
         generateId,

--- a/packages/ui-utils/src/duplicated/token-usage.ts
+++ b/packages/ui-utils/src/duplicated/token-usage.ts
@@ -1,0 +1,40 @@
+/**
+Represents the number of tokens used in a prompt and completion.
+ */
+export type CompletionTokenUsage = {
+  /**
+The number of tokens used in the prompt
+   */
+  promptTokens: number;
+
+  /**
+The number of tokens used in the completion.
+ */
+  completionTokens: number;
+
+  /**
+The total number of tokens used (promptTokens + completionTokens).
+   */
+  totalTokens: number;
+};
+
+/**
+Represents the number of tokens used in an embedding.
+ */
+export type EmbeddingTokenUsage = {
+  /**
+The number of tokens used in the embedding.
+   */
+  tokens: number;
+};
+
+export function calculateCompletionTokenUsage(usage: {
+  promptTokens: number;
+  completionTokens: number;
+}): CompletionTokenUsage {
+  return {
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    totalTokens: usage.promptTokens + usage.completionTokens,
+  };
+}

--- a/packages/ui-utils/src/duplicated/token-usage.ts
+++ b/packages/ui-utils/src/duplicated/token-usage.ts
@@ -3,7 +3,7 @@ Represents the number of tokens used in a prompt and completion.
  */
 export type CompletionTokenUsage = {
   /**
-The number of tokens used in the prompt
+The number of tokens used in the prompt.
    */
   promptTokens: number;
 

--- a/packages/ui-utils/src/stream-parts.test.ts
+++ b/packages/ui-utils/src/stream-parts.test.ts
@@ -195,3 +195,27 @@ describe('tool_call_delta stream part', () => {
     });
   });
 });
+
+describe('finish_message stream part', () => {
+  it('should format a finish_message stream part', () => {
+    expect(
+      formatStreamPart('finish_message', {
+        finishReason: 'stop',
+        usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+      }),
+    ).toEqual(
+      `d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20,"totalTokens":30}}\n`,
+    );
+  });
+
+  it('should parse a finish_message stream part', () => {
+    const input = `d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20,"totalTokens":30}}`;
+    expect(parseStreamPart(input)).toEqual({
+      type: 'finish_message',
+      value: {
+        finishReason: 'stop',
+        usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+      },
+    });
+  });
+});

--- a/packages/ui-utils/src/stream-parts.ts
+++ b/packages/ui-utils/src/stream-parts.ts
@@ -1,3 +1,4 @@
+import { LanguageModelV1FinishReason } from '@ai-sdk/provider';
 import { ToolCall as CoreToolCall } from './duplicated/tool-call';
 import { ToolResult as CoreToolResult } from './duplicated/tool-result';
 import {
@@ -362,6 +363,55 @@ const toolCallDeltaStreamPart: StreamPart<
   },
 };
 
+const finishMessageStreamPart: StreamPart<
+  'd',
+  'finish_message',
+  {
+    finishReason: LanguageModelV1FinishReason;
+    usage: {
+      promptTokens: number;
+      completionTokens: number;
+      totalTokens: number;
+    };
+  }
+> = {
+  code: 'd',
+  name: 'finish_message',
+  parse: (value: JSONValue) => {
+    if (
+      value == null ||
+      typeof value !== 'object' ||
+      !('finishReason' in value) ||
+      typeof value.finishReason !== 'string' ||
+      !('usage' in value) ||
+      value.usage == null ||
+      typeof value.usage !== 'object' ||
+      !('promptTokens' in value.usage) ||
+      typeof value.usage.promptTokens !== 'number' ||
+      !('completionTokens' in value.usage) ||
+      typeof value.usage.completionTokens !== 'number' ||
+      !('totalTokens' in value.usage) ||
+      typeof value.usage.totalTokens !== 'number'
+    ) {
+      throw new Error(
+        '"finish_message" parts expect an object with a "finishReason" and "usage" property.',
+      );
+    }
+
+    return {
+      type: 'finish_message',
+      value: value as unknown as {
+        finishReason: LanguageModelV1FinishReason;
+        usage: {
+          promptTokens: number;
+          completionTokens: number;
+          totalTokens: number;
+        };
+      },
+    };
+  },
+};
+
 const streamParts = [
   textStreamPart,
   functionCallStreamPart,
@@ -376,6 +426,7 @@ const streamParts = [
   toolResultStreamPart,
   toolCallStreamingStartStreamPart,
   toolCallDeltaStreamPart,
+  finishMessageStreamPart,
 ] as const;
 
 // union type of all stream parts
@@ -392,7 +443,8 @@ type StreamParts =
   | typeof toolCallStreamPart
   | typeof toolResultStreamPart
   | typeof toolCallStreamingStartStreamPart
-  | typeof toolCallDeltaStreamPart;
+  | typeof toolCallDeltaStreamPart
+  | typeof finishMessageStreamPart;
 
 /**
  * Maps the type of a stream part to its value type.
@@ -414,7 +466,8 @@ export type StreamPartType =
   | ReturnType<typeof toolCallStreamPart.parse>
   | ReturnType<typeof toolResultStreamPart.parse>
   | ReturnType<typeof toolCallStreamingStartStreamPart.parse>
-  | ReturnType<typeof toolCallDeltaStreamPart.parse>;
+  | ReturnType<typeof toolCallDeltaStreamPart.parse>
+  | ReturnType<typeof finishMessageStreamPart.parse>;
 
 export const streamPartsByCode = {
   [textStreamPart.code]: textStreamPart,
@@ -430,6 +483,7 @@ export const streamPartsByCode = {
   [toolResultStreamPart.code]: toolResultStreamPart,
   [toolCallStreamingStartStreamPart.code]: toolCallStreamingStartStreamPart,
   [toolCallDeltaStreamPart.code]: toolCallDeltaStreamPart,
+  [finishMessageStreamPart.code]: finishMessageStreamPart,
 } as const;
 
 /**
@@ -469,6 +523,7 @@ export const StreamStringPrefixes = {
   [toolCallStreamingStartStreamPart.name]:
     toolCallStreamingStartStreamPart.code,
   [toolCallDeltaStreamPart.name]: toolCallDeltaStreamPart.code,
+  [finishMessageStreamPart.name]: finishMessageStreamPart.code,
 } as const;
 
 export const validCodes = streamParts.map(part => part.code);

--- a/packages/ui-utils/src/types.ts
+++ b/packages/ui-utils/src/types.ts
@@ -1,5 +1,7 @@
 import { ToolCall as CoreToolCall } from './duplicated/tool-call';
 import { ToolResult as CoreToolResult } from './duplicated/tool-result';
+import { CompletionTokenUsage } from './duplicated/token-usage';
+import { LanguageModelV1FinishReason } from '@ai-sdk/provider';
 
 export * from './use-assistant-types';
 
@@ -426,9 +428,19 @@ either synchronously or asynchronously.
   onResponse?: (response: Response) => void | Promise<void>;
 
   /**
-   * Callback function to be called when the chat is finished streaming.
+   * Optional callback function that is called when the assistant message is finished streaming.
+   *
+   * @param message The message that was streamed.
+   * @param options.usage The token usage of the message.
+   * @param options.finishReason The finish reason of the message.
    */
-  onFinish?: (message: Message) => void;
+  onFinish?: (
+    message: Message,
+    options: {
+      usage: CompletionTokenUsage;
+      finishReason: LanguageModelV1FinishReason;
+    },
+  ) => void;
 
   /**
    * Callback function to be called when an error is encountered.
@@ -559,7 +571,7 @@ or to provide a custom fetch implementation for e.g. testing.
 };
 
 /**
-A JSON value can be a string, number, boolean, object, array, or null. 
+A JSON value can be a string, number, boolean, object, array, or null.
 JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods.
  */
 export type JSONValue =

--- a/packages/vue/src/TestChatComponent.vue
+++ b/packages/vue/src/TestChatComponent.vue
@@ -1,7 +1,23 @@
 <script setup lang="ts">
 import { useChat } from './use-chat';
 
-const { messages, append, data, error, isLoading } = useChat();
+const onFinishCalls: Array<{
+  message: Message;
+  options: {
+    finishReason: string;
+    usage: {
+      completionTokens: number;
+      promptTokens: number;
+      totalTokens: number;
+    };
+  };
+}> = [];
+
+const { messages, append, data, error, isLoading } = useChat({
+  onFinish: (message, options) => {
+    onFinishCalls.push({ message, options });
+  },
+});
 </script>
 
 <template>
@@ -19,8 +35,10 @@ const { messages, append, data, error, isLoading } = useChat();
     </div>
 
     <button
-      data-testid="button"
+      data-testid="do-append"
       @click="append({ role: 'user', content: 'hi' })"
     />
+
+    <div data-testid="on-finish-calls">{{ JSON.stringify(onFinishCalls) }}</div>
   </div>
 </template>

--- a/packages/vue/src/TestChatTextStreamComponent.vue
+++ b/packages/vue/src/TestChatTextStreamComponent.vue
@@ -1,8 +1,23 @@
 <script setup lang="ts">
 import { useChat } from './use-chat';
 
+const onFinishCalls: Array<{
+  message: Message;
+  options: {
+    finishReason: string;
+    usage: {
+      completionTokens: number;
+      promptTokens: number;
+      totalTokens: number;
+    };
+  };
+}> = [];
+
 const { messages, append, data, error, isLoading } = useChat({
   streamMode: 'text',
+  onFinish: (message, options) => {
+    onFinishCalls.push({ message, options });
+  },
 });
 </script>
 
@@ -21,8 +36,10 @@ const { messages, append, data, error, isLoading } = useChat({
     </div>
 
     <button
-      data-testid="button"
+      data-testid="do-append"
       @click="append({ role: 'user', content: 'hi' })"
     />
+
+    <div data-testid="on-finish-calls">{{ JSON.stringify(onFinishCalls) }}</div>
   </div>
 </template>

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -193,11 +193,11 @@ export function useChat({
               mutate([...chatRequest.messages, ...merged]);
               streamData.value = [...existingData, ...(data ?? [])];
             },
-            onFinish(message) {
+            onFinish(message, options) {
               // workaround: sometimes the last chunk is not shown in the UI.
               // push it twice to make sure it's displayed.
               mutate([...chatRequest.messages, message]);
-              onFinish?.(message);
+              onFinish?.(message, options);
             },
             restoreMessagesOnFailure() {
               // Restore the previous messages if the request fails.

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -30,7 +30,7 @@ describe('stream data stream', () => {
       chunks: ['0:"Hello"\n', '0:","\n', '0:" world"\n', '0:"."\n'],
     });
 
-    await userEvent.click(screen.getByTestId('button'));
+    await userEvent.click(screen.getByTestId('do-append'));
 
     await screen.findByTestId('message-0');
     expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
@@ -47,7 +47,7 @@ describe('stream data stream', () => {
       chunks: ['2:[{"t1":"v1"}]\n', '0:"Hello"\n'],
     });
 
-    await userEvent.click(screen.getByTestId('button'));
+    await userEvent.click(screen.getByTestId('do-append'));
 
     await screen.findByTestId('data');
     expect(screen.getByTestId('data')).toHaveTextContent('[{"t1":"v1"}]');
@@ -59,7 +59,7 @@ describe('stream data stream', () => {
   it('should show error response', async () => {
     mockFetchError({ statusCode: 404, errorMessage: 'Not found' });
 
-    await userEvent.click(screen.getByTestId('button'));
+    await userEvent.click(screen.getByTestId('do-append'));
 
     // TODO bug? the user message does not show up
     // await screen.findByTestId('message-0');
@@ -85,7 +85,7 @@ describe('stream data stream', () => {
         })(),
       });
 
-      await userEvent.click(screen.getByTestId('button'));
+      await userEvent.click(screen.getByTestId('do-append'));
 
       await screen.findByTestId('loading');
       expect(screen.getByTestId('loading')).toHaveTextContent('true');
@@ -100,12 +100,62 @@ describe('stream data stream', () => {
     it('should reset loading state on error', async () => {
       mockFetchError({ statusCode: 404, errorMessage: 'Not found' });
 
-      await userEvent.click(screen.getByTestId('button'));
+      await userEvent.click(screen.getByTestId('do-append'));
 
       await screen.findByTestId('loading');
       expect(screen.getByTestId('loading')).toHaveTextContent('false');
     });
   });
+
+  it(
+    'should invoke onFinish when the stream finishes',
+    withTestServer(
+      {
+        url: '/api/chat',
+        type: 'stream-values',
+        content: [
+          formatStreamPart('text', 'Hello'),
+          formatStreamPart('text', ','),
+          formatStreamPart('text', ' world'),
+          formatStreamPart('text', '.'),
+          formatStreamPart('finish_message', {
+            finishReason: 'stop',
+            usage: {
+              completionTokens: 1,
+              promptTokens: 3,
+              totalTokens: 4,
+            },
+          }),
+        ],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append'));
+
+        await screen.findByTestId('message-1');
+
+        const onFinishCalls = screen.getByTestId('on-finish-calls');
+        const onFinishCallsText = onFinishCalls.textContent ?? '';
+        expect(JSON.parse(onFinishCallsText)).toStrictEqual([
+          {
+            message: {
+              id: expect.any(String),
+              createdAt: expect.any(String),
+              role: 'assistant',
+              content: 'Hello, world.',
+            },
+            options: {
+              finishReason: 'stop',
+              usage: {
+                completionTokens: 1,
+                promptTokens: 3,
+                totalTokens: 4,
+              },
+            },
+          },
+        ]);
+      },
+    ),
+  );
 });
 
 describe('text stream', () => {
@@ -124,7 +174,7 @@ describe('text stream', () => {
       chunks: ['Hello', ',', ' world', '.'],
     });
 
-    await userEvent.click(screen.getByTestId('button'));
+    await userEvent.click(screen.getByTestId('do-append'));
 
     await screen.findByTestId('message-0');
     expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
@@ -134,6 +184,44 @@ describe('text stream', () => {
       'AI: Hello, world.',
     );
   });
+
+  it(
+    'should invoke onFinish when the stream finishes',
+    withTestServer(
+      {
+        url: '/api/chat',
+        type: 'stream-values',
+        content: ['Hello', ',', ' world', '.'],
+      },
+      async () => {
+        await userEvent.click(screen.getByTestId('do-append'));
+
+        await screen.findByTestId('message-1');
+
+        const onFinishCalls = screen.getByTestId('on-finish-calls');
+        const onFinishCallsText = onFinishCalls.textContent ?? '';
+        expect(JSON.parse(onFinishCallsText)).toStrictEqual([
+          {
+            message: {
+              id: expect.any(String),
+              createdAt: expect.any(String),
+              role: 'assistant',
+              content: 'Hello, world.',
+            },
+            options: {
+              finishReason: 'unknown',
+              usage: {
+                // note: originally NaN (lost in JSON stringify)
+                completionTokens: null,
+                promptTokens: null,
+                totalTokens: null,
+              },
+            },
+          },
+        ]);
+      },
+    ),
+  );
 });
 
 describe('form actions', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1370,6 +1370,9 @@ importers:
 
   packages/ui-utils:
     dependencies:
+      '@ai-sdk/provider':
+        specifier: 0.0.14
+        version: link:../provider
       '@ai-sdk/provider-utils':
         specifier: 1.0.5
         version: link:../provider-utils


### PR DESCRIPTION
## Summary
* add second parameter to `useChat` `onFinish` callback that receives `usage` and `finishReason`
* introduce new `finish_message` stream part
* send `finish_message` stream part in `streamText.toAIStream()`

## Tasks

- [x] implementation
   - [x] interface definition
   - [x] finish message message part
   - [x] streamText send message part
   - [x] react
   - [x] vue
   - [x] svelte
   - [x] solid
- [x] examples
  - [x] next
  - [x] vue
  - [x] solid
  - [x] svelte
- [x] docs
  - [x] chatbot guide
  - [x] useChat reference
- [x] changeset