### PR TITLE
feat (ai/core): add responseMessages to streamText

### DIFF
--- a/.changeset/long-apes-heal.md
+++ b/.changeset/long-apes-heal.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): add responseMessages to streamText

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -36,49 +36,23 @@ import { generateText } from 'ai';
 const { text } = await generateText({
   model: yourModel,
   system:
-    'You are a professional writer. You write simple, clear, and concise content.',
-  prompt: `summarize the following article in 3-5 sentences:\n${article}`,
+    'You are a professional writer. ' +
+    'You write simple, clear, and concise content.',
+  prompt: `Summarize the following article in 3-5 sentences: ${article}`,
 });
 ```
-
-### `onStepFinish` callback
-
-When using `generateText`, you can provide an `onStepFinish` callback that is triggered when a step is finished,
-i.e. all text deltas, tool calls, and tool results for the step are available.
-When you have multiple steps, the callback is triggered for each step.
-
-```tsx highlight="7-9"
-import { generateText } from 'ai';
-
-const result = await generateText({
-  model: yourModel,
-  prompt: 'Invent a new holiday and describe its traditions.',
-  maxSteps: 5, // more than one step
-  onStepFinish({ text, toolCalls, toolResults, finishReason, usage }) {
-    // your own logic, e.g. for saving the chat history or recording usage
-  },
-});
-```
-
-### Result properties
 
 The result object of `generateText` contains several promises that resolve when all required data is available:
 
 - `result.text`: The generated text.
-- `result.toolCalls`: The tool calls made during text generation.
-- `result.toolResults`: The tool results from the tool calls.
 - `result.finishReason`: The reason the model finished generating text.
 - `result.usage`: The usage of the model during text generation.
-- `result.steps`: Information about each step.
 
 ## `streamText`
 
 Depending on your model and prompt, it can take a large language model (LLM) up to a minute to finish generating it's response. This delay can be unacceptable for interactive use cases such as chatbots or real-time applications, where users expect immediate responses.
 
-Vercel AI SDK Core provides the [`streamText`](/docs/reference/ai-sdk-core/stream-text) function which simplifies streaming text from LLMs.
-Its result has methods that can be used in different environments, e.g.
-`result.toDataStreamResponse()` to create a response object that can be used
-in a Next.js App Router API route.
+AI SDK Core provides the [`streamText`](/docs/reference/ai-sdk-core/stream-text) function which simplifies streaming text from LLMs:
 
 ```ts
 import { streamText } from 'ai';
