### PR TITLE
chore (docs): update openai dimensions description

### DIFF
--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -479,7 +479,8 @@ The following optional settings are available for OpenAI embedding models:
 
 - **dimensions**: _number_
 
-  Echo back the prompt in addition to the completion.
+  The number of dimensions the resulting output embeddings should have.
+  Only supported in text-embedding-3 and later models.
 
 - **user** _string_
 

--- a/content/providers/01-ai-sdk-providers/02-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/02-azure.mdx
@@ -257,7 +257,8 @@ The following optional settings are available for Azure OpenAI embedding models:
 
 - **dimensions**: _number_
 
-  Echo back the prompt in addition to the completion.
+  The number of dimensions the resulting output embeddings should have.
+  Only supported in text-embedding-3 and later models.
 
 - **user** _string_
 


### PR DESCRIPTION
This PR updates the docs for OpenAI embeddings, currently the wrong description is being used to describe the optional dimensions setting