### PR TITLE
fix (docs): use `pnpm add <pkg>` instead of `pnpm install <pkg>`

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -71,7 +71,7 @@ You can install Zod with:
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install zod" dark />
+    <Snippet text="pnpm add zod" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install zod" dark />

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -50,7 +50,7 @@ Install `ai` and `@ai-sdk/openai`, the Vercel AI package and Vercel AI SDK's [ O
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet text="pnpm install ai @ai-sdk/openai zod" dark />
+      <Snippet text="pnpm add ai @ai-sdk/openai zod" dark />
     </Tab>
     <Tab>
       <Snippet text="npm install ai @ai-sdk/openai zod" dark />

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -50,7 +50,7 @@ Install `ai` and `@ai-sdk/openai`, Vercel AI SDK's OpenAI provider.
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet text="pnpm install ai @ai-sdk/openai zod" dark />
+      <Snippet text="pnpm add ai @ai-sdk/openai zod" dark />
     </Tab>
     <Tab>
       <Snippet text="npm install ai @ai-sdk/openai zod" dark />

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -44,7 +44,7 @@ Install `ai` and `@ai-sdk/openai`, Vercel AI SDK's OpenAI provider.
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet text="pnpm install ai @ai-sdk/openai @ai-sdk/svelte zod" dark />
+      <Snippet text="pnpm add ai @ai-sdk/openai @ai-sdk/svelte zod" dark />
     </Tab>
     <Tab>
       <Snippet text="npm install ai @ai-sdk/openai @ai-sdk/svelte zod" dark />

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -44,7 +44,7 @@ Install `ai` and `@ai-sdk/openai`, Vercel AI SDK's OpenAI provider.
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet text="pnpm install ai @ai-sdk/openai @ai-sdk/vue zod" dark />
+      <Snippet text="pnpm add ai @ai-sdk/openai @ai-sdk/vue zod" dark />
     </Tab>
     <Tab>
       <Snippet text="npm install ai @ai-sdk/openai @ai-sdk/vue zod" dark />

--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -242,7 +242,7 @@ This function will take an input string and split it by periods, filtering out a
 
 You will use the Vercel AI SDK to create embeddings. This will require two more dependencies, which you can install by running the following command:
 
