### PR TITLE
feat (ai/openai): structured outputs

### DIFF
--- a/.changeset/cool-vans-stare.md
+++ b/.changeset/cool-vans-stare.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider': patch
+'@ai-sdk/openai': patch
+'ai': patch
+---
+
+feat (ai/openai): structured outputs

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -188,7 +188,7 @@ The following optional settings are available for OpenAI chat models:
 
   Whether to enable parallel function calling during tool use. Default to true.
 
-- **useLegacyFunctionCalls**
+- **useLegacyFunctionCalls** _boolean_
 
   Whether to use legacy function calling. Defaults to false.
 
@@ -197,6 +197,12 @@ The following optional settings are available for OpenAI chat models:
   which causes `streamObject` to be non-streaming.
 
   Prefer setting `parallelToolCalls: false` over this option.
+
+- **structuredOutputs** _boolean_
+
+  Whether to use structured outputs. Defaults to false.
+
+  When enabled, tool calls and object generation will be strict and follow the provided schema.
 
 - **user** _string_
 

--- a/examples/ai-core/src/generate-object/openai-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/openai-structured-outputs.ts
@@ -21,6 +21,7 @@ async function main() {
     model: openai('gpt-4o-2024-08-06', {
       structuredOutputs: true,
     }),
+    mode: 'tool',
     schema: z.object({
       recipe: z.object({
         name: z.string(),

--- a/examples/ai-core/src/generate-object/openai-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/openai-structured-outputs.ts
@@ -1,9 +1,20 @@
-import { openai } from '@ai-sdk/openai';
+import { createOpenAI } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 import dotenv from 'dotenv';
 import { z } from 'zod';
 
 dotenv.config();
+
+const openai = createOpenAI({
+  fetch: async (url, options) => {
+    console.log(
+      'Fetching',
+      url,
+      JSON.stringify(JSON.parse(options!.body! as string), null, 2),
+    );
+    return await fetch(url, options);
+  },
+});
 
 async function main() {
   const result = await generateObject({

--- a/examples/ai-core/src/generate-object/openai-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/openai-structured-outputs.ts
@@ -1,0 +1,34 @@
+import { openai } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import dotenv from 'dotenv';
+import { z } from 'zod';
+
+dotenv.config();
+
+async function main() {
+  const result = await generateObject({
+    model: openai('gpt-4o-2024-08-06', {
+      structuredOutputs: true,
+    }),
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({
+            name: z.string(),
+            amount: z.string(),
+          }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log(JSON.stringify(result.object.recipe, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-object/openai-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/openai-structured-outputs.ts
@@ -1,20 +1,9 @@
-import { createOpenAI } from '@ai-sdk/openai';
+import { openai } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 import dotenv from 'dotenv';
 import { z } from 'zod';
 
 dotenv.config();
-
-const openai = createOpenAI({
-  fetch: async (url, options) => {
-    console.log(
-      'Fetching',
-      url,
-      JSON.stringify(JSON.parse(options!.body! as string), null, 2),
-    );
-    return await fetch(url, options);
-  },
-});
 
 async function main() {
   const result = await generateObject({

--- a/examples/ai-core/src/generate-object/openai-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/openai-structured-outputs.ts
@@ -10,7 +10,6 @@ async function main() {
     model: openai('gpt-4o-2024-08-06', {
       structuredOutputs: true,
     }),
-    mode: 'tool',
     schema: z.object({
       recipe: z.object({
         name: z.string(),

--- a/examples/ai-core/src/stream-object/openai-structured-outputs.ts
+++ b/examples/ai-core/src/stream-object/openai-structured-outputs.ts
@@ -1,0 +1,34 @@
+import { openai } from '@ai-sdk/openai';
+import { streamObject } from 'ai';
+import dotenv from 'dotenv';
+import { z } from 'zod';
+
+dotenv.config();
+
+async function main() {
+  const result = await streamObject({
+    model: openai('gpt-4o-2024-08-06', {
+      structuredOutputs: true,
+    }),
+    schema: z.object({
+      characters: z.array(
+        z.object({
+          name: z.string(),
+          class: z
+            .string()
+            .describe('Character class, e.g. warrior, mage, or thief.'),
+          description: z.string(),
+        }),
+      ),
+    }),
+    prompt:
+      'Generate 3 character descriptions for a fantasy role playing game.',
+  });
+
+  for await (const partialObject of result.partialObjectStream) {
+    console.clear();
+    console.log(partialObject);
+  }
+}
+
+main().catch(console.error);

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -18,7 +18,17 @@ describe('result.object', () => {
     const result = await generateObject({
       model: new MockLanguageModelV1({
         doGenerate: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, { type: 'object-json' });
+          assert.deepStrictEqual(mode, {
+            type: 'object-json',
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              additionalProperties: false,
+              properties: { content: { type: 'string' } },
+              required: ['content'],
+              type: 'object',
+            },
+          });
+
           assert.deepStrictEqual(prompt, [
             {
               role: 'system',
@@ -463,7 +473,15 @@ describe('custom schema', () => {
     const result = await generateObject({
       model: new MockLanguageModelV1({
         doGenerate: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, { type: 'object-json' });
+          assert.deepStrictEqual(mode, {
+            type: 'object-json',
+            schema: {
+              type: 'object',
+              properties: { content: { type: 'string' } },
+              required: ['content'],
+              additionalProperties: false,
+            },
+          });
           assert.deepStrictEqual(prompt, [
             {
               role: 'system',
@@ -496,11 +514,20 @@ describe('custom schema', () => {
 });
 
 describe('zod schema', () => {
-  it('should generate object  when using zod transform', async () => {
+  it('should generate object when using zod transform', async () => {
     const result = await generateObject({
       model: new MockLanguageModelV1({
         doGenerate: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, { type: 'object-json' });
+          assert.deepStrictEqual(mode, {
+            type: 'object-json',
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              additionalProperties: false,
+              properties: { content: { type: 'string' } },
+              required: ['content'],
+              type: 'object',
+            },
+          });
           assert.deepStrictEqual(prompt, [
             {
               role: 'system',
@@ -532,7 +559,16 @@ describe('zod schema', () => {
     const result = await generateObject({
       model: new MockLanguageModelV1({
         doGenerate: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, { type: 'object-json' });
+          assert.deepStrictEqual(mode, {
+            type: 'object-json',
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              additionalProperties: false,
+              properties: { content: { type: 'string' } },
+              required: ['content'],
+              type: 'object',
+            },
+          });
           assert.deepStrictEqual(prompt, [
             {
               role: 'system',

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -153,10 +153,12 @@ Default and recommended: 'auto' (best mode for the model).
       switch (mode) {
         case 'json': {
           const validatedPrompt = getValidatedPrompt({
-            system: injectJsonSchemaIntoSystem({
-              system,
-              schema: schema.jsonSchema,
-            }),
+            system: model.supportsStructuredOutputs
+              ? system
+              : injectJsonSchemaIntoSystem({
+                  system,
+                  schema: schema.jsonSchema,
+                }),
             prompt,
             messages,
           });
@@ -198,7 +200,7 @@ Default and recommended: 'auto' (best mode for the model).
               tracer,
               fn: async span => {
                 const result = await model.doGenerate({
-                  mode: { type: 'object-json' },
+                  mode: { type: 'object-json', schema: schema.jsonSchema },
                   ...prepareCallSettings(settings),
                   inputFormat,
                   prompt: promptMessages,

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -684,19 +684,17 @@ describe('options.headers', () => {
 
 describe('custom schema', () => {
   it('should send object deltas with json mode', async () => {
-    const testSchema = jsonSchema({
-      type: 'object',
-      properties: { content: { type: 'string' } },
-      required: ['content'],
-      additionalProperties: false,
-    });
-
     const result = await streamObject({
       model: new MockLanguageModelV1({
         doStream: async ({ prompt, mode }) => {
           assert.deepStrictEqual(mode, {
             type: 'object-json',
-            schema: testSchema.jsonSchema,
+            schema: jsonSchema({
+              type: 'object',
+              properties: { content: { type: 'string' } },
+              required: ['content'],
+              additionalProperties: false,
+            }).jsonSchema,
           });
 
           assert.deepStrictEqual(prompt, [
@@ -728,7 +726,12 @@ describe('custom schema', () => {
           };
         },
       }),
-      schema: testSchema,
+      schema: jsonSchema({
+        type: 'object',
+        properties: { content: { type: 'string' } },
+        required: ['content'],
+        additionalProperties: false,
+      }),
       mode: 'json',
       prompt: 'prompt',
     });

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -6,19 +6,31 @@ import {
 } from '@ai-sdk/provider-utils/test';
 import assert from 'node:assert';
 import { z } from 'zod';
+import { setTestTracer } from '../telemetry/get-tracer';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
 import { createMockServerResponse } from '../test/mock-server-response';
+import { MockTracer } from '../test/mock-tracer';
 import { jsonSchema } from '../util/schema';
 import { streamObject } from './stream-object';
-import { MockTracer } from '../test/mock-tracer';
-import { setTestTracer } from '../telemetry/get-tracer';
 
 describe('result.objectStream', () => {
   it('should send object deltas with json mode', async () => {
+    const testSchema = z.object({ content: z.string() });
+
     const result = await streamObject({
       model: new MockLanguageModelV1({
         doStream: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, { type: 'object-json' });
+          assert.deepStrictEqual(mode, {
+            type: 'object-json',
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              additionalProperties: false,
+              properties: { content: { type: 'string' } },
+              required: ['content'],
+              type: 'object',
+            },
+          });
+
           assert.deepStrictEqual(prompt, [
             {
               role: 'system',
@@ -48,7 +60,7 @@ describe('result.objectStream', () => {
           };
         },
       }),
-      schema: z.object({ content: z.string() }),
+      schema: testSchema,
       mode: 'json',
       prompt: 'prompt',
     });
@@ -162,25 +174,23 @@ describe('result.fullStream', () => {
   it('should send full stream data', async () => {
     const result = await streamObject({
       model: new MockLanguageModelV1({
-        doStream: async () => {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 2 },
-                logprobs: [{ token: '-', logprob: 1, topLogprobs: [] }],
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: { logprobs: 0 } },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '{ ' },
+            { type: 'text-delta', textDelta: '"content": ' },
+            { type: 'text-delta', textDelta: `"Hello, ` },
+            { type: 'text-delta', textDelta: `world` },
+            { type: 'text-delta', textDelta: `!"` },
+            { type: 'text-delta', textDelta: ' }' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 2 },
+              logprobs: [{ token: '-', logprob: 1, topLogprobs: [] }],
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: { logprobs: 0 } },
+        }),
       }),
       schema: z.object({ content: z.string() }),
       mode: 'json',
@@ -247,24 +257,22 @@ describe('result.textStream', () => {
   it('should send text stream', async () => {
     const result = await streamObject({
       model: new MockLanguageModelV1({
-        doStream: async () => {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 2 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '{ ' },
+            { type: 'text-delta', textDelta: '"content": ' },
+            { type: 'text-delta', textDelta: `"Hello, ` },
+            { type: 'text-delta', textDelta: `world` },
+            { type: 'text-delta', textDelta: `!"` },
+            { type: 'text-delta', textDelta: ' }' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 2 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       schema: z.object({ content: z.string() }),
       mode: 'json',
@@ -282,24 +290,22 @@ describe('result.toTextStreamResponse', () => {
   it('should create a Response with a text stream', async () => {
     const result = await streamObject({
       model: new MockLanguageModelV1({
-        doStream: async () => {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 2 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '{ ' },
+            { type: 'text-delta', textDelta: '"content": ' },
+            { type: 'text-delta', textDelta: `"Hello, ` },
+            { type: 'text-delta', textDelta: `world` },
+            { type: 'text-delta', textDelta: `!"` },
+            { type: 'text-delta', textDelta: ' }' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 2 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       schema: z.object({ content: z.string() }),
       mode: 'json',
@@ -329,24 +335,22 @@ describe('result.pipeTextStreamToResponse', async () => {
 
     const result = await streamObject({
       model: new MockLanguageModelV1({
-        doStream: async () => {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 2 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '{ ' },
+            { type: 'text-delta', textDelta: '"content": ' },
+            { type: 'text-delta', textDelta: `"Hello, ` },
+            { type: 'text-delta', textDelta: `world` },
+            { type: 'text-delta', textDelta: `!"` },
+            { type: 'text-delta', textDelta: ' }' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 2 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       schema: z.object({ content: z.string() }),
       mode: 'json',
@@ -384,36 +388,22 @@ describe('result.usage', () => {
   it('should resolve with token usage', async () => {
     const result = await streamObject({
       model: new MockLanguageModelV1({
-        doStream: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, { type: 'object-json' });
-          assert.deepStrictEqual(prompt, [
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '{ ' },
+            { type: 'text-delta', textDelta: '"content": ' },
+            { type: 'text-delta', textDelta: `"Hello, ` },
+            { type: 'text-delta', textDelta: `world` },
+            { type: 'text-delta', textDelta: `!"` },
+            { type: 'text-delta', textDelta: ' }' },
             {
-              role: 'system',
-              content:
-                'JSON schema:\n' +
-                '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
-                'You MUST answer with a JSON object that matches the JSON schema above.',
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 3 },
             },
-            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
-          ]);
-
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       schema: z.object({ content: z.string() }),
       mode: 'json',
@@ -435,24 +425,22 @@ describe('result.object', () => {
   it('should resolve with typed object', async () => {
     const result = await streamObject({
       model: new MockLanguageModelV1({
-        doStream: async () => {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '{ ' },
+            { type: 'text-delta', textDelta: '"content": ' },
+            { type: 'text-delta', textDelta: `"Hello, ` },
+            { type: 'text-delta', textDelta: `world` },
+            { type: 'text-delta', textDelta: `!"` },
+            { type: 'text-delta', textDelta: ' }' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 3 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       schema: z.object({ content: z.string() }),
       mode: 'json',
@@ -470,24 +458,22 @@ describe('result.object', () => {
   it('should reject object promise when the streamed object does not match the schema', async () => {
     const result = await streamObject({
       model: new MockLanguageModelV1({
-        doStream: async () => {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"invalid": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '{ ' },
+            { type: 'text-delta', textDelta: '"invalid": ' },
+            { type: 'text-delta', textDelta: `"Hello, ` },
+            { type: 'text-delta', textDelta: `world` },
+            { type: 'text-delta', textDelta: `!"` },
+            { type: 'text-delta', textDelta: ' }' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 3 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       schema: z.object({ content: z.string() }),
       mode: 'json',
@@ -509,24 +495,22 @@ describe('result.object', () => {
   it('should not lead to unhandled promise rejections when the streamed object does not match the schema', async () => {
     const result = await streamObject({
       model: new MockLanguageModelV1({
-        doStream: async () => {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"invalid": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '{ ' },
+            { type: 'text-delta', textDelta: '"invalid": ' },
+            { type: 'text-delta', textDelta: `"Hello, ` },
+            { type: 'text-delta', textDelta: `world` },
+            { type: 'text-delta', textDelta: `!"` },
+            { type: 'text-delta', textDelta: ' }' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 3 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       schema: z.object({ content: z.string() }),
       mode: 'json',
@@ -549,36 +533,22 @@ describe('options.onFinish', () => {
     beforeEach(async () => {
       const { partialObjectStream } = await streamObject({
         model: new MockLanguageModelV1({
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, { type: 'object-json' });
-            assert.deepStrictEqual(prompt, [
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              { type: 'text-delta', textDelta: '{ ' },
+              { type: 'text-delta', textDelta: '"content": ' },
+              { type: 'text-delta', textDelta: `"Hello, ` },
+              { type: 'text-delta', textDelta: `world` },
+              { type: 'text-delta', textDelta: `!"` },
+              { type: 'text-delta', textDelta: ' }' },
               {
-                role: 'system',
-                content:
-                  'JSON schema:\n' +
-                  '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
-                  'You MUST answer with a JSON object that matches the JSON schema above.',
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { completionTokens: 10, promptTokens: 3 },
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
-            ]);
-
-            return {
-              stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          }),
         }),
         schema: z.object({ content: z.string() }),
         mode: 'json',
@@ -619,36 +589,22 @@ describe('options.onFinish', () => {
     beforeEach(async () => {
       const { partialObjectStream, object } = await streamObject({
         model: new MockLanguageModelV1({
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, { type: 'object-json' });
-            assert.deepStrictEqual(prompt, [
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              { type: 'text-delta', textDelta: '{ ' },
+              { type: 'text-delta', textDelta: '"invalid": ' },
+              { type: 'text-delta', textDelta: `"Hello, ` },
+              { type: 'text-delta', textDelta: `world` },
+              { type: 'text-delta', textDelta: `!"` },
+              { type: 'text-delta', textDelta: ' }' },
               {
-                role: 'system',
-                content:
-                  'JSON schema:\n' +
-                  '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
-                  'You MUST answer with a JSON object that matches the JSON schema above.',
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { completionTokens: 10, promptTokens: 3 },
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
-            ]);
-
-            return {
-              stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"invalid": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          }),
         }),
         schema: z.object({ content: z.string() }),
         mode: 'json',
@@ -728,10 +684,21 @@ describe('options.headers', () => {
 
 describe('custom schema', () => {
   it('should send object deltas with json mode', async () => {
+    const testSchema = jsonSchema({
+      type: 'object',
+      properties: { content: { type: 'string' } },
+      required: ['content'],
+      additionalProperties: false,
+    });
+
     const result = await streamObject({
       model: new MockLanguageModelV1({
         doStream: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, { type: 'object-json' });
+          assert.deepStrictEqual(mode, {
+            type: 'object-json',
+            schema: testSchema.jsonSchema,
+          });
+
           assert.deepStrictEqual(prompt, [
             {
               role: 'system',
@@ -761,12 +728,7 @@ describe('custom schema', () => {
           };
         },
       }),
-      schema: jsonSchema({
-        type: 'object',
-        properties: { content: { type: 'string' } },
-        required: ['content'],
-        additionalProperties: false,
-      }),
+      schema: testSchema,
       mode: 'json',
       prompt: 'prompt',
     });

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -212,16 +212,18 @@ Warnings from the model provider (e.g. unsupported settings).
       switch (mode) {
         case 'json': {
           const validatedPrompt = getValidatedPrompt({
-            system: injectJsonSchemaIntoSystem({
-              system,
-              schema: schema.jsonSchema,
-            }),
+            system: model.supportsStructuredOutputs
+              ? system
+              : injectJsonSchemaIntoSystem({
+                  system,
+                  schema: schema.jsonSchema,
+                }),
             prompt,
             messages,
           });
 
           callOptions = {
-            mode: { type: 'object-json' },
+            mode: { type: 'object-json', schema: schema.jsonSchema },
             ...prepareCallSettings(settings),
             inputFormat: validatedPrompt.type,
             prompt: await convertToLanguageModelPrompt({

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -285,7 +285,7 @@ describe('doGenerate', () => {
     withTestServer(prepareJsonResponse({}), async ({ call }) => {
       await model.doGenerate({
         inputFormat: 'prompt',
-        mode: { type: 'object-json' },
+        mode: { type: 'object-json', schema: { type: 'object' } },
         prompt: TEST_PROMPT,
       });
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -559,36 +559,18 @@ describe('doGenerate', () => {
     ]);
   });
 
-  it('should use json_schema when structured outputs are enabled', async () => {
-    prepareJsonResponse({ content: '{"value":"Spark"}' });
+  describe('structuredOutputs', () => {
+    it('should use json_schema when structured outputs are enabled', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
 
-    const model = provider.chat('gpt-4o-2024-08-06', {
-      structuredOutputs: true,
-    });
+      const model = provider.chat('gpt-4o-2024-08-06', {
+        structuredOutputs: true,
+      });
 
-    const response = await model.doGenerate({
-      inputFormat: 'prompt',
-      mode: {
-        type: 'object-json',
-        schema: {
-          type: 'object',
-          properties: { value: { type: 'string' } },
-          required: ['value'],
-          additionalProperties: false,
-          $schema: 'http://json-schema.org/draft-07/schema#',
-        },
-      },
-      prompt: TEST_PROMPT,
-    });
-
-    expect(await server.getRequestBodyJson()).toStrictEqual({
-      model: 'gpt-4o-2024-08-06',
-      messages: [{ role: 'user', content: 'Hello' }],
-      response_format: {
-        type: 'json_schema',
-        json_schema: {
-          name: 'response',
-          strict: true,
+      const response = await model.doGenerate({
+        inputFormat: 'prompt',
+        mode: {
+          type: 'object-json',
           schema: {
             type: 'object',
             properties: { value: { type: 'string' } },
@@ -597,10 +579,30 @@ describe('doGenerate', () => {
             $schema: 'http://json-schema.org/draft-07/schema#',
           },
         },
-      },
-    });
+        prompt: TEST_PROMPT,
+      });
 
-    expect(response.text).toStrictEqual('{"value":"Spark"}');
+      expect(await server.getRequestBodyJson()).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'response',
+            strict: true,
+            schema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        },
+      });
+
+      expect(response.text).toStrictEqual('{"value":"Spark"}');
+    });
   });
 });
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -558,6 +558,50 @@ describe('doGenerate', () => {
       },
     ]);
   });
+
+  it('should use json_schema when structured outputs are enabled', async () => {
+    prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+    const model = provider.chat('gpt-4o-2024-08-06', {
+      structuredOutputs: true,
+    });
+
+    const response = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: {
+        type: 'object-json',
+        schema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+          $schema: 'http://json-schema.org/draft-07/schema#',
+        },
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.getRequestBodyJson()).toStrictEqual({
+      model: 'gpt-4o-2024-08-06',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'response',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      },
+    });
+
+    expect(response.text).toStrictEqual('{"value":"Spark"}');
+  });
 });
 
 describe('doStream', () => {

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -36,7 +36,6 @@ type OpenAIChatConfig = {
 
 export class OpenAIChatLanguageModel implements LanguageModelV1 {
   readonly specificationVersion = 'v1';
-  readonly defaultObjectGenerationMode = 'tool';
 
   readonly modelId: OpenAIChatModelId;
   readonly settings: OpenAIChatSettings;
@@ -55,6 +54,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
 
   get supportsStructuredOutputs(): boolean {
     return this.settings.structuredOutputs === true;
+  }
+
+  get defaultObjectGenerationMode() {
+    return this.supportsStructuredOutputs ? 'json' : 'tool';
   }
 
   get provider(): string {
@@ -172,7 +175,11 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
               this.settings.structuredOutputs === true
                 ? {
                     type: 'json_schema',
-                    json_schema: { name: 'response', schema: mode.schema },
+                    json_schema: {
+                      name: 'response',
+                      strict: true,
+                      schema: mode.schema,
+                    },
                   }
                 : { type: 'json_object' },
           },

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -161,7 +161,11 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
         return {
           args: {
             ...baseArgs,
-            ...prepareToolsAndToolChoice({ mode, useLegacyFunctionCalling }),
+            ...prepareToolsAndToolChoice({
+              mode,
+              useLegacyFunctionCalling,
+              structuredOutputs: this.settings.structuredOutputs,
+            }),
           },
           warnings,
         };

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -217,6 +217,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
                       description: mode.tool.description,
                       parameters: mode.tool.parameters,
                     },
+                    strict:
+                      this.settings.structuredOutputs === true
+                        ? true
+                        : undefined,
                   },
                 ],
               },
@@ -641,11 +645,13 @@ const openaiChatChunkSchema = z.union([
 function prepareToolsAndToolChoice({
   mode,
   useLegacyFunctionCalling = false,
+  structuredOutputs = false,
 }: {
   mode: Parameters<LanguageModelV1['doGenerate']>[0]['mode'] & {
     type: 'regular';
   };
   useLegacyFunctionCalling?: boolean;
+  structuredOutputs?: boolean;
 }) {
   // when the tools array is empty, change it to undefined to prevent errors:
   const tools = mode.tools?.length ? mode.tools : undefined;
@@ -696,6 +702,7 @@ function prepareToolsAndToolChoice({
       description: tool.description,
       parameters: tool.parameters,
     },
+    strict: structuredOutputs === true ? true : undefined,
   }));
 
   if (toolChoice == null) {

--- a/packages/openai/src/openai-chat-settings.ts
+++ b/packages/openai/src/openai-chat-settings.ts
@@ -2,6 +2,7 @@
 export type OpenAIChatModelId =
   | 'gpt-4o'
   | 'gpt-4o-2024-05-13'
+  | 'gpt-4o-2024-08-06'
   | 'gpt-4o-mini'
   | 'gpt-4o-mini-2024-07-18'
   | 'gpt-4-turbo'
@@ -50,6 +51,13 @@ tokens that were generated.
 Whether to enable parallel function calling during tool use. Default to true.
    */
   parallelToolCalls?: boolean;
+
+  /**
+Whether to use structured outputs. Defaults to false.
+
+When enabled, tool calls and object generation will be strict and follow the provided schema.
+ */
+  structuredOutputs?: boolean;
 
   /**
 Whether to use legacy function calling. Defaults to false.

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -1,3 +1,4 @@
+import { JSONSchema7 } from 'json-schema';
 import { LanguageModelV1CallSettings } from './language-model-v1-call-settings';
 import { LanguageModelV1FunctionTool } from './language-model-v1-function-tool';
 import { LanguageModelV1Prompt } from './language-model-v1-prompt';
@@ -20,7 +21,7 @@ low level grammar, etc. It can also be used to optimize the efficiency of the
 streaming, e.g. tool-delta stream parts are only needed in the
 object-tool mode.
 
-@deprecated mode will be removed in v2. 
+@deprecated mode will be removed in v2.
 All necessary settings will be directly supported through the call settings.
    */
   mode:
@@ -43,6 +44,9 @@ Specifies how the tool should be selected. Defaults to 'auto'.
     | {
         // object generation with json mode enabled (streaming: text delta)
         type: 'object-json';
+
+        // schema for the object generation
+        schema: JSONSchema7;
       }
     | {
         // object generation with tool mode enabled (streaming: tool call deltas)

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -46,6 +46,16 @@ pass the image data to the model.
   readonly supportsImageUrls?: boolean;
 
   /**
+Flag whether this model supports structured outputs,
+i.e. follows JSON schemas for object generation
+when the response format is set to 'json' or
+when the `object-json` mode is used.
+
+Defaults to `false`.
+*/
+  readonly supportsStructuredOutputs?: boolean;
+
+  /**
 Generates a language model output (non-streaming).
 
 Naming: "do" prefix to prevent accidental direct usage of the method


### PR DESCRIPTION
## Summary
- add `structuredOutputs` flag on OpenAI chat models to enable structured outputs
- language model spec: add `schema` param to `object-mode: json`
- language model spec: add `supportsStructuredOutputs` flag to model

## Background
OpenAI has [introduced structured outputs](https://openai.com/index/introducing-structured-outputs-in-the-api/), which is grammar-guided generation that guarantees adherence to a specific json schema for tools and output formats.

## Constraints
Given its limitations (only works for some schemas and models, compilation overhead, etc.) and it being specific to OpenAI, it needs to be opt-in on the model (implemented via the `structuredOutputs` flag).

## Example
```ts
const {object} = await generateObject({
  model: openai('gpt-4o-2024-08-06', {
    structuredOutputs: true,
  }),
  schema: z.object({
    recipe: z.object({
      name: z.string(),
      ingredients: z.array(
        z.object({
          name: z.string(),
          amount: z.string(),
        }),
      ),
      steps: z.array(z.string()),
    }),
  }),
  prompt: 'Generate a lasagna recipe.',
});
```

## Tasks

- [x] implementation
   - [x] language model spec additions
   - [x] openai object-json mode
   - [x] openai object-tool mode
   - [x] openai tools (regular mode)
   - [x] generate object json
   - [x] stream object json
- [x] examples
   - [x] generate object
   - [x] stream object
- [x] documentation
   - [x] openai provider
- [x] changeset