### PR TITLE
chore (ai/ui): remove "args" and "toolName" from tool result stream part.

### DIFF
--- a/.changeset/beige-students-beg.md
+++ b/.changeset/beige-students-beg.md
@@ -2,4 +2,4 @@
 '@ai-sdk/ui-utils': patch
 ---
 
-chore (ai/ui): remove "args" from tool result stream part.
+chore (ai/ui): remove "args" and "toolName" from tool result stream part.

--- a/.changeset/beige-students-beg.md
+++ b/.changeset/beige-students-beg.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/ui-utils': patch
+---
+
+chore (ai/ui): remove "args" from tool result stream part.

--- a/content/docs/05-ai-sdk-ui/50-stream-protocol.mdx
+++ b/content/docs/05-ai-sdk-ui/50-stream-protocol.mdx
@@ -135,9 +135,9 @@ The following stream parts are currently supported:
 
   The result part needs to be sent after the tool call part for that tool call.
 
-  Format: `a:{toolCallId:string; toolName:string; result:object}\n`
+  Format: `a:{toolCallId:string; result:object}\n`
 
-  Example: `a:{"toolCallId":"call-123","toolName":"my-tool","result":"tool output"}\n`
+  Example: `a:{"toolCallId":"call-123","result":"tool output"}\n`
 
 - **finish message**: A part indicating the completion of a message with additional metadata.
 

--- a/content/docs/05-ai-sdk-ui/50-stream-protocol.mdx
+++ b/content/docs/05-ai-sdk-ui/50-stream-protocol.mdx
@@ -135,9 +135,9 @@ The following stream parts are currently supported:
 
   The result part needs to be sent after the tool call part for that tool call.
 
-  Format: `a:{toolCallId:string; toolName:string; args:object; result:object}\n`
+  Format: `a:{toolCallId:string; toolName:string; result:object}\n`
 
-  Example: `a:{"toolCallId":"call-123","toolName":"my-tool","args":{"some":"argument"},"result":"tool output"}\n`
+  Example: `a:{"toolCallId":"call-123","toolName":"my-tool","result":"tool output"}\n`
 
 - **finish message**: A part indicating the completion of a message with additional metadata.
 

