### PR TITLE
feat (ai/core): add continuationSteps to generateText

### DIFF
--- a/.changeset/metal-stingrays-prove.md
+++ b/.changeset/metal-stingrays-prove.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): add continuationSteps to generateText

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -66,10 +66,11 @@ const {
   usage, // combined usage of all steps
 } = await generateText({
   model: openai('gpt-4o'), // 4096 output tokens
-  maxSteps: 5,
+  maxSteps: 5, // enable multi-step calls
   experimental_continuationSteps: true,
   prompt:
-    'Write a book about the Roman history, from the founding of the city ' +
+    'Write a book about Roman history, ' +
+    'from the founding of the city of Rome ' +
     'to the fall of the Western Roman Empire. ' +
     'Each chapter MUST HAVE at least 1000 words.',
 });

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -48,6 +48,33 @@ The result object of `generateText` contains several promises that resolve when 
 - `result.finishReason`: The reason the model finished generating text.
 - `result.usage`: The usage of the model during text generation.
 
+### Generating Long Text
+
+Most language models have an output limit that is much shorter than their context window.
+This means that you cannot generate long text in one go,
+but it is possible to add responses back to the input and continue generating
+to create longer text.
+
+`generateText` supports such continuations for long text generation using the experimental `continuationSteps` setting:
+
+```tsx
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const {
+  text, // combined text
+  usage, // combined usage of all steps
+} = await generateText({
+  model: openai('gpt-4o'), // 4096 output tokens
+  maxSteps: 5,
+  experimental_continuationSteps: true,
+  prompt:
+    'Write a book about the Roman history, from the founding of the city ' +
+    'to the fall of the Western Roman Empire. ' +
+    'Each chapter MUST HAVE at least 1000 words.',
+});
+```
+
 ## `streamText`
 
 Depending on your model and prompt, it can take a large language model (LLM) up to a minute to finish generating it's response. This delay can be unacceptable for interactive use cases such as chatbots or real-time applications, where users expect immediate responses.

