### PR TITLE
feat (ai/react): support custom HTTP headers in experimental_useObject hook

### DIFF
--- a/packages/react/src/use-object.ts
+++ b/packages/react/src/use-object.ts
@@ -66,6 +66,11 @@ Optional error object. This is e.g. a TypeValidationError when the final object 
    * Callback function to be called when an error is encountered.
    */
   onError?: (error: Error) => void;
+
+  /**
+   * Additional HTTP headers to be included in the request.
+   */
+  headers?: HeadersInit;
 };
 
 export type Experimental_UseObjectHelpers<RESULT, INPUT> = {
@@ -108,6 +113,7 @@ function useObject<RESULT, INPUT = any>({
   fetch,
   onError,
   onFinish,
+  headers,
 }: Experimental_UseObjectOptions<RESULT>): Experimental_UseObjectHelpers<
   RESULT,
   INPUT
@@ -151,7 +157,10 @@ function useObject<RESULT, INPUT = any>({
       const actualFetch = fetch ?? getOriginalFetch();
       const response = await actualFetch(api, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
         signal: abortController.signal,
         body: JSON.stringify(input),
       });


### PR DESCRIPTION
This  PR adds support for custom HTTP headers in the `experimental_useObject` hook.
It addresses the following feature enhancement issue:
https://github.com/vercel/ai/issues/3080