### PR TITLE
fix (docs): Fix minor typos in next-app and bedrock docs.

### DIFF
--- a/content/examples/01-next-app/01-basics/03-generating-object.mdx
+++ b/content/examples/01-next-app/01-basics/03-generating-object.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generating Structured Data
-description: Learn to generate sturctured data using the AI SDK in your Next.js App Router application
+description: Learn to generate structured data using the AI SDK in your Next.js App Router application
 ---
 
 # Generate Object

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -163,12 +163,12 @@ You can use Amazon Bedrock language models to generate text with the `generateTe
 
 ```ts
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText } from 'ai'
+import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: bedrock('meta.llama3-70b-instruct-v1:0')
-  prompt: 'Write a vegetarian lasagna recipe for 4 people.'
-})
+  model: bedrock('meta.llama3-70b-instruct-v1:0'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
 ```
 
 Amazon Bedrock language models can also be used in the `streamText` function


### PR DESCRIPTION
I happened across these while debugging #3018. Super minor other than the missing comma in the example code for Bedrock, which feels nice to correct.