### PR TITLE
fix (docs): fix a minor typo in 02-streaming-react-components

### DIFF
--- a/content/docs/04-ai-sdk-rsc/02-streaming-react-components.mdx
+++ b/content/docs/04-ai-sdk-rsc/02-streaming-react-components.mdx
@@ -12,7 +12,7 @@ import { Weather } from '@/components/home/weather';
 
 The RSC API allows you to stream React components from the server to the client with the [`streamUI`](/docs/reference/ai-sdk-rsc/stream-ui) function. This is useful when you want to go beyond raw text and stream components to the client in real-time.
 
-Similar to [ AI SDK Core ](/docs/ai-sdk-core/overview) APIs (like [ `streamText` ](/docs/reference/ai-sdk-core/stream-text) and [ `streamObject` ](/docs/reference/ai-sdk-core/stream-object), `streamUI` provides a single function to call a model and allow it to respond with React Server Components.
+Similar to [ AI SDK Core ](/docs/ai-sdk-core/overview) APIs (like [ `streamText` ](/docs/reference/ai-sdk-core/stream-text) and [ `streamObject` ](/docs/reference/ai-sdk-core/stream-object)), `streamUI` provides a single function to call a model and allow it to respond with React Server Components.
 It supports the same model interfaces as AI SDK Core APIs.
 
 ### Concepts


### PR DESCRIPTION
Add the missing close parenthesis.