--- a/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/ai-sdk-core/01-generate-text.mdx
@@ -354,6 +354,12 @@ To see `generateText` in action, check out [these examples](#examples).
         'Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
     },
     {
+      name: 'experimental_continuationSteps',
+      type: 'boolean',
+      isOptional: true,
+      description: 'Enable or disable continuation steps. Disabled by default.',
+    },
+    {
       name: 'experimental_telemetry',
       type: 'TelemetrySettings',
       isOptional: true,

--- a/examples/ai-core/src/generate-text/openai-multi-step-continuation.ts
+++ b/examples/ai-core/src/generate-text/openai-multi-step-continuation.ts
@@ -1,0 +1,22 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const { text, usage, steps } = await generateText({
+    model: openai('gpt-4o'), // 4096 output tokens
+    maxSteps: 5,
+    experimental_continuationSteps: true,
+    prompt:
+      'Write a book about the Roman history, from the founding of the city ' +
+      'to the fall of the Western Roman Empire. ' +
+      'Each chapter MUST HAVE at least 1000 words.',
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Usage:', usage);
+  console.log('# of steps:', steps.length);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-multi-step-continuation.ts
+++ b/examples/ai-core/src/generate-text/openai-multi-step-continuation.ts
@@ -8,7 +8,8 @@ async function main() {
     maxSteps: 5,
     experimental_continuationSteps: true,
     prompt:
-      'Write a book about the Roman history, from the founding of the city ' +
+      'Write a book about Roman history, ' +
+      'from the founding of the city of Rome ' +
       'to the fall of the Western Roman Empire. ' +
       'Each chapter MUST HAVE at least 1000 words.',
   });

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -1,139 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`options.maxSteps > 2 steps: initial, continuation > onStepFinish should be called for each step 1`] = `
-[
-  {
-    "experimental_providerMetadata": undefined,
-    "finishReason": "length",
-    "logprobs": undefined,
-    "response": {
-      "headers": undefined,
-      "id": "test-id-1-from-model",
-      "modelId": "test-response-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
-    },
-    "text": "part-1",
-    "toolCalls": [],
-    "toolResults": [],
-    "usage": {
-      "completionTokens": 20,
-      "promptTokens": 10,
-      "totalTokens": 30,
-    },
-    "warnings": undefined,
-  },
-  {
-    "experimental_providerMetadata": undefined,
-    "finishReason": "length",
-    "logprobs": undefined,
-    "response": {
-      "headers": {
-        "custom-response-header": "response-header-value",
-      },
-      "id": "test-id-2-from-model",
-      "modelId": "test-response-model-id",
-      "timestamp": 1970-01-01T00:00:10.000Z,
-    },
-    "text": "part-2",
-    "toolCalls": [],
-    "toolResults": [],
-    "usage": {
-      "completionTokens": 5,
-      "promptTokens": 30,
-      "totalTokens": 35,
-    },
-    "warnings": undefined,
-  },
-  {
-    "experimental_providerMetadata": undefined,
-    "finishReason": "stop",
-    "logprobs": undefined,
-    "response": {
-      "headers": undefined,
-      "id": "test-id-3-from-model",
-      "modelId": "test-response-model-id",
-      "timestamp": 1970-01-01T00:00:20.000Z,
-    },
-    "text": "part-3",
-    "toolCalls": [],
-    "toolResults": [],
-    "usage": {
-      "completionTokens": 2,
-      "promptTokens": 3,
-      "totalTokens": 5,
-    },
-    "warnings": undefined,
-  },
-]
-`;
-
-exports[`options.maxSteps > 2 steps: initial, continuation > result.steps should contain all steps 1`] = `
-[
-  {
-    "experimental_providerMetadata": undefined,
-    "finishReason": "length",
-    "logprobs": undefined,
-    "response": {
-      "headers": undefined,
-      "id": "test-id-1-from-model",
-      "modelId": "test-response-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
-    },
-    "text": "part-1",
-    "toolCalls": [],
-    "toolResults": [],
-    "usage": {
-      "completionTokens": 20,
-      "promptTokens": 10,
-      "totalTokens": 30,
-    },
-    "warnings": undefined,
-  },
-  {
-    "experimental_providerMetadata": undefined,
-    "finishReason": "length",
-    "logprobs": undefined,
-    "response": {
-      "headers": {
-        "custom-response-header": "response-header-value",
-      },
-      "id": "test-id-2-from-model",
-      "modelId": "test-response-model-id",
-      "timestamp": 1970-01-01T00:00:10.000Z,
-    },
-    "text": "part-2",
-    "toolCalls": [],
-    "toolResults": [],
-    "usage": {
-      "completionTokens": 5,
-      "promptTokens": 30,
-      "totalTokens": 35,
-    },
-    "warnings": undefined,
-  },
-  {
-    "experimental_providerMetadata": undefined,
-    "finishReason": "stop",
-    "logprobs": undefined,
-    "response": {
-      "headers": undefined,
-      "id": "test-id-3-from-model",
-      "modelId": "test-response-model-id",
-      "timestamp": 1970-01-01T00:00:20.000Z,
-    },
-    "text": "part-3",
-    "toolCalls": [],
-    "toolResults": [],
-    "usage": {
-      "completionTokens": 2,
-      "promptTokens": 3,
-      "totalTokens": 5,
-    },
-    "warnings": undefined,
-  },
-]
-`;
-
 exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should be called for each step 1`] = `
 [
   {
@@ -300,6 +166,140 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
       "completionTokens": 20,
       "promptTokens": 10,
       "totalTokens": 30,
+    },
+    "warnings": undefined,
+  },
+]
+`;
+
+exports[`options.maxSteps > 3 steps: initial, continuation, continuation > onStepFinish should be called for each step 1`] = `
+[
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "length",
+    "logprobs": undefined,
+    "response": {
+      "headers": undefined,
+      "id": "test-id-1-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "text": "part-1",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 20,
+      "promptTokens": 10,
+      "totalTokens": 30,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "length",
+    "logprobs": undefined,
+    "response": {
+      "headers": {
+        "custom-response-header": "response-header-value",
+      },
+      "id": "test-id-2-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:10.000Z,
+    },
+    "text": "part-2",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 5,
+      "promptTokens": 30,
+      "totalTokens": 35,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "headers": undefined,
+      "id": "test-id-3-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:20.000Z,
+    },
+    "text": "part-3",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 2,
+      "promptTokens": 3,
+      "totalTokens": 5,
+    },
+    "warnings": undefined,
+  },
+]
+`;
+
+exports[`options.maxSteps > 3 steps: initial, continuation, continuation > result.steps should contain all steps 1`] = `
+[
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "length",
+    "logprobs": undefined,
+    "response": {
+      "headers": undefined,
+      "id": "test-id-1-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "text": "part-1",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 20,
+      "promptTokens": 10,
+      "totalTokens": 30,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "length",
+    "logprobs": undefined,
+    "response": {
+      "headers": {
+        "custom-response-header": "response-header-value",
+      },
+      "id": "test-id-2-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:10.000Z,
+    },
+    "text": "part-2",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 5,
+      "promptTokens": 30,
+      "totalTokens": 35,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "headers": undefined,
+      "id": "test-id-3-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:20.000Z,
+    },
+    "text": "part-3",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 2,
+      "promptTokens": 3,
+      "totalTokens": 5,
     },
     "warnings": undefined,
   },

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -1,6 +1,100 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`options.maxSteps > 2 steps > onStepFinish should be called for each step 1`] = `
+exports[`options.maxSteps > 2 steps: initial, continuation > onStepFinish should be called for each step 1`] = `
+[
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "length",
+    "logprobs": undefined,
+    "response": {
+      "headers": undefined,
+      "id": "test-id-1-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "text": "part-1",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 20,
+      "promptTokens": 10,
+      "totalTokens": 30,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "headers": {
+        "custom-response-header": "response-header-value",
+      },
+      "id": "test-id-2-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:10.000Z,
+    },
+    "text": "part-2",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 5,
+      "promptTokens": 30,
+      "totalTokens": 35,
+    },
+    "warnings": undefined,
+  },
+]
+`;
+
+exports[`options.maxSteps > 2 steps: initial, continuation > result.steps should contain all steps 1`] = `
+[
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "length",
+    "logprobs": undefined,
+    "response": {
+      "headers": undefined,
+      "id": "test-id-1-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "text": "part-1",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 20,
+      "promptTokens": 10,
+      "totalTokens": 30,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "headers": {
+        "custom-response-header": "response-header-value",
+      },
+      "id": "test-id-2-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:10.000Z,
+    },
+    "text": "part-2",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 5,
+      "promptTokens": 30,
+      "totalTokens": 35,
+    },
+    "warnings": undefined,
+  },
+]
+`;
+
+exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should be called for each step 1`] = `
 [
   {
     "experimental_providerMetadata": undefined,
@@ -65,7 +159,7 @@ exports[`options.maxSteps > 2 steps > onStepFinish should be called for each ste
 ]
 `;
 
-exports[`options.maxSteps > 2 steps > result.responseMessages should contain response messages from all steps 1`] = `
+exports[`options.maxSteps > 2 steps: initial, tool-result > result.responseMessages should contain response messages from all steps 1`] = `
 [
   {
     "content": [
@@ -107,7 +201,7 @@ exports[`options.maxSteps > 2 steps > result.responseMessages should contain res
 ]
 `;
 
-exports[`options.maxSteps > 2 steps > result.steps should contain all steps 1`] = `
+exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should contain all steps 1`] = `
 [
   {
     "experimental_providerMetadata": undefined,

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -24,7 +24,7 @@ exports[`options.maxSteps > 2 steps: initial, continuation > onStepFinish should
   },
   {
     "experimental_providerMetadata": undefined,
-    "finishReason": "stop",
+    "finishReason": "length",
     "logprobs": undefined,
     "response": {
       "headers": {
@@ -41,6 +41,26 @@ exports[`options.maxSteps > 2 steps: initial, continuation > onStepFinish should
       "completionTokens": 5,
       "promptTokens": 30,
       "totalTokens": 35,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "headers": undefined,
+      "id": "test-id-3-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:20.000Z,
+    },
+    "text": "part-3",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 2,
+      "promptTokens": 3,
+      "totalTokens": 5,
     },
     "warnings": undefined,
   },
@@ -71,7 +91,7 @@ exports[`options.maxSteps > 2 steps: initial, continuation > result.steps should
   },
   {
     "experimental_providerMetadata": undefined,
-    "finishReason": "stop",
+    "finishReason": "length",
     "logprobs": undefined,
     "response": {
       "headers": {
@@ -88,6 +108,26 @@ exports[`options.maxSteps > 2 steps: initial, continuation > result.steps should
       "completionTokens": 5,
       "promptTokens": 30,
       "totalTokens": 35,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "finishReason": "stop",
+    "logprobs": undefined,
+    "response": {
+      "headers": undefined,
+      "id": "test-id-3-from-model",
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:20.000Z,
+    },
+    "text": "part-3",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 2,
+      "promptTokens": 3,
+      "totalTokens": 5,
     },
     "warnings": undefined,
   },

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -467,7 +467,7 @@ describe('options.maxSteps', () => {
     });
   });
 
-  describe('2 steps: initial, continuation', () => {
+  describe('3 steps: initial, continuation, continuation', () => {
     let result: GenerateTextResult<any>;
     let onStepFinishResults: StepResult<any>[];
 

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -559,10 +559,10 @@ describe('options.maxSteps', () => {
         }),
         prompt: 'test-input',
         maxSteps: 3,
+        experimental_continuationSteps: true,
         onStepFinish: async event => {
           onStepFinishResults.push(event);
         },
-        experimental_continuation: true,
       });
     });
 

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -534,7 +534,7 @@ describe('options.maxSteps', () => {
                 return {
                   ...dummyResponseValues,
                   text: 'part-2',
-                  finishReason: 'stop',
+                  finishReason: 'length',
                   response: {
                     id: 'test-id-2-from-model',
                     timestamp: new Date(10000),
@@ -552,13 +552,57 @@ describe('options.maxSteps', () => {
                     },
                   },
                 };
+              case 2:
+                expect(mode).toStrictEqual({
+                  type: 'regular',
+                  toolChoice: undefined,
+                  tools: undefined,
+                });
+                expect(prompt).toStrictEqual([
+                  {
+                    role: 'user',
+                    content: [{ type: 'text', text: 'test-input' }],
+                  },
+                  {
+                    role: 'assistant',
+                    content: [
+                      {
+                        type: 'text',
+                        text: 'part-1',
+                        providerMetadata: undefined,
+                      },
+                      {
+                        type: 'text',
+                        text: ' part-2',
+                        providerMetadata: undefined,
+                      },
+                    ],
+                    providerMetadata: undefined,
+                  },
+                ]);
+
+                return {
+                  ...dummyResponseValues,
+                  text: 'part-3',
+                  finishReason: 'stop',
+                  response: {
+                    id: 'test-id-3-from-model',
+                    timestamp: new Date(20000),
+                    modelId: 'test-response-model-id',
+                  },
+                  usage: {
+                    completionTokens: 2,
+                    promptTokens: 3,
+                    totalTokens: 5,
+                  },
+                };
               default:
                 throw new Error(`Unexpected response count: ${responseCount}`);
             }
           },
         }),
         prompt: 'test-input',
-        maxSteps: 3,
+        maxSteps: 5,
         experimental_continuationSteps: true,
         onStepFinish: async event => {
           onStepFinishResults.push(event);
@@ -567,7 +611,7 @@ describe('options.maxSteps', () => {
     });
 
     it('result.text should return text from both steps separated by space', async () => {
-      assert.deepStrictEqual(result.text, 'part-1 part-2');
+      assert.deepStrictEqual(result.text, 'part-1 part-2 part-3');
     });
 
     it('result.responseMessages should contain an assistant message with the combined text', () => {
@@ -582,6 +626,10 @@ describe('options.maxSteps', () => {
               text: ' part-2',
               type: 'text',
             },
+            {
+              text: ' part-3',
+              type: 'text',
+            },
           ],
           role: 'assistant',
         },
@@ -590,9 +638,9 @@ describe('options.maxSteps', () => {
 
     it('result.usage should sum token usage', () => {
       assert.deepStrictEqual(result.usage, {
-        completionTokens: 25,
-        promptTokens: 40,
-        totalTokens: 65,
+        completionTokens: 27,
+        promptTokens: 43,
+        totalTokens: 70,
       });
     });
 

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -272,7 +272,7 @@ describe('result.responseMessages', () => {
 });
 
 describe('options.maxSteps', () => {
-  describe('2 steps', () => {
+  describe('2 steps: initial, tool-result', () => {
     let result: GenerateTextResult<any>;
     let onStepFinishResults: StepResult<any>[];
 
@@ -455,6 +455,144 @@ describe('options.maxSteps', () => {
         completionTokens: 25,
         promptTokens: 20,
         totalTokens: 45,
+      });
+    });
+
+    it('result.steps should contain all steps', () => {
+      expect(result.steps).toMatchSnapshot();
+    });
+
+    it('onStepFinish should be called for each step', () => {
+      expect(onStepFinishResults).toMatchSnapshot();
+    });
+  });
+
+  describe('2 steps: initial, continuation', () => {
+    let result: GenerateTextResult<any>;
+    let onStepFinishResults: StepResult<any>[];
+
+    beforeEach(async () => {
+      onStepFinishResults = [];
+
+      let responseCount = 0;
+      result = await generateText({
+        model: new MockLanguageModelV1({
+          doGenerate: async ({ prompt, mode }) => {
+            switch (responseCount++) {
+              case 0:
+                expect(mode).toStrictEqual({
+                  type: 'regular',
+                  toolChoice: undefined,
+                  tools: undefined,
+                });
+                expect(prompt).toStrictEqual([
+                  {
+                    role: 'user',
+                    content: [{ type: 'text', text: 'test-input' }],
+                  },
+                ]);
+
+                return {
+                  ...dummyResponseValues,
+                  text: 'part-1',
+                  finishReason: 'length', // trigger continuation
+                  usage: {
+                    completionTokens: 20,
+                    promptTokens: 10,
+                    totalTokens: 30,
+                  },
+                  response: {
+                    id: 'test-id-1-from-model',
+                    timestamp: new Date(0),
+                    modelId: 'test-response-model-id',
+                  },
+                };
+              case 1:
+                expect(mode).toStrictEqual({
+                  type: 'regular',
+                  toolChoice: undefined,
+                  tools: undefined,
+                });
+                expect(prompt).toStrictEqual([
+                  {
+                    role: 'user',
+                    content: [{ type: 'text', text: 'test-input' }],
+                  },
+                  {
+                    role: 'assistant',
+                    content: [
+                      {
+                        type: 'text',
+                        text: 'part-1',
+                        providerMetadata: undefined,
+                      },
+                    ],
+                    providerMetadata: undefined,
+                  },
+                ]);
+
+                return {
+                  ...dummyResponseValues,
+                  text: 'part-2',
+                  finishReason: 'stop',
+                  response: {
+                    id: 'test-id-2-from-model',
+                    timestamp: new Date(10000),
+                    modelId: 'test-response-model-id',
+                  },
+                  usage: {
+                    completionTokens: 5,
+                    promptTokens: 30,
+                    totalTokens: 35,
+                  },
+                  // test handling of custom response headers:
+                  rawResponse: {
+                    headers: {
+                      'custom-response-header': 'response-header-value',
+                    },
+                  },
+                };
+              default:
+                throw new Error(`Unexpected response count: ${responseCount}`);
+            }
+          },
+        }),
+        prompt: 'test-input',
+        maxSteps: 3,
+        onStepFinish: async event => {
+          onStepFinishResults.push(event);
+        },
+        experimental_continuation: true,
+      });
+    });
+
+    it('result.text should return text from both steps separated by space', async () => {
+      assert.deepStrictEqual(result.text, 'part-1 part-2');
+    });
+
+    it('result.responseMessages should contain an assistant message with the combined text', () => {
+      expect(result.responseMessages).toStrictEqual([
+        {
+          content: [
+            {
+              text: 'part-1',
+              type: 'text',
+            },
+            {
+              text: ' part-2',
+              type: 'text',
+            },
+          ],
+          role: 'assistant',
+        },
+      ]);
+    });
+
+    it('result.usage should sum token usage', () => {
+      assert.deepStrictEqual(result.usage, {
+        completionTokens: 25,
+        promptTokens: 40,
+        totalTokens: 65,
       });
     });
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -92,7 +92,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
   maxSteps = maxToolRoundtrips != null ? maxToolRoundtrips + 1 : 1,
-  experimental_continuation: continuation = false,
+  experimental_continuationSteps: continuationSteps = false,
   experimental_telemetry: telemetry,
   experimental_providerMetadata: providerMetadata,
   _internal: {
@@ -148,7 +148,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
      */
     maxSteps?: number;
 
-    experimental_continuation?: boolean;
+    experimental_continuationSteps?: boolean;
 
     /**
      * Optional telemetry configuration (experimental).
@@ -437,7 +437,7 @@ functionality that can be fully encapsulated in the provider.
           // only use continuation when there are no tool calls:
           currentToolCalls.length === 0 &&
           currentStep.finishReason === 'length' &&
-          continuation === true
+          continuationSteps === true
         ) {
           stepType = 'continuation';
         } else if (

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -434,10 +434,10 @@ functionality that can be fully encapsulated in the provider.
         if (++stepCount >= maxSteps) {
           stepType = 'done';
         } else if (
-          // only use continuation when there are no tool calls:
-          currentToolCalls.length === 0 &&
+          continuationSteps === true &&
           currentStep.finishReason === 'length' &&
-          continuationSteps === true
+          // only use continuation when there are no tool calls:
+          currentToolCalls.length === 0
         ) {
           stepType = 'continuation';
         } else if (

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -92,6 +92,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
   maxAutomaticRoundtrips = 0,
   maxToolRoundtrips = maxAutomaticRoundtrips,
   maxSteps = maxToolRoundtrips != null ? maxToolRoundtrips + 1 : 1,
+  experimental_continuation: continuation = false,
   experimental_telemetry: telemetry,
   experimental_providerMetadata: providerMetadata,
   _internal: {
@@ -146,6 +147,8 @@ A maximum number is required to prevent infinite loops in the case of misconfigu
 By default, it's set to 1, which means that only a single LLM call is made.
      */
     maxSteps?: number;
+
+    experimental_continuation?: boolean;
 
     /**
      * Optional telemetry configuration (experimental).
@@ -232,12 +235,16 @@ functionality that can be fully encapsulated in the provider.
       let stepCount = 0;
       const responseMessages: Array<CoreAssistantMessage | CoreToolMessage> =
         [];
+      let text = '';
       const steps: GenerateTextResult<TOOLS>['steps'] = [];
       const usage: LanguageModelUsage = {
         completionTokens: 0,
         promptTokens: 0,
         totalTokens: 0,
       };
+
+      let stepType: 'initial' | 'tool-result' | 'continuation' | 'done' =
+        'initial';
 
       do {
         // once we have a 2nd step, we need to switch to messages format:
@@ -359,6 +366,13 @@ functionality that can be fully encapsulated in the provider.
         usage.promptTokens += currentUsage.promptTokens;
         usage.totalTokens += currentUsage.totalTokens;
 
+        // text
+        if (stepType === 'continuation') {
+          text += ' ' + (currentModelResponse.text ?? '');
+        } else {
+          text = currentModelResponse.text ?? '';
+        }
+
         // Add step information:
         const currentStep: StepResult<TOOLS> = {
           text: currentModelResponse.text ?? '',
@@ -378,25 +392,65 @@ functionality that can be fully encapsulated in the provider.
         await onStepFinish?.(currentStep);
 
         // append to messages for potential next step:
-        const newResponseMessages = toResponseMessages({
-          text: currentModelResponse.text,
-          toolCalls: currentToolCalls,
-          toolResults: currentToolResults,
-        });
-        responseMessages.push(...newResponseMessages);
-        promptMessages.push(
-          ...newResponseMessages.map(message =>
-            convertToLanguageModelMessage(message, null),
-          ),
-        );
-      } while (
-        // there are tool calls:
-        currentToolCalls.length > 0 &&
-        // all current tool calls have results:
-        currentToolResults.length === currentToolCalls.length &&
-        // the number of steps is less than the maximum:
-        ++stepCount < maxSteps
-      );
+        if (stepType === 'continuation') {
+          // continuation step: update the last assistant message
+          // continuation is only possible when there are no tool calls,
+          // so we can assume that there is a single last assistant message:
+          const lastResponseMessage =
+            responseMessages.pop() as CoreAssistantMessage;
+          promptMessages.pop();
+
+          if (typeof lastResponseMessage.content === 'string') {
+            lastResponseMessage.content = text;
+          } else {
+            lastResponseMessage.content.push({
+              text: ' ' + currentModelResponse.text,
+              type: 'text',
+            });
+          }
+
+          responseMessages.push(lastResponseMessage);
+          promptMessages.push(
+            convertToLanguageModelMessage(lastResponseMessage, null),
+          );
+        } else {
+          // tool result step
+          // add the assistant message with the tool calls
+          // and the tool result messages:
+          const newResponseMessages = toResponseMessages({
+            text: currentModelResponse.text,
+            toolCalls: currentToolCalls,
+            toolResults: currentToolResults,
+          });
+          responseMessages.push(...newResponseMessages);
+          promptMessages.push(
+            ...newResponseMessages.map(message =>
+              convertToLanguageModelMessage(message, null),
+            ),
+          );
+        }
+
+        // figure out next step type
+        if (++stepCount >= maxSteps) {
+          stepType = 'done';
+        } else if (
+          // only use continuation when there are no tool calls:
+          currentToolCalls.length === 0 &&
+          currentStep.finishReason === 'length' &&
+          continuation === true
+        ) {
+          stepType = 'continuation';
+        } else if (
+          // there are tool calls:
+          currentToolCalls.length > 0 &&
+          // all current tool calls have results:
+          currentToolResults.length === currentToolCalls.length
+        ) {
+          stepType = 'tool-result';
+        } else {
+          stepType = 'done';
+        }
+      } while (stepType !== 'done');
 
       // Add response information to the span:
       span.setAttributes(
@@ -428,10 +482,7 @@ functionality that can be fully encapsulated in the provider.
       );
 
       return new DefaultGenerateTextResult({
-        // Always return a string so that the caller doesn't have to check for undefined.
-        // If they need to check if the model did not return any text,
-        // they can check the length of the string:
-        text: currentModelResponse.text ?? '',
+        text,
         toolCalls: currentToolCalls,
         toolResults: currentToolResults,
         finishReason: currentModelResponse.finishReason,


### PR DESCRIPTION
## Tasks

- [x] basic implementation
- [x] test two sequential continuations
- [x] rename: `continuationSteps`
- [x] example
- [x] docs: guide
- [x] docs: reference
- [x] changeset