### PR TITLE
fix (ui/vue): prevent infinite looping steps

### DIFF
--- a/.changeset/young-clocks-end.md
+++ b/.changeset/young-clocks-end.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/vue': patch
+---
+
+fix maxSteps

--- a/.changeset/young-clocks-end.md
+++ b/.changeset/young-clocks-end.md
@@ -2,4 +2,4 @@
 '@ai-sdk/vue': patch
 ---
 
-fix maxSteps
+fix (ui/vue): prevent infinite looping steps

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -270,7 +270,7 @@ export function useChat(
       lastMessage != null &&
       // check if the feature is enabled:
       maxSteps &&
-      maxSteps > 0 &&
+      maxSteps > 1 &&
       // check that next step is possible:
       isAssistantMessageWithCompletedToolCalls(lastMessage) &&
       // limit the number of automatic steps:


### PR DESCRIPTION
This pr fixes issue where useChat with vue automatically sends tool results back to the model

This would have been previously correct with maxToolRoundtrips.