### PR TITLE
feat (provider/mistral): support continuation and trailing assistant messages

### DIFF
--- a/.changeset/rich-books-shop.md
+++ b/.changeset/rich-books-shop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+feat (provider/mistral): support continuation and trailing assistant messages

--- a/examples/ai-core/src/generate-text/mistral-multi-step-continue.ts
+++ b/examples/ai-core/src/generate-text/mistral-multi-step-continue.ts
@@ -1,0 +1,24 @@
+import { mistral } from '@ai-sdk/mistral';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const { text, usage, steps } = await generateText({
+    model: mistral('open-mistral-7b'),
+    maxTokens: 512,
+    maxSteps: 5,
+    experimental_continueSteps: true,
+    prompt:
+      'Write a book about Roman history, ' +
+      'from the founding of the city of Rome ' +
+      'to the fall of the Western Roman Empire. ' +
+      'Each chapter MUST HAVE at least 1000 words.',
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Usage:', usage);
+  console.log('# of steps:', steps.length);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/mistral-multi-step-continue.ts
+++ b/examples/ai-core/src/stream-text/mistral-multi-step-continue.ts
@@ -1,0 +1,28 @@
+import { mistral } from '@ai-sdk/mistral';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await streamText({
+    model: mistral('open-mistral-7b'),
+    maxTokens: 512, // artificial limit for demo purposes
+    maxSteps: 5,
+    experimental_continueSteps: true,
+    prompt:
+      'Write a book about Roman history, ' +
+      'from the founding of the city of Rome ' +
+      'to the fall of the Western Roman Empire. ' +
+      'Each chapter MUST HAVE at least 1000 words.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log('# of steps:', (await result.steps).length);
+}
+
+main().catch(console.error);

--- a/packages/mistral/src/__snapshots__/convert-to-mistral-chat-messages.test.ts.snap
+++ b/packages/mistral/src/__snapshots__/convert-to-mistral-chat-messages.test.ts.snap
@@ -1,9 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`assistant messages > should add prefix true to trailing assistant messages 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "Hello",
+        "type": "text",
+      },
+    ],
+    "role": "user",
+  },
+  {
+    "content": "Hello!",
+    "prefix": true,
+    "role": "assistant",
+    "tool_calls": undefined,
+  },
+]
+`;
+
 exports[`tool calls > should stringify arguments to tool calls 1`] = `
 [
   {
     "content": "",
+    "prefix": undefined,
     "role": "assistant",
     "tool_calls": [
       {
@@ -21,6 +42,24 @@ exports[`tool calls > should stringify arguments to tool calls 1`] = `
     "name": "tool-1",
     "role": "tool",
     "tool_call_id": "tool-call-id-1",
+  },
+]
+`;
+
+exports[`user messages > should convert messages with image parts 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "Hello",
+        "type": "text",
+      },
+      {
+        "image_url": "data:image/png;base64,AAECAw==",
+        "type": "image_url",
+      },
+    ],
+    "role": "user",
   },
 ]
 `;

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -16,18 +16,7 @@ describe('user messages', () => {
       },
     ]);
 
-    expect(result).toEqual([
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: 'Hello' },
-          {
-            type: 'image_url',
-            image_url: 'data:image/png;base64,AAECAw==',
-          },
-        ],
-      },
-    ]);
+    expect(result).toMatchSnapshot();
   });
 });
 
@@ -55,6 +44,23 @@ describe('tool calls', () => {
             result: { key: 'result-value' },
           },
         ],
+      },
+    ]);
+
+    expect(result).toMatchSnapshot();
+  });
+});
+
+describe('assistant messages', () => {
+  it('should add prefix true to trailing assistant messages', () => {
+    const result = convertToMistralChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
       },
     ]);
 

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -3,14 +3,17 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
-import { MistralChatPrompt } from './mistral-chat-prompt';
+import { MistralPrompt } from './mistral-chat-prompt';
 
 export function convertToMistralChatMessages(
   prompt: LanguageModelV1Prompt,
-): MistralChatPrompt {
-  const messages: MistralChatPrompt = [];
+): MistralPrompt {
+  const messages: MistralPrompt = [];
 
-  for (const { role, content } of prompt) {
+  for (let i = 0; i < prompt.length; i++) {
+    const { role, content } = prompt[i];
+    const isLastMessage = i === prompt.length - 1;
+
     switch (role) {
       case 'system': {
         messages.push({ role: 'system', content });
@@ -82,6 +85,7 @@ export function convertToMistralChatMessages(
         messages.push({
           role: 'assistant',
           content: text,
+          prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -74,6 +74,24 @@ describe('doGenerate', () => {
     expect(text).toStrictEqual('Hello, World!');
   });
 
+  it('should avoid duplication when there is a trailing assistant message', async () => {
+    prepareJsonResponse({ content: 'prefix and more content' });
+
+    const { text } = await model.doGenerate({
+      inputFormat: 'messages',
+      mode: { type: 'regular' },
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'prefix ' }],
+        },
+      ],
+    });
+
+    expect(text).toStrictEqual('and more content');
+  });
+
   it('should extract tool call response', async () => {
     server.responseBodyJson = {
       id: 'b3999b8c93e04e11bcbff7bcab829667',

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -231,7 +231,8 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
       promptTokens: Number.NaN,
       completionTokens: Number.NaN,
     };
-    let isFirstChunk = true;
+    let chunkNumber = 0;
+    let trimLeadingSpace = false;
 
     return {
       stream: response.pipeThrough(
@@ -245,11 +246,11 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
               return;
             }
 
+            chunkNumber++;
+
             const value = chunk.value;
 
-            if (isFirstChunk) {
-              isFirstChunk = false;
-
+            if (chunkNumber === 1) {
               controller.enqueue({
                 type: 'response-metadata',
                 ...getResponseMetadata(value),
@@ -275,11 +276,36 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
 
             const delta = choice.delta;
 
+            // when there is a trailing assistant message, mistral will send the
+            // content of that message again. we skip this repeated content to
+            // avoid duplication, e.g. in continuation mode.
+            if (chunkNumber <= 2) {
+              const lastMessage = rawPrompt[rawPrompt.length - 1];
+
+              if (
+                lastMessage.role === 'assistant' &&
+                delta.content === lastMessage.content.trimEnd()
+              ) {
+                // Mistral moves the trailing space from the prefix to the next chunk.
+                // We trim the leading space to avoid duplication.
+                if (delta.content.length < lastMessage.content.length) {
+                  trimLeadingSpace = true;
+                }
+
+                // skip the repeated content:
+                return;
+              }
+            }
+
             if (delta.content != null) {
               controller.enqueue({
                 type: 'text-delta',
-                textDelta: delta.content,
+                textDelta: trimLeadingSpace
+                  ? delta.content.trimStart()
+                  : delta.content,
               });
+
+              trimLeadingSpace = false;
             }
 
             if (delta.tool_calls != null) {

--- a/packages/mistral/src/mistral-chat-prompt.ts
+++ b/packages/mistral/src/mistral-chat-prompt.ts
@@ -1,6 +1,6 @@
-export type MistralChatPrompt = Array<MistralChatMessage>;
+export type MistralPrompt = Array<MistralMessage>;
 
-export type MistralChatMessage =
+export type MistralMessage =
   | MistralSystemMessage
   | MistralUserMessage
   | MistralAssistantMessage
@@ -33,6 +33,7 @@ export interface MistralUserMessageTextContent {
 export interface MistralAssistantMessage {
   role: 'assistant';
   content: string;
+  prefix?: boolean;
   tool_calls?: Array<{
     id: string;
     type: 'function';


### PR DESCRIPTION
## Summary
- add `prefix: true` to trailing assistant messages
- automatically remove duplicated content when streaming or generating text