### PR TITLE
chore (ai/core): rename ai stream methods to data stream

### DIFF
--- a/.changeset/cuddly-zebras-notice.md
+++ b/.changeset/cuddly-zebras-notice.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore (ai/core): rename ai stream methods to data stream (in streamText, LangChainAdapter).

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -103,7 +103,7 @@ export async function POST(req: Request) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 
@@ -111,7 +111,7 @@ Let's take a look at what is happening in this code:
 
 1. Define an asynchronous `POST` request handler and extract `messages` from the body of the request. The `messages` variable contains a history of the conversation between you and the chatbot and provides the chatbot with the necessary context to make the next generation.
 2. Call [`streamText`](/docs/reference/ai-sdk-core/stream-text), which is imported from the `ai` package. This function accepts a configuration object that contains a `model` provider (imported from `@ai-sdk/openai`) and `messages` (defined in step 1). You can pass additional [settings](/docs/ai-sdk-core/settings) to further customise the model's behaviour.
-3. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toAIStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
+3. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toDataStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
 4. Finally, return the result to the client to stream the response.
 
 This Route Handler creates a POST request endpoint at `/api/chat`.
@@ -200,7 +200,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse({ data });
+  return result.toDataStreamResponse({ data });
 }
 ```
 
@@ -209,7 +209,7 @@ In this code, you:
 1. Create a new instance of `StreamData`.
 2. Append the data you want to stream alongside the model's response.
 3. Listen for the `onFinish` callback on `streamText` and close the stream data.
-4. Pass the data into the `toAIStreamResponse` method.
+4. Pass the data into the `toDataStreamResponse` method.
 
 ### Update your frontend
 

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -109,7 +109,7 @@ export async function POST(req: Request) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 
@@ -117,7 +117,7 @@ Let's take a look at what is happening in this code:
 
 1. Define an asynchronous `POST` request and extract `messages` from the body of the request. The `messages` variable contains a history of the conversation with you and the chatbot and will provide the chatbot with the necessary context to make the next generation.
 2. Call the [`streamText`](/docs/reference/ai-sdk-core/stream-text) function which is imported from the `ai` package. To use this function, you pass it a configuration object that contains a `model` provider (imported from `@ai-sdk/openai`) and `messages` (defined in step 2). You can use pass additional [settings](/docs/ai-sdk-core/settings) in this configuration object to further customise the models behaviour.
-3. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toAIStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
+3. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toDataStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
 4. Return the result to the client to stream the response.
 
 This Route Handler creates a POST request endpint at `/api/chat`.
@@ -199,7 +199,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse({ data });
+  return result.toDataStreamResponse({ data });
 }
 ```
 
@@ -208,7 +208,7 @@ In this code, you:
 1. Create a new instance of `StreamData`.
 2. Append the data you want to stream alongside the model's response.
 3. Listen for the `onFinish` callback on `streamText` and close the stream data.
-4. Pass the data into the `toAIStreamResponse` method.
+4. Pass the data into the `toDataStreamResponse` method.
 
 ### Update your frontend
 

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -101,7 +101,7 @@ export const POST = (async ({ request }) => {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }) satisfies RequestHandler;
 ```
 
@@ -110,7 +110,7 @@ Let's take a look at what is happening in this code:
 1. Create an OpenAI provider instance with the `createOpenAI` function from the `@ai-sdk/openai` package.
 2. Define a `POST` request and extract `messages` from the body of the request. The `messages` variable contains a history of the conversation with you and the chatbot and will provide the chatbot with the necessary context to make the next generation.
 3. Call the [`streamText`](/docs/reference/ai-sdk-core/stream-text) function which is imported from the `ai` package. To use this function, you pass it a configuration object that contains a `model` provider (defined in step 1) and `messages` (defined in step 2). You can use pass additional [settings](/docs/ai-sdk-core/settings) in this configuration object to further customise the models behaviour.
-4. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toAIStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
+4. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toDataStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
 5. Return the result to the client to stream the response.
 
 ## Wire up the UI
@@ -187,7 +187,7 @@ export const POST = (async ({ request }) => {
     messages,
   });
 
-  return result.toAIStreamResponse({ data });
+  return result.toDataStreamResponse({ data });
 }) satisfies RequestHandler;
 ```
 
@@ -196,7 +196,7 @@ In this code, you:
 1. Create a new instance of `StreamData`.
 2. Append the data you want to stream alongside the model's response.
 3. Listen for the `onFinish` callback on `streamText` and close the stream data.
-4. Pass the data into the `toAIStreamResponse` method.
+4. Pass the data into the `toDataStreamResponse` method.
 
 ### Update your frontend
 

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -109,7 +109,7 @@ export default defineLazyEventHandler(async () => {
       messages,
     });
 
-    return result.toAIStreamResponse();
+    return result.toDataStreamResponse();
   });
 });
 ```
@@ -119,7 +119,7 @@ Let's take a look at what is happening in this code:
 1. First, you create an OpenAI provider instance with the `createOpenAI` function that is imported from the `@ai-sdk/openai` package.
 2. Next, you define an Event Handler and extract `messages` from the body of the request. The `messages` variable contains a history of the conversation with you and the chatbot and will provide the chatbot with the necessary context to make the next generation.
 3. Next, you call the [`streamText`](/docs/reference/ai-sdk-core/stream-text) function which is imported from the `ai` package. To use this function, you pass it a configuration object that contains a `model` provider (defined in step 1) and `messages` (defined in step 2). You can use pass additional [settings](/docs/ai-sdk-core/settings) in this configuration object to further customise the models behaviour.
-4. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toAIStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
+4. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toDataStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
 5. Return the result to the client to stream the response.
 
 ## Wire up the UI
@@ -201,7 +201,7 @@ export default defineLazyEventHandler(async () => {
       messages,
     });
 
-    return result.toAIStreamResponse({ data });
+    return result.toDataStreamResponse({ data });
   });
 });
 ```
