### PR TITLE
feat (ai/ui): add setData helper to useChat

### DIFF
--- a/.changeset/selfish-beans-poke.md
+++ b/.changeset/selfish-beans-poke.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/svelte': patch
+'@ai-sdk/react': patch
+'@ai-sdk/solid': patch
+'@ai-sdk/vue': patch
+'ai': patch
+---
+
+feat (ai/ui): add setData helper to useChat

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -293,7 +293,9 @@ const {
 
 It's worth noting that you can abort the processing by throwing an error in the `onResponse` callback. This will trigger the `onError` callback and stop the message from being appended to the chat UI. This can be useful for handling unexpected responses from the AI provider.
 
-## Configure Request Options
+## Request Configuration
+
+### Custom headers, body, and credentials
 
 By default, the `useChat` hook sends a HTTP POST request to the `/api/chat` endpoint with the message list as the request body. You can customize the request by passing additional options to the `useChat` hook:
 
@@ -312,7 +314,7 @@ const { messages, input, handleInputChange, handleSubmit } = useChat({
 
 In this example, the `useChat` hook sends a POST request to the `/api/custom-chat` endpoint with the specified headers, additional body fields, and credentials for that fetch request. On your server side, you can handle the request with these additional information.
 
-## Setting custom body fields per request
+### Setting custom body fields per request
 
 You can configure custom `body` fields on a per-request basis using the `body` option of the `handleSubmit` function.
 This is useful if you want to pass in additional information to your backend that is not part of the message list.

--- a/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
+++ b/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
@@ -10,7 +10,7 @@ This can be achieved with [`StreamData`](/docs/reference/stream-helpers/stream-d
 
 ## What is StreamData
 
-The `StreamData` class allows you to stream arbitrary data to the client alongside your LLM response.
+The `StreamData` class allows you to stream arbitrary JSON data to the client alongside your LLM response.
 This can be particularly useful in applications that need to augment AI responses with metadata, auxiliary information,
 or custom data structures that are relevant to the ongoing interaction.
 
@@ -26,10 +26,10 @@ On the client, the [`useChat`](/docs/reference/ai-sdk-ui/use-chat) hook returns 
 
 ### On the server
 
-<Note>
-  While this example uses Next.js (App Router), `StreamData` is compatible with
-  any framework.
-</Note>
+You can use `StreamData` in combination with `streamText`.
+It is initialized as a separate object and you can append data to it with `append`.
+Once the stream is finished, you need to call `close()` on the `StreamData` object to
+ensure that the connection is closed.
 
 ```tsx
 import { openai } from '@ai-sdk/openai';
@@ -62,12 +62,35 @@ export async function POST(req: Request) {
 }
 ```
 
+<Note>
+  While this example uses Next.js (App Router), `StreamData` is compatible with
+  any framework.
+</Note>
+
 ### On the client
 
-On the client, you can destructure `data` from the `useChat` hook which stores all `StreamData` in an array. The `data` is of the type `JSONValue[]`.
+On the client, you can destructure `data` from the `useChat` hook which stores all `StreamData`
+as a `JSONValue[]`.
 
 ```tsx
 const { data } = useChat();
 ```
 
 Future versions of the AI SDK will support each `Message` having a `data` object attached to it.
+
+## Updating and Clearing Data
+
+You can update and clear the `data` object of the `useChat` hook using the `setData` function.
+
+```tsx
+const { setData } = useChat();
+
+// clear existing data
+setData(undefined);
+
+// set new data
+setData([{ test: 'value' }]);
+
+// transform existing data, e.g. adding additional values:
+setData(currentData => [...currentData, { test: 'value' }]);
+```

--- a/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
+++ b/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
@@ -94,3 +94,35 @@ setData([{ test: 'value' }]);
 // transform existing data, e.g. adding additional values:
 setData(currentData => [...currentData, { test: 'value' }]);
 ```
+
+#### Example: Clear on Submit
+
+```tsx highlight="18-21"
+'use client';
+
+import { Message, useChat } from 'ai/react';
+
+export default function Chat() {
+  const { messages, input, handleInputChange, handleSubmit, data, setData } =
+    useChat();
+
+  return (
+    <>
+      {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
+
+      {messages?.map((m: Message) => (
+        <div key={m.id}>{`${m.role}: ${m.content}`}</div>
+      ))}
+
+      <form
+        onSubmit={e => {
+          setData(undefined); // clear stream data
+          handleSubmit(e);
+        }}
+      >
+        <input value={input} onChange={handleInputChange} />
+      </form>
+    </>
+  );
+}
+```

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -41,45 +41,53 @@ Allows you to easily create a conversational user interface for your chatbot app
     {
       name: 'api',
       type: "string = '/api/chat'",
+      isOptional: true,
       description: 'The chat completion API endpoint offered by the provider.',
     },
     {
       name: 'keepLastMessageOnError',
       type: 'boolean',
+      isOptional: true,
       description:
         'Keeps the last message when an error happens. This will be the default behavior starting with the next major release. The flag was introduced for backwards compatibility and currently defaults to `false`. Please enable it and update your error handling/resubmit behavior.',
     },
     {
       name: 'id',
       type: 'string',
+      isOptional: true,
       description:
         'An unique identifier for the chat. If not provided, a random one will be generated. When provided, the `useChat` hook with the same `id` will have shared states across components. This is useful when you have multiple components showing the same chat stream.',
     },
     {
       name: 'initialInput',
       type: "string = ''",
+      isOptional: true,
       description: 'An optional string for the initial prompt input.',
     },
     {
       name: 'initialMessages',
       type: 'Messages[] = []',
+      isOptional: true,
       description: 'An optional array of initial chat messages',
     },
     {
       name: 'onToolCall',
       type: '({toolCall: ToolCall}) => void | unknown| Promise<unknown>',
+      isOptional: true,
       description:
         'Optional callback function that is invoked when a tool call is received. Intended for automatic client-side tool execution. You can optionally return a result for the tool call, either synchronously or asynchronously.',
     },
     {
       name: 'onResponse',
       type: '(response: Response) => void',
+      isOptional: true,
       description:
         'An optional callback that will be called with the response from the API endpoint. Useful for throwing customized errors or logging',
     },
     {
       name: 'onFinish',
       type: '(message: Message, options: OnFinishOptions) => void',
+      isOptional: true,
       description:
         'An optional callback function that is called when the completion stream ends.',
       properties: [
@@ -126,42 +134,48 @@ Allows you to easily create a conversational user interface for your chatbot app
     {
       name: 'onError',
       type: '(error: Error) => void',
+      isOptional: true,
       description:
-        'An optional callback that will be called when the chat stream encounters an error.',
+        'A callback that will be called when the chat stream encounters an error. Optional.',
     },
     {
       name: 'generateId',
       type: '() => string',
-      description:
-        'Optional. A way to provide a function that is going to be used for ids for messages. If not provided generateId is used by default.',
+      isOptional: true,
+      description: 'A custom id generator for messages. Optional.',
     },
     {
       name: 'headers',
       type: 'Record<string, string> | Headers',
+      isOptional: true,
       description:
-        'An optional object of headers to be passed to the API endpoint.',
+        'Additional headers to be passed to the API endpoint. Optional.',
     },
     {
       name: 'body',
       type: 'any',
+      isOptional: true,
       description:
-        'An optional, additional body object to be passed to the API endpoint.',
+        'Additional body object to be passed to the API endpoint. Optional.',
     },
     {
       name: 'credentials',
       type: "'omit' | 'same-origin' | 'include'",
+      isOptional: true,
       description:
         'An optional literal that sets the mode of credentials to be used on the request. Defaults to same-origin.',
     },
     {
       name: 'sendExtraMessageFields',
       type: 'boolean',
+      isOptional: true,
       description:
         "An optional boolean that determines whether to send extra fields you've added to `messages`. Defaults to `false` and only the `content` and `role` fields will be sent to the API endpoint. If set to `true`, the `name`, `data`, and `annotations` fields will also be sent.",
     },
     {
       name: 'maxSteps',
       type: 'number',
+      isOptional: true,
       description:
         'Maximum number of backend calls to generate a response. A maximum number is required to prevent infinite loops in the case of misconfigured tools. By default, it is set to 1.',
     },
@@ -540,7 +554,13 @@ Allows you to easily create a conversational user interface for your chatbot app
     {
       name: 'data',
       type: 'JSONValue[]',
-      description: 'Data returned from StreamData',
+      description: 'Data returned from StreamData.',
+    },
+    {
+      name: 'setData',
+      type: '(data: JSONValue[] | undefined | ((data: JSONValue[] | undefined) => JSONValue[] | undefined)) => void',
+      description:
+        'Function to update the `data` state which contains data from StreamData.',
     },
     {
       name: 'addToolResult',

--- a/examples/next-openai/app/api/use-chat-streamdata/route.ts
+++ b/examples/next-openai/app/api/use-chat-streamdata/route.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { StreamData, streamText } from 'ai';
+import { convertToCoreMessages, StreamData, streamText } from 'ai';
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
@@ -7,13 +7,13 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
-  // optional: use stream data
+  // use stream data
   const data = new StreamData();
   data.append('initialized call');
 
   const result = await streamText({
-    model: openai('gpt-4-turbo'),
-    messages,
+    model: openai('gpt-4o'),
+    messages: convertToCoreMessages(messages),
     onFinish() {
       data.append('call completed');
       data.close();

--- a/examples/next-openai/app/use-chat-streamdata/page.tsx
+++ b/examples/next-openai/app/use-chat-streamdata/page.tsx
@@ -3,16 +3,23 @@
 import { Message, useChat } from 'ai/react';
 
 export default function Chat() {
-  const { messages, input, handleInputChange, handleSubmit, data } = useChat({
-    api: '/api/use-chat-streamdata',
-  });
+  const { messages, input, handleInputChange, handleSubmit, data, setData } =
+    useChat({ api: '/api/use-chat-streamdata' });
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {data && (
-        <pre className="p-4 text-sm bg-gray-100">
-          {JSON.stringify(data, null, 2)}
-        </pre>
+        <>
+          <pre className="p-4 text-sm bg-gray-100">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+          <button
+            onClick={() => setData(undefined)}
+            className="px-4 py-2 mt-2 text-white bg-blue-500 rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
+          >
+            Clear Data
+          </button>
+        </>
       )}
 
       {messages?.map((m: Message) => (

--- a/examples/next-openai/app/use-chat-streamdata/page.tsx
+++ b/examples/next-openai/app/use-chat-streamdata/page.tsx
@@ -31,7 +31,12 @@ export default function Chat() {
         </div>
       ))}
 
-      <form onSubmit={handleSubmit}>
+      <form
+        onSubmit={e => {
+          setData(undefined); // clear stream data
+          handleSubmit(e);
+        }}
+      >
         <input
           className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
           value={input}

--- a/examples/nuxt-openai/pages/use-chat-streamdata/index.vue
+++ b/examples/nuxt-openai/pages/use-chat-streamdata/index.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { useChat } from '@ai-sdk/vue';
+
+const { input, isLoading, handleSubmit, messages, stop, data, setData } =
+  useChat({ api: '/api/use-chat-streamdata' });
+</script>
+
+<template>
+  <div class="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+    <div v-if="data">
+      <pre class="p-4 text-sm bg-gray-100">
+        {{ JSON.stringify(data, null, 2) }}
+      </pre>
+      <button
+        @click="() => setData(undefined)"
+        class="px-4 py-2 mt-2 text-white bg-blue-500 rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
+      >
+        Clear Data
+      </button>
+    </div>
+
+    <div v-for="m in messages" :key="m.id" class="whitespace-pre-wrap">
+      <strong>{{ m.role === 'user' ? 'User: ' : 'AI: ' }}</strong>
+      {{ m.content }}
+      <br />
+      <br />
+    </div>
+
+    <div v-if="isLoading" class="mt-4 text-gray-500">
+      <div>Loading...</div>
+      <button
+        type="button"
+        class="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+        @click="stop"
+      >
+        Stop
+      </button>
+    </div>
+
+    <form @submit="handleSubmit">
+      <input
+        class="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+        v-model="input"
+      />
+    </form>
+  </div>
+</template>

--- a/examples/nuxt-openai/server/api/use-chat-streamdata.ts
+++ b/examples/nuxt-openai/server/api/use-chat-streamdata.ts
@@ -1,0 +1,27 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { convertToCoreMessages, StreamData, streamText } from 'ai';
+
+export default defineLazyEventHandler(async () => {
+  const openai = createOpenAI({
+    apiKey: useRuntimeConfig().openaiApiKey,
+  });
+
+  return defineEventHandler(async (event: any) => {
+    const { messages } = await readBody(event);
+
+    // use stream data
+    const data = new StreamData();
+    data.append('initialized call');
+
+    const result = await streamText({
+      model: openai('gpt-4o'),
+      messages: convertToCoreMessages(messages),
+      onFinish() {
+        data.append('call completed');
+        data.close();
+      },
+    });
+
+    return result.toDataStreamResponse({ data });
+  });
+});

--- a/examples/solidstart-openai/src/routes/api/use-chat-streamdata/index.ts
+++ b/examples/solidstart-openai/src/routes/api/use-chat-streamdata/index.ts
@@ -1,0 +1,22 @@
+import { openai } from '@ai-sdk/openai';
+import { APIEvent } from '@solidjs/start/server';
+import { convertToCoreMessages, StreamData, streamText } from 'ai';
+
+export const POST = async (event: APIEvent) => {
+  const { messages } = await event.request.json();
+
+  // use stream data
+  const data = new StreamData();
+  data.append('initialized call');
+
+  const result = await streamText({
+    model: openai('gpt-4o'),
+    messages: convertToCoreMessages(messages),
+    onFinish() {
+      data.append('call completed');
+      data.close();
+    },
+  });
+
+  return result.toDataStreamResponse({ data });
+};

--- a/examples/solidstart-openai/src/routes/use-chat-streamdata/index.tsx
+++ b/examples/solidstart-openai/src/routes/use-chat-streamdata/index.tsx
@@ -1,0 +1,79 @@
+import { For, Show } from 'solid-js';
+import { useChat } from '@ai-sdk/solid';
+
+export default function Chat() {
+  const {
+    messages,
+    input,
+    handleInputChange,
+    handleSubmit,
+    data,
+    setData,
+    isLoading,
+    error,
+    stop,
+    reload,
+  } = useChat({ api: '/api/use-chat-streamdata' });
+
+  return (
+    <div class="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      <Show when={data()}>
+        <pre class="p-4 text-sm bg-gray-100">
+          {JSON.stringify(data(), null, 2)}
+        </pre>
+        <button
+          onClick={() => setData(undefined)}
+          class="px-4 py-2 mt-2 text-white bg-blue-500 rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
+        >
+          Clear Data
+        </button>
+      </Show>
+
+      <For each={messages()}>
+        {m => (
+          <div class="whitespace-pre-wrap">
+            <strong>{`${m.role}: `}</strong>
+            {m.content}
+            <br />
+            <br />
+          </div>
+        )}
+      </For>
+
+      <Show when={isLoading()}>
+        <div class="mt-4 text-gray-500">
+          <div>Loading...</div>
+          <button
+            type="button"
+            class="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+            onClick={stop}
+          >
+            Stop
+          </button>
+        </div>
+      </Show>
+
+      <Show when={error()}>
+        <div class="mt-4">
+          <div class="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            class="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+            onClick={() => reload()}
+          >
+            Retry
+          </button>
+        </div>
+      </Show>
+
+      <form onSubmit={handleSubmit}>
+        <input
+          class="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          value={input()}
+          placeholder="Say something..."
+          onInput={handleInputChange}
+        />
+      </form>
+    </div>
+  );
+}

--- a/examples/sveltekit-openai/src/routes/api/use-chat-streamdata/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/use-chat-streamdata/+server.ts
@@ -1,0 +1,33 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { convertToCoreMessages, StreamData, streamText } from 'ai';
+
+import { env } from '$env/dynamic/private';
+// You may want to replace the above with a static private env variable
+// for dead-code elimination and build-time type-checking:
+// import { OPENAI_API_KEY } from '$env/static/private'
+
+import type { RequestHandler } from './$types';
+
+// Create an OpenAI Provider instance
+const openai = createOpenAI({
+  apiKey: env.OPENAI_API_KEY ?? '',
+});
+
+export const POST = (async ({ request }) => {
+  const { messages } = await request.json();
+
+  // use stream data
+  const data = new StreamData();
+  data.append('initialized call');
+
+  const result = await streamText({
+    model: openai('gpt-4o'),
+    messages: convertToCoreMessages(messages),
+    onFinish() {
+      data.append('call completed');
+      data.close();
+    },
+  });
+
+  return result.toDataStreamResponse({ data });
+}) satisfies RequestHandler;

--- a/examples/sveltekit-openai/src/routes/use-chat-streamdata/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/use-chat-streamdata/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { useChat } from '@ai-sdk/svelte';
+
+  const {
+    error,
+    input,
+    isLoading,
+    handleSubmit,
+    messages,
+    data,
+    setData
+  } = useChat({ api: '/api/use-chat-streamdata' });
+</script>
+
+<svelte:head>
+  <title>Home</title>
+  <meta name="description" content="Svelte demo app" />
+</svelte:head>
+
+<section>
+  <h1>useChat</h1>
+
+  {#if $data}
+    <pre class="p-4 text-sm bg-gray-100">
+      {JSON.stringify($data, null, 2)}
+    </pre>
+    <button
+      on:click={() => setData(undefined)}
+      class="px-4 py-2 mt-2 text-white bg-blue-500 rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
+    >
+      Clear Data
+    </button>
+  {/if}
+
+  <ul>
+    {#each $messages as message}
+      <li class="whitespace-pre-wrap">
+        <strong>{message.role}: </strong>
+        {message.content}
+      </li>
+    {/each}
+  </ul>
+
+  <form on:submit={handleSubmit}>
+    <input
+      bind:value={$input}
+      disabled={$isLoading || $error != null}
+      class="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+      placeholder="Say something..."
+    />
+    <button type="submit">Send</button>
+  </form>
+</section>
+
+<style>
+  section {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    flex: 0.6;
+  }
+
+  h1 {
+    width: 100%;
+  }
+</style>

--- a/packages/ai/svelte/use-chat.ts
+++ b/packages/ai/svelte/use-chat.ts
@@ -93,6 +93,13 @@ export type UseChatHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Readable<JSONValue[] | undefined>;
+  /** Set the data of the chat. You can use this to transform or clear the chat data. */
+  setData: (
+    data:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => void;
 };
 
 const getStreamedResponse = async (
@@ -482,6 +489,19 @@ export function useChat({
     mutate(messagesArg);
   };
 
+  const setData = (
+    dataArg:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => {
+    if (typeof dataArg === 'function') {
+      dataArg = dataArg(get(streamData));
+    }
+
+    streamData.set(dataArg);
+  };
+
   const input = writable(initialInput);
 
   const handleSubmit = (
@@ -571,6 +591,7 @@ export function useChat({
     handleSubmit,
     isLoading,
     data: streamData,
+    setData,
     addToolResult,
   };
 }

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -74,6 +74,13 @@ export type UseChatHelpers = {
   isLoading: boolean;
   /** Additional data added on the server via StreamData */
   data?: JSONValue[];
+  /** Set the data object of the chat. You can use this to transform or clear the data object. */
+  setData: (
+    data:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => void;
 };
 
 const getStreamedResponse = async (
@@ -302,25 +309,32 @@ By default, it's set to 1, which means that only a single LLM call is made.
     { fallbackData: initialMessages ?? initialMessagesFallback },
   );
 
+  // Keep the latest messages in a ref.
+  const messagesRef = useRef<Message[]>(messages || []);
+  useEffect(() => {
+    messagesRef.current = messages || [];
+  }, [messages]);
+
+  // stream data
+  const { data: streamData, mutate: mutateStreamData } = useSWR<
+    JSONValue[] | undefined
+  >([chatKey, 'streamData'], null);
+
+  // keep the latest stream data in a ref
+  const streamDataRef = useRef<JSONValue[] | undefined>(streamData);
+  useEffect(() => {
+    streamDataRef.current = streamData;
+  }, [streamData]);
+
   // We store loading state in another hook to sync loading states across hook invocations
   const { data: isLoading = false, mutate: mutateLoading } = useSWR<boolean>(
     [chatKey, 'loading'],
     null,
   );
 
-  const { data: streamData, mutate: mutateStreamData } = useSWR<
-    JSONValue[] | undefined
-  >([chatKey, 'streamData'], null);
-
   const { data: error = undefined, mutate: setError } = useSWR<
     undefined | Error
   >([chatKey, 'error'], null);
-
-  // Keep the latest messages in a ref.
-  const messagesRef = useRef<Message[]>(messages || []);
-  useEffect(() => {
-    messagesRef.current = messages || [];
-  }, [messages]);
 
   // Abort controller to cancel the current API call.
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -565,6 +579,23 @@ By default, it's set to 1, which means that only a single LLM call is made.
     [mutate],
   );
 
+  const setData = useCallback(
+    (
+      data:
+        | JSONValue[]
+        | undefined
+        | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+    ) => {
+      if (typeof data === 'function') {
+        data = data(streamDataRef.current);
+      }
+
+      mutateStreamData(data, false);
+      streamDataRef.current = data;
+    },
+    [mutateStreamData],
+  );
+
   // Input state and handlers.
   const [input, setInput] = useState(initialInput);
 
@@ -661,17 +692,18 @@ By default, it's set to 1, which means that only a single LLM call is made.
 
   return {
     messages: messages || [],
+    setMessages,
+    data: streamData,
+    setData,
     error,
     append,
     reload,
     stop,
-    setMessages,
     input,
     setInput,
     handleInputChange,
     handleSubmit,
     isLoading,
-    data: streamData,
     addToolResult,
     experimental_addToolResult: addToolResult,
   };

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -89,7 +89,7 @@ const getStreamedResponse = async (
   chatRequest: ChatRequest,
   mutate: KeyedMutator<Message[]>,
   mutateStreamData: KeyedMutator<JSONValue[] | undefined>,
-  existingData: JSONValue[] | undefined,
+  existingDataRef: React.MutableRefObject<JSONValue[] | undefined>,
   extraMetadataRef: React.MutableRefObject<any>,
   messagesRef: React.MutableRefObject<Message[]>,
   abortControllerRef: React.MutableRefObject<AbortController | null>,
@@ -144,6 +144,8 @@ const getStreamedResponse = async (
         }),
       );
 
+  const existingData = existingDataRef.current;
+
   return await callChatApi({
     api,
     body: experimental_prepareRequestBody?.({
@@ -183,7 +185,7 @@ const getStreamedResponse = async (
     onResponse,
     onUpdate(merged, data) {
       mutate([...chatRequest.messages, ...merged], false);
-      mutateStreamData([...(existingData || []), ...(data || [])], false);
+      mutateStreamData([...(existingData ?? []), ...(data ?? [])], false);
     },
     onToolCall,
     onFinish,
@@ -372,7 +374,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
               chatRequest,
               mutate,
               mutateStreamData,
-              streamData!,
+              streamDataRef,
               extraMetadataRef,
               messagesRef,
               abortControllerRef,

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -72,9 +72,10 @@ export type UseChatHelpers = {
   metadata?: Object;
   /** Whether the API request is in progress */
   isLoading: boolean;
-  /** Additional data added on the server via StreamData */
+
+  /** Additional data added on the server via StreamData. */
   data?: JSONValue[];
-  /** Set the data object of the chat. You can use this to transform or clear the data object. */
+  /** Set the data of the chat. You can use this to transform or clear the chat data. */
   setData: (
     data:
       | JSONValue[]

--- a/packages/solid/src/use-chat.ts
+++ b/packages/solid/src/use-chat.ts
@@ -77,8 +77,16 @@ export type UseChatHelpers = {
   ) => void;
   /** Whether the API request is in progress */
   isLoading: Accessor<boolean>;
+
   /** Additional data added on the server via StreamData */
   data: Accessor<JSONValue[] | undefined>;
+  /** Set the data of the chat. You can use this to transform or clear the chat data. */
+  setData: (
+    data:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => void;
 
   /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
@@ -408,6 +416,19 @@ export function useChat(
     messagesRef = messagesArg;
   };
 
+  const setData = (
+    dataArg:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => {
+    if (typeof dataArg === 'function') {
+      dataArg = dataArg(streamData());
+    }
+
+    setStreamData(dataArg);
+  };
+
   const [input, setInput] = createSignal(
     useChatOptions().initialInput?.() || '',
   );
@@ -506,6 +527,7 @@ export function useChat(
     handleSubmit,
     isLoading,
     data: streamData,
+    setData,
     addToolResult,
   };
 }

--- a/packages/svelte/src/use-chat.ts
+++ b/packages/svelte/src/use-chat.ts
@@ -93,6 +93,13 @@ export type UseChatHelpers = {
 
   /** Additional data added on the server via StreamData */
   data: Readable<JSONValue[] | undefined>;
+  /** Set the data of the chat. You can use this to transform or clear the chat data. */
+  setData: (
+    data:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => void;
 };
 
 const getStreamedResponse = async (
@@ -479,6 +486,19 @@ export function useChat({
     mutate(messagesArg);
   };
 
+  const setData = (
+    dataArg:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => {
+    if (typeof dataArg === 'function') {
+      dataArg = dataArg(get(streamData));
+    }
+
+    streamData.set(dataArg);
+  };
+
   const input = writable(initialInput);
 
   const handleSubmit = (
@@ -568,6 +588,7 @@ export function useChat({
     handleSubmit,
     isLoading,
     data: streamData,
+    setData,
     addToolResult,
   };
 }

--- a/packages/vue/src/TestChatComponent.vue
+++ b/packages/vue/src/TestChatComponent.vue
@@ -14,7 +14,7 @@ const onFinishCalls: Array<{
   };
 }> = reactive([]);
 
-const { messages, append, data, error, isLoading } = useChat({
+const { messages, append, data, error, isLoading, setData } = useChat({
   onFinish: (message, options) => {
     onFinishCalls.push({ message, options });
   },
@@ -25,7 +25,7 @@ const { messages, append, data, error, isLoading } = useChat({
   <div>
     <div data-testid="loading">{{ isLoading?.toString() }}</div>
     <div data-testid="error">{{ error?.toString() }}</div>
-    <div data-testid="data">{{ JSON.stringify(data) }}</div>
+    <div data-testid="data">{{ data != null ? JSON.stringify(data) : '' }}</div>
     <div
       v-for="(m, idx) in messages"
       key="m.id"
@@ -39,6 +39,9 @@ const { messages, append, data, error, isLoading } = useChat({
       data-testid="do-append"
       @click="append({ role: 'user', content: 'hi' })"
     />
+
+    <button data-testid="do-set-data" @click="setData([{ t1: 'set' }])" />
+    <button data-testid="do-clear-data" @click="setData(undefined)" />
 
     <div data-testid="on-finish-calls">{{ JSON.stringify(onFinishCalls) }}</div>
   </div>

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -60,8 +60,15 @@ export type UseChatHelpers = {
   /** Whether the API request is in progress */
   isLoading: Ref<boolean | undefined>;
 
-  /** Additional data added on the server via StreamData */
+  /** Additional data added on the server via StreamData. */
   data: Ref<JSONValue[] | undefined>;
+  /** Set the data of the chat. You can use this to transform or clear the chat data. */
+  setData: (
+    data:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => void;
 
   addToolResult: ({
     toolCallId,
@@ -317,6 +324,19 @@ export function useChat(
     mutate(messagesArg);
   };
 
+  const setData = (
+    dataArg:
+      | JSONValue[]
+      | undefined
+      | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
+  ) => {
+    if (typeof dataArg === 'function') {
+      dataArg = dataArg(streamData.value as JSONValue[] | undefined);
+    }
+
+    streamData.value = dataArg;
+  };
+
   const input = ref(initialInput);
 
   const handleSubmit = (
@@ -388,6 +408,7 @@ export function useChat(
     handleSubmit,
     isLoading,
     data: streamData as Ref<undefined | JSONValue[]>,
+    setData,
     addToolResult,
   };
 }

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -21,7 +21,7 @@ import TestChatFormOptionsComponent from './TestChatFormOptionsComponent.vue';
 import TestChatReloadComponent from './TestChatReloadComponent.vue';
 import TestChatTextStreamComponent from './TestChatTextStreamComponent.vue';
 
-describe('stream data stream', () => {
+describe('data protocol stream', () => {
   beforeEach(() => {
     render(TestChatComponent);
   });
@@ -61,6 +61,37 @@ describe('stream data stream', () => {
 
     await screen.findByTestId('message-1');
     expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+  });
+
+  describe('setData', () => {
+    it('should set data', async () => {
+      await userEvent.click(screen.getByTestId('do-set-data'));
+
+      await screen.findByTestId('data');
+      expect(screen.getByTestId('data')).toHaveTextContent('[{"t1":"set"}]');
+    });
+
+    it(
+      'should clear data',
+      withTestServer(
+        {
+          type: 'stream-values',
+          url: '/api/chat',
+          content: ['2:[{"t1":"v1"}]\n', '0:"Hello"\n'],
+        },
+        async () => {
+          await userEvent.click(screen.getByTestId('do-append'));
+
+          await screen.findByTestId('data');
+          expect(screen.getByTestId('data')).toHaveTextContent('[{"t1":"v1"}]');
+
+          await userEvent.click(screen.getByTestId('do-clear-data'));
+
+          await screen.findByTestId('data');
+          expect(screen.getByTestId('data')).toHaveTextContent('');
+        },
+      ),
+    );
   });
 
   it('should show error response', async () => {


### PR DESCRIPTION
## Summary

Adds a `setData` helper to `useChat` that you can use to clear, transform, or set the `data` property.

## Tasks

- [x] implementation
   - [x] react
      - [x] code
      - [x] test
   - [x] vue
      - [x] code
      - [x] test
   - [x] svelte x2
      - [x] code 1
      - [x] code 2
   - [x] solid
      - [x] code
      - [x] test
- [x] examples
   - [x] react
   - [x] svelte
   - [x] vue
   - [x] solid
- [x] documentation
   - [x] guide
   - [x] useChat reference
- [x] changeset