### PR TITLE
feat (provider/anthropic): add cache control support

### DIFF
--- a/.changeset/nine-paws-flash.md
+++ b/.changeset/nine-paws-flash.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+feat (provider/anthropic): add cache control support

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -482,6 +482,12 @@ To see `generateText` in action, check out [these examples](#examples).
         'Warnings from the model provider (e.g. unsupported settings).',
     },
     {
+      name: 'experimental_providerMetadata',
+      type: 'Record<string,Record<string,JSONValue>> | undefined',
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
+    {
       name: 'responseMessages',
       type: 'Array<CoreAssistantMessage | CoreToolMessage>',
       description:

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -596,6 +596,12 @@ To see `streamText` in action, check out [these examples](#examples).
               ],
             },
             {
+              name: 'experimental_providerMetadata',
+              type: 'Record<string,Record<string,JSONValue>> | undefined',
+              description:
+                'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+            },
+            {
               name: 'text',
               type: 'string',
               description: 'The full text that has been generated.',
@@ -678,6 +684,12 @@ To see `streamText` in action, check out [these examples](#examples).
           ],
         },
       ],
+    },
+    {
+      name: 'experimental_providerMetadata',
+      type: 'Promise<Record<string,Record<string,JSONValue>> | undefined>',
+      description:
+        'Optional metadata from the provider. Resolved whe the response is finished. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
     {
       name: 'text',

--- a/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
@@ -450,6 +450,12 @@ To see `generateObject` in action, check out [these examples](#examples).
         'Warnings from the model provider (e.g. unsupported settings).',
     },
     {
+      name: 'experimental_providerMetadata',
+      type: 'Record<string,Record<string,JSONValue>> | undefined',
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
+    {
       name: 'toJsonResponse',
       type: '(init?: ResponseInit) => Response',
       description:

--- a/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
@@ -421,6 +421,12 @@ To see `streamObject` in action, check out [these examples](#examples).
               ],
             },
             {
+              name: 'experimental_providerMetadata',
+              type: 'Record<string,Record<string,JSONValue>> | undefined',
+              description:
+                'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+            },
+            {
               name: 'object',
               type: 'T | undefined',
               description:
@@ -494,6 +500,12 @@ To see `streamObject` in action, check out [these examples](#examples).
           ],
         },
       ],
+    },
+    {
+      name: 'experimental_providerMetadata',
+      type: 'Promise<Record<string,Record<string,JSONValue>> | undefined>',
+      description:
+        'Optional metadata from the provider. Resolved whe the response is finished. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
     {
       name: 'object',

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anthropic
-description: Learn how to use Anthropic.
+description: Learn how to use the Anthropic provider for the Vercel AI SDK.
 ---
 
 # Anthropic Provider
@@ -74,7 +74,15 @@ Some models have multi-modal capabilities.
 const model = anthropic('claude-3-haiku-20240307');
 ```
 
-### Example
+The following optional settings are available for Anthropic models:
+
+- **cacheControl** _boolean_
+
+  Enable the Anthropic cache control beta.
+
+  You can then use provider metadata to set cache control breakpoints ([example](#example-cache-control))
+
+### Example: Generate Text
 
 You can use Anthropic language models to generate text with the `generateText` function:
 
@@ -90,6 +98,52 @@ const { text } = await generateText({
 
 Anthropic language models can also be used in the `streamText`, `generateObject`, `streamObject`, and `streamUI` functions
 (see [AI SDK Core](/docs/ai-sdk-core) and [AI SDK RSC](/docs/ai-sdk-rsc)).
+
+### Example: Cache Control
+
+You can enable the cache control beta by setting the `cacheControl` option to `true` when creating the model instance.
+
+In the messages and message parts, you can then use the `experimental_providerMetadata` property to set cache control breakpoints.
+You need to set the `anthropic` property in the `experimental_providerMetadata` object to `{ cacheControl: { type: 'ephemeral' } }` to set a cache control breakpoint.
+
+The cache creation input tokens are then returned in the `experimental_providerMetadata` object
+for `generateText` and `generateObject`, again under the `anthropic` property.
+When you use `streamText` or `streamObject`, the response contains a promise
+that resolves to the metadata. Alternatively you can receive it in the
+`onFinish` callback.
+
+```ts highlight="8,18-20,29-30"
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const errorMessage = '... long error message ...';
+
+const result = await generateText({
+  model: anthropic('claude-3-5-sonnet-20240620', {
+    cacheControl: true,
+  }),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'You are a JavaScript expert.' },
+        {
+          type: 'text',
+          text: `Error message: ${errorMessage}`,
+          experimental_providerMetadata: {
+            anthropic: { cacheControl: { type: 'ephemeral' } },
+          },
+        },
+        { type: 'text', text: 'Explain the error message.' },
+      ],
+    },
+  ],
+});
+
+console.log(result.text);
+console.log(result.experimental_providerMetadata?.anthropic);
+// e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
+```
 
 ### Model Capabilities
 

--- a/examples/ai-core/data/error-message.txt
+++ b/examples/ai-core/data/error-message.txt
@@ -1,0 +1,83 @@
+❯ pnpm tsx src/generate-text/anthropic-cache-control.ts
+Body {
+  "model": "claude-3-5-sonnet-20240620",
+  "max_tokens": 4096,
+  "temperature": 0,
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "You are a JavaScript expert."
+        },
+        {
+          "type": "text",
+          "text": "Error messages: \nAPICallError [AI_APICallError]: Failed to process error response\n    at postToApi (/Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:382:15)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    ... 4 lines matching cause stack trace ...\n    at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2723:36)\n    at async /Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:339:22\n    at async main (/Users/larsgrammel/repositories/ai/examples/ai-core/src/generate-text/anthropic-cache-control.ts:2:1351) {\n  cause: TypeError: Body is unusable\n      at consumeBody (node:internal/deps/undici/undici:4281:15)\n      at _Response.text (node:internal/deps/undici/undici:4236:18)\n      at /Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:443:39\n      at postToApi (/Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:373:34)\n      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n      at async AnthropicMessagesLanguageModel.doGenerate (/Users/larsgrammel/repositories/ai/packages/anthropic/dist/index.js:316:50)\n      at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2748:34)\n      at async /Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:339:22\n      at async _retryWithExponentialBackoff (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:170:12)\n      at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2723:36),\n  url: 'https://api.anthropic.com/v1/messages',\n  requestBodyValues: {\n    model: 'claude-3-5-sonnet-20240620',\n    top_k: undefined,\n    max_tokens: 4096,\n    temperature: 0,\n    top_p: undefined,\n    stop_sequences: undefined,\n    system: undefined,\n    messages: [ [Object] ],\n    tools: undefined,\n    tool_choice: undefined\n  },\n  statusCode: 400,\n  responseHeaders: {\n    'cf-cache-status': 'DYNAMIC',\n    'cf-ray': '8b39b60ab8734516-TXL',\n    connection: 'keep-alive',\n    'content-length': '171',\n    'content-type': 'application/json',\n    date: 'Thu, 15 Aug 2024 14:00:28 GMT',\n    'request-id': 'req_01PLrS159iiihG7kS9PFQiqx',\n    server: 'cloudflare',\n    via: '1.1 google',\n    'x-cloud-trace-context': '1371f8e6d358102b79d109db3829d62e',\n    'x-robots-tag': 'none',\n    'x-should-retry': 'false'\n  },\n  responseBody: undefined,\n  isRetryable: false,\n  data: undefined,\n  [Symbol(vercel.ai.error)]: true,\n  [Symbol(vercel.ai.error.AI_APICallError)]: true\n}",
+          "cache_control": {
+            "type": "ephemeral"
+          }
+        },
+        {
+          "type": "text",
+          "text": "Explain the error message."
+        }
+      ]
+    }
+  ]
+}
+Fetched {"type":"error","error":{"type":"invalid_request_error","message":"The message up to and including the first cache-control block must be at least 1024 tokens. Found: 939."}}
+
+APICallError [AI_APICallError]: Failed to process error response
+    at postToApi (/Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:382:15)
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+    ... 4 lines matching cause stack trace ...
+    at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2723:36)
+    at async /Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:339:22
+    at async main (/Users/larsgrammel/repositories/ai/examples/ai-core/src/generate-text/anthropic-cache-control.ts:54:361) {
+  cause: TypeError: Body is unusable
+      at consumeBody (node:internal/deps/undici/undici:4281:15)
+      at _Response.text (node:internal/deps/undici/undici:4236:18)
+      at /Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:443:39
+      at postToApi (/Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:373:34)
+      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+      at async AnthropicMessagesLanguageModel.doGenerate (/Users/larsgrammel/repositories/ai/packages/anthropic/dist/index.js:316:50)
+      at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2748:34)
+      at async /Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:339:22
+      at async _retryWithExponentialBackoff (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:170:12)
+      at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2723:36),
+  url: 'https://api.anthropic.com/v1/messages',
+  requestBodyValues: {
+    model: 'claude-3-5-sonnet-20240620',
+    top_k: undefined,
+    max_tokens: 4096,
+    temperature: 0,
+    top_p: undefined,
+    stop_sequences: undefined,
+    system: undefined,
+    messages: [ [Object] ],
+    tools: undefined,
+    tool_choice: undefined
+  },
+  statusCode: 400,
+  responseHeaders: {
+    'cf-cache-status': 'DYNAMIC',
+    'cf-ray': '8b39b87a8f684541-TXL',
+    connection: 'keep-alive',
+    'content-length': '173',
+    'content-type': 'application/json',
+    date: 'Thu, 15 Aug 2024 14:02:08 GMT',
+    'request-id': 'req_01YZqjpifTdvLZqfwBieLs44',
+    server: 'cloudflare',
+    via: '1.1 google',
+    'x-cloud-trace-context': '00f2b1629d0dc8c6a4714db1dbdb4c2c',
+    'x-robots-tag': 'none',
+    'x-should-retry': 'false'
+  },
+  responseBody: undefined,
+  isRetryable: false,
+  data: undefined,
+  [Symbol(vercel.ai.error)]: true,
+  [Symbol(vercel.ai.error.AI_APICallError)]: true
+}
+}

--- a/examples/ai-core/src/generate-text/anthropic-cache-control.ts
+++ b/examples/ai-core/src/generate-text/anthropic-cache-control.ts
@@ -133,6 +133,8 @@ async function main() {
   });
 
   console.log(result.text);
+  console.log(result.experimental_providerMetadata?.anthropic);
+  // e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-text/anthropic-cache-control.ts
+++ b/examples/ai-core/src/generate-text/anthropic-cache-control.ts
@@ -1,0 +1,138 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const error = `
+❯ pnpm tsx src/generate-text/anthropic-cache-control.ts
+Body {
+  "model": "claude-3-5-sonnet-20240620",
+  "max_tokens": 4096,
+  "temperature": 0,
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "You are a JavaScript expert."
+        },
+        {
+          "type": "text",
+          "text": "Error messages: \nAPICallError [AI_APICallError]: Failed to process error response\n    at postToApi (/Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:382:15)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    ... 4 lines matching cause stack trace ...\n    at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2723:36)\n    at async /Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:339:22\n    at async main (/Users/larsgrammel/repositories/ai/examples/ai-core/src/generate-text/anthropic-cache-control.ts:2:1351) {\n  cause: TypeError: Body is unusable\n      at consumeBody (node:internal/deps/undici/undici:4281:15)\n      at _Response.text (node:internal/deps/undici/undici:4236:18)\n      at /Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:443:39\n      at postToApi (/Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:373:34)\n      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n      at async AnthropicMessagesLanguageModel.doGenerate (/Users/larsgrammel/repositories/ai/packages/anthropic/dist/index.js:316:50)\n      at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2748:34)\n      at async /Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:339:22\n      at async _retryWithExponentialBackoff (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:170:12)\n      at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2723:36),\n  url: 'https://api.anthropic.com/v1/messages',\n  requestBodyValues: {\n    model: 'claude-3-5-sonnet-20240620',\n    top_k: undefined,\n    max_tokens: 4096,\n    temperature: 0,\n    top_p: undefined,\n    stop_sequences: undefined,\n    system: undefined,\n    messages: [ [Object] ],\n    tools: undefined,\n    tool_choice: undefined\n  },\n  statusCode: 400,\n  responseHeaders: {\n    'cf-cache-status': 'DYNAMIC',\n    'cf-ray': '8b39b60ab8734516-TXL',\n    connection: 'keep-alive',\n    'content-length': '171',\n    'content-type': 'application/json',\n    date: 'Thu, 15 Aug 2024 14:00:28 GMT',\n    'request-id': 'req_01PLrS159iiihG7kS9PFQiqx',\n    server: 'cloudflare',\n    via: '1.1 google',\n    'x-cloud-trace-context': '1371f8e6d358102b79d109db3829d62e',\n    'x-robots-tag': 'none',\n    'x-should-retry': 'false'\n  },\n  responseBody: undefined,\n  isRetryable: false,\n  data: undefined,\n  [Symbol(vercel.ai.error)]: true,\n  [Symbol(vercel.ai.error.AI_APICallError)]: true\n}",
+          "cache_control": {
+            "type": "ephemeral"
+          }
+        },
+        {
+          "type": "text",
+          "text": "Explain the error message."
+        }
+      ]
+    }
+  ]
+}
+Fetched {"type":"error","error":{"type":"invalid_request_error","message":"The message up to and including the first cache-control block must be at least 1024 tokens. Found: 939."}}
+
+APICallError [AI_APICallError]: Failed to process error response
+    at postToApi (/Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:382:15)
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+    ... 4 lines matching cause stack trace ...
+    at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2723:36)
+    at async /Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:339:22
+    at async main (/Users/larsgrammel/repositories/ai/examples/ai-core/src/generate-text/anthropic-cache-control.ts:54:361) {
+  cause: TypeError: Body is unusable
+      at consumeBody (node:internal/deps/undici/undici:4281:15)
+      at _Response.text (node:internal/deps/undici/undici:4236:18)
+      at /Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:443:39
+      at postToApi (/Users/larsgrammel/repositories/ai/packages/provider-utils/dist/index.js:373:34)
+      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+      at async AnthropicMessagesLanguageModel.doGenerate (/Users/larsgrammel/repositories/ai/packages/anthropic/dist/index.js:316:50)
+      at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2748:34)
+      at async /Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:339:22
+      at async _retryWithExponentialBackoff (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:170:12)
+      at async fn (/Users/larsgrammel/repositories/ai/packages/ai/dist/index.js:2723:36),
+  url: 'https://api.anthropic.com/v1/messages',
+  requestBodyValues: {
+    model: 'claude-3-5-sonnet-20240620',
+    top_k: undefined,
+    max_tokens: 4096,
+    temperature: 0,
+    top_p: undefined,
+    stop_sequences: undefined,
+    system: undefined,
+    messages: [ [Object] ],
+    tools: undefined,
+    tool_choice: undefined
+  },
+  statusCode: 400,
+  responseHeaders: {
+    'cf-cache-status': 'DYNAMIC',
+    'cf-ray': '8b39b87a8f684541-TXL',
+    connection: 'keep-alive',
+    'content-length': '173',
+    'content-type': 'application/json',
+    date: 'Thu, 15 Aug 2024 14:02:08 GMT',
+    'request-id': 'req_01YZqjpifTdvLZqfwBieLs44',
+    server: 'cloudflare',
+    via: '1.1 google',
+    'x-cloud-trace-context': '00f2b1629d0dc8c6a4714db1dbdb4c2c',
+    'x-robots-tag': 'none',
+    'x-should-retry': 'false'
+  },
+  responseBody: undefined,
+  isRetryable: false,
+  data: undefined,
+  [Symbol(vercel.ai.error)]: true,
+  [Symbol(vercel.ai.error.AI_APICallError)]: true
+}
+}`;
+
+const anthropic = createAnthropic({
+  // example fetch wrapper that logs the input to the API call:
+  fetch: async (url, options) => {
+    console.log('URL', url);
+    console.log('Headers', JSON.stringify(options!.headers, null, 2));
+    console.log(
+      `Body ${JSON.stringify(JSON.parse(options!.body! as string), null, 2)}`,
+    );
+    return await fetch(url, options);
+  },
+});
+
+async function main() {
+  const result = await generateText({
+    model: anthropic('claude-3-5-sonnet-20240620', {
+      cacheControl: true,
+    }),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a JavaScript expert.',
+          },
+          {
+            type: 'text',
+            text: `Error messages: ${error}`,
+            experimental_providerMetadata: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Explain the error message.',
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/anthropic-cache-control.ts
+++ b/examples/ai-core/src/stream-text/anthropic-cache-control.ts
@@ -1,4 +1,4 @@
-import { createAnthropic } from '@ai-sdk/anthropic';
+import { anthropic } from '@ai-sdk/anthropic';
 import { streamText } from 'ai';
 import dotenv from 'dotenv';
 import fs from 'node:fs';
@@ -6,18 +6,6 @@ import fs from 'node:fs';
 dotenv.config();
 
 const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
-
-const anthropic = createAnthropic({
-  // example fetch wrapper that logs the input to the API call:
-  fetch: async (url, options) => {
-    console.log('URL', url);
-    console.log('Headers', JSON.stringify(options!.headers, null, 2));
-    console.log(
-      `Body ${JSON.stringify(JSON.parse(options!.body! as string), null, 2)}`,
-    );
-    return await fetch(url, options);
-  },
-});
 
 async function main() {
   const result = await streamText({
@@ -48,13 +36,19 @@ async function main() {
         ],
       },
     ],
+    onFinish({ experimental_providerMetadata }) {
+      console.log();
+      console.log('=== onFinish ===');
+      console.log(experimental_providerMetadata?.anthropic);
+    },
   });
 
   for await (const textPart of result.textStream) {
     process.stdout.write(textPart);
   }
 
-  // console.log(await result.experimental_providerMetadata?.anthropic);
+  console.log('=== providerMetadata Promise ===');
+  console.log((await result.experimental_providerMetadata)?.anthropic);
   // e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
 }
 

--- a/packages/ai/core/generate-object/generate-object-result.ts
+++ b/packages/ai/core/generate-object/generate-object-result.ts
@@ -1,4 +1,9 @@
-import { CallWarning, FinishReason, LogProbs } from '../types';
+import {
+  CallWarning,
+  FinishReason,
+  LogProbs,
+  ProviderMetadata,
+} from '../types';
 import { CompletionTokenUsage } from '../types/token-usage';
 
 /**
@@ -40,6 +45,13 @@ export interface GenerateObjectResult<T> {
   `undefined` if the mode does not support logprobs or if was not enabled
      */
   readonly logprobs: LogProbs | undefined;
+
+  /**
+Additional provider-specific metadata. They are passed through
+from the provider to the AI SDK and enable provider-specific
+results that can be fully encapsulated in the provider.
+   */
+  readonly experimental_providerMetadata: ProviderMetadata | undefined;
 
   /**
   Converts the object to a JSON response.

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -252,6 +252,35 @@ describe('result.toJsonResponse', () => {
   });
 });
 
+describe('result.providerMetadata', () => {
+  it('should contain provider metadata', async () => {
+    const result = await generateObject({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({}) => ({
+          ...dummyResponseValues,
+          text: `{ "content": "Hello, world!" }`,
+          providerMetadata: {
+            anthropic: {
+              cacheCreationInputTokens: 10,
+              cacheReadInputTokens: 20,
+            },
+          },
+        }),
+      }),
+      schema: z.object({ content: z.string() }),
+      mode: 'json',
+      prompt: 'prompt',
+    });
+
+    assert.deepStrictEqual(result.experimental_providerMetadata, {
+      anthropic: {
+        cacheCreationInputTokens: 10,
+        cacheReadInputTokens: 20,
+      },
+    });
+  });
+});
+
 describe('options.headers', () => {
   it('should set headers', async () => {
     const result = await generateObject({

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -13,7 +13,13 @@ import { getTracer } from '../telemetry/get-tracer';
 import { recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
-import { CallWarning, FinishReason, LanguageModel, LogProbs } from '../types';
+import {
+  CallWarning,
+  FinishReason,
+  LanguageModel,
+  LogProbs,
+  ProviderMetadata,
+} from '../types';
 import { calculateCompletionTokenUsage } from '../types/token-usage';
 import { prepareResponseHeaders } from '../util/prepare-response-headers';
 import { GenerateObjectResult } from './generate-object-result';
@@ -169,6 +175,7 @@ Default and recommended: 'auto' (best mode for the model).
       let warnings: CallWarning[] | undefined;
       let rawResponse: { headers?: Record<string, string> } | undefined;
       let logprobs: LogProbs | undefined;
+      let providerMetadata: ProviderMetadata | undefined;
 
       switch (mode) {
         case 'json': {
@@ -268,6 +275,7 @@ Default and recommended: 'auto' (best mode for the model).
           warnings = generateResult.warnings;
           rawResponse = generateResult.rawResponse;
           logprobs = generateResult.logprobs;
+          providerMetadata = generateResult.providerMetadata;
 
           break;
         }
@@ -369,6 +377,7 @@ Default and recommended: 'auto' (best mode for the model).
           warnings = generateResult.warnings;
           rawResponse = generateResult.rawResponse;
           logprobs = generateResult.logprobs;
+          providerMetadata = generateResult.providerMetadata;
 
           break;
         }
@@ -413,6 +422,7 @@ Default and recommended: 'auto' (best mode for the model).
         warnings,
         rawResponse,
         logprobs,
+        providerMetadata,
       });
     },
   });
@@ -425,6 +435,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
   readonly warnings: GenerateObjectResult<T>['warnings'];
   readonly rawResponse: GenerateObjectResult<T>['rawResponse'];
   readonly logprobs: GenerateObjectResult<T>['logprobs'];
+  readonly experimental_providerMetadata: GenerateObjectResult<T>['experimental_providerMetadata'];
 
   constructor(options: {
     object: GenerateObjectResult<T>['object'];
@@ -433,6 +444,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
     warnings: GenerateObjectResult<T>['warnings'];
     rawResponse: GenerateObjectResult<T>['rawResponse'];
     logprobs: GenerateObjectResult<T>['logprobs'];
+    providerMetadata: GenerateObjectResult<T>['experimental_providerMetadata'];
   }) {
     this.object = options.object;
     this.finishReason = options.finishReason;
@@ -440,6 +452,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
     this.warnings = options.warnings;
     this.rawResponse = options.rawResponse;
     this.logprobs = options.logprobs;
+    this.experimental_providerMetadata = options.providerMetadata;
   }
 
   toJsonResponse(init?: ResponseInit): Response {

--- a/packages/ai/core/generate-object/stream-object-result.ts
+++ b/packages/ai/core/generate-object/stream-object-result.ts
@@ -1,6 +1,11 @@
 import { DeepPartial } from '@ai-sdk/ui-utils';
 import { ServerResponse } from 'http';
-import { CallWarning, FinishReason, LogProbs } from '../types';
+import {
+  CallWarning,
+  FinishReason,
+  LogProbs,
+  ProviderMetadata,
+} from '../types';
 import { CompletionTokenUsage } from '../types/token-usage';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
 
@@ -17,6 +22,13 @@ export interface StreamObjectResult<T> {
   The token usage of the generated response. Resolved when the response is finished.
      */
   readonly usage: Promise<CompletionTokenUsage>;
+
+  /**
+Additional provider-specific metadata. They are passed through
+from the provider to the AI SDK and enable provider-specific
+results that can be fully encapsulated in the provider.
+   */
+  readonly experimental_providerMetadata: Promise<ProviderMetadata | undefined>;
 
   /**
   Optional raw response data.
@@ -91,6 +103,7 @@ export type ObjectStreamInputPart =
         completionTokens: number;
         totalTokens: number;
       };
+      providerMetadata?: ProviderMetadata;
     };
 
 export type ObjectStreamPart<T> =

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -1,6 +1,11 @@
 import { CoreAssistantMessage, CoreToolMessage } from '../prompt';
 import { CoreTool } from '../tool/tool';
-import { CallWarning, FinishReason, LogProbs } from '../types';
+import {
+  CallWarning,
+  FinishReason,
+  LogProbs,
+  ProviderMetadata,
+} from '../types';
 import { CompletionTokenUsage } from '../types/token-usage';
 import { ToToolCallArray } from './tool-call';
 import { ToToolResultArray } from './tool-result';
@@ -116,4 +121,11 @@ export interface GenerateTextResult<TOOLS extends Record<string, CoreTool>> {
   `undefined` if the mode does not support logprobs or if was not enabled.
      */
   readonly logprobs: LogProbs | undefined;
+
+  /**
+Additional provider-specific metadata. They are passed through
+from the provider to the AI SDK and enable provider-specific
+results that can be fully encapsulated in the provider.
+   */
+  readonly experimental_providerMetadata: ProviderMetadata | undefined;
 }

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -189,50 +189,75 @@ describe('result.toolResults', () => {
   });
 });
 
+describe('result.providerMetadata', () => {
+  it('should contain provider metadata', async () => {
+    const result = await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async () => ({
+          ...dummyResponseValues,
+          providerMetadata: {
+            anthropic: {
+              cacheCreationInputTokens: 10,
+              cacheReadInputTokens: 20,
+            },
+          },
+        }),
+      }),
+      prompt: 'test-input',
+    });
+
+    assert.deepStrictEqual(result.experimental_providerMetadata, {
+      anthropic: {
+        cacheCreationInputTokens: 10,
+        cacheReadInputTokens: 20,
+      },
+    });
+  });
+});
+
 describe('result.responseMessages', () => {
   it('should contain assistant response message when there are no tool calls', async () => {
     const result = await generateText({
       model: new MockLanguageModelV1({
-        doGenerate: async ({ prompt, mode }) => {
-          return {
-            ...dummyResponseValues,
-            text: 'Hello, world!',
-          };
-        },
+        doGenerate: async ({}) => ({
+          ...dummyResponseValues,
+          text: 'Hello, world!',
+        }),
       }),
       prompt: 'test-input',
     });
 
     assert.deepStrictEqual(result.responseMessages, [
-      { role: 'assistant', content: [{ type: 'text', text: 'Hello, world!' }] },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello, world!' }],
+      },
     ]);
   });
 
   it('should contain assistant response message and tool message when there are tool calls with results', async () => {
     const result = await generateText({
       model: new MockLanguageModelV1({
-        doGenerate: async ({ prompt, mode }) => {
-          return {
-            ...dummyResponseValues,
-            text: 'Hello, world!',
-            toolCalls: [
-              {
-                toolCallType: 'function',
-                toolCallId: 'call-1',
-                toolName: 'tool1',
-                args: `{ "value": "value" }`,
-              },
-            ],
-            toolResults: [
-              {
-                toolCallId: 'call-1',
-                toolName: 'tool1',
-                args: { value: 'value' },
-                result: 'result1',
-              },
-            ],
-          };
-        },
+        doGenerate: async ({}) => ({
+          ...dummyResponseValues,
+          text: 'Hello, world!',
+          toolCalls: [
+            {
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'tool1',
+              args: `{ "value": "value" }`,
+            },
+          ],
+          toolResults: [
+            {
+              toolCallId: 'call-1',
+              toolName: 'tool1',
+              args: { value: 'value' },
+              result: 'result1',
+            },
+          ],
+        }),
       }),
       tools: {
         tool1: {
@@ -273,88 +298,88 @@ describe('result.responseMessages', () => {
     ]);
   });
 
-  it('should contain assistant response message and tool message from all roundtrips', async () => {
-    let responseCount = 0;
-    const result = await generateText({
-      model: new MockLanguageModelV1({
-        doGenerate: async ({ prompt, mode }) => {
-          switch (responseCount++) {
-            case 0:
-              return {
-                ...dummyResponseValues,
-                toolCalls: [
-                  {
-                    toolCallType: 'function',
-                    toolCallId: 'call-1',
-                    toolName: 'tool1',
-                    args: `{ "value": "value" }`,
-                  },
-                ],
-                toolResults: [
-                  {
-                    toolCallId: 'call-1',
-                    toolName: 'tool1',
-                    args: { value: 'value' },
-                    result: 'result1',
-                  },
-                ],
-              };
-            case 1:
-              return {
-                ...dummyResponseValues,
-                text: 'Hello, world!',
-              };
-            default:
-              throw new Error(`Unexpected response count: ${responseCount}`);
-          }
-        },
-      }),
-      tools: {
-        tool1: {
-          parameters: z.object({ value: z.string() }),
-          execute: async args => {
-            assert.deepStrictEqual(args, { value: 'value' });
-            return 'result1';
+  describe('options.maxToolRoundtrips', () => {
+    it('should contain assistant response message and tool message from all roundtrips', async () => {
+      let responseCount = 0;
+      const result = await generateText({
+        model: new MockLanguageModelV1({
+          doGenerate: async ({}) => {
+            switch (responseCount++) {
+              case 0:
+                return {
+                  ...dummyResponseValues,
+                  toolCalls: [
+                    {
+                      toolCallType: 'function',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      args: `{ "value": "value" }`,
+                    },
+                  ],
+                  toolResults: [
+                    {
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      args: { value: 'value' },
+                      result: 'result1',
+                    },
+                  ],
+                };
+              case 1:
+                return {
+                  ...dummyResponseValues,
+                  text: 'Hello, world!',
+                };
+              default:
+                throw new Error(`Unexpected response count: ${responseCount}`);
+            }
+          },
+        }),
+        tools: {
+          tool1: {
+            parameters: z.object({ value: z.string() }),
+            execute: async args => {
+              assert.deepStrictEqual(args, { value: 'value' });
+              return 'result1';
+            },
           },
         },
-      },
-      prompt: 'test-input',
-      maxToolRoundtrips: 2,
+        prompt: 'test-input',
+        maxToolRoundtrips: 2,
+      });
+
+      assert.deepStrictEqual(result.responseMessages, [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: '' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'tool1',
+              args: { value: 'value' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'tool1',
+              result: 'result1',
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello, world!' }],
+        },
+      ]);
     });
-
-    assert.deepStrictEqual(result.responseMessages, [
-      {
-        role: 'assistant',
-        content: [
-          { type: 'text', text: '' },
-          {
-            type: 'tool-call',
-            toolCallId: 'call-1',
-            toolName: 'tool1',
-            args: { value: 'value' },
-          },
-        ],
-      },
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'call-1',
-            toolName: 'tool1',
-            result: 'result1',
-          },
-        ],
-      },
-      {
-        role: 'assistant',
-        content: [{ type: 'text', text: 'Hello, world!' }],
-      },
-    ]);
   });
-});
 
-describe('options.maxToolRoundtrips', () => {
   describe('single roundtrip', () => {
     let result: GenerateTextResult<any>;
 
@@ -389,6 +414,7 @@ describe('options.maxToolRoundtrips', () => {
                     content: [{ type: 'text', text: 'test-input' }],
                   },
                 ]);
+
                 return {
                   ...dummyResponseValues,
                   toolCalls: [
@@ -436,7 +462,12 @@ describe('options.maxToolRoundtrips', () => {
                 assert.deepStrictEqual(prompt, [
                   {
                     role: 'user',
-                    content: [{ type: 'text', text: 'test-input' }],
+                    content: [
+                      {
+                        type: 'text',
+                        text: 'test-input',
+                      },
+                    ],
                   },
                   {
                     role: 'assistant',
@@ -448,6 +479,7 @@ describe('options.maxToolRoundtrips', () => {
                         args: { value: 'value' },
                       },
                     ],
+                    providerMetadata: undefined,
                   },
                   {
                     role: 'tool',
@@ -457,8 +489,10 @@ describe('options.maxToolRoundtrips', () => {
                         toolCallId: 'call-1',
                         toolName: 'tool1',
                         result: 'result1',
+                        providerMetadata: undefined,
                       },
                     ],
+                    providerMetadata: undefined,
                   },
                 ]);
                 return {

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -342,6 +342,7 @@ By default, it's set to 0, which will disable the feature.
         logprobs: currentModelResponse.logprobs,
         responseMessages,
         roundtrips,
+        providerMetadata: currentModelResponse.providerMetadata,
       });
     },
   });
@@ -435,6 +436,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
   readonly roundtrips: GenerateTextResult<TOOLS>['roundtrips'];
   readonly rawResponse: GenerateTextResult<TOOLS>['rawResponse'];
   readonly logprobs: GenerateTextResult<TOOLS>['logprobs'];
+  readonly experimental_providerMetadata: GenerateTextResult<TOOLS>['experimental_providerMetadata'];
 
   constructor(options: {
     text: GenerateTextResult<TOOLS>['text'];
@@ -447,6 +449,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
     logprobs: GenerateTextResult<TOOLS>['logprobs'];
     responseMessages: GenerateTextResult<TOOLS>['responseMessages'];
     roundtrips: GenerateTextResult<TOOLS>['roundtrips'];
+    providerMetadata: GenerateTextResult<TOOLS>['experimental_providerMetadata'];
   }) {
     this.text = options.text;
     this.toolCalls = options.toolCalls;
@@ -458,6 +461,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
     this.logprobs = options.logprobs;
     this.responseMessages = options.responseMessages;
     this.roundtrips = options.roundtrips;
+    this.experimental_providerMetadata = options.providerMetadata;
   }
 }
 

--- a/packages/ai/core/generate-text/run-tools-transformation.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.ts
@@ -208,6 +208,7 @@ export function runToolsTransformation<TOOLS extends Record<string, CoreTool>>({
             finishReason: chunk.finishReason,
             logprobs: chunk.logprobs,
             usage: calculateCompletionTokenUsage(chunk.usage),
+            experimental_providerMetadata: chunk.providerMetadata,
           });
           break;
         }

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -1,7 +1,12 @@
 import { ServerResponse } from 'node:http';
 import { AIStreamCallbacksAndOptions, StreamData } from '../../streams';
 import { CoreTool } from '../tool';
-import { CallWarning, FinishReason, LogProbs } from '../types';
+import {
+  CallWarning,
+  FinishReason,
+  LogProbs,
+  ProviderMetadata,
+} from '../types';
 import { CompletionTokenUsage } from '../types/token-usage';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { ToToolCall } from './tool-call';
@@ -25,6 +30,13 @@ export interface StreamTextResult<TOOLS extends Record<string, CoreTool>> {
   The reason why the generation finished. Resolved when the response is finished.
      */
   readonly finishReason: Promise<FinishReason>;
+
+  /**
+Additional provider-specific metadata. They are passed through
+from the provider to the AI SDK and enable provider-specific
+results that can be fully encapsulated in the provider.
+   */
+  readonly experimental_providerMetadata: Promise<ProviderMetadata | undefined>;
 
   /**
   The full text that has been generated. Resolved when the response is finished.
@@ -191,6 +203,7 @@ export type TextStreamPart<TOOLS extends Record<string, CoreTool>> =
         completionTokens: number;
         totalTokens: number;
       };
+      experimental_providerMetadata?: ProviderMetadata;
     }
   | {
       type: 'error';

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -135,6 +135,7 @@ describe('result.fullStream', () => {
           finishReason: 'stop',
           logprobs: undefined,
           usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
+          experimental_providerMetadata: undefined,
         },
       ],
     );
@@ -209,6 +210,7 @@ describe('result.fullStream', () => {
           finishReason: 'stop',
           logprobs: undefined,
           usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
+          experimental_providerMetadata: undefined,
         },
       ],
     );
@@ -332,6 +334,7 @@ describe('result.fullStream', () => {
           finishReason: 'tool-calls',
           logprobs: undefined,
           usage: { promptTokens: 53, completionTokens: 17, totalTokens: 70 },
+          experimental_providerMetadata: undefined,
         },
       ],
     );
@@ -503,6 +506,7 @@ describe('result.fullStream', () => {
           finishReason: 'tool-calls',
           logprobs: undefined,
           usage: { promptTokens: 53, completionTokens: 17, totalTokens: 70 },
+          experimental_providerMetadata: undefined,
         },
       ],
     );
@@ -584,6 +588,7 @@ describe('result.fullStream', () => {
           finishReason: 'stop',
           logprobs: undefined,
           usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
+          experimental_providerMetadata: undefined,
         },
       ],
     );
@@ -592,26 +597,24 @@ describe('result.fullStream', () => {
   it('should filter out empty text deltas', async () => {
     const result = await streamText({
       model: new MockLanguageModelV1({
-        doStream: async () => {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '' },
-              { type: 'text-delta', textDelta: 'Hello' },
-              { type: 'text-delta', textDelta: '' },
-              { type: 'text-delta', textDelta: ', ' },
-              { type: 'text-delta', textDelta: '' },
-              { type: 'text-delta', textDelta: 'world!' },
-              { type: 'text-delta', textDelta: '' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                logprobs: undefined,
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: '' },
+            { type: 'text-delta', textDelta: 'Hello' },
+            { type: 'text-delta', textDelta: '' },
+            { type: 'text-delta', textDelta: ', ' },
+            { type: 'text-delta', textDelta: '' },
+            { type: 'text-delta', textDelta: 'world!' },
+            { type: 'text-delta', textDelta: '' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              logprobs: undefined,
+              usage: { completionTokens: 10, promptTokens: 3 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       prompt: 'test-input',
     });
@@ -627,6 +630,7 @@ describe('result.fullStream', () => {
           finishReason: 'stop',
           logprobs: undefined,
           usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
+          experimental_providerMetadata: undefined,
         },
       ],
     );
@@ -1267,6 +1271,7 @@ describe('multiple stream consumption', () => {
           finishReason: 'stop',
           logprobs: undefined,
           usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
+          experimental_providerMetadata: undefined,
         },
       ],
     );
@@ -1277,31 +1282,20 @@ describe('result.usage', () => {
   it('should resolve with token usage', async () => {
     const result = await streamText({
       model: new MockLanguageModelV1({
-        doStream: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, {
-            type: 'regular',
-            tools: undefined,
-            toolChoice: undefined,
-          });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
-          ]);
-
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello' },
-              { type: 'text-delta', textDelta: ', ' },
-              { type: 'text-delta', textDelta: `world!` },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                logprobs: undefined,
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: 'Hello' },
+            { type: 'text-delta', textDelta: ', ' },
+            { type: 'text-delta', textDelta: `world!` },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              logprobs: undefined,
+              usage: { completionTokens: 10, promptTokens: 3 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       prompt: 'test-input',
     });
@@ -1321,31 +1315,18 @@ describe('result.finishReason', () => {
   it('should resolve with finish reason', async () => {
     const result = await streamText({
       model: new MockLanguageModelV1({
-        doStream: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, {
-            type: 'regular',
-            tools: undefined,
-            toolChoice: undefined,
-          });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
-          ]);
-
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello' },
-              { type: 'text-delta', textDelta: ', ' },
-              { type: 'text-delta', textDelta: `world!` },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                logprobs: undefined,
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: 'Hello' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              logprobs: undefined,
+              usage: { completionTokens: 10, promptTokens: 3 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
       }),
       prompt: 'test-input',
     });
@@ -1354,6 +1335,38 @@ describe('result.finishReason', () => {
     convertAsyncIterableToArray(result.textStream);
 
     assert.strictEqual(await result.finishReason, 'stop');
+  });
+});
+
+describe('result.providerMetadata', () => {
+  it('should resolve with provider metadata', async () => {
+    const result = await streamText({
+      model: new MockLanguageModelV1({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'text-delta', textDelta: 'Hello' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              logprobs: undefined,
+              usage: { completionTokens: 10, promptTokens: 3 },
+              providerMetadata: {
+                testProvider: { testKey: 'testValue' },
+              },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+        }),
+      }),
+      prompt: 'test-input',
+    });
+
+    // consume stream (runs in parallel)
+    convertAsyncIterableToArray(result.textStream);
+
+    assert.deepStrictEqual(await result.experimental_providerMetadata, {
+      testProvider: { testKey: 'testValue' },
+    });
   });
 });
 
@@ -1690,6 +1703,9 @@ describe('options.onFinish', () => {
               finishReason: 'stop',
               logprobs: undefined,
               usage: { completionTokens: 10, promptTokens: 3 },
+              providerMetadata: {
+                testProvider: { testKey: 'testValue' },
+              },
             },
           ]),
           rawCall: { rawPrompt: 'prompt', rawSettings: {} },
@@ -1748,6 +1764,12 @@ describe('options.onFinish', () => {
         result: 'value-result',
       },
     ]);
+  });
+
+  it('should contain provider metadata', async () => {
+    assert.deepStrictEqual(result.experimental_providerMetadata, {
+      testProvider: { testKey: 'testValue' },
+    });
   });
 });
 
@@ -2160,6 +2182,7 @@ describe('tools with custom schema', () => {
           finishReason: 'stop',
           logprobs: undefined,
           usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
+          experimental_providerMetadata: undefined,
         },
       ],
     );

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -369,11 +369,11 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
     // store information for onFinish callback:
     let finishReason: FinishReason | undefined;
     let usage: CompletionTokenUsage | undefined;
+    let providerMetadata: ProviderMetadata | undefined;
     let text = '';
     const toolCalls: ToToolCall<TOOLS>[] = [];
     const toolResults: ToToolResult<TOOLS>[] = [];
     let firstChunk = true;
-    let providerMetadata: ProviderMetadata | undefined;
 
     // pipe chunks through a transformation stream that extracts metadata:
     this.originalStream = stream.pipeThrough(

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -26,6 +26,7 @@ import {
   CoreToolChoice,
   FinishReason,
   LanguageModel,
+  ProviderMetadata,
 } from '../types';
 import { CompletionTokenUsage } from '../types/token-usage';
 import {
@@ -186,6 +187,13 @@ Response headers.
 Warnings from the model provider (e.g. unsupported settings).
        */
       warnings?: CallWarning[];
+
+      /**
+Additional provider-specific metadata. They are passed through
+from the provider to the AI SDK and enable provider-specific
+results that can be fully encapsulated in the provider.
+   */
+      readonly experimental_providerMetadata: ProviderMetadata | undefined;
     }) => Promise<void> | void;
   }): Promise<DefaultStreamTextResult<TOOLS>> {
   const baseTelemetryAttributes = getBaseTelemetryAttributes({
@@ -298,6 +306,7 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
   readonly warnings: StreamTextResult<TOOLS>['warnings'];
   readonly usage: StreamTextResult<TOOLS>['usage'];
   readonly finishReason: StreamTextResult<TOOLS>['finishReason'];
+  readonly experimental_providerMetadata: StreamTextResult<TOOLS>['experimental_providerMetadata'];
   readonly text: StreamTextResult<TOOLS>['text'];
   readonly toolCalls: StreamTextResult<TOOLS>['toolCalls'];
   readonly toolResults: StreamTextResult<TOOLS>['toolResults'];
@@ -350,6 +359,13 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
       createResolvablePromise<ToToolResult<TOOLS>[]>();
     this.toolResults = toolResultsPromise;
 
+    // initialize experimental_providerMetadata promise
+    const {
+      resolve: resolveProviderMetadata,
+      promise: providerMetadataPromise,
+    } = createResolvablePromise<ProviderMetadata | undefined>();
+    this.experimental_providerMetadata = providerMetadataPromise;
+
     // store information for onFinish callback:
     let finishReason: FinishReason | undefined;
     let usage: CompletionTokenUsage | undefined;
@@ -357,6 +373,7 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
     const toolCalls: ToToolCall<TOOLS>[] = [];
     const toolResults: ToToolResult<TOOLS>[] = [];
     let firstChunk = true;
+    let providerMetadata: ProviderMetadata | undefined;
 
     // pipe chunks through a transformation stream that extracts metadata:
     this.originalStream = stream.pipeThrough(
@@ -401,12 +418,14 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
               // store usage and finish reason for promises and onFinish callback:
               usage = chunk.usage;
               finishReason = chunk.finishReason;
+              providerMetadata = chunk.experimental_providerMetadata;
 
               // resolve promises that can be resolved now:
               resolveUsage(usage);
               resolveFinishReason(finishReason);
               resolveText(text);
               resolveToolCalls(toolCalls);
+              resolveProviderMetadata(providerMetadata);
               break;
 
             case 'tool-call-streaming-start':
@@ -489,6 +508,7 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
               toolResults: toolResults as any,
               rawResponse,
               warnings,
+              experimental_providerMetadata: providerMetadata,
             });
           } catch (error) {
             controller.error(error);

--- a/packages/ai/core/prompt/content-part.ts
+++ b/packages/ai/core/prompt/content-part.ts
@@ -17,7 +17,7 @@ Additional provider-specific metadata. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
  */
-  providerMetadata?: ProviderMetadata;
+  experimental_providerMetadata?: ProviderMetadata;
 }
 
 /**
@@ -44,7 +44,7 @@ Additional provider-specific metadata. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
  */
-  providerMetadata?: ProviderMetadata;
+  experimental_providerMetadata?: ProviderMetadata;
 }
 
 /**
@@ -100,5 +100,5 @@ Additional provider-specific metadata. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
  */
-  providerMetadata?: ProviderMetadata;
+  experimental_providerMetadata?: ProviderMetadata;
 }

--- a/packages/ai/core/prompt/content-part.ts
+++ b/packages/ai/core/prompt/content-part.ts
@@ -1,3 +1,4 @@
+import { ProviderMetadata } from '../types/language-model';
 import { DataContent } from './data-content';
 
 /**
@@ -10,6 +11,13 @@ export interface TextPart {
 The text content.
    */
   text: string;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+  providerMetadata?: ProviderMetadata;
 }
 
 /**
@@ -30,6 +38,13 @@ Image data. Can either be:
 Optional mime type of the image.
    */
   mimeType?: string;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+  providerMetadata?: ProviderMetadata;
 }
 
 /**
@@ -79,4 +94,11 @@ Result of the tool call. This is a JSON-serializable object.
 Optional flag if the result is an error or an error message.
    */
   isError?: boolean;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+  providerMetadata?: ProviderMetadata;
 }

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -106,6 +106,7 @@ export function convertToLanguageModelMessage(
                       type: 'image',
                       image: part.image,
                       mimeType: part.mimeType,
+                      providerMetadata: part.providerMetadata,
                     };
                   } else {
                     const downloadedImage =
@@ -114,6 +115,7 @@ export function convertToLanguageModelMessage(
                       type: 'image',
                       image: downloadedImage.data,
                       mimeType: part.mimeType ?? downloadedImage.mimeType,
+                      providerMetadata: part.providerMetadata,
                     };
                   }
                 }
@@ -131,6 +133,7 @@ export function convertToLanguageModelMessage(
                             type: 'image',
                             image: url,
                             mimeType: part.mimeType,
+                            providerMetadata: part.providerMetadata,
                           };
                         } else {
                           const downloadedImage = downloadedImages[part.image];
@@ -138,6 +141,7 @@ export function convertToLanguageModelMessage(
                             type: 'image',
                             image: downloadedImage.data,
                             mimeType: part.mimeType ?? downloadedImage.mimeType,
+                            providerMetadata: part.providerMetadata,
                           };
                         }
                       }
@@ -155,6 +159,7 @@ export function convertToLanguageModelMessage(
                             image:
                               convertDataContentToUint8Array(base64Content),
                             mimeType,
+                            providerMetadata: part.providerMetadata,
                           };
                         } catch (error) {
                           throw new Error(
@@ -181,6 +186,7 @@ export function convertToLanguageModelMessage(
                   type: 'image',
                   image: imageUint8,
                   mimeType: part.mimeType ?? detectImageMimeType(imageUint8),
+                  providerMetadata: part.providerMetadata,
                 };
               }
             }

--- a/packages/ai/core/prompt/message.ts
+++ b/packages/ai/core/prompt/message.ts
@@ -1,3 +1,4 @@
+import { ProviderMetadata } from '../types';
 import {
   ImagePart,
   TextPart,
@@ -6,7 +7,7 @@ import {
 } from './content-part';
 
 /**
-A message that can be used in the `messages` field of a prompt. 
+A message that can be used in the `messages` field of a prompt.
 It can be a user message, an assistant message, or a tool message.
  */
 export type CoreMessage =
@@ -32,7 +33,17 @@ export type ExperimentalMessage = CoreMessage;
 /**
 A user message. It can contain text or a combination of text and images.
  */
-export type CoreUserMessage = { role: 'user'; content: UserContent };
+export type CoreUserMessage = {
+  role: 'user';
+  content: UserContent;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+  providerMetadata?: ProviderMetadata;
+};
 
 /**
  * @deprecated Use `CoreUserMessage` instead.
@@ -65,7 +76,17 @@ export type AssistantContent = string | Array<TextPart | ToolCallPart>;
 /**
 A tool message. It contains the result of one or more tool calls.
  */
-export type CoreToolMessage = { role: 'tool'; content: ToolContent };
+export type CoreToolMessage = {
+  role: 'tool';
+  content: ToolContent;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+  providerMetadata?: ProviderMetadata;
+};
 
 /**
  * @deprecated Use `CoreToolMessage` instead.

--- a/packages/ai/core/prompt/message.ts
+++ b/packages/ai/core/prompt/message.ts
@@ -23,7 +23,17 @@ export type CoreMessage =
  to increase the resilience against prompt injection attacks,
  and because not all providers support several system messages.
  */
-export type CoreSystemMessage = { role: 'system'; content: string };
+export type CoreSystemMessage = {
+  role: 'system';
+  content: string;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+  experimental_providerMetadata?: ProviderMetadata;
+};
 
 /**
  * @deprecated Use `CoreMessage` instead.
@@ -42,7 +52,7 @@ Additional provider-specific metadata. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
  */
-  providerMetadata?: ProviderMetadata;
+  experimental_providerMetadata?: ProviderMetadata;
 };
 
 /**
@@ -61,6 +71,13 @@ An assistant message. It can contain text, tool calls, or a combination of text 
 export type CoreAssistantMessage = {
   role: 'assistant';
   content: AssistantContent;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+  experimental_providerMetadata?: ProviderMetadata;
 };
 
 /**
@@ -85,7 +102,7 @@ Additional provider-specific metadata. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
  */
-  providerMetadata?: ProviderMetadata;
+  experimental_providerMetadata?: ProviderMetadata;
 };
 
 /**

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -3,6 +3,7 @@ import {
   LanguageModelV1CallWarning,
   LanguageModelV1FinishReason,
   LanguageModelV1LogProbs,
+  LanguageModelV1ProviderMetadata,
 } from '@ai-sdk/provider';
 
 /**
@@ -33,6 +34,13 @@ Warning from the model provider for this call. The call will proceed, but e.g.
 some settings might not be supported, which can lead to suboptimal results.
 */
 export type CallWarning = LanguageModelV1CallWarning;
+
+/**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+export type ProviderMetadata = LanguageModelV1ProviderMetadata;
 
 /**
 Tool choice for the generation. It supports the following settings:

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -411,6 +411,7 @@ describe('doStream', () => {
         type: 'finish',
         finishReason: 'stop',
         usage: { promptTokens: 17, completionTokens: 227 },
+        providerMetadata: undefined,
       },
     ]);
   });
@@ -518,6 +519,7 @@ describe('doStream', () => {
         type: 'finish',
         finishReason: 'tool-calls',
         usage: { promptTokens: 441, completionTokens: 65 },
+        providerMetadata: undefined,
       },
     ]);
   });
@@ -610,5 +612,46 @@ describe('doStream', () => {
       'custom-request-header': 'request-header-value',
       'x-api-key': 'test-api-key',
     });
+  });
+
+  it('should support cache control', async () => {
+    server.responseChunks = [
+      `data: {"type":"message_start","message":{"id":"msg_01KfpJoAEabmH2iHRRFjQMAG","type":"message","role":"assistant","content":[],` +
+        `"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":` +
+        // send cache output tokens:
+        `{"input_tokens":17,"output_tokens":1,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}}      }\n\n`,
+      `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }\n\n`,
+      `data: {"type": "ping"}\n\n`,
+      `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"${'Hello'}"}              }\n\n`,
+      `data: {"type":"content_block_stop","index":0             }\n\n`,
+      `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":227}          }\n\n`,
+      `data: {"type":"message_stop"           }\n\n`,
+    ];
+
+    const model = provider('claude-3-haiku-20240307', {
+      cacheControl: true,
+    });
+
+    const { stream } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    // note: space moved to last chunk bc of trimming
+    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+      { type: 'text-delta', textDelta: 'Hello' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { promptTokens: 17, completionTokens: 227 },
+        providerMetadata: {
+          anthropic: {
+            cacheCreationInputTokens: 10,
+            cacheReadInputTokens: 5,
+          },
+        },
+      },
+    ]);
   });
 });

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -100,7 +100,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
       });
     }
 
