### PR TITLE
chore (provider/azure): update Azure OpenAI API version to 2024-08-01-preview

### DIFF
--- a/.changeset/ninety-buses-press.md
+++ b/.changeset/ninety-buses-press.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/azure': patch
+---
+
+chore (provider/azure): update Azure OpenAI API version to 2024-08-01-preview

--- a/content/providers/01-ai-sdk-providers/02-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/02-azure.mdx
@@ -39,6 +39,7 @@ import { createAzure } from '@ai-sdk/azure';
 const azure = createAzure({
   resourceName: 'your-resource-name', // Azure resource name
   apiKey: 'your-api-key',
+  apiVersion: '2024-06-01', // Optional: specify Azure OpenAI API version
 });
 ```
 
@@ -77,6 +78,11 @@ You can use the following optional settings to customize the OpenAI provider ins
   You can use it as a middleware to intercept requests,
   or to provide a custom fetch implementation for e.g. testing.
 
+- **apiVersion** _string_
+
+  Specify an API version for Azure OpenAI requests. 
+  Defaults to '2024-06-01' if not provided.
+
 ## Language Models
 
 The Azure OpenAI provider instance is a function that you can invoke to create a language model:
@@ -114,7 +120,8 @@ OpenAI language models can also be used in the `streamText`, `generateObject`, `
 
 <Note>
   The URL for calling Azure chat models will be constructed as follows:
-  `https://RESOURCE_NAME.openai.azure.com/openai/deployments/DEPLOYMENT_NAME/chat/completions?api-version=2024-06-01`
+  `https://RESOURCE_NAME.openai.azure.com/openai/deployments/DEPLOYMENT_NAME/chat/completions?api-version=API_VERSION`
+  Where API_VERSION is either the default '2024-06-01' or the custom version you specified.
 </Note>
 
 Azure OpenAI chat models support also some model specific settings that are not part of the [standard call settings](/docs/ai-sdk-core/settings).

--- a/content/providers/01-ai-sdk-providers/02-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/02-azure.mdx
@@ -39,7 +39,6 @@ import { createAzure } from '@ai-sdk/azure';
 const azure = createAzure({
   resourceName: 'your-resource-name', // Azure resource name
   apiKey: 'your-api-key',
-  apiVersion: '2024-06-01', // Optional: specify Azure OpenAI API version
 });
 ```
 
@@ -78,11 +77,6 @@ You can use the following optional settings to customize the OpenAI provider ins
   You can use it as a middleware to intercept requests,
   or to provide a custom fetch implementation for e.g. testing.
 
-- **apiVersion** _string_
-
-  Specify an API version for Azure OpenAI requests. 
-  Defaults to '2024-06-01' if not provided.
-
 ## Language Models
 
 The Azure OpenAI provider instance is a function that you can invoke to create a language model:
@@ -120,8 +114,7 @@ OpenAI language models can also be used in the `streamText`, `generateObject`, `
 
 <Note>
   The URL for calling Azure chat models will be constructed as follows:
-  `https://RESOURCE_NAME.openai.azure.com/openai/deployments/DEPLOYMENT_NAME/chat/completions?api-version=API_VERSION`
-  Where API_VERSION is either the default '2024-06-01' or the custom version you specified.
+  `https://RESOURCE_NAME.openai.azure.com/openai/deployments/DEPLOYMENT_NAME/chat/completions?api-version=2024-08-01-preview`
 </Note>
 
 Azure OpenAI chat models support also some model specific settings that are not part of the [standard call settings](/docs/ai-sdk-core/settings).

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -57,7 +57,9 @@ describe('chat', () => {
       });
 
       const searchParams = await server.getRequestUrlSearchParams();
-      expect(searchParams.get('api-version')).toStrictEqual('2024-08-01-preview');
+      expect(searchParams.get('api-version')).toStrictEqual(
+        '2024-08-01-preview',
+      );
     });
 
     it('should pass headers', async () => {
@@ -170,7 +172,9 @@ describe('completion', () => {
       });
 
       const searchParams = await server.getRequestUrlSearchParams();
-      expect(searchParams.get('api-version')).toStrictEqual('2024-08-01-preview');
+      expect(searchParams.get('api-version')).toStrictEqual(
+        '2024-08-01-preview',
+      );
     });
 
     it('should pass headers', async () => {
@@ -246,7 +250,9 @@ describe('embedding', () => {
       });
 
       const searchParams = await server.getRequestUrlSearchParams();
-      expect(searchParams.get('api-version')).toStrictEqual('2024-08-01-preview');
+      expect(searchParams.get('api-version')).toStrictEqual(
+        '2024-08-01-preview',
+      );
     });
 
     it('should pass headers', async () => {

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -57,7 +57,7 @@ describe('chat', () => {
       });
 
       const searchParams = await server.getRequestUrlSearchParams();
-      expect(searchParams.get('api-version')).toStrictEqual('2024-06-01');
+      expect(searchParams.get('api-version')).toStrictEqual('2024-08-01-preview');
     });
 
     it('should pass headers', async () => {
@@ -106,7 +106,7 @@ describe('chat', () => {
 
       const requestUrl = await server.getRequestUrl();
       expect(requestUrl).toStrictEqual(
-        'https://test-resource.openai.azure.com/openai/deployments/test-deployment/chat/completions?api-version=2024-06-01',
+        'https://test-resource.openai.azure.com/openai/deployments/test-deployment/chat/completions?api-version=2024-08-01-preview',
       );
     });
   });
@@ -170,7 +170,7 @@ describe('completion', () => {
       });
 
       const searchParams = await server.getRequestUrlSearchParams();
-      expect(searchParams.get('api-version')).toStrictEqual('2024-06-01');
+      expect(searchParams.get('api-version')).toStrictEqual('2024-08-01-preview');
     });
 
     it('should pass headers', async () => {
@@ -246,7 +246,7 @@ describe('embedding', () => {
       });
 
       const searchParams = await server.getRequestUrlSearchParams();
-      expect(searchParams.get('api-version')).toStrictEqual('2024-06-01');
+      expect(searchParams.get('api-version')).toStrictEqual('2024-08-01-preview');
     });
 
     it('should pass headers', async () => {

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -93,11 +93,6 @@ Custom fetch implementation. You can use it as a middleware to intercept request
 or to provide a custom fetch implementation for e.g. testing.
     */
   fetch?: FetchFunction;
-
-  /**
-API version to use for Azure OpenAI requests. Defaults to '2024-06-01'.
-   */
-  apiVersion?: string;
 }
 
 /**
@@ -123,12 +118,10 @@ export function createAzure(
       description: 'Azure OpenAI resource name',
     });
 
-  const apiVersion = options.apiVersion || '2024-06-01';
-
   const url = ({ path, modelId }: { path: string; modelId: string }) =>
     options.baseURL
-      ? `${options.baseURL}/${modelId}${path}?api-version=${apiVersion}`
-      : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=${apiVersion}`;
+      ? `${options.baseURL}/${modelId}${path}?api-version=2024-08-01-preview`
+      : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=2024-08-01-preview`;
 
   const createChatModel = (
     deploymentName: string,

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -93,6 +93,11 @@ Custom fetch implementation. You can use it as a middleware to intercept request
 or to provide a custom fetch implementation for e.g. testing.
     */
   fetch?: FetchFunction;
+
+  /**
+API version to use for Azure OpenAI requests. Defaults to '2024-06-01'.
+   */
+  apiVersion?: string;
 }
 
 /**
@@ -118,10 +123,12 @@ export function createAzure(
       description: 'Azure OpenAI resource name',
     });
 
+  const apiVersion = options.apiVersion || '2024-06-01';
+
   const url = ({ path, modelId }: { path: string; modelId: string }) =>
     options.baseURL
-      ? `${options.baseURL}/${modelId}${path}?api-version=2024-06-01`
-      : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=2024-06-01`;
+      ? `${options.baseURL}/${modelId}${path}?api-version=${apiVersion}`
+      : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=${apiVersion}`;
 
   const createChatModel = (
     deploymentName: string,


### PR DESCRIPTION
`api-version` param is currently hardcoded to `2024-06-01`, it prevents using features like `toolChoice` since it's only enabled for `2024-07-01-preview` and later 