--- a/packages/core/core/generate-text/stream-text.test.ts
+++ b/packages/core/core/generate-text/stream-text.test.ts
@@ -733,8 +733,6 @@ describe('result.toAIStream', () => {
         }),
         formatStreamPart('tool_result', {
           toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
           result: 'value-result',
         }),
         formatStreamPart('finish_message', {
@@ -839,8 +837,6 @@ describe('result.toAIStream', () => {
         }),
         formatStreamPart('tool_result', {
           toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
           result: 'value-result',
         }),
         formatStreamPart('finish_message', {

--- a/packages/core/core/generate-text/stream-text.ts
+++ b/packages/core/core/generate-text/stream-text.ts
@@ -577,8 +577,6 @@ However, the LLM results are expected to be small enough to not cause issues.
             controller.enqueue(
               formatStreamPart('tool_result', {
                 toolCallId: chunk.toolCallId,
-                toolName: chunk.toolName,
-                args: chunk.args,
                 result: chunk.result,
               }),
             );

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -770,8 +770,6 @@ describe('tool invocations', () => {
         streamController.enqueue(
           formatStreamPart('tool_result', {
             toolCallId: 'tool-call-0',
-            toolName: 'test-tool',
-            args: { testArg: 'test-value' },
             result: 'test-result',
           }),
         );
@@ -810,8 +808,6 @@ describe('tool invocations', () => {
         streamController.enqueue(
           formatStreamPart('tool_result', {
             toolCallId: 'tool-call-0',
-            toolName: 'test-tool',
-            args: { testArg: 'test-value' },
             result: 'test-result',
           }),
         );

--- a/packages/ui-utils/src/parse-complex-response.ts
+++ b/packages/ui-utils/src/parse-complex-response.ts
@@ -224,7 +224,12 @@ export async function parseComplexResponse({
         invocation => invocation.toolCallId === value.toolCallId,
       );
 
-      const result = { state: 'result' as const, ...value };
+      const result = {
+        state: 'result' as const,
+        args: prefixMap.text.toolInvocations[toolInvocationIndex].args,
+        ...value,
+      };
+
       if (toolInvocationIndex !== -1) {
         prefixMap.text.toolInvocations[toolInvocationIndex] = result;
       } else {

--- a/packages/ui-utils/src/parse-complex-response.ts
+++ b/packages/ui-utils/src/parse-complex-response.ts
@@ -204,37 +204,29 @@ export async function parseComplexResponse({
         }
       }
     } else if (type === 'tool_result') {
-      // create message if it doesn't exist
-      if (prefixMap.text == null) {
-        prefixMap.text = {
-          id: generateId(),
-          role: 'assistant',
-          content: '',
-          createdAt,
-        };
-      }
+      const toolInvocations = prefixMap.text?.toolInvocations;
 
-      if (prefixMap.text.toolInvocations == null) {
-        prefixMap.text.toolInvocations = [];
+      if (toolInvocations == null) {
+        throw new Error('tool_result must be preceded by a tool_call');
       }
 
       // find if there is any tool invocation with the same toolCallId
       // and replace it with the result
-      const toolInvocationIndex = prefixMap.text.toolInvocations.findIndex(
+      const toolInvocationIndex = toolInvocations.findIndex(
         invocation => invocation.toolCallId === value.toolCallId,
       );
 
-      const result = {
+      if (toolInvocationIndex === -1) {
+        throw new Error(
+          'tool_result must be preceded by a tool_call with the same toolCallId',
+        );
+      }
+
+      toolInvocations[toolInvocationIndex] = {
+        ...toolInvocations[toolInvocationIndex],
         state: 'result' as const,
-        args: prefixMap.text.toolInvocations[toolInvocationIndex].args,
         ...value,
       };
-
-      if (toolInvocationIndex !== -1) {
-        prefixMap.text.toolInvocations[toolInvocationIndex] = result;
-      } else {
-        prefixMap.text.toolInvocations.push(result);
-      }
     }
 
     let functionCallMessage: Message | null | undefined = null;

--- a/packages/ui-utils/src/stream-parts.test.ts
+++ b/packages/ui-utils/src/stream-parts.test.ts
@@ -128,10 +128,11 @@ describe('tool_call stream part', () => {
 
 describe('tool_result stream part', () => {
   it('should format a tool_result stream part', () => {
-    const toolResult: CoreToolResult<string, any, any> = {
+    const toolResult: Omit<
+      CoreToolResult<string, any, any>,
+      'args' | 'toolName'
+    > = {
       toolCallId: 'tc_0',
-      toolName: 'example_tool',
-      args: { test: 'value' },
       result: 'result',
     };
 
@@ -143,8 +144,6 @@ describe('tool_result stream part', () => {
   it('should parse a tool_result stream part', () => {
     const toolResult = {
       toolCallId: 'tc_0',
-      toolName: 'example_tool',
-      args: { test: 'value' },
       result: 'result',
     };
 

--- a/packages/ui-utils/src/stream-parts.ts
+++ b/packages/ui-utils/src/stream-parts.ts
@@ -276,7 +276,7 @@ const toolCallStreamPart: StreamPart<
 const toolResultStreamPart: StreamPart<
   'a',
   'tool_result',
-  CoreToolResult<string, any, any>
+  Omit<CoreToolResult<string, any, any>, 'args'>
 > = {
   code: 'a',
   name: 'tool_result',
@@ -288,18 +288,16 @@ const toolResultStreamPart: StreamPart<
       typeof value.toolCallId !== 'string' ||
       !('toolName' in value) ||
       typeof value.toolName !== 'string' ||
-      !('args' in value) ||
-      typeof value.args !== 'object' ||
       !('result' in value)
     ) {
       throw new Error(
-        '"tool_result" parts expect an object with a "toolCallId", "toolName", "args", and "result" property.',
+        '"tool_result" parts expect an object with a "toolCallId", "toolName", and "result" property.',
       );
     }
 
     return {
       type: 'tool_result',
-      value: value as unknown as CoreToolResult<string, any, any>,
+      value: value as unknown as Omit<CoreToolResult<string, any, any>, 'args'>,
     };
   },
 };

--- a/packages/ui-utils/src/stream-parts.ts
+++ b/packages/ui-utils/src/stream-parts.ts
@@ -276,7 +276,7 @@ const toolCallStreamPart: StreamPart<
 const toolResultStreamPart: StreamPart<
   'a',
   'tool_result',
-  Omit<CoreToolResult<string, any, any>, 'args'>
+  Omit<CoreToolResult<string, any, any>, 'args' | 'toolName'>
 > = {
   code: 'a',
   name: 'tool_result',
@@ -286,18 +286,19 @@ const toolResultStreamPart: StreamPart<
       typeof value !== 'object' ||
       !('toolCallId' in value) ||
       typeof value.toolCallId !== 'string' ||
-      !('toolName' in value) ||
-      typeof value.toolName !== 'string' ||
       !('result' in value)
     ) {
       throw new Error(
-        '"tool_result" parts expect an object with a "toolCallId", "toolName", and "result" property.',
+        '"tool_result" parts expect an object with a "toolCallId" and a "result" property.',
       );
     }
 
     return {
       type: 'tool_result',
-      value: value as unknown as Omit<CoreToolResult<string, any, any>, 'args'>,
+      value: value as unknown as Omit<
+        CoreToolResult<string, any, any>,
+        'args' | 'toolName'
+      >,
     };
   },
 };


### PR DESCRIPTION
## Background
`tool_result` stream parts must always be follow `tool_call` stream parts with the same tool call id. The `args` and `toolName` fields are therefore redundant and removed to reduce the data transfer.