@@ -95,31 +69,24 @@ for await (const textPart of result.textStream) {
 ```
 
 <Note>
-  You can use `streamText` on it's own or in combination with [AI SDK
-  UI](/examples/next-pages/basics/streaming-text-generation) and [AI SDK
-  RSC](/examples/next-app/basics/streaming-text-generation)
+  `result.textStream` is both a `ReadableStream` and an `AsyncIterable`.
 </Note>
 
-`result.textStream` is also a `ReadableStream`, so you can use it in a browser or Node.js environment.
+You can use `streamText` on it's own or in combination with [AI SDK
+UI](/examples/next-pages/basics/streaming-text-generation) and [AI SDK
+RSC](/examples/next-app/basics/streaming-text-generation).
+The result object contains several helper functions to make the integration into [AI SDK UI](/docs/ai-sdk-ui) easier:
 
-```ts
-import { streamText } from 'ai';
+- `result.toDataStreamResponse()`: Creates a data stream HTTP response (with tool calls etc.) that can be used in a Next.js App Router API route.
+- `result.pipeDataStreamToResponse()`: Writes AI stream delta output to a Node.js response-like object.
+- `result.toTextStreamResponse()`: Creates a simple text stream HTTP response.
+- `result.pipeTextStreamToResponse()`: Writes text delta output to a Node.js response-like object.
 
-const result = await streamText({
-  model: yourModel,
-  prompt: 'Invent a new holiday and describe its traditions.',
-});
+It also provides several promises that resolve when all required data is available:
 
-// use textStream as a ReadableStream:
-const reader = result.textStream.getReader();
-while (true) {
-  const { done, value } = await reader.read();
-  if (done) {
-    break;
-  }
-  process.stdout.write(value);
-}
-```
+- `result.text`: The generated text.
+- `result.finishReason`: The reason the model finished generating text.
+- `result.usage`: The usage of the model during text generation.
 
 ### `onChunk` callback
 
@@ -148,29 +115,10 @@ const result = await streamText({
 });
 ```
 
-### `onStepFinish` callback
-
-When using `streamText`, you can provide an `onStepFinish` callback that is triggered when a step is finished,
-i.e. all text deltas, tool calls, and tool results for the step are available.
-When you have multiple steps, the callback is triggered for each step.
-
-```tsx highlight="7-9"
-import { streamText } from 'ai';
-
-const result = await streamText({
-  model: yourModel,
-  prompt: 'Invent a new holiday and describe its traditions.',
-  maxSteps: 5, // more than one step
-  onStepFinish({ text, toolCalls, toolResults, finishReason, usage }) {
-    // your own logic, e.g. for saving the chat history or recording usage
-  },
-});
-```
-
 ### `onFinish` callback
 
-When using `streamText`, you can provide an `onFinish` callback that is triggered when all steps are finished.
-It contains the text and tool calls from the last step, the combined usage of all steps, and an array of all steps.
+When using `streamText`, you can provide an `onFinish` callback that is triggered when the stream is finished.
+It contains the text, usage information, finish reason, and more:
 
 ```tsx highlight="6-8"
 import { streamText } from 'ai';
@@ -178,30 +126,11 @@ import { streamText } from 'ai';
 const result = await streamText({
   model: yourModel,
   prompt: 'Invent a new holiday and describe its traditions.',
-  onFinish({ text, toolCalls, toolResults, finishReason, usage, steps }) {
+  onFinish({ text, finishReason, usage }) {
     // your own logic, e.g. for saving the chat history or recording usage
   },
 });
 ```
-
-### Result helper functions
-
-The result object of `streamText` contains several helper functions to make the integration into [AI SDK UI](/docs/ai-sdk-ui) easier:
-
-- `result.toDataStreamResponse()`: Creates a data stream response (with tool calls etc.).
-- `result.toTextStreamResponse()`: Creates a simple text stream response.
-- `result.pipeDataStreamToResponse()`: Writes AI stream delta output to a Node.js response-like object.
-- `result.pipeTextStreamToResponse()`: Writes text delta output to a Node.js response-like object.
-
-### Result promises
-
-The result object of `streamText` contains several promises that resolve when all required data is available:
-
-- `result.text`: The generated text.
-- `result.toolCalls`: The tool calls made during text generation.
-- `result.toolResults`: The tool results from the tool calls.
-- `result.finishReason`: The reason the model finished generating text.
-- `result.usage`: The usage of the model during text generation.
 
 ## Examples
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -104,12 +104,17 @@ It contains all the text, tool calls, tool results, and more from each step.
 
 #### Example: Extract tool results from all steps
 
-```ts highlight="5"
-const result = await generateText({
+```ts highlight="3,9-10"
+import { generateText } from 'ai';
+
+const { steps } = await generateText({
+  model: openai('gpt-4-turbo'),
+  maxSteps: 10,
   // ...
 });
 
-const allToolResults = result.steps.flatMap(step => step.toolResults);
+// extract all tool calls from the steps:
+const allToolCalls = steps.flatMap(step => step.toolCalls);
 ```
 
 ### Response Messages

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -102,6 +102,16 @@ To access intermediate tool calls and results, you can use the `steps` property 
 or the `streamText` `onFinish` callback.
 It contains all the text, tool calls, tool results, and more from each step.
 
+#### Example: Extract all tool results from all steps
+
+```ts highlight="5"
+const result = await generateText({
+  // ...
+});
+
+const allToolResults = result.steps.flatMap(step => step.toolResults);
+```
+
 ### Response Messages
 
 When you run multi-step tool calls, multiple assistant and tool messages will be executed.

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -102,7 +102,7 @@ To access intermediate tool calls and results, you can use the `steps` property 
 or the `streamText` `onFinish` callback.
 It contains all the text, tool calls, tool results, and more from each step.
 
-#### Example: Extract all tool results from all steps
+#### Example: Extract tool results from all steps
 
 ```ts highlight="5"
 const result = await generateText({

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -6,12 +6,16 @@ description: Learn about tool calling with Vercel AI SDK Core.
 # Tool Calling
 
 As covered under Foundations, [tools](/docs/foundations/tools) are objects that can be called by the model to perform a specific task.
-
-When used with AI SDK Core, tools contain three elements:
+AI SDK Core tools contain three elements:
 
 - **`description`**: An optional description of the tool that can influence when the tool is picked.
-- **`parameters`**: A [Zod schema](/docs/foundations/tools#schema-specification-and-validation-with-zod) or a [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the parameters. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
+- **`parameters`**: A [Zod schema](/docs/foundations/tools#schemas) or a [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the parameters. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
 - **`execute`**: An optional async function that is called with the arguments from the tool call. It produces a value of type `RESULT` (generic type). It is optional because you might want to forward tool calls to the client or to a queue instead of executing them in the same process.
+
+<Note className="mb-2">
+  You can use the [`tool`](/docs/reference/ai-sdk-core/tool) helper function to
+  infer the types of the `execute` parameters.
+</Note>
 
 The `tools` parameter of `generateText` and `streamText` is an object that has the tool names as keys and the tools as values:
 
@@ -37,18 +41,13 @@ const result = await generateText({
 });
 ```
 
-<Note className="mb-2">
-  You can use the [`tool`](/docs/reference/ai-sdk-core/tool) helper function to
-  infer the types of the `execute` parameters.
-</Note>
-
 <Note>
   When a model uses a tool, it is called a "tool call" and the output of the
   tool is called a "tool result".
 </Note>
 
 Tool calling is not restricted to only text generation.
-You can also use it to render user interfaces with Generative AI.
+You can also use it to render user interfaces (Generative UI).
 
 ## Multi-Step Calls
 
@@ -60,7 +59,17 @@ When `maxSteps` is set to a number greater than 1, the language model will be ca
 in a loop when there are tool calls and for every tool call there is a tool result, until there
 are no further tool calls or the maximum number of tool steps is reached.
 
-### Example: generateText
+### Example
+
+In the following example, there are two steps:
+
+1. **Step 1**
+   1. The prompt `'What is the weather in San Francisco?'` is sent to the model.
+   1. The model generates a tool call.
+   1. The tool call is executed.
+1. **Step 2**
+   1. The tool result is sent to the model.
+   1. The model generates a response considering the tool result.
 
 ```ts highlight="18"
 import { z } from 'zod';
@@ -85,49 +94,38 @@ const { text, steps } = await generateText({
 });
 ```
 
-In the above example, there are two steps:
+<Note>You can use `streamText` in a similar way.</Note>
 
-1. **Step 1**
-   1. The prompt `'What is the weather in San Francisco?'` is sent to the model.
-   1. The model generates a tool call.
-   1. The tool call is executed.
-1. **Step 2**
-   1. The tool result is sent to the model.
-   1. The model generates a response considering the tool result.
+### Steps
 
-To access intermediate tool calls and results, you can use the `steps` property in the result object.
+To access intermediate tool calls and results, you can use the `steps` property in the result object
+or the `streamText` `onFinish` callback.
 It contains all the text, tool calls, tool results, and more from each step.
 
-### Example: streamText
+### Response Messages
 
-```ts highlight="18"
-import { streamText, tool } from 'ai';
-import { z } from 'zod';
+When you run multi-step tool calls, multiple assistant and tool messages will be executed.
+To help you keep a consistent conversation history, you can use the `responseMessages` property
+on the result object or the `streamText` `onFinish` callback.
+It contains all the assistant and tool messages that have been generated.
 
-const { textStream, steps } = await streamText({
-  model: yourModel,
-  tools: {
-    weather: tool({
-      description: 'Get the weather in a location',
-      parameters: z.object({
-        location: z.string().describe('The location to get the weather for'),
-      }),
-      execute: async ({ location }) => ({
-        location,
-        temperature: 72 + Math.floor(Math.random() * 21) - 10,
-      }),
-    }),
+### `onStepFinish` callback
+
+When using `generateText` or `streamText`, you can provide an `onStepFinish` callback that
+is triggered when a step is finished,
+i.e. all text deltas, tool calls, and tool results for the step are available.
+When you have multiple steps, the callback is triggered for each step.
+
+```tsx highlight="5-7"
+import { generateText } from 'ai';
+
+const result = await generateText({
+  // ...
+  onStepFinish({ text, toolCalls, toolResults, finishReason, usage }) {
+    // your own logic, e.g. for saving the chat history or recording usage
   },
-  maxSteps: 5, // allow up to 5 tool steps
-  prompt: 'What is the weather in San Francisco?',
 });
-
-for await (const textPart of textStream) {
-  process.stdout.write(textPart);
-}
 ```
-
-Similar to `generateText`, you can access intermediate tool calls and results using the `steps` property in the result object.
 
 ## Tool Choice
 

--- a/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/02-stream-text.mdx
@@ -791,6 +791,12 @@ To see `streamText` in action, check out [these examples](#examples).
               description:
                 'Response information for every step. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
             },
+            {
+              name: 'responseMessages',
+              type: 'Array<CoreAssistantMessage | CoreToolMessage>',
+              description:
+                'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+            },
           ],
         },
       ],
@@ -841,6 +847,12 @@ To see `streamText` in action, check out [these examples](#examples).
       type: 'Promise<Record<string,Record<string,JSONValue>> | undefined>',
       description:
         'Optional metadata from the provider. Resolved whe the response is finished. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
+    {
+      name: 'responseMessages',
+      type: 'Promise<Array<CoreAssistantMessage | CoreToolMessage>>',
+      description:
+        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately. Resolved when the response is finished.',
     },
     {
       name: 'text',

--- a/examples/ai-core/src/stream-text/openai-on-finish-response-messages.ts
+++ b/examples/ai-core/src/stream-text/openai-on-finish-response-messages.ts
@@ -1,0 +1,30 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await streamText({
+    model: openai('gpt-4o'),
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location',
+        parameters: z.object({ location: z.string() }),
+        execute: async () => ({
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+        }),
+      }),
+    },
+    maxSteps: 5,
+    onFinish({ responseMessages }) {
+      console.log(JSON.stringify(responseMessages, null, 2));
+    },
+    prompt: 'What is the current weather in San Francisco?',
+  });
+
+  // consume the text stream
+  for await (const textPart of result.textStream) {
+  }
+}
+
+main().catch(console.error);

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -65,6 +65,48 @@ exports[`options.maxSteps > 2 steps > onStepFinish should be called for each ste
 ]
 `;
 
+exports[`options.maxSteps > 2 steps > result.responseMessages should contain response messages from all steps 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "",
+        "type": "text",
+      },
+      {
+        "args": {
+          "value": "value",
+        },
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "role": "assistant",
+  },
+  {
+    "content": [
+      {
+        "result": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "role": "tool",
+  },
+  {
+    "content": [
+      {
+        "text": "Hello, world!",
+        "type": "text",
+      },
+    ],
+    "role": "assistant",
+  },
+]
+`;
+
 exports[`options.maxSteps > 2 steps > result.steps should contain all steps 1`] = `
 [
   {
@@ -126,6 +168,53 @@ exports[`options.maxSteps > 2 steps > result.steps should contain all steps 1`] 
       "totalTokens": 30,
     },
     "warnings": undefined,
+  },
+]
+`;
+
+exports[`result.responseMessages > should contain assistant response message and tool message when there are tool calls with results 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "Hello, world!",
+        "type": "text",
+      },
+      {
+        "args": {
+          "value": "value",
+        },
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "role": "assistant",
+  },
+  {
+    "content": [
+      {
+        "result": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "role": "tool",
+  },
+]
+`;
+
+exports[`result.responseMessages > should contain assistant response message when there are no tool calls 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "Hello, world!",
+        "type": "text",
+      },
+    ],
+    "role": "assistant",
   },
 ]
 `;

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -80,6 +80,45 @@ exports[`options.maxSteps > 2 steps > callbacks > onFinish should send correct i
     "modelId": "mock-model-id",
     "timestamp": 1970-01-01T00:00:01.000Z,
   },
+  "responseMessages": [
+    {
+      "content": [
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "args": {
+            "value": "value",
+          },
+          "toolCallId": "call-1",
+          "toolName": "tool1",
+          "type": "tool-call",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "result": "result1",
+          "toolCallId": "call-1",
+          "toolName": "tool1",
+          "type": "tool-result",
+        },
+      ],
+      "role": "tool",
+    },
+    {
+      "content": [
+        {
+          "text": "Hello, world!",
+          "type": "text",
+        },
+      ],
+      "role": "assistant",
+    },
+  ],
   "steps": [
     {
       "experimental_providerMetadata": undefined,
@@ -564,6 +603,36 @@ exports[`options.onFinish > options.onFinish should send correct information 1`]
     "modelId": "mock-model-id",
     "timestamp": 1970-01-01T00:00:00.000Z,
   },
+  "responseMessages": [
+    {
+      "content": [
+        {
+          "text": "Hello, world!",
+          "type": "text",
+        },
+        {
+          "args": {
+            "value": "value",
+          },
+          "toolCallId": "call-1",
+          "toolName": "tool1",
+          "type": "tool-call",
+        },
+      ],
+      "role": "assistant",
+    },
+    {
+      "content": [
+        {
+          "result": "value-result",
+          "toolCallId": "call-1",
+          "toolName": "tool1",
+          "type": "tool-result",
+        },
+      ],
+      "role": "tool",
+    },
+  ],
   "steps": [
     {
       "experimental_providerMetadata": {

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -432,6 +432,48 @@ exports[`options.maxSteps > 2 steps > should record telemetry data for each step
 ]
 `;
 
+exports[`options.maxSteps > 2 steps > value promises > result.responseMessages should contain response messages from all steps 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "",
+        "type": "text",
+      },
+      {
+        "args": {
+          "value": "value",
+        },
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "role": "assistant",
+  },
+  {
+    "content": [
+      {
+        "result": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "role": "tool",
+  },
+  {
+    "content": [
+      {
+        "text": "Hello, world!",
+        "type": "text",
+      },
+    ],
+    "role": "assistant",
+  },
+]
+`;
+
 exports[`options.maxSteps > 2 steps > value promises > result.steps should contain all steps 1`] = `
 [
   {
@@ -1035,6 +1077,53 @@ exports[`result.fullStream > should use fallback response metadata when response
       "promptTokens": 3,
       "totalTokens": 13,
     },
+  },
+]
+`;
+
+exports[`result.responseMessages > should contain assistant response message and tool message when there are tool calls with results 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "Hello, world!",
+        "type": "text",
+      },
+      {
+        "args": {
+          "value": "value",
+        },
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "role": "assistant",
+  },
+  {
+    "content": [
+      {
+        "result": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "role": "tool",
+  },
+]
+`;
+
+exports[`result.responseMessages > should contain assistant response message when there are no tool calls 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "Hello, world!",
+        "type": "text",
+      },
+    ],
+    "role": "assistant",
   },
 ]
 `;

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -48,11 +48,12 @@ export interface GenerateTextResult<TOOLS extends Record<string, CoreTool>> {
   readonly warnings: CallWarning[] | undefined;
 
   /**
-  The response messages that were generated during the call. It consists of an assistant message,
-  potentially containing tool calls.
-  When there are tool results, there is an additional tool message with the tool results that are available.
-  If there are tools that do not have execute functions, they are not included in the tool results and
-  need to be added separately.
+The response messages that were generated during the call. It consists of an assistant message,
+potentially containing tool calls.
+
+When there are tool results, there is an additional tool message with the tool results that are available.
+If there are tools that do not have execute functions, they are not included in the tool results and
+need to be added separately.
      */
   readonly responseMessages: Array<CoreAssistantMessage | CoreToolMessage>;
 

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -220,7 +220,7 @@ describe('result.responseMessages', () => {
   it('should contain assistant response message when there are no tool calls', async () => {
     const result = await generateText({
       model: new MockLanguageModelV1({
-        doGenerate: async ({}) => ({
+        doGenerate: async () => ({
           ...dummyResponseValues,
           text: 'Hello, world!',
         }),
@@ -228,18 +228,13 @@ describe('result.responseMessages', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(result.responseMessages, [
-      {
-        role: 'assistant',
-        content: [{ type: 'text', text: 'Hello, world!' }],
-      },
-    ]);
+    expect(result.responseMessages).toMatchSnapshot();
   });
 
   it('should contain assistant response message and tool message when there are tool calls with results', async () => {
     const result = await generateText({
       model: new MockLanguageModelV1({
-        doGenerate: async ({}) => ({
+        doGenerate: async () => ({
           ...dummyResponseValues,
           text: 'Hello, world!',
           toolCalls: [
@@ -272,31 +267,7 @@ describe('result.responseMessages', () => {
       prompt: 'test-input',
     });
 
-    assert.deepStrictEqual(result.responseMessages, [
-      {
-        role: 'assistant',
-        content: [
-          { type: 'text', text: 'Hello, world!' },
-          {
-            type: 'tool-call',
-            toolCallId: 'call-1',
-            toolName: 'tool1',
-            args: { value: 'value' },
-          },
-        ],
-      },
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'call-1',
-            toolName: 'tool1',
-            result: 'result1',
-          },
-        ],
-      },
-    ]);
+    expect(result.responseMessages).toMatchSnapshot();
   });
 });
 
@@ -476,35 +447,7 @@ describe('options.maxSteps', () => {
     });
 
     it('result.responseMessages should contain response messages from all steps', () => {
-      assert.deepStrictEqual(result.responseMessages, [
-        {
-          role: 'assistant',
-          content: [
-            { type: 'text', text: '' },
-            {
-              type: 'tool-call',
-              toolCallId: 'call-1',
-              toolName: 'tool1',
-              args: { value: 'value' },
-            },
-          ],
-        },
-        {
-          role: 'tool',
-          content: [
-            {
-              type: 'tool-result',
-              toolCallId: 'call-1',
-              toolName: 'tool1',
-              result: 'result1',
-            },
-          ],
-        },
-        {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Hello, world!' }],
-        },
-      ]);
+      expect(result.responseMessages).toMatchSnapshot();
     });
 
     it('result.usage should sum token usage', () => {

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -1,5 +1,10 @@
 import { ServerResponse } from 'node:http';
-import { AIStreamCallbacksAndOptions, StreamData } from '../../streams';
+import {
+  AIStreamCallbacksAndOptions,
+  CoreAssistantMessage,
+  CoreToolMessage,
+  StreamData,
+} from '../../streams';
 import { CoreTool } from '../tool';
 import {
   CallWarning,
@@ -80,6 +85,20 @@ Optional raw response data.
        */
     headers?: Record<string, string>;
   };
+
+  /**
+The response messages that were generated during the call. It consists of an assistant message,
+potentially containing tool calls.
+
+When there are tool results, there is an additional tool message with the tool results that are available.
+If there are tools that do not have execute functions, they are not included in the tool results and
+need to be added separately.
+
+Resolved when the response is finished.
+     */
+  readonly responseMessages: Promise<
+    Array<CoreAssistantMessage | CoreToolMessage>
+  >;
 
   /**
 Details for all steps.


### PR DESCRIPTION
## Summary
- add `responseMessages` to `streamText`
- docs: simplify "generating text" by removing tool-calling related content
- docs: rewrite tool calling section to incorporate additional content and streamline 

## Tasks

- [x] implementation
  - [x] promise
  - [x] onFinish callback
- [x] example
- [x] docs
   - [x] reference
   - [x] guide
- [x] changeset