-<Snippet text="pnpm install ai @ai-sdk/openai" />
+<Snippet text="pnpm add ai @ai-sdk/openai" />
 
 This will install the [Vercel AI SDK](https://sdk.vercel.ai/docs) and the [OpenAI provider](/providers/ai-sdk-providers/openai).
 

--- a/content/docs/02-guides/02-multi-modal-chatbot.mdx
+++ b/content/docs/02-guides/02-multi-modal-chatbot.mdx
@@ -50,7 +50,7 @@ Install `ai` and `@ai-sdk/openai`, the Vercel AI package and Vercel AI SDK's [ O
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet text="pnpm install ai @ai-sdk/openai" dark />
+      <Snippet text="pnpm add ai @ai-sdk/openai" dark />
     </Tab>
     <Tab>
       <Snippet text="npm install ai @ai-sdk/openai" dark />

--- a/content/docs/08-troubleshooting/01-migration-guide/01-migration-guide-3-1.mdx
+++ b/content/docs/08-troubleshooting/01-migration-guide/01-migration-guide-3-1.mdx
@@ -19,7 +19,7 @@ Upgrading to Vercel AI SDK 3.1 does not require using the newly released AI SDK 
 
 To update to Vercel AI SDK version 3.1, run the following command using your preferred package manager:
 
-<Snippet text="pnpm install ai@3.1" />
+<Snippet text="pnpm add ai@3.1" />
 
 ## Next Steps
 

--- a/content/docs/08-troubleshooting/01-migration-guide/02-migration-guide-3-2.mdx
+++ b/content/docs/08-troubleshooting/01-migration-guide/02-migration-guide-3-2.mdx
@@ -17,7 +17,7 @@ This guide will help you upgrade to Vercel AI SDK 3.2:
 
 To update to Vercel AI SDK version 3.2, run the following command using your preferred package manager:
 
-<Snippet text="pnpm install ai@latest" />
+<Snippet text="pnpm add ai@latest" />
 
 ## Removed Functionality
 

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -14,7 +14,7 @@ The OpenAI provider is available in the `@ai-sdk/openai` module. You can install
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/openai" dark />
+    <Snippet text="pnpm add @ai-sdk/openai" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/openai" dark />

--- a/content/providers/01-ai-sdk-providers/02-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/02-azure.mdx
@@ -13,7 +13,7 @@ The Azure OpenAI provider is available in the `@ai-sdk/azure` module. You can in
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/azure" dark />
+    <Snippet text="pnpm add @ai-sdk/azure" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/azure" dark />

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -13,7 +13,7 @@ The Anthropic provider is available in the `@ai-sdk/anthropic` module. You can i
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/anthropic" dark />
+    <Snippet text="pnpm add @ai-sdk/anthropic" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/anthropic" dark />

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -13,7 +13,7 @@ The Bedrock provider is available in the `@ai-sdk/amazon-bedrock` module. You ca
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/amazon-bedrock" dark />
+    <Snippet text="pnpm add @ai-sdk/amazon-bedrock" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/amazon-bedrock" dark />

--- a/content/providers/01-ai-sdk-providers/10-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/10-google-generative-ai.mdx
@@ -13,7 +13,7 @@ The Google provider is available in the `@ai-sdk/google` module. You can install
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/google" dark />
+    <Snippet text="pnpm add @ai-sdk/google" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/google" dark />

--- a/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
@@ -17,7 +17,7 @@ The Google provider is available in the `@ai-sdk/google-vertex` module. You can 
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/google-vertex" dark />
+    <Snippet text="pnpm add @ai-sdk/google-vertex" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/google-vertex" dark />

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -13,7 +13,7 @@ The Mistral provider is available in the `@ai-sdk/mistral` module. You can insta
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/mistral" dark />
+    <Snippet text="pnpm add @ai-sdk/mistral" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/mistral" dark />

--- a/content/providers/01-ai-sdk-providers/25-cohere.mdx
+++ b/content/providers/01-ai-sdk-providers/25-cohere.mdx
@@ -13,7 +13,7 @@ The Cohere provider is available in the `@ai-sdk/cohere` module. You can install
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/cohere" dark />
+    <Snippet text="pnpm add @ai-sdk/cohere" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/cohere" dark />

--- a/content/providers/01-ai-sdk-providers/50-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/50-groq.mdx
@@ -21,7 +21,7 @@ You can install it with
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/openai" dark />
+    <Snippet text="pnpm add @ai-sdk/openai" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/openai" dark />

--- a/content/providers/01-ai-sdk-providers/60-perplexity.mdx
+++ b/content/providers/01-ai-sdk-providers/60-perplexity.mdx
@@ -20,7 +20,7 @@ You can install it with
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/openai" dark />
+    <Snippet text="pnpm add @ai-sdk/openai" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/openai" dark />

--- a/content/providers/01-ai-sdk-providers/70-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/70-fireworks.mdx
@@ -20,7 +20,7 @@ You can install it with
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install @ai-sdk/openai" dark />
+    <Snippet text="pnpm add @ai-sdk/openai" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install @ai-sdk/openai" dark />

--- a/content/providers/03-community-providers/03-ollama.mdx
+++ b/content/providers/03-community-providers/03-ollama.mdx
@@ -13,7 +13,7 @@ The Ollama provider is available in the `ollama-ai-provider` module. You can ins
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install ollama-ai-provider" dark />
+    <Snippet text="pnpm add ollama-ai-provider" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install ollama-ai-provider" dark />

--- a/content/providers/03-community-providers/04-chrome-ai.mdx
+++ b/content/providers/03-community-providers/04-chrome-ai.mdx
@@ -18,7 +18,7 @@ The ChromeAI provider is available in the `chrome-ai` module. You can install it
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm install chrome-ai" dark />
+    <Snippet text="pnpm add chrome-ai" dark />
   </Tab>
   <Tab>
     <Snippet text="npm install chrome-ai" dark />

--- a/content/providers/05-legacy-providers/anthropic.mdx
+++ b/content/providers/05-legacy-providers/anthropic.mdx
@@ -22,7 +22,7 @@ Create a Next.js application and install `ai`:
 ```sh
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai
+pnpm add ai
 ```
 
 ### 2. Add your Anthropic API Key to `.env`

--- a/content/providers/05-legacy-providers/aws-bedrock.mdx
+++ b/content/providers/05-legacy-providers/aws-bedrock.mdx
@@ -24,7 +24,7 @@ Create a Next.js application and install `ai`:
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai
+pnpm add ai
 ```
 
 ### Add your AWS Credentials to `.env`

--- a/content/providers/05-legacy-providers/azure-openai.mdx
+++ b/content/providers/05-legacy-providers/azure-openai.mdx
@@ -24,7 +24,7 @@ Create a Next.js application and install `ai` and `@azure/openai`, the Vercel AI
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai @azure/openai
+pnpm add ai @azure/openai
 ```
 
 ### Add your Azure OpenAI API Key to `.env`

--- a/content/providers/05-legacy-providers/cohere.mdx
+++ b/content/providers/05-legacy-providers/cohere.mdx
@@ -26,7 +26,7 @@ Create a Next.js application and install `ai`:
 ```sh
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai
+pnpm add ai
 ```
 
 ### Add your Cohere API Key to `.env`
@@ -158,7 +158,7 @@ Create a Next.js application and install `ai`:
 ```sh
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai
+pnpm add ai
 ```
 
 ### Add your Cohere API Key to `.env`

--- a/content/providers/05-legacy-providers/fireworks-ai.mdx
+++ b/content/providers/05-legacy-providers/fireworks-ai.mdx
@@ -31,7 +31,7 @@ Create a Next.js application and install `ai` and `openai`, the Vercel AI SDK an
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai openai
+pnpm add ai openai
 ```
 
 ### Add your Fireworks API Key to `.env`

--- a/content/providers/05-legacy-providers/google.mdx
+++ b/content/providers/05-legacy-providers/google.mdx
@@ -27,7 +27,7 @@ Create a Next.js application and install `ai`:
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai @google/generative-ai
+pnpm add ai @google/generative-ai
 ```
 
 ### Add your Google API Key to `.env`

--- a/content/providers/05-legacy-providers/hugging-face.mdx
+++ b/content/providers/05-legacy-providers/hugging-face.mdx
@@ -21,7 +21,7 @@ Create a Next.js application and install `ai` and `@huggingface/inference`:
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai @huggingface/inference
+pnpm add ai @huggingface/inference
 ```
 
 ### Add your Hugging Face API Key to `.env`

--- a/content/providers/05-legacy-providers/mistral.mdx
+++ b/content/providers/05-legacy-providers/mistral.mdx
@@ -24,7 +24,7 @@ Create a Next.js application and install `ai` and `@mistralai/mistralai`, the Ve
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai @mistralai/mistralai
+pnpm add ai @mistralai/mistralai
 ```
 
 ### Add your Mistral API Key to `.env`

--- a/content/providers/05-legacy-providers/openai.mdx
+++ b/content/providers/05-legacy-providers/openai.mdx
@@ -24,7 +24,7 @@ Create a Next.js application and install `ai` and `openai`, the Vercel AI SDK an
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai openai
+pnpm add ai openai
 ```
 
 ### Add your OpenAI API Key to `.env`

--- a/content/providers/05-legacy-providers/perplexity.mdx
+++ b/content/providers/05-legacy-providers/perplexity.mdx
@@ -30,7 +30,7 @@ Create a Next.js application and install `ai` and `openai`, the Vercel AI SDK an
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai openai
+pnpm add ai openai
 ```
 
 ### Add your Perplexity API Key to `.env`

--- a/content/providers/05-legacy-providers/replicate.mdx
+++ b/content/providers/05-legacy-providers/replicate.mdx
@@ -19,7 +19,7 @@ Create a Next.js application and install `ai` and `replicate`.
 ```shell
 pnpm dlx create-next-app my-ai-app
 cd my-ai-app
-pnpm install ai replicate
+pnpm add ai replicate
 ```
 
 ### Add your Replicate API Key to `.env`


### PR DESCRIPTION
It should be `pnpm add <pkg>` instead of `pnpm install <pkg>`.

`pnpm install` is used to install all dependencies for a project while `pnpm add <pkg>` is used to install a package and any packages that it depends on.

More info (official source):

- https://pnpm.io/cli/add
- https://pnpm.io/cli/install

---

`pnpm install <pkg>` does the same as `pnpm add <pkg>` today, but it might stop functioning that way in future versions since the official docs clarify the difference between the two. It might be that `pnpm install <pkg>` was used in past versions, and the PNPM team didn't want to remove support for it right away after introducing `pnpm add <pkg>`.