### PR TITLE
fix (provider/anthropic): support prompt caching on assistant messages

### DIFF
--- a/.changeset/two-boxes-attend.md
+++ b/.changeset/two-boxes-attend.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+fix (provider/anthropic): support prompt caching on assistant messages

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -390,7 +390,7 @@ describe('result.responseMessages', () => {
           doGenerate: async ({ prompt, mode }) => {
             switch (responseCount++) {
               case 0:
-                assert.deepStrictEqual(mode, {
+                expect(mode).toStrictEqual({
                   type: 'regular',
                   toolChoice: { type: 'auto' },
                   tools: [
@@ -408,7 +408,8 @@ describe('result.responseMessages', () => {
                     },
                   ],
                 });
-                assert.deepStrictEqual(prompt, [
+
+                expect(prompt).toStrictEqual([
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
@@ -441,7 +442,7 @@ describe('result.responseMessages', () => {
                   },
                 };
               case 1:
-                assert.deepStrictEqual(mode, {
+                expect(mode).toStrictEqual({
                   type: 'regular',
                   toolChoice: { type: 'auto' },
                   tools: [
@@ -459,7 +460,8 @@ describe('result.responseMessages', () => {
                     },
                   ],
                 });
-                assert.deepStrictEqual(prompt, [
+
+                expect(prompt).toStrictEqual([
                   {
                     role: 'user',
                     content: [
@@ -477,6 +479,7 @@ describe('result.responseMessages', () => {
                         toolCallId: 'call-1',
                         toolName: 'tool1',
                         args: { value: 'value' },
+                        providerMetadata: undefined,
                       },
                     ],
                     providerMetadata: undefined,

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1997,7 +1997,7 @@ describe('options.maxToolRoundtrips', () => {
           doStream: async ({ prompt, mode }) => {
             switch (responseCount++) {
               case 0:
-                assert.deepStrictEqual(mode, {
+                expect(mode).toStrictEqual({
                   type: 'regular',
                   tools: [
                     {
@@ -2015,7 +2015,8 @@ describe('options.maxToolRoundtrips', () => {
                   ],
                   toolChoice: { type: 'auto' },
                 });
-                assert.deepStrictEqual(prompt, [
+
+                expect(prompt).toStrictEqual([
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
@@ -2041,7 +2042,7 @@ describe('options.maxToolRoundtrips', () => {
                   rawCall: { rawPrompt: 'prompt', rawSettings: {} },
                 };
               case 1:
-                assert.deepStrictEqual(mode, {
+                expect(mode).toStrictEqual({
                   type: 'regular',
                   tools: [
                     {
@@ -2059,7 +2060,8 @@ describe('options.maxToolRoundtrips', () => {
                   ],
                   toolChoice: { type: 'auto' },
                 });
-                assert.deepStrictEqual(prompt, [
+
+                expect(prompt).toStrictEqual([
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
@@ -2072,6 +2074,7 @@ describe('options.maxToolRoundtrips', () => {
                         toolCallId: 'call-1',
                         toolName: 'tool1',
                         args: { value: 'value' },
+                        providerMetadata: undefined,
                       },
                     ],
                     providerMetadata: undefined,

--- a/packages/ai/core/prompt/content-part.ts
+++ b/packages/ai/core/prompt/content-part.ts
@@ -84,6 +84,13 @@ Name of the tool that is being called.
 Arguments of the tool call. This is a JSON-serializable object that matches the tool's input schema.
    */
   args: unknown;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+  experimental_providerMetadata?: ProviderMetadata;
 }
 
 export const toolCallPartSchema: z.ZodType<ToolCallPart> = z.object({

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -230,5 +230,48 @@ describe('convertToLanguageModelMessage', () => {
         });
       });
     });
+
+    describe('tool call parts', () => {
+      it('should pass through provider metadata', () => {
+        const result = convertToLanguageModelMessage(
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolName: 'toolName',
+                toolCallId: 'toolCallId',
+                args: {},
+                experimental_providerMetadata: {
+                  'test-provider': {
+                    'key-a': 'test-value-1',
+                    'key-b': 'test-value-2',
+                  },
+                },
+              },
+            ],
+          },
+          null,
+        );
+
+        expect(result).toEqual({
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              args: {},
+              toolCallId: 'toolCallId',
+              toolName: 'toolName',
+              providerMetadata: {
+                'test-provider': {
+                  'key-a': 'test-value-1',
+                  'key-b': 'test-value-2',
+                },
+              },
+            },
+          ],
+        });
+      });
+    });
   });
 });

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -219,10 +219,18 @@ export function convertToLanguageModelMessage(
 
       return {
         role: 'assistant',
-        content: message.content.filter(
-          // remove empty text parts:
-          part => part.type !== 'text' || part.text !== '',
-        ),
+        content: message.content
+          .filter(
+            // remove empty text parts:
+            part => part.type !== 'text' || part.text !== '',
+          )
+          .map(part => {
+            const { experimental_providerMetadata, ...rest } = part;
+            return {
+              ...rest,
+              providerMetadata: experimental_providerMetadata,
+            };
+          }),
         providerMetadata: message.experimental_providerMetadata,
       };
     }

--- a/packages/anthropic/src/anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/anthropic-messages-prompt.ts
@@ -40,6 +40,7 @@ export interface AnthropicToolCallContent {
   id: string;
   name: string;
   input: unknown;
+  cache_control?: AnthropicCacheControl;
 }
 
 export interface AnthropicToolResultContent {

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -406,7 +406,7 @@ describe('cache control', () => {
   });
 
   describe('assistant message', () => {
-    it('should set cache_control on user message part with part cache control', async () => {
+    it('should set cache_control on assistant message text part with part cache control', async () => {
       const result = convertToAnthropicMessagesPrompt({
         prompt: [
           { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
@@ -437,6 +437,50 @@ describe('cache control', () => {
               {
                 type: 'text',
                 text: 'test',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      });
+    });
+
+    it('should set cache_control on assistant tool call part with part cache control', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'test-id',
+                toolName: 'test-tool',
+                args: { some: 'arg' },
+                providerMetadata: {
+                  anthropic: {
+                    cacheControl: { type: 'ephemeral' },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        cacheControl: true,
+      });
+
+      expect(result).toEqual({
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool_use',
+                name: 'test-tool',
+                id: 'test-id',
+                input: { some: 'arg' },
                 cache_control: { type: 'ephemeral' },
               },
             ],

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -405,6 +405,91 @@ describe('cache control', () => {
     });
   });
 
+  describe('assistant message', () => {
+    it('should set cache_control on user message part with part cache control', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'test',
+                providerMetadata: {
+                  anthropic: {
+                    cacheControl: { type: 'ephemeral' },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        cacheControl: true,
+      });
+
+      expect(result).toEqual({
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'test',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      });
+    });
+
+    it('should set cache_control on last assistant message part with message cache control', async () => {
+      const result = convertToAnthropicMessagesPrompt({
+        prompt: [
+          { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'part1' },
+              { type: 'text', text: 'part2' },
+            ],
+            providerMetadata: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+        cacheControl: true,
+      });
+
+      expect(result).toEqual({
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'user-content' }] },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'part1',
+                cache_control: undefined,
+              },
+              {
+                type: 'text',
+                text: 'part2',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      });
+    });
+  });
+
   describe('tool message', () => {
     it('should set cache_control on tool result message part with part cache control', async () => {
       const result = convertToAnthropicMessagesPrompt({

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -72,13 +72,13 @@ export function convertToAnthropicMessagesPrompt({
           const { role, content } = message;
           switch (role) {
             case 'user': {
-              for (let i = 0; i < content.length; i++) {
-                const part = content[i];
+              for (let j = 0; j < content.length; j++) {
+                const part = content[j];
 
                 // cache control: first add cache control from part.
                 // for the last part of a message,
                 // check also if the message has cache control.
-                const isLastPart = i === content.length - 1;
+                const isLastPart = j === content.length - 1;
 
                 const cacheControl =
                   getCacheControl(part.providerMetadata) ??
@@ -162,9 +162,26 @@ export function convertToAnthropicMessagesPrompt({
         // combines multiple assistant messages in this block into a single message:
         const anthropicContent: AnthropicAssistantMessage['content'] = [];
 
-        for (const { content } of block.messages) {
+        for (const message of block.messages) {
+          const { content } = message;
+
           for (let j = 0; j < content.length; j++) {
             const part = content[j];
+
+            // cache control: first add cache control from part.
+            // for the last part of a message,
+            // check also if the message has cache control.
+            const isLastPart = j === content.length - 1;
+
+            const cacheControl =
+              getCacheControl(
+                // TODO support tool call parts
+                part.type === 'text' ? part.providerMetadata : undefined,
+              ) ??
+              (isLastPart
+                ? getCacheControl(message.providerMetadata)
+                : undefined);
+
             switch (part.type) {
               case 'text': {
                 anthropicContent.push({
@@ -177,7 +194,7 @@ export function convertToAnthropicMessagesPrompt({
                       ? part.text.trim()
                       : part.text,
 
-                  cache_control: undefined, // not used in assistant messages
+                  cache_control: cacheControl,
                 });
                 break;
               }

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -174,10 +174,7 @@ export function convertToAnthropicMessagesPrompt({
             const isLastPart = j === content.length - 1;
 
             const cacheControl =
-              getCacheControl(
-                // TODO support tool call parts
-                part.type === 'text' ? part.providerMetadata : undefined,
-              ) ??
+              getCacheControl(part.providerMetadata) ??
               (isLastPart
                 ? getCacheControl(message.providerMetadata)
                 : undefined);
@@ -205,6 +202,7 @@ export function convertToAnthropicMessagesPrompt({
                   id: part.toolCallId,
                   name: part.toolName,
                   input: part.args,
+                  cache_control: cacheControl,
                 });
                 break;
               }

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -2,6 +2,7 @@ import { JSONSchema7 } from 'json-schema';
 import { LanguageModelV1CallSettings } from './language-model-v1-call-settings';
 import { LanguageModelV1FunctionTool } from './language-model-v1-function-tool';
 import { LanguageModelV1Prompt } from './language-model-v1-prompt';
+import { LanguageModelV1ProviderMetadata } from './language-model-v1-provider-metadata';
 import { LanguageModelV1ToolChoice } from './language-model-v1-tool-choice';
 
 export type LanguageModelV1CallOptions = LanguageModelV1CallSettings & {
@@ -76,4 +77,11 @@ That approach allows us to evolve the user  facing prompts without breaking
 the language model interface.
    */
   prompt: LanguageModelV1Prompt;
+
+  /**
+   * Additional provider-specific metadata. They are passed through
+   * to the provider from the AI SDK and enable provider-specific
+   * functionality that can be fully encapsulated in the provider.
+   */
+  providerMetadata?: LanguageModelV1ProviderMetadata;
 };

--- a/packages/provider/src/language-model/v1/language-model-v1-prompt.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-prompt.ts
@@ -104,6 +104,13 @@ Name of the tool that is being called.
 Arguments of the tool call. This is a JSON-serializable object that matches the tool's input schema.
    */
   args: unknown;
+
+  /**
+   * Additional provider-specific metadata. They are passed through
+   * to the provider from the AI SDK and enable provider-specific
+   * functionality that can be fully encapsulated in the provider.
+   */
+  providerMetadata?: LanguageModelV1ProviderMetadata;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `providerMetadata` to language model v1 tool content parts
- add `providerMetadata` to language model v1 requests (for future use)
- support caching text and tool call parts of assistant messages (anthropic)
- add `experimental_providerMetadata` to tool content parts