### PR TITLE
refactoring (ai/rsc): streamable value tests

### DIFF
--- a/packages/ai/rsc/streamable-value/create-streamable-value.test.tsx
+++ b/packages/ai/rsc/streamable-value/create-streamable-value.test.tsx
@@ -1,12 +1,185 @@
+import { delay } from '../../util/delay';
 import { createStreamableValue } from './create-streamable-value';
+import { STREAMABLE_VALUE_TYPE, StreamableValue } from './streamable-value';
 
-it('should return self', async () => {
-  const value = createStreamableValue(1).update(2).update(3).done(4);
+async function getRawChunks(streamableValue: StreamableValue<any, any>) {
+  const { next, ...otherFields } = streamableValue;
+  const chunks = [otherFields];
 
-  expect(value.value).toMatchInlineSnapshot(`
-      {
-        "curr": 4,
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
+  if (next) {
+    chunks.push(...(await getRawChunks(await next)));
+  }
+
+  return chunks;
+}
+
+it('should return latest value', async () => {
+  const streamableValue = createStreamableValue(1).update(2).update(3).done(4);
+
+  expect(streamableValue.value.curr).toStrictEqual(4);
+});
+
+it('should be able to stream any JSON values', async () => {
+  const streamable = createStreamableValue();
+  streamable.update({ v: 123 });
+
+  expect(streamable.value.curr).toStrictEqual({ v: 123 });
+
+  streamable.done();
+});
+
+it('should support .error()', async () => {
+  const streamable = createStreamableValue();
+  streamable.error('This is an error');
+
+  expect(streamable.value).toStrictEqual({
+    error: 'This is an error',
+    type: STREAMABLE_VALUE_TYPE,
+  });
+});
+
+it('should directly emit the final value when reading .value', async () => {
+  const streamable = createStreamableValue('1');
+  streamable.update('2');
+  streamable.update('3');
+
+  expect(streamable.value.curr).toStrictEqual('3');
+
+  streamable.done('4');
+
+  expect(streamable.value.curr).toStrictEqual('4');
+});
+
+it('should be able to append strings as patch', async () => {
+  const streamable = createStreamableValue();
+  const value = streamable.value;
+
+  streamable.update('hello');
+  streamable.update('hello world');
+  streamable.update('hello world!');
+  streamable.update('new string');
+  streamable.done('new string with patch!');
+
+  expect(await getRawChunks(value)).toStrictEqual([
+    { curr: undefined, type: STREAMABLE_VALUE_TYPE },
+    { curr: 'hello' },
+    { diff: [0, ' world'] },
+    { diff: [0, '!'] },
+    { curr: 'new string' },
+    { diff: [0, ' with patch!'] },
+  ]);
+});
+
+it('should be able to call .append() to send patches', async () => {
+  const streamable = createStreamableValue();
+  const value = streamable.value;
+
+  streamable.append('hello');
+  streamable.append(' world');
+  streamable.append('!');
+  streamable.done();
+
+  expect(await getRawChunks(value)).toStrictEqual([
+    { curr: undefined, type: STREAMABLE_VALUE_TYPE },
+    { curr: 'hello' },
+    { diff: [0, ' world'] },
+    { diff: [0, '!'] },
+    {},
+  ]);
+});
+
+it('should be able to mix .update() and .append() with optimized payloads', async () => {
+  const streamable = createStreamableValue('hello');
+  const value = streamable.value;
+
+  streamable.append(' world');
+  streamable.update('hello world!!');
+  streamable.update('some new');
+  streamable.update('some new string');
+  streamable.append(' with patch!');
+  streamable.done();
+
+  expect(await getRawChunks(value)).toStrictEqual([
+    { curr: 'hello', type: STREAMABLE_VALUE_TYPE },
+    { diff: [0, ' world'] },
+    { diff: [0, '!!'] },
+    { curr: 'some new' },
+    { diff: [0, ' string'] },
+    { diff: [0, ' with patch!'] },
+    {},
+  ]);
+});
+
+it('should behave like .update() with .append() and .done()', async () => {
+  const streamable = createStreamableValue('hello');
+  const value = streamable.value;
+
+  streamable.append(' world');
+  streamable.done('fin');
+
+  expect(await getRawChunks(value)).toStrictEqual([
+    { curr: 'hello', type: STREAMABLE_VALUE_TYPE },
+    { diff: [0, ' world'] },
+    { curr: 'fin' },
+  ]);
+});
+
+it('should be able to accept readableStream as the source', async () => {
+  const streamable = createStreamableValue(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue('hello');
+        controller.enqueue(' world');
+        controller.enqueue('!');
+        controller.close();
+      },
+    }),
+  );
+  const value = streamable.value;
+
+  expect(await getRawChunks(value)).toStrictEqual([
+    { curr: undefined, type: STREAMABLE_VALUE_TYPE },
+    { curr: 'hello' },
+    { diff: [0, ' world'] },
+    { diff: [0, '!'] },
+    {},
+  ]);
+});
+
+it('should accept readableStream with JSON payloads', async () => {
+  const streamable = createStreamableValue(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue({ v: 1 });
+        controller.enqueue({ v: 2 });
+        controller.enqueue({ v: 3 });
+        controller.close();
+      },
+    }),
+  );
+  const value = streamable.value;
+
+  expect(await getRawChunks(value)).toStrictEqual([
+    { curr: undefined, type: STREAMABLE_VALUE_TYPE },
+    { curr: { v: 1 } },
+    { curr: { v: 2 } },
+    { curr: { v: 3 } },
+    {},
+  ]);
+});
+
+it('should lock the streamable if from readableStream', async () => {
+  const streamable = createStreamableValue(
+    new ReadableStream({
+      async start(controller) {
+        await delay();
+        controller.enqueue('hello');
+        controller.close();
+      },
+    }),
+  );
+
+  expect(() => streamable.update('world')).toThrowErrorMatchingInlineSnapshot(
+    '[Error: .update(): Value stream is locked and cannot be updated.]',
+  );
 });

--- a/packages/ai/rsc/streamable-value/read-streamble-value.ui.test.tsx
+++ b/packages/ai/rsc/streamable-value/read-streamble-value.ui.test.tsx
@@ -1,18 +1,6 @@
+import { delay } from '../../util/delay';
 import { createStreamableValue } from './create-streamable-value';
 import { readStreamableValue } from './read-streamable-value';
-
-function nextTick() {
-  return Promise.resolve();
-}
-
-async function getRawChunks(s: any) {
-  const { next, ...otherFields } = s;
-  const chunks = [otherFields];
-  if (next) {
-    chunks.push(...(await getRawChunks(await next)));
-  }
-  return chunks;
-}
 
 it('should return an async iterable', () => {
   const streamable = createStreamableValue();
@@ -23,66 +11,15 @@ it('should return an async iterable', () => {
   expect(result[Symbol.asyncIterator]).toBeDefined();
 });
 
-it('should directly emit the final value when reading .value', async () => {
-  const streamable = createStreamableValue('1');
-  streamable.update('2');
-  streamable.update('3');
-
-  expect(streamable.value).toMatchInlineSnapshot(`
-      {
-        "curr": "3",
-        "next": Promise {},
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
-
-  streamable.done('4');
-
-  expect(streamable.value).toMatchInlineSnapshot(`
-      {
-        "curr": "4",
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
-});
-
-it('should be able to stream any JSON values', async () => {
-  const streamable = createStreamableValue();
-  streamable.update({ v: 123 });
-
-  expect(streamable.value).toMatchInlineSnapshot(`
-      {
-        "curr": {
-          "v": 123,
-        },
-        "next": Promise {},
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
-
-  streamable.done();
-});
-
-it('should support .error()', async () => {
-  const streamable = createStreamableValue();
-  streamable.error('This is an error');
-
-  expect(streamable.value).toMatchInlineSnapshot(`
-      {
-        "error": "This is an error",
-        "type": Symbol(ui.streamable.value),
-      }
-    `);
-});
-
 it('should support reading streamed values and errors', async () => {
   const streamable = createStreamableValue(1);
+
   (async () => {
-    await nextTick();
+    await delay();
     streamable.update(2);
-    await nextTick();
+    await delay();
     streamable.update(3);
-    await nextTick();
+    await delay();
     streamable.error('This is an error');
   })();
 
@@ -92,25 +29,19 @@ it('should support reading streamed values and errors', async () => {
     for await (const v of readStreamableValue(streamable.value)) {
       values.push(v);
     }
+    expect.fail('should not be reached');
   } catch (e) {
-    expect(e).toMatchInlineSnapshot(`"This is an error"`);
+    expect(e).toStrictEqual('This is an error');
   }
 
-  expect(values).toMatchInlineSnapshot(`
-      [
-        1,
-        2,
-        3,
-      ]
-    `);
+  expect(values).toStrictEqual([1, 2, 3]);
 });
 
 it('should be able to read values asynchronously with different value types', async () => {
   const streamable = createStreamableValue({});
 
   (async () => {
-    // Defer this a bit.
-    await Promise.resolve();
+    await delay();
     streamable.update([1]);
     streamable.update(['2']);
     streamable.done({ 3: 3 });
@@ -120,28 +51,15 @@ it('should be able to read values asynchronously with different value types', as
   for await (const v of readStreamableValue(streamable.value)) {
     values.push(v);
   }
-  expect(values).toMatchInlineSnapshot(`
-      [
-        {},
-        [
-          1,
-        ],
-        [
-          "2",
-        ],
-        {
-          "3": 3,
-        },
-      ]
-    `);
+
+  expect(values).toStrictEqual([{}, [1], ['2'], { '3': 3 }]);
 });
 
 it('should be able to replay errors', async () => {
   const streamable = createStreamableValue(0);
 
   (async () => {
-    // Defer this a bit.
-    await Promise.resolve();
+    await delay();
     streamable.update(1);
     streamable.update(2);
     streamable.error({ customErrorMessage: 'this is an error' });
@@ -153,353 +71,94 @@ it('should be able to replay errors', async () => {
     for await (const v of readStreamableValue(streamable.value)) {
       values.push(v);
     }
+
+    expect.fail('should not be reached');
   } catch (e) {
-    expect(e).toMatchInlineSnapshot(`
-        {
-          "customErrorMessage": "this is an error",
-        }
-      `);
+    expect(e).toStrictEqual({
+      customErrorMessage: 'this is an error',
+    });
   }
-  expect(values).toMatchInlineSnapshot(`
-      [
-        0,
-        1,
-        2,
-      ]
-    `);
+  expect(values).toStrictEqual([0, 1, 2]);
 });
 
-describe('patch', () => {
-  it('should be able to append strings as patch', async () => {
-    const streamable = createStreamableValue();
-    const value = streamable.value;
+it('should be able to append strings as patch', async () => {
+  const streamable = createStreamableValue();
+  const value = streamable.value;
 
-    streamable.update('hello');
-    streamable.update('hello world');
-    streamable.update('hello world!');
-    streamable.update('new string');
-    streamable.done('new string with patch!');
+  streamable.update('hello');
+  streamable.update('hello world');
+  streamable.update('hello world!');
+  streamable.update('new string');
+  streamable.done('new string with patch!');
 
-    expect(await getRawChunks(value)).toMatchInlineSnapshot(`
-        [
-          {
-            "curr": undefined,
-            "type": Symbol(ui.streamable.value),
-          },
-          {
-            "curr": "hello",
-          },
-          {
-            "diff": [
-              0,
-              " world",
-            ],
-          },
-          {
-            "diff": [
-              0,
-              "!",
-            ],
-          },
-          {
-            "curr": "new string",
-          },
-          {
-            "diff": [
-              0,
-              " with patch!",
-            ],
-          },
-        ]
-      `);
+  const values = [];
+  for await (const v of readStreamableValue(value)) {
+    values.push(v);
+  }
 
-    const values = [];
-    for await (const v of readStreamableValue(value)) {
-      values.push(v);
-    }
-    expect(values).toMatchInlineSnapshot(`
-        [
-          "hello",
-          "hello world",
-          "hello world!",
-          "new string",
-          "new string with patch!",
-        ]
-      `);
-  });
-
-  it('should be able to call .append() to send patches', async () => {
-    const streamable = createStreamableValue();
-    const value = streamable.value;
-
-    streamable.append('hello');
-    streamable.append(' world');
-    streamable.append('!');
-    streamable.done();
-
-    expect(await getRawChunks(value)).toMatchInlineSnapshot(`
-        [
-          {
-            "curr": undefined,
-            "type": Symbol(ui.streamable.value),
-          },
-          {
-            "curr": "hello",
-          },
-          {
-            "diff": [
-              0,
-              " world",
-            ],
-          },
-          {
-            "diff": [
-              0,
-              "!",
-            ],
-          },
-          {},
-        ]
-      `);
-
-    const values = [];
-    for await (const v of readStreamableValue(value)) {
-      values.push(v);
-    }
-    expect(values).toMatchInlineSnapshot(`
-        [
-          "hello",
-          "hello world",
-          "hello world!",
-        ]
-      `);
-  });
-
-  it('should be able to mix .update() and .append() with optimized payloads', async () => {
-    const streamable = createStreamableValue('hello');
-    const value = streamable.value;
-
-    streamable.append(' world');
-    streamable.update('hello world!!');
-    streamable.update('some new');
-    streamable.update('some new string');
-    streamable.append(' with patch!');
-    streamable.done();
-
-    expect(await getRawChunks(value)).toMatchInlineSnapshot(`
-        [
-          {
-            "curr": "hello",
-            "type": Symbol(ui.streamable.value),
-          },
-          {
-            "diff": [
-              0,
-              " world",
-            ],
-          },
-          {
-            "diff": [
-              0,
-              "!!",
-            ],
-          },
-          {
-            "curr": "some new",
-          },
-          {
-            "diff": [
-              0,
-              " string",
-            ],
-          },
-          {
-            "diff": [
-              0,
-              " with patch!",
-            ],
-          },
-          {},
-        ]
-      `);
-
-    const values = [];
-    for await (const v of readStreamableValue(value)) {
-      values.push(v);
-    }
-    expect(values).toMatchInlineSnapshot(`
-        [
-          "hello",
-          "hello world",
-          "hello world!!",
-          "some new",
-          "some new string",
-          "some new string with patch!",
-        ]
-      `);
-  });
-
-  it('should behave like .update() with .append() and .done()', async () => {
-    const streamable = createStreamableValue('hello');
-    const value = streamable.value;
-
-    streamable.append(' world');
-    streamable.done('fin');
-
-    expect(await getRawChunks(value)).toMatchInlineSnapshot(`
-        [
-          {
-            "curr": "hello",
-            "type": Symbol(ui.streamable.value),
-          },
-          {
-            "diff": [
-              0,
-              " world",
-            ],
-          },
-          {
-            "curr": "fin",
-          },
-        ]
-      `);
-
-    const values = [];
-    for await (const v of readStreamableValue(value)) {
-      values.push(v);
-    }
-    expect(values).toMatchInlineSnapshot(`
-        [
-          "hello",
-          "hello world",
-          "fin",
-        ]
-      `);
-  });
+  expect(values).toStrictEqual([
+    'hello',
+    'hello world',
+    'hello world!',
+    'new string',
+    'new string with patch!',
+  ]);
 });
 
-describe('readableStream', () => {
-  it('should be able to accept readableStream as the source', async () => {
-    const streamable = createStreamableValue(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue('hello');
-          controller.enqueue(' world');
-          controller.enqueue('!');
-          controller.close();
-        },
-      }),
-    );
-    const value = streamable.value;
+it('should be able to call .append() to send patches', async () => {
+  const streamable = createStreamableValue();
+  const value = streamable.value;
 
-    expect(await getRawChunks(value)).toMatchInlineSnapshot(`
-        [
-          {
-            "curr": undefined,
-            "type": Symbol(ui.streamable.value),
-          },
-          {
-            "curr": "hello",
-          },
-          {
-            "diff": [
-              0,
-              " world",
-            ],
-          },
-          {
-            "diff": [
-              0,
-              "!",
-            ],
-          },
-          {},
-        ]
-      `);
+  streamable.append('hello');
+  streamable.append(' world');
+  streamable.append('!');
+  streamable.done();
 
-    const values = [];
-    for await (const v of readStreamableValue(value)) {
-      values.push(v);
-    }
-    expect(values).toMatchInlineSnapshot(`
-        [
-          "hello",
-          "hello world",
-          "hello world!",
-        ]
-      `);
-  });
+  const values = [];
+  for await (const v of readStreamableValue(value)) {
+    values.push(v);
+  }
 
-  it('should accept readableStream with JSON payloads', async () => {
-    const streamable = createStreamableValue(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue({ v: 1 });
-          controller.enqueue({ v: 2 });
-          controller.enqueue({ v: 3 });
-          controller.close();
-        },
-      }),
-    );
-    const value = streamable.value;
+  expect(values).toStrictEqual(['hello', 'hello world', 'hello world!']);
+});
 
-    expect(await getRawChunks(value)).toMatchInlineSnapshot(`
-        [
-          {
-            "curr": undefined,
-            "type": Symbol(ui.streamable.value),
-          },
-          {
-            "curr": {
-              "v": 1,
-            },
-          },
-          {
-            "curr": {
-              "v": 2,
-            },
-          },
-          {
-            "curr": {
-              "v": 3,
-            },
-          },
-          {},
-        ]
-      `);
+it('should be able to mix .update() and .append() with optimized payloads', async () => {
+  const streamable = createStreamableValue('hello');
+  const value = streamable.value;
 
-    const values = [];
-    for await (const v of readStreamableValue(value)) {
-      values.push(v);
-    }
-    expect(values).toMatchInlineSnapshot(`
-        [
-          {
-            "v": 1,
-          },
-          {
-            "v": 2,
-          },
-          {
-            "v": 3,
-          },
-        ]
-      `);
-  });
+  streamable.append(' world');
+  streamable.update('hello world!!');
+  streamable.update('some new');
+  streamable.update('some new string');
+  streamable.append(' with patch!');
+  streamable.done();
 
-  it('should lock the streamable if from readableStream', async () => {
-    const streamable = createStreamableValue(
-      new ReadableStream({
-        async start(controller) {
-          await nextTick();
-          controller.enqueue('hello');
-          controller.close();
-        },
-      }),
-    );
+  const values = [];
+  for await (const v of readStreamableValue(value)) {
+    values.push(v);
+  }
 
-    expect(() => streamable.update('world')).toThrowErrorMatchingInlineSnapshot(
-      '[Error: .update(): Value stream is locked and cannot be updated.]',
-    );
-  });
+  expect(values).toStrictEqual([
+    'hello',
+    'hello world',
+    'hello world!!',
+    'some new',
+    'some new string',
+    'some new string with patch!',
+  ]);
+});
+
+it('should behave like .update() with .append() and .done()', async () => {
+  const streamable = createStreamableValue('hello');
+  const value = streamable.value;
+
+  streamable.append(' world');
+  streamable.done('fin');
+
+  const values = [];
+  for await (const v of readStreamableValue(value)) {
+    values.push(v);
+  }
+
+  expect(values).toStrictEqual(['hello', 'hello world', 'fin']);
 });

--- a/packages/ai/util/delay.ts
+++ b/packages/ai/util/delay.ts
@@ -1,3 +1,5 @@
-export async function delay(delayInMs: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, delayInMs));
+export async function delay(delayInMs?: number): Promise<void> {
+  return delayInMs === undefined
+    ? Promise.resolve()
+    : new Promise(resolve => setTimeout(resolve, delayInMs));
 }


### PR DESCRIPTION
## Summary
- allow empty arg in `delay` and replace `nextTick`
- split tests into `create-streamable-value` tests and `read-streamable-value` tests
- replace snapshot tests with strict equal tests
- add fail expects
- refactor `getRawChunks` into loop (no recursion)
- use `convertArrayToReadableStream`