### PR TITLE
chore (ai): rename roundtrips to steps

### DIFF
--- a/.changeset/small-roses-fail.md
+++ b/.changeset/small-roses-fail.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/ui-utils': patch
+'ai': patch
+---
+
+chore (ai): rename roundtrips to steps

--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -596,11 +596,11 @@ export default function Chat() {
 
 With this change, you now conditionally render the tool that has been called directly in the UI. Save the file and head back to browser. Tell the model your favorite movie. You should see which tool is called in place of the model’s typical text response.
 
-### Improving UX with Tool Roundtrips
+### Improving UX with Multi-Step Calls
 
 It would be nice if the model could summarize the action too. However, technically, once the model calls a tool, it has completed its generation as it ‘generated’ a tool call. How could you achieve this desired behaviour?
 
-The AI SDK has a feature called [`maxToolCallRoundtrips`](/docs/ai-sdk-core/tools-and-tool-calling#tool-roundtrips) which will automatically send tool call results back to the model!
+The AI SDK has a feature called [`maxSteps`](/docs/ai-sdk-core/tools-and-tool-calling#multi-step-calls) which will automatically send tool call results back to the model!
 
 Open your root page (`app/page.tsx`) and add the following key to the `useChat` configuration object:
 
@@ -608,7 +608,7 @@ Open your root page (`app/page.tsx`) and add the following key to the `useChat` 
 // ... Rest of your code
 
 const { messages, input, handleInputChange, handleSubmit } = useChat({
-  maxToolRoundtrips: 2,
+  maxSteps: 3,
 });
 
 // ... Rest of your code

--- a/content/docs/02-guides/03-llama-3_1.mdx
+++ b/content/docs/02-guides/03-llama-3_1.mdx
@@ -165,7 +165,7 @@ Agents use LLMs to choose the next step in a problem-solving process. They can r
 
 ### Implementing Agents with the Vercel AI SDK
 
-The Vercel AI SDK supports agent implementation through the `maxToolRoundtrips` parameter. This allows the model to make multiple decisions and tool calls in a single interaction.
+The Vercel AI SDK supports agent implementation through the `maxSteps` parameter. This allows the model to make multiple decisions and tool calls in a single interaction.
 
 Here's an example of an agent that solves math problems:
 
@@ -195,7 +195,7 @@ const { text: answer } = await generateText({
       execute: async ({ expression }) => mathjs.evaluate(expression),
     }),
   },
-  maxToolRoundtrips: 5,
+  maxSteps: 5,
 });
 ```
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -50,15 +50,15 @@ const result = await generateText({
 Tool calling is not restricted to only text generation.
 You can also use it to render user interfaces with Generative AI.
 
-## Tool Roundtrips
+## Multi-Step Calls
 
 Large language models need to know the tool results before they can continue to generate text.
 This requires sending the tool results back to the model.
-You can enable this feature by setting the `maxToolRoundtrips` setting to a number greater than 0.
+You can enable this feature by setting the `maxSteps` setting to a number greater than 1.
 
-When `maxToolRoundtrips` is set to a number greater than 0, the language model will be called
+When `maxSteps` is set to a number greater than 1, the language model will be called
 in a loop when there are tool calls and for every tool call there is a tool result, until there
-are no further tool calls or the maximum number of tool roundtrips is reached.
+are no further tool calls or the maximum number of tool steps is reached.
 
 ### Example: generateText
 
@@ -66,7 +66,7 @@ are no further tool calls or the maximum number of tool roundtrips is reached.
 import { z } from 'zod';
 import { generateText, tool } from 'ai';
 
-const { text, roundtrips } = await generateText({
+const { text, steps } = await generateText({
   model: yourModel,
   tools: {
     weather: tool({
@@ -80,27 +80,25 @@ const { text, roundtrips } = await generateText({
       }),
     }),
   },
-  maxToolRoundtrips: 5, // allow up to 5 tool roundtrips
+  maxSteps: 5, // allow up to 5 steps
   prompt: 'What is the weather in San Francisco?',
 });
 ```
 
-In the above example, there is a single roundtrip:
+In the above example, there are two steps:
 
-1. **Call 1**
+1. **Step 1**
    1. The prompt `'What is the weather in San Francisco?'` is sent to the model.
    1. The model generates a tool call.
    1. The tool call is executed.
-1. **Call 2 (Roundtrip)**
+1. **Step 2**
    1. The tool result is sent to the model.
    1. The model generates a response considering the tool result.
 
-To access intermediate tool calls and results, you can use the `roundTrips` property in the result object.
-It contains all the text, tool calls, tool results, and more from each roundtrip.
+To access intermediate tool calls and results, you can use the `steps` property in the result object.
+It contains all the text, tool calls, tool results, and more from each step.
 
-<Note>
-  The roundtrips result property is only available in `generateText` .
-</Note>
+<Note>The `steps` result property is only available in `generateText`.</Note>
 
 ### Example: streamText
 
@@ -122,7 +120,7 @@ const result = await streamText({
       }),
     }),
   },
-  maxToolRoundtrips: 5, // allow up to 5 tool roundtrips
+  maxSteps: 5, // allow up to 5 tool steps
   prompt: 'What is the weather in San Francisco?',
 });
 

--- a/content/docs/03-ai-sdk-core/17-agents.mdx
+++ b/content/docs/03-ai-sdk-core/17-agents.mdx
@@ -9,7 +9,7 @@ AI agents let the language model execute several steps in a non-deterministic wa
 The model can make decisions based on the context of the conversation and the user's input.
 
 One approach to implementing agents is to allow the LLM to choose the next step in a loop.
-With `generateText`, you can combine [tools](/docs/ai-sdk-core/tools-and-tool-calling) with `maxToolRoundtrips`.
+With `generateText`, you can combine [tools](/docs/ai-sdk-core/tools-and-tool-calling) with `maxSteps`.
 This makes it possible to implement basic agents that reason at each step and make decisions based on the context.
 
 ### Example
@@ -50,24 +50,24 @@ const { text: answer } = await generateText({
       execute: async ({ expression }) => mathjs.evaluate(expression),
     }),
   },
-  maxToolRoundtrips: 10,
+  maxSteps: 10,
 });
 
 console.log(`ANSWER: ${answer}`);
 ```
 
-## Accessing information from all roundtrips
+## Accessing information from all steps
 
-Calling `generateText` with `maxToolRoundtrips` can result in several calls to the LLM (roundtrips).
-You can access information from all roundtrips by using the `roundtrips` property of the response.
+Calling `generateText` with `maxSteps` can result in several calls to the LLM (steps).
+You can access information from all steps by using the `steps` property of the response.
 
 ```ts
-const { roundtrips } = await generateText({
+const { steps } = await generateText({
   model: openai('gpt-4-turbo'),
-  maxToolRoundtrips: 10,
+  maxSteps: 10,
   // ...
 });
 
-// extract all tool calls from the roundtrips:
-const allToolCalls = roundtrips.flatMap(roundtrip => roundtrip.toolCalls);
+// extract all tool calls from the steps:
+const allToolCalls = steps.flatMap(step => step.toolCalls);
 ```

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -98,6 +98,7 @@ const result = await generateText({
   - `ai.response.text`: the text that was generated
   - `ai.response.toolCalls`: the tool calls that were made as part of the generation (stringified JSON)
   - `ai.response.finishReason`: the reason why the generation finished
+  - `ai.settings.maxSteps`: the maximum number of steps that were set
 
 - `ai.streamText.doStream` (span): a provider doStream call.
   This span contains an `ai.stream.firstChunk` event and `ai.toolCall` spans.

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -70,7 +70,7 @@ const result = await generateText({
   - `ai.response.text`: the text that was generated
   - `ai.response.toolCalls`: the tool calls that were made as part of the generation (stringified JSON)
   - `ai.response.finishReason`: the reason why the generation finished
-  - `ai.settings.maxToolRoundtrips`: the maximum number of tool roundtrips that were set
+  - `ai.settings.maxSteps`: the maximum number of steps that were set
 
 - `ai.generateText.doGenerate` (span): a provider doGenerate call. It can contain `ai.toolCall` spans.
   It contains the [call LLM span information](#call-llm-span-information) and the following attributes:

--- a/content/docs/05-ai-sdk-ui/03-chatbot-with-tool-calling.mdx
+++ b/content/docs/05-ai-sdk-ui/03-chatbot-with-tool-calling.mdx
@@ -40,9 +40,9 @@ The tool result contains all information about the tool call as well as the resu
 <Note>
   In order to automatically send another request to the server when all tool
   calls are server-side, you need to set
-  [`maxToolRoundtrips`](/docs/reference/ai-sdk-ui/use-chat#max-tool-roundtrips)
-  to a value greater than 0 in the `useChat` options. It is disabled by default
-  for backward compatibility.
+  [`maxSteps`](/docs/reference/ai-sdk-ui/use-chat#max-steps) to a value greater
+  than 1 in the `useChat` options. It is disabled by default for backward
+  compatibility.
 </Note>
 
 ## Example
@@ -116,7 +116,7 @@ There are three things worth mentioning:
    It asks the user for confirmation and displays the result once the user confirms or denies the execution.
    The result is added to the chat using `addToolResult`.
 
-3. The [`maxToolRoundtrips`](/docs/reference/ai-sdk-ui/use-chat#max-tool-roundtrips) option is set to 5.
+3. The [`maxSteps`](/docs/reference/ai-sdk-ui/use-chat#max-steps) option is set to 5.
    This enables several tool use iterations between the client and the server.
 
 ```tsx filename='app/page.tsx' highlight="9,12,31"
@@ -128,7 +128,7 @@ import { Message, useChat } from 'ai/react';
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit, addToolResult } =
     useChat({
-      maxToolRoundtrips: 5,
+      maxSteps: 5,
 
       // run client-side tools that are automatically executed:
       async onToolCall({ toolCall }) {
@@ -245,9 +245,9 @@ export default function Chat() {
 }
 ```
 
-## Server-side roundtrips
+## Server-side Multi-Step Calls
 
-You can also use server-side tool roundtrips with `streamText`.
+You can also use multi-step calls on the server-side with `streamText`.
 This works when all invoked tools have an `execute` function on the server side.
 
 ```tsx filename='app/api/chat/route.ts' highlight="15-21,24"
@@ -274,7 +274,7 @@ export async function POST(req: Request) {
         },
       },
     },
-    maxToolRoundtrips: 5, // server-side roundtrips for server-side tools
+    maxSteps: 5,
   });
 
   return result.toDataStreamResponse();

--- a/content/docs/05-ai-sdk-ui/50-stream-protocol.mdx
+++ b/content/docs/05-ai-sdk-ui/50-stream-protocol.mdx
@@ -201,12 +201,12 @@ Example: `a:{"toolCallId":"call-123","result":"tool output"}\n`
   height={1148}
 />
 
-### Finish Roundtrip Part
+### Finish Step Part
 
-A part indicating the one roundtrip (i.e., one LLM API call in the backend) has been completed.
-This is necessary to correctly process multiple stitched assistant calls, e.g. when calling tools in the backend, and using roundtrips in `useChat` at the same time.
-It includes addition metadata, such as [`FinishReason`](/docs/reference/ai-sdk-ui/use-chat#on-finish-finish-reason) and [`Usage`](/docs/reference/ai-sdk-ui/use-chat#on-finish-usage), for that roundtrip.
-This part needs to come at the end of a roundtrip.
+A part indicating that a step (i.e., one LLM API call in the backend) has been completed.
+This is necessary to correctly process multiple stitched assistant calls, e.g. when calling tools in the backend, and using steps in `useChat` at the same time.
+It includes addition metadata, such as [`FinishReason`](/docs/reference/ai-sdk-ui/use-chat#on-finish-finish-reason) and [`Usage`](/docs/reference/ai-sdk-ui/use-chat#on-finish-usage), for that step.
+This part needs to come at the end of a step.
 
 Format: `e:{finishReason:'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other' | 'unknown';usage:{promptTokens:number; completionTokens:number;}}\n`
 

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -351,7 +351,7 @@ To see `generateText` in action, check out [these examples](#examples).
       type: 'number',
       isOptional: true,
       description:
-        'Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
+        'Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
     },
     {
       name: 'experimental_telemetry',

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -347,11 +347,11 @@ To see `generateText` in action, check out [these examples](#examples).
         'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
     },
     {
-      name: 'maxToolRoundtrips',
+      name: 'maxSteps',
       type: 'number',
       isOptional: true,
       description:
-        'Maximum number of automatic roundtrips for tool calls. An automatic tool call roundtrip is another LLM call with the tool call results when all tool calls of the last assistant message have results. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 0, which will disable the feature.',
+        'Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
     },
     {
       name: 'experimental_telemetry',
@@ -519,13 +519,13 @@ To see `generateText` in action, check out [these examples](#examples).
         'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
     },
     {
-      name: 'roundtrips',
-      type: 'Array<Roundtrip>',
+      name: 'steps',
+      type: 'Array<Step>',
       description:
-        'Response information for every roundtrip. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
+        'Response information for every step. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
       properties: [
         {
-          type: 'Roundtrip',
+          type: 'Step',
           parameters: [
             {
               name: 'text',

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -353,7 +353,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: 'number',
       isOptional: true,
       description:
-        'Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
+        'Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
     },
     {
       name: 'experimental_telemetry',

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -349,11 +349,11 @@ To see `streamText` in action, check out [these examples](#examples).
         'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
     },
     {
-      name: 'maxToolRoundtrips',
+      name: 'maxSteps',
       type: 'number',
       isOptional: true,
       description:
-        'Maximum number of automatic roundtrips for tool calls. An automatic tool call roundtrip is another LLM call with the tool call results when all tool calls of the last assistant message have results. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 0, which will disable the feature.',
+        'Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
     },
     {
       name: 'experimental_telemetry',
@@ -943,9 +943,8 @@ To see `streamText` in action, check out [these examples](#examples).
           parameters: [
             {
               name: 'type',
-              type: "'roundtrip-finish'",
-              description:
-                'The type to identify the object as roundtrip finish.',
+              type: "'step-finish'",
+              description: 'The type to identify the object as step finish.',
             },
             {
               name: 'finishReason',

--- a/content/docs/07-reference/ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/ai-sdk-ui/01-use-chat.mdx
@@ -160,10 +160,10 @@ Allows you to easily create a conversational user interface for your chatbot app
         "An optional boolean that determines whether to send extra fields you've added to `messages`. Defaults to `false` and only the `content` and `role` fields will be sent to the API endpoint. If set to `true`, the `name`, `data`, and `annotations` fields will also be sent.",
     },
     {
-      name: 'maxToolRoundtrips',
+      name: 'maxSteps',
       type: 'number',
       description:
-        'React and SolidJS only. Maximal number of automatic roundtrips for tool calls. An automatic tool call roundtrip is a call to the server with the  tool call results when all tool calls in the last assistant  message have results. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 0, which will disable the feature.',
+        'React, Svelte and SolidJS only. Maximal number of backend calls to generate a response. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
     },
     {
       name: 'streamProtocol',

--- a/content/docs/07-reference/ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/ai-sdk-ui/01-use-chat.mdx
@@ -163,7 +163,7 @@ Allows you to easily create a conversational user interface for your chatbot app
       name: 'maxSteps',
       type: 'number',
       description:
-        'React, Svelte and SolidJS only. Maximal number of backend calls to generate a response. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
+        'React, Svelte and SolidJS only. Maximum number of backend calls to generate a response. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
     },
     {
       name: 'streamProtocol',

--- a/content/docs/08-troubleshooting/01-migration-guide/03-migration-guide-3-3.mdx
+++ b/content/docs/08-troubleshooting/01-migration-guide/03-migration-guide-3-3.mdx
@@ -33,7 +33,7 @@ introducing significant improvements and new features across the AI SDK and its 
 - Added raw JSON schema support alongside existing Zod support, providing more options for schema and data validation.
 - Introduced usage information for **`embed`** and **`embedMany`** functions, offering insights into token usage.
 - Added support for additional settings including **`stopSequences`** and **`topK`**, allowing for finer control over text generation.
-- Provided access to information for all roundtrips on **`generateText`**, providing access to intermediate tool calls and results.
+- Provided access to information for all steps on **`generateText`**, providing access to intermediate tool calls and results.
 
 ### **New Providers**
 

--- a/content/docs/08-troubleshooting/03-common-issues/10-use-chat-tools-no-response.mdx
+++ b/content/docs/08-troubleshooting/03-common-issues/10-use-chat-tools-no-response.mdx
@@ -1,13 +1,14 @@
 ---
-title: useChat No Response with maxToolsRoundtrips
+title: useChat No Response with maxSteps
 description: Troubleshooting errors related to the Use Chat Failed to Parse Stream error.
 ---
 
-# `useChat` No Response with maxToolsRoundtrips
+# `useChat` No Response with maxSteps
 
 ## Issue
 
-I am using [`useChat`](/docs/reference/ai-sdk-ui/use-chat) with [`maxToolRoundtrips`](/docs/reference/ai-sdk-ui/use-chat#max-tool-roundtrips). When I log the incoming messages on the server, I can see the tool call and the tool result, but the model does not respond with anything.
+I am using [`useChat`](/docs/reference/ai-sdk-ui/use-chat) with [`maxSteps`](/docs/reference/ai-sdk-ui/use-chat#max-steps).
+When I log the incoming messages on the server, I can see the tool call and the tool result, but the model does not respond with anything.
 
 ## Background
 

--- a/content/docs/08-troubleshooting/03-common-issues/index.mdx
+++ b/content/docs/08-troubleshooting/03-common-issues/index.mdx
@@ -17,5 +17,5 @@ description: Troubleshooting information for common issues encountered with the 
 - [ useChat Failed to Parse Stream ](/docs/troubleshooting/common-issues/use-chat-failed-to-parse-stream)
 - [ NaN token counts when using streamText with OpenAI models](/docs/troubleshooting/common-issues/nan-token-counts-openai-streaming)
 - [ Model is not assignable to type "LanguageModelV1" ](/docs/troubleshooting/common-issues/model-is-not-assignable-to-type)
-- [ useChat no response with `maxToolRoundTrips` ](/docs/troubleshooting/common-issues/use-chat-tools-no-response)
+- [ useChat no response with `maxSteps` ](/docs/troubleshooting/common-issues/use-chat-tools-no-response)
 - [ TypeScript error "Cannot find namespace 'JSX'" ](/docs/troubleshooting/common-issues/typescript-cannot-find-namespace-jsx)

--- a/content/examples/02-next-pages/10-tools/01-call-tool.mdx
+++ b/content/examples/02-next-pages/10-tools/01-call-tool.mdx
@@ -29,7 +29,7 @@ Some models allow developers to provide a list of tools that can be called at an
 
 Let's create a React component that imports the `useChat` hook from the `ai/react` module. The `useChat` hook will call the `/api/chat` endpoint when the user sends a message. The endpoint will generate the assistant's response based on the conversation history and stream it to the client. If the assistant responds with a tool call, the hook will automatically display them as well.
 
-We will use the `maxToolRoundtrips` to specify the maximum number of consecutive tool calls that can made before the model or the user responds with a text message. In this example, you will set it to `1` to allow for one round trip to happen.
+We will use the `maxSteps` to specify the maximum number of steps (i.e., LLM calls) that can be made to prevent infinite loops. In this example, you will set it to `2` to allow for one round trip to happen.
 
 ```tsx filename='pages/index.tsx'
 import { useChat } from 'ai/react';
@@ -37,7 +37,7 @@ import { useChat } from 'ai/react';
 export default function Page() {
   const { messages, input, setInput, append } = useChat({
     api: '/api/chat',
-    maxToolRoundtrips: 1,
+    maxSteps: 2,
   });
 
   return (

--- a/content/examples/02-next-pages/10-tools/01-call-tool.mdx
+++ b/content/examples/02-next-pages/10-tools/01-call-tool.mdx
@@ -29,7 +29,7 @@ Some models allow developers to provide a list of tools that can be called at an
 
 Let's create a React component that imports the `useChat` hook from the `ai/react` module. The `useChat` hook will call the `/api/chat` endpoint when the user sends a message. The endpoint will generate the assistant's response based on the conversation history and stream it to the client. If the assistant responds with a tool call, the hook will automatically display them as well.
 
-We will use the `maxSteps` to specify the maximum number of steps (i.e., LLM calls) that can be made to prevent infinite loops. In this example, you will set it to `2` to allow for one round trip to happen.
+We will use the `maxSteps` to specify the maximum number of steps (i.e., LLM calls) that can be made to prevent infinite loops. In this example, you will set it to `2` to allow for two backend calls to happen.
 
 ```tsx filename='pages/index.tsx'
 import { useChat } from 'ai/react';

--- a/content/examples/02-next-pages/10-tools/05-call-tools-in-parallel.mdx
+++ b/content/examples/02-next-pages/10-tools/05-call-tools-in-parallel.mdx
@@ -29,7 +29,7 @@ Some language models support calling tools in parallel. This is particularly use
 
 Let's create a React component that imports the `useChat` hook from the `ai/react` module. The `useChat` hook will call the `/api/chat` endpoint when the user sends a message. The endpoint will generate the assistant's response based on the conversation history and stream it to the client. If the assistant responds with a tool call, the hook will automatically display them as well.
 
-You will use the `maxToolRoundtrips` to specify the maximum number of consecutive tool calls that can made before the model or the user responds with a text message. In this example, you will set it to `1` to allow for one round trip to happen.
+You will use the `maxSteps` to specify the maximum number of steps that can made before the model or the user responds with a text message. In this example, you will set it to `2` to allow for another call with the tool result to happen.
 
 ```tsx filename='pages/index.tsx'
 import { useChat } from 'ai/react';
@@ -37,7 +37,7 @@ import { useChat } from 'ai/react';
 export default function Page() {
   const { messages, input, setInput, append } = useChat({
     api: '/api/chat',
-    maxToolRoundtrips: 1,
+    maxSteps: 2,
   });
 
   return (

--- a/content/examples/02-next-pages/10-tools/10-render-interface-during-tool-call.mdx
+++ b/content/examples/02-next-pages/10-tools/10-render-interface-during-tool-call.mdx
@@ -48,7 +48,7 @@ export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit, addToolResult } =
     useChat({
       api: '/api/use-chat-tools-ui',
-      maxToolRoundtrips: 5,
+      maxSteps: 5,
 
       // run client-side tools that are automatically executed:
       async onToolCall({ toolCall }) {

--- a/content/examples/03-node/03-tools/01-call-tool.mdx
+++ b/content/examples/03-node/03-tools/01-call-tool.mdx
@@ -150,4 +150,8 @@ main().catch(console.error);
 
 ## Model Response
 
-When using tools, it's important to note that the model won't respond with the tool call results by default. This is because the model has technically already generated its response to the prompt: the tool call. Many use cases will require the model to summarise the results of the tool call within the context of the original prompt automatically. You can achieve this by [using `maxToolRoundtrips`](/examples/node/tools/call-tools-with-automatic-roundtrips) which will automatically send toolResults to the model to trigger another generation.
+When using tools, it's important to note that the model won't respond with the tool call results by default.
+This is because the model has technically already generated its response to the prompt: the tool call.
+Many use cases will require the model to summarise the results of the tool call within the context of the original prompt automatically.
+You can achieve this by [using `maxSteps`](/examples/node/tools/call-tools-with-automatic-roundtrips)
+which will automatically send toolResults to the model to trigger another generation.

--- a/content/examples/03-node/03-tools/05-call-tools-with-automatic-roundtrips.mdx
+++ b/content/examples/03-node/03-tools/05-call-tools-with-automatic-roundtrips.mdx
@@ -1,16 +1,16 @@
 ---
-title: Call Tools with Roundtrips
-description: Learn how to call tools with automatic roundtrips in a Node.js application.
+title: Multi-step Tool Calls
+description: Learn how to execute multi-step calls in a Node.js application.
 ---
 
-# Call Tools with Roundtrips
+# Multi-step Tool Calls
 
 Models call tools to gather information or perform actions that are not directly available to the model.
 When tool results are available, the model can use them to generate another response.
 
-You can enable automatic roundtrips in `generateText` by setting the `maxToolRoundtrips` option to
+You can enable multi-step tool calls in `generateText` by setting the `maxSteps` option to
 a number greater than 0.
-This option specifies the maximum number of automatic roundtrips that can be made to prevent infinite loops.
+This option specifies the maximum number of steps (i.e., LLM calls) that can be made to prevent infinite loops.
 
 ```ts highlight={"7"}
 import { generateText, tool } from 'ai';
@@ -19,7 +19,7 @@ import { z } from 'zod';
 
 const { text } = await generateText({
   model: openai('gpt-4-turbo'),
-  maxToolRoundtrips: 5,
+  maxSteps: 5,
   tools: {
     weather: tool({
       description: 'Get the weather in a location',

--- a/content/examples/03-node/03-tools/05-call-tools-with-automatic-roundtrips.mdx
+++ b/content/examples/03-node/03-tools/05-call-tools-with-automatic-roundtrips.mdx
@@ -9,7 +9,7 @@ Models call tools to gather information or perform actions that are not directly
 When tool results are available, the model can use them to generate another response.
 
 You can enable multi-step tool calls in `generateText` by setting the `maxSteps` option to
-a number greater than 0.
+a number greater than 1.
 This option specifies the maximum number of steps (i.e., LLM calls) that can be made to prevent infinite loops.
 
 ```ts highlight={"7"}

--- a/content/examples/03-node/03-tools/index.mdx
+++ b/content/examples/03-node/03-tools/index.mdx
@@ -22,8 +22,8 @@ The following sections will guide you through tool use with Node.js and the Verc
       href: '/examples/node/tools/call-tools-in-parallel',
     },
     {
-      title: 'Call Tools with Automatic Roundtrips',
-      href: '/examples/node/tools/call-tools-with-automatic-roundtrips',
+      title: 'Multi-step Tool Calls',
+      href: '/examples/node/tools/tool-calls-with-automatic-roundtrips',
     },
   ]}
 />

--- a/content/examples/03-node/03-tools/index.mdx
+++ b/content/examples/03-node/03-tools/index.mdx
@@ -23,7 +23,7 @@ The following sections will guide you through tool use with Node.js and the Verc
     },
     {
       title: 'Multi-step Tool Calls',
-      href: '/examples/node/tools/tool-calls-with-automatic-roundtrips',
+      href: '/examples/node/tools/call-tools-with-automatic-roundtrips',
     },
   ]}
 />

--- a/examples/ai-core/src/complex/math-agent/agent.ts
+++ b/examples/ai-core/src/complex/math-agent/agent.ts
@@ -41,7 +41,7 @@ async function main() {
       }),
     },
     toolChoice: 'required',
-    maxToolRoundtrips: 10,
+    maxSteps: 10,
   });
 }
 

--- a/examples/ai-core/src/generate-text/google-vertex-tool-call.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-tool-call.ts
@@ -24,7 +24,7 @@ async function main() {
         },
       }),
     },
-    maxToolRoundtrips: 5,
+    maxSteps: 5,
   });
 
   console.log(text);

--- a/examples/ai-core/src/stream-text/openai-tool-call-simple.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call-simple.ts
@@ -30,7 +30,7 @@ async function main() {
         }),
       }),
     },
-    maxToolRoundtrips: 5,
+    maxSteps: 5,
     prompt: 'What is the weather in my current location?',
   });
 

--- a/examples/ai-core/src/stream-text/openai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call.ts
@@ -9,7 +9,7 @@ dotenv.config();
 async function main() {
   const result = await streamText({
     model: openai('gpt-4-turbo'),
-    maxToolRoundtrips: 5,
+    maxSteps: 5,
     tools: {
       currentLocation: tool({
         description: 'Get the current location.',
@@ -47,10 +47,10 @@ async function main() {
         break;
       }
 
-      case 'roundtrip-finish': {
+      case 'step-finish': {
         console.log();
         console.log();
-        console.log('ROUNDTRIP FINISH');
+        console.log('STEP FINISH');
         console.log('Finish reason:', chunk.finishReason);
         console.log('Usage:', chunk.usage);
         console.log();

--- a/examples/next-fastapi/app/(examples)/02-chat-data/page.tsx
+++ b/examples/next-fastapi/app/(examples)/02-chat-data/page.tsx
@@ -8,15 +8,15 @@ export default function Page() {
   const { messages, input, handleSubmit, handleInputChange, isLoading } =
     useChat({
       streamProtocol: 'data',
-      maxToolRoundtrips: 2,
+      maxSteps: 3,
     });
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex flex-col p-4 gap-2">
+      <div className="flex flex-col gap-2 p-4">
         {messages.map(message => (
           <div key={message.id} className="flex flex-row gap-2">
-            <div className="w-24 text-zinc-500 flex-shrink-0">{`${message.role}: `}</div>
+            <div className="flex-shrink-0 w-24 text-zinc-500">{`${message.role}: `}</div>
 
             <div className="flex flex-col gap-2">
               {message.content && <div>{message.content}</div>}
@@ -44,13 +44,13 @@ export default function Page() {
 
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col fixed bottom-0 w-full border-t"
+        className="fixed bottom-0 flex flex-col w-full border-t"
       >
         <input
           value={input}
           placeholder="What's the weather in San Francisco?"
           onChange={handleInputChange}
-          className="w-full p-4 outline-none bg-transparent"
+          className="w-full p-4 bg-transparent outline-none"
           disabled={isLoading}
         />
       </form>

--- a/examples/next-openai-pages/pages/generative-user-interface/route-components/index.tsx
+++ b/examples/next-openai-pages/pages/generative-user-interface/route-components/index.tsx
@@ -5,7 +5,7 @@ export default function Page() {
   const { messages, input, handleInputChange, handleSubmit, addToolResult } =
     useChat({
       api: '/api/generative-ui-route',
-      maxToolRoundtrips: 5,
+      maxSteps: 5,
       async onToolCall({ toolCall }) {
         if (toolCall.toolName === 'getLocation') {
           const cities = [
@@ -107,7 +107,7 @@ export default function Page() {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex flex-col p-2 gap-2">
+      <div className="flex flex-col gap-2 p-2">
         {messages.map(message => (
           <div key={message.id} className="flex flex-row gap-2">
             <div className="w-24 text-zinc-500">{`${
@@ -122,12 +122,12 @@ export default function Page() {
         ))}
       </div>
 
-      <form onSubmit={handleSubmit} className="fixed bottom-0 p-2 w-full">
+      <form onSubmit={handleSubmit} className="fixed bottom-0 w-full p-2">
         <input
           value={input}
           placeholder="Send message..."
           onChange={handleInputChange}
-          className="bg-zinc-100 w-full p-2"
+          className="w-full p-2 bg-zinc-100"
         />
       </form>
     </div>

--- a/examples/next-openai-pages/pages/tools/call-tool/index.tsx
+++ b/examples/next-openai-pages/pages/tools/call-tool/index.tsx
@@ -3,12 +3,12 @@ import { useChat } from 'ai/react';
 export default function Page() {
   const { messages, input, handleInputChange, handleSubmit } = useChat({
     api: '/api/call-tool',
-    maxToolRoundtrips: 1,
+    maxSteps: 2,
   });
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex flex-col p-2 gap-2">
+      <div className="flex flex-col gap-2 p-2">
         {messages.map(message => (
           <div key={message.id} className="flex flex-row gap-2">
             <div className="w-24 text-zinc-500">{`${
@@ -25,12 +25,12 @@ export default function Page() {
         ))}
       </div>
 
-      <form onSubmit={handleSubmit} className="fixed bottom-0 p-2 w-full">
+      <form onSubmit={handleSubmit} className="fixed bottom-0 w-full p-2">
         <input
           value={input}
           placeholder="Send message..."
           onChange={handleInputChange}
-          className="bg-zinc-100 w-full p-2"
+          className="w-full p-2 bg-zinc-100"
         />
       </form>
     </div>

--- a/examples/next-openai-pages/pages/tools/call-tools-in-parallel/index.tsx
+++ b/examples/next-openai-pages/pages/tools/call-tools-in-parallel/index.tsx
@@ -3,18 +3,18 @@ import { useChat } from 'ai/react';
 export default function Page() {
   const { messages, input, handleInputChange, handleSubmit } = useChat({
     api: '/api/call-tools-in-parallel',
-    maxToolRoundtrips: 1,
+    maxSteps: 2,
   });
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex flex-col p-2 gap-2">
+      <div className="flex flex-col gap-2 p-2">
         {messages.map(message => (
           <div key={message.id} className="flex flex-row gap-2">
             <div className="w-24 text-zinc-500">{`${
               message.toolInvocations ? 'tool' : message.role
             }: `}</div>
-            <div className="w-full flex flex-col gap-2">
+            <div className="flex flex-col w-full gap-2">
               {message.toolInvocations
                 ? message.toolInvocations.map(tool => (
                     <div key={tool.toolCallId}>{`${
@@ -27,12 +27,12 @@ export default function Page() {
         ))}
       </div>
 
-      <form onSubmit={handleSubmit} className="fixed bottom-0 p-2 w-full">
+      <form onSubmit={handleSubmit} className="fixed bottom-0 w-full p-2">
         <input
           value={input}
           placeholder="Send message..."
           onChange={handleInputChange}
-          className="bg-zinc-100 w-full p-2"
+          className="w-full p-2 bg-zinc-100"
         />
       </form>
     </div>

--- a/examples/next-openai/app/api/use-chat-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-tools/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
     model: openai('gpt-4-turbo'),
     messages: convertToCoreMessages(messages),
     experimental_toolCallStreaming: true,
-    maxToolRoundtrips: 5, // server-side roundtrips for server-side tools
+    maxSteps: 5, // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:
       getWeatherInformation: {

--- a/examples/next-openai/app/api/use-completion-server-side-multi-step/route.ts
+++ b/examples/next-openai/app/api/use-completion-server-side-multi-step/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
         }),
       }),
     },
-    maxToolRoundtrips: 3,
+    maxSteps: 4,
     prompt,
   });
 

--- a/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
+++ b/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
@@ -6,7 +6,7 @@ import { Message, useChat } from 'ai/react';
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit } = useChat({
     api: '/api/use-chat-streaming-tool-calls',
-    maxToolRoundtrips: 5,
+    maxSteps: 5,
 
     // run client-side tools that are automatically executed:
     async onToolCall({ toolCall }) {

--- a/examples/next-openai/app/use-chat-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-tools/page.tsx
@@ -7,7 +7,7 @@ export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit, addToolResult } =
     useChat({
       api: '/api/use-chat-tools',
-      maxToolRoundtrips: 5,
+      maxSteps: 5,
 
       // run client-side tools that are automatically executed:
       async onToolCall({ toolCall }) {

--- a/examples/next-openai/app/use-completion-server-side-multi-step/page.tsx
+++ b/examples/next-openai/app/use-completion-server-side-multi-step/page.tsx
@@ -5,7 +5,7 @@ import { useCompletion } from 'ai/react';
 export default function Chat() {
   const { completion, input, handleInputChange, handleSubmit, error, data } =
     useCompletion({
-      api: '/api/use-completion-server-side-roundtrip',
+      api: '/api/use-completion-server-side-multi-step',
     });
 
   return (

--- a/examples/solidstart-openai/src/routes/use-chat-tools/index.tsx
+++ b/examples/solidstart-openai/src/routes/use-chat-tools/index.tsx
@@ -6,7 +6,7 @@ export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit, addToolResult } =
     useChat({
       api: '/api/use-chat-tools',
-      maxToolRoundtrips: 5,
+      maxSteps: 5,
 
       // run client-side tools that are automatically executed:
       async onToolCall({ toolCall }) {

--- a/examples/sveltekit-openai/package.json
+++ b/examples/sveltekit-openai/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "vite dev",
+    "dev": "vite dev --port 3000",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/examples/sveltekit-openai/src/routes/chat-with-tools/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat-with-tools/+page.svelte
@@ -3,7 +3,7 @@
 
   const { input, handleSubmit, messages, addToolResult } = useChat({
     api: '/api/use-chat-tools',
-    maxToolRoundtrips: 5,
+    maxSteps: 5,
     // run client-side tools that are automatically executed:
 
     async onToolCall({ toolCall }) {

--- a/examples/sveltekit-openai/src/routes/use-chat-tools/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/use-chat-tools/+page.svelte
@@ -5,7 +5,6 @@
     api: '/api/use-chat-tools',
     maxSteps: 5,
     // run client-side tools that are automatically executed:
-
     async onToolCall({ toolCall }) {
         if (toolCall.toolName === 'getLocation') {
             const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`result.responseMessages > single roundtrip > should return information about all roundtrips 1`] = `
+exports[`result.responseMessages > single step > should return information about all steps 1`] = `
 [
   {
     "finishReason": "tool-calls",
@@ -74,7 +74,7 @@ exports[`telemetry > should not record telemetry inputs / outputs when disabled 
       "ai.model.provider": "mock-provider",
       "ai.operationId": "ai.generateText",
       "ai.response.finishReason": "stop",
-      "ai.settings.maxToolRoundtrips": 0,
+      "ai.settings.maxSteps": 1,
       "ai.usage.completionTokens": 20,
       "ai.usage.promptTokens": 10,
       "operation.name": "ai.generateText",
@@ -133,7 +133,7 @@ exports[`telemetry > should record successful tool call 1`] = `
       "ai.response.finishReason": "stop",
       "ai.response.toolCalls": "[{"toolCallType":"function","toolCallId":"call-1","toolName":"tool1","args":"{ \\"value\\": \\"value\\" }"}]",
       "ai.result.toolCalls": "[{"toolCallType":"function","toolCallId":"call-1","toolName":"tool1","args":"{ \\"value\\": \\"value\\" }"}]",
-      "ai.settings.maxToolRoundtrips": 0,
+      "ai.settings.maxSteps": 1,
       "ai.usage.completionTokens": 20,
       "ai.usage.promptTokens": 10,
       "operation.name": "ai.generateText",
@@ -201,7 +201,7 @@ exports[`telemetry > should record telemetry data when enabled 1`] = `
       "ai.response.text": "Hello, world!",
       "ai.result.text": "Hello, world!",
       "ai.settings.frequencyPenalty": 0.3,
-      "ai.settings.maxToolRoundtrips": 0,
+      "ai.settings.maxSteps": 1,
       "ai.settings.presencePenalty": 0.4,
       "ai.settings.stopSequences": [
         "stop",

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -1,52 +1,71 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`multiple stream consumption > should support text stream, ai stream, full stream on single result object 1`] = `
-[
-  {
-    "textDelta": "Hello",
-    "type": "text-delta",
-  },
-  {
-    "textDelta": ", ",
-    "type": "text-delta",
-  },
-  {
-    "textDelta": "world!",
-    "type": "text-delta",
-  },
-  {
-    "experimental_providerMetadata": undefined,
-    "finishReason": "stop",
-    "logprobs": undefined,
-    "response": {
-      "id": "id-0",
-      "modelId": "mock-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
+{
+  "dataStream": [
+    "0:"Hello"
+",
+    "0:", "
+",
+    "0:"world!"
+",
+    "e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}
+",
+    "d:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}
+",
+  ],
+  "fullStream": [
+    {
+      "textDelta": "Hello",
+      "type": "text-delta",
     },
-    "type": "step-finish",
-    "usage": {
-      "completionTokens": 10,
-      "promptTokens": 3,
-      "totalTokens": 13,
+    {
+      "textDelta": ", ",
+      "type": "text-delta",
     },
-  },
-  {
-    "experimental_providerMetadata": undefined,
-    "finishReason": "stop",
-    "logprobs": undefined,
-    "response": {
-      "id": "id-0",
-      "modelId": "mock-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
+    {
+      "textDelta": "world!",
+      "type": "text-delta",
     },
-    "type": "finish",
-    "usage": {
-      "completionTokens": 10,
-      "promptTokens": 3,
-      "totalTokens": 13,
+    {
+      "experimental_providerMetadata": undefined,
+      "finishReason": "stop",
+      "logprobs": undefined,
+      "response": {
+        "id": "id-0",
+        "modelId": "mock-model-id",
+        "timestamp": 1970-01-01T00:00:00.000Z,
+      },
+      "type": "step-finish",
+      "usage": {
+        "completionTokens": 10,
+        "promptTokens": 3,
+        "totalTokens": 13,
+      },
     },
-  },
-]
+    {
+      "experimental_providerMetadata": undefined,
+      "finishReason": "stop",
+      "logprobs": undefined,
+      "response": {
+        "id": "id-0",
+        "modelId": "mock-model-id",
+        "timestamp": 1970-01-01T00:00:00.000Z,
+      },
+      "type": "finish",
+      "usage": {
+        "completionTokens": 10,
+        "promptTokens": 3,
+        "totalTokens": 13,
+      },
+    },
+  ],
+  "textStream": [
+    "Hello",
+    ", ",
+    "world!",
+  ],
+}
 `;
 
 exports[`options.maxToolRoundtrips > 2 roundtrips > onFinish should send correct information 1`] = `
@@ -765,6 +784,53 @@ exports[`result.fullStream > should use fallback response metadata when response
       "totalTokens": 13,
     },
   },
+]
+`;
+
+exports[`result.toAIStream > should send tool call and tool result stream parts 1`] = `
+[
+  "9:{"toolCallId":"call-1","toolName":"tool1","args":{"value":"value"}}
+",
+  "a:{"toolCallId":"call-1","result":"value-result"}
+",
+  "e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}
+",
+  "d:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}
+",
+]
+`;
+
+exports[`result.toAIStream > should send tool call, tool call stream start, tool call deltas, and tool result stream parts when tool call delta flag is enabled 1`] = `
+[
+  "b:{"toolCallId":"call-1","toolName":"tool1"}
+",
+  "c:{"toolCallId":"call-1","argsTextDelta":"{ \\"value\\":"}
+",
+  "c:{"toolCallId":"call-1","argsTextDelta":" \\"value\\" }"}
+",
+  "9:{"toolCallId":"call-1","toolName":"tool1","args":{"value":"value"}}
+",
+  "a:{"toolCallId":"call-1","result":"value-result"}
+",
+  "e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}
+",
+  "d:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}
+",
+]
+`;
+
+exports[`result.toAIStream > should transform textStream through callbacks and data transformers 1`] = `
+[
+  "0:"Hello"
+",
+  "0:", "
+",
+  "0:"world!"
+",
+  "e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}
+",
+  "d:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10}}
+",
 ]
 `;
 

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -1,5 +1,54 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`multiple stream consumption > should support text stream, ai stream, full stream on single result object 1`] = `
+[
+  {
+    "textDelta": "Hello",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": ", ",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": "world!",
+    "type": "text-delta",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+]
+`;
+
 exports[`options.maxToolRoundtrips > 2 roundtrips > onFinish should send correct information 1`] = `
 {
   "experimental_providerMetadata": undefined,
@@ -23,6 +72,84 @@ exports[`options.maxToolRoundtrips > 2 roundtrips > onFinish should send correct
 }
 `;
 
+exports[`options.maxToolRoundtrips > 2 roundtrips > should contain assistant response message and tool message from all roundtrips 1`] = `
+[
+  {
+    "args": {
+      "value": "value",
+    },
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-call",
+  },
+  {
+    "args": {
+      "value": "value",
+    },
+    "result": "result1",
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-result",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "tool-calls",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "textDelta": "Hello, ",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": "world!",
+    "type": "text-delta",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-1",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:01.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 5,
+      "promptTokens": 1,
+      "totalTokens": 6,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-1",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:01.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 15,
+      "promptTokens": 4,
+      "totalTokens": 19,
+    },
+  },
+]
+`;
+
 exports[`options.maxToolRoundtrips > 2 roundtrips > should record telemetry data for each roundtrip 1`] = `
 [
   {
@@ -35,6 +162,7 @@ exports[`options.maxToolRoundtrips > 2 roundtrips > should record telemetry data
       "ai.response.finishReason": "stop",
       "ai.response.text": "Hello, world!",
       "ai.result.text": "Hello, world!",
+      "ai.settings.maxSteps": 3,
       "ai.usage.completionTokens": 15,
       "ai.usage.promptTokens": 4,
       "operation.name": "ai.streamText",
@@ -203,6 +331,443 @@ exports[`options.onFinish should send correct information 1`] = `
 }
 `;
 
+exports[`result.fullStream > should filter out empty text deltas 1`] = `
+[
+  {
+    "textDelta": "Hello",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": ", ",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": "world!",
+    "type": "text-delta",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+]
+`;
+
+exports[`result.fullStream > should not send tool call deltas when toolCallStreaming is disabled 1`] = `
+[
+  {
+    "args": {
+      "value": "Sparkle Day",
+    },
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "tool-calls",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 17,
+      "promptTokens": 53,
+      "totalTokens": 70,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "tool-calls",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 17,
+      "promptTokens": 53,
+      "totalTokens": 70,
+    },
+  },
+]
+`;
+
+exports[`result.fullStream > should send delayed asynchronous tool results 1`] = `
+[
+  {
+    "args": {
+      "value": "value",
+    },
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-call",
+  },
+  {
+    "args": {
+      "value": "value",
+    },
+    "result": "value-result",
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-result",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+]
+`;
+
+exports[`result.fullStream > should send text deltas 1`] = `
+[
+  {
+    "textDelta": "Hello",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": ", ",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": "world!",
+    "type": "text-delta",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "response-id",
+      "modelId": "response-model-id",
+      "timestamp": 1970-01-01T00:00:05.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "response-id",
+      "modelId": "response-model-id",
+      "timestamp": 1970-01-01T00:00:05.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+]
+`;
+
+exports[`result.fullStream > should send tool call deltas when toolCallStreaming is enabled 1`] = `
+[
+  {
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call-streaming-start",
+  },
+  {
+    "argsTextDelta": "{"",
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call-delta",
+  },
+  {
+    "argsTextDelta": "value",
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call-delta",
+  },
+  {
+    "argsTextDelta": "":"",
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call-delta",
+  },
+  {
+    "argsTextDelta": "Spark",
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call-delta",
+  },
+  {
+    "argsTextDelta": "le",
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call-delta",
+  },
+  {
+    "argsTextDelta": " Day",
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call-delta",
+  },
+  {
+    "argsTextDelta": ""}",
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call-delta",
+  },
+  {
+    "args": {
+      "value": "Sparkle Day",
+    },
+    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
+    "toolName": "test-tool",
+    "type": "tool-call",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "tool-calls",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 17,
+      "promptTokens": 53,
+      "totalTokens": 70,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "tool-calls",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 17,
+      "promptTokens": 53,
+      "totalTokens": 70,
+    },
+  },
+]
+`;
+
+exports[`result.fullStream > should send tool calls 1`] = `
+[
+  {
+    "args": {
+      "value": "value",
+    },
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-call",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+]
+`;
+
+exports[`result.fullStream > should send tool results 1`] = `
+[
+  {
+    "args": {
+      "value": "value",
+    },
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-call",
+  },
+  {
+    "args": {
+      "value": "value",
+    },
+    "result": "value-result",
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-result",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+]
+`;
+
+exports[`result.fullStream > should use fallback response metadata when response metadata is not provided 1`] = `
+[
+  {
+    "textDelta": "Hello",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": ", ",
+    "type": "text-delta",
+  },
+  {
+    "textDelta": "world!",
+    "type": "text-delta",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-2000",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:02.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-2000",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:02.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+]
+`;
+
 exports[`telemetry > should not record any telemetry data when not explicitly enabled 1`] = `[]`;
 
 exports[`telemetry > should not record telemetry inputs / outputs when disabled 1`] = `
@@ -214,6 +779,7 @@ exports[`telemetry > should not record telemetry inputs / outputs when disabled 
       "ai.model.provider": "mock-provider",
       "ai.operationId": "ai.streamText",
       "ai.response.finishReason": "stop",
+      "ai.settings.maxSteps": 1,
       "ai.usage.completionTokens": 20,
       "ai.usage.promptTokens": 10,
       "operation.name": "ai.streamText",
@@ -290,6 +856,7 @@ exports[`telemetry > should record successful tool call 1`] = `
       "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","args":{"value":"value"}}]",
       "ai.result.text": "",
       "ai.result.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","args":{"value":"value"}}]",
+      "ai.settings.maxSteps": 1,
       "ai.usage.completionTokens": 20,
       "ai.usage.promptTokens": 10,
       "operation.name": "ai.streamText",
@@ -375,6 +942,7 @@ exports[`telemetry > should record telemetry data when enabled 1`] = `
       "ai.response.text": "Hello, world!",
       "ai.result.text": "Hello, world!",
       "ai.settings.frequencyPenalty": 0.3,
+      "ai.settings.maxSteps": 1,
       "ai.settings.presencePenalty": 0.4,
       "ai.settings.stopSequences": [
         "stop",
@@ -460,6 +1028,51 @@ exports[`telemetry > should record telemetry data when enabled 1`] = `
       },
     ],
     "name": "ai.streamText.doStream",
+  },
+]
+`;
+
+exports[`tools with custom schema > should send tool calls 1`] = `
+[
+  {
+    "args": {
+      "value": "value",
+    },
+    "toolCallId": "call-1",
+    "toolName": "tool1",
+    "type": "tool-call",
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "step-finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "id": "id-0",
+      "modelId": "mock-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "type": "finish",
+    "usage": {
+      "completionTokens": 10,
+      "promptTokens": 3,
+      "totalTokens": 13,
+    },
   },
 ]
 `;

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -56,8 +56,10 @@ export interface GenerateTextResult<TOOLS extends Record<string, CoreTool>> {
   readonly responseMessages: Array<CoreAssistantMessage | CoreToolMessage>;
 
   /**
-  Response information for every roundtrip.
-  You can use this to get information about intermediate steps, such as the tool calls or the response headers.
+Response information for every roundtrip.
+You can use this to get information about intermediate steps, such as the tool calls or the response headers.
+
+@deprecated use `steps` instead.
    */
   readonly roundtrips: Array<{
     /**
@@ -111,6 +113,53 @@ Response headers.
     /**
 Additional response information.
  */
+    readonly response: LanguageModelResponseMetadataWithHeaders;
+  }>;
+
+  /**
+Response information for every steps.
+You can use this to get information about intermediate steps, such as the tool calls or the response headers.
+   */
+  readonly steps: Array<{
+    /**
+The generated text.
+ */
+    readonly text: string;
+
+    /**
+The tool calls that were made during the generation.
+*/
+    readonly toolCalls: ToToolCallArray<TOOLS>;
+
+    /**
+The results of the tool calls.
+*/
+    readonly toolResults: ToToolResultArray<TOOLS>;
+
+    /**
+The reason why the generation finished.
+ */
+    readonly finishReason: FinishReason;
+
+    /**
+The token usage of the generated text.
+*/
+    readonly usage: LanguageModelUsage;
+
+    /**
+Warnings from the model provider (e.g. unsupported settings)
+ */
+    readonly warnings: CallWarning[] | undefined;
+
+    /**
+Logprobs for the completion.
+`undefined` if the mode does not support logprobs or if was not enabled.
+ */
+    readonly logprobs: LogProbs | undefined;
+
+    /**
+Additional response information.
+*/
     readonly response: LanguageModelResponseMetadataWithHeaders;
   }>;
 

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -117,7 +117,7 @@ Additional response information.
   }>;
 
   /**
-Response information for every steps.
+Response information for every step.
 You can use this to get information about intermediate steps, such as the tool calls or the response headers.
    */
   readonly steps: Array<{
@@ -182,7 +182,7 @@ Additional response information.
 
   /**
 Logprobs for the completion.
-`undefined` if the mode does not support logprobs or if was not enabled.
+`undefined` if the mode does not support logprobs or if it was not enabled.
 
 @deprecated Will become a provider extension in the future.
      */

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -298,8 +298,8 @@ describe('result.responseMessages', () => {
     ]);
   });
 
-  describe('options.maxToolRoundtrips', () => {
-    it('should contain assistant response message and tool message from all roundtrips', async () => {
+  describe('options.maxSteps', () => {
+    it('should contain assistant response message and tool message from all steps', async () => {
       let responseCount = 0;
       const result = await generateText({
         model: new MockLanguageModelV1({
@@ -345,7 +345,7 @@ describe('result.responseMessages', () => {
           },
         },
         prompt: 'test-input',
-        maxToolRoundtrips: 2,
+        maxSteps: 3,
       });
 
       assert.deepStrictEqual(result.responseMessages, [
@@ -380,7 +380,7 @@ describe('result.responseMessages', () => {
     });
   });
 
-  describe('single roundtrip', () => {
+  describe('single step', () => {
     let result: GenerateTextResult<any>;
 
     beforeEach(async () => {
@@ -532,19 +532,19 @@ describe('result.responseMessages', () => {
           },
         },
         prompt: 'test-input',
-        maxToolRoundtrips: 2,
+        maxSteps: 3,
       });
     });
 
-    it('should return text from last roundtrip', async () => {
+    it('should return text from last step', async () => {
       assert.deepStrictEqual(result.text, 'Hello, world!');
     });
 
-    it('should return empty tool calls from last roundtrip', async () => {
+    it('should return empty tool calls from last step', async () => {
       assert.deepStrictEqual(result.toolCalls, []);
     });
 
-    it('should return empty tool results from last roundtrip', async () => {
+    it('should return empty tool results from last step', async () => {
       assert.deepStrictEqual(result.toolResults, []);
     });
 
@@ -556,8 +556,8 @@ describe('result.responseMessages', () => {
       });
     });
 
-    it('should return information about all roundtrips', () => {
-      expect(result.roundtrips).toMatchSnapshot();
+    it('should return information about all steps', () => {
+      expect(result.steps).toMatchSnapshot();
     });
   });
 });

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -1,5 +1,6 @@
 import { createIdGenerator } from '@ai-sdk/provider-utils';
 import { Tracer } from '@opentelemetry/api';
+import { InvalidArgumentError } from '../../errors';
 import { retryWithExponentialBackoff } from '../../util/retry-with-exponential-backoff';
 import { CoreAssistantMessage, CoreToolMessage } from '../prompt';
 import { CallSettings } from '../prompt/call-settings';
@@ -69,7 +70,7 @@ If set and supported by the model, calls will generate deterministic results.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
 @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
-@param maxToolRoundtrips - Maximal number of automatic roundtrips for tool calls.
+@param maxSteps - Maximal number of sequential LLM calls (steps), e.g. when you use tool calls.
 
 @returns
 A result object that contains the generated text, the results of the tool calls, and additional information.
@@ -86,6 +87,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   headers,
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
+  maxSteps = maxToolRoundtrips != null ? maxToolRoundtrips + 1 : 1,
   experimental_telemetry: telemetry,
   experimental_providerMetadata: providerMetadata,
   _internal: {
@@ -126,8 +128,19 @@ A maximum number is required to prevent infinite loops in the
 case of misconfigured tools.
 
 By default, it's set to 0, which will disable the feature.
+
+@deprecated Use `maxSteps` instead (which is `maxToolRoundtrips` + 1).
      */
     maxToolRoundtrips?: number;
+
+    /**
+Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+
+A maximum number is required to prevent infinite loops in the case of misconfigured tools.
+
+By default, it's set to 1, which means that only a single LLM call is made.
+     */
+    maxSteps?: number;
 
     /**
      * Optional telemetry configuration (experimental).
@@ -149,6 +162,14 @@ functionality that can be fully encapsulated in the provider.
       currentDate?: () => Date;
     };
   }): Promise<GenerateTextResult<TOOLS>> {
+  if (maxSteps < 1) {
+    throw new InvalidArgumentError({
+      parameter: 'maxSteps',
+      value: maxSteps,
+      message: 'maxSteps must be at least 1',
+    });
+  }
+
   const baseTelemetryAttributes = getBaseTelemetryAttributes({
     model,
     telemetry,
@@ -171,7 +192,7 @@ functionality that can be fully encapsulated in the provider.
         'ai.prompt': {
           input: () => JSON.stringify({ system, prompt, messages }),
         },
-        'ai.settings.maxToolRoundtrips': maxToolRoundtrips,
+        'ai.settings.maxSteps': maxSteps,
       },
     }),
     tracer,
@@ -198,10 +219,10 @@ functionality that can be fully encapsulated in the provider.
       > & { response: { id: string; timestamp: Date; modelId: string } };
       let currentToolCalls: ToToolCallArray<TOOLS> = [];
       let currentToolResults: ToToolResultArray<TOOLS> = [];
-      let roundtripCount = 0;
+      let stepCount = 0;
       const responseMessages: Array<CoreAssistantMessage | CoreToolMessage> =
         [];
-      const roundtrips: GenerateTextResult<TOOLS>['roundtrips'] = [];
+      const steps: GenerateTextResult<TOOLS>['steps'] = [];
       const usage: LanguageModelUsage = {
         completionTokens: 0,
         promptTokens: 0,
@@ -209,9 +230,9 @@ functionality that can be fully encapsulated in the provider.
       };
 
       do {
-        // once we have a roundtrip, we need to switch to messages format:
+        // once we have a 2nd step, we need to switch to messages format:
         const currentInputFormat =
-          roundtripCount === 0 ? validatedPrompt.type : 'messages';
+          stepCount === 0 ? validatedPrompt.type : 'messages';
 
         currentModelResponse = await retry(() =>
           recordSpan({
@@ -328,8 +349,8 @@ functionality that can be fully encapsulated in the provider.
         usage.promptTokens += currentUsage.promptTokens;
         usage.totalTokens += currentUsage.totalTokens;
 
-        // add roundtrip information:
-        roundtrips.push({
+        // add step information:
+        steps.push({
           text: currentModelResponse.text ?? '',
           toolCalls: currentToolCalls,
           toolResults: currentToolResults,
@@ -343,7 +364,7 @@ functionality that can be fully encapsulated in the provider.
           },
         });
 
-        // append to messages for potential next roundtrip:
+        // append to messages for potential next step:
         const newResponseMessages = toResponseMessages({
           text: currentModelResponse.text,
           toolCalls: currentToolCalls,
@@ -360,8 +381,8 @@ functionality that can be fully encapsulated in the provider.
         currentToolCalls.length > 0 &&
         // all current tool calls have results:
         currentToolResults.length === currentToolCalls.length &&
-        // the number of roundtrips is less than the maximum:
-        roundtripCount++ < maxToolRoundtrips
+        // the number of steps is less than the maximum:
+        ++stepCount < maxSteps
       );
 
       // Add response information to the span:
@@ -409,7 +430,7 @@ functionality that can be fully encapsulated in the provider.
         },
         logprobs: currentModelResponse.logprobs,
         responseMessages,
-        roundtrips,
+        steps,
         providerMetadata: currentModelResponse.providerMetadata,
       });
     },
@@ -502,6 +523,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
   readonly warnings: GenerateTextResult<TOOLS>['warnings'];
   readonly responseMessages: GenerateTextResult<TOOLS>['responseMessages'];
   readonly roundtrips: GenerateTextResult<TOOLS>['roundtrips'];
+  readonly steps: GenerateTextResult<TOOLS>['steps'];
   readonly rawResponse: GenerateTextResult<TOOLS>['rawResponse'];
   readonly logprobs: GenerateTextResult<TOOLS>['logprobs'];
   readonly experimental_providerMetadata: GenerateTextResult<TOOLS>['experimental_providerMetadata'];
@@ -516,7 +538,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
     warnings: GenerateTextResult<TOOLS>['warnings'];
     logprobs: GenerateTextResult<TOOLS>['logprobs'];
     responseMessages: GenerateTextResult<TOOLS>['responseMessages'];
-    roundtrips: GenerateTextResult<TOOLS>['roundtrips'];
+    steps: GenerateTextResult<TOOLS>['steps'];
     providerMetadata: GenerateTextResult<TOOLS>['experimental_providerMetadata'];
     response: GenerateTextResult<TOOLS>['response'];
   }) {
@@ -528,7 +550,8 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
     this.warnings = options.warnings;
     this.response = options.response;
     this.responseMessages = options.responseMessages;
-    this.roundtrips = options.roundtrips;
+    this.roundtrips = options.steps;
+    this.steps = options.steps;
     this.experimental_providerMetadata = options.providerMetadata;
 
     // deprecated:

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -70,7 +70,7 @@ If set and supported by the model, calls will generate deterministic results.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
 @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
-@param maxSteps - Maximal number of sequential LLM calls (steps), e.g. when you use tool calls.
+@param maxSteps - Maximum number of sequential LLM calls (steps), e.g. when you use tool calls.
 
 @returns
 A result object that contains the generated text, the results of the tool calls, and additional information.

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -118,7 +118,7 @@ The tool choice strategy. Default: 'auto'.
     maxAutomaticRoundtrips?: number;
 
     /**
-Maximal number of automatic roundtrips for tool calls.
+Maximum number of automatic roundtrips for tool calls.
 
 An automatic tool call roundtrip is another LLM call with the
 tool call results when all tool calls of the last assistant
@@ -134,7 +134,7 @@ By default, it's set to 0, which will disable the feature.
     maxToolRoundtrips?: number;
 
     /**
-Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
 
 A maximum number is required to prevent infinite loops in the case of misconfigured tools.
 

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -242,7 +242,7 @@ export type TextStreamPart<TOOLS extends Record<string, CoreTool>> =
       type: 'tool-result';
     } & ToToolResult<TOOLS>)
   | {
-      type: 'roundtrip-finish';
+      type: 'step-finish';
       finishReason: FinishReason;
       logprobs?: LogProbs;
       usage: LanguageModelUsage;

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -672,24 +672,11 @@ describe('result.toAIStream', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertReadableStreamToArray(
         result.toAIStream().pipeThrough(new TextDecoderStream()),
       ),
-      [
-        formatStreamPart('text', 'Hello'),
-        formatStreamPart('text', ', '),
-        formatStreamPart('text', 'world!'),
-        formatStreamPart('finish_roundtrip', {
-          finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10 },
-        }),
-        formatStreamPart('finish_message', {
-          finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10 },
-        }),
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should invoke callback', async () => {
@@ -821,30 +808,11 @@ describe('result.toAIStream', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertReadableStreamToArray(
         result.toAIStream().pipeThrough(new TextDecoderStream()),
       ),
-      [
-        formatStreamPart('tool_call', {
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-        }),
-        formatStreamPart('tool_result', {
-          toolCallId: 'call-1',
-          result: 'value-result',
-        }),
-        formatStreamPart('finish_roundtrip', {
-          finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10 },
-        }),
-        formatStreamPart('finish_message', {
-          finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10 },
-        }),
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should send tool call, tool call stream start, tool call deltas, and tool result stream parts when tool call delta flag is enabled', async () => {
@@ -917,42 +885,11 @@ describe('result.toAIStream', () => {
       experimental_toolCallStreaming: true,
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertReadableStreamToArray(
         result.toAIStream().pipeThrough(new TextDecoderStream()),
       ),
-      [
-        formatStreamPart('tool_call_streaming_start', {
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-        }),
-        formatStreamPart('tool_call_delta', {
-          toolCallId: 'call-1',
-          argsTextDelta: '{ "value":',
-        }),
-        formatStreamPart('tool_call_delta', {
-          toolCallId: 'call-1',
-          argsTextDelta: ' "value" }',
-        }),
-        formatStreamPart('tool_call', {
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-        }),
-        formatStreamPart('tool_result', {
-          toolCallId: 'call-1',
-          result: 'value-result',
-        }),
-        formatStreamPart('finish_roundtrip', {
-          finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10 },
-        }),
-        formatStreamPart('finish_message', {
-          finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10 },
-        }),
-      ],
-    );
+    ).toMatchSnapshot();
   });
 });
 
@@ -1649,33 +1586,13 @@ describe('multiple stream consumption', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
-      await convertAsyncIterableToArray(result.textStream),
-      ['Hello', ', ', 'world!'],
-    );
-
-    assert.deepStrictEqual(
-      await convertReadableStreamToArray(
-        result.toAIStream().pipeThrough(new TextDecoderStream()),
+    expect({
+      textStream: await convertAsyncIterableToArray(result.textStream),
+      fullStream: await convertAsyncIterableToArray(result.fullStream),
+      dataStream: await convertReadableStreamToArray(
+        result.toDataStream().pipeThrough(new TextDecoderStream()),
       ),
-      [
-        formatStreamPart('text', 'Hello'),
-        formatStreamPart('text', ', '),
-        formatStreamPart('text', 'world!'),
-        formatStreamPart('finish_roundtrip', {
-          finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10 },
-        }),
-        formatStreamPart('finish_message', {
-          finishReason: 'stop',
-          usage: { promptTokens: 3, completionTokens: 10 },
-        }),
-      ],
-    );
-
-    expect(
-      await convertAsyncIterableToArray(result.fullStream),
-    ).toMatchSnapshot();
+    }).toMatchSnapshot();
   });
 });
 

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -133,38 +133,9 @@ describe('result.fullStream', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertAsyncIterableToArray(result.fullStream),
-      [
-        { type: 'text-delta', textDelta: 'Hello' },
-        { type: 'text-delta', textDelta: ', ' },
-        { type: 'text-delta', textDelta: 'world!' },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'response-id',
-            modelId: 'response-model-id',
-            timestamp: new Date(5000),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'response-id',
-            modelId: 'response-model-id',
-            timestamp: new Date(5000),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should use fallback response metadata when response metadata is not provided', async () => {
@@ -203,38 +174,9 @@ describe('result.fullStream', () => {
       },
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertAsyncIterableToArray(result.fullStream),
-      [
-        { type: 'text-delta', textDelta: 'Hello' },
-        { type: 'text-delta', textDelta: ', ' },
-        { type: 'text-delta', textDelta: 'world!' },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-2000',
-            modelId: 'mock-model-id',
-            timestamp: new Date(2000),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-2000',
-            modelId: 'mock-model-id',
-            timestamp: new Date(2000),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should send tool calls', async () => {
@@ -298,41 +240,9 @@ describe('result.fullStream', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertAsyncIterableToArray(result.fullStream),
-      [
-        {
-          type: 'tool-call',
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-        },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should not send tool call deltas when toolCallStreaming is disabled', async () => {
@@ -445,41 +355,9 @@ describe('result.fullStream', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertAsyncIterableToArray(result.fullStream),
-      [
-        {
-          type: 'tool-call',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          args: { value: 'Sparkle Day' },
-        },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'tool-calls',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { promptTokens: 53, completionTokens: 17, totalTokens: 70 },
-          experimental_providerMetadata: undefined,
-        },
-        {
-          type: 'finish',
-          finishReason: 'tool-calls',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { promptTokens: 53, completionTokens: 17, totalTokens: 70 },
-          experimental_providerMetadata: undefined,
-        },
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should send tool call deltas when toolCallStreaming is enabled', async () => {
@@ -593,88 +471,9 @@ describe('result.fullStream', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertAsyncIterableToArray(result.fullStream),
-      [
-        {
-          type: 'tool-call-streaming-start',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          argsTextDelta: '{"',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          argsTextDelta: 'value',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          argsTextDelta: '":"',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          argsTextDelta: 'Spark',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          argsTextDelta: 'le',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          argsTextDelta: ' Day',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          argsTextDelta: '"}',
-        },
-        {
-          type: 'tool-call',
-          toolCallId: 'call_O17Uplv4lJvD6DVdIvFFeRMw',
-          toolName: 'test-tool',
-          args: { value: 'Sparkle Day' },
-        },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'tool-calls',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { promptTokens: 53, completionTokens: 17, totalTokens: 70 },
-          experimental_providerMetadata: undefined,
-        },
-        {
-          type: 'finish',
-          finishReason: 'tool-calls',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { promptTokens: 53, completionTokens: 17, totalTokens: 70 },
-          experimental_providerMetadata: undefined,
-        },
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should send tool results', async () => {
@@ -738,48 +537,9 @@ describe('result.fullStream', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertAsyncIterableToArray(result.fullStream),
-      [
-        {
-          type: 'tool-call',
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-        },
-        {
-          type: 'tool-result',
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-          result: 'value-result',
-        },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should send delayed asynchronous tool results', async () => {
@@ -846,48 +606,9 @@ describe('result.fullStream', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(
+    expect(
       await convertAsyncIterableToArray(result.fullStream),
-      [
-        {
-          type: 'tool-call',
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-        },
-        {
-          type: 'tool-result',
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-          result: 'value-result',
-        },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-          experimental_providerMetadata: undefined,
-        },
-      ],
-    );
+    ).toMatchSnapshot();
   });
 
   it('should filter out empty text deltas', async () => {
@@ -921,35 +642,9 @@ describe('result.fullStream', () => {
       prompt: 'test-input',
     });
 
-    expect(await convertAsyncIterableToArray(result.fullStream)).toStrictEqual([
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'world!' },
-      {
-        type: 'roundtrip-finish',
-        finishReason: 'stop',
-        logprobs: undefined,
-        response: {
-          id: 'id-0',
-          modelId: 'mock-model-id',
-          timestamp: new Date(0),
-        },
-        usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-        experimental_providerMetadata: undefined,
-      },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        logprobs: undefined,
-        response: {
-          id: 'id-0',
-          modelId: 'mock-model-id',
-          timestamp: new Date(0),
-        },
-        usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-        experimental_providerMetadata: undefined,
-      },
-    ]);
+    expect(
+      await convertAsyncIterableToArray(result.fullStream),
+    ).toMatchSnapshot();
   });
 });
 
@@ -1978,35 +1673,9 @@ describe('multiple stream consumption', () => {
       ],
     );
 
-    expect(await convertAsyncIterableToArray(result.fullStream)).toStrictEqual([
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'world!' },
-      {
-        type: 'roundtrip-finish',
-        finishReason: 'stop',
-        logprobs: undefined,
-        response: {
-          id: 'id-0',
-          modelId: 'mock-model-id',
-          timestamp: new Date(0),
-        },
-        usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-        experimental_providerMetadata: undefined,
-      },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        logprobs: undefined,
-        response: {
-          id: 'id-0',
-          modelId: 'mock-model-id',
-          timestamp: new Date(0),
-        },
-        usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-        experimental_providerMetadata: undefined,
-      },
-    ]);
+    expect(
+      await convertAsyncIterableToArray(result.fullStream),
+    ).toMatchSnapshot();
   });
 });
 
@@ -2685,73 +2354,7 @@ describe('options.maxToolRoundtrips', () => {
     it('should contain assistant response message and tool message from all roundtrips', async () => {
       expect(
         await convertAsyncIterableToArray(result.fullStream),
-      ).toStrictEqual([
-        {
-          type: 'tool-call',
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-        },
-        {
-          type: 'tool-result',
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          args: { value: 'value' },
-          result: 'result1',
-        },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'tool-calls',
-          logprobs: undefined,
-          response: {
-            id: 'id-0',
-            modelId: 'mock-model-id',
-            timestamp: new Date(0),
-          },
-          experimental_providerMetadata: undefined,
-          usage: {
-            completionTokens: 10,
-            promptTokens: 3,
-            totalTokens: 13,
-          },
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'Hello, ',
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'world!',
-        },
-        {
-          type: 'roundtrip-finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          experimental_providerMetadata: undefined,
-          response: {
-            id: 'id-1',
-            modelId: 'mock-model-id',
-            timestamp: new Date(1000),
-          },
-          usage: {
-            completionTokens: 5,
-            promptTokens: 1,
-            totalTokens: 6,
-          },
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          logprobs: undefined,
-          response: {
-            id: 'id-1',
-            modelId: 'mock-model-id',
-            timestamp: new Date(1000),
-          },
-          usage: { completionTokens: 15, promptTokens: 4, totalTokens: 19 },
-          experimental_providerMetadata: undefined,
-        },
-      ]);
+      ).toMatchSnapshot();
     });
 
     describe('rawSettings', () => {
@@ -3134,37 +2737,8 @@ describe('tools with custom schema', () => {
       },
     });
 
-    expect(await convertAsyncIterableToArray(result.fullStream)).toStrictEqual([
-      {
-        type: 'tool-call',
-        toolCallId: 'call-1',
-        toolName: 'tool1',
-        args: { value: 'value' },
-      },
-      {
-        type: 'roundtrip-finish',
-        finishReason: 'stop',
-        logprobs: undefined,
-        response: {
-          id: 'id-0',
-          modelId: 'mock-model-id',
-          timestamp: new Date(0),
-        },
-        usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-        experimental_providerMetadata: undefined,
-      },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        logprobs: undefined,
-        response: {
-          id: 'id-0',
-          modelId: 'mock-model-id',
-          timestamp: new Date(0),
-        },
-        usage: { completionTokens: 10, promptTokens: 3, totalTokens: 13 },
-        experimental_providerMetadata: undefined,
-      },
-    ]);
+    expect(
+      await convertAsyncIterableToArray(result.fullStream),
+    ).toMatchSnapshot();
   });
 });

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1023,7 +1023,7 @@ However, the LLM results are expected to be small enough to not cause issues.
 
           case 'step-finish': {
             controller.enqueue(
-              formatStreamPart('finish_roundtrip', {
+              formatStreamPart('finish_step', {
                 finishReason: chunk.finishReason,
                 usage: sendUsage
                   ? {

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -145,7 +145,7 @@ The tool choice strategy. Default: 'auto'.
     toolChoice?: CoreToolChoice<TOOLS>;
 
     /**
-Maximal number of automatic roundtrips for tool calls.
+Maximum number of automatic roundtrips for tool calls.
 
 An automatic tool call roundtrip is another LLM call with the
 tool call results when all tool calls of the last assistant
@@ -161,7 +161,7 @@ By default, it's set to 0, which will disable the feature.
     maxToolRoundtrips?: number;
 
     /**
-Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
 
 A maximum number is required to prevent infinite loops in the case of misconfigured tools.
 

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -95,7 +95,7 @@ If set and supported by the model, calls will generate deterministic results.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
 @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
-@param maxSteps - Maximal number of sequential LLM calls (steps), e.g. when you use tool calls.
+@param maxSteps - Maximum number of sequential LLM calls (steps), e.g. when you use tool calls.
 
 @param onChunk - Callback that is called for each chunk of the stream. The stream processing will pause until the callback promise is resolved.
 @param onFinish - Callback that is called when the LLM response and all request tool executions

--- a/packages/ai/svelte/use-chat.ts
+++ b/packages/ai/svelte/use-chat.ts
@@ -29,8 +29,19 @@ export type UseChatOptions = SharedUseChatOptions & {
   case of misconfigured tools.
 
   By default, it's set to 0, which will disable the feature.
-  */
+
+@deprecated Use `maxSteps` instead (which is `maxToolRoundtrips` + 1).
+     */
   maxToolRoundtrips?: number;
+
+  /**
+Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+
+A maximum number is required to prevent infinite loops in the case of misconfigured tools.
+
+By default, it's set to 1, which means that only a single LLM call is made.
+ */
+  maxSteps?: number;
 };
 
 export type UseChatHelpers = {
@@ -82,19 +93,6 @@ export type UseChatHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Readable<JSONValue[] | undefined>;
-  /**
-  Maximal number of automatic roundtrips for tool calls.
-
-  An automatic tool call roundtrip is a call to the server with the
-  tool call results when all tool calls in the last assistant
-  message have results.
-
-  A maximum number is required to prevent infinite loops in the
-  case of misconfigured tools.
-
-  By default, it's set to 0, which will disable the feature.
-  */
-  maxToolRoundtrips?: number;
 };
 
 const getStreamedResponse = async (
@@ -252,6 +250,7 @@ export function useChat({
   fetch,
   keepLastMessageOnError = false,
   maxToolRoundtrips = 0,
+  maxSteps = maxToolRoundtrips != null ? maxToolRoundtrips + 1 : 1,
 }: UseChatOptions = {}): UseChatHelpers & {
   addToolResult: ({
     toolCallId,
@@ -373,11 +372,11 @@ export function useChat({
       // ensure there is a last message:
       lastMessage != null &&
       // check if the feature is enabled:
-      maxToolRoundtrips > 0 &&
-      // check that roundtrip is possible:
+      maxSteps > 1 &&
+      // check that next step is possible:
       isAssistantMessageWithCompletedToolCalls(lastMessage) &&
-      // limit the number of automatic roundtrips:
-      countTrailingAssistantMessages(newMessagesSnapshot) <= maxToolRoundtrips
+      // limit the number of automatic steps:
+      countTrailingAssistantMessages(newMessagesSnapshot) < maxSteps
     ) {
       await triggerRequest({ messages: newMessagesSnapshot });
     }

--- a/packages/ai/svelte/use-chat.ts
+++ b/packages/ai/svelte/use-chat.ts
@@ -19,7 +19,7 @@ export type { CreateMessage, Message };
 
 export type UseChatOptions = SharedUseChatOptions & {
   /**
-  Maximal number of automatic roundtrips for tool calls.
+  Maximum number of automatic roundtrips for tool calls.
 
   An automatic tool call roundtrip is a call to the server with the
   tool call results when all tool calls in the last assistant
@@ -35,7 +35,7 @@ export type UseChatOptions = SharedUseChatOptions & {
   maxToolRoundtrips?: number;
 
   /**
-Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
 
 A maximum number is required to prevent infinite loops in the case of misconfigured tools.
 

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -238,7 +238,7 @@ export function useChat({
   }) => JSONValue;
 
   /**
-Maximal number of automatic roundtrips for tool calls.
+Maximum number of automatic roundtrips for tool calls.
 
 An automatic tool call roundtrip is a call to the server with the
 tool call results when all tool calls in the last assistant
@@ -254,7 +254,7 @@ By default, it's set to 0, which will disable the feature.
   maxToolRoundtrips?: number;
 
   /**
-Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
 
 A maximum number is required to prevent infinite loops in the case of misconfigured tools.
 

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -197,6 +197,7 @@ export function useChat({
   experimental_maxAutomaticRoundtrips = 0,
   maxAutomaticRoundtrips = experimental_maxAutomaticRoundtrips,
   maxToolRoundtrips = maxAutomaticRoundtrips,
+  maxSteps = maxToolRoundtrips != null ? maxToolRoundtrips + 1 : 1,
   streamMode,
   streamProtocol,
   onResponse,
@@ -247,8 +248,19 @@ A maximum number is required to prevent infinite loops in the
 case of misconfigured tools.
 
 By default, it's set to 0, which will disable the feature.
-   */
+
+@deprecated Use `maxSteps` instead (which is `maxToolRoundtrips` + 1).
+     */
   maxToolRoundtrips?: number;
+
+  /**
+Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+
+A maximum number is required to prevent infinite loops in the case of misconfigured tools.
+
+By default, it's set to 1, which means that only a single LLM call is made.
+ */
+  maxSteps?: number;
 } = {}): UseChatHelpers & {
   /**
    * @deprecated Use `addToolResult` instead.
@@ -393,11 +405,11 @@ By default, it's set to 0, which will disable the feature.
         // ensure there is a last message:
         lastMessage != null &&
         // check if the feature is enabled:
-        maxToolRoundtrips > 0 &&
-        // check that roundtrip is possible:
+        maxSteps > 1 &&
+        // check that next step is possible:
         isAssistantMessageWithCompletedToolCalls(lastMessage) &&
-        // limit the number of automatic roundtrips:
-        countTrailingAssistantMessages(messages) <= maxToolRoundtrips
+        // limit the number of automatic steps:
+        countTrailingAssistantMessages(messages) < maxSteps
       ) {
         await triggerRequest({ messages });
       }
@@ -419,7 +431,7 @@ By default, it's set to 0, which will disable the feature.
       experimental_onToolCall,
       experimental_prepareRequestBody,
       onToolCall,
-      maxToolRoundtrips,
+      maxSteps,
       messagesRef,
       abortControllerRef,
       generateId,

--- a/packages/solid/src/use-chat.ts
+++ b/packages/solid/src/use-chat.ts
@@ -173,8 +173,19 @@ A maximum number is required to prevent infinite loops in the
 case of misconfigured tools.
 
 By default, it's set to 0, which will disable the feature.
- */
+
+@deprecated Use `maxSteps` instead (which is `maxToolRoundtrips` + 1).
+     */
   maxToolRoundtrips?: number;
+
+  /**
+Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+
+A maximum number is required to prevent infinite loops in the case of misconfigured tools.
+
+By default, it's set to 1, which means that only a single LLM call is made.
+*/
+  maxSteps?: number;
 };
 
 export function useChat(
@@ -295,7 +306,9 @@ export function useChat(
       setIsLoading(false);
     }
 
-    const maxToolRoundtrips = useChatOptions().maxToolRoundtrips?.() ?? 0;
+    const maxSteps =
+      useChatOptions().maxSteps?.() ??
+      (useChatOptions().maxToolRoundtrips?.() ?? 0) + 1;
     // auto-submit when all tool calls in the last assistant message have results:
     const messages = messagesRef;
     const lastMessage = messages[messages.length - 1];
@@ -305,11 +318,11 @@ export function useChat(
       // ensure there is a last message:
       lastMessage != null &&
       // check if the feature is enabled:
-      maxToolRoundtrips > 0 &&
-      // check that roundtrip is possible:
+      maxSteps > 1 &&
+      // check that next step is possible:
       isAssistantMessageWithCompletedToolCalls(lastMessage) &&
-      // limit the number of automatic roundtrips:
-      countTrailingAssistantMessages(messages) <= maxToolRoundtrips
+      // limit the number of automatic steps:
+      countTrailingAssistantMessages(messages) < maxSteps
     ) {
       await triggerRequest({ messages });
     }

--- a/packages/solid/src/use-chat.ts
+++ b/packages/solid/src/use-chat.ts
@@ -163,7 +163,7 @@ const [store, setStore] = createStore<Record<string, Message[]>>({});
 
 export type UseChatOptions = SharedUseChatOptions & {
   /**
-Maximal number of automatic roundtrips for tool calls.
+Maximum number of automatic roundtrips for tool calls.
 
 An automatic tool call roundtrip is a call to the server with the
 tool call results when all tool calls in the last assistant
@@ -179,7 +179,7 @@ By default, it's set to 0, which will disable the feature.
   maxToolRoundtrips?: number;
 
   /**
-Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
 
 A maximum number is required to prevent infinite loops in the case of misconfigured tools.
 

--- a/packages/svelte/src/use-chat.ts
+++ b/packages/svelte/src/use-chat.ts
@@ -29,8 +29,19 @@ export type UseChatOptions = SharedUseChatOptions & {
   case of misconfigured tools.
 
   By default, it's set to 0, which will disable the feature.
-  */
+
+@deprecated Use `maxSteps` instead (which is `maxToolRoundtrips` + 1).
+     */
   maxToolRoundtrips?: number;
+
+  /**
+Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+
+A maximum number is required to prevent infinite loops in the case of misconfigured tools.
+
+By default, it's set to 1, which means that only a single LLM call is made.
+ */
+  maxSteps?: number;
 };
 
 export type UseChatHelpers = {
@@ -82,19 +93,6 @@ export type UseChatHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Readable<JSONValue[] | undefined>;
-  /**
-  Maximal number of automatic roundtrips for tool calls.
-
-  An automatic tool call roundtrip is a call to the server with the
-  tool call results when all tool calls in the last assistant
-  message have results.
-
-  A maximum number is required to prevent infinite loops in the
-  case of misconfigured tools.
-
-  By default, it's set to 0, which will disable the feature.
-  */
-  maxToolRoundtrips?: number;
 };
 
 const getStreamedResponse = async (
@@ -249,6 +247,7 @@ export function useChat({
   fetch,
   keepLastMessageOnError = false,
   maxToolRoundtrips = 0,
+  maxSteps = maxToolRoundtrips != null ? maxToolRoundtrips + 1 : 1,
 }: UseChatOptions = {}): UseChatHelpers & {
   addToolResult: ({
     toolCallId,
@@ -362,19 +361,19 @@ export function useChat({
 
     // auto-submit when all tool calls in the last assistant message have results:
     const newMessagesSnapshot = get(messages);
-    const lastMessage = newMessagesSnapshot[newMessagesSnapshot.length - 1];
 
+    const lastMessage = newMessagesSnapshot[newMessagesSnapshot.length - 1];
     if (
       // ensure we actually have new messages (to prevent infinite loops in case of errors):
       newMessagesSnapshot.length > messageCount &&
       // ensure there is a last message:
       lastMessage != null &&
       // check if the feature is enabled:
-      maxToolRoundtrips > 0 &&
-      // check that roundtrip is possible:
+      maxSteps > 1 &&
+      // check that next step is possible:
       isAssistantMessageWithCompletedToolCalls(lastMessage) &&
-      // limit the number of automatic roundtrips:
-      countTrailingAssistantMessages(newMessagesSnapshot) <= maxToolRoundtrips
+      // limit the number of automatic steps:
+      countTrailingAssistantMessages(newMessagesSnapshot) < maxSteps
     ) {
       await triggerRequest({ messages: newMessagesSnapshot });
     }

--- a/packages/svelte/src/use-chat.ts
+++ b/packages/svelte/src/use-chat.ts
@@ -19,7 +19,7 @@ export type { CreateMessage, Message };
 
 export type UseChatOptions = SharedUseChatOptions & {
   /**
-  Maximal number of automatic roundtrips for tool calls.
+  Maximum number of automatic roundtrips for tool calls.
 
   An automatic tool call roundtrip is a call to the server with the
   tool call results when all tool calls in the last assistant
@@ -35,7 +35,7 @@ export type UseChatOptions = SharedUseChatOptions & {
   maxToolRoundtrips?: number;
 
   /**
-Maximal number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
+Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
 
 A maximum number is required to prevent infinite loops in the case of misconfigured tools.
 

--- a/packages/ui-utils/src/process-data-procotol-response.test.ts
+++ b/packages/ui-utils/src/process-data-procotol-response.test.ts
@@ -48,7 +48,7 @@ describe('scenario: simple text response', () => {
     const stream = createDataProtocolStream([
       formatStreamPart('text', 'Hello, '),
       formatStreamPart('text', 'world!'),
-      formatStreamPart('finish_roundtrip', {
+      formatStreamPart('finish_step', {
         finishReason: 'stop',
         usage: { completionTokens: 5, promptTokens: 10 },
       }),
@@ -139,12 +139,12 @@ describe('scenario: server-side tool roundtrip', () => {
         toolCallId: 'tool-call-id',
         result: { weather: 'sunny' },
       }),
-      formatStreamPart('finish_roundtrip', {
+      formatStreamPart('finish_step', {
         finishReason: 'tool-calls',
         usage: { completionTokens: 5, promptTokens: 10 },
       }),
       formatStreamPart('text', 'The weather in London is sunny.'),
-      formatStreamPart('finish_roundtrip', {
+      formatStreamPart('finish_step', {
         finishReason: 'stop',
         usage: { completionTokens: 2, promptTokens: 4 },
       }),

--- a/packages/ui-utils/src/process-data-protocol-response.ts
+++ b/packages/ui-utils/src/process-data-protocol-response.ts
@@ -96,7 +96,7 @@ export async function processDataProtocolResponse({
       throw new Error(value);
     }
 
-    if (type === 'finish_roundtrip') {
+    if (type === 'finish_step') {
       nextPrefixMap = {};
       continue;
     }

--- a/packages/ui-utils/src/stream-parts.test.ts
+++ b/packages/ui-utils/src/stream-parts.test.ts
@@ -248,10 +248,10 @@ describe('finish_message stream part', () => {
   });
 });
 
-describe('finish_roundtrip stream part', () => {
-  it('should format a finish_roundtrip stream part', () => {
+describe('finish_step stream part', () => {
+  it('should format a finish_step stream part', () => {
     expect(
-      formatStreamPart('finish_roundtrip', {
+      formatStreamPart('finish_step', {
         finishReason: 'stop',
         usage: { promptTokens: 10, completionTokens: 20 },
       }),
@@ -260,18 +260,18 @@ describe('finish_roundtrip stream part', () => {
     );
   });
 
-  it('should format a finish_roundtrip stream part without usage information', () => {
+  it('should format a finish_step stream part without usage information', () => {
     expect(
-      formatStreamPart('finish_roundtrip', {
+      formatStreamPart('finish_step', {
         finishReason: 'stop',
       }),
     ).toEqual(`e:{"finishReason":"stop"}\n`);
   });
 
-  it('should parse a finish_roundtrip stream part', () => {
+  it('should parse a finish_step stream part', () => {
     const input = `e:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":20}}`;
     expect(parseStreamPart(input)).toEqual({
-      type: 'finish_roundtrip',
+      type: 'finish_step',
       value: {
         finishReason: 'stop',
         usage: { promptTokens: 10, completionTokens: 20 },
@@ -279,10 +279,10 @@ describe('finish_roundtrip stream part', () => {
     });
   });
 
-  it('should parse a finish_roundtrip with null completion and prompt tokens', () => {
+  it('should parse a finish_step with null completion and prompt tokens', () => {
     const input = `e:{"finishReason":"stop","usage":{"promptTokens":null,"completionTokens":null}}`;
     expect(parseStreamPart(input)).toEqual({
-      type: 'finish_roundtrip',
+      type: 'finish_step',
       value: {
         finishReason: 'stop',
         usage: { promptTokens: NaN, completionTokens: NaN },
@@ -290,10 +290,10 @@ describe('finish_roundtrip stream part', () => {
     });
   });
 
-  it('should parse a finish_roundtrip without usage information', () => {
+  it('should parse a finish_step without usage information', () => {
     const input = `e:{"finishReason":"stop","usage":null}`;
     expect(parseStreamPart(input)).toEqual({
-      type: 'finish_roundtrip',
+      type: 'finish_step',
       value: {
         finishReason: 'stop',
       },

--- a/packages/ui-utils/src/stream-parts.ts
+++ b/packages/ui-utils/src/stream-parts.ts
@@ -423,9 +423,9 @@ const finishMessageStreamPart: StreamPart<
   },
 };
 
-const finishRoundtripStreamPart: StreamPart<
+const finishStepStreamPart: StreamPart<
   'e',
-  'finish_roundtrip',
+  'finish_step',
   {
     finishReason: LanguageModelV1FinishReason;
     usage?: {
@@ -435,7 +435,7 @@ const finishRoundtripStreamPart: StreamPart<
   }
 > = {
   code: 'e',
-  name: 'finish_roundtrip',
+  name: 'finish_step',
   parse: (value: JSONValue) => {
     if (
       value == null ||
@@ -444,7 +444,7 @@ const finishRoundtripStreamPart: StreamPart<
       typeof value.finishReason !== 'string'
     ) {
       throw new Error(
-        '"finish_roundtrip" parts expect an object with a "finishReason" property.',
+        '"finish_step" parts expect an object with a "finishReason" property.',
       );
     }
 
@@ -478,7 +478,7 @@ const finishRoundtripStreamPart: StreamPart<
     }
 
     return {
-      type: 'finish_roundtrip',
+      type: 'finish_step',
       value: result,
     };
   },
@@ -499,7 +499,7 @@ const streamParts = [
   toolCallStreamingStartStreamPart,
   toolCallDeltaStreamPart,
   finishMessageStreamPart,
-  finishRoundtripStreamPart,
+  finishStepStreamPart,
 ] as const;
 
 // union type of all stream parts
@@ -518,7 +518,7 @@ type StreamParts =
   | typeof toolCallStreamingStartStreamPart
   | typeof toolCallDeltaStreamPart
   | typeof finishMessageStreamPart
-  | typeof finishRoundtripStreamPart;
+  | typeof finishStepStreamPart;
 
 /**
  * Maps the type of a stream part to its value type.
@@ -542,7 +542,7 @@ export type StreamPartType =
   | ReturnType<typeof toolCallStreamingStartStreamPart.parse>
   | ReturnType<typeof toolCallDeltaStreamPart.parse>
   | ReturnType<typeof finishMessageStreamPart.parse>
-  | ReturnType<typeof finishRoundtripStreamPart.parse>;
+  | ReturnType<typeof finishStepStreamPart.parse>;
 
 export const streamPartsByCode = {
   [textStreamPart.code]: textStreamPart,
@@ -559,7 +559,7 @@ export const streamPartsByCode = {
   [toolCallStreamingStartStreamPart.code]: toolCallStreamingStartStreamPart,
   [toolCallDeltaStreamPart.code]: toolCallDeltaStreamPart,
   [finishMessageStreamPart.code]: finishMessageStreamPart,
-  [finishRoundtripStreamPart.code]: finishRoundtripStreamPart,
+  [finishStepStreamPart.code]: finishStepStreamPart,
 } as const;
 
 /**
@@ -600,7 +600,7 @@ export const StreamStringPrefixes = {
     toolCallStreamingStartStreamPart.code,
   [toolCallDeltaStreamPart.name]: toolCallDeltaStreamPart.code,
   [finishMessageStreamPart.name]: finishMessageStreamPart.code,
-  [finishRoundtripStreamPart.name]: finishRoundtripStreamPart.code,
+  [finishStepStreamPart.name]: finishStepStreamPart.code,
 } as const;
 
 export const validCodes = streamParts.map(part => part.code);


### PR DESCRIPTION
## Summary
- changes `maxToolRoundtrips` parameter to `maxSteps` (for `generateText`, `streamText`)
- add `ai.settings.maxSteps` telemetry to `streamText` (and rename for `generateText`)
- **breaking change**: `roundtrip-finish` stream part from `streamText` is now called `step-finish`
- align Svelte example URL with other examples

## Background
The term `roundtrips` was idiosyncratic and had semantic issues (what is a roundtrip? how does the roundtrip number map to the `roundtrip` object size?). We are renaming to steps which has a clear meaning and maps correctly the the executed iterations.

## Tasks

- [x] generateText
- [x] generateText docs
- [x] streamText
- [x] streamText docs
- [x] rename stream part
- [x] useChat react
- [x] useChat svelte x2
- [x] useChat solid
- [x] useChat docs
- [x] general docs search
- [x] examples
   - [x] core
   - [x] react
   - [x] svelte
   - [x] solid
- [x] changeset