### PR TITLE
feat (ai/core): responseFormat for generateText/streamText

### DIFF
--- a/.changeset/modern-avocados-rest.md
+++ b/.changeset/modern-avocados-rest.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): responseFormat for generateText/streamText

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -326,6 +326,13 @@ To see `generateText` in action, check out [these examples](#examples).
         'The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results.',
     },
     {
+      name: 'experimental_responseFormat',
+      type: '"text" | "json" | undefined',
+      isOptional: true,
+      description:
+        'The response format. Can be either text or json. Useful when you want a JSON response, but do not have a schema. Use generateObject when you have a schema. Default: "text". Please note that you often need to also instruct the model in the prompt to return JSON.',
+    },
+    {
       name: 'maxRetries',
       type: 'number',
       isOptional: true,

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -328,6 +328,13 @@ To see `streamText` in action, check out [these examples](#examples).
         'The seed (integer) to use for random sampling. If set and supported by the model, calls will generate deterministic results.',
     },
     {
+      name: 'experimental_responseFormat',
+      type: '"text" | "json" | undefined',
+      isOptional: true,
+      description:
+        'The response format. Can be either text or json. Useful when you want a JSON response, but do not have a schema. Use streamObject when you have a schema. Default: "text". Please note that you often need to also instruct the model in the prompt to return JSON.',
+    },
+    {
       name: 'maxRetries',
       type: 'number',
       isOptional: true,

--- a/examples/ai-core/src/generate-text/openai-json.ts
+++ b/examples/ai-core/src/generate-text/openai-json.ts
@@ -1,0 +1,20 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const { text, usage } = await generateText({
+    model: openai('gpt-3.5-turbo'),
+    experimental_responseFormat: 'json',
+    prompt:
+      'Invent a new holiday and describe its traditions. Respond with JSON.',
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Usage:', usage);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/mistral-json.ts
+++ b/examples/ai-core/src/stream-text/mistral-json.ts
@@ -1,0 +1,27 @@
+import { mistral } from '@ai-sdk/mistral';
+import { streamText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const result = await streamText({
+    model: mistral('open-mistral-7b'),
+    maxTokens: 512,
+    temperature: 0.3,
+    maxRetries: 5,
+    experimental_responseFormat: 'json',
+    prompt:
+      'Invent a new holiday and describe its traditions. Respond with JSON.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-json.ts
+++ b/examples/ai-core/src/stream-text/openai-json.ts
@@ -1,0 +1,27 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const result = await streamText({
+    model: openai('gpt-3.5-turbo'),
+    maxTokens: 512,
+    temperature: 0.3,
+    maxRetries: 5,
+    experimental_responseFormat: 'json',
+    prompt:
+      'Invent a new holiday and describe its traditions. Respond with JSON.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -962,3 +962,35 @@ describe('tools with custom schema', () => {
     ]);
   });
 });
+
+describe('options.responseFormat', () => {
+  it('should handle JSON response format', async () => {
+    const result = await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({ prompt, mode, responseFormat }) => {
+          assert.deepStrictEqual(mode, {
+            type: 'regular',
+            tools: undefined,
+            toolChoice: undefined,
+          });
+          assert.deepStrictEqual(prompt, [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'Generate JSON' }],
+            },
+          ]);
+          assert.deepStrictEqual(responseFormat, { type: 'json' });
+
+          return {
+            ...dummyResponseValues,
+            text: `{"key": "value"}`,
+          };
+        },
+      }),
+      prompt: 'Generate JSON',
+      experimental_responseFormat: 'json',
+    });
+
+    assert.deepStrictEqual(result.text, '{"key": "value"}');
+  });
+});

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -125,6 +125,8 @@ By default, it's set to 0, which will disable the feature.
     /**
 The response format. Can be either text or json. Default: 'text'.
 
+Useful when you want a JSON response, but do not have a schema. Use `generateObject` when you have a schema.
+
 Please note that you often need to also instruct the model in the prompt to return JSON.
      */
     experimental_responseFormat?: 'text' | 'json';

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -23,6 +23,7 @@ import {
   calculateCompletionTokenUsage,
 } from '../types/token-usage';
 import { GenerateTextResult } from './generate-text-result';
+import { mapResponseFormat } from './map-response-format';
 import { ToToolCallArray, parseToolCall } from './tool-call';
 import { ToToolResultArray } from './tool-result';
 
@@ -82,6 +83,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   headers,
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
+  experimental_responseFormat: responseFormat,
   experimental_telemetry: telemetry,
   ...settings
 }: CallSettings &
@@ -119,6 +121,13 @@ case of misconfigured tools.
 By default, it's set to 0, which will disable the feature.
      */
     maxToolRoundtrips?: number;
+
+    /**
+The response format. Can be either text or json. Default: 'text'.
+
+Please note that you often need to also instruct the model in the prompt to return JSON.
+     */
+    experimental_responseFormat?: 'text' | 'json';
 
     /**
      * Optional telemetry configuration (experimental).
@@ -218,6 +227,7 @@ By default, it's set to 0, which will disable the feature.
               const result = await model.doGenerate({
                 mode,
                 ...callSettings,
+                responseFormat: mapResponseFormat(responseFormat),
                 inputFormat: currentInputFormat,
                 prompt: promptMessages,
                 abortSignal,

--- a/packages/ai/core/generate-text/map-response-format.ts
+++ b/packages/ai/core/generate-text/map-response-format.ts
@@ -1,0 +1,12 @@
+export function mapResponseFormat(responseFormat: 'text' | 'json' | undefined) {
+  switch (responseFormat) {
+    case 'text':
+      return { type: 'text' } as const;
+    case 'json':
+      return { type: 'json' } as const;
+    case undefined:
+      return undefined;
+    default:
+      throw new Error(`Unsupported response format: ${responseFormat}`);
+  }
+}

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -35,6 +35,7 @@ import {
 } from '../util/async-iterable-stream';
 import { mergeStreams } from '../util/merge-streams';
 import { prepareResponseHeaders } from '../util/prepare-response-headers';
+import { mapResponseFormat } from './map-response-format';
 import { runToolsTransformation } from './run-tools-transformation';
 import { StreamTextResult } from './stream-text-result';
 import { ToToolCall } from './tool-call';
@@ -94,6 +95,7 @@ export async function streamText<TOOLS extends Record<string, CoreTool>>({
   maxRetries,
   abortSignal,
   headers,
+  experimental_responseFormat: responseFormat,
   experimental_telemetry: telemetry,
   experimental_toolCallStreaming: toolCallStreaming = false,
   onChunk,
@@ -115,6 +117,13 @@ The tools that the model can call. The model needs to support calling tools.
 The tool choice strategy. Default: 'auto'.
      */
     toolChoice?: CoreToolChoice<TOOLS>;
+
+    /**
+The response format. Can be either text or json. Default: 'text'.
+
+Please note that you often need to also instruct the model in the prompt to return JSON.
+     */
+    experimental_responseFormat?: 'text' | 'json';
 
     /**
 Optional telemetry configuration (experimental).
@@ -269,6 +278,7 @@ results that can be fully encapsulated in the provider.
                 ...prepareToolsAndToolChoice({ tools, toolChoice }),
               },
               ...prepareCallSettings(settings),
+              responseFormat: mapResponseFormat(responseFormat),
               inputFormat: validatedPrompt.type,
               prompt: promptMessages,
               abortSignal,

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -121,6 +121,8 @@ The tool choice strategy. Default: 'auto'.
     /**
 The response format. Can be either text or json. Default: 'text'.
 
+Useful when you want a JSON response, but do not have a schema. Use `streamObject` when you have a schema.
+
 Please note that you often need to also instruct the model in the prompt to return JSON.
      */
     experimental_responseFormat?: 'text' | 'json';


### PR DESCRIPTION
## Status
on hold, might be better to integrate into generateObject/streamObject

## Background

There are use cases for a generic JSON mode without a schema, see e.g. #2286 

## Tasks

- [x] implementation
- [x] tests
- [x] examples
- [x] documentation
   - [x] reference
- [x] changeset