### PR TITLE
refactoring (ai/rsc): streamable value

### DIFF
--- a/packages/ai/rsc/streamable-value/is-streamable-value.ts
+++ b/packages/ai/rsc/streamable-value/is-streamable-value.ts
@@ -1,0 +1,10 @@
+import { STREAMABLE_VALUE_TYPE, StreamableValue } from './streamable-value';
+
+export function isStreamableValue(value: unknown): value is StreamableValue {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    'type' in value &&
+    value.type === STREAMABLE_VALUE_TYPE
+  );
+}

--- a/packages/ai/rsc/streamable-value/streamable-value.ts
+++ b/packages/ai/rsc/streamable-value/streamable-value.ts
@@ -35,34 +35,3 @@ export type StreamableValue<T = any, E = any> = {
   [__internal_curr]?: T;
   [__internal_error]?: E;
 };
-
-function hasReadableValueSignature(value: unknown): value is StreamableValue {
-  return !!(
-    value &&
-    typeof value === 'object' &&
-    'type' in value &&
-    value.type === STREAMABLE_VALUE_TYPE
-  );
-}
-
-export function assertStreamableValue(
-  value: unknown,
-): asserts value is StreamableValue {
-  if (!hasReadableValueSignature(value)) {
-    throw new Error(
-      'Invalid value: this hook only accepts values created via `createStreamableValue`.',
-    );
-  }
-}
-
-export function isStreamableValue(value: unknown): value is StreamableValue {
-  const hasSignature = hasReadableValueSignature(value);
-
-  if (!hasSignature && typeof value !== 'undefined') {
-    throw new Error(
-      'Invalid value: this hook only accepts values created via `createStreamableValue`.',
-    );
-  }
-
-  return hasSignature;
-}

--- a/packages/ai/rsc/streamable-value/use-streamable-value.tsx
+++ b/packages/ai/rsc/streamable-value/use-streamable-value.tsx
@@ -1,6 +1,19 @@
 import { startTransition, useLayoutEffect, useState } from 'react';
 import { readStreamableValue } from './read-streamable-value';
-import { isStreamableValue, StreamableValue } from './streamable-value';
+import { StreamableValue } from './streamable-value';
+import { isStreamableValue } from './is-streamable-value';
+
+function checkStreamableValue(value: unknown): value is StreamableValue {
+  const hasSignature = isStreamableValue(value);
+
+  if (!hasSignature && value !== undefined) {
+    throw new Error(
+      'Invalid value: this hook only accepts values created via `createStreamableValue`.',
+    );
+  }
+
+  return hasSignature;
+}
 
 /**
  * `useStreamableValue` is a React hook that takes a streamable value created via the `createStreamableValue().value` API,
@@ -23,17 +36,17 @@ export function useStreamableValue<T = unknown, Error = unknown>(
   streamableValue?: StreamableValue<T>,
 ): [data: T | undefined, error: Error | undefined, pending: boolean] {
   const [curr, setCurr] = useState<T | undefined>(
-    isStreamableValue(streamableValue) ? streamableValue.curr : undefined,
+    checkStreamableValue(streamableValue) ? streamableValue.curr : undefined,
   );
   const [error, setError] = useState<Error | undefined>(
-    isStreamableValue(streamableValue) ? streamableValue.error : undefined,
+    checkStreamableValue(streamableValue) ? streamableValue.error : undefined,
   );
   const [pending, setPending] = useState<boolean>(
-    isStreamableValue(streamableValue) ? !!streamableValue.next : false,
+    checkStreamableValue(streamableValue) ? !!streamableValue.next : false,
   );
 
   useLayoutEffect(() => {
-    if (!isStreamableValue(streamableValue)) return;
+    if (!checkStreamableValue(streamableValue)) return;
 
     let cancelled = false;
 


### PR DESCRIPTION
## Summary
* rename `hasReadableValueSignature` to `isStreamableValue` and move to separate file
* inline `assertStreamableValue`
* inline original `isStreamableValue` and rename to `checkStreamableValue`
* rename variables in `readStreamableValue` and add documentation comments
* change `typeof curr === 'undefined'` to `curr === undefined` etc. since we're long past ES5, which made the global undefined unmodifiable