@@ -211,7 +211,7 @@ In this code, you:
 1. Create a new instance of `StreamData`.
 2. Append the data you want to stream alongside the model's response.
 3. Listen for the `onFinish` callback on `streamText` and close the stream data.
-4. Pass the data into the `toAIStreamResponse` method.
+4. Pass the data into the `toDataStreamResponse` method.
 
 ### Update your frontend
 

--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -446,7 +446,7 @@ export async function POST(req: Request) {
     messages: convertToCoreMessages(messages),
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 
@@ -478,7 +478,7 @@ export async function POST(req: Request) {
     messages: convertToCoreMessages(messages),
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 
@@ -528,7 +528,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 
@@ -718,7 +718,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/docs/02-guides/02-multi-modal-chatbot.mdx
+++ b/content/docs/02-guides/02-multi-modal-chatbot.mdx
@@ -111,7 +111,7 @@ export async function POST(req: Request) {
     messages: convertToCoreMessages(messages),
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 
@@ -119,7 +119,7 @@ Let's take a look at what is happening in this code:
 
 1. Define an asynchronous `POST` request handler and extract `messages` from the body of the request. The `messages` variable contains a history of the conversation between you and the chatbot and provides the chatbot with the necessary context to make the next generation.
 2. Call [`streamText`](/docs/reference/ai-sdk-core/stream-text), which is imported from the `ai` package. This function accepts a configuration object that contains a `model` provider (imported from `@ai-sdk/openai`) and `messages` (defined in step 1). You can pass additional [settings](/docs/ai-sdk-core/settings) to further customise the model's behaviour.
-3. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toAIStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
+3. The `streamText` function returns a [`StreamTextResult`](/docs/reference/ai-sdk-core/stream-text#result-object). This result object contains the [ `toDataStreamResponse` ](/docs/reference/ai-sdk-core/stream-text#to-ai-stream-response) function which converts the result to a streamed response object.
 4. Finally, return the result to the client to stream the response.
 
 This Route Handler creates a POST request endpoint at `/api/chat`.

--- a/content/docs/02-guides/03-llama-3_1.mdx
+++ b/content/docs/02-guides/03-llama-3_1.mdx
@@ -232,7 +232,7 @@ export async function POST(req: Request) {
     messages: convertToCoreMessages(messages),
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -108,11 +108,10 @@ const result = await streamText({
 
 The result object of `streamText` contains several helper functions to make the integration into [AI SDK UI](/docs/ai-sdk-ui) easier:
 
-- `result.toAIStream()`: Creates an AI stream object (with tool calls etc.) that can be used with `StreamingTextResponse()` and `StreamData`.
-- `result.toAIStreamResponse()`: Creates an AI stream response (with tool calls etc.).
+- `result.toDataStreamResponse()`: Creates a data stream response (with tool calls etc.).
 - `result.toTextStreamResponse()`: Creates a simple text stream response.
-- `result.pipeTextStreamToResponse()`: Writes text delta output to a Node.js response-like object.
 - `result.pipeAIStreamToResponse()`: Writes AI stream delta output to a Node.js response-like object.
+- `result.pipeTextStreamToResponse()`: Writes text delta output to a Node.js response-like object.
 
 ### Result promises
 

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -110,7 +110,7 @@ The result object of `streamText` contains several helper functions to make the 
 
 - `result.toDataStreamResponse()`: Creates a data stream response (with tool calls etc.).
 - `result.toTextStreamResponse()`: Creates a simple text stream response.
-- `result.pipeAIStreamToResponse()`: Writes AI stream delta output to a Node.js response-like object.
+- `result.pipeDataStreamToResponse()`: Writes AI stream delta output to a Node.js response-like object.
 - `result.pipeTextStreamToResponse()`: Writes text delta output to a Node.js response-like object.
 
 ### Result promises

--- a/content/docs/05-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/05-ai-sdk-ui/02-chatbot.mdx
@@ -61,7 +61,7 @@ export async function POST(req: Request) {
     messages: convertToCoreMessages(messages),
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/docs/05-ai-sdk-ui/03-chatbot-with-tool-calling.mdx
+++ b/content/docs/05-ai-sdk-ui/03-chatbot-with-tool-calling.mdx
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 
@@ -212,7 +212,7 @@ export async function POST(req: Request) {
     // ...
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/docs/05-ai-sdk-ui/05-completion.mdx
+++ b/content/docs/05-ai-sdk-ui/05-completion.mdx
@@ -51,7 +51,7 @@ export async function POST(req: Request) {
     prompt,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/docs/05-ai-sdk-ui/15-storing-messages.mdx
+++ b/content/docs/05-ai-sdk-ui/15-storing-messages.mdx
@@ -39,7 +39,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 
@@ -61,6 +61,6 @@ export async function continueConversation(messages: CoreMessage[]) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```

--- a/content/docs/05-ai-sdk-ui/20-streaming-data.mdx
+++ b/content/docs/05-ai-sdk-ui/20-streaming-data.mdx
@@ -17,7 +17,7 @@ or custom data structures that are relevant to the ongoing interaction.
 ## How To Use StreamData
 
 To use `StreamData`, create a `StreamData` value on the server,
-append some data, and then include it in `toAIStreamResponse`.
+append some data, and then include it in `toDataStreamResponse`.
 
 You need to call `close()` on the `StreamData` object to ensure the data is sent to the client.
 This can best be done in the `onFinish` callback of `streamText`.
@@ -58,7 +58,7 @@ export async function POST(req: Request) {
   });
 
   // Respond with the stream and additional StreamData
-  return result.toAIStreamResponse({ data });
+  return result.toDataStreamResponse({ data });
 }
 ```
 

--- a/content/docs/06-advanced/06-rate-limiting.mdx
+++ b/content/docs/06-advanced/06-rate-limiting.mdx
@@ -49,7 +49,7 @@ export async function POST(req: NextRequest) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -756,7 +756,7 @@ for await (const textPart of textStream) {
       ],
     },
     {
-      name: 'toAIStream',
+      name: 'toDataStream',
       type: '(callbacks?: AIStreamCallbacksAndOptions) => AIStream',
       description:
         'Converts the result to an `AIStream` object that is compatible with `StreamingTextResponse`. It can be used with the `useChat` and `useCompletion` hooks.',
@@ -774,13 +774,13 @@ for await (const textPart of textStream) {
         'Writes text delta output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each text delta as a separate chunk.',
     },
     {
-      name: 'toAIStreamResponse',
-      type: '(options?: ToAIStreamOptions) => Response',
+      name: 'toDataStreamResponse',
+      type: '(options?: toDataStreamOptions) => Response',
       description:
         'Converts the result to a streamed response object with a stream data part stream. It can be used with the `useChat` and `useCompletion` hooks.',
       properties: [
         {
-          type: 'ToAIStreamOptions',
+          type: 'toDataStreamOptions',
           parameters: [
             {
               name: 'init',

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -762,7 +762,7 @@ for await (const textPart of textStream) {
         'Converts the result to an `AIStream` object that is compatible with `StreamingTextResponse`. It can be used with the `useChat` and `useCompletion` hooks.',
     },
     {
-      name: 'pipeAIStreamToResponse',
+      name: 'pipeDataStreamToResponse',
       type: '(response: ServerResponse, init?: { headers?: Record<string, string>; status?: number } => void',
       description:
         'Writes stream data output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each stream data part as a separate chunk.',

--- a/content/docs/07-reference/ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/ai-sdk-rsc/01-stream-ui.mdx
@@ -670,7 +670,7 @@ A helper function to create a streamable UI from LLM providers. This function is
         'Converts the result to an `AIStream` object that is compatible with `StreamingTextResponse`. It can be used with the `useChat` and `useCompletion` hooks.',
     },
     {
-      name: 'pipeAIStreamToResponse',
+      name: 'pipeDataStreamToResponse',
       type: '(response: ServerResponse, init?: { headers?: Record<string, string>; status?: number } => void',
       description:
         'Writes stream data output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each stream data part as a separate chunk.',

--- a/content/docs/07-reference/ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/ai-sdk-rsc/01-stream-ui.mdx
@@ -664,7 +664,7 @@ A helper function to create a streamable UI from LLM providers. This function is
       ],
     },
     {
-      name: 'toAIStream',
+      name: 'toDataStream',
       type: '(callbacks?: AIStreamCallbacksAndOptions) => AIStream',
       description:
         'Converts the result to an `AIStream` object that is compatible with `StreamingTextResponse`. It can be used with the `useChat` and `useCompletion` hooks.',
@@ -682,7 +682,7 @@ A helper function to create a streamable UI from LLM providers. This function is
         'Writes text delta output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each text delta as a separate chunk.',
     },
     {
-      name: 'toAIStreamResponse',
+      name: 'toDataStreamResponse',
       type: '(init?: ResponseInit) => Response',
       description:
         'Converts the result to a streamed response object with a stream data part stream. It can be used with the `useChat` and `useCompletion` hooks.',

--- a/content/docs/07-reference/ai-sdk-ui/31-convert-to-core-message.mdx
+++ b/content/docs/07-reference/ai-sdk-ui/31-convert-to-core-message.mdx
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
     messages: convertToCoreMessages(messages),
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/docs/07-reference/stream-helpers/02-streaming-text-response.mdx
+++ b/content/docs/07-reference/stream-helpers/02-streaming-text-response.mdx
@@ -5,35 +5,17 @@ description: Learn to use StreamingTextResponse helper function in your applicat
 
 # `StreamingTextResponse`
 
-It is a utility class that simplifies the process of returning a ReadableStream of text in HTTP responses. It is a lightweight wrapper around the native Response class, automatically setting the status code to 200 and the Content-Type header to 'text/plain; charset=utf-8'
+<Note type="warning">
+  This helper function is deprecated. Use `streamText.toDataStreamResponse()`
+  instead.
+</Note>
+
+It is a utility class that simplifies the process of returning a ReadableStream of text in HTTP responses.
+It is a lightweight wrapper around the native Response class, automatically setting the status code to 200 and the Content-Type header to 'text/plain; charset=utf-8'.
 
 ## Import
 
 <Snippet text={`import { StreamingTextResponse } from "ai"`} prompt={false} />
-
-## Example
-
-```tsx
-const result = await streamText({ model, messages });
-
-// use stream data
-const data = new StreamData();
-
-data.append('initialized call');
-
-// return a StreamingTextResponse that combines
-// the result stream with the data stream:
-return new StreamingTextResponse(
-  result.toAIStream({
-    onFinal() {
-      data.append('call completed');
-      data.close();
-    },
-  }),
-  {},
-  data,
-);
-```
 
 ## API Signature
 

--- a/content/docs/07-reference/stream-helpers/16-langchain-adapter.mdx
+++ b/content/docs/07-reference/stream-helpers/16-langchain-adapter.mdx
@@ -25,7 +25,7 @@ It supports:
 <PropertiesTable
   content={[
     {
-      name: 'toAIStream',
+      name: 'toDataStream',
       type: '(stream: ReadableStream<LangChainAIMessageChunk> | ReadableStream<string>, AIStreamCallbacksAndOptions) => AIStream',
       description: 'Converts LangChain output streams to AIStream.',
     },
@@ -50,7 +50,7 @@ export async function POST(req: Request) {
 
   const stream = await model.stream(prompt);
 
-  const aiStream = LangChainAdapter.toAIStream(stream);
+  const aiStream = LangChainAdapter.toDataStream(stream);
 
   return new StreamingTextResponse(aiStream);
 }
@@ -74,7 +74,7 @@ export async function POST(req: Request) {
   const parser = new StringOutputParser();
   const stream = await model.pipe(parser).stream(prompt);
 
-  const aiStream = LangChainAdapter.toAIStream(stream);
+  const aiStream = LangChainAdapter.toDataStream(stream);
 
   return new StreamingTextResponse(aiStream);
 }

--- a/content/docs/08-troubleshooting/01-migration-guide/01-migration-guide-3-1.mdx
+++ b/content/docs/08-troubleshooting/01-migration-guide/01-migration-guide-3-1.mdx
@@ -59,7 +59,7 @@ export async function POST(req: Request) {
 
 With Vercel AI SDK Core you have a unified API for any provider that implements the [AI SDK Language Model Specification](https://sdk.vercel.ai/providers/community-providers/custom-providers).
 
-Let’s take a look at the example above, but refactored to utilize the AI SDK Core API alongside the AI SDK OpenAI provider. In this example, you import the LLM function you want to use from the `ai` package, import the OpenAI provider from `@ai-sdk/openai`, and then you call the model and return the response using the `toAIStreamResponse()` helper function.
+Let’s take a look at the example above, but refactored to utilize the AI SDK Core API alongside the AI SDK OpenAI provider. In this example, you import the LLM function you want to use from the `ai` package, import the OpenAI provider from `@ai-sdk/openai`, and then you call the model and return the response using the `toDataStreamResponse()` helper function.
 
 ```tsx
 import { streamText } from 'ai';
@@ -73,7 +73,7 @@ export async function POST(req: Request) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/docs/08-troubleshooting/03-common-issues/06-streaming-not-working-on-vercel-pages-router.mdx
+++ b/content/docs/08-troubleshooting/03-common-issues/06-streaming-not-working-on-vercel-pages-router.mdx
@@ -38,6 +38,6 @@ export async function POST(req: Request) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```

--- a/content/examples/02-next-pages/01-basics/02-streaming-text-generation.mdx
+++ b/content/examples/02-next-pages/01-basics/02-streaming-text-generation.mdx
@@ -62,7 +62,7 @@ export async function POST(req: Request) {
     prompt,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/examples/02-next-pages/05-chat/02-stream-chat-completion.mdx
+++ b/content/examples/02-next-pages/05-chat/02-stream-chat-completion.mdx
@@ -71,7 +71,7 @@ export async function POST(req: Request) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/examples/02-next-pages/05-chat/10-use-chat-image-input.mdx
+++ b/content/examples/02-next-pages/05-chat/10-use-chat-image-input.mdx
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
   });
 
   // Respond with the stream
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/examples/02-next-pages/05-chat/15-use-chat-custom-body.mdx
+++ b/content/examples/02-next-pages/05-chat/15-use-chat-custom-body.mdx
@@ -87,6 +87,6 @@ export async function POST(req: Request) {
   })
 
   // Respond with the stream
-  return result.toAIStreamResponse()
+  return result.toDataStreamResponse()
 }
 ```

--- a/content/examples/02-next-pages/10-tools/01-call-tool.mdx
+++ b/content/examples/02-next-pages/10-tools/01-call-tool.mdx
@@ -109,7 +109,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/examples/02-next-pages/10-tools/05-call-tools-in-parallel.mdx
+++ b/content/examples/02-next-pages/10-tools/05-call-tools-in-parallel.mdx
@@ -109,7 +109,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }
 ```
 

--- a/content/examples/02-next-pages/10-tools/10-render-interface-during-tool-call.mdx
+++ b/content/examples/02-next-pages/10-tools/10-render-interface-during-tool-call.mdx
@@ -233,6 +233,6 @@ export default async function handler(
     },
   });
 
-  result.pipeAIStreamToResponse(response);
+  result.pipeDataStreamToResponse(response);
 }
 ```

--- a/content/providers/04-adapters/langchain.mdx
+++ b/content/providers/04-adapters/langchain.mdx
@@ -14,7 +14,7 @@ However, LangChain does not provide a way to easily build UIs or a standard way 
 Here is a basic example that uses both Vercel AI SDK and LangChain together with the [Next.js](https://nextjs.org/docs) App Router.
 
 The AI SDK `LangChainAdapter` uses the result from [LangChain ExpressionLanguage streaming](https://js.langchain.com/docs/expression_language/streaming) to pipe text to the client.
-`LangChainAdapter.toAIStream()` is compatible with the LangChain Expression Language `.stream()` function response.
+`LangChainAdapter.toDataStream()` is compatible with the LangChain Expression Language `.stream()` function response.
 
 ```tsx filename="app/api/completion/route.ts" highlight={"17"}
 import { ChatOpenAI } from '@langchain/openai';
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
 
   const stream = await model.stream(prompt);
 
-  const aiStream = LangChainAdapter.toAIStream(stream);
+  const aiStream = LangChainAdapter.toDataStream(stream);
 
   return new StreamingTextResponse(aiStream);
 }

--- a/examples/next-langchain/app/api/chat/route.ts
+++ b/examples/next-langchain/app/api/chat/route.ts
@@ -25,5 +25,5 @@ export async function POST(req: Request) {
     ),
   );
 
-  return new StreamingTextResponse(LangChainAdapter.toAIStream(stream));
+  return new StreamingTextResponse(LangChainAdapter.toDataStream(stream));
 }

--- a/examples/next-langchain/app/api/completion-stream-data/route.ts
+++ b/examples/next-langchain/app/api/completion-stream-data/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: Request) {
 
   data.append({ test: 'value' });
 
-  const aiStream = LangChainAdapter.toAIStream(stream, {
+  const aiStream = LangChainAdapter.toDataStream(stream, {
     onFinal() {
       data.close();
     },

--- a/examples/next-langchain/app/api/completion-string-output-parser/route.ts
+++ b/examples/next-langchain/app/api/completion-string-output-parser/route.ts
@@ -17,5 +17,5 @@ export async function POST(req: Request) {
 
   const stream = await model.pipe(parser).stream(prompt);
 
-  return new StreamingTextResponse(LangChainAdapter.toAIStream(stream));
+  return new StreamingTextResponse(LangChainAdapter.toDataStream(stream));
 }

--- a/examples/next-langchain/app/api/completion/route.ts
+++ b/examples/next-langchain/app/api/completion/route.ts
@@ -14,5 +14,5 @@ export async function POST(req: Request) {
 
   const stream = await model.stream(prompt);
 
-  return new StreamingTextResponse(LangChainAdapter.toAIStream(stream));
+  return new StreamingTextResponse(LangChainAdapter.toDataStream(stream));
 }

--- a/examples/next-openai-pages/app/api/call-tool/route.ts
+++ b/examples/next-openai-pages/app/api/call-tool/route.ts
@@ -31,5 +31,5 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai-pages/app/api/call-tools-in-parallel/route.ts
+++ b/examples/next-openai-pages/app/api/call-tools-in-parallel/route.ts
@@ -37,5 +37,5 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai-pages/app/api/generative-ui-route/route.ts
+++ b/examples/next-openai-pages/app/api/generative-ui-route/route.ts
@@ -46,5 +46,5 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai-pages/app/api/stream-chat/route.ts
+++ b/examples/next-openai-pages/app/api/stream-chat/route.ts
@@ -10,5 +10,5 @@ export async function POST(req: Request) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai-pages/app/api/stream-text/route.ts
+++ b/examples/next-openai-pages/app/api/stream-text/route.ts
@@ -10,5 +10,5 @@ export async function POST(req: Request) {
     prompt,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai-pages/pages/api/chat-api-route.ts
+++ b/examples/next-openai-pages/pages/api/chat-api-route.ts
@@ -15,5 +15,5 @@ export default async function handler(
 
   // write the AI stream to the response
   // Note: this is sent as a single response, not a stream
-  result.pipeAIStreamToResponse(response);
+  result.pipeDataStreamToResponse(response);
 }

--- a/examples/next-openai-pages/pages/api/chat-edge.ts
+++ b/examples/next-openai-pages/pages/api/chat-edge.ts
@@ -11,5 +11,5 @@ export default async function handler(req: Request) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai/app/api/chat/route.ts
+++ b/examples/next-openai/app/api/chat/route.ts
@@ -19,5 +19,5 @@ export async function POST(req: Request) {
   });
 
   // Respond with the stream
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai/app/api/completion/route.ts
+++ b/examples/next-openai/app/api/completion/route.ts
@@ -23,5 +23,5 @@ export async function POST(req: Request) {
   });
 
   // Respond with the stream
-  return result.toAIStreamResponse({ data });
+  return result.toDataStreamResponse({ data });
 }

--- a/examples/next-openai/app/api/use-chat-streamdata/route.ts
+++ b/examples/next-openai/app/api/use-chat-streamdata/route.ts
@@ -20,5 +20,5 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse({ data });
+  return result.toDataStreamResponse({ data });
 }

--- a/examples/next-openai/app/api/use-chat-streaming-tool-calls/route.ts
+++ b/examples/next-openai/app/api/use-chat-streaming-tool-calls/route.ts
@@ -47,5 +47,5 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai/app/api/use-chat-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-tools/route.ts
@@ -40,5 +40,5 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/next-openai/app/api/use-chat-vision/route.ts
+++ b/examples/next-openai/app/api/use-chat-vision/route.ts
@@ -27,5 +27,5 @@ export async function POST(req: Request) {
   });
 
   // Respond with the stream
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }

--- a/examples/node-http-server/package.json
+++ b/examples/node-http-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-sdk-express-example",
+  "name": "ai-sdk-http-server-example",
   "version": "0.0.0",
   "private": true,
   "dependencies": {

--- a/examples/node-http-server/src/server.ts
+++ b/examples/node-http-server/src/server.ts
@@ -17,7 +17,7 @@ createServer(async (req, res) => {
   data.append('initialized call');
 
   streamToResponse(
-    result.toDataStream({
+    result.toAIStream({
       onFinal() {
         data.append('call completed');
         data.close();

--- a/examples/node-http-server/src/server.ts
+++ b/examples/node-http-server/src/server.ts
@@ -17,7 +17,7 @@ createServer(async (req, res) => {
   data.append('initialized call');
 
   streamToResponse(
-    result.toAIStream({
+    result.toDataStream({
       onFinal() {
         data.append('call completed');
         data.close();

--- a/examples/nuxt-openai/server/api/chat-with-vision.ts
+++ b/examples/nuxt-openai/server/api/chat-with-vision.ts
@@ -32,6 +32,6 @@ export default defineLazyEventHandler(async () => {
     });
 
     // Respond with the stream
-    return response.toAIStreamResponse();
+    return response.toDataStreamResponse();
   });
 });

--- a/examples/nuxt-openai/server/api/chat.ts
+++ b/examples/nuxt-openai/server/api/chat.ts
@@ -21,6 +21,6 @@ export default defineLazyEventHandler(async () => {
     });
 
     // Respond with the stream
-    return result.toAIStreamResponse();
+    return result.toDataStreamResponse();
   });
 });

--- a/examples/nuxt-openai/server/api/completion.ts
+++ b/examples/nuxt-openai/server/api/completion.ts
@@ -1,5 +1,5 @@
-import { streamText, StreamingTextResponse, StreamData } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
+import { StreamData, streamText } from 'ai';
 
 export default defineLazyEventHandler(async () => {
   const apiKey = useRuntimeConfig().openaiApiKey;
@@ -12,25 +12,22 @@ export default defineLazyEventHandler(async () => {
     // Extract the `prompt` from the body of the request
     const { prompt } = await readBody(event);
 
-    // Ask OpenAI for a streaming chat completion given the prompt
-    const result = await streamText({
-      model: openai('gpt-3.5-turbo'),
-      messages: [{ role: 'user', content: prompt }],
-    });
-
     // optional: use stream data
     const data = new StreamData();
 
     data.append({ test: 'value' });
 
-    // Convert the response into a friendly text-stream
-    const stream = result.toAIStream({
-      onFinal(_) {
+    // Ask OpenAI for a streaming chat completion given the prompt
+    const result = await streamText({
+      model: openai('gpt-3.5-turbo'),
+      messages: [{ role: 'user', content: prompt }],
+      onFinish() {
+        data.append('call completed');
         data.close();
       },
     });
 
     // Respond with the stream
-    return new StreamingTextResponse(stream, {}, data);
+    return result.toDataStreamResponse({ data });
   });
 });

--- a/examples/solidstart-openai/src/routes/api/chat/index.ts
+++ b/examples/solidstart-openai/src/routes/api/chat/index.ts
@@ -17,5 +17,5 @@ export const POST = async (event: APIEvent) => {
   });
 
   // Respond with the stream
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 };

--- a/examples/solidstart-openai/src/routes/api/completion/index.ts
+++ b/examples/solidstart-openai/src/routes/api/completion/index.ts
@@ -1,28 +1,24 @@
-import { StreamingTextResponse, StreamData, streamText } from 'ai';
-import { APIEvent } from '@solidjs/start/server';
 import { openai } from '@ai-sdk/openai';
+import { APIEvent } from '@solidjs/start/server';
+import { StreamData, streamText } from 'ai';
 
 export const POST = async (event: APIEvent) => {
   // Extract the `prompt` from the body of the request
   const { prompt } = await event.request.json();
 
-  const result = await streamText({
-    model: openai('gpt-3.5-turbo'),
-    messages: [{ role: 'user', content: prompt }],
-  });
-
   // optional: use stream data
   const data = new StreamData();
   data.append({ test: 'value' });
 
+  const result = await streamText({
+    model: openai('gpt-3.5-turbo'),
+    messages: [{ role: 'user', content: prompt }],
+    onFinish() {
+      data.append('call completed');
+      data.close();
+    },
+  });
+
   // Respond with the stream
-  return new StreamingTextResponse(
-    result.toAIStream({
-      onFinal: () => {
-        data.close();
-      },
-    }),
-    {},
-    data,
-  );
+  return result.toDataStreamResponse({ data });
 };

--- a/examples/solidstart-openai/src/routes/api/use-chat-tools/index.ts
+++ b/examples/solidstart-openai/src/routes/api/use-chat-tools/index.ts
@@ -37,5 +37,5 @@ export const POST = async (event: APIEvent) => {
     },
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 };

--- a/examples/solidstart-openai/src/routes/api/use-chat-vision/index.ts
+++ b/examples/solidstart-openai/src/routes/api/use-chat-vision/index.ts
@@ -27,5 +27,5 @@ export const POST = async (event: APIEvent) => {
   });
 
   // Respond with the stream
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 };

--- a/examples/sveltekit-openai/src/routes/api/chat/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/chat/+server.ts
@@ -28,5 +28,5 @@ export const POST = (async ({ request }) => {
   });
 
   // Respond with the stream
-  return result.toAIStreamResponse();
+  return result.toDataStreamResponse();
 }) satisfies RequestHandler;

--- a/examples/sveltekit-openai/src/routes/api/completion/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/completion/+server.ts
@@ -31,5 +31,5 @@ export const POST = (async ({ request }) => {
   });
 
   // Respond with the stream
-  return result.toAIStreamResponse({ data });
+  return result.toDataStreamResponse({ data });
 }) satisfies RequestHandler;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
     messages,
   });
 
-  return result.toAIStreamResponse();
+  return result.toDataStreamamResponse();
 }
 ```
 

--- a/packages/core/core/generate-text/stream-text-result.ts
+++ b/packages/core/core/generate-text/stream-text-result.ts
@@ -73,7 +73,9 @@ export interface StreamTextResult<TOOLS extends Record<string, CoreTool>> {
   @param callbacks
   Stream callbacks that will be called when the stream emits events.
 
-  @returns an `AIStream` object.
+  @returns an data stream.
+
+  @deprecated Use `toDataStreamResponse` instead.
      */
   toAIStream(
     callbacks?: AIStreamCallbacksAndOptions,
@@ -113,8 +115,23 @@ export interface StreamTextResult<TOOLS extends Record<string, CoreTool>> {
   You can also pass in a ResponseInit directly (deprecated).
 
   @return A response object.
+
+  @deprecated Use `toDataStreamResponse` instead.
      */
   toAIStreamResponse(
+    options?: ResponseInit | { init?: ResponseInit; data?: StreamData },
+  ): Response;
+
+  /**
+  Converts the result to a streamed response object with a stream data part stream.
+  It can be used with the `useChat` and `useCompletion` hooks.
+
+  @param options An object with an init property (ResponseInit) and a data property.
+  You can also pass in a ResponseInit directly (deprecated).
+
+  @return A response object.
+     */
+  toDataStreamResponse(
     options?: ResponseInit | { init?: ResponseInit; data?: StreamData },
   ): Response;
 

--- a/packages/core/core/generate-text/stream-text-result.ts
+++ b/packages/core/core/generate-text/stream-text-result.ts
@@ -73,7 +73,7 @@ export interface StreamTextResult<TOOLS extends Record<string, CoreTool>> {
   @param callbacks
   Stream callbacks that will be called when the stream emits events.
 
-  @returns an data stream.
+  @returns A data stream.
 
   @deprecated Use `toDataStreamResponse` instead.
      */

--- a/packages/core/core/generate-text/stream-text-result.ts
+++ b/packages/core/core/generate-text/stream-text-result.ts
@@ -88,8 +88,23 @@ export interface StreamTextResult<TOOLS extends Record<string, CoreTool>> {
 
   @param response A Node.js response-like object (ServerResponse).
   @param init Optional headers and status code.
+
+  @deprecated Use `pipeDataStreamToResponse` instead.
      */
   pipeAIStreamToResponse(
+    response: ServerResponse,
+    init?: { headers?: Record<string, string>; status?: number },
+  ): void;
+
+  /**
+  Writes data stream output to a Node.js response-like object.
+  It sets a `Content-Type` header to `text/plain; charset=utf-8` and
+  writes each data stream part as a separate chunk.
+
+  @param response A Node.js response-like object (ServerResponse).
+  @param init Optional headers and status code.
+     */
+  pipeDataStreamToResponse(
     response: ServerResponse,
     init?: { headers?: Record<string, string>; status?: number },
   ): void;

--- a/packages/core/core/generate-text/stream-text.test.ts
+++ b/packages/core/core/generate-text/stream-text.test.ts
@@ -852,7 +852,7 @@ describe('result.toAIStream', () => {
   });
 });
 
-describe('result.pipeAIStreamToResponse', async () => {
+describe('result.pipeDataStreamToResponse', async () => {
   it('should write data stream parts to a Node.js response-like object', async () => {
     const mockResponse = createMockServerResponse();
 
@@ -872,7 +872,7 @@ describe('result.pipeAIStreamToResponse', async () => {
       prompt: 'test-input',
     });
 
-    result.pipeAIStreamToResponse(mockResponse);
+    result.pipeDataStreamToResponse(mockResponse);
 
     // Wait for the stream to finish writing to the mock response
     await new Promise(resolve => {

--- a/packages/core/core/generate-text/stream-text.test.ts
+++ b/packages/core/core/generate-text/stream-text.test.ts
@@ -946,8 +946,8 @@ describe('result.pipeTextStreamToResponse', async () => {
   });
 });
 
-describe('result.toAIStreamResponse', () => {
-  it('should create a Response with a stream data stream', async () => {
+describe('result.toDataStreamResponse', () => {
+  it('should create a Response with a data stream', async () => {
     const result = await streamText({
       model: new MockLanguageModelV1({
         doStream: async () => ({
@@ -962,7 +962,7 @@ describe('result.toAIStreamResponse', () => {
       prompt: 'test-input',
     });
 
-    const response = result.toAIStreamResponse();
+    const response = result.toDataStreamResponse();
 
     assert.strictEqual(response.status, 200);
     assert.strictEqual(
@@ -977,7 +977,7 @@ describe('result.toAIStreamResponse', () => {
     ]);
   });
 
-  it('should create a Response with a stream data stream and custom headers', async () => {
+  it('should create a Response with a data stream and custom headers', async () => {
     const result = await streamText({
       model: new MockLanguageModelV1({
         doStream: async () => ({
@@ -992,7 +992,7 @@ describe('result.toAIStreamResponse', () => {
       prompt: 'test-input',
     });
 
-    const response = result.toAIStreamResponse({
+    const response = result.toDataStreamResponse({
       status: 201,
       statusText: 'foo',
       headers: {
@@ -1034,7 +1034,7 @@ describe('result.toAIStreamResponse', () => {
     streamData.append('stream-data-value');
     streamData.close();
 
-    const response = result.toAIStreamResponse({ data: streamData });
+    const response = result.toDataStreamResponse({ data: streamData });
 
     assert.strictEqual(response.status, 200);
     assert.strictEqual(

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -586,6 +586,13 @@ However, the LLM results are expected to be small enough to not cause issues.
   pipeAIStreamToResponse(
     response: ServerResponse,
     init?: { headers?: Record<string, string>; status?: number },
+  ): void {
+    return this.pipeDataStreamToResponse(response, init);
+  }
+
+  pipeDataStreamToResponse(
+    response: ServerResponse,
+    init?: { headers?: Record<string, string>; status?: number },
   ) {
     response.writeHead(init?.status ?? 200, {
       'Content-Type': 'text/plain; charset=utf-8',

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -644,6 +644,12 @@ However, the LLM results are expected to be small enough to not cause issues.
   toAIStreamResponse(
     options?: ResponseInit | { init?: ResponseInit; data?: StreamData },
   ): Response {
+    return this.toDataStreamResponse(options);
+  }
+
+  toDataStreamResponse(
+    options?: ResponseInit | { init?: ResponseInit; data?: StreamData },
+  ): Response {
     const init: ResponseInit | undefined =
       options == null
         ? undefined

--- a/packages/core/streams/langchain-adapter.test.ts
+++ b/packages/core/streams/langchain-adapter.test.ts
@@ -2,9 +2,9 @@ import {
   convertArrayToReadableStream,
   convertReadableStreamToArray,
 } from '@ai-sdk/provider-utils/test';
-import { toAIStream } from './langchain-adapter';
+import { toDataStream } from './langchain-adapter';
 
-describe('toAIStream', () => {
+describe('toDataStream', () => {
   it('should convert ReadableStream<LangChainAIMessageChunk>', async () => {
     const inputStream = convertArrayToReadableStream([
       { content: 'Hello' },
@@ -13,7 +13,7 @@ describe('toAIStream', () => {
 
     assert.deepStrictEqual(
       await convertReadableStreamToArray(
-        toAIStream(inputStream).pipeThrough(new TextDecoderStream()),
+        toDataStream(inputStream).pipeThrough(new TextDecoderStream()),
       ),
       ['0:"Hello"\n', '0:"World"\n'],
     );
@@ -24,7 +24,7 @@ describe('toAIStream', () => {
 
     assert.deepStrictEqual(
       await convertReadableStreamToArray(
-        toAIStream(inputStream).pipeThrough(new TextDecoderStream()),
+        toDataStream(inputStream).pipeThrough(new TextDecoderStream()),
       ),
       ['0:"Hello"\n', '0:"World"\n'],
     );
@@ -38,7 +38,7 @@ describe('toAIStream', () => {
 
     assert.deepStrictEqual(
       await convertReadableStreamToArray(
-        toAIStream(inputStream).pipeThrough(new TextDecoderStream()),
+        toDataStream(inputStream).pipeThrough(new TextDecoderStream()),
       ),
       ['0:"Hello"\n', '0:"World"\n'],
     );

--- a/packages/core/streams/langchain-adapter.ts
+++ b/packages/core/streams/langchain-adapter.ts
@@ -44,13 +44,32 @@ type LangChainStreamEvent = {
 };
 
 /**
-Converts LangChain output streams to AIStream. 
+Converts LangChain output streams to AIStream.
+
+The following streams are supported:
+- `LangChainAIMessageChunk` streams (LangChain `model.stream` output)
+- `string` streams (LangChain `StringOutputParser` output)
+
+@deprecated Use `toDataStream` instead.
+ */
+export function toAIStream(
+  stream:
+    | ReadableStream<LangChainStreamEvent>
+    | ReadableStream<LangChainAIMessageChunk>
+    | ReadableStream<string>,
+  callbacks?: AIStreamCallbacksAndOptions,
+) {
+  return toDataStream(stream, callbacks);
+}
+
+/**
+Converts LangChain output streams to AIStream.
 
 The following streams are supported:
 - `LangChainAIMessageChunk` streams (LangChain `model.stream` output)
 - `string` streams (LangChain `StringOutputParser` output)
  */
-export function toAIStream(
+export function toDataStream(
   stream:
     | ReadableStream<LangChainStreamEvent>
     | ReadableStream<LangChainAIMessageChunk>

--- a/packages/core/streams/streaming-text-response.ts
+++ b/packages/core/streams/streaming-text-response.ts
@@ -4,6 +4,8 @@ import { StreamData } from './stream-data';
 
 /**
  * A utility class for streaming text responses.
+ *
+ * @deprecated Use `streamText.toDataStreamResponse()` instead.
  */
 export class StreamingTextResponse extends Response {
   constructor(res: ReadableStream, init?: ResponseInit, data?: StreamData) {


### PR DESCRIPTION
## Summary
* rename `streamText` result `.toAIStreamResponse()` -> `.toDataStreamResponse()`
* rename `streamText` result `.pipeAIStreamResponse()` -> `.pipeDataStreamResponse()`
* rename `LangChainAdapter.toAIStream()` -> `LangChainAdapter.toDataStream()`