-    const messagesPrompt = convertToAnthropicMessagesPrompt(prompt);
+    const messagesPrompt = convertToAnthropicMessagesPrompt({
+      prompt,
+      cacheControl: this.settings.cacheControl ?? false,
+    });
 
     const baseArgs = {
       // model id:
@@ -161,7 +164,13 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/messages`,
-      headers: combineHeaders(this.config.headers(), options.headers),
+      headers: combineHeaders(
+        this.config.headers(),
+        this.settings.cacheControl
+          ? { 'anthropic-beta': 'prompt-caching-2024-07-31' }
+          : {},
+        options.headers,
+      ),
       body: args,
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -157,6 +157,18 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
     }
   }
 
+  private getHeaders(
+    optionHeaders: Record<string, string | undefined> | undefined,
+  ) {
+    return combineHeaders(
+      this.config.headers(),
+      this.settings.cacheControl
+        ? { 'anthropic-beta': 'prompt-caching-2024-07-31' }
+        : {},
+      optionHeaders,
+    );
+  }
+
   async doGenerate(
     options: Parameters<LanguageModelV1['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
@@ -164,13 +176,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/messages`,
-      headers: combineHeaders(
-        this.config.headers(),
-        this.settings.cacheControl
-          ? { 'anthropic-beta': 'prompt-caching-2024-07-31' }
-          : {},
-        options.headers,
-      ),
+      headers: this.getHeaders(options.headers),
       body: args,
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
@@ -238,7 +244,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/messages`,
-      headers: combineHeaders(this.config.headers(), options.headers),
+      headers: this.getHeaders(options.headers),
       body: {
         ...args,
         stream: true,

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -217,6 +217,17 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
       rawCall: { rawPrompt, rawSettings },
       rawResponse: { headers: responseHeaders },
       warnings,
+      providerMetadata:
+        this.settings.cacheControl === true
+          ? {
+              anthropic: {
+                cacheCreationInputTokens:
+                  response.usage.cache_creation_input_tokens ?? null,
+                cacheReadInputTokens:
+                  response.usage.cache_read_input_tokens ?? null,
+              },
+            }
+          : undefined,
     };
   }
 
@@ -413,10 +424,12 @@ const anthropicMessagesResponseSchema = z.object({
       }),
     ]),
   ),
-  stop_reason: z.string().optional().nullable(),
+  stop_reason: z.string().nullish(),
   usage: z.object({
     input_tokens: z.number(),
     output_tokens: z.number(),
+    cache_creation_input_tokens: z.number().nullish(),
+    cache_read_input_tokens: z.number().nullish(),
   }),
 });
 

--- a/packages/anthropic/src/anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/anthropic-messages-prompt.ts
@@ -5,7 +5,7 @@ export type AnthropicMessagesPrompt = {
 
 export type AnthropicMessage = AnthropicUserMessage | AnthropicAssistantMessage;
 
-export type AnthropicCacheControl = { type: 'ephemeral' } | undefined;
+export type AnthropicCacheControl = { type: 'ephemeral' };
 
 export interface AnthropicUserMessage {
   role: 'user';
@@ -22,7 +22,7 @@ export interface AnthropicAssistantMessage {
 export interface AnthropicTextContent {
   type: 'text';
   text: string;
-  cache_control: AnthropicCacheControl;
+  cache_control?: AnthropicCacheControl;
 }
 
 export interface AnthropicImageContent {
@@ -32,7 +32,7 @@ export interface AnthropicImageContent {
     media_type: string;
     data: string;
   };
-  cache_control: AnthropicCacheControl;
+  cache_control?: AnthropicCacheControl;
 }
 
 export interface AnthropicToolCallContent {
@@ -47,5 +47,5 @@ export interface AnthropicToolResultContent {
   tool_use_id: string;
   content: unknown;
   is_error: boolean | undefined;
-  cache_control: AnthropicCacheControl;
+  cache_control?: AnthropicCacheControl;
 }

--- a/packages/anthropic/src/anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/anthropic-messages-prompt.ts
@@ -5,6 +5,8 @@ export type AnthropicMessagesPrompt = {
 
 export type AnthropicMessage = AnthropicUserMessage | AnthropicAssistantMessage;
 
+export type AnthropicCacheControl = { type: 'ephemeral' } | undefined;
+
 export interface AnthropicUserMessage {
   role: 'user';
   content: Array<
@@ -20,6 +22,7 @@ export interface AnthropicAssistantMessage {
 export interface AnthropicTextContent {
   type: 'text';
   text: string;
+  cache_control: AnthropicCacheControl;
 }
 
 export interface AnthropicImageContent {
@@ -29,6 +32,7 @@ export interface AnthropicImageContent {
     media_type: string;
     data: string;
   };
+  cache_control: AnthropicCacheControl;
 }
 
 export interface AnthropicToolCallContent {
@@ -42,5 +46,6 @@ export interface AnthropicToolResultContent {
   type: 'tool_result';
   tool_use_id: string;
   content: unknown;
-  is_error?: boolean;
+  is_error: boolean | undefined;
+  cache_control: AnthropicCacheControl;
 }

--- a/packages/anthropic/src/anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/anthropic-messages-prompt.ts
@@ -1,5 +1,5 @@
 export type AnthropicMessagesPrompt = {
-  system?: string;
+  system: Array<AnthropicTextContent> | undefined;
   messages: AnthropicMessage[];
 };
 

--- a/packages/anthropic/src/anthropic-messages-settings.ts
+++ b/packages/anthropic/src/anthropic-messages-settings.ts
@@ -10,10 +10,16 @@ export interface AnthropicMessagesSettings {
   /**
 Only sample from the top K options for each subsequent token.
 
-Used to remove "long tail" low probability responses. 
+Used to remove "long tail" low probability responses.
 Recommended for advanced use cases only. You usually only need to use temperature.
 
 @deprecated use the topK setting on the request instead.
    */
   topK?: number;
+
+  /**
+Enable Anthropic cache control (beta feature). This will add the beta header and
+allow you to use provider-specific cacheControl metadata.
+   */
+  cacheControl?: boolean;
 }

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -291,3 +291,92 @@ describe('assistant messages', () => {
     });
   });
 });
+
+describe('cache control', () => {
+  // TODO test system message
+
+  describe('user message', () => {
+    it('should set cache_control on user message part with part cache control', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'test',
+                providerMetadata: {
+                  anthropic: {
+                    cacheControl: { type: 'ephemeral' },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        cacheControl: true,
+      });
+
+      expect(result).toEqual({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'test',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      });
+    });
+
+    it('should set cache_control on last user message part with message cache control', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'part1' },
+              { type: 'text', text: 'part2' },
+            ],
+            providerMetadata: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+        cacheControl: true,
+      });
+
+      expect(result).toEqual({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'part1',
+                cache_control: undefined,
+              },
+              {
+                type: 'text',
+                text: 'part2',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      });
+    });
+  });
+
+  // TODO test tool message
+  // TODO test tool message parts
+  // TODO test disabled cache control
+});

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -376,7 +376,104 @@ describe('cache control', () => {
     });
   });
 
-  // TODO test tool message
-  // TODO test tool message parts
+  describe('tool message', () => {
+    it('should set cache_control on tool result message part with part cache control', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'test',
+                toolCallId: 'test',
+                result: { test: 'test' },
+                providerMetadata: {
+                  anthropic: {
+                    cacheControl: { type: 'ephemeral' },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        cacheControl: true,
+      });
+
+      expect(result).toEqual({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                content: '{"test":"test"}',
+                is_error: undefined,
+                tool_use_id: 'test',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      });
+    });
+
+    it('should set cache_control on last tool result message part with message cache control', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolName: 'test',
+                toolCallId: 'part1',
+                result: { test: 'part1' },
+              },
+              {
+                type: 'tool-result',
+                toolName: 'test',
+                toolCallId: 'part2',
+                result: { test: 'part2' },
+              },
+            ],
+            providerMetadata: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+        cacheControl: true,
+      });
+
+      expect(result).toEqual({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'part1',
+                content: '{"test":"part1"}',
+                is_error: undefined,
+                cache_control: undefined,
+              },
+              {
+                type: 'tool_result',
+                tool_use_id: 'part2',
+                content: '{"test":"part2"}',
+                is_error: undefined,
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      });
+    });
+  });
+
   // TODO test disabled cache control
 });

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -504,5 +504,43 @@ describe('cache control', () => {
     });
   });
 
-  // TODO test disabled cache control
+  describe('disabled cache control', () => {
+    it('should not set cache_control on messages', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'test',
+                providerMetadata: {
+                  anthropic: {
+                    cacheControl: { type: 'ephemeral' },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        cacheControl: false,
+      });
+
+      expect(result).toEqual({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'test',
+                cache_control: undefined,
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      });
+    });
+  });
 });

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -9,11 +9,11 @@ describe('system messages', () => {
 
     expect(result).toEqual({
       messages: [],
-      system: 'This is a system message',
+      system: [{ type: 'text', text: 'This is a system message' }],
     });
   });
 
-  it('should convert multiple system messages into an anthropic system message separated by a newline', async () => {
+  it('should convert multiple system messages into an anthropic system message', async () => {
     const result = convertToAnthropicMessagesPrompt({
       prompt: [
         { role: 'system', content: 'This is a system message' },
@@ -24,7 +24,10 @@ describe('system messages', () => {
 
     expect(result).toEqual({
       messages: [],
-      system: 'This is a system message\nThis is another system message',
+      system: [
+        { type: 'text', text: 'This is a system message' },
+        { type: 'text', text: 'This is another system message' },
+      ],
     });
   });
 });
@@ -293,7 +296,33 @@ describe('assistant messages', () => {
 });
 
 describe('cache control', () => {
-  // TODO test system message
+  describe('system message', () => {
+    it('should set cache_control on system message with message cache control', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          {
+            role: 'system',
+            content: 'system message',
+            providerMetadata: {
+              anthropic: { cacheControl: { type: 'ephemeral' } },
+            },
+          },
+        ],
+        cacheControl: true,
+      });
+
+      expect(result).toEqual({
+        messages: [],
+        system: [
+          {
+            type: 'text',
+            text: 'system message',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
+    });
+  });
 
   describe('user message', () => {
     it('should set cache_control on user message part with part cache control', async () => {

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -2,9 +2,10 @@ import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-message
 
 describe('system messages', () => {
   it('should convert a single system message into an anthropic system message', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      { role: 'system', content: 'This is a system message' },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [{ role: 'system', content: 'This is a system message' }],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [],
@@ -13,10 +14,13 @@ describe('system messages', () => {
   });
 
   it('should convert multiple system messages into an anthropic system message separated by a newline', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      { role: 'system', content: 'This is a system message' },
-      { role: 'system', content: 'This is another system message' },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        { role: 'system', content: 'This is a system message' },
+        { role: 'system', content: 'This is another system message' },
+      ],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [],
@@ -27,18 +31,21 @@ describe('system messages', () => {
 
 describe('user messages', () => {
   it('should add image parts for UInt8Array images', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'image',
-            image: new Uint8Array([0, 1, 2, 3]),
-            mimeType: 'image/png',
-          },
-        ],
-      },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              image: new Uint8Array([0, 1, 2, 3]),
+              mimeType: 'image/png',
+            },
+          ],
+        },
+      ],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [
@@ -63,19 +70,22 @@ describe('user messages', () => {
 
 describe('tool messages', () => {
   it('should convert a single tool result into an anthropic user message', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolName: 'tool-1',
-            toolCallId: 'tool-call-1',
-            result: { test: 'This is a tool message' },
-          },
-        ],
-      },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolName: 'tool-1',
+              toolCallId: 'tool-call-1',
+              result: { test: 'This is a tool message' },
+            },
+          ],
+        },
+      ],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [
@@ -96,25 +106,28 @@ describe('tool messages', () => {
   });
 
   it('should convert multiple tool results into an anthropic user message', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolName: 'tool-1',
-            toolCallId: 'tool-call-1',
-            result: { test: 'This is a tool message' },
-          },
-          {
-            type: 'tool-result',
-            toolName: 'tool-2',
-            toolCallId: 'tool-call-2',
-            result: { something: 'else' },
-          },
-        ],
-      },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolName: 'tool-1',
+              toolCallId: 'tool-call-1',
+              result: { test: 'This is a tool message' },
+            },
+            {
+              type: 'tool-result',
+              toolName: 'tool-2',
+              toolCallId: 'tool-call-2',
+              result: { something: 'else' },
+            },
+          ],
+        },
+      ],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [
@@ -141,23 +154,26 @@ describe('tool messages', () => {
   });
 
   it('should combine user and tool messages', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolName: 'tool-1',
-            toolCallId: 'tool-call-1',
-            result: { test: 'This is a tool message' },
-          },
-        ],
-      },
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'This is a user message' }],
-      },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolName: 'tool-1',
+              toolCallId: 'tool-call-1',
+              result: { test: 'This is a tool message' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'This is a user message' }],
+        },
+      ],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [
@@ -181,16 +197,19 @@ describe('tool messages', () => {
 
 describe('assistant messages', () => {
   it('should remove trailing whitespace from last assistant message when there is no further user message', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'user content' }],
-      },
-      {
-        role: 'assistant',
-        content: [{ type: 'text', text: 'assistant content  ' }],
-      },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'assistant content  ' }],
+        },
+      ],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [
@@ -208,20 +227,23 @@ describe('assistant messages', () => {
   });
 
   it('should keep trailing whitespace from assistant message when there is a further user message', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'user content' }],
-      },
-      {
-        role: 'assistant',
-        content: [{ type: 'text', text: 'assistant content  ' }],
-      },
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'user content 2' }],
-      },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'assistant content  ' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content 2' }],
+        },
+      ],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [
@@ -243,12 +265,15 @@ describe('assistant messages', () => {
   });
 
   it('should combine multiple sequential assistant messages into a single message', async () => {
-    const result = convertToAnthropicMessagesPrompt([
-      { role: 'user', content: [{ type: 'text', text: 'Hi!' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'Hello' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'World' }] },
-      { role: 'assistant', content: [{ type: 'text', text: '!' }] },
-    ]);
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'Hi!' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'Hello' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'World' }] },
+        { role: 'assistant', content: [{ type: 'text', text: '!' }] },
+      ],
+      cacheControl: false,
+    });
 
     expect(result).toEqual({
       messages: [

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -8,7 +8,6 @@ import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 import {
   AnthropicAssistantMessage,
   AnthropicCacheControl,
-  AnthropicMessage,
   AnthropicMessagesPrompt,
   AnthropicUserMessage,
 } from './anthropic-messages-prompt';
@@ -22,8 +21,8 @@ export function convertToAnthropicMessagesPrompt({
 }): AnthropicMessagesPrompt {
   const blocks = groupIntoBlocks(prompt);
 
-  let system: string | undefined = undefined;
-  const messages: AnthropicMessage[] = [];
+  let system: AnthropicMessagesPrompt['system'] = undefined;
+  const messages: AnthropicMessagesPrompt['messages'] = [];
 
   function getCacheControl(
     providerMetadata: LanguageModelV1ProviderMetadata | undefined,
@@ -56,7 +55,12 @@ export function convertToAnthropicMessagesPrompt({
           });
         }
 
-        system = block.messages.map(({ content }) => content).join('\n');
+        system = block.messages.map(({ content, providerMetadata }) => ({
+          type: 'text',
+          text: content,
+          cache_control: getCacheControl(providerMetadata),
+        }));
+
         break;
       }
 

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,3 +1,4 @@
 export * from './embedding-model/index';
 export * from './errors/index';
+export * from './json-value/index';
 export * from './language-model/index';

--- a/packages/provider/src/json-value/index.ts
+++ b/packages/provider/src/json-value/index.ts
@@ -1,0 +1,2 @@
+export { isJSONArray, isJSONObject, isJSONValue } from './is-json';
+export type { JSONArray, JSONObject, JSONValue } from './json-value';

--- a/packages/provider/src/json-value/is-json.ts
+++ b/packages/provider/src/json-value/is-json.ts
@@ -1,0 +1,38 @@
+import { JSONArray, JSONObject, JSONValue } from './json-value';
+
+export function isJSONValue(value: unknown): value is JSONValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(isJSONValue);
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value).every(
+      ([key, val]) => typeof key === 'string' && isJSONValue(val),
+    );
+  }
+
+  return false;
+}
+
+export function isJSONArray(value: unknown): value is JSONArray {
+  return Array.isArray(value) && value.every(isJSONValue);
+}
+
+export function isJSONObject(value: unknown): value is JSONObject {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    Object.entries(value).every(
+      ([key, val]) => typeof key === 'string' && isJSONValue(val),
+    )
+  );
+}

--- a/packages/provider/src/json-value/json-value.ts
+++ b/packages/provider/src/json-value/json-value.ts
@@ -1,0 +1,13 @@
+export type JSONValue =
+  | null
+  | string
+  | number
+  | boolean
+  | JSONObject
+  | JSONArray;
+
+export type JSONObject = {
+  [key: string]: JSONValue;
+};
+
+export type JSONArray = JSONValue[];

--- a/packages/provider/src/language-model/v1/index.ts
+++ b/packages/provider/src/language-model/v1/index.ts
@@ -6,4 +6,5 @@ export * from './language-model-v1-function-tool';
 export * from './language-model-v1-function-tool-call';
 export * from './language-model-v1-logprobs';
 export * from './language-model-v1-prompt';
+export * from './language-model-v1-provider-metadata';
 export * from './language-model-v1-tool-choice';

--- a/packages/provider/src/language-model/v1/language-model-v1-prompt.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-prompt.ts
@@ -1,3 +1,5 @@
+import { LanguageModelV1ProviderMetadata } from './language-model-v1-provider-metadata';
+
 /**
 A prompt is a list of messages.
 
@@ -20,6 +22,7 @@ export type LanguageModelV1Message =
   | {
       role: 'user';
       content: Array<LanguageModelV1TextPart | LanguageModelV1ImagePart>;
+      providerMetadata?: LanguageModelV1ProviderMetadata;
     }
   | {
       role: 'assistant';
@@ -28,6 +31,7 @@ export type LanguageModelV1Message =
   | {
       role: 'tool';
       content: Array<LanguageModelV1ToolResultPart>;
+      providerMetadata?: LanguageModelV1ProviderMetadata;
     };
 
 /**
@@ -40,6 +44,13 @@ export interface LanguageModelV1TextPart {
 The text content.
    */
   text: string;
+
+  /**
+   * Additional provider-specific metadata. They are passed through
+   * to the provider from the AI SDK and enable provider-specific
+   * functionality that can be fully encapsulated in the provider.
+   */
+  providerMetadata?: LanguageModelV1ProviderMetadata;
 }
 
 /**
@@ -57,6 +68,13 @@ Image data as a Uint8Array (e.g. from a Blob or Buffer) or a URL.
 Optional mime type of the image.
    */
   mimeType?: string;
+
+  /**
+   * Additional provider-specific metadata. They are passed through
+   * to the provider from the AI SDK and enable provider-specific
+   * functionality that can be fully encapsulated in the provider.
+   */
+  providerMetadata?: LanguageModelV1ProviderMetadata;
 }
 
 /**
@@ -106,4 +124,11 @@ Result of the tool call. This is a JSON-serializable object.
 Optional flag if the result is an error or an error message.
    */
   isError?: boolean;
+
+  /**
+   * Additional provider-specific metadata. They are passed through
+   * to the provider from the AI SDK and enable provider-specific
+   * functionality that can be fully encapsulated in the provider.
+   */
+  providerMetadata?: LanguageModelV1ProviderMetadata;
 }

--- a/packages/provider/src/language-model/v1/language-model-v1-prompt.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-prompt.ts
@@ -15,24 +15,31 @@ export type LanguageModelV1Message =
   // Note: there could be additional parts for each role in the future,
   // e.g. when the assistant can return images or the user can share files
   // such as PDFs.
-  | {
-      role: 'system';
-      content: string;
-    }
-  | {
-      role: 'user';
-      content: Array<LanguageModelV1TextPart | LanguageModelV1ImagePart>;
-      providerMetadata?: LanguageModelV1ProviderMetadata;
-    }
-  | {
-      role: 'assistant';
-      content: Array<LanguageModelV1TextPart | LanguageModelV1ToolCallPart>;
-    }
-  | {
-      role: 'tool';
-      content: Array<LanguageModelV1ToolResultPart>;
-      providerMetadata?: LanguageModelV1ProviderMetadata;
-    };
+  (
+    | {
+        role: 'system';
+        content: string;
+      }
+    | {
+        role: 'user';
+        content: Array<LanguageModelV1TextPart | LanguageModelV1ImagePart>;
+      }
+    | {
+        role: 'assistant';
+        content: Array<LanguageModelV1TextPart | LanguageModelV1ToolCallPart>;
+      }
+    | {
+        role: 'tool';
+        content: Array<LanguageModelV1ToolResultPart>;
+      }
+  ) & {
+    /**
+     * Additional provider-specific metadata. They are passed through
+     * to the provider from the AI SDK and enable provider-specific
+     * functionality that can be fully encapsulated in the provider.
+     */
+    providerMetadata?: LanguageModelV1ProviderMetadata;
+  };
 
 /**
 Text content part of a prompt. It contains a string of text.

--- a/packages/provider/src/language-model/v1/language-model-v1-provider-metadata.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-provider-metadata.ts
@@ -7,5 +7,19 @@ import { JSONValue } from '../../json-value/json-value';
  *
  * This enables us to quickly ship provider-specific functionality
  * without affecting the core AI SDK.
+ *
+ * The outer record is keyed by the provider name, and the inner
+ * record is keyed by the provider-specific metadata key.
+ *
+ * ```ts
+ * {
+ *   "anthropic": {
+ *     "cacheControl": { "type": "ephemeral" }
+ *   }
+ * }
+ * ```
  */
-export type LanguageModelV1ProviderMetadata = Record<string, JSONValue>;
+export type LanguageModelV1ProviderMetadata = Record<
+  string,
+  Record<string, JSONValue>
+>;

--- a/packages/provider/src/language-model/v1/language-model-v1-provider-metadata.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-provider-metadata.ts
@@ -1,0 +1,11 @@
+import { JSONValue } from '../../json-value/json-value';
+
+/**
+ * Additional provider-specific metadata. They are passed through
+ * to the provider from the AI SDK and enable provider-specific
+ * functionality that can be fully encapsulated in the provider.
+ *
+ * This enables us to quickly ship provider-specific functionality
+ * without affecting the core AI SDK.
+ */
+export type LanguageModelV1ProviderMetadata = Record<string, JSONValue>;

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -3,6 +3,7 @@ import { LanguageModelV1CallWarning } from './language-model-v1-call-warning';
 import { LanguageModelV1FinishReason } from './language-model-v1-finish-reason';
 import { LanguageModelV1FunctionToolCall } from './language-model-v1-function-tool-call';
 import { LanguageModelV1LogProbs } from './language-model-v1-logprobs';
+import { LanguageModelV1ProviderMetadata } from './language-model-v1-provider-metadata';
 
 /**
 Specification for a language model that implements the language model interface version 1.
@@ -171,6 +172,8 @@ Response headers.
       headers?: Record<string, string>;
     };
 
+    providerMetadata?: LanguageModelV1ProviderMetadata;
+
     warnings?: LanguageModelV1CallWarning[];
   }>;
 };
@@ -197,7 +200,8 @@ export type LanguageModelV1StreamPart =
   | {
       type: 'finish';
       finishReason: LanguageModelV1FinishReason;
-      logprobs?: LanguageModelV1LogProbs;
+      logprobs?: LanguageModelV1LogProbs; // TODO move into provider specific part in v2
+      providerMetadata?: LanguageModelV1ProviderMetadata;
       usage: { promptTokens: number; completionTokens: number };
     }
 

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -200,7 +200,7 @@ export type LanguageModelV1StreamPart =
   | {
       type: 'finish';
       finishReason: LanguageModelV1FinishReason;
-      logprobs?: LanguageModelV1LogProbs; // TODO move into provider specific part in v2
+      logprobs?: LanguageModelV1LogProbs;
       providerMetadata?: LanguageModelV1ProviderMetadata;
       usage: { promptTokens: number; completionTokens: number };
     }

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -128,6 +128,13 @@ Response headers.
     warnings?: LanguageModelV1CallWarning[];
 
     /**
+Additional provider-specific metadata. They are passed through
+from the provider to the AI SDK and enable provider-specific
+results that can be fully encapsulated in the provider.
+     */
+    providerMetadata?: LanguageModelV1ProviderMetadata;
+
+    /**
   Logprobs for the completion.
   `undefined` if the mode does not support logprobs or if was not enabled
      */
@@ -171,8 +178,6 @@ Response headers.
        */
       headers?: Record<string, string>;
     };
-
-    providerMetadata?: LanguageModelV1ProviderMetadata;
 
     warnings?: LanguageModelV1CallWarning[];
   }>;


### PR DESCRIPTION
## Summary
* introduce mechanism for provider-specific metadata on messages, message parts, and results
* add anthropic cache control support

## Background
Anthropic has [introduced cache control](https://x.com/alexalbert__/status/1823751966893465630). They are currently the only provider that implements caching in such a way.

We need to be able to ship provider-specific extensions quickly without committing to a generalized API. These extensions should ideally be fully encapsulated in a particular provider and require no other changes to the codebase / packages. 

## Tasks

- [x] language model specification extension
- [x] implementation: anthropic provider
   - [x] test: prompt mapping
   - [x] test: non streaming return extras
   - [x] test: streaming return extras
- [x] implementation: messages/message parts and prompt transformation
- [x] implementation: extended returns
   - [x] generateText
   - [x] generateObject
   - [x] streamText
   - [x] streamObject
- [x] example: generateText
- [x] example: streamText
- [x] documentation
   - [x] anthropic provider
   - [x] generateText (returns etc)
   - [x] streamText (returns etc)
   - [x] generateObject (returns etc)
   - [x] streamObject (returns etc)
- [x] changeset