### PR TITLE
fix (docs): update usage of new lines to match json5 spec

### DIFF
--- a/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/03-generate-object.mdx
@@ -112,42 +112,42 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
       name: 'mode',
       type: "'auto' | 'json' | 'tool'",
       description:
-        'The mode to use for object generation. Not every model supports all modes. ' +
-        "Defaults to 'auto' for 'object' output and to 'json' for 'no-schema' output. " +
-        "Must be 'json' for 'no-schema' output.",
+        "The mode to use for object generation. Not every model supports all modes. \
+        Defaults to 'auto' for 'object' output and to 'json' for 'no-schema' output. \
+        Must be 'json' for 'no-schema' output.",
     },
     {
       name: 'schema',
       type: 'Zod Schema | JSON Schema',
       description:
-        'The schema that describes the shape of the object to generate. ' +
-        'It is sent to the model to generate the object and used to validate the output. ' +
-        'You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function). ' +
-        'In "array" mode, the schema is used to describe an array element. ' +
-        'Not available with "no-schema" or "enum" output.',
+        "The schema that describes the shape of the object to generate. \
+        It is sent to the model to generate the object and used to validate the output. \
+        You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function). \
+        In 'array' mode, the schema is used to describe an array element. \
+        Not available with 'no-schema' or 'enum' output.",
     },
     {
       name: 'schemaName',
       type: 'string | undefined',
       description:
-        'Optional name of the output that should be generated. ' +
-        'Used by some providers for additional LLM guidance, e.g. via tool or schema name. ' +
-        'Not available with "no-schema" or "enum" output.',
+        "Optional name of the output that should be generated. \
+        Used by some providers for additional LLM guidance, e.g. via tool or schema name. \
+        Not available with 'no-schema' or 'enum' output.",
     },
     {
       name: 'schemaDescription',
       type: 'string | undefined',
       description:
-        'Optional description of the output that should be generated. ' +
-        'Used by some providers for additional LLM guidance, e.g. via tool or schema name. ' +
-        'Not available with "no-schema" or "enum" output.',
+        "Optional description of the output that should be generated. \
+        Used by some providers for additional LLM guidance, e.g. via tool or schema name. \
+        Not available with 'no-schema' or 'enum' output.",
     },
     {
       name: 'enum',
       type: 'string[]',
       description:
-        'List of possible values to generate. ' +
-        'Only available with "enum" output.',
+        "List of possible values to generate. \
+        Only available with 'enum' output.",
     },
     {
       name: 'system',

--- a/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/ai-sdk-core/04-stream-object.mdx
@@ -106,35 +106,35 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
       name: 'mode',
       type: "'auto' | 'json' | 'tool'",
       description:
-        'The mode to use for object generation. Not every model supports all modes. ' +
-        "Defaults to 'auto' for 'object' output and to 'json' for 'no-schema' output. " +
-        "Must be 'json' for 'no-schema' output.",
+        "The mode to use for object generation. Not every model supports all modes. \
+        Defaults to 'auto' for 'object' output and to 'json' for 'no-schema' output. \
+        Must be 'json' for 'no-schema' output.",
     },
     {
       name: 'schema',
       type: 'Zod Schema | JSON Schema',
       description:
-        'The schema that describes the shape of the object to generate. ' +
-        'It is sent to the model to generate the object and used to validate the output. ' +
-        'You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function). ' +
-        'In "array" mode, the schema is used to describe an array element. ' +
-        'Not available with "no-schema" output.',
+        "The schema that describes the shape of the object to generate. \
+        It is sent to the model to generate the object and used to validate the output. \
+        You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function). \
+        In 'array' mode, the schema is used to describe an array element. \
+        Not available with 'no-schema' output.",
     },
     {
       name: 'schemaName',
       type: 'string | undefined',
       description:
-        'Optional name of the output that should be generated. ' +
-        'Used by some providers for additional LLM guidance, e.g. via tool or schema name. ' +
-        'Not available with "no-schema" output.',
+        "Optional name of the output that should be generated. \
+        Used by some providers for additional LLM guidance, e.g. via tool or schema name. \
+        Not available with 'no-schema' output.",
     },
     {
       name: 'schemaDescription',
       type: 'string | undefined',
       description:
-        'Optional description of the output that should be generated. ' +
-        'Used by some providers for additional LLM guidance, e.g. via tool or schema name. ' +
-        'Not available with "no-schema" output.',
+        "Optional description of the output that should be generated. \
+        Used by some providers for additional LLM guidance, e.g. via tool or schema name. \
+        Not available with 'no-schema' output.",
     },
     {
       name: 'system',


### PR DESCRIPTION
we use [JSON5](https://json5.org/) to render the reference parts in the markdown content, so updated the formatting of new lines – this should also fix search indexing!