### PR TITLE
feat (ai/core): mask data stream error messages.

### DIFF
--- a/.changeset/tricky-trains-yawn.md
+++ b/.changeset/tricky-trains-yawn.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): mask data stream error messages with streamText

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -770,11 +770,6 @@ for await (const textPart of textStream) {
       ],
     },
     {
-      name: 'toDataStream',
-      type: '(callbacks?: AIStreamCallbacksAndOptions) => data stream',
-      description: 'Converts the result to an data stream.',
-    },
-    {
       name: 'pipeDataStreamToResponse',
       type: '(response: ServerResponse, init?: { headers?: Record<string, string>; status?: number } => void',
       description:
@@ -825,6 +820,13 @@ for await (const textPart of textStream) {
               type: 'StreamData',
               optional: true,
               description: 'The stream data object.',
+            },
+            {
+              name: 'getErrorMessage',
+              type: '(error: unknown) => string',
+              description:
+                'A function to get the error message from the error object. By default, all errors are masked as "" for safety reasons.',
+              optional: true,
             },
           ],
         },

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1054,6 +1054,48 @@ describe('result.toDataStreamResponse', () => {
       '0:"world!"\n',
     ]);
   });
+
+  it('should mask error messages by default', async () => {
+    const result = await streamText({
+      model: new MockLanguageModelV1({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'error', error: 'error' },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
+      }),
+      prompt: 'test-input',
+    });
+
+    const response = result.toDataStreamResponse();
+
+    assert.deepStrictEqual(await convertResponseStreamToArray(response), [
+      '3:""\n',
+    ]);
+  });
+
+  it('should support custom error messages', async () => {
+    const result = await streamText({
+      model: new MockLanguageModelV1({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'error', error: 'error' },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
+      }),
+      prompt: 'test-input',
+    });
+
+    const response = result.toDataStreamResponse({
+      getErrorMessage: error => `custom error message: ${error}`,
+    });
+
+    assert.deepStrictEqual(await convertResponseStreamToArray(response), [
+      '3:"custom error message: error"\n',
+    ]);
+  });
 });
 
 describe('result.toTextStreamResponse', () => {


### PR DESCRIPTION
## Background
Error messages in the stream from the model provider might include sensitive information. The error messages should not be exposed to the client by default.