### PR TITLE
feat (ai/core): add output: enum to generateObject

### DIFF
--- a/.changeset/late-jeans-pull.md
+++ b/.changeset/late-jeans-pull.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): add output: enum to generateObject

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -101,7 +101,8 @@ for await (const hero of elementStream) {
 
 ### Enum
 
-If you want to generate a specific enum value, you can set the output strategy to `enum`
+If you want to generate a specific enum value, e.g. for classification tasks,
+you can set the output strategy to `enum`
 and provide a list of possible values in the `enum` parameter.
 
 <Note>Enum output is only available with `generateObject`.</Note>

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -106,7 +106,7 @@ and provide the list of possible values in the `enum` parameter.
 
 <Note>Enum output is only available with `generateObject`.</Note>
 
-```ts
+```ts highlight="5-6"
 import { generateObject } from 'ai';
 
 const { object } = await generateObject({

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -65,12 +65,12 @@ You can use `streamObject` to stream generated UIs in combination with React Ser
 
 You can use both functions with different output strategies, e.g. `array`, `object`, or `no-schema`.
 
-### Output Strategy: Object
+### Object
 
 The default output strategy is `object`, which returns the generated data as an object.
 You don't need to specify the output strategy if you want to use the default.
 
-### Output Strategy: Array
+### Array
 
 If you want to generate an array of objects, you can set the output strategy to `array`.
 When you use the `array` output strategy, the schema specifies the shape of an array element.
@@ -99,7 +99,28 @@ for await (const hero of elementStream) {
 }
 ```
 
-### Output Strategy: No Schema
+### Enum
+
+If you want to generate a specific enum value, you can set the output strategy to `enum`
+and provide the list of possible values in the `enum` parameter.
+
+<Note>Enum output is only available with `generateObject`.</Note>
+
+```ts
+import { generateObject } from 'ai';
+
+const { object } = await generateObject({
+  model: yourModel,
+  output: 'enum',
+  enum: ['action', 'comedy', 'drama', 'horror', 'sci-fi'],
+  prompt:
+    'Classify the genre of this movie plot: ' +
+    '"A group of astronauts travel through a wormhole in search of a ' +
+    'new habitable planet for humanity."',
+});
+```
+
+### No Schema
 
 In some cases, you might not want to use a schema,
 for example when the data is a dynamic user request.

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -102,7 +102,7 @@ for await (const hero of elementStream) {
 ### Enum
 
 If you want to generate a specific enum value, you can set the output strategy to `enum`
-and provide the list of possible values in the `enum` parameter.
+and provide a list of possible values in the `enum` parameter.
 
 <Note>Enum output is only available with `generateObject`.</Note>
 

--- a/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
@@ -57,7 +57,7 @@ const { object } = await generateObject({
 #### Example: generate an enum
 
 When you want to generate a specific enum value, you can set the output strategy to `enum`
-and provide the list of possible values in the `enum` parameter.
+and provide a list of possible values in the `enum` parameter.
 
 ```ts highlight="5-6"
 import { generateObject } from 'ai';

--- a/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
@@ -54,6 +54,25 @@ const { object } = await generateObject({
 });
 ```
 
+#### Example: generate an enum
+
+When you want to generate a specific enum value, you can set the output strategy to `enum`
+and provide the list of possible values in the `enum` parameter.
+
+```ts highlight="5-6"
+import { generateObject } from 'ai';
+
+const { object } = await generateObject({
+  model: yourModel,
+  output: 'enum',
+  enum: ['action', 'comedy', 'drama', 'horror', 'sci-fi'],
+  prompt:
+    'Classify the genre of this movie plot: ' +
+    '"A group of astronauts travel through a wormhole in search of a ' +
+    'new habitable planet for humanity."',
+});
+```
+
 #### Example: generate JSON without a schema
 
 ```ts highlight="6"
@@ -86,7 +105,7 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
     },
     {
       name: 'output',
-      type: "'object' | 'array' | 'no-schema' | undefined",
+      type: "'object' | 'array' | 'enum' | 'no-schema' | undefined",
       description: "The type of output to generate. Defaults to 'object'.",
     },
     {
@@ -105,7 +124,7 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
         'It is sent to the model to generate the object and used to validate the output. ' +
         'You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function). ' +
         'In "array" mode, the schema is used to describe an array element. ' +
-        'Not available with "no-schema" output.',
+        'Not available with "no-schema" or "enum" output.',
     },
     {
       name: 'schemaName',
@@ -113,7 +132,7 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
       description:
         'Optional name of the output that should be generated. ' +
         'Used by some providers for additional LLM guidance, e.g. via tool or schema name. ' +
-        'Not available with "no-schema" output.',
+        'Not available with "no-schema" or "enum" output.',
     },
     {
       name: 'schemaDescription',
@@ -121,7 +140,14 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
       description:
         'Optional description of the output that should be generated. ' +
         'Used by some providers for additional LLM guidance, e.g. via tool or schema name. ' +
-        'Not available with "no-schema" output.',
+        'Not available with "no-schema" or "enum" output.',
+    },
+    {
+      name: 'enum',
+      type: 'string[]',
+      description:
+        'List of possible values to generate. ' +
+        'Only available with "enum" output.',
     },
     {
       name: 'system',

--- a/examples/ai-core/src/generate-object/google-enum.ts
+++ b/examples/ai-core/src/generate-object/google-enum.ts
@@ -1,10 +1,10 @@
-import { openai } from '@ai-sdk/openai';
+import { google } from '@ai-sdk/google';
 import { generateObject } from 'ai';
 import 'dotenv/config';
 
 async function main() {
   const result = await generateObject({
-    model: openai('gpt-4o-mini', { structuredOutputs: true }),
+    model: google('gemini-1.5-pro-latest'),
     output: 'enum',
     enum: ['sunny', 'rainy', 'snowy'],
     prompt: 'Choose a random weather condition.',

--- a/examples/ai-core/src/generate-object/google-enum.ts
+++ b/examples/ai-core/src/generate-object/google-enum.ts
@@ -6,8 +6,11 @@ async function main() {
   const result = await generateObject({
     model: google('gemini-1.5-pro-latest'),
     output: 'enum',
-    enum: ['sunny', 'rainy', 'snowy'],
-    prompt: 'Choose a random weather condition.',
+    enum: ['action', 'comedy', 'drama', 'horror', 'sci-fi'],
+    prompt:
+      'Classify the genre of this movie plot: ' +
+      '"A group of astronauts travel through a wormhole in search of a ' +
+      'new habitable planet for humanity."',
   });
 
   console.log(result.object);

--- a/examples/ai-core/src/generate-object/openai-enum.ts
+++ b/examples/ai-core/src/generate-object/openai-enum.ts
@@ -6,8 +6,11 @@ async function main() {
   const result = await generateObject({
     model: openai('gpt-4o-mini', { structuredOutputs: true }),
     output: 'enum',
-    enum: ['sunny', 'rainy', 'snowy'],
-    prompt: 'Choose a random weather condition.',
+    enum: ['action', 'comedy', 'drama', 'horror', 'sci-fi'],
+    prompt:
+      'Classify the genre of this movie plot: ' +
+      '"A group of astronauts travel through a wormhole in search of a ' +
+      'new habitable planet for humanity."',
   });
 
   console.log(result.object);

--- a/examples/ai-core/src/generate-object/openai-enum.ts
+++ b/examples/ai-core/src/generate-object/openai-enum.ts
@@ -1,0 +1,21 @@
+import { openai } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const result = await generateObject({
+    model: openai('gpt-4o-mini', { structuredOutputs: true }),
+    output: 'enum',
+    enum: ['sunny', 'rainy', 'snowy'],
+    prompt: 'Choose a random weather condition.',
+  });
+
+  console.log(result.object);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -587,6 +587,57 @@ describe('output = "array"', () => {
   });
 });
 
+describe('output = "enum"', () => {
+  it('should generate an enum value', async () => {
+    const result = await generateObject({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({ prompt, mode }) => {
+          expect(mode).toEqual({
+            type: 'object-json',
+            name: undefined,
+            description: undefined,
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              additionalProperties: false,
+              properties: {
+                result: {
+                  type: 'string',
+                  enum: ['sunny', 'rainy', 'snowy'],
+                },
+              },
+              required: ['result'],
+              type: 'object',
+            },
+          });
+
+          expect(prompt).toEqual([
+            {
+              role: 'system',
+              content:
+                'JSON schema:\n' +
+                `{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"result\":{\"type\":\"string\",\"enum\":[\"sunny\",\"rainy\",\"snowy\"]}},\"required\":[\"result\"],\"additionalProperties\":false}` +
+                `\n` +
+                'You MUST answer with a JSON object that matches the JSON schema above.',
+            },
+            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+          ]);
+
+          return {
+            ...dummyResponseValues,
+            text: JSON.stringify({ result: 'sunny' }),
+          };
+        },
+      }),
+      output: 'enum',
+      enum: ['sunny', 'rainy', 'snowy'],
+      mode: 'json',
+      prompt: 'prompt',
+    });
+
+    expect(result.object).toEqual('sunny');
+  });
+});
+
 describe('output = "no-schema"', () => {
   it('should generate object', async () => {
     const result = await generateObject({

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -166,6 +166,58 @@ Optional telemetry configuration (experimental).
     },
 ): Promise<GenerateObjectResult<Array<ELEMENT>>>;
 /**
+Generate a value from an enum (limited list of string values) using a language model.
+
+This function does not stream the output.
+
+@return
+A result object that contains the generated value, the finish reason, the token usage, and additional information.
+ */
+export async function generateObject<ENUM extends string>(
+  options: Omit<CallSettings, 'stopSequences'> &
+    Prompt & {
+      output: 'enum';
+
+      /**
+The language model to use.
+     */
+      model: LanguageModel;
+
+      /**
+The enum values that the model should use.
+     */
+      enum: Array<ENUM>;
+
+      /**
+The mode to use for object generation.
+
+The schema is converted in a JSON schema and used in one of the following ways
+
+- 'auto': The provider will choose the best mode for the model.
+- 'tool': A tool with the JSON schema as parameters is is provided and the provider is instructed to use it.
+- 'json': The JSON schema and an instruction is injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
+
+Please note that most providers do not support all modes.
+
+Default and recommended: 'auto' (best mode for the model).
+     */
+      mode?: 'auto' | 'json' | 'tool';
+
+      /**
+Optional telemetry configuration (experimental).
+     */
+      experimental_telemetry?: TelemetrySettings;
+
+      /**
+       * Internal. For test use only. May change without notice.
+       */
+      _internal?: {
+        generateId?: () => string;
+        currentDate?: () => Date;
+      };
+    },
+): Promise<GenerateObjectResult<ENUM>>;
+/**
 Generate JSON with any schema for a given prompt using a language model.
 
 This function does not stream the output. If you want to stream the output, use `streamObject` instead.
@@ -204,6 +256,7 @@ Optional telemetry configuration (experimental).
 ): Promise<GenerateObjectResult<JSONValue>>;
 export async function generateObject<SCHEMA, RESULT>({
   model,
+  enum: enumValues, // rename bc enum is reserved by typescript
   schema: inputSchema,
   schemaName,
   schemaDescription,
@@ -232,9 +285,10 @@ export async function generateObject<SCHEMA, RESULT>({
      *
      * Default is 'object' if not specified.
      */
-    output?: 'object' | 'array' | 'no-schema';
+    output?: 'object' | 'array' | 'enum' | 'no-schema';
 
     model: LanguageModel;
+    enum?: Array<SCHEMA>;
     schema?: z.Schema<SCHEMA, z.ZodTypeDef, any> | Schema<SCHEMA>;
     schemaName?: string;
     schemaDescription?: string;
@@ -249,6 +303,7 @@ export async function generateObject<SCHEMA, RESULT>({
       currentDate?: () => Date;
     };
   }): Promise<GenerateObjectResult<RESULT>> {
+  // TODO extend validation to support enum output
   validateObjectGenerationInput({
     output,
     mode,
@@ -257,7 +312,11 @@ export async function generateObject<SCHEMA, RESULT>({
     schemaDescription,
   });
 
-  const outputStrategy = getOutputStrategy({ output, schema: inputSchema });
+  const outputStrategy = getOutputStrategy({
+    output,
+    schema: inputSchema,
+    enumValues,
+  });
 
   // automatically set mode to 'json' for no-schema output
   if (outputStrategy.type === 'no-schema' && mode === undefined) {

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -303,13 +303,13 @@ export async function generateObject<SCHEMA, RESULT>({
       currentDate?: () => Date;
     };
   }): Promise<GenerateObjectResult<RESULT>> {
-  // TODO extend validation to support enum output
   validateObjectGenerationInput({
     output,
     mode,
     schema: inputSchema,
     schemaName,
     schemaDescription,
+    enumValues,
   });
 
   const outputStrategy = getOutputStrategy({

--- a/packages/ai/core/generate-object/validate-object-generation-input.ts
+++ b/packages/ai/core/generate-object/validate-object-generation-input.ts
@@ -9,7 +9,7 @@ export function validateObjectGenerationInput({
   schemaName,
   schemaDescription,
 }: {
-  output?: 'object' | 'array' | 'no-schema';
+  output?: 'object' | 'array' | 'enum' | 'no-schema';
   schema?: z.Schema<any, z.ZodTypeDef, any> | Schema<any>;
   schemaName?: string;
   schemaDescription?: string;
@@ -19,6 +19,7 @@ export function validateObjectGenerationInput({
     output != null &&
     output !== 'object' &&
     output !== 'array' &&
+    output !== 'enum' &&
     output !== 'no-schema'
   ) {
     throw new InvalidArgumentError({

--- a/packages/ai/core/generate-object/validate-object-generation-input.ts
+++ b/packages/ai/core/generate-object/validate-object-generation-input.ts
@@ -8,11 +8,13 @@ export function validateObjectGenerationInput({
   schema,
   schemaName,
   schemaDescription,
+  enumValues,
 }: {
   output?: 'object' | 'array' | 'enum' | 'no-schema';
   schema?: z.Schema<any, z.ZodTypeDef, any> | Schema<any>;
   schemaName?: string;
   schemaDescription?: string;
+  enumValues?: Array<unknown>;
   mode?: 'auto' | 'json' | 'tool';
 }) {
   if (
@@ -61,6 +63,14 @@ export function validateObjectGenerationInput({
         message: 'Schema name is not supported for no-schema output.',
       });
     }
+
+    if (enumValues != null) {
+      throw new InvalidArgumentError({
+        parameter: 'enumValues',
+        value: enumValues,
+        message: 'Enum values are not supported for no-schema output.',
+      });
+    }
   }
 
   if (output === 'object') {
@@ -69,6 +79,14 @@ export function validateObjectGenerationInput({
         parameter: 'schema',
         value: schema,
         message: 'Schema is required for object output.',
+      });
+    }
+
+    if (enumValues != null) {
+      throw new InvalidArgumentError({
+        parameter: 'enumValues',
+        value: enumValues,
+        message: 'Enum values are not supported for object output.',
       });
     }
   }
@@ -80,6 +98,58 @@ export function validateObjectGenerationInput({
         value: schema,
         message: 'Element schema is required for array output.',
       });
+    }
+
+    if (enumValues != null) {
+      throw new InvalidArgumentError({
+        parameter: 'enumValues',
+        value: enumValues,
+        message: 'Enum values are not supported for array output.',
+      });
+    }
+  }
+
+  if (output === 'enum') {
+    if (schema != null) {
+      throw new InvalidArgumentError({
+        parameter: 'schema',
+        value: schema,
+        message: 'Schema is not supported for enum output.',
+      });
+    }
+
+    if (schemaDescription != null) {
+      throw new InvalidArgumentError({
+        parameter: 'schemaDescription',
+        value: schemaDescription,
+        message: 'Schema description is not supported for enum output.',
+      });
+    }
+
+    if (schemaName != null) {
+      throw new InvalidArgumentError({
+        parameter: 'schemaName',
+        value: schemaName,
+        message: 'Schema name is not supported for enum output.',
+      });
+    }
+
+    if (enumValues == null) {
+      throw new InvalidArgumentError({
+        parameter: 'enumValues',
+        value: enumValues,
+        message: 'Enum values are required for enum output.',
+      });
+    }
+
+    for (const value of enumValues) {
+      if (typeof value !== 'string') {
+        throw new InvalidArgumentError({
+          parameter: 'enumValues',
+          value,
+          message: 'Enum values must be strings.',
+        });
+      }
     }
   }
 }

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -21,10 +21,11 @@ The model can take this information and e.g. configure json mode, the correct
 low level grammar, etc. It can also be used to optimize the efficiency of the
 streaming, e.g. tool-delta stream parts are only needed in the
 object-tool mode.
-   */
-  // deprecated: mode will be removed in v2.
-  // All necessary settings will be directly supported through the call settings,
-  // in particular responseFormat, toolChoice, and tools.
+
+@deprecated mode will be removed in v2.
+All necessary settings will be directly supported through the call settings,
+in particular responseFormat, toolChoice, and tools.
+  */
   mode:
     | {
         // stream text & complete tool calls

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -25,7 +25,7 @@ object-tool mode.
 @deprecated mode will be removed in v2.
 All necessary settings will be directly supported through the call settings,
 in particular responseFormat, toolChoice, and tools.
-  */
+   */
   mode:
     | {
         // stream text & complete tool calls

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -21,11 +21,10 @@ The model can take this information and e.g. configure json mode, the correct
 low level grammar, etc. It can also be used to optimize the efficiency of the
 streaming, e.g. tool-delta stream parts are only needed in the
 object-tool mode.
-
-@deprecated mode will be removed in v2.
-All necessary settings will be directly supported through the call settings,
-in particular responseFormat, toolChoice, and tools.
    */
+  // deprecated: mode will be removed in v2.
+  // All necessary settings will be directly supported through the call settings,
+  // in particular responseFormat, toolChoice, and tools.
   mode:
     | {
         // stream text & complete tool calls


### PR DESCRIPTION
## Background
Classification tasks are common in AI workflows. This PR improves support for such tasks.

## Tasks

- [x] implementation
   - [x] basic implementation
   - [x] enum mode validation
   - [x] enum mode testing
- [x] examples
   - [x] openai 
   - [x] gemini
- [x] docs
   - [x] reference
   - [x] guide
- [x] changeset