### PR TITLE
feat (ai/core): enhance pipeToData/TextStreamResponse methods

### DIFF
--- a/.changeset/sixty-rats-build.md
+++ b/.changeset/sixty-rats-build.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): enhance pipeToData/TextStreamResponse methods

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -1232,6 +1232,31 @@ To see `streamText` in action, check out [these examples](#examples).
       type: '(init?: ResponseInit) => Response',
       description:
         'Creates a simple text stream response. Each text delta is encoded as UTF-8 and sent as a separate chunk. Non-text-delta events are ignored.',
+      properties: [
+        {
+          type: 'ResponseInit',
+          parameters: [
+            {
+              name: 'status',
+              type: 'number',
+              optional: true,
+              description: 'The response status code.',
+            },
+            {
+              name: 'statusText',
+              type: 'string',
+              optional: true,
+              description: 'The response status text.',
+            },
+            {
+              name: 'headers',
+              type: 'Record<string, string>',
+              optional: true,
+              description: 'The response headers.',
+            },
+          ],
+        },
+      ],
     },
   ]}
 />

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -1084,24 +1084,12 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'pipeDataStreamToResponse',
-      type: '(response: ServerResponse, init?: { headers?: Record<string, string>; status?: number } => void',
+      type: '(response: ServerResponse, options: PipeDataStreamToResponseOptions } => void',
       description:
         'Writes stream data output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each stream data part as a separate chunk.',
-    },
-    {
-      name: 'pipeTextStreamToResponse',
-      type: '(response: ServerResponse, init?: { headers?: Record<string, string>; status?: number } => void',
-      description:
-        'Writes text delta output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each text delta as a separate chunk.',
-    },
-    {
-      name: 'toDataStreamResponse',
-      type: '(options?: toDataStreamOptions) => Response',
-      description:
-        'Converts the result to a streamed response object with a stream data part stream. It can be used with the `useChat` and `useCompletion` hooks.',
       properties: [
         {
-          type: 'toDataStreamOptions',
+          type: 'PipeDataStreamToResponseOptions',
           parameters: [
             {
               name: 'init',
@@ -1117,6 +1105,100 @@ To see `streamText` in action, check out [these examples](#examples).
                       type: 'number',
                       optional: true,
                       description: 'The response status code.',
+                    },
+                    {
+                      name: 'statusText',
+                      type: 'string',
+                      optional: true,
+                      description: 'The response status text.',
+                    },
+                    {
+                      name: 'headers',
+                      type: 'Record<string, string>',
+                      optional: true,
+                      description: 'The response headers.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'data',
+              type: 'StreamData',
+              optional: true,
+              description: 'The stream data object.',
+            },
+            {
+              name: 'getErrorMessage',
+              type: '(error: unknown) => string',
+              description:
+                'A function to get the error message from the error object. By default, all errors are masked as "" for safety reasons.',
+              optional: true,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'pipeTextStreamToResponse',
+      type: '(response: ServerResponse, init?: ResponseInit => void',
+      description:
+        'Writes text delta output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each text delta as a separate chunk.',
+      properties: [
+        {
+          type: 'ResponseInit',
+          parameters: [
+            {
+              name: 'status',
+              type: 'number',
+              optional: true,
+              description: 'The response status code.',
+            },
+            {
+              name: 'statusText',
+              type: 'string',
+              optional: true,
+              description: 'The response status text.',
+            },
+            {
+              name: 'headers',
+              type: 'Record<string, string>',
+              optional: true,
+              description: 'The response headers.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'toDataStreamResponse',
+      type: '(options?: ToDataStreamOptions) => Response',
+      description:
+        'Converts the result to a streamed response object with a stream data part stream. It can be used with the `useChat` and `useCompletion` hooks.',
+      properties: [
+        {
+          type: 'ToDataStreamOptions',
+          parameters: [
+            {
+              name: 'init',
+              type: 'ResponseInit',
+              optional: true,
+              description: 'The response init options.',
+              properties: [
+                {
+                  type: 'ResponseInit',
+                  parameters: [
+                    {
+                      name: 'status',
+                      type: 'number',
+                      optional: true,
+                      description: 'The response status code.',
+                    },
+                    {
+                      name: 'statusText',
+                      type: 'string',
+                      optional: true,
+                      description: 'The response status text.',
                     },
                     {
                       name: 'headers',

--- a/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
@@ -761,15 +761,65 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
     },
     {
       name: 'pipeTextStreamToResponse',
-      type: '(response: ServerResponse, init?: { headers?: Record<string, string>; status?: number } => void',
+      type: '(response: ServerResponse, init?: ResponseInit => void',
       description:
         'Writes text delta output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each text delta as a separate chunk.',
+      properties: [
+        {
+          type: 'ResponseInit',
+          parameters: [
+            {
+              name: 'status',
+              type: 'number',
+              optional: true,
+              description: 'The response status code.',
+            },
+            {
+              name: 'statusText',
+              type: 'string',
+              optional: true,
+              description: 'The response status text.',
+            },
+            {
+              name: 'headers',
+              type: 'Record<string, string>',
+              optional: true,
+              description: 'The response headers.',
+            },
+          ],
+        },
+      ],
     },
     {
       name: 'toTextStreamResponse',
       type: '(init?: ResponseInit) => Response',
       description:
         'Creates a simple text stream response. Each text delta is encoded as UTF-8 and sent as a separate chunk. Non-text-delta events are ignored.',
+      properties: [
+        {
+          type: 'ResponseInit',
+          parameters: [
+            {
+              name: 'status',
+              type: 'number',
+              optional: true,
+              description: 'The response status code.',
+            },
+            {
+              name: 'statusText',
+              type: 'string',
+              optional: true,
+              description: 'The response status text.',
+            },
+            {
+              name: 'headers',
+              type: 'Record<string, string>',
+              optional: true,
+              description: 'The response headers.',
+            },
+          ],
+        },
+      ],
     },
   ]}
 />

--- a/content/docs/07-reference/stream-helpers/05-stream-to-response.mdx
+++ b/content/docs/07-reference/stream-helpers/05-stream-to-response.mdx
@@ -5,6 +5,11 @@ description: Learn to use streamToResponse helper function in your application.
 
 # `streamToResponse`
 
+<Note type="warning">
+  `streamToResponse` is deprecated. Use `pipeDataStreamToResponse` from
+  [streamText](/docs/reference/ai-sdk-core/stream-text) instead.
+</Note>
+
 `streamToResponse` pipes an AI stream to a Node.js `ServerResponse` object and sets the status code and headers.
 
 This is useful to create AI stream responses in environments that use `ServerResponse` objects, such as Node.js HTTP servers.
@@ -13,8 +18,6 @@ The status code and headers can be configured using the `options` parameter.
 By default, the status code is set to 200 and the Content-Type header is set to `text/plain; charset=utf-8`.
 
 ## Import
-
-### React
 
 <Snippet text={`import { streamToResponse } from "ai"`} prompt={false} />
 

--- a/examples/node-http-server/src/server.ts
+++ b/examples/node-http-server/src/server.ts
@@ -1,30 +1,21 @@
 import { openai } from '@ai-sdk/openai';
-import { StreamData, streamText, streamToResponse } from 'ai';
+import { StreamData, streamText } from 'ai';
+import 'dotenv/config';
 import { createServer } from 'http';
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 createServer(async (req, res) => {
+  // use stream data (optional):
+  const data = new StreamData();
+  data.append('initialized call');
+
   const result = await streamText({
     model: openai('gpt-4-turbo'),
     prompt: 'What is the weather in San Francisco?',
+    onFinish() {
+      data.append('call completed');
+      data.close();
+    },
   });
 
-  // use stream data
-  const data = new StreamData();
-
-  data.append('initialized call');
-
-  streamToResponse(
-    result.toAIStream({
-      onFinal() {
-        data.append('call completed');
-        data.close();
-      },
-    }),
-    res,
-    {},
-    data,
-  );
+  result.pipeDataStreamToResponse(res, { data });
 }).listen(8080);

--- a/packages/ai/core/generate-object/stream-object-result.ts
+++ b/packages/ai/core/generate-object/stream-object-result.ts
@@ -85,12 +85,9 @@ Additional response information.
   writes each text delta as a separate chunk.
 
   @param response A Node.js response-like object (ServerResponse).
-  @param init Optional headers and status code.
+  @param init Optional headers, status code, and status text.
      */
-  pipeTextStreamToResponse(
-    response: ServerResponse,
-    init?: { headers?: Record<string, string>; status?: number },
-  ): void;
+  pipeTextStreamToResponse(response: ServerResponse, init?: ResponseInit): void;
 
   /**
   Creates a simple text stream response.
@@ -98,7 +95,7 @@ Additional response information.
   Each text delta is encoded as UTF-8 and sent as a separate chunk.
   Non-text-delta events are ignored.
 
-  @param init Optional headers and status code.
+  @param init Optional headers, status code, and status text.
      */
   toTextStreamResponse(init?: ResponseInit): Response;
 }

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -527,28 +527,19 @@ describe('output = "object"', () => {
 
       result.pipeTextStreamToResponse(mockResponse);
 
-      // Wait for the stream to finish writing to the mock response
-      await new Promise(resolve => {
-        const checkIfEnded = () => {
-          if (mockResponse.ended) {
-            resolve(undefined);
-          } else {
-            setImmediate(checkIfEnded);
-          }
-        };
-        checkIfEnded();
-      });
+      await mockResponse.waitForEnd();
 
-      const decoder = new TextDecoder();
-
-      assert.strictEqual(mockResponse.statusCode, 200);
-      assert.deepStrictEqual(mockResponse.headers, {
+      expect(mockResponse.statusCode).toBe(200);
+      expect(mockResponse.headers).toEqual({
         'Content-Type': 'text/plain; charset=utf-8',
       });
-      assert.deepStrictEqual(
-        mockResponse.writtenChunks.map(chunk => decoder.decode(chunk)),
-        ['{ ', '"content": "Hello, ', 'world', '!"', ' }'],
-      );
+      expect(mockResponse.getDecodedChunks()).toEqual([
+        '{ ',
+        '"content": "Hello, ',
+        'world',
+        '!"',
+        ' }',
+      ]);
     });
   });
 

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -50,6 +50,7 @@ import { OutputStrategy, getOutputStrategy } from './output-strategy';
 import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
 import { createIdGenerator } from '@ai-sdk/provider-utils';
+import { prepareOutgoingHttpHeaders } from '../util/prepare-outgoing-http-headers';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj-', length: 24 });
 
@@ -963,10 +964,13 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
     response: ServerResponse,
     init?: { headers?: Record<string, string>; status?: number },
   ) {
-    response.writeHead(init?.status ?? 200, {
-      'Content-Type': 'text/plain; charset=utf-8',
-      ...init?.headers,
-    });
+    response.writeHead(
+      init?.status ?? 200,
+      undefined,
+      prepareOutgoingHttpHeaders(init, {
+        contentType: 'text/plain; charset=utf-8',
+      }),
+    );
 
     const reader = this.textStream
       .pipeThrough(new TextEncoderStream())

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -141,17 +141,9 @@ Additional response information.
   pipeDataStreamToResponse(
     response: ServerResponse,
     init?:
+      | ResponseInit
       | {
-          headers?: Record<string, string>;
-          status?: number;
-          statusMessage?: string;
-        }
-      | {
-          init?: {
-            headers?: Record<string, string>;
-            status?: number;
-            statusMessage?: string;
-          };
+          init?: ResponseInit;
           data?: StreamData;
           getErrorMessage?: (error: unknown) => string;
         },

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -154,12 +154,9 @@ Additional response information.
   writes each text delta as a separate chunk.
 
   @param response A Node.js response-like object (ServerResponse).
-  @param init Optional headers and status code.
+  @param init Optional headers, status code, and status text.
      */
-  pipeTextStreamToResponse(
-    response: ServerResponse,
-    init?: { headers?: Record<string, string>; status?: number },
-  ): void;
+  pipeTextStreamToResponse(response: ServerResponse, init?: ResponseInit): void;
 
   /**
   Converts the result to a streamed response object with a stream data part stream.
@@ -200,7 +197,7 @@ Additional response information.
   Each text delta is encoded as UTF-8 and sent as a separate chunk.
   Non-text-delta events are ignored.
 
-  @param init Optional headers and status code.
+  @param init Optional headers, status code, and status text.
      */
   toTextStreamResponse(init?: ResponseInit): Response;
 }

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -140,7 +140,21 @@ Additional response information.
      */
   pipeDataStreamToResponse(
     response: ServerResponse,
-    init?: { headers?: Record<string, string>; status?: number },
+    init?:
+      | {
+          headers?: Record<string, string>;
+          status?: number;
+          statusMessage?: string;
+        }
+      | {
+          init?: {
+            headers?: Record<string, string>;
+            status?: number;
+            statusMessage?: string;
+          };
+          data?: StreamData;
+          getErrorMessage?: (error: unknown) => string;
+        },
   ): void;
 
   /**

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -132,15 +132,14 @@ Additional response information.
 
   /**
   Writes data stream output to a Node.js response-like object.
-  It sets a `Content-Type` header to `text/plain; charset=utf-8` and
-  writes each data stream part as a separate chunk.
 
   @param response A Node.js response-like object (ServerResponse).
-  @param init Optional headers and status code.
+  @param options An object with an init property (ResponseInit) and a data property.
+  You can also pass in a ResponseInit directly (deprecated).
      */
   pipeDataStreamToResponse(
     response: ServerResponse,
-    init?:
+    options?:
       | ResponseInit
       | {
           init?: ResponseInit;

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1291,11 +1291,11 @@ describe('result.pipeDataStreamToResponse', async () => {
 
     await mockResponse.waitForEnd();
 
-    assert.strictEqual(mockResponse.statusCode, 200);
-    assert.deepStrictEqual(mockResponse.headers, {
+    expect(mockResponse.statusCode).toBe(200);
+    expect(mockResponse.headers).toEqual({
       'Content-Type': 'text/plain; charset=utf-8',
     });
-    assert.deepStrictEqual(mockResponse.getDecodedChunks(), [
+    expect(mockResponse.getDecodedChunks()).toEqual([
       '0:"Hello"\n',
       '0:", "\n',
       '0:"world!"\n',
@@ -1336,16 +1336,16 @@ describe('result.pipeDataStreamToResponse', async () => {
 
     await mockResponse.waitForEnd();
 
-    assert.strictEqual(mockResponse.statusCode, 201);
-    // assert.strictEqual(mockResponse.statusMessage, 'foo');
+    expect(mockResponse.statusCode).toBe(201);
+    // expect(mockResponse.statusMessage).toBe('foo');
 
-    expect(mockResponse.headers).toStrictEqual({
+    expect(mockResponse.headers).toEqual({
       'Content-Type': 'text/plain; charset=utf-8',
       // 'x-vercel-ai-data-stream': 'v1',
       'custom-header': 'custom-value',
     });
 
-    assert.deepStrictEqual(mockResponse.getDecodedChunks(), [
+    expect(mockResponse.getDecodedChunks()).toEqual([
       '0:"Hello"\n',
       '0:", "\n',
       '0:"world!"\n',

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1289,34 +1289,19 @@ describe('result.pipeDataStreamToResponse', async () => {
 
     result.pipeDataStreamToResponse(mockResponse);
 
-    // Wait for the stream to finish writing to the mock response
-    await new Promise(resolve => {
-      const checkIfEnded = () => {
-        if (mockResponse.ended) {
-          resolve(undefined);
-        } else {
-          setImmediate(checkIfEnded);
-        }
-      };
-      checkIfEnded();
-    });
-
-    const decoder = new TextDecoder();
+    await mockResponse.waitForEnd();
 
     assert.strictEqual(mockResponse.statusCode, 200);
     assert.deepStrictEqual(mockResponse.headers, {
       'Content-Type': 'text/plain; charset=utf-8',
     });
-    assert.deepStrictEqual(
-      mockResponse.writtenChunks.map(chunk => decoder.decode(chunk)),
-      [
-        '0:"Hello"\n',
-        '0:", "\n',
-        '0:"world!"\n',
-        'e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}\n',
-        'd:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}\n',
-      ],
-    );
+    assert.deepStrictEqual(mockResponse.getDecodedChunks(), [
+      '0:"Hello"\n',
+      '0:", "\n',
+      '0:"world!"\n',
+      'e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}\n',
+      'd:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}\n',
+    ]);
   });
 
   it('should create a Response with a data stream and custom headers', async () => {
@@ -1349,19 +1334,7 @@ describe('result.pipeDataStreamToResponse', async () => {
       },
     });
 
-    // Wait for the stream to finish writing to the mock response
-    await new Promise(resolve => {
-      const checkIfEnded = () => {
-        if (mockResponse.ended) {
-          resolve(undefined);
-        } else {
-          setImmediate(checkIfEnded);
-        }
-      };
-      checkIfEnded();
-    });
-
-    const decoder = new TextDecoder();
+    await mockResponse.waitForEnd();
 
     assert.strictEqual(mockResponse.statusCode, 201);
     // assert.strictEqual(mockResponse.statusMessage, 'foo');
@@ -1372,16 +1345,13 @@ describe('result.pipeDataStreamToResponse', async () => {
       'custom-header': 'custom-value',
     });
 
-    assert.deepStrictEqual(
-      mockResponse.writtenChunks.map(chunk => decoder.decode(chunk)),
-      [
-        '0:"Hello"\n',
-        '0:", "\n',
-        '0:"world!"\n',
-        'e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}\n',
-        'd:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}\n',
-      ],
-    );
+    assert.deepStrictEqual(mockResponse.getDecodedChunks(), [
+      '0:"Hello"\n',
+      '0:", "\n',
+      '0:"world!"\n',
+      'e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}\n',
+      'd:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}\n',
+    ]);
   });
 
   // it('should support merging with existing stream data', async () => {

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1263,8 +1263,6 @@ describe('result.toAIStream', () => {
 
 describe('result.pipeDataStreamToResponse', async () => {
   it('should write data stream parts to a Node.js response-like object', async () => {
-    const mockResponse = createMockServerResponse();
-
     const result = await streamText({
       model: new MockLanguageModelV1({
         doStream: async () => {
@@ -1287,6 +1285,8 @@ describe('result.pipeDataStreamToResponse', async () => {
       prompt: 'test-input',
     });
 
+    const mockResponse = createMockServerResponse();
+
     result.pipeDataStreamToResponse(mockResponse);
 
     await mockResponse.waitForEnd();
@@ -1305,8 +1305,6 @@ describe('result.pipeDataStreamToResponse', async () => {
   });
 
   it('should create a Response with a data stream and custom headers', async () => {
-    const mockResponse = createMockServerResponse();
-
     const result = await streamText({
       model: new MockLanguageModelV1({
         doStream: async () => ({
@@ -1325,6 +1323,8 @@ describe('result.pipeDataStreamToResponse', async () => {
       }),
       prompt: 'test-input',
     });
+
+    const mockResponse = createMockServerResponse();
 
     result.pipeDataStreamToResponse(mockResponse, {
       status: 201,

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1294,6 +1294,7 @@ describe('result.pipeDataStreamToResponse', async () => {
     expect(mockResponse.statusCode).toBe(200);
     expect(mockResponse.headers).toEqual({
       'Content-Type': 'text/plain; charset=utf-8',
+      'X-Vercel-AI-Data-Stream': 'v1',
     });
     expect(mockResponse.getDecodedChunks()).toEqual([
       '0:"Hello"\n',
@@ -1328,7 +1329,7 @@ describe('result.pipeDataStreamToResponse', async () => {
 
     result.pipeDataStreamToResponse(mockResponse, {
       status: 201,
-      statusMessage: 'foo',
+      statusText: 'foo',
       headers: {
         'custom-header': 'custom-value',
       },
@@ -1337,11 +1338,11 @@ describe('result.pipeDataStreamToResponse', async () => {
     await mockResponse.waitForEnd();
 
     expect(mockResponse.statusCode).toBe(201);
-    // expect(mockResponse.statusMessage).toBe('foo');
+    expect(mockResponse.statusMessage).toBe('foo');
 
     expect(mockResponse.headers).toEqual({
       'Content-Type': 'text/plain; charset=utf-8',
-      // 'x-vercel-ai-data-stream': 'v1',
+      'X-Vercel-AI-Data-Stream': 'v1',
       'custom-header': 'custom-value',
     });
 
@@ -1467,28 +1468,13 @@ describe('result.pipeTextStreamToResponse', async () => {
 
     result.pipeTextStreamToResponse(mockResponse);
 
-    // Wait for the stream to finish writing to the mock response
-    await new Promise(resolve => {
-      const checkIfEnded = () => {
-        if (mockResponse.ended) {
-          resolve(undefined);
-        } else {
-          setImmediate(checkIfEnded);
-        }
-      };
-      checkIfEnded();
-    });
+    await mockResponse.waitForEnd();
 
-    const decoder = new TextDecoder();
-
-    assert.strictEqual(mockResponse.statusCode, 200);
-    assert.deepStrictEqual(mockResponse.headers, {
+    expect(mockResponse.statusCode).toBe(200);
+    expect(mockResponse.headers).toEqual({
       'Content-Type': 'text/plain; charset=utf-8',
     });
-    assert.deepStrictEqual(
-      mockResponse.writtenChunks.map(chunk => decoder.decode(chunk)),
-      ['Hello', ', ', 'world!'],
-    );
+    expect(mockResponse.getDecodedChunks()).toEqual(['Hello', ', ', 'world!']);
   });
 });
 

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1263,6 +1263,8 @@ describe('result.toAIStream', () => {
 
 describe('result.pipeDataStreamToResponse', async () => {
   it('should write data stream parts to a Node.js response-like object', async () => {
+    const mockResponse = createMockServerResponse();
+
     const result = await streamText({
       model: new MockLanguageModelV1({
         doStream: async () => {
@@ -1285,8 +1287,6 @@ describe('result.pipeDataStreamToResponse', async () => {
       prompt: 'test-input',
     });
 
-    const mockResponse = createMockServerResponse();
-
     result.pipeDataStreamToResponse(mockResponse);
 
     await mockResponse.waitForEnd();
@@ -1305,6 +1305,8 @@ describe('result.pipeDataStreamToResponse', async () => {
   });
 
   it('should create a Response with a data stream and custom headers', async () => {
+    const mockResponse = createMockServerResponse();
+
     const result = await streamText({
       model: new MockLanguageModelV1({
         doStream: async () => ({
@@ -1323,8 +1325,6 @@ describe('result.pipeDataStreamToResponse', async () => {
       }),
       prompt: 'test-input',
     });
-
-    const mockResponse = createMockServerResponse();
 
     result.pipeDataStreamToResponse(mockResponse, {
       status: 201,

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1088,12 +1088,12 @@ However, the LLM results are expected to be small enough to not cause issues.
 
   pipeTextStreamToResponse(response: ServerResponse, init?: ResponseInit) {
     writeToServerResponse({
+      response,
       status: init?.status,
       statusText: init?.statusText,
       headers: prepareOutgoingHttpHeaders(init, {
         contentType: 'text/plain; charset=utf-8',
       }),
-      response,
       stream: this.textStream.pipeThrough(new TextEncoderStream()),
     });
   }

--- a/packages/ai/core/test/mock-server-response.ts
+++ b/packages/ai/core/test/mock-server-response.ts
@@ -4,6 +4,7 @@ class MockServerResponse {
   writtenChunks: any[] = [];
   headers = {};
   statusCode = 0;
+  statusMessage = '';
   ended = false;
 
   write(chunk: any): void {
@@ -15,8 +16,13 @@ class MockServerResponse {
     this.ended = true;
   }
 
-  writeHead(statusCode: number, headers: Record<string, string>): void {
+  writeHead(
+    statusCode: number,
+    statusMessage: string,
+    headers: Record<string, string>,
+  ): void {
     this.statusCode = statusCode;
+    this.statusMessage = statusMessage;
     this.headers = headers;
   }
 

--- a/packages/ai/core/test/mock-server-response.ts
+++ b/packages/ai/core/test/mock-server-response.ts
@@ -24,6 +24,30 @@ class MockServerResponse {
     // Combine all written chunks into a single string
     return this.writtenChunks.join('');
   }
+
+  /**
+   * Get the decoded chunks as strings.
+   */
+  getDecodedChunks() {
+    const decoder = new TextDecoder();
+    return this.writtenChunks.map(chunk => decoder.decode(chunk));
+  }
+
+  /**
+   * Wait for the stream to finish writing to the mock response.
+   */
+  async waitForEnd() {
+    await new Promise(resolve => {
+      const checkIfEnded = () => {
+        if (this.ended) {
+          resolve(undefined);
+        } else {
+          setImmediate(checkIfEnded);
+        }
+      };
+      checkIfEnded();
+    });
+  }
 }
 
 export function createMockServerResponse(): ServerResponse &

--- a/packages/ai/core/util/prepare-outgoing-http-headers.test.ts
+++ b/packages/ai/core/util/prepare-outgoing-http-headers.test.ts
@@ -1,0 +1,57 @@
+import { prepareOutgoingHttpHeaders } from './prepare-outgoing-http-headers';
+
+it('should set Content-Type header if not present', () => {
+  const headers = prepareOutgoingHttpHeaders(
+    {},
+    { contentType: 'application/json' },
+  );
+
+  expect(headers['Content-Type']).toBe('application/json');
+});
+
+it('should not overwrite existing Content-Type header', () => {
+  const headers = prepareOutgoingHttpHeaders(
+    { headers: { 'Content-Type': 'text/html' } },
+    { contentType: 'application/json' },
+  );
+
+  expect(headers['Content-Type']).toBe('text/html');
+});
+
+it('should handle undefined init', () => {
+  const headers = prepareOutgoingHttpHeaders(undefined, {
+    contentType: 'application/json',
+  });
+
+  expect(headers['Content-Type']).toBe('application/json');
+});
+
+it('should handle init headers as object', () => {
+  const headers = prepareOutgoingHttpHeaders(
+    { headers: { init: 'foo' } },
+    { contentType: 'application/json' },
+  );
+
+  expect(headers['init']).toBe('foo');
+  expect(headers['Content-Type']).toBe('application/json');
+});
+
+it('should set X-Vercel-AI-Data-Stream header when dataStreamVersion is provided', () => {
+  const headers = prepareOutgoingHttpHeaders(
+    {},
+    { contentType: 'application/json', dataStreamVersion: 'v1' },
+  );
+
+  expect(headers['Content-Type']).toBe('application/json');
+  expect(headers['X-Vercel-AI-Data-Stream']).toBe('v1');
+});
+
+it('should not set X-Vercel-AI-Data-Stream header when dataStreamVersion is undefined', () => {
+  const headers = prepareOutgoingHttpHeaders(
+    {},
+    { contentType: 'application/json' },
+  );
+
+  expect(headers['Content-Type']).toBe('application/json');
+  expect(headers['X-Vercel-AI-Data-Stream']).toBeUndefined();
+});

--- a/packages/ai/core/util/prepare-outgoing-http-headers.ts
+++ b/packages/ai/core/util/prepare-outgoing-http-headers.ts
@@ -1,0 +1,25 @@
+export function prepareOutgoingHttpHeaders(
+  init: ResponseInit | undefined,
+  {
+    contentType,
+    dataStreamVersion,
+  }: { contentType: string; dataStreamVersion?: 'v1' | undefined },
+) {
+  const headers: Record<string, string | number | string[]> = {};
+
+  if (init?.headers != null) {
+    for (const [key, value] of Object.entries(init.headers)) {
+      headers[key] = value;
+    }
+  }
+
+  if (headers['Content-Type'] == null) {
+    headers['Content-Type'] = contentType;
+  }
+
+  if (dataStreamVersion !== undefined) {
+    headers['X-Vercel-AI-Data-Stream'] = dataStreamVersion;
+  }
+
+  return headers;
+}

--- a/packages/ai/core/util/prepare-response-headers.test.ts
+++ b/packages/ai/core/util/prepare-response-headers.test.ts
@@ -1,4 +1,3 @@
-import { expect, it } from 'vitest';
 import { prepareResponseHeaders } from './prepare-response-headers';
 
 it('should set Content-Type header if not present', () => {

--- a/packages/ai/core/util/write-to-server-response.ts
+++ b/packages/ai/core/util/write-to-server-response.ts
@@ -1,0 +1,37 @@
+import { ServerResponse } from 'node:http';
+
+/**
+ * Writes the content of a stream to a server response.
+ */
+export function writeToServerResponse({
+  response,
+  status,
+  statusText,
+  headers,
+  stream,
+}: {
+  response: ServerResponse;
+  status?: number;
+  statusText?: string;
+  headers?: Record<string, string | number | string[]>;
+  stream: ReadableStream<Uint8Array>;
+}): void {
+  response.writeHead(status ?? 200, statusText, headers);
+
+  const reader = stream.getReader();
+  const read = async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        response.write(value);
+      }
+    } catch (error) {
+      throw error;
+    } finally {
+      response.end();
+    }
+  };
+
+  read();
+}

--- a/packages/ai/streams/stream-to-response.ts
+++ b/packages/ai/streams/stream-to-response.ts
@@ -4,6 +4,8 @@ import { mergeStreams } from '../core/util/merge-streams';
 
 /**
  * A utility function to stream a ReadableStream to a Node.js response-like object.
+ *
+ * @deprecated Use `pipeDataStreamToResponse` (part of `StreamTextResult`) instead.
  */
 export function streamToResponse(
   res: ReadableStream,


### PR DESCRIPTION
## Summary
* support stream data, standard `ResponseInit`, and custom error messages in `StreamTextResult.pipeDataStreamToResponse`
* support response text in `StreamTextResult.pipeTextStreamToResponse`
* support response text in `StreamObjectResult.pipeTextStreamToResponse`
* deprecate `streamToResponse` helper

## Tasks

- [x] implementation
   - [x] streamText pipeDataStreamToResponse
   - [x] streamText pipeTextStreamToResponse signature
   - [x] streamObject pipeTextStreamToResponse signature
   - [x] deprecate streamToResponse
- [x] examples
   - [x] update node server example
- [x] docs
   - [x] streamText reference
   - [x] streamObject reference
   - [x] deprecation warning in `streamToResponse`
- [x] changeset