### PR TITLE
feat (provider/openai): support store parameter

### DIFF
--- a/.changeset/calm-swans-pump.md
+++ b/.changeset/calm-swans-pump.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat (provider/openai): support store parameter for distillation

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -290,6 +290,33 @@ const result = await generateText({
 });
 ```
 
+#### Distillation
+OpenAI supports model distillation for some models. If you want to store a generation for use in the distillation process, you can add the `store` option to the `experimental_providerMetadata.openai` object. This will save the generation to the OpenAI platform for later use in distillation.
+
+```typescript highlight="9-13"
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const { text, usage } = await generateText({
+    model: openai('gpt-4o-mini'),
+    prompt: 'Who worked on the original macintosh?',
+    experimental_providerMetadata: {
+      openai: {
+        store: true,
+      },
+    },
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Usage:', usage);
+}
+
+main().catch(console.error);
+```
+
 #### Reasoning Models
 
 OpenAI has introduced the `o1` series of [reasoning models](https://platform.openai.com/docs/guides/reasoning).

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -291,6 +291,7 @@ const result = await generateText({
 ```
 
 #### Distillation
+
 OpenAI supports model distillation for some models. If you want to store a generation for use in the distillation process, you can add the `store` option to the `experimental_providerMetadata.openai` object. This will save the generation to the OpenAI platform for later use in distillation.
 
 ```typescript highlight="9-13"

--- a/examples/ai-core/src/generate-object/openai-store-generation.ts
+++ b/examples/ai-core/src/generate-object/openai-store-generation.ts
@@ -1,0 +1,35 @@
+import { openai } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await generateObject({
+    model: openai('gpt-4o-mini', { structuredOutputs: true }),
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({
+            name: z.string(),
+            amount: z.string(),
+          }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+    experimental_providerMetadata: {
+      openai: {
+        store: true,
+      },
+    },
+  });
+
+  console.log(JSON.stringify(result.object.recipe, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-store-generation.ts
+++ b/examples/ai-core/src/generate-text/openai-store-generation.ts
@@ -1,0 +1,21 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const { text, usage } = await generateText({
+    model: openai('gpt-4o-mini'),
+    prompt: 'Who worked on the original macintosh?',
+    experimental_providerMetadata: {
+      openai: {
+        store: true,
+      },
+    },
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Usage:', usage);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-object/openai-store-generation.ts
+++ b/examples/ai-core/src/stream-object/openai-store-generation.ts
@@ -1,0 +1,35 @@
+import { openai } from '@ai-sdk/openai';
+import { streamObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await streamObject({
+    model: openai('gpt-4-turbo'),
+    schema: z.object({
+      characters: z.array(
+        z.object({
+          name: z.string(),
+          class: z
+            .string()
+            .describe('Character class, e.g. warrior, mage, or thief.'),
+          description: z.string(),
+        }),
+      ),
+    }),
+    prompt:
+      'Generate 3 character descriptions for a fantasy role playing game.',
+    experimental_providerMetadata: {
+      openai: {
+        store: true,
+      },
+    },
+  });
+
+  for await (const partialObject of result.partialObjectStream) {
+    console.clear();
+    console.log(partialObject);
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-store-generation.ts
+++ b/examples/ai-core/src/stream-text/openai-store-generation.ts
@@ -1,0 +1,28 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await streamText({
+    model: openai('gpt-3.5-turbo'),
+    maxTokens: 512,
+    temperature: 0.3,
+    maxRetries: 5,
+    prompt: 'Invent a new holiday and describe its traditions.',
+    experimental_providerMetadata: {
+      openai: {
+        store: true,
+      },
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -912,6 +912,27 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should send store extension setting', async () => {
+    prepareJsonResponse({  content: '' });
+
+    await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+      providerMetadata: {
+        openai: {
+          store: true,
+        },
+      },
+    });
+
+    expect(await server.getRequestBodyJson()).toStrictEqual({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: 'Hello' }],
+      store: true,
+    });
+  });
+
   describe('should simulate streaming for reasoning models', () => {
     it('should stream text delta', async () => {
       prepareJsonResponse({ content: 'Hello, World!', model: 'o1-preview' });
@@ -1678,6 +1699,29 @@ describe('doStream', () => {
       'custom-request-header': 'request-header-value',
       'openai-organization': 'test-organization',
       'openai-project': 'test-project',
+    });
+  });
+
+  it('should send store extension setting', async () => {
+    prepareStreamResponse({ content: [] });
+
+    await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+      providerMetadata: {
+        openai: {
+          store: true,
+        },
+      },
+    });
+
+    expect(await server.getRequestBodyJson()).toStrictEqual({
+      model: 'gpt-3.5-turbo',
+      stream: true,
+      stream_options: { include_usage: true },
+      messages: [{ role: 'user', content: 'Hello' }],
+      store: true,
     });
   });
 });

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -913,7 +913,7 @@ describe('doGenerate', () => {
   });
 
   it('should send store extension setting', async () => {
-    prepareJsonResponse({  content: '' });
+    prepareJsonResponse({ content: '' });
 
     await model.doGenerate({
       inputFormat: 'prompt',

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -156,6 +156,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
       // openai specific settings:
       max_completion_tokens:
         providerMetadata?.openai?.maxCompletionTokens ?? undefined,
+      store: providerMetadata?.openai?.store ?? undefined,
 
       // response format:
       response_format:


### PR DESCRIPTION
This pr adds support for the new `store` parameter. This parameter allows the user to store generations for use during the model distillation process.