### PR TITLE
chore (examples/next-langchain): Fix schema deprecation warning.

### DIFF
--- a/examples/next-langchain/app/api/chat/route.ts
+++ b/examples/next-langchain/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { ChatOpenAI } from '@langchain/openai';
 import { LangChainAdapter, Message } from 'ai';
-import { AIMessage, HumanMessage } from 'langchain/schema';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;


### PR DESCRIPTION
Fixes build warning, seen when building with `0.1.63` (current version used for this example).

```
[WARNING]: Importing from "langchain/schema" is deprecated.

Instead, please import from the appropriate entrypoint in "@langchain/core" or "langchain".

This will be mandatory after the next "langchain" minor version bump to 0.2.
```

Separately, we could consider updating to a more recent `langchain`, they're on `v0.3.2` https://www.npmjs.com/package/langchain but I expect we do that more on-demand.