### PR TITLE
fix (ai/core): explicitly import Buffer

### DIFF
--- a/packages/ai/core/prompt/data-content.ts
+++ b/packages/ai/core/prompt/data-content.ts
@@ -2,6 +2,7 @@ import {
   convertBase64ToUint8Array,
   convertUint8ArrayToBase64,
 } from '@ai-sdk/provider-utils';
+import { Buffer } from 'node:buffer';
 import { InvalidDataContentError } from './invalid-data-content-error';
 import { z } from 'zod';
 


### PR DESCRIPTION
Fixes #2741.

The Node.js documentation recommends importing `Buffer` explicitly:

> While the `Buffer` class is available within the global scope, it is still recommended to explicitly reference it via an import or require statement.

https://nodejs.org/docs/latest-v22.x/api/buffer.html#buffer

Without importing `Buffer` explicitly, this fails to run in a Cloudflare Worker.