### PR TITLE
fix (provider/bedrock): don't use env var for session token default.

### DIFF
--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -121,8 +121,11 @@ You can use the following optional settings to customize the Amazon Bedrock prov
 
 - **sessionToken** _string_
 
-  Optional. The AWS session token that you want to use for the API calls.
-  It uses the `AWS_SESSION_TOKEN` environment variable by default.
+  Optional. The AWS session token that you want to use for the API calls. Note
+  this does **not** use the `AWS_SESSION_TOKEN` environment variable by default.
+  That variable is sometimes pre-populated with alternate credentials, e.g. when
+  running within an AWS serverless function, and so default use risks
+  conflicting in a non-obvious manner with any other credential settings.
 
 - **bedrockOptions** _object_
 
@@ -135,7 +138,7 @@ You can use the following optional settings to customize the Amazon Bedrock prov
   - **credentials** _object_
     The AWS credentials that you want to use for the API calls.
 
-  When `bedrockOptions` are provided, the `region`, `accessKeyId`, and `secretAccessKey` settings are ignored.
+  When `bedrockOptions` are provided, the `region`, `accessKeyId`, `secretAccessKey`, and `sessionToken` settings are ignored.
 
 ## Language Models
 

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -3,11 +3,7 @@ import {
   NoSuchModelError,
   ProviderV1,
 } from '@ai-sdk/provider';
-import {
-  generateId,
-  loadOptionalSetting,
-  loadSetting,
-} from '@ai-sdk/provider-utils';
+import { generateId, loadSetting } from '@ai-sdk/provider-utils';
 import {
   BedrockRuntimeClient,
   BedrockRuntimeClientConfig,
@@ -75,10 +71,10 @@ export function createAmazonBedrock(
             environmentVariableName: 'AWS_SECRET_ACCESS_KEY',
             description: 'AWS secret access key',
           }),
-          sessionToken: loadOptionalSetting({
-            settingValue: options.sessionToken,
-            environmentVariableName: 'AWS_SESSION_TOKEN',
-          }),
+          // Note we don't use `AWS_SESSION_TOKEN` as a default fallback here
+          // because in some cases e.g. AWS serverless functions it can be
+          // pre-populated with conflicting credentials.
+          sessionToken: options.sessionToken,
         },
       },
     );


### PR DESCRIPTION
Deployments using the Bedrock provider can run in a serverless function that pre-declares a value for `AWS_SESSION_TOKEN` representing an alternate set of credentials than those intended and specified by the developer. If we silently use the environment variable for a default it can create a non-obvious credentials failure that surprises the developer.

The session token credentials are less commonly used, and the developer can still pass them along manually (and reference the environment variable themselves if they choose to do so).

We also update the documentation to state this behavior as it's admittedly deviant from common practice in the AI SDK providers (but for good reason due to the idiosyncratic way it can be already-present in the serverless environment).

Fixes #3018.