### PR TITLE
feat (docs): add Node.js http server example

### DIFF
--- a/content/examples/15-api-servers/10-node-js-http-server.mdx
+++ b/content/examples/15-api-servers/10-node-js-http-server.mdx
@@ -5,7 +5,7 @@ description: Example of using Vercel AI SDK in a Node.js HTTP server.
 
 # Node.js HTTP Server
 
-You can use the Vercel AI SDK in a Node.js HTTP server to generate text and stream it to the client.
+You can use the Vercel AI SDK in a Node.js HTTP server to generate and stream text and objects to the client.
 
 ## Examples
 

--- a/content/examples/15-api-servers/10-node-js-http-server.mdx
+++ b/content/examples/15-api-servers/10-node-js-http-server.mdx
@@ -1,0 +1,64 @@
+---
+title: Node.js HTTP Server
+description: Example of using Vercel AI SDK in a Node.js HTTP server.
+---
+
+# Node.js HTTP Server
+
+You can use the Vercel AI SDK in a Node.js HTTP server to generate text and stream it to the client.
+
+## Examples
+
+The examples start a simple HTTP server that listens on port 8080. You can e.g. test it using `curl`:
+
+```bash
+curl -X POST http://localhost:8080
+```
+
+<Note>
+  The examples use the OpenAI `gpt-4o` model. Ensure that the OpenAI API key is
+  set in the `OPENAI_API_KEY` environment variable.
+</Note>
+
+### Basic
+
+You can use the `pipeDataStreamToResponse` method to pipe the stream data to the server response.
+
+```ts file='index.ts'
+import { openai } from '@ai-sdk/openai';
+import { StreamData, streamText } from 'ai';
+import { createServer } from 'http';
+
+createServer(async (req, res) => {
+  const result = await streamText({
+    model: openai('gpt-4o'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  result.pipeDataStreamToResponse(res);
+}).listen(8080);
+```
+
+### With Stream Data
+
+```ts file='index.ts' highlight="6-7,12-15,18"
+import { openai } from '@ai-sdk/openai'
+import { StreamData, streamText } from 'ai'
+import { createServer } from 'http'
+
+createServer(async (req, res) => {
+ const data = new StreamData()
+ data.append('initialized call')
+
+ const result = await streamText({
+   model: openai('gpt-4-turbo'),
+   prompt: 'Invent a new holiday and describe its traditions.'
+   onFinish() {
+     data.append('call completed')
+     data.close()
+   }
+ })
+
+ result.pipeDataStreamToResponse(res, { data })
+}).listen(8080)
+```

--- a/content/examples/15-api-servers/10-node-js-http-server.mdx
+++ b/content/examples/15-api-servers/10-node-js-http-server.mdx
@@ -51,7 +51,7 @@ createServer(async (req, res) => {
  data.append('initialized call')
 
  const result = await streamText({
-   model: openai('gpt-4-turbo'),
+   model: openai('gpt-4o'),
    prompt: 'Invent a new holiday and describe its traditions.'
    onFinish() {
      data.append('call completed')

--- a/content/examples/15-api-servers/10-node-js-http-server.mdx
+++ b/content/examples/15-api-servers/10-node-js-http-server.mdx
@@ -42,23 +42,23 @@ createServer(async (req, res) => {
 ### With Stream Data
 
 ```ts file='index.ts' highlight="6-7,12-15,18"
-import { openai } from '@ai-sdk/openai'
-import { StreamData, streamText } from 'ai'
-import { createServer } from 'http'
+import { openai } from '@ai-sdk/openai';
+import { StreamData, streamText } from 'ai';
+import { createServer } from 'http';
 
 createServer(async (req, res) => {
- const data = new StreamData()
- data.append('initialized call')
+  const data = new StreamData();
+  data.append('initialized call');
 
- const result = await streamText({
-   model: openai('gpt-4o'),
-   prompt: 'Invent a new holiday and describe its traditions.'
-   onFinish() {
-     data.append('call completed')
-     data.close()
-   }
- })
+  const result = await streamText({
+    model: openai('gpt-4o'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    onFinish() {
+      data.append('call completed');
+      data.close();
+    },
+  });
 
- result.pipeDataStreamToResponse(res, { data })
-}).listen(8080)
+  result.pipeDataStreamToResponse(res, { data });
+}).listen(8080);
 ```

--- a/content/examples/15-api-servers/index.mdx
+++ b/content/examples/15-api-servers/index.mdx
@@ -1,0 +1,18 @@
+---
+title: API Servers
+description: Explore examples of using Vercel AI SDK in your Node.js application.
+---
+
+# API Server Examples
+
+You can use the Vercel AI SDK in any JavaScript API server to generate text and stream it to the client.
+
+<IndexCards
+  cards={[
+    {
+      title: 'Node.js HTTP Server',
+      description: 'Stream text to a Node.js HTTP server.',
+      href: '/examples/api-servers/node-js-http-server',
+    },
+  ]}
+/>

--- a/examples/node-http-server/src/server.ts
+++ b/examples/node-http-server/src/server.ts
@@ -9,8 +9,8 @@ createServer(async (req, res) => {
   data.append('initialized call');
 
   const result = await streamText({
-    model: openai('gpt-4-turbo'),
-    prompt: 'What is the weather in San Francisco?',
+    model: openai('gpt-4o'),
+    prompt: 'Invent a new holiday and describe its traditions.',
     onFinish() {
       data.append('call completed');
       data.close();


### PR DESCRIPTION
## Summary
* Introduces a new section "API Servers" (where Hono, Fastify, Express etc examples can go)