### PR TITLE
feat (ai/core): add sendUsage information to streamText data stream methods

### DIFF
--- a/.changeset/neat-jokes-beg.md
+++ b/.changeset/neat-jokes-beg.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/ui-utils': patch
+'ai': patch
+---
+
+feat (ai/core): add sendUsage information to streamText data stream methods

--- a/content/docs/05-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/05-ai-sdk-ui/02-chatbot.mdx
@@ -358,6 +358,68 @@ export async function POST(req: Request) {
 }
 ```
 
+## Controlling the response stream
+
+With `streamText`, you can control how error messages and usage information are sent back to the client.
+
+### Error Messages
+
+By default, the error message is suppressed for security reasons. You can forward it or send your own error message by providing a `getErrorMessage` function:
+
+```ts filename="app/api/chat/route.ts" highlight="13-27"
+import { openai } from '@ai-sdk/openai';
+import { convertToCoreMessages, streamText } from 'ai';
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = await streamText({
+    model: openai('gpt-4o'),
+    messages: convertToCoreMessages(messages),
+  });
+
+  return result.toDataStreamResponse({
+    getErrorMessage: error => {
+      if (error == null) {
+        return 'unknown error';
+      }
+
+      if (typeof error === 'string') {
+        return error;
+      }
+
+      if (error instanceof Error) {
+        return error.message;
+      }
+
+      return JSON.stringify(error);
+    },
+  });
+}
+```
+
+### Usage Information
+
+By default, the usage information is sent back to the client. You can disable it by setting the `sendUsage` option to `false`:
+
+```ts filename="app/api/chat/route.ts" highlight="13"
+import { openai } from '@ai-sdk/openai';
+import { convertToCoreMessages, streamText } from 'ai';
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = await streamText({
+    model: openai('gpt-4o'),
+    messages: convertToCoreMessages(messages),
+  });
+
+  return result.toDataStreamResponse({
+    sendUsage: false,
+  });
+}
+```
+
 ## Empty Submissions
 
 You can configure the `useChat` hook to allow empty submissions by setting the `allowEmptySubmit` option to `true`.

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -1142,6 +1142,13 @@ To see `streamText` in action, check out [these examples](#examples).
                 'A function to get the error message from the error object. By default, all errors are masked as "" for safety reasons.',
               optional: true,
             },
+            {
+              name: 'sendUsage',
+              type: 'boolean',
+              optional: true,
+              description:
+                'Whether to send the usage information in the stream. Default to true.',
+            },
           ],
         },
       ],
@@ -1197,6 +1204,13 @@ To see `streamText` in action, check out [these examples](#examples).
               description:
                 'A function to get the error message from the error object. By default, all errors are masked as "" for safety reasons.',
               optional: true,
+            },
+            {
+              name: 'sendUsage',
+              type: 'boolean',
+              optional: true,
+              description:
+                'Whether to send the usage information in the stream. Default to true.',
             },
           ],
         },
@@ -1254,6 +1268,13 @@ To see `streamText` in action, check out [these examples](#examples).
               description:
                 'A function to get the error message from the error object. By default, all errors are masked as "" for safety reasons.',
               optional: true,
+            },
+            {
+              name: 'sendUsage',
+              type: 'boolean',
+              optional: true,
+              description:
+                'Whether to send the usage information in the stream. Default to true.',
             },
           ],
         },

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -1147,7 +1147,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'boolean',
               optional: true,
               description:
-                'Whether to send the usage information in the stream. Default to true.',
+                'Whether to send the usage information in the stream. Defaults to true.',
             },
           ],
         },
@@ -1210,7 +1210,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'boolean',
               optional: true,
               description:
-                'Whether to send the usage information in the stream. Default to true.',
+                'Whether to send the usage information in the stream. Defaults to true.',
             },
           ],
         },
@@ -1274,7 +1274,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'boolean',
               optional: true,
               description:
-                'Whether to send the usage information in the stream. Default to true.',
+                'Whether to send the usage information in the stream. Defaults to true.',
             },
           ],
         },

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -120,12 +120,14 @@ Additional response information.
 
   @param data an optional StreamData object that will be merged into the stream.
   @param getErrorMessage an optional function that converts an error to an error message.
+  @param sendUsage whether to send the usage information to the client. Defaults to true.
 
   @return A data stream.
      */
   toDataStream(options?: {
     data?: StreamData;
     getErrorMessage?: (error: unknown) => string;
+    sendUsage?: boolean; // default to true (change to false in v4: secure by default)
   }): ReadableStream<Uint8Array>;
 
   /**
@@ -158,6 +160,7 @@ Additional response information.
           init?: ResponseInit;
           data?: StreamData;
           getErrorMessage?: (error: unknown) => string;
+          sendUsage?: boolean; // default to true (change to false in v4: secure by default)
         },
   ): void;
 
@@ -202,6 +205,7 @@ Additional response information.
           init?: ResponseInit;
           data?: StreamData;
           getErrorMessage?: (error: unknown) => string;
+          sendUsage?: boolean; // default to true (change to false in v4: secure by default)
         },
   ): Response;
 

--- a/packages/ui-utils/src/process-data-protocol-response.ts
+++ b/packages/ui-utils/src/process-data-protocol-response.ts
@@ -102,14 +102,17 @@ export async function processDataProtocolResponse({
     }
 
     if (type === 'finish_message') {
-      const { completionTokens, promptTokens } = value.usage;
-
       finishReason = value.finishReason;
-      usage = {
-        completionTokens,
-        promptTokens,
-        totalTokens: completionTokens + promptTokens,
-      };
+
+      if (value.usage != null) {
+        const { completionTokens, promptTokens } = value.usage;
+
+        usage = {
+          completionTokens,
+          promptTokens,
+          totalTokens: completionTokens + promptTokens,
+        };
+      }
 
       continue;
     }

--- a/packages/ui-utils/src/stream-parts.test.ts
+++ b/packages/ui-utils/src/stream-parts.test.ts
@@ -207,6 +207,14 @@ describe('finish_message stream part', () => {
     );
   });
 
+  it('should format a finish_message stream part without usage information', () => {
+    expect(
+      formatStreamPart('finish_message', {
+        finishReason: 'stop',
+      }),
+    ).toEqual(`d:{"finishReason":"stop"}\n`);
+  });
+
   it('should parse a finish_message stream part', () => {
     const input = `d:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20}}`;
     expect(parseStreamPart(input)).toEqual({
@@ -228,6 +236,16 @@ describe('finish_message stream part', () => {
       },
     });
   });
+
+  it('should parse a finish_message without usage information', () => {
+    const input = `d:{"finishReason":"stop"}`;
+    expect(parseStreamPart(input)).toEqual({
+      type: 'finish_message',
+      value: {
+        finishReason: 'stop',
+      },
+    });
+  });
 });
 
 describe('finish_roundtrip stream part', () => {
@@ -240,6 +258,14 @@ describe('finish_roundtrip stream part', () => {
     ).toEqual(
       `e:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20}}\n`,
     );
+  });
+
+  it('should format a finish_roundtrip stream part without usage information', () => {
+    expect(
+      formatStreamPart('finish_roundtrip', {
+        finishReason: 'stop',
+      }),
+    ).toEqual(`e:{"finishReason":"stop"}\n`);
   });
 
   it('should parse a finish_roundtrip stream part', () => {
@@ -260,6 +286,16 @@ describe('finish_roundtrip stream part', () => {
       value: {
         finishReason: 'stop',
         usage: { promptTokens: NaN, completionTokens: NaN },
+      },
+    });
+  });
+
+  it('should parse a finish_roundtrip without usage information', () => {
+    const input = `e:{"finishReason":"stop","usage":null}`;
+    expect(parseStreamPart(input)).toEqual({
+      type: 'finish_roundtrip',
+      value: {
+        finishReason: 'stop',
       },
     });
   });

--- a/packages/ui-utils/src/stream-parts.ts
+++ b/packages/ui-utils/src/stream-parts.ts
@@ -367,10 +367,10 @@ const finishMessageStreamPart: StreamPart<
   'finish_message',
   {
     finishReason: LanguageModelV1FinishReason;
-    usage: {
+    usage?: {
       promptTokens: number;
       completionTokens: number;
-    } | null;
+    };
   }
 > = {
   code: 'd',
@@ -380,34 +380,45 @@ const finishMessageStreamPart: StreamPart<
       value == null ||
       typeof value !== 'object' ||
       !('finishReason' in value) ||
-      typeof value.finishReason !== 'string' ||
-      !('usage' in value) ||
-      value.usage == null ||
-      typeof value.usage !== 'object' ||
-      !('promptTokens' in value.usage) ||
-      !('completionTokens' in value.usage)
+      typeof value.finishReason !== 'string'
     ) {
       throw new Error(
-        '"finish_message" parts expect an object with a "finishReason" and "usage" property.',
+        '"finish_message" parts expect an object with a "finishReason" property.',
       );
     }
-    // NaN is JSON parsed as null.
-    if (typeof value.usage.promptTokens !== 'number') {
-      value.usage.promptTokens = Number.NaN;
+
+    const result: {
+      finishReason: LanguageModelV1FinishReason;
+      usage?: {
+        promptTokens: number;
+        completionTokens: number;
+      };
+    } = {
+      finishReason: value.finishReason as LanguageModelV1FinishReason,
+    };
+
+    if (
+      'usage' in value &&
+      value.usage != null &&
+      typeof value.usage === 'object' &&
+      'promptTokens' in value.usage &&
+      'completionTokens' in value.usage
+    ) {
+      result.usage = {
+        promptTokens:
+          typeof value.usage.promptTokens === 'number'
+            ? value.usage.promptTokens
+            : Number.NaN,
+        completionTokens:
+          typeof value.usage.completionTokens === 'number'
+            ? value.usage.completionTokens
+            : Number.NaN,
+      };
     }
-    if (typeof value.usage.completionTokens !== 'number') {
-      value.usage.completionTokens = Number.NaN;
-    }
+
     return {
       type: 'finish_message',
-      value: value as unknown as {
-        finishReason: LanguageModelV1FinishReason;
-        usage: {
-          promptTokens: number;
-          completionTokens: number;
-          totalTokens: number;
-        };
-      },
+      value: result,
     };
   },
 };
@@ -417,10 +428,10 @@ const finishRoundtripStreamPart: StreamPart<
   'finish_roundtrip',
   {
     finishReason: LanguageModelV1FinishReason;
-    usage: {
+    usage?: {
       promptTokens: number;
       completionTokens: number;
-    } | null;
+    };
   }
 > = {
   code: 'e',
@@ -430,34 +441,45 @@ const finishRoundtripStreamPart: StreamPart<
       value == null ||
       typeof value !== 'object' ||
       !('finishReason' in value) ||
-      typeof value.finishReason !== 'string' ||
-      !('usage' in value) ||
-      value.usage == null ||
-      typeof value.usage !== 'object' ||
-      !('promptTokens' in value.usage) ||
-      !('completionTokens' in value.usage)
+      typeof value.finishReason !== 'string'
     ) {
       throw new Error(
-        '"finish_roundtrip" parts expect an object with a "finishReason" and "usage" property.',
+        '"finish_roundtrip" parts expect an object with a "finishReason" property.',
       );
     }
-    // NaN is JSON parsed as null.
-    if (typeof value.usage.promptTokens !== 'number') {
-      value.usage.promptTokens = Number.NaN;
+
+    const result: {
+      finishReason: LanguageModelV1FinishReason;
+      usage?: {
+        promptTokens: number;
+        completionTokens: number;
+      };
+    } = {
+      finishReason: value.finishReason as LanguageModelV1FinishReason,
+    };
+
+    if (
+      'usage' in value &&
+      value.usage != null &&
+      typeof value.usage === 'object' &&
+      'promptTokens' in value.usage &&
+      'completionTokens' in value.usage
+    ) {
+      result.usage = {
+        promptTokens:
+          typeof value.usage.promptTokens === 'number'
+            ? value.usage.promptTokens
+            : Number.NaN,
+        completionTokens:
+          typeof value.usage.completionTokens === 'number'
+            ? value.usage.completionTokens
+            : Number.NaN,
+      };
     }
-    if (typeof value.usage.completionTokens !== 'number') {
-      value.usage.completionTokens = Number.NaN;
-    }
+
     return {
       type: 'finish_roundtrip',
-      value: value as unknown as {
-        finishReason: LanguageModelV1FinishReason;
-        usage: {
-          promptTokens: number;
-          completionTokens: number;
-          totalTokens: number;
-        };
-      },
+      value: result,
     };
   },
 };

--- a/packages/ui-utils/src/stream-parts.ts
+++ b/packages/ui-utils/src/stream-parts.ts
@@ -370,7 +370,7 @@ const finishMessageStreamPart: StreamPart<
     usage: {
       promptTokens: number;
       completionTokens: number;
-    };
+    } | null;
   }
 > = {
   code: 'd',
@@ -420,7 +420,7 @@ const finishRoundtripStreamPart: StreamPart<
     usage: {
       promptTokens: number;
       completionTokens: number;
-    };
+    } | null;
   }
 > = {
   code: 'e',


### PR DESCRIPTION
## Tasks

- [x] implementation
   - [x] support undefined token usage in finishMessage and finishRoundtrip stream parts
   - [x] handle undefined token usage in useChat
   - [x] add flag to control sending token usage to toDataStream (streamText)
- [x] manual testing both scenarios with useChat
- [x] docs
   - [x] add to guide
   - [x] add to reference docs
- [x] changeset