### PR TITLE
feat (ai/core): support providerMetadata in functions

### DIFF
--- a/.changeset/dirty-ears-think.md
+++ b/.changeset/dirty-ears-think.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): support providerMetadata in functions

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -401,6 +401,13 @@ To see `generateText` in action, check out [these examples](#examples).
         },
       ],
     },
+    {
+      name: 'experimental_providerMetadata',
+      type: 'Record<string,Record<string,JSONValue>> | undefined',
+      isOptional: true,
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
   ]}
 />
 

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -411,6 +411,13 @@ To see `streamText` in action, check out [these examples](#examples).
         'Enable streaming of tool call deltas as they are generated. Disabled by default.',
     },
     {
+      name: 'experimental_providerMetadata',
+      type: 'Record<string,Record<string,JSONValue>> | undefined',
+      isOptional: true,
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
+    {
       name: 'onChunk',
       type: '(event: OnChunkResult) => Promise<void> |void',
       isOptional: true,

--- a/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
@@ -57,7 +57,7 @@ const { object } = await generateObject({
 #### Example: generate an enum
 
 When you want to generate a specific enum value, you can set the output strategy to `enum`
-and provide a list of possible values in the `enum` parameter.
+and provide the list of possible values in the `enum` parameter.
 
 ```ts highlight="5-6"
 import { generateObject } from 'ai';
@@ -457,6 +457,13 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
           ],
         },
       ],
+    },
+    {
+      name: 'experimental_providerMetadata',
+      type: 'Record<string,Record<string,JSONValue>> | undefined',
+      isOptional: true,
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
   ]}
 />

--- a/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
@@ -446,6 +446,13 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
       ],
     },
     {
+      name: 'experimental_providerMetadata',
+      type: 'Record<string,Record<string,JSONValue>> | undefined',
+      isOptional: true,
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
+    {
       name: 'onFinish',
       type: '(result: OnFinishResult) => void',
       isOptional: true,

--- a/content/docs/07-reference/ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/ai-sdk-rsc/01-stream-ui.mdx
@@ -357,6 +357,13 @@ To see `streamUI` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'experimental_providerMetadata',
+      type: 'Record<string,Record<string,JSONValue>> | undefined',
+      isOptional: true,
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
+    {
       name: 'onFinish',
       type: '(result: OnFinishResult) => void',
       isOptional: true,

--- a/examples/ai-core/src/generate-text/openai-log-metadata-middleware.ts
+++ b/examples/ai-core/src/generate-text/openai-log-metadata-middleware.ts
@@ -1,0 +1,35 @@
+import { openai } from '@ai-sdk/openai';
+import {
+  generateText,
+  Experimental_LanguageModelV1Middleware as LanguageModelV1Middleware,
+  experimental_wrapLanguageModel as wrapLanguageModel,
+} from 'ai';
+import 'dotenv/config';
+
+const logProviderMetadataMiddleware: LanguageModelV1Middleware = {
+  transformParams: async ({ params }) => {
+    console.log(
+      'providerMetadata: ' + JSON.stringify(params.providerMetadata, null, 2),
+    );
+    return params;
+  },
+};
+
+async function main() {
+  const { text } = await generateText({
+    model: wrapLanguageModel({
+      model: openai('gpt-4o'),
+      middleware: logProviderMetadataMiddleware,
+    }),
+    experimental_providerMetadata: {
+      myMiddleware: {
+        example: 'value',
+      },
+    },
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(text);
+}
+
+main().catch(console.error);

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -91,6 +91,13 @@ Optional telemetry configuration (experimental).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+      experimental_providerMetadata?: ProviderMetadata;
+
+      /**
        * Internal. For test use only. May change without notice.
        */
       _internal?: {
@@ -157,6 +164,13 @@ Optional telemetry configuration (experimental).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+      experimental_providerMetadata?: ProviderMetadata;
+
+      /**
        * Internal. For test use only. May change without notice.
        */
       _internal?: {
@@ -209,6 +223,13 @@ Optional telemetry configuration (experimental).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+      experimental_providerMetadata?: ProviderMetadata;
+
+      /**
        * Internal. For test use only. May change without notice.
        */
       _internal?: {
@@ -246,6 +267,13 @@ Optional telemetry configuration (experimental).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+      experimental_providerMetadata?: ProviderMetadata;
+
+      /**
        * Internal. For test use only. May change without notice.
        */
       _internal?: {
@@ -269,6 +297,7 @@ export async function generateObject<SCHEMA, RESULT>({
   abortSignal,
   headers,
   experimental_telemetry: telemetry,
+  experimental_providerMetadata: providerMetadata,
   _internal: {
     generateId = originalGenerateId,
     currentDate = () => new Date(),
@@ -294,6 +323,7 @@ export async function generateObject<SCHEMA, RESULT>({
     schemaDescription?: string;
     mode?: 'auto' | 'json' | 'tool';
     experimental_telemetry?: TelemetrySettings;
+    experimental_providerMetadata?: ProviderMetadata;
 
     /**
      * Internal. For test use only. May change without notice.
@@ -371,7 +401,7 @@ export async function generateObject<SCHEMA, RESULT>({
       let rawResponse: { headers?: Record<string, string> } | undefined;
       let response: LanguageModelResponseMetadata;
       let logprobs: LogProbs | undefined;
-      let providerMetadata: ProviderMetadata | undefined;
+      let resultProviderMetadata: ProviderMetadata | undefined;
 
       switch (mode) {
         case 'json': {
@@ -438,6 +468,7 @@ export async function generateObject<SCHEMA, RESULT>({
                   ...prepareCallSettings(settings),
                   inputFormat,
                   prompt: promptMessages,
+                  providerMetadata,
                   abortSignal,
                   headers,
                 });
@@ -494,7 +525,7 @@ export async function generateObject<SCHEMA, RESULT>({
           warnings = generateResult.warnings;
           rawResponse = generateResult.rawResponse;
           logprobs = generateResult.logprobs;
-          providerMetadata = generateResult.providerMetadata;
+          resultProviderMetadata = generateResult.providerMetadata;
           response = generateResult.responseData;
 
           break;
@@ -559,6 +590,7 @@ export async function generateObject<SCHEMA, RESULT>({
                   ...prepareCallSettings(settings),
                   inputFormat,
                   prompt: promptMessages,
+                  providerMetadata,
                   abortSignal,
                   headers,
                 });
@@ -617,7 +649,7 @@ export async function generateObject<SCHEMA, RESULT>({
           warnings = generateResult.warnings;
           rawResponse = generateResult.rawResponse;
           logprobs = generateResult.logprobs;
-          providerMetadata = generateResult.providerMetadata;
+          resultProviderMetadata = generateResult.providerMetadata;
           response = generateResult.responseData;
 
           break;
@@ -681,7 +713,7 @@ export async function generateObject<SCHEMA, RESULT>({
           headers: rawResponse?.headers,
         },
         logprobs,
-        providerMetadata,
+        providerMetadata: resultProviderMetadata,
       });
     },
   });

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -159,6 +159,13 @@ Optional telemetry configuration (experimental).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+      experimental_providerMetadata?: ProviderMetadata;
+
+      /**
 Callback that is called when the LLM response and the final object validation are finished.
      */
       onFinish?: OnFinishCallback<OBJECT>;
@@ -231,6 +238,13 @@ Optional telemetry configuration (experimental).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+      experimental_providerMetadata?: ProviderMetadata;
+
+      /**
 Callback that is called when the LLM response and the final object validation are finished.
      */
       onFinish?: OnFinishCallback<Array<ELEMENT>>;
@@ -280,6 +294,13 @@ Optional telemetry configuration (experimental).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+      experimental_providerMetadata?: ProviderMetadata;
+
+      /**
 Callback that is called when the LLM response and the final object validation are finished.
      */
       onFinish?: OnFinishCallback<JSONValue>;
@@ -308,6 +329,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
   abortSignal,
   headers,
   experimental_telemetry: telemetry,
+  experimental_providerMetadata: providerMetadata,
   onFinish,
   _internal: {
     generateId = originalGenerateId,
@@ -334,6 +356,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
     schemaDescription?: string;
     mode?: 'auto' | 'json' | 'tool';
     experimental_telemetry?: TelemetrySettings;
+    experimental_providerMetadata?: ProviderMetadata;
     onFinish?: OnFinishCallback<RESULT>;
     _internal?: {
       generateId?: () => string;
@@ -434,6 +457,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
               prompt: validatedPrompt,
               modelSupportsImageUrls: model.supportsImageUrls,
             }),
+            providerMetadata,
             abortSignal,
             headers,
           };
@@ -479,6 +503,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
               prompt: validatedPrompt,
               modelSupportsImageUrls: model.supportsImageUrls,
             }),
+            providerMetadata,
             abortSignal,
             headers,
           };

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -6,8 +6,6 @@ import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
 import { MockTracer } from '../test/mock-tracer';
 import { generateText } from './generate-text';
 import { GenerateTextResult } from './generate-text-result';
-import { mockId } from '../test/mock-id';
-import { mockValues } from '../test/mock-values';
 
 const dummyResponseValues = {
   rawCall: { rawPrompt: 'prompt', rawSettings: {} },
@@ -628,6 +626,28 @@ describe('options.headers', () => {
     });
 
     assert.deepStrictEqual(result.text, 'Hello, world!');
+  });
+});
+
+describe('options.providerMetadata', () => {
+  it('should pass provider metadata to model', async () => {
+    const result = await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({ providerMetadata }) => {
+          expect(providerMetadata).toStrictEqual({
+            aProvider: { someKey: 'someValue' },
+          });
+
+          return { ...dummyResponseValues, text: 'provider metadata test' };
+        },
+      }),
+      prompt: 'test-input',
+      experimental_providerMetadata: {
+        aProvider: { someKey: 'someValue' },
+      },
+    });
+
+    expect(result.text).toStrictEqual('provider metadata test');
   });
 });
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -87,7 +87,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
   experimental_telemetry: telemetry,
-  experimental_providerMetadata,
+  experimental_providerMetadata: providerMetadata,
   _internal: {
     generateId = originalGenerateId,
     currentDate = () => new Date(),
@@ -248,7 +248,7 @@ functionality that can be fully encapsulated in the provider.
                 ...callSettings,
                 inputFormat: currentInputFormat,
                 prompt: promptMessages,
-                providerMetadata: experimental_providerMetadata,
+                providerMetadata,
                 abortSignal,
                 headers,
               });

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -87,6 +87,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
   experimental_telemetry: telemetry,
+  experimental_providerMetadata,
   _internal: {
     generateId = originalGenerateId,
     currentDate = () => new Date(),
@@ -247,6 +248,7 @@ functionality that can be fully encapsulated in the provider.
                 ...callSettings,
                 inputFormat: currentInputFormat,
                 prompt: promptMessages,
+                providerMetadata: experimental_providerMetadata,
                 abortSignal,
                 headers,
               });

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -18,7 +18,7 @@ import { recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { CoreTool } from '../tool/tool';
-import { CoreToolChoice, LanguageModel } from '../types';
+import { CoreToolChoice, LanguageModel, ProviderMetadata } from '../types';
 import {
   LanguageModelUsage,
   calculateLanguageModelUsage,
@@ -132,6 +132,13 @@ By default, it's set to 0, which will disable the feature.
      * Optional telemetry configuration (experimental).
      */
     experimental_telemetry?: TelemetrySettings;
+
+    /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+    experimental_providerMetadata?: ProviderMetadata;
 
     /**
      * Internal. For test use only. May change without notice.

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -2745,6 +2745,42 @@ describe('options.headers', () => {
   });
 });
 
+describe('options.providerMetadata', () => {
+  it('should pass provider metadata to model', async () => {
+    const result = await streamText({
+      model: new MockLanguageModelV1({
+        doStream: async ({ providerMetadata }) => {
+          expect(providerMetadata).toStrictEqual({
+            aProvider: { someKey: 'someValue' },
+          });
+
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'text-delta', textDelta: 'provider metadata test' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                logprobs: undefined,
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          };
+        },
+      }),
+      prompt: 'test-input',
+      experimental_providerMetadata: {
+        aProvider: { someKey: 'someValue' },
+      },
+    });
+
+    assert.deepStrictEqual(
+      await convertAsyncIterableToArray(result.textStream),
+      ['provider metadata test'],
+    );
+  });
+});
+
 describe('telemetry', () => {
   let tracer: MockTracer;
 

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -115,6 +115,7 @@ export async function streamText<TOOLS extends Record<string, CoreTool>>({
   headers,
   maxToolRoundtrips = 0,
   experimental_telemetry: telemetry,
+  experimental_providerMetadata: providerMetadata,
   experimental_toolCallStreaming: toolCallStreaming = false,
   onChunk,
   onFinish,
@@ -159,6 +160,13 @@ By default, it's set to 0, which will disable the feature.
 Optional telemetry configuration (experimental).
      */
     experimental_telemetry?: TelemetrySettings;
+
+    /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+    experimental_providerMetadata?: ProviderMetadata;
 
     /**
 Enable streaming of tool call deltas as they are generated. Disabled by default.
@@ -332,6 +340,7 @@ results that can be fully encapsulated in the provider.
                 ...prepareCallSettings(settings),
                 inputFormat: promptType,
                 prompt: promptMessages,
+                providerMetadata,
                 abortSignal,
                 headers,
               }),

--- a/packages/ai/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
+++ b/packages/ai/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`options.headers > should set headers 1`] = `
+exports[`options.headers > should pass headers to model 1`] = `
 {
   "children": {
     "children": {},
@@ -9,30 +9,10 @@ exports[`options.headers > should set headers 1`] = `
       "n": {
         "done": false,
         "next": {
-          "done": false,
-          "next": {
-            "done": false,
-            "next": {
-              "done": false,
-              "next": {
-                "done": false,
-                "next": {
-                  "done": false,
-                  "next": {
-                    "done": true,
-                    "value": "{ "content": "Hello, world!" }",
-                  },
-                  "value": "{ "content": "Hello, world!" }",
-                },
-                "value": "{ "content": "Hello, world!"",
-              },
-              "value": "{ "content": "Hello, world",
-            },
-            "value": "{ "content": "Hello, ",
-          },
-          "value": "{ "content": ",
+          "done": true,
+          "value": "{ "content": "headers test" }",
         },
-        "value": "{ ",
+        "value": "{ "content": "headers test" }",
       },
     },
     "type": "",

--- a/packages/ai/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
+++ b/packages/ai/rsc/stream-ui/__snapshots__/stream-ui.ui.test.tsx.snap
@@ -24,6 +24,30 @@ exports[`options.headers > should pass headers to model 1`] = `
 }
 `;
 
+exports[`options.providerMetadata > should pass provider metadata to model 1`] = `
+{
+  "children": {
+    "children": {},
+    "props": {
+      "c": undefined,
+      "n": {
+        "done": false,
+        "next": {
+          "done": true,
+          "value": "{ "content": "provider metadata test" }",
+        },
+        "value": "{ "content": "provider metadata test" }",
+      },
+    },
+    "type": "",
+  },
+  "props": {
+    "fallback": undefined,
+  },
+  "type": "Symbol(react.suspense)",
+}
+`;
+
 exports[`result.value > should render text 1`] = `
 {
   "children": {

--- a/packages/ai/rsc/stream-ui/stream-ui.tsx
+++ b/packages/ai/rsc/stream-ui/stream-ui.tsx
@@ -8,7 +8,12 @@ import { prepareCallSettings } from '../../core/prompt/prepare-call-settings';
 import { prepareToolsAndToolChoice } from '../../core/prompt/prepare-tools-and-tool-choice';
 import { Prompt } from '../../core/prompt/prompt';
 import { validatePrompt } from '../../core/prompt/validate-prompt';
-import { CallWarning, CoreToolChoice, FinishReason } from '../../core/types';
+import {
+  CallWarning,
+  CoreToolChoice,
+  FinishReason,
+  ProviderMetadata,
+} from '../../core/types';
 import {
   LanguageModelUsage,
   calculateLanguageModelUsage,
@@ -90,6 +95,7 @@ export async function streamUI<
   headers,
   initial,
   text,
+  experimental_providerMetadata: providerMetadata,
   onFinish,
   ...settings
 }: CallSettings &
@@ -113,6 +119,14 @@ export async function streamUI<
 
     text?: RenderText;
     initial?: ReactNode;
+
+    /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+ */
+    experimental_providerMetadata?: ProviderMetadata;
+
     /**
      * Callback that is called when the LLM response and the final object validation are finished.
      */
@@ -242,6 +256,7 @@ export async function streamUI<
         prompt: validatedPrompt,
         modelSupportsImageUrls: model.supportsImageUrls,
       }),
+      providerMetadata,
       abortSignal,
       headers,
     }),

--- a/packages/ai/rsc/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/ai/rsc/stream-ui/stream-ui.ui.test.tsx
@@ -231,22 +231,20 @@ describe('rsc - streamUI() onFinish callback', () => {
 });
 
 describe('options.headers', () => {
-  it('should set headers', async () => {
+  it('should pass headers to model', async () => {
     const result = await streamUI({
       model: new MockLanguageModelV1({
         doStream: async ({ headers }) => {
-          assert.deepStrictEqual(headers, {
+          expect(headers).toStrictEqual({
             'custom-request-header': 'request-header-value',
           });
 
           return {
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
+              {
+                type: 'text-delta',
+                textDelta: '{ "content": "headers test" }',
+              },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -262,7 +260,6 @@ describe('options.headers', () => {
       headers: { 'custom-request-header': 'request-header-value' },
     });
 
-    const rendered = await simulateFlightServerRender(result.value);
-    expect(rendered).toMatchSnapshot();
+    expect(await simulateFlightServerRender(result.value)).toMatchSnapshot();
   });
 });

--- a/packages/ai/rsc/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/ai/rsc/stream-ui/stream-ui.ui.test.tsx
@@ -263,3 +263,39 @@ describe('options.headers', () => {
     expect(await simulateFlightServerRender(result.value)).toMatchSnapshot();
   });
 });
+
+describe('options.providerMetadata', () => {
+  it('should pass provider metadata to model', async () => {
+    const result = await streamUI({
+      model: new MockLanguageModelV1({
+        doStream: async ({ providerMetadata }) => {
+          expect(providerMetadata).toStrictEqual({
+            aProvider: { someKey: 'someValue' },
+          });
+
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'text-delta',
+                textDelta: '{ "content": "provider metadata test" }',
+              },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                logprobs: undefined,
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          };
+        },
+      }),
+      prompt: '',
+      experimental_providerMetadata: {
+        aProvider: { someKey: 'someValue' },
+      },
+    });
+
+    expect(await simulateFlightServerRender(result.value)).toMatchSnapshot();
+  });
+});

--- a/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-call-options.ts
@@ -79,9 +79,9 @@ the language model interface.
   prompt: LanguageModelV1Prompt;
 
   /**
-   * Additional provider-specific metadata. They are passed through
-   * to the provider from the AI SDK and enable provider-specific
-   * functionality that can be fully encapsulated in the provider.
+Additional provider-specific metadata.
+The metadata is passed through to the provider from the AI SDK and enables
+provider-specific functionality that can be fully encapsulated in the provider.
    */
   providerMetadata?: LanguageModelV1ProviderMetadata;
 };


### PR DESCRIPTION
## Summary
- add `experimental_providerMetadata` option to functions and pass it through to the model
- improve some headers tests

## Tasks
- [x] implementation
   - [x] generateText passthrough
   - [x] streamText passthrough
   - [x] generateObject json mode passthrough
   - [x] generateObject tool mode passthrough
   - [x] streamObject json mode passthrough
   - [x] streamObject tool mode passthrough
   - [x] streamUI passthrough
- [x] examples
  - [x] generateText
- [x] documentation
   - [x] generateText reference
   - [x] streamText reference
   - [x] generateObject reference
   - [x] streamObject reference
   - [x] streamUI reference
- [x] changeset