### PR TITLE
feat (ai/core): support schema name & description in generateObject & streamObject

### DIFF
--- a/.changeset/dull-trees-cry.md
+++ b/.changeset/dull-trees-cry.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider': patch
+'@ai-sdk/openai': patch
+'ai': patch
+---
+
+feat (ai/core): support schema name & description in generateObject & streamObject

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -50,19 +50,19 @@ While some models (like OpenAI) natively support object generation, others requi
 
 You can optionally specify a name and description for the schema. These are used by some providers for additional LLM guidance, e.g. via tool or schema name.
 
-```ts highlight="11-12"
+```ts highlight="6-7"
 import { generateObject } from 'ai';
 import { z } from 'zod';
 
 const { object } = await generateObject({
   model: yourModel,
+  schemaName: 'Recipe',
+  schemaDescription: 'A recipe for a dish.',
   schema: z.object({
     name: z.string(),
     ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
     steps: z.array(z.string()),
   }),
-  schemaName: 'Recipe',
-  schemaDescription: 'A recipe for a dish.',
   prompt: 'Generate a lasagna recipe.',
 });
 ```

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -39,9 +39,33 @@ While some models (like OpenAI) natively support object generation, others requi
 
 - `auto`: The provider will choose the best mode for the model. This recommended mode is used by default.
 - `tool`: A tool with the JSON schema as parameters is provided and the provider is instructed to use it.
-- `json`: The JSON schema and an instruction is injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
+- `json`: The response format is set to JSON when supported by the provider, e.g. via json modes or grammar-guided generation. If grammar-guided generation is not supported, the JSON schema and instructions to generate JSON that conforms to the schema are injected into the system prompt.
 
-<Note>Please note that not every provider supports all generation modes.</Note>
+<Note>
+  Please note that not every provider supports all generation modes. Some
+  providers do not support object generation at all.
+</Note>
+
+### Specifying Schema Name and Description
+
+You can optionally specify a name and description for the schema. These are used by some providers for additional LLM guidance, e.g. via tool or schema name.
+
+```ts highlight="11-12"
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const { object } = await generateObject({
+  model: yourModel,
+  schema: z.object({
+    name: z.string(),
+    ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+    steps: z.array(z.string()),
+  }),
+  schemaName: 'Recipe',
+  schemaDescription: 'A recipe for a dish.',
+  prompt: 'Generate a lasagna recipe.',
+});
+```
 
 ## Streaming Objects
 

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -125,6 +125,8 @@ It also records a `ai.stream.firstChunk` event when the first chunk of the strea
   - `operation.name`: `ai.generateObject` and the functionId that was set through `telemetry.functionId`
   - `ai.prompt`: the prompt that was used when calling `generateObject`
   - `ai.schema`: Stringified JSON schema version of the schema that was passed into the `generateObject` function
+  - `ai.schema.name`: the name of the schema that was passed into the `generateObject` function
+  - `ai.schema.description`: the description of the schema that was passed into the `generateObject` function
   - `ai.result.object`: the object that was generated (stringified JSON)
   - `ai.settings.mode`: the object generation mode
 - `ai.generateObject.doGenerate`: a provider doGenerate call.
@@ -151,6 +153,8 @@ It also records a `ai.stream.firstChunk` event when the first chunk of the strea
   - `operation.name`: `ai.streamObject` and the functionId that was set through `telemetry.functionId`
   - `ai.prompt`: the prompt that was used when calling `streamObject`
   - `ai.schema`: Stringified JSON schema version of the schema that was passed into the `streamObject` function
+  - `ai.schema.name`: the name of the schema that was passed into the `streamObject` function
+  - `ai.schema.description`: the description of the schema that was passed into the `streamObject` function
   - `ai.result.object`: the object that was generated (stringified JSON)
   - `ai.settings.mode`: the object generation mode
 - `ai.streamObject.doStream`: a provider doStream call.

--- a/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
@@ -57,6 +57,18 @@ console.log(JSON.stringify(object, null, 2));
         'The schema that describes the shape of the object to generate. It is sent to the model to generate the object and used to validate the output. You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function).',
     },
     {
+      name: 'schemaName',
+      type: 'string | undefined',
+      description:
+        'Optional name of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema name.',
+    },
+    {
+      name: 'schemaDescription',
+      type: 'string | undefined',
+      description:
+        'Optional description of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema name.',
+    },
+    {
       name: 'system',
       type: 'string',
       description:

--- a/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
@@ -60,6 +60,18 @@ for await (const partialObject of partialObjectStream) {
         'The schema that describes the shape of the object to generate. It is sent to the model to generate the object and used to validate the output. You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function).',
     },
     {
+      name: 'schemaName',
+      type: 'string | undefined',
+      description:
+        'Optional name of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema name.',
+    },
+    {
+      name: 'schemaDescription',
+      type: 'string | undefined',
+      description:
+        'Optional description of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema name.',
+    },
+    {
       name: 'system',
       type: 'string',
       description:

--- a/examples/ai-core/src/generate-object/openai-structured-outputs-name-description.ts
+++ b/examples/ai-core/src/generate-object/openai-structured-outputs-name-description.ts
@@ -1,0 +1,41 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import dotenv from 'dotenv';
+import { z } from 'zod';
+
+dotenv.config();
+
+const openai = createOpenAI({
+  fetch: async (url, options) => {
+    console.log(JSON.stringify(JSON.parse(options!.body! as string), null, 2));
+    return await fetch(url, options);
+  },
+});
+
+async function main() {
+  const result = await generateObject({
+    model: openai('gpt-4o-2024-08-06', {
+      structuredOutputs: true,
+    }),
+    name: 'recipe',
+    description: 'A recipe for lasagna.',
+    schema: z.object({
+      name: z.string(),
+      ingredients: z.array(
+        z.object({
+          name: z.string(),
+          amount: z.string(),
+        }),
+      ),
+      steps: z.array(z.string()),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log(JSON.stringify(result.object, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-object/openai-structured-outputs-name-description.ts
+++ b/examples/ai-core/src/generate-object/openai-structured-outputs-name-description.ts
@@ -17,8 +17,8 @@ async function main() {
     model: openai('gpt-4o-2024-08-06', {
       structuredOutputs: true,
     }),
-    name: 'recipe',
-    description: 'A recipe for lasagna.',
+    schemaName: 'recipe',
+    schemaDescription: 'A recipe for lasagna.',
     schema: z.object({
       name: z.string(),
       ingredients: z.array(

--- a/examples/ai-core/src/stream-object/openai-structured-outputs-name-description.ts
+++ b/examples/ai-core/src/stream-object/openai-structured-outputs-name-description.ts
@@ -1,12 +1,12 @@
 import { openai } from '@ai-sdk/openai';
-import { generateObject } from 'ai';
+import { streamObject } from 'ai';
 import dotenv from 'dotenv';
 import { z } from 'zod';
 
 dotenv.config();
 
 async function main() {
-  const result = await generateObject({
+  const result = await streamObject({
     model: openai('gpt-4o-2024-08-06', {
       structuredOutputs: true,
     }),
@@ -25,10 +25,10 @@ async function main() {
     prompt: 'Generate a lasagna recipe.',
   });
 
-  console.log(JSON.stringify(result.object, null, 2));
-  console.log();
-  console.log('Token usage:', result.usage);
-  console.log('Finish reason:', result.finishReason);
+  for await (const partialObject of result.partialObjectStream) {
+    console.clear();
+    console.log(partialObject);
+  }
 }
 
 main().catch(console.error);

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -121,8 +121,8 @@ describe('result.object', () => {
         },
       }),
       schema: z.object({ content: z.string() }),
-      name: 'test-name',
-      description: 'test description',
+      schemaName: 'test-name',
+      schemaDescription: 'test description',
       mode: 'json',
       prompt: 'prompt',
     });
@@ -211,8 +211,8 @@ describe('result.object', () => {
         },
       }),
       schema: z.object({ content: z.string() }),
-      name: 'test-name',
-      description: 'test description',
+      schemaName: 'test-name',
+      schemaDescription: 'test description',
       mode: 'tool',
       prompt: 'prompt',
     });
@@ -314,8 +314,8 @@ describe('telemetry', () => {
         }),
       }),
       schema: z.object({ content: z.string() }),
-      name: 'test-name',
-      description: 'test description',
+      schemaName: 'test-name',
+      schemaDescription: 'test description',
       mode: 'json',
       prompt: 'prompt',
       headers: {
@@ -409,8 +409,8 @@ describe('telemetry', () => {
         }),
       }),
       schema: z.object({ content: z.string() }),
-      name: 'test-name',
-      description: 'test description',
+      schemaName: 'test-name',
+      schemaDescription: 'test description',
       mode: 'tool',
       prompt: 'prompt',
       headers: {

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -20,6 +20,8 @@ describe('result.object', () => {
         doGenerate: async ({ prompt, mode }) => {
           assert.deepStrictEqual(mode, {
             type: 'object-json',
+            name: undefined,
+            description: undefined,
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               additionalProperties: false,
@@ -47,6 +49,80 @@ describe('result.object', () => {
         },
       }),
       schema: z.object({ content: z.string() }),
+      mode: 'json',
+      prompt: 'prompt',
+    });
+
+    assert.deepStrictEqual(result.object, { content: 'Hello, world!' });
+  });
+
+  it('should generate object with json mode when structured outputs are enabled', async () => {
+    const result = await generateObject({
+      model: new MockLanguageModelV1({
+        supportsStructuredOutputs: true,
+        doGenerate: async ({ prompt, mode }) => {
+          assert.deepStrictEqual(mode, {
+            type: 'object-json',
+            name: undefined,
+            description: undefined,
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              additionalProperties: false,
+              properties: { content: { type: 'string' } },
+              required: ['content'],
+              type: 'object',
+            },
+          });
+
+          assert.deepStrictEqual(prompt, [
+            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+          ]);
+
+          return {
+            ...dummyResponseValues,
+            text: `{ "content": "Hello, world!" }`,
+          };
+        },
+      }),
+      schema: z.object({ content: z.string() }),
+      mode: 'json',
+      prompt: 'prompt',
+    });
+
+    assert.deepStrictEqual(result.object, { content: 'Hello, world!' });
+  });
+
+  it('should use name and description with json mode when structured outputs are enabled', async () => {
+    const result = await generateObject({
+      model: new MockLanguageModelV1({
+        supportsStructuredOutputs: true,
+        doGenerate: async ({ prompt, mode }) => {
+          assert.deepStrictEqual(mode, {
+            type: 'object-json',
+            name: 'test-name',
+            description: 'test description',
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              additionalProperties: false,
+              properties: { content: { type: 'string' } },
+              required: ['content'],
+              type: 'object',
+            },
+          });
+
+          assert.deepStrictEqual(prompt, [
+            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+          ]);
+
+          return {
+            ...dummyResponseValues,
+            text: `{ "content": "Hello, world!" }`,
+          };
+        },
+      }),
+      schema: z.object({ content: z.string() }),
+      name: 'test-name',
+      description: 'test description',
       mode: 'json',
       prompt: 'prompt',
     });
@@ -475,6 +551,8 @@ describe('custom schema', () => {
         doGenerate: async ({ prompt, mode }) => {
           assert.deepStrictEqual(mode, {
             type: 'object-json',
+            name: undefined,
+            description: undefined,
             schema: {
               type: 'object',
               properties: { content: { type: 'string' } },
@@ -520,6 +598,8 @@ describe('zod schema', () => {
         doGenerate: async ({ prompt, mode }) => {
           assert.deepStrictEqual(mode, {
             type: 'object-json',
+            name: undefined,
+            description: undefined,
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               additionalProperties: false,
@@ -561,6 +641,8 @@ describe('zod schema', () => {
         doGenerate: async ({ prompt, mode }) => {
           assert.deepStrictEqual(mode, {
             type: 'object-json',
+            name: undefined,
+            description: undefined,
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               additionalProperties: false,

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -314,6 +314,8 @@ describe('telemetry', () => {
         }),
       }),
       schema: z.object({ content: z.string() }),
+      name: 'test-name',
+      description: 'test description',
       mode: 'json',
       prompt: 'prompt',
       headers: {
@@ -342,6 +344,8 @@ describe('telemetry', () => {
           'ai.result.object': '{"content":"Hello, world!"}',
           'ai.schema':
             '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}',
+          'ai.schema.name': 'test-name',
+          'ai.schema.description': 'test description',
           'ai.settings.mode': 'json',
           'ai.telemetry.functionId': 'test-function-id',
           'ai.telemetry.metadata.test1': 'value1',
@@ -405,6 +409,8 @@ describe('telemetry', () => {
         }),
       }),
       schema: z.object({ content: z.string() }),
+      name: 'test-name',
+      description: 'test description',
       mode: 'tool',
       prompt: 'prompt',
       headers: {
@@ -433,6 +439,8 @@ describe('telemetry', () => {
           'ai.result.object': '{"content":"Hello, world!"}',
           'ai.schema':
             '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}',
+          'ai.schema.name': 'test-name',
+          'ai.schema.description': 'test description',
           'ai.settings.mode': 'tool',
           'ai.telemetry.functionId': 'test-function-id',
           'ai.telemetry.metadata.test1': 'value1',

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -28,8 +28,8 @@ This function does not stream the output. If you want to stream the output, use 
 @param model - The language model to use.
 
 @param schema - The schema of the object that the model should generate.
-@param name - Optional name of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema name.
-@param description - Optional description of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema description.
+@param schemaName - Optional name of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema name.
+@param schemaDescription - Optional description of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema description.
 @param mode - The mode to use for object generation. Not all models support all modes. Defaults to 'auto'.
 
 @param system - A system message that will be part of the prompt.
@@ -65,8 +65,8 @@ A result object that contains the generated object, the finish reason, the token
 export async function generateObject<T>({
   model,
   schema: inputSchema,
-  name,
-  description,
+  schemaName,
+  schemaDescription,
   mode,
   system,
   prompt,
@@ -93,14 +93,14 @@ Optional name of the output that should be generated.
 Used by some providers for additional LLM guidance, e.g.
 via tool or schema name.
      */
-    name?: string;
+    schemaName?: string;
 
     /**
 Optional description of the output that should be generated.
 Used by some providers for additional LLM guidance, e.g.
 via tool or schema description.
      */
-    description?: string;
+    schemaDescription?: string;
 
     /**
 The mode to use for object generation.
@@ -149,8 +149,8 @@ Default and recommended: 'auto' (best mode for the model).
         'ai.schema': {
           input: () => JSON.stringify(schema.jsonSchema),
         },
-        'ai.schema.name': name,
-        'ai.schema.description': description,
+        'ai.schema.name': schemaName,
+        'ai.schema.description': schemaDescription,
         'ai.settings.mode': mode,
       },
     }),
@@ -223,8 +223,8 @@ Default and recommended: 'auto' (best mode for the model).
                   mode: {
                     type: 'object-json',
                     schema: schema.jsonSchema,
-                    name,
-                    description,
+                    name: schemaName,
+                    description: schemaDescription,
                   },
                   ...prepareCallSettings(settings),
                   inputFormat,
@@ -319,8 +319,9 @@ Default and recommended: 'auto' (best mode for the model).
                     type: 'object-tool',
                     tool: {
                       type: 'function',
-                      name: name ?? 'json',
-                      description: description ?? 'Respond with a JSON object.',
+                      name: schemaName ?? 'json',
+                      description:
+                        schemaDescription ?? 'Respond with a JSON object.',
                       parameters: schema.jsonSchema,
                     },
                   },

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -317,8 +317,8 @@ Default and recommended: 'auto' (best mode for the model).
                     type: 'object-tool',
                     tool: {
                       type: 'function',
-                      name: 'json',
-                      description: 'Respond with a JSON object.',
+                      name: name ?? 'json',
+                      description: description ?? 'Respond with a JSON object.',
                       parameters: schema.jsonSchema,
                     },
                   },

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -149,6 +149,8 @@ Default and recommended: 'auto' (best mode for the model).
         'ai.schema': {
           input: () => JSON.stringify(schema.jsonSchema),
         },
+        'ai.schema.name': name,
+        'ai.schema.description': description,
         'ai.settings.mode': mode,
       },
     }),

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -28,6 +28,8 @@ This function does not stream the output. If you want to stream the output, use 
 @param model - The language model to use.
 
 @param schema - The schema of the object that the model should generate.
+@param name - Optional name of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema name.
+@param description - Optional description of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema description.
 @param mode - The mode to use for object generation. Not all models support all modes. Defaults to 'auto'.
 
 @param system - A system message that will be part of the prompt.
@@ -63,6 +65,8 @@ A result object that contains the generated object, the finish reason, the token
 export async function generateObject<T>({
   model,
   schema: inputSchema,
+  name,
+  description,
   mode,
   system,
   prompt,
@@ -83,6 +87,20 @@ The language model to use.
 The schema of the object that the model should generate.
      */
     schema: z.Schema<T, z.ZodTypeDef, any> | Schema<T>;
+
+    /**
+Optional name of the output that should be generated.
+Used by some providers for additional LLM guidance, e.g.
+via tool or schema name.
+     */
+    name?: string;
+
+    /**
+Optional description of the output that should be generated.
+Used by some providers for additional LLM guidance, e.g.
+via tool or schema description.
+     */
+    description?: string;
 
     /**
 The mode to use for object generation.
@@ -200,7 +218,12 @@ Default and recommended: 'auto' (best mode for the model).
               tracer,
               fn: async span => {
                 const result = await model.doGenerate({
-                  mode: { type: 'object-json', schema: schema.jsonSchema },
+                  mode: {
+                    type: 'object-json',
+                    schema: schema.jsonSchema,
+                    name,
+                    description,
+                  },
                   ...prepareCallSettings(settings),
                   inputFormat,
                   prompt: promptMessages,

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -1023,6 +1023,8 @@ describe('telemetry', () => {
         }),
       }),
       schema: z.object({ content: z.string() }),
+      schemaName: 'test-name',
+      schemaDescription: 'test description',
       mode: 'json',
       prompt: 'prompt',
       headers: {
@@ -1062,6 +1064,8 @@ describe('telemetry', () => {
           'ai.settings.mode': 'json',
           'ai.schema':
             '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}',
+          'ai.schema.name': 'test-name',
+          'ai.schema.description': 'test description',
         },
         events: [],
       },
@@ -1153,6 +1157,8 @@ describe('telemetry', () => {
         }),
       }),
       schema: z.object({ content: z.string() }),
+      schemaName: 'test-name',
+      schemaDescription: 'test description',
       mode: 'tool',
       prompt: 'prompt',
       headers: {
@@ -1176,6 +1182,8 @@ describe('telemetry', () => {
       {
         name: 'ai.streamObject',
         attributes: {
+          'operation.name': 'ai.streamObject test-function-id',
+          'resource.name': 'test-function-id',
           'ai.model.id': 'mock-model-id',
           'ai.model.provider': 'mock-provider',
           'ai.prompt': '{"prompt":"prompt"}',
@@ -1190,8 +1198,8 @@ describe('telemetry', () => {
           'ai.settings.mode': 'tool',
           'ai.schema':
             '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}',
-          'operation.name': 'ai.streamObject test-function-id',
-          'resource.name': 'test-function-id',
+          'ai.schema.name': 'test-name',
+          'ai.schema.description': 'test description',
         },
         events: [],
       },

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -52,6 +52,8 @@ This function streams the output. If you do not want to stream the output, use `
 @param model - The language model to use.
 
 @param schema - The schema of the object that the model should generate.
+@param schemaName - Optional name of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema name.
+@param schemaDescription - Optional description of the output that should be generated. Used by some providers for additional LLM guidance, e.g. via tool or schema description.
 @param mode - The mode to use for object generation. Not all models support all modes. Defaults to 'auto'.
 
 @param system - A system message that will be part of the prompt.
@@ -87,6 +89,8 @@ A result object for accessing the partial object stream and additional informati
 export async function streamObject<T>({
   model,
   schema: inputSchema,
+  schemaName,
+  schemaDescription,
   mode,
   system,
   prompt,
@@ -108,6 +112,20 @@ The language model to use.
 The schema of the object that the model should generate.
  */
     schema: z.Schema<T, z.ZodTypeDef, any> | Schema<T>;
+
+    /**
+Optional name of the output that should be generated.
+Used by some providers for additional LLM guidance, e.g.
+via tool or schema name.
+     */
+    schemaName?: string;
+
+    /**
+Optional description of the output that should be generated.
+Used by some providers for additional LLM guidance, e.g.
+via tool or schema description.
+ */
+    schemaDescription?: string;
 
     /**
 The mode to use for object generation.
@@ -226,8 +244,8 @@ Warnings from the model provider (e.g. unsupported settings).
             mode: {
               type: 'object-json',
               schema: schema.jsonSchema,
-              name: undefined,
-              description: undefined,
+              name: schemaName,
+              description: schemaDescription,
             },
             ...prepareCallSettings(settings),
             inputFormat: validatedPrompt.type,

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -210,6 +210,8 @@ Warnings from the model provider (e.g. unsupported settings).
           input: () => JSON.stringify({ system, prompt, messages }),
         },
         'ai.schema': { input: () => JSON.stringify(schema.jsonSchema) },
+        'ai.schema.name': schemaName,
+        'ai.schema.description': schemaDescription,
         'ai.settings.mode': mode,
       },
     }),

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -286,8 +286,8 @@ Warnings from the model provider (e.g. unsupported settings).
               type: 'object-tool',
               tool: {
                 type: 'function',
-                name: 'json',
-                description: 'Respond with a JSON object.',
+                name: schemaName ?? 'json',
+                description: schemaDescription ?? 'Respond with a JSON object.',
                 parameters: schema.jsonSchema,
               },
             },

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -223,7 +223,12 @@ Warnings from the model provider (e.g. unsupported settings).
           });
 
           callOptions = {
-            mode: { type: 'object-json', schema: schema.jsonSchema },
+            mode: {
+              type: 'object-json',
+              schema: schema.jsonSchema,
+              name: undefined,
+              description: undefined,
+            },
             ...prepareCallSettings(settings),
             inputFormat: validatedPrompt.type,
             prompt: await convertToLanguageModelPrompt({

--- a/packages/ai/core/test/mock-language-model-v1.ts
+++ b/packages/ai/core/test/mock-language-model-v1.ts
@@ -10,19 +10,21 @@ export class MockLanguageModelV1 implements LanguageModelV1 {
   doStream: LanguageModelV1['doStream'];
 
   readonly defaultObjectGenerationMode: LanguageModelV1['defaultObjectGenerationMode'];
-
+  readonly supportsStructuredOutputs: LanguageModelV1['supportsStructuredOutputs'];
   constructor({
     provider = 'mock-provider',
     modelId = 'mock-model-id',
     doGenerate = notImplemented,
     doStream = notImplemented,
     defaultObjectGenerationMode = undefined,
+    supportsStructuredOutputs = undefined,
   }: {
     provider?: LanguageModelV1['provider'];
     modelId?: LanguageModelV1['modelId'];
     doGenerate?: LanguageModelV1['doGenerate'];
     doStream?: LanguageModelV1['doStream'];
     defaultObjectGenerationMode?: LanguageModelV1['defaultObjectGenerationMode'];
+    supportsStructuredOutputs?: LanguageModelV1['supportsStructuredOutputs'];
   } = {}) {
     this.provider = provider;
     this.modelId = modelId;
@@ -30,6 +32,7 @@ export class MockLanguageModelV1 implements LanguageModelV1 {
     this.doStream = doStream;
 
     this.defaultObjectGenerationMode = defaultObjectGenerationMode;
+    this.supportsStructuredOutputs = supportsStructuredOutputs;
   }
 }
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -580,6 +580,51 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should set name & description in object-json mode', async () => {
+    prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+    const model = provider.chat('gpt-4o-2024-08-06', {
+      structuredOutputs: true,
+    });
+
+    await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: {
+        type: 'object-json',
+        name: 'test-name',
+        description: 'test description',
+        schema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+          $schema: 'http://json-schema.org/draft-07/schema#',
+        },
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.getRequestBodyJson()).toStrictEqual({
+      model: 'gpt-4o-2024-08-06',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'test-name',
+          description: 'test description',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      },
+    });
+  });
+
   it('should set strict in object-tool mode', async () => {
     prepareJsonResponse({
       tool_calls: [
@@ -605,6 +650,7 @@ describe('doGenerate', () => {
         tool: {
           type: 'function',
           name: 'test-tool',
+          description: 'test description',
           parameters: {
             type: 'object',
             properties: { value: { type: 'string' } },
@@ -626,6 +672,7 @@ describe('doGenerate', () => {
           type: 'function',
           function: {
             name: 'test-tool',
+            description: 'test description',
             parameters: {
               type: 'object',
               properties: { value: { type: 'string' } },

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -180,9 +180,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
                 ? {
                     type: 'json_schema',
                     json_schema: {
-                      name: 'response',
-                      strict: true,
                       schema: mode.schema,
+                      strict: true,
+                      name: mode.name ?? 'response',
+                      description: mode.description,
                     },
                   }
                 : { type: 'json_object' },

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -45,8 +45,20 @@ Specifies how the tool should be selected. Defaults to 'auto'.
         // object generation with json mode enabled (streaming: text delta)
         type: 'object-json';
 
-        // schema for the object generation
-        schema: JSONSchema7;
+        /**
+         * JSON schema that the generated output should conform to.
+         */
+        schema?: JSONSchema7;
+
+        /**
+         * Name of output that should be generated. Used by some providers for additional LLM guidance.
+         */
+        name?: string;
+
+        /**
+         * Description of the output that should be generated. Used by some providers for additional LLM guidance.
+         */
+        description?: string;
       }
     | {
         // object generation with tool mode enabled (streaming: tool call deltas)

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -22,7 +22,8 @@ streaming, e.g. tool-delta stream parts are only needed in the
 object-tool mode.
 
 @deprecated mode will be removed in v2.
-All necessary settings will be directly supported through the call settings.
+All necessary settings will be directly supported through the call settings,
+in particular responseFormat, toolChoice, and tools.
    */
   mode:
     | {

--- a/packages/provider/src/language-model/v1/language-model-v1-call-settings.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-settings.ts
@@ -14,7 +14,7 @@ It is recommended to set either `temperature` or `topP`, but not both.
   temperature?: number;
 
   /**
-Stop sequences. 
+Stop sequences.
 If set, the model will stop generating text when one of the stop sequences is generated.
 Providers may have limits on the number of stop sequences.
    */
@@ -30,7 +30,7 @@ It is recommended to set either `temperature` or `topP`, but not both.
   /**
 Only sample from the top K options for each subsequent token.
 
-Used to remove "long tail" low probability responses. 
+Used to remove "long tail" low probability responses.
 Recommended for advanced use cases only. You usually only need to use temperature.
    */
   topK?: number;
@@ -52,7 +52,26 @@ Response format. The output can either be text or JSON. Default is text.
 
 If JSON is selected, a schema can optionally be provided to guide the LLM.
    */
-  responseFormat?: { type: 'text' } | { type: 'json'; schema?: JSONSchema7 };
+  responseFormat?:
+    | { type: 'text' }
+    | {
+        type: 'json';
+
+        /**
+         * JSON schema that the generated output should conform to.
+         */
+        schema?: JSONSchema7;
+
+        /**
+         * Name of output that should be generated. Used by some providers for additional LLM guidance.
+         */
+        name?: string;
+
+        /**
+         * Description of the output that should be generated. Used by some providers for additional LLM guidance.
+         */
+        description?: string;
+      };
 
   /**
 The seed (integer) to use for random sampling. If set and supported

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -52,6 +52,8 @@ when the response format is set to 'json' or
 when the `object-json` mode is used.
 
 Defaults to `false`.
+
+TODO rename to supportsGrammarGuidedGeneration in v2
 */
   readonly supportsStructuredOutputs?: boolean;
 

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -46,10 +46,14 @@ pass the image data to the model.
   readonly supportsImageUrls?: boolean;
 
   /**
-Flag whether this model supports structured outputs,
+Flag whether this model supports grammar-guided generation,
 i.e. follows JSON schemas for object generation
 when the response format is set to 'json' or
 when the `object-json` mode is used.
+
+This means that the model guarantees that the generated JSON
+will be a valid JSON object AND that the object will match the
+JSON schema.
 
 Defaults to `false`.
 


### PR DESCRIPTION
## Summary
- `generateObject`: add `schemaName` and `schemaDescription` parameters
- `streamObject`: add `schemaName` and `schemaDescription` parameters
- language model spec: add `name` and `description` properties to language model `object-json` mode
- language model spec: add `name` and `description` properties to `responseFormat: json`

## Background
Providing a name and description, e.g. for tools or schema generation, can help with producing better outputs. It gives the users more control over the generation.

## Example

```ts
const { object: recipe } = await generateObject({
  model: openai('gpt-4o-2024-08-06', {
    structuredOutputs: true,
  }),
  schemaName: 'recipe',
  schemaDescription: 'A recipe for lasagna.',
  schema: z.object({
    name: z.string(),
    ingredients: z.array(
      z.object({
        name: z.string(),
        amount: z.string(),
      }),
    ),
    steps: z.array(z.string()),
  }),
  prompt: 'Generate a lasagna recipe.',
});
```

## Implementation notes
- the parameter names `schemaName/Description` were chosen over `name`/`description` to make it clear that the parameters are associated with the schema

## Tasks

- [x] implementation
   - [x] language model spec
   - [x] openai provider json (with structured outputs)
   - [x] generateObject tool
   - [x] generateObject json
   - [x] generateObject telemetry
   - [x] streamObject tool
   - [x] streamObject json
   - [x] streamObject telemetry
- [x] examples
   - [x] generateObject
   - [x] streamObject
- [x] docs
   - [x] generate object guide
   - [x] generateObject ref
   - [x] streamObject ref
   - [x] telemetry guide updates
- [x] changeset