### PR TITLE
fix (examples/next-fastapi): Handle JSON encoding for text stream parts

### DIFF
--- a/examples/next-fastapi/api/index.py
+++ b/examples/next-fastapi/api/index.py
@@ -110,7 +110,7 @@ def stream_text(messages: List[ClientMessage], protocol: str = 'data'):
                             draft_tool_calls[draft_tool_calls_index]["arguments"] += arguments
 
                 else:
-                    yield '0:"{text}"\n'.format(text=choice.delta.content)
+                    yield '0:{text}\n'.format(text=json.dumps(choice.delta.content))
 
             if chunk.choices == []:
                 usage = chunk.usage


### PR DESCRIPTION
When the LLM returns newline characters (`\n`), they are not properly escaped. This causes issues when the string is directly passed to `JSON.parse` in `parseStreamPart`, resulting in an error and the stream stopping.

https://github.com/vercel/ai/blob/14eb2b884d6d4a50013570b0c5d1f40b9d2dab77/packages/ui-utils/src/stream-parts.ts#L637-L638

This fix ensures that the text stream part is properly JSON encoded, preventing errors during parsing. 

The docs on [Data Stream Protocol - Text Part](https://sdk.vercel.ai/docs/ai-sdk-ui/stream-protocol#text-part) don't mention that the string needs to be JSON encoded so people may pass unescaped JSON characters to it.

