### PR TITLE
Image url validation #2838

### DIFF
--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -131,6 +131,10 @@ export function convertToLanguageModelMessage(
 
                 // try to convert string image parts to urls
                 if (typeof part.image === 'string') {
+                  const invalidUrlPattern = /\s/;
+                  if (invalidUrlPattern.test(part.image)) {
+                    throw new Error(`Invalid Image URL: ${part.image}`);
+                  }
                   try {
                     const url = new URL(part.image);
 
@@ -146,7 +150,8 @@ export function convertToLanguageModelMessage(
                               part.experimental_providerMetadata,
                           };
                         } else {
-                          const downloadedImage = downloadedImages[part.image];
+                          const downloadedImage =
+                            downloadedImages[url.toString()];
                           return {
                             type: 'image',
                             image: downloadedImage.data,


### PR DESCRIPTION
Test evidence:
![image](https://github.com/user-attachments/assets/73be4c22-ddb9-4973-804f-79fb4a955f8c)

Added validation to check if the url string has space. Also, updated llogic to get the image data from   downloadedImages based on URL string.