### PR TITLE
feat (ai/core): introduce x-vercel-ai-data-stream header

### DIFF
--- a/packages/core/core/generate-text/stream-text.test.ts
+++ b/packages/core/core/generate-text/stream-text.test.ts
@@ -968,7 +968,7 @@ describe('result.toAIStreamResponse', () => {
 
     assert.deepStrictEqual(Object.fromEntries(response.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
-      'x-vercel-ai-stream': 'v1',
+      'x-vercel-ai-data-stream': 'v1',
     });
 
     assert.strictEqual(
@@ -1011,7 +1011,7 @@ describe('result.toAIStreamResponse', () => {
 
     assert.deepStrictEqual(Object.fromEntries(response.headers.entries()), {
       'content-type': 'text/plain; charset=utf-8',
-      'x-vercel-ai-stream': 'v1',
+      'x-vercel-ai-data-stream': 'v1',
       'custom-header': 'custom-value',
     });
 

--- a/packages/core/core/generate-text/stream-text.test.ts
+++ b/packages/core/core/generate-text/stream-text.test.ts
@@ -965,6 +965,12 @@ describe('result.toAIStreamResponse', () => {
     const response = result.toAIStreamResponse();
 
     assert.strictEqual(response.status, 200);
+
+    assert.deepStrictEqual(Object.fromEntries(response.headers.entries()), {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-vercel-ai-stream': 'v1',
+    });
+
     assert.strictEqual(
       response.headers.get('Content-Type'),
       'text/plain; charset=utf-8',
@@ -1002,11 +1008,12 @@ describe('result.toAIStreamResponse', () => {
 
     assert.strictEqual(response.status, 201);
     assert.strictEqual(response.statusText, 'foo');
-    assert.strictEqual(
-      response.headers.get('Content-Type'),
-      'text/plain; charset=utf-8',
-    );
-    assert.strictEqual(response.headers.get('custom-header'), 'custom-value');
+
+    assert.deepStrictEqual(Object.fromEntries(response.headers.entries()), {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-vercel-ai-stream': 'v1',
+      'custom-header': 'custom-value',
+    });
 
     assert.deepStrictEqual(await convertResponseStreamToArray(response), [
       '0:"Hello"\n',
@@ -1074,10 +1081,9 @@ describe('result.toTextStreamResponse', () => {
     const response = result.toTextStreamResponse();
 
     assert.strictEqual(response.status, 200);
-    assert.strictEqual(
-      response.headers.get('Content-Type'),
-      'text/plain; charset=utf-8',
-    );
+    assert.deepStrictEqual(Object.fromEntries(response.headers.entries()), {
+      'content-type': 'text/plain; charset=utf-8',
+    });
 
     assert.deepStrictEqual(await convertResponseStreamToArray(response), [
       'Hello',

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -672,7 +672,7 @@ However, the LLM results are expected to be small enough to not cause issues.
       statusText: init?.statusText,
       headers: prepareResponseHeaders(init, {
         contentType: 'text/plain; charset=utf-8',
-        aiStreamVersion: 'v1',
+        dataStreamVersion: 'v1',
       }),
     });
   }

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -672,6 +672,7 @@ However, the LLM results are expected to be small enough to not cause issues.
       statusText: init?.statusText,
       headers: prepareResponseHeaders(init, {
         contentType: 'text/plain; charset=utf-8',
+        aiStreamVersion: 'v1',
       }),
     });
   }

--- a/packages/core/core/util/prepare-response-headers.ts
+++ b/packages/core/core/util/prepare-response-headers.ts
@@ -2,8 +2,8 @@ export function prepareResponseHeaders(
   init: ResponseInit | undefined,
   {
     contentType,
-    aiStreamVersion,
-  }: { contentType: string; aiStreamVersion?: string | undefined },
+    dataStreamVersion,
+  }: { contentType: string; dataStreamVersion?: 'v1' | undefined },
 ) {
   const headers = new Headers(init?.headers ?? {});
 
@@ -11,8 +11,8 @@ export function prepareResponseHeaders(
     headers.set('Content-Type', contentType);
   }
 
-  if (aiStreamVersion !== undefined) {
-    headers.set('X-Vercel-AI-Stream', aiStreamVersion);
+  if (dataStreamVersion !== undefined) {
+    headers.set('X-Vercel-AI-Data-Stream', dataStreamVersion);
   }
 
   return headers;

--- a/packages/core/core/util/prepare-response-headers.ts
+++ b/packages/core/core/util/prepare-response-headers.ts
@@ -1,11 +1,18 @@
 export function prepareResponseHeaders(
   init: ResponseInit | undefined,
-  { contentType }: { contentType: string },
+  {
+    contentType,
+    aiStreamVersion,
+  }: { contentType: string; aiStreamVersion?: string | undefined },
 ) {
   const headers = new Headers(init?.headers ?? {});
 
   if (!headers.has('Content-Type')) {
     headers.set('Content-Type', contentType);
+  }
+
+  if (aiStreamVersion !== undefined) {
+    headers.set('X-Vercel-AI-Stream', aiStreamVersion);
   }
 
   return headers;


### PR DESCRIPTION
## Background

This header flags and versions AI SDK data streams. It will be used in the frontend in future versions to automatically detect the type of stream (`protocol: "auto"`).