### PR TITLE
Telemetry settings getTracer function

### DIFF
--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -55,6 +55,25 @@ const result = await generateText({
 });
 ```
 
+## Providing a custom tracer
+
+You can provide a `getTracer` function which must return an OpenTelemetry `Tracer`. This is useful in situations where
+you may want your traces to use an alternate `TracerProvider`.
+
+```ts highlight="7-9"
+const aiTracerProvider = new NodeTracerProvider();
+const result = await generateText({
+  model: openai('gpt-4-turbo'),
+  prompt: 'Write a short story about a cat.',
+  experimental_telemetry: {
+    isEnabled: true,
+    getTracer() {
+      return aiTracerProvider.getTracer('ai')
+    },
+  },
+});
+```
+
 ## Collected Data
 
 ### generateText function

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -55,10 +55,10 @@ const result = await generateText({
 });
 ```
 
-## Providing a custom tracer
+## Custom Tracer
 
-You can provide a `getTracer` function which must return an OpenTelemetry `Tracer`. This is useful in situations where
-you may want your traces to use an alternate `TracerProvider`.
+You may provide a `getTracer` function which must return an OpenTelemetry `Tracer`. This is useful in situations where
+you want your traces to use a `TracerProvider` other than the one provided by the `@opentelemetry/api` singleton.
 
 ```ts highlight="7-9"
 const aiTracerProvider = new NodeTracerProvider();

--- a/packages/ai/core/embed/embed-many.test.ts
+++ b/packages/ai/core/embed/embed-many.test.ts
@@ -3,9 +3,8 @@ import {
   MockEmbeddingModelV1,
   mockEmbed,
 } from '../test/mock-embedding-model-v1';
-import { embedMany } from './embed-many';
 import { MockTracer } from '../test/mock-tracer';
-import { setTestTracer } from '../telemetry/get-tracer';
+import { embedMany } from './embed-many';
 
 const dummyEmbeddings = [
   [0.1, 0.2, 0.3],
@@ -129,11 +128,6 @@ describe('telemetry', () => {
 
   beforeEach(() => {
     tracer = new MockTracer();
-    setTestTracer(tracer);
-  });
-
-  afterEach(() => {
-    setTestTracer(undefined);
   });
 
   it('should not record any telemetry data when not explicitly enabled', async () => {
@@ -181,6 +175,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
     });
 
@@ -201,6 +196,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
     });
 
@@ -218,6 +214,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
+        getTracer: () => tracer,
       },
     });
 

--- a/packages/ai/core/embed/embed-many.ts
+++ b/packages/ai/core/embed/embed-many.ts
@@ -73,7 +73,7 @@ Only applicable for HTTP-based providers.
     settings: { maxRetries },
   });
 
-  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false });
+  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false, getTracer: telemetry?.getTracer });
 
   return recordSpan({
     name: 'ai.embedMany',

--- a/packages/ai/core/embed/embed.test.ts
+++ b/packages/ai/core/embed/embed.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert';
-import { setTestTracer } from '../telemetry/get-tracer';
 import {
   MockEmbeddingModelV1,
   mockEmbed,
@@ -74,11 +73,6 @@ describe('telemetry', () => {
 
   beforeEach(() => {
     tracer = new MockTracer();
-    setTestTracer(tracer);
-  });
-
-  afterEach(() => {
-    setTestTracer(undefined);
   });
 
   it('should not record any telemetry data when not explicitly enabled', async () => {
@@ -87,6 +81,9 @@ describe('telemetry', () => {
         doEmbed: mockEmbed([testValue], [dummyEmbedding]),
       }),
       value: testValue,
+      experimental_telemetry: {
+        getTracer: () => tracer,
+      },      
     });
 
     expect(tracer.jsonSpans).toMatchSnapshot();
@@ -105,6 +102,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
     });
 
@@ -121,6 +119,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
+        getTracer: () => tracer,
       },
     });
 

--- a/packages/ai/core/embed/embed.ts
+++ b/packages/ai/core/embed/embed.ts
@@ -68,7 +68,7 @@ Only applicable for HTTP-based providers.
     settings: { maxRetries },
   });
 
-  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false });
+  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false, getTracer: telemetry?.getTracer });
 
   return recordSpan({
     name: 'ai.embed',

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -2,7 +2,6 @@ import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { jsonSchema } from '@ai-sdk/ui-utils';
 import assert from 'node:assert';
 import { z } from 'zod';
-import { setTestTracer } from '../telemetry/get-tracer';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
 import { MockTracer } from '../test/mock-tracer';
 import { generateObject } from './generate-object';
@@ -767,11 +766,6 @@ describe('telemetry', () => {
 
   beforeEach(() => {
     tracer = new MockTracer();
-    setTestTracer(tracer);
-  });
-
-  afterEach(() => {
-    setTestTracer(undefined);
   });
 
   it('should not record any telemetry data when not explicitly enabled', async () => {
@@ -824,6 +818,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
     });
 
@@ -871,6 +866,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
     });
 
@@ -897,6 +893,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
+        getTracer: () => tracer,
       },
     });
 
@@ -930,6 +927,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
+        getTracer: () => tracer,
       },
     });
 

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -360,7 +360,7 @@ export async function generateObject<SCHEMA, RESULT>({
     settings: { ...settings, maxRetries },
   });
 
-  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false });
+  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false, getTracer: telemetry?.getTracer });
   return recordSpan({
     name: 'ai.generateObject',
     attributes: selectTelemetryAttributes({

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -7,7 +7,6 @@ import {
 import { jsonSchema } from '@ai-sdk/ui-utils';
 import assert from 'node:assert';
 import { z } from 'zod';
-import { setTestTracer } from '../telemetry/get-tracer';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
 import { createMockServerResponse } from '../test/mock-server-response';
 import { MockTracer } from '../test/mock-tracer';
@@ -1446,11 +1445,6 @@ describe('telemetry', () => {
 
   beforeEach(() => {
     tracer = new MockTracer();
-    setTestTracer(tracer);
-  });
-
-  afterEach(() => {
-    setTestTracer(undefined);
   });
 
   it('should not record any telemetry data when not explicitly enabled', async () => {
@@ -1538,6 +1532,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
       _internal: { now: () => 0 },
     });
@@ -1631,6 +1626,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
       _internal: { now: () => 0 },
     });
@@ -1674,6 +1670,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
+        getTracer: () => tracer,
       },
       _internal: { now: () => 0 },
     });
@@ -1753,6 +1750,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
+        getTracer: () => tracer,
       },
       _internal: { now: () => 0 },
     });

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -4,6 +4,7 @@ import {
   LanguageModelV1FinishReason,
   LanguageModelV1StreamPart,
 } from '@ai-sdk/provider';
+import { createIdGenerator } from '@ai-sdk/provider-utils';
 import {
   DeepPartial,
   Schema,
@@ -44,14 +45,13 @@ import {
   createAsyncIterableStream,
 } from '../util/async-iterable-stream';
 import { now as originalNow } from '../util/now';
+import { prepareOutgoingHttpHeaders } from '../util/prepare-outgoing-http-headers';
 import { prepareResponseHeaders } from '../util/prepare-response-headers';
+import { writeToServerResponse } from '../util/write-to-server-response';
 import { injectJsonInstruction } from './inject-json-instruction';
 import { OutputStrategy, getOutputStrategy } from './output-strategy';
 import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
-import { createIdGenerator } from '@ai-sdk/provider-utils';
-import { prepareOutgoingHttpHeaders } from '../util/prepare-outgoing-http-headers';
-import { writeToServerResponse } from '../util/write-to-server-response';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj-', size: 24 });
 
@@ -386,7 +386,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
     settings: { ...settings, maxRetries },
   });
 
-  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false });
+  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false, getTracer: telemetry?.getTracer });
 
   const retry = retryWithExponentialBackoff({ maxRetries });
 

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -1,7 +1,6 @@
 import { jsonSchema } from '@ai-sdk/ui-utils';
 import assert from 'node:assert';
 import { z } from 'zod';
-import { setTestTracer } from '../telemetry/get-tracer';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
 import { MockTracer } from '../test/mock-tracer';
 import { generateText } from './generate-text';
@@ -734,11 +733,6 @@ describe('telemetry', () => {
 
   beforeEach(() => {
     tracer = new MockTracer();
-    setTestTracer(tracer);
-  });
-
-  afterEach(() => {
-    setTestTracer(undefined);
   });
 
   it('should not record any telemetry data when not explicitly enabled', async () => {
@@ -750,6 +744,9 @@ describe('telemetry', () => {
         }),
       }),
       prompt: 'prompt',
+      experimental_telemetry: {
+        getTracer: () => tracer,
+      },      
     });
 
     expect(tracer.jsonSpans).toMatchSnapshot();
@@ -786,6 +783,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
     });
 
@@ -816,6 +814,7 @@ describe('telemetry', () => {
       prompt: 'test-input',
       experimental_telemetry: {
         isEnabled: true,
+        getTracer: () => tracer,
       },
       _internal: {
         generateId: () => 'test-id',
@@ -852,6 +851,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
+        getTracer: () => tracer,
       },
       _internal: {
         generateId: () => 'test-id',

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -203,7 +203,7 @@ functionality that can be fully encapsulated in the provider.
     settings: { ...settings, maxRetries },
   });
 
-  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false });
+  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false, getTracer: telemetry?.getTracer });
   return recordSpan({
     name: 'ai.generateText',
     attributes: selectTelemetryAttributes({

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -13,7 +13,6 @@ import {
   jsonSchema,
 } from '../../streams';
 import { delay } from '../../util/delay';
-import { setTestTracer } from '../telemetry/get-tracer';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
 import { createMockServerResponse } from '../test/mock-server-response';
 import { MockTracer } from '../test/mock-tracer';
@@ -2030,11 +2029,6 @@ describe('options.maxSteps', () => {
 
   beforeEach(() => {
     tracer = new MockTracer();
-    setTestTracer(tracer);
-  });
-
-  afterEach(() => {
-    setTestTracer(undefined);
   });
 
   describe('2 steps: initial, tool-result', () => {
@@ -2194,7 +2188,7 @@ describe('options.maxSteps', () => {
         onStepFinish: async event => {
           onStepFinishResults.push(event);
         },
-        experimental_telemetry: { isEnabled: true },
+        experimental_telemetry: { isEnabled: true, getTracer: () => tracer },
         maxSteps: 3,
         _internal: {
           now: mockValues(0, 100, 500, 600, 1000),
@@ -2421,7 +2415,7 @@ describe('options.maxSteps', () => {
         onStepFinish: async event => {
           onStepFinishResults.push(event);
         },
-        experimental_telemetry: { isEnabled: true },
+        experimental_telemetry: { isEnabled: true, getTracer: () => tracer },
         _internal: {
           now: mockValues(0, 100, 500, 600, 1000),
         },
@@ -2697,11 +2691,6 @@ describe('telemetry', () => {
 
   beforeEach(() => {
     tracer = new MockTracer();
-    setTestTracer(tracer);
-  });
-
-  afterEach(() => {
-    setTestTracer(undefined);
   });
 
   it('should not record any telemetry data when not explicitly enabled', async () => {
@@ -2782,6 +2771,7 @@ describe('telemetry', () => {
           test1: 'value1',
           test2: false,
         },
+        getTracer: () => tracer,
       },
       _internal: { now: mockValues(0, 100, 500) },
     });
@@ -2827,7 +2817,7 @@ describe('telemetry', () => {
         },
       },
       prompt: 'test-input',
-      experimental_telemetry: { isEnabled: true },
+      experimental_telemetry: { isEnabled: true, getTracer: () => tracer },
       _internal: { now: mockValues(0, 100, 500) },
     });
 
@@ -2876,6 +2866,7 @@ describe('telemetry', () => {
         isEnabled: true,
         recordInputs: false,
         recordOutputs: false,
+        getTracer: () => tracer
       },
       _internal: { now: mockValues(0, 100, 500) },
     });

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -275,7 +275,7 @@ need to be added separately.
     settings: { ...settings, maxRetries },
   });
 
-  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false });
+  const tracer = getTracer({ isEnabled: telemetry?.isEnabled ?? false, getTracer: telemetry?.getTracer });
 
   return recordSpan({
     name: 'ai.streamText',

--- a/packages/ai/core/telemetry/get-tracer.ts
+++ b/packages/ai/core/telemetry/get-tracer.ts
@@ -1,22 +1,13 @@
 import { Tracer, trace } from '@opentelemetry/api';
 import { noopTracer } from './noop-tracer';
 
-/**
- * Tracer variable for testing. Tests can set this to a mock tracer.
- */
-let testTracer: Tracer | undefined = undefined;
-
-export function setTestTracer(tracer: Tracer | undefined) {
-  testTracer = tracer;
-}
-
-export function getTracer({ isEnabled }: { isEnabled: boolean }): Tracer {
+export function getTracer({ isEnabled, getTracer }: { isEnabled: boolean; getTracer?: () => Tracer }): Tracer {
   if (!isEnabled) {
     return noopTracer;
   }
 
-  if (testTracer) {
-    return testTracer;
+  if (getTracer) {
+    return getTracer();
   }
 
   return trace.getTracer('ai');

--- a/packages/ai/core/telemetry/telemetry-settings.ts
+++ b/packages/ai/core/telemetry/telemetry-settings.ts
@@ -1,4 +1,4 @@
-import { AttributeValue } from '@opentelemetry/api';
+import { AttributeValue, Tracer } from '@opentelemetry/api';
 
 /**
  * Telemetry configuration.
@@ -36,4 +36,9 @@ export type TelemetrySettings = {
    * Additional information to include in the telemetry data.
    */
   metadata?: Record<string, AttributeValue>;
+
+  /**
+   * Callback to get a custom Tracer.
+   */
+  getTracer?: () => Tracer;  
 };


### PR DESCRIPTION
This PR addresses issue #3226. 

## What it does

- Adds the new `getTracer` fn to `TelemetrySettings` and plumbs it.
- Returns the value from `experimental_telemetry.getTracer` if the function has been supplied in the `getTracer` utility.
- Replaces use of `setTestTracer` in tests to take advantage of `experimental_telemetry.getTracer `.
- Docs