### PR TITLE
chore (provider/vertex): update GoogleVertexModelId

### DIFF
--- a/.changeset/red-points-peel.md
+++ b/.changeset/red-points-peel.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+chore (provider/vertex): update GoogleVertexModelId

--- a/packages/google-vertex/src/google-vertex-settings.ts
+++ b/packages/google-vertex/src/google-vertex-settings.ts
@@ -1,5 +1,13 @@
 // https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models
 export type GoogleVertexModelId =
+  // Stable version
+  | 'gemini-1.5-flash-001'
+  | 'gemini-1.5-flash-002'
+  | 'gemini-1.5-pro-001'
+  | 'gemini-1.5-pro-002'
+  | 'gemini-1.0-pro-001'
+  | 'gemini-1.0-pro-vision-001'
+  // Auto-updated alias
   | 'gemini-1.5-flash'
   | 'gemini-1.5-pro'
   | 'gemini-1.0-pro'


### PR DESCRIPTION
This PR updates the GoogleVertexModelId.
The latest stable versions are now specifically listed.