### PR TITLE
fix (react): restore sending annotations with message during submission

### DIFF
--- a/.changeset/quiet-jeans-pump.md
+++ b/.changeset/quiet-jeans-pump.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix (react): restore sending annotations with during submission

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -457,10 +457,7 @@ By default, it's set to 0, which will disable the feature.
       };
 
       const messages = messagesRef.current.concat({
-        id: generateId(),
-        createdAt: new Date(),
-        role: 'user',
-        content: message.content,
+        ...message,
         experimental_attachments:
           attachmentsForRequest.length > 0 ? attachmentsForRequest : undefined,
       });

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -458,6 +458,7 @@ By default, it's set to 0, which will disable the feature.
 
       const messages = messagesRef.current.concat({
         ...message,
+        id: message.id ?? generateId(),
         experimental_attachments:
           attachmentsForRequest.length > 0 ? attachmentsForRequest : undefined,
       });

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -459,6 +459,7 @@ By default, it's set to 0, which will disable the feature.
       const messages = messagesRef.current.concat({
         ...message,
         id: message.id ?? generateId(),
+        createdAt: message.createdAt ?? new Date(),
         experimental_attachments:
           attachmentsForRequest.length > 0 ? attachmentsForRequest : undefined,
       });


### PR DESCRIPTION
expands on #2997, thanks @thucpn!

- [x] handle additional fields
- [x] add tests
- [x] add changeset
