### PR TITLE
Ensure toolName and toolCallId are passed to errors thrown at tool execution

### DIFF
--- a/packages/ai/core/generate-text/run-tools-transformation.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.ts
@@ -85,6 +85,7 @@ export function runToolsTransformation<TOOLS extends Record<string, CoreTool>>({
         // process tool call:
         case 'tool-call': {
           const toolName = chunk.toolName as keyof TOOLS & string;
+          const toolCallId = chunk.toolCallId as string
 
           if (tools == null) {
             toolResultsStreamController!.enqueue({
@@ -192,6 +193,8 @@ export function runToolsTransformation<TOOLS extends Record<string, CoreTool>>({
               });
             }
           } catch (error) {
+            error.toolName = toolName
+            error.toolCallId = toolCallId
             toolResultsStreamController!.enqueue({
               type: 'error',
               error,


### PR DESCRIPTION
Well. I guess we don't have errors when they are always so unknown so I didn't bother with types and just added the toolCallId and toolName inside the catch block.

Issue #2578 