### PR TITLE
Include the created at field in assistant response and use assistant #3129

### DIFF
--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -131,10 +131,6 @@ export function convertToLanguageModelMessage(
 
                 // try to convert string image parts to urls
                 if (typeof part.image === 'string') {
-                  const invalidUrlPattern = /\s/;
-                  if (invalidUrlPattern.test(part.image)) {
-                    throw new Error(`Invalid Image URL: ${part.image}`);
-                  }
                   try {
                     const url = new URL(part.image);
 
@@ -150,8 +146,6 @@ export function convertToLanguageModelMessage(
                               part.experimental_providerMetadata,
                           };
                         } else {
-                          const downloadedImage =
-                            downloadedImages[url.toString()];
                           return {
                             type: 'image',
                             image: downloadedImage.data,

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -146,6 +146,7 @@ export function convertToLanguageModelMessage(
                               part.experimental_providerMetadata,
                           };
                         } else {
+                          const downloadedImage = downloadedImages[part.image];
                           return {
                             type: 'image',
                             image: downloadedImage.data,

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -131,6 +131,10 @@ export function convertToLanguageModelMessage(
 
                 // try to convert string image parts to urls
                 if (typeof part.image === 'string') {
+                  const invalidUrlPattern = /\s/;
+                  if (invalidUrlPattern.test(part.image)) {
+                    throw new Error(`Invalid Image URL: ${part.image}`);
+                  }
                   try {
                     const url = new URL(part.image);
 
@@ -146,7 +150,8 @@ export function convertToLanguageModelMessage(
                               part.experimental_providerMetadata,
                           };
                         } else {
-                          const downloadedImage = downloadedImages[part.image];
+                          const downloadedImage =
+                            downloadedImages[url.toString()];
                           return {
                             type: 'image',
                             image: downloadedImage.data,

--- a/packages/ai/streams/assistant-response.ts
+++ b/packages/ai/streams/assistant-response.ts
@@ -92,6 +92,7 @@ export function AssistantResponse(
                 textEncoder.encode(
                   formatStreamPart('assistant_message', {
                     id: value.data.id,
+                    createdAt: value.data.created_at ? new Date(value.data.created_at * 1000) : undefined,
                     role: 'assistant',
                     content: [{ type: 'text', text: { value: '' } }],
                   }),

--- a/packages/react/src/use-assistant.ts
+++ b/packages/react/src/use-assistant.ts
@@ -186,6 +186,7 @@ export function useAssistant({
               {
                 id: value.id,
                 role: value.role,
+                createdAt: value.createdAt,
                 content: value.content[0].text.value,
               },
             ]);
@@ -201,6 +202,7 @@ export function useAssistant({
                 {
                   id: lastMessage.id,
                   role: lastMessage.role,
+                  createdAt: lastMessage.createdAt,
                   content: lastMessage.content + value,
                 },
               ];

--- a/packages/ui-utils/src/stream-parts.ts
+++ b/packages/ui-utils/src/stream-parts.ts
@@ -121,7 +121,7 @@ const assistantMessageStreamPart: StreamPart<
 
     return {
       type: 'assistant_message',
-      value: value as AssistantMessage,
+      value: value as unknown as AssistantMessage,
     };
   },
 };

--- a/packages/ui-utils/src/types.ts
+++ b/packages/ui-utils/src/types.ts
@@ -604,6 +604,7 @@ export type JSONValue =
 export type AssistantMessage = {
   id: string;
   role: 'assistant';
+  createdAt?: Date;
   content: Array<{
     type: 'text';
     text: {


### PR DESCRIPTION
fixes  #3129
Tests:
1. use-assistant.ui.test.tsx
![image](https://github.com/user-attachments/assets/5e11f2d5-76f3-4f56-8ed0-ea6bc152fe15)
2. example Stream-assistance-response
![image](https://github.com/user-attachments/assets/5a4857ec-7044-4da8-9a9d-bc6ec7ef0e41)

![image](https://github.com/user-attachments/assets/f97a2587-83ff-4318-8498-5f2ba0cf183a)
3. example next-openai
![image](https://github.com/user-attachments/assets/200d3fd9-7bc7-4b21-83f5-bcfa7f28a125)
![image](https://github.com/user-attachments/assets/73b34f23-2328-40b0-b0b9-37b7fe6bd696)
 

