### PR TITLE
chore (ai/ui): remove total tokens from finish message part

### DIFF
--- a/packages/core/core/generate-text/stream-text.test.ts
+++ b/packages/core/core/generate-text/stream-text.test.ts
@@ -586,7 +586,7 @@ describe('result.toAIStream', () => {
         formatStreamPart('text', 'world!'),
         formatStreamPart('finish_message', {
           finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10, totalTokens: 13 },
+          usage: { promptTokens: 3, completionTokens: 10 },
         }),
       ],
     );
@@ -739,7 +739,7 @@ describe('result.toAIStream', () => {
         }),
         formatStreamPart('finish_message', {
           finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10, totalTokens: 13 },
+          usage: { promptTokens: 3, completionTokens: 10 },
         }),
       ],
     );
@@ -845,7 +845,7 @@ describe('result.toAIStream', () => {
         }),
         formatStreamPart('finish_message', {
           finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10, totalTokens: 13 },
+          usage: { promptTokens: 3, completionTokens: 10 },
         }),
       ],
     );
@@ -1132,7 +1132,7 @@ describe('multiple stream consumption', () => {
         formatStreamPart('text', 'world!'),
         formatStreamPart('finish_message', {
           finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10, totalTokens: 13 },
+          usage: { promptTokens: 3, completionTokens: 10 },
         }),
       ],
     );

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -565,7 +565,10 @@ However, the LLM results are expected to be small enough to not cause issues.
             controller.enqueue(
               formatStreamPart('finish_message', {
                 finishReason: chunk.finishReason,
-                usage: chunk.usage,
+                usage: {
+                  promptTokens: chunk.usage.promptTokens,
+                  completionTokens: chunk.usage.completionTokens,
+                },
               }),
             );
             break;

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -183,11 +183,7 @@ describe('stream data stream', () => {
           formatStreamPart('text', '.'),
           formatStreamPart('finish_message', {
             finishReason: 'stop',
-            usage: {
-              completionTokens: 1,
-              promptTokens: 3,
-              totalTokens: 4,
-            },
+            usage: { completionTokens: 1, promptTokens: 3 },
           }),
         ],
       },

--- a/packages/solid/src/use-chat.ui.test.tsx
+++ b/packages/solid/src/use-chat.ui.test.tsx
@@ -175,11 +175,7 @@ describe('stream data stream', () => {
           formatStreamPart('text', '.'),
           formatStreamPart('finish_message', {
             finishReason: 'stop',
-            usage: {
-              completionTokens: 1,
-              promptTokens: 3,
-              totalTokens: 4,
-            },
+            usage: { completionTokens: 1, promptTokens: 3 },
           }),
         ],
       },

--- a/packages/ui-utils/src/parse-complex-response.ts
+++ b/packages/ui-utils/src/parse-complex-response.ts
@@ -106,8 +106,14 @@ export async function parseComplexResponse({
     }
 
     if (type === 'finish_message') {
+      const { completionTokens, promptTokens } = value.usage;
+
       finishReason = value.finishReason;
-      usage = value.usage;
+      usage = {
+        completionTokens,
+        promptTokens,
+        totalTokens: completionTokens + promptTokens,
+      };
     }
 
     // Tool invocations are part of an assistant message

--- a/packages/ui-utils/src/stream-parts.test.ts
+++ b/packages/ui-utils/src/stream-parts.test.ts
@@ -201,20 +201,20 @@ describe('finish_message stream part', () => {
     expect(
       formatStreamPart('finish_message', {
         finishReason: 'stop',
-        usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+        usage: { promptTokens: 10, completionTokens: 20 },
       }),
     ).toEqual(
-      `d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20,"totalTokens":30}}\n`,
+      `d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20}}\n`,
     );
   });
 
   it('should parse a finish_message stream part', () => {
-    const input = `d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20,"totalTokens":30}}`;
+    const input = `d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20}}`;
     expect(parseStreamPart(input)).toEqual({
       type: 'finish_message',
       value: {
         finishReason: 'stop',
-        usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+        usage: { promptTokens: 10, completionTokens: 20 },
       },
     });
   });

--- a/packages/ui-utils/src/stream-parts.ts
+++ b/packages/ui-utils/src/stream-parts.ts
@@ -371,7 +371,6 @@ const finishMessageStreamPart: StreamPart<
     usage: {
       promptTokens: number;
       completionTokens: number;
-      totalTokens: number;
     };
   }
 > = {
@@ -389,9 +388,7 @@ const finishMessageStreamPart: StreamPart<
       !('promptTokens' in value.usage) ||
       typeof value.usage.promptTokens !== 'number' ||
       !('completionTokens' in value.usage) ||
-      typeof value.usage.completionTokens !== 'number' ||
-      !('totalTokens' in value.usage) ||
-      typeof value.usage.totalTokens !== 'number'
+      typeof value.usage.completionTokens !== 'number'
     ) {
       throw new Error(
         '"finish_message" parts expect an object with a "finishReason" and "usage" property.',

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -120,11 +120,7 @@ describe('stream data stream', () => {
           formatStreamPart('text', '.'),
           formatStreamPart('finish_message', {
             finishReason: 'stop',
-            usage: {
-              completionTokens: 1,
-              promptTokens: 3,
-              totalTokens: 4,
-            },
+            usage: { completionTokens: 1, promptTokens: 3 },
           }),
         ],
       },


### PR DESCRIPTION
## Background
The goal is to reduce data transfer. `totalTokens` can easily be calculated and do not to be transferred separately.