### PR TITLE
feat (ai/core): export Schema type

### DIFF
--- a/.changeset/tasty-jobs-dance.md
+++ b/.changeset/tasty-jobs-dance.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): export Schema type

--- a/packages/ai/core/index.ts
+++ b/packages/ai/core/index.ts
@@ -8,3 +8,4 @@ export * from './tool';
 export * from './types';
 export { cosineSimilarity } from './util/cosine-similarity';
 export { jsonSchema } from './util/schema';
+export type { Schema } from './util/schema';


### PR DESCRIPTION
## Background
Defining custom schema validator functions, e.g. for libraries such as valibot or tschema, requires this type.