### PR TITLE
fix: missing annotations in messages when submitting

### DIFF
--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -457,10 +457,7 @@ By default, it's set to 0, which will disable the feature.
       };
 
       const messages = messagesRef.current.concat({
-        id: generateId(),
-        createdAt: new Date(),
-        role: 'user',
-        content: message.content,
+        ...message,
         experimental_attachments:
           attachmentsForRequest.length > 0 ? attachmentsForRequest : undefined,
       });


### PR DESCRIPTION
Please check my comment here @lgrammel
https://github.com/vercel/ai/pull/2976/files#r1758681163

The changes in PR #2976 causes the message annotations not exist in the messages when submitting
