### PR TITLE
fix (docs): update createAI example, move AI to separate module

### DIFF
--- a/content/docs/04-ai-sdk-rsc/03-generative-ui-state.mdx
+++ b/content/docs/04-ai-sdk-rsc/03-generative-ui-state.mdx
@@ -69,6 +69,11 @@ export const sendMessage = async (input: string): Promise<ClientMessage> => {
   "use server"
   ...
 }
+```
+
+```tsx filename='app/ai.ts'
+import { createAI } from 'ai/rsc';
+import { ClientMessage, ServerMessage, sendMessage } from './actions';
 
 export type AIState = ServerMessage[];
 export type UIState = ClientMessage[];
@@ -91,7 +96,7 @@ Next, wrap your application with your newly created context. With that, you can 
 
 ```tsx filename='app/layout.tsx'
 import { type ReactNode } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function RootLayout({
   children,
@@ -216,7 +221,7 @@ To call the `sendMessage` action from the client, you can use the [`useActions`]
 'use client';
 
 import { useActions, useUIState } from 'ai/rsc';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function Page() {
   const { sendMessage } = useActions<typeof AI>();

--- a/content/docs/04-ai-sdk-rsc/03-saving-and-restoring-states.mdx
+++ b/content/docs/04-ai-sdk-rsc/03-saving-and-restoring-states.mdx
@@ -13,7 +13,7 @@ AI SDK RSC provides convenient methods for saving and restoring AI and UI state.
 
 The AI state can be saved using the [`onSetAIState`](/docs/reference/ai-sdk-rsc/create-ai#on-set-ai-state) callback, which gets called whenever the AI state is updated. In the following example, you save the chat history to a database whenever the generation is marked as done.
 
-```tsx
+```tsx filename='app/ai.ts'
 export const AI = createAI<ServerMessage[], ClientMessage[]>({
   actions: {
     continueConversation,
@@ -34,7 +34,7 @@ The AI state can be restored using the [`initialAIState`](/docs/reference/ai-sdk
 
 ```tsx file='app/layout.tsx'
 import { ReactNode } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default async function RootLayout({
   children,
@@ -61,7 +61,7 @@ The UI state cannot be saved directly, since the contents aren't yet serializabl
 
 The UI state can be restored using the AI state as a proxy. In the following example, you restore the chat history from the AI state when the component is mounted. You use the [`onGetUIState`](/docs/reference/ai-sdk-rsc/create-ai#on-get-ui-state) callback to listen for SSR events and restore the UI state.
 
-```tsx file='app/components/Chat.tsx'
+```tsx filename='app/ai.ts'
 export const AI = createAI<ServerMessage[], ClientMessage[]>({
   actions: {
     continueConversation,

--- a/content/docs/04-ai-sdk-rsc/04-multistep-interfaces.mdx
+++ b/content/docs/04-ai-sdk-rsc/04-multistep-interfaces.mdx
@@ -43,7 +43,7 @@ The turn-by-turn implementation is the simplest form of multistep interfaces. In
 In the following example, you specify two tools (`searchFlights` and `lookupFlight`) that the model can use to search for flights and lookup details for a specific flight.
 
 ```tsx filename="app/actions.tsx"
-import { createAI, streamUI } from 'ai/rsc';
+import { streamUI } from 'ai/rsc';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 
@@ -126,6 +126,13 @@ export async function submitUserMessage(input: string) {
 
   return ui.value;
 }
+```
+
+Next, create an AI context that will hold the UI State and AI State.
+
+```ts filename='app/ai.ts'
+import { createAI } from 'ai/rsc';
+import { submitUserMessage } from './actions';
 
 export const AI = createAI<any[], React.ReactNode[]>({
   initialUIState: [],
@@ -140,7 +147,7 @@ Next, wrap your application with your newly created context.
 
 ```tsx filename='app/layout.tsx'
 import { type ReactNode } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function RootLayout({
   children,
@@ -161,7 +168,7 @@ To call your Server Action, update your root page with the following:
 'use client';
 
 import { useState } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 import { useActions, useUIState } from 'ai/rsc';
 
 export default function Page() {

--- a/content/examples/01-next-app/04-state-management/01-ai-ui-states.mdx
+++ b/content/examples/01-next-app/04-state-management/01-ai-ui-states.mdx
@@ -15,7 +15,7 @@ Let's use layout to wrap the children components of page with the AI context pro
 
 ```tsx filename='app/layout.tsx'
 import { ReactNode } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function RootLayout({
   children,
@@ -92,7 +92,7 @@ export default function Home() {
 ```tsx filename='app/actions.tsx'
 'use server';
 
-import { createAI, getMutableAIState, streamUI } from 'ai/rsc';
+import { getMutableAIState, streamUI } from 'ai/rsc';
 import { openai } from '@ai-sdk/openai';
 import { ReactNode } from 'react';
 import { z } from 'zod';
@@ -163,6 +163,13 @@ export async function continueConversation(
     display: result.value,
   };
 }
+```
+
+Finally, create the AI context provider.
+
+```typescript filename='app/ai.ts'
+import { createAI } from 'ai/rsc';
+import { ServerMessage, ClientMessage, continueConversation } from './actions';
 
 export const AI = createAI<ServerMessage[], ClientMessage[]>({
   actions: {

--- a/content/examples/01-next-app/04-state-management/02-save-and-restore-states.mdx
+++ b/content/examples/01-next-app/04-state-management/02-save-and-restore-states.mdx
@@ -12,7 +12,8 @@ Sometimes conversations with language models can get interesting and you might w
 ## Client
 
 ```tsx filename='app/layout.tsx'
-import { AI, ServerMessage } from './actions';
+import { ServerMessage } from './actions';
+import { AI } from './ai';
 
 export default function RootLayout({
   children,
@@ -98,7 +99,7 @@ We will use the callback function to listen to state changes and save the conver
 ```tsx filename='app/actions.tsx'
 'use server';
 
-import { createAI, getAIState, getMutableAIState, streamUI } from 'ai/rsc';
+import { getAIState, getMutableAIState, streamUI } from 'ai/rsc';
 import { openai } from '@ai-sdk/openai';
 import { ReactNode } from 'react';
 import { z } from 'zod';
@@ -171,6 +172,11 @@ export async function continueConversation(
     display: result.value,
   };
 }
+```
+
+```ts filename='app/ai.ts'
+import { createAI } from 'ai/rsc';
+import { ServerMessage, ClientMessage, continueConversation } from './actions';
 
 export const AI = createAI<ServerMessage[], ClientMessage[]>({
   actions: {

--- a/content/examples/01-next-app/05-interface/01-route-components.mdx
+++ b/content/examples/01-next-app/05-interface/01-route-components.mdx
@@ -111,7 +111,7 @@ export async function Flight({ flightNumber }) {
 ```tsx filename='app/actions.tsx'
 'use server';
 
-import { createAI, getMutableAIState, streamUI } from 'ai/rsc';
+import { getMutableAIState, streamUI } from 'ai/rsc';
 import { openai } from '@ai-sdk/openai';
 import { ReactNode } from 'react';
 import { z } from 'zod';
@@ -202,6 +202,11 @@ export async function continueConversation(
     display: result.value,
   };
 }
+```
+
+```typescript filename='app/ai.ts'
+import { createAI } from 'ai/rsc';
+import { ServerMessage, ClientMessage, continueConversation } from './actions';
 
 export const AI = createAI<ServerMessage[], ClientMessage[]>({
   actions: {

--- a/content/examples/01-next-app/05-interface/02-stream-component-updates.mdx
+++ b/content/examples/01-next-app/05-interface/02-stream-component-updates.mdx
@@ -71,7 +71,7 @@ export default function Home() {
 ```tsx filename='app/actions.tsx'
 'use server';
 
-import { createAI, getMutableAIState, streamUI } from 'ai/rsc';
+import { getMutableAIState, streamUI } from 'ai/rsc';
 import { openai } from '@ai-sdk/openai';
 import { ReactNode } from 'react';
 import { z } from 'zod';
@@ -133,6 +133,11 @@ export async function continueConversation(
     display: result.value,
   };
 }
+```
+
+```typescript filename='app/ai.ts'
+import { createAI } from 'ai/rsc';
+import { ServerMessage, ClientMessage, continueConversation } from './actions';
 
 export const AI = createAI<ServerMessage[], ClientMessage[]>({
   actions: {

--- a/content/examples/01-next-app/05-interface/03-token-usage.mdx
+++ b/content/examples/01-next-app/05-interface/03-token-usage.mdx
@@ -144,6 +144,11 @@ export async function continueConversation(
     display: result.value,
   };
 }
+```
+
+```typescript filename='app/ai.ts'
+import { createAI } from 'ai/rsc';
+import { ServerMessage, ClientMessage, continueConversation } from './actions';
 
 export const AI = createAI<ServerMessage[], ClientMessage[]>({
   actions: {

--- a/content/examples/01-next-app/06-assistants/01-stream-assistant-responses.mdx
+++ b/content/examples/01-next-app/06-assistants/01-stream-assistant-responses.mdx
@@ -98,7 +98,7 @@ In your server action, you will create a function called `submitMessage` that ad
 'use server';
 
 import { generateId } from 'ai';
-import { createAI, createStreamableUI, createStreamableValue } from 'ai/rsc';
+import { createStreamableUI, createStreamableValue } from 'ai/rsc';
 import { OpenAI } from 'openai';
 import { ReactNode } from 'react';
 import { Message } from './message';
@@ -190,6 +190,10 @@ export async function submitMessage(question: string): Promise<ClientMessage> {
     text: textUIStream.value,
   };
 }
+```
+
+```tsx filename="app/ai.ts"
+import { createAI } from 'ai/rsc';
 
 export const AI = createAI({
   actions: {
@@ -202,7 +206,7 @@ And finally, make sure to update your layout component to wrap the children with
 
 ```tsx filename="app/layout.tsx"
 import { ReactNode } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <AI>{children}</AI>;

--- a/content/examples/01-next-app/06-assistants/01-stream-assistant-responses.mdx
+++ b/content/examples/01-next-app/06-assistants/01-stream-assistant-responses.mdx
@@ -194,11 +194,14 @@ export async function submitMessage(question: string): Promise<ClientMessage> {
 
 ```tsx filename="app/ai.ts"
 import { createAI } from 'ai/rsc';
+import { submitMessage } from './actions';
 
 export const AI = createAI({
   actions: {
     submitMessage,
   },
+  initialAIState: [],
+  initialUIState: [],
 });
 ```
 

--- a/content/examples/01-next-app/06-assistants/02-stream-assistant-responses-with-tools.mdx
+++ b/content/examples/01-next-app/06-assistants/02-stream-assistant-responses-with-tools.mdx
@@ -101,7 +101,7 @@ In case the assistant requires a tool call, the server action will handle the to
 'use server';
 
 import { generateId } from 'ai';
-import { createAI, createStreamableUI, createStreamableValue } from 'ai/rsc';
+import { createStreamableUI, createStreamableValue } from 'ai/rsc';
 import { OpenAI } from 'openai';
 import { ReactNode } from 'react';
 import { searchEmails } from './function';
@@ -259,9 +259,18 @@ export async function submitMessage(question: string): Promise<ClientMessage> {
     gui: gui.value,
   };
 }
+```
+
+```typescript filename='app/ai.ts'
+import { createAI } from 'ai/rsc';
+import { submitMessage } from './actions';
 
 export const AI = createAI({
-  actions: { submitMessage },
+  actions: {
+    submitMessage,
+  },
+  initialAIState: [],
+  initialUIState: [],
 });
 ```
 
@@ -269,7 +278,7 @@ And finally, make sure to update your layout component to wrap the children with
 
 ```tsx filename="app/layout.tsx"
 import { ReactNode } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <AI>{children}</AI>;

--- a/examples/next-openai/app/stream-assistant-responses-with-tools/actions.tsx
+++ b/examples/next-openai/app/stream-assistant-responses-with-tools/actions.tsx
@@ -1,7 +1,7 @@
 'use server';
 
 import { generateId } from 'ai';
-import { createAI, createStreamableUI, createStreamableValue } from 'ai/rsc';
+import { createStreamableUI, createStreamableValue } from 'ai/rsc';
 import { OpenAI } from 'openai';
 import { ReactNode } from 'react';
 import { searchEmails } from './function';
@@ -159,7 +159,3 @@ export async function submitMessage(question: string): Promise<ClientMessage> {
     gui: gui.value,
   };
 }
-
-export const AI = createAI({
-  actions: { submitMessage },
-});

--- a/examples/next-openai/app/stream-assistant-responses-with-tools/ai.ts
+++ b/examples/next-openai/app/stream-assistant-responses-with-tools/ai.ts
@@ -1,0 +1,10 @@
+import { createAI } from 'ai/rsc';
+import { submitMessage } from './actions';
+
+export const AI = createAI({
+  actions: {
+    submitMessage,
+  },
+  initialAIState: [],
+  initialUIState: [],
+});

--- a/examples/next-openai/app/stream-assistant-responses-with-tools/layout.tsx
+++ b/examples/next-openai/app/stream-assistant-responses-with-tools/layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <AI>{children}</AI>;

--- a/examples/next-openai/app/stream-assistant-responses/actions.tsx
+++ b/examples/next-openai/app/stream-assistant-responses/actions.tsx
@@ -1,7 +1,7 @@
 'use server';
 
 import { generateId } from 'ai';
-import { createAI, createStreamableUI, createStreamableValue } from 'ai/rsc';
+import { createStreamableUI, createStreamableValue } from 'ai/rsc';
 import { OpenAI } from 'openai';
 import { ReactNode } from 'react';
 import { Message } from './message';
@@ -93,9 +93,3 @@ export async function submitMessage(question: string): Promise<ClientMessage> {
     text: textUIStream.value,
   };
 }
-
-export const AI = createAI({
-  actions: {
-    submitMessage,
-  },
-});

--- a/examples/next-openai/app/stream-assistant-responses/ai.ts
+++ b/examples/next-openai/app/stream-assistant-responses/ai.ts
@@ -1,0 +1,10 @@
+import { createAI } from 'ai/rsc';
+import { submitMessage } from './actions';
+
+export const AI = createAI({
+  actions: {
+    submitMessage,
+  },
+  initialAIState: [],
+  initialUIState: [],
+});

--- a/examples/next-openai/app/stream-assistant-responses/layout.tsx
+++ b/examples/next-openai/app/stream-assistant-responses/layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <AI>{children}</AI>;

--- a/examples/next-openai/app/stream-ui/actions.tsx
+++ b/examples/next-openai/app/stream-ui/actions.tsx
@@ -111,9 +111,3 @@ export type UIState = {
   id: string;
   display: React.ReactNode;
 }[];
-
-export const AI = createAI({
-  actions: { submitUserMessage },
-  initialUIState: [] as UIState,
-  initialAIState: { chatId: generateId(), messages: [] } as AIState,
-});

--- a/examples/next-openai/app/stream-ui/ai.ts
+++ b/examples/next-openai/app/stream-ui/ai.ts
@@ -1,0 +1,9 @@
+import { createAI } from 'ai/rsc';
+import { AIState, submitUserMessage, UIState } from './actions';
+import { generateId } from 'ai';
+
+export const AI = createAI({
+  actions: { submitUserMessage },
+  initialUIState: [] as UIState,
+  initialAIState: { chatId: generateId(), messages: [] } as AIState,
+});

--- a/examples/next-openai/app/stream-ui/layout.tsx
+++ b/examples/next-openai/app/stream-ui/layout.tsx
@@ -1,4 +1,4 @@
-import { AI } from './actions';
+import { AI } from './ai';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return <AI>{children}</AI>;

--- a/examples/next-openai/app/stream-ui/page.tsx
+++ b/examples/next-openai/app/stream-ui/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Fragment, useState } from 'react';
-import type { AI } from './actions';
+import type { AI } from './ai';
 import { useActions } from 'ai/rsc';
 
 import { useAIState, useUIState } from 'ai/rsc';

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -148,6 +148,13 @@ async function submitMessage() {
     ui: stream.value,
   };
 }
+```
+
+###### @/app/ai.ts (Next.js App Router)
+
+```tsx
+import { createAI } from 'ai/rsc';
+import { submitMessage } from '@/app/actions';
 
 export const AI = createAI({
   initialAIState: {},
@@ -162,7 +169,7 @@ export const AI = createAI({
 
 ```tsx
 import { ReactNode } from 'react';
-import { AI } from '@/app/actions';
+import { AI } from '@/app/ai';
 
 export default function Layout({ children }: { children: ReactNode }) {
   <AI>{children}</AI>;


### PR DESCRIPTION
### What & Why

Server action module (the module conatining "use server" on the top level) should only contain server actions but the `AI` component itself is not. So that's why I want to move it outside of `actions.tsx` and leave it as a file or a module only containing actions with top-level directive convenience.

Related issue: #2948 
Related Next.js issue comment: https://github.com/vercel/next.js/issues/69756#issuecomment-2339033901
