### PR TITLE
Add svelte support for tool calling

### DIFF
--- a/examples/sveltekit-openai/package.json
+++ b/examples/sveltekit-openai/package.json
@@ -13,7 +13,8 @@
     "@ai-sdk/openai": "latest",
     "@ai-sdk/svelte": "latest",
     "ai": "latest",
-    "openai": "4.52.6"
+    "openai": "4.52.6",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@fontsource/fira-mono": "^5",

--- a/examples/sveltekit-openai/src/routes/chat-with-tools/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat-with-tools/+page.svelte
@@ -1,95 +1,59 @@
 <script lang="ts">
   import { useChat } from '@ai-sdk/svelte';
-  import type { ChatRequest, ToolCallHandler } from 'ai';
-  import { nanoid } from 'ai';
 
-  const toolCallHandler: ToolCallHandler = async (chatMessages, toolCalls) => {
-    let handledFunction = false;
-    for (const tool of toolCalls) {
-      if (tool.type === 'function') {
-        const { name, arguments: args } = tool.function;
+  const { input, handleSubmit, messages, data, addToolResult } = useChat({
+      maxToolRoundtrips: 5,
+      // run client-side tools that are automatically executed:
 
-        if (name === 'eval_code_in_browser') {
-          // Parsing here does not always work since it seems that some characters in generated code aren't escaped properly.
-          const parsedFunctionCallArguments: { code: string } =
-            JSON.parse(args);
+      async onToolCall({ toolCall }) {
+          if (toolCall.toolName === 'getLocation') {
+              const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
 
-          // WARNING: Do NOT do this in real-world applications!
-          eval(parsedFunctionCallArguments.code);
-
-          const result = parsedFunctionCallArguments.code;
-
-          if (result) {
-            handledFunction = true;
-
-            chatMessages.push({
-              id: nanoid(),
-              tool_call_id: tool.id,
-              name: tool.function.name,
-              role: 'tool' as const,
-              content: result,
-            });
+              let city = cities[Math.floor(Math.random() * cities.length)];
+              addToolResult({toolCallId: toolCall.toolCallId, result: city});
+              return city;
           }
-        }
       }
-    }
-
-    if (handledFunction) {
-      const toolResponse: ChatRequest = {
-        messages: chatMessages,
-      };
-      return toolResponse;
-    }
-  };
-
-  const { messages, input, handleSubmit } = useChat({
-    api: '/api/chat-with-tools',
-    experimental_onToolCall: toolCallHandler,
   });
 </script>
 
-<svelte:head>
-  <title>Home</title>
-  <meta name="description" content="Svelte demo app" />
-</svelte:head>
-
-<section>
-  <h1>useChat</h1>
-
-  <p>
-    This is a demo of the <code>useChat</code> hook. It uses the
-    <code>experimental_onToolCall</code> option to handle using tools from the model.
-  </p>
-  <p>
-    Currently only the <code>function</code> type of tool is supported.
-  </p>
-  <p>
-    The available functions are: <code>get_current_weather</code>, handled
-    server side and
-    <code>eval_code_in_browser</code> handled client side.
-  </p>
-
+<main>
+  <br />
   <ul>
-    {#each $messages as message}
-      <li>{message.role}: {message.content}</li>
-    {/each}
+      {#each $messages as message (message.id)}
+          <li>{message.role}: {message.content}</li>
+          {#if message.toolInvocations}
+              {#each message.toolInvocations as toolInvocation (toolInvocation.toolCallId)}
+                  {@const toolCallId = toolInvocation.toolCallId}
+
+                  {#if toolInvocation.toolName === 'askForConfirmation'}
+                      <div>
+                          {toolInvocation.args.message}
+                          <div>
+                              {#if 'result' in toolInvocation}
+                                  <b>{toolInvocation.result}</b>
+                              {:else}
+                                  <button on:click={() => addToolResult({ toolCallId, result: 'Yes' })}>Yes</button>
+                                  <button on:click={() => addToolResult({ toolCallId, result: 'No' })}>No</button>
+                              {/if}
+                          </div>
+                      </div>
+                  {/if}
+
+                  {#if 'result' in toolInvocation}
+                      <div>
+                          Tool call {`${toolInvocation.toolName}: `}
+                          {toolInvocation.result}
+                      </div>
+                  {:else}
+                      <div>Calling {toolInvocation.toolName}...</div>
+                  {/if}
+              {/each}
+          {/if}
+      {/each}
   </ul>
   <form on:submit={handleSubmit}>
-    <input bind:value={$input} />
-    <button type="submit">Send</button>
+      <input class="outline-chaplin-1 bg-white outline outline-1" bind:value={$input} />
+      <button type="submit">Send</button>
   </form>
-</section>
-
-<style>
-  section {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    flex: 0.6;
-  }
-
-  h1 {
-    width: 100%;
-  }
-</style>
+</main>

--- a/examples/sveltekit-openai/src/routes/chat-with-tools/+server.ts
+++ b/examples/sveltekit-openai/src/routes/chat-with-tools/+server.ts
@@ -1,0 +1,43 @@
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { convertToCoreMessages, StreamData, StreamingTextResponse, streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+export const POST = (async ({ request }) => {
+    const r = await request.json();
+    const { messages } = r;
+
+    const result = await streamText({
+        model: openai('gpt-4-turbo'),
+        messages: convertToCoreMessages(messages),
+        tools: {
+          // server-side tool with execute function:
+          getWeatherInformation: {
+            description: 'show the weather in a given city to the user',
+            parameters: z.object({ city: z.string() }),
+            execute: async ({}: { city: string }) => {
+              const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
+              return weatherOptions[
+                Math.floor(Math.random() * weatherOptions.length)
+              ];
+            },
+          },
+          // client-side tool that starts user interaction:
+          askForConfirmation: {
+            description: 'Ask the user for confirmation.',
+            parameters: z.object({
+              message: z.string().describe('The message to ask for confirmation.'),
+            }),
+          },
+          // client-side tool that is automatically executed on the client:
+          getLocation: {
+            description:
+              'Get the user location. Always ask for confirmation before using this tool.',
+            parameters: z.object({}),
+          },
+        },
+      });
+    
+
+    return result.toAIStreamResponse();
+}) satisfies RequestHandler;

--- a/packages/svelte/src/use-chat.ts
+++ b/packages/svelte/src/use-chat.ts
@@ -132,6 +132,9 @@ const getStreamedResponse = async (
           name,
           data,
           annotations,
+          function_call,
+          tool_calls,
+          tool_call_id,
           toolInvocations,
         }) => ({
           role,
@@ -140,6 +143,10 @@ const getStreamedResponse = async (
           ...(data !== undefined && { data }),
           ...(annotations !== undefined && { annotations }),
           ...(toolInvocations !== undefined && { toolInvocations }),
+          // outdated function/tool call handling (TODO deprecate):
+          tool_call_id,
+          ...(function_call !== undefined && { function_call }),
+          ...(tool_calls !== undefined && { tool_calls }),
         }),
       );
 
@@ -150,6 +157,18 @@ const getStreamedResponse = async (
       data: chatRequest.data,
       ...extraMetadata.body,
       ...chatRequest.body,
+      ...(chatRequest.functions !== undefined && {
+        functions: chatRequest.functions,
+      }),
+      ...(chatRequest.function_call !== undefined && {
+        function_call: chatRequest.function_call,
+      }),
+      ...(chatRequest.tools !== undefined && {
+        tools: chatRequest.tools,
+      }),
+      ...(chatRequest.tool_choice !== undefined && {
+        tool_choice: chatRequest.tool_choice,
+      }),
     },
     streamProtocol,
     credentials: extraMetadata.credentials,
@@ -367,6 +386,10 @@ export function useChat({
     message: Message | CreateMessage,
     {
       options,
+      functions,
+      function_call,
+      tools,
+      tool_choice,
       data,
       headers,
       body,
@@ -386,13 +409,21 @@ export function useChat({
       options: requestOptions,
       headers: requestOptions.headers,
       body: requestOptions.body,
-      data
+      data,
+      ...(functions !== undefined && { functions }),
+      ...(function_call !== undefined && { function_call }),
+      ...(tools !== undefined && { tools }),
+      ...(tool_choice !== undefined && { tool_choice }),
     };
     return triggerRequest(chatRequest);
   };
 
   const reload: UseChatHelpers['reload'] = async ({
     options,
+    functions,
+    function_call,
+    tools,
+    tool_choice,
     data,
     headers,
     body,
@@ -413,7 +444,11 @@ export function useChat({
         options: requestOptions,
         headers: requestOptions.headers,
         body: requestOptions.body,
-        data
+        data,
+        ...(functions !== undefined && { functions }),
+        ...(function_call !== undefined && { function_call }),
+        ...(tools !== undefined && { tools }),
+        ...(tool_choice !== undefined && { tool_choice }),
       };
 
       return triggerRequest(chatRequest);
@@ -424,7 +459,7 @@ export function useChat({
       options: requestOptions,
       headers: requestOptions.headers,
       body: requestOptions.body,
-      data
+      data,
     };
 
     return triggerRequest(chatRequest);


### PR DESCRIPTION
This PR reimplements the tool calling from Solid/React as best I could track it. There's a bit of code copied between the two useChat files, but I'm not sure how/if/where the maintainers would like to put that sort of shared code + type definitions. 

This PR also removes the deprecated tools/functions fields (keeping it in line with the solid implementation).

Bugs:
- Anthropic API complains about empty content field on messages and throws an error

## Testing

`/routes/api/chat/+page.ts`

```svelte
<script lang="ts">
    import { useChat } from '@ai-sdk/svelte';

    const { input, handleSubmit, messages, data, addToolResult } = useChat({
        maxToolRoundtrips: 5,
        // run client-side tools that are automatically executed:

        async onToolCall({ toolCall }) {
            if (toolCall.toolName === 'getLocation') {
                const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];

                let city = cities[Math.floor(Math.random() * cities.length)];
                addToolResult({toolCallId: toolCall.toolCallId, result: city});
                return city;
            }
        }
    });
</script>

<main>
    <!-- <pre>{JSON.stringify($data, null, 2)}</pre> -->

    <br />
    <ul>
        {#each $messages as message (message.id)}
            <li>{message.role}: {message.content}</li>
            {#if message.toolInvocations}
                {#each message.toolInvocations as toolInvocation (toolInvocation.toolCallId)}
                    {@const toolCallId = toolInvocation.toolCallId}

                    {#if toolInvocation.toolName === 'askForConfirmation'}
                        <div>
                            {toolInvocation.args.message}
                            <div>
                                {#if 'result' in toolInvocation}
                                    <b>{toolInvocation.result}</b>
                                {:else}
                                    <button on:click={() => addToolResult({ toolCallId, result: 'Yes' })}>Yes</button>
                                    <button on:click={() => addToolResult({ toolCallId, result: 'No' })}>No</button>
                                {/if}
                            </div>
                        </div>
                    {/if}

                    {#if 'result' in toolInvocation}
                        <div>
                            Tool call {`${toolInvocation.toolName}: `}
                            {toolInvocation.result}
                        </div>
                    {:else}
                        <div>Calling {toolInvocation.toolName}...</div>
                    {/if}
                {/each}
            {/if}
        {/each}
    </ul>
    <form on:submit={handleSubmit}>
        <input class="outline-chaplin-1 bg-white outline outline-1" bind:value={$input} />
        <button type="submit">Send</button>
    </form>
</main>
```

`/routes/api/chat/+server.ts`

```ts
import type { RequestHandler } from './$types';
import { z } from 'zod';
import { createAnthropic } from '@ai-sdk/anthropic';
import { convertToCoreMessages, StreamData, StreamingTextResponse, streamText } from 'ai';
import { openai } from '@ai-sdk/openai';

// Anthropic haiku 3 model does not like empty content field in message
// const anthropic = createAnthropic({
//     // custom settings
// });

export const POST = (async ({ request }) => {
    const r = await request.json();
    const { messages } = r;
    // const data = new StreamData();
    // data.append({ test: 'value' });

    const result = await streamText({
        model: openai('gpt-4-turbo'),
        messages: convertToCoreMessages(messages),
        tools: {
          // server-side tool with execute function:
          getWeatherInformation: {
            description: 'show the weather in a given city to the user',
            parameters: z.object({ city: z.string() }),
            execute: async ({}: { city: string }) => {
              const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
              return weatherOptions[
                Math.floor(Math.random() * weatherOptions.length)
              ];
            },
          },
          // client-side tool that starts user interaction:
          askForConfirmation: {
            description: 'Ask the user for confirmation.',
            parameters: z.object({
              message: z.string().describe('The message to ask for confirmation.'),
            }),
          },
          // client-side tool that is automatically executed on the client:
          getLocation: {
            description:
              'Get the user location. Always ask for confirmation before using this tool.',
            parameters: z.object({}),
          },
        },
      });
    

    return result.toAIStreamResponse();
}) satisfies RequestHandler;

```