### PR TITLE
fix (docs): added forgotten links

### DIFF
--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -207,7 +207,7 @@ The following optional settings are available for OpenAI chat models:
 - **user** _string_
 
   A unique identifier representing your end-user, which can help OpenAI to
-  monitor and detect abuse. Learn more.
+  monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
 
 - **downloadImages** _boolean_
 
@@ -353,7 +353,7 @@ The following optional settings are available for OpenAI completion models:
 - **user** _string_
 
   A unique identifier representing your end-user, which can help OpenAI to
-  monitor and detect abuse. Learn more.
+  monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
 
 ## Embedding Models
 
@@ -383,7 +383,7 @@ The following optional settings are available for OpenAI embedding models:
 - **user** _string_
 
   A unique identifier representing your end-user, which can help OpenAI to
-  monitor and detect abuse. Learn more.
+  monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
 
 ### Model Capabilities
 


### PR DESCRIPTION
Hi,

Added forgotten links in OpenAI vendor documentation