### PR TITLE
feat (ai/core): add experimental activeTools option to generateText and streamText

### DIFF
--- a/.changeset/forty-items-complain.md
+++ b/.changeset/forty-items-complain.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): add experimental activeTools option to generateText and streamText

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -274,6 +274,26 @@ async function generateSomething(prompt: string): Promise<{
 }
 ```
 
+## Active Tools
+
+Language models can only handle a limited number of tools at a time, depending on the model.
+To allow for static typing using a large number of tools and limiting the available tools to the model at the same time,
+the AI SDK provides the `experimental_activeTools` property.
+
+It is an array of tool names that are currently active.
+By default, the value is `undefined` and all tools are active.
+
+```ts highlight="7"
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  tools: myToolSet,
+  experimental_activeTools: ['firstTool'],
+});
+```
+
 ## Prompt Engineering with Tools
 
 When you create prompts that include tools, getting good results can be tricky as the number and complexity of your tools increases.

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -442,6 +442,13 @@ To see `generateText` in action, check out [these examples](#examples).
         'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
     {
+      name: 'experimental_activeTools',
+      type: 'Array<TOOLNAME> | undefined',
+      isOptional: true,
+      description:
+        'The tools that are currently active. All tools are active by default.',
+    },
+    {
       name: 'onStepFinish',
       type: '(result: onStepFinishResult) => Promise<void> | void',
       isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -451,6 +451,13 @@ To see `streamText` in action, check out [these examples](#examples).
         'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
     {
+      name: 'experimental_activeTools',
+      type: 'Array<TOOLNAME> | undefined',
+      isOptional: true,
+      description:
+        'The tools that are currently active. All tools are active by default.',
+    },
+    {
       name: 'onChunk',
       type: '(event: OnChunkResult) => Promise<void> |void',
       isOptional: true,

--- a/examples/ai-core/src/generate-text/openai-active-tools.ts
+++ b/examples/ai-core/src/generate-text/openai-active-tools.ts
@@ -1,0 +1,25 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+import { weatherTool } from '../tools/weather-tool';
+
+async function main() {
+  const { text } = await generateText({
+    model: openai('gpt-4o'),
+    tools: {
+      weather: weatherTool,
+      cityAttractions: tool({
+        parameters: z.object({ city: z.string() }),
+      }),
+    },
+    experimental_activeTools: [], // disable all tools
+    maxSteps: 5,
+    prompt:
+      'What is the weather in San Francisco and what attractions should I visit?',
+  });
+
+  console.log(text);
+}
+
+main().catch(console.error);

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -98,6 +98,7 @@ export async function generateText<TOOLS extends Record<string, CoreTool>>({
     false,
   experimental_telemetry: telemetry,
   experimental_providerMetadata: providerMetadata,
+  experimental_activeTools: activeTools,
   _internal: {
     generateId = originalGenerateId,
     currentDate = () => new Date(),
@@ -176,6 +177,12 @@ functionality that can be fully encapsulated in the provider.
     experimental_providerMetadata?: ProviderMetadata;
 
     /**
+Limits the tools that are available for the model to call without
+changing the tool call and result types in the result.
+     */
+    experimental_activeTools?: Array<keyof TOOLS>;
+
+    /**
     Callback that is called when each step (LLM call) is finished, including intermediate steps.
     */
     onStepFinish?: (event: StepResult<TOOLS>) => Promise<void> | void;
@@ -233,7 +240,7 @@ functionality that can be fully encapsulated in the provider.
 
       const mode = {
         type: 'regular' as const,
-        ...prepareToolsAndToolChoice({ tools, toolChoice }),
+        ...prepareToolsAndToolChoice({ tools, toolChoice, activeTools }),
       };
       const callSettings = prepareCallSettings(settings);
       const promptMessages = await convertToLanguageModelPrompt({

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -127,6 +127,7 @@ export async function streamText<TOOLS extends Record<string, CoreTool>>({
   experimental_telemetry: telemetry,
   experimental_providerMetadata: providerMetadata,
   experimental_toolCallStreaming: toolCallStreaming = false,
+  experimental_activeTools: activeTools,
   onChunk,
   onFinish,
   onStepFinish,
@@ -196,6 +197,12 @@ to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
  */
     experimental_providerMetadata?: ProviderMetadata;
+
+    /**
+Limits the tools that are available for the model to call without
+changing the tool call and result types in the result.
+     */
+    experimental_activeTools?: Array<keyof TOOLS>;
 
     /**
 Enable streaming of tool call deltas as they are generated. Disabled by default.
@@ -345,7 +352,11 @@ need to be added separately.
               result: await model.doStream({
                 mode: {
                   type: 'regular',
-                  ...prepareToolsAndToolChoice({ tools, toolChoice }),
+                  ...prepareToolsAndToolChoice({
+                    tools,
+                    toolChoice,
+                    activeTools,
+                  }),
                 },
                 ...prepareCallSettings(settings),
                 inputFormat: promptType,

--- a/packages/ai/core/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/core/prompt/prepare-tools-and-tool-choice.test.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { CoreTool, tool } from '../tool/tool';
+import { prepareToolsAndToolChoice } from './prepare-tools-and-tool-choice';
+
+const mockTools: Record<string, CoreTool> = {
+  tool1: tool({
+    description: 'Tool 1 description',
+    parameters: z.object({}),
+  }),
+  tool2: tool({
+    description: 'Tool 2 description',
+    parameters: z.object({ city: z.string() }),
+  }),
+};
+
+it('should return undefined for both tools and toolChoice when tools is not provided', () => {
+  const result = prepareToolsAndToolChoice({
+    tools: undefined,
+    toolChoice: undefined,
+    activeTools: undefined,
+  });
+  expect(result).toEqual({ tools: undefined, toolChoice: undefined });
+});
+
+it('should return all tools when activeTools is not provided', () => {
+  const result = prepareToolsAndToolChoice({
+    tools: mockTools,
+    toolChoice: undefined,
+    activeTools: undefined,
+  });
+  expect(result.tools).toHaveLength(2);
+  expect(result.tools?.[0].name).toBe('tool1');
+  expect(result.tools?.[1].name).toBe('tool2');
+  expect(result.toolChoice).toEqual({ type: 'auto' });
+});
+
+it('should filter tools based on activeTools', () => {
+  const result = prepareToolsAndToolChoice({
+    tools: mockTools,
+    toolChoice: undefined,
+    activeTools: ['tool1'],
+  });
+  expect(result.tools).toHaveLength(1);
+  expect(result.tools?.[0].name).toBe('tool1');
+  expect(result.toolChoice).toEqual({ type: 'auto' });
+});
+
+it('should handle string toolChoice', () => {
+  const result = prepareToolsAndToolChoice({
+    tools: mockTools,
+    toolChoice: 'none',
+    activeTools: undefined,
+  });
+  expect(result.tools).toHaveLength(2);
+  expect(result.toolChoice).toEqual({ type: 'none' });
+});
+
+it('should handle object toolChoice', () => {
+  const result = prepareToolsAndToolChoice({
+    tools: mockTools,
+    toolChoice: { type: 'tool', toolName: 'tool2' },
+    activeTools: undefined,
+  });
+  expect(result.tools).toHaveLength(2);
+  expect(result.toolChoice).toEqual({ type: 'tool', toolName: 'tool2' });
+});
+
+it('should correctly map tool properties', () => {
+  const result = prepareToolsAndToolChoice({
+    tools: mockTools,
+    toolChoice: undefined,
+    activeTools: undefined,
+  });
+  expect(result.tools?.[0]).toEqual({
+    type: 'function',
+    name: 'tool1',
+    description: 'Tool 1 description',
+    parameters: {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      additionalProperties: false,
+      type: 'object',
+      properties: {},
+    },
+  });
+});

--- a/packages/ai/core/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/core/prompt/prepare-tools-and-tool-choice.ts
@@ -12,9 +12,11 @@ export function prepareToolsAndToolChoice<
 >({
   tools,
   toolChoice,
+  activeTools,
 }: {
   tools: TOOLS | undefined;
   toolChoice: CoreToolChoice<TOOLS> | undefined;
+  activeTools: Array<keyof TOOLS> | undefined;
 }): {
   tools: LanguageModelV1FunctionTool[] | undefined;
   toolChoice: LanguageModelV1ToolChoice | undefined;
@@ -26,8 +28,16 @@ export function prepareToolsAndToolChoice<
     };
   }
 
+  // when activeTools is provided, we only include the tools that are in the list:
+  const filteredTools =
+    activeTools != null
+      ? Object.entries(tools).filter(([name]) =>
+          activeTools.includes(name as keyof TOOLS),
+        )
+      : Object.entries(tools);
+
   return {
-    tools: Object.entries(tools).map(([name, tool]) => ({
+    tools: filteredTools.map(([name, tool]) => ({
       type: 'function' as const,
       name,
       description: tool.description,

--- a/packages/ai/rsc/stream-ui/stream-ui.tsx
+++ b/packages/ai/rsc/stream-ui/stream-ui.tsx
@@ -257,7 +257,11 @@ functionality that can be fully encapsulated in the provider.
     model.doStream({
       mode: {
         type: 'regular',
-        ...prepareToolsAndToolChoice({ tools, toolChoice }),
+        ...prepareToolsAndToolChoice({
+          tools,
+          toolChoice,
+          activeTools: undefined,
+        }),
       },
       ...prepareCallSettings(settings),
       inputFormat: validatedPrompt.type,


### PR DESCRIPTION
## Summary

Adds an experimental `activeTools` property to `streamText` and `generateText` that limits which tools are available to the language model.

## Tasks

- [x] implementation
- [x] tests
- [x] example
- [x] docs (generateText reference)
- [x] docs (streamText reference)
- [x] docs (guide)
- [x] changeset 