### PR TITLE
refactoring (ai/core): use standardized prompt as input for multi-step calls

### DIFF
--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -31,7 +31,7 @@ describe('output = "object"', () => {
               },
             });
 
-            assert.deepStrictEqual(prompt, [
+            expect(prompt).toStrictEqual([
               {
                 role: 'system',
                 content:
@@ -39,7 +39,11 @@ describe('output = "object"', () => {
                   '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -74,8 +78,12 @@ describe('output = "object"', () => {
               },
             });
 
-            assert.deepStrictEqual(prompt, [
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            expect(prompt).toStrictEqual([
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -110,8 +118,12 @@ describe('output = "object"', () => {
               },
             });
 
-            assert.deepStrictEqual(prompt, [
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            expect(prompt).toStrictEqual([
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -149,8 +161,13 @@ describe('output = "object"', () => {
                 },
               },
             });
-            assert.deepStrictEqual(prompt, [
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+
+            expect(prompt).toStrictEqual([
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -193,8 +210,12 @@ describe('output = "object"', () => {
                 },
               },
             });
-            assert.deepStrictEqual(prompt, [
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            expect(prompt).toStrictEqual([
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -313,7 +334,7 @@ describe('output = "object"', () => {
                 type: 'object',
               },
             });
-            assert.deepStrictEqual(prompt, [
+            expect(prompt).toStrictEqual([
               {
                 role: 'system',
                 content:
@@ -321,7 +342,11 @@ describe('output = "object"', () => {
                   '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -356,7 +381,7 @@ describe('output = "object"', () => {
                 type: 'object',
               },
             });
-            assert.deepStrictEqual(prompt, [
+            expect(prompt).toStrictEqual([
               {
                 role: 'system',
                 content:
@@ -364,7 +389,11 @@ describe('output = "object"', () => {
                   '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -403,7 +432,7 @@ describe('output = "object"', () => {
                 additionalProperties: false,
               },
             });
-            assert.deepStrictEqual(prompt, [
+            expect(prompt).toStrictEqual([
               {
                 role: 'system',
                 content:
@@ -411,7 +440,11 @@ describe('output = "object"', () => {
                   '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false}\n' +
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -641,7 +674,7 @@ describe('output = "array"', () => {
             },
           });
 
-          assert.deepStrictEqual(prompt, [
+          expect(prompt).toStrictEqual([
             {
               role: 'system',
               content:
@@ -650,7 +683,11 @@ describe('output = "array"', () => {
                 `\n` +
                 'You MUST answer with a JSON object that matches the JSON schema above.',
             },
-            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'prompt' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -742,9 +779,13 @@ describe('output = "no-schema"', () => {
             schema: undefined,
           });
 
-          assert.deepStrictEqual(prompt, [
+          expect(prompt).toStrictEqual([
             { role: 'system', content: 'You MUST answer with JSON.' },
-            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'prompt' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -406,7 +406,7 @@ export async function generateObject<SCHEMA, RESULT>({
 
       switch (mode) {
         case 'json': {
-          const validatedPrompt = standardizePrompt({
+          const standardPrompt = standardizePrompt({
             system:
               outputStrategy.jsonSchema == null
                 ? injectJsonInstruction({ prompt: system })
@@ -421,11 +421,9 @@ export async function generateObject<SCHEMA, RESULT>({
           });
 
           const promptMessages = await convertToLanguageModelPrompt({
-            prompt: validatedPrompt,
+            prompt: standardPrompt,
             modelSupportsImageUrls: model.supportsImageUrls,
           });
-
-          const inputFormat = validatedPrompt.type;
 
           const generateResult = await retry(() =>
             recordSpan({
@@ -439,7 +437,7 @@ export async function generateObject<SCHEMA, RESULT>({
                   }),
                   ...baseTelemetryAttributes,
                   'ai.prompt.format': {
-                    input: () => inputFormat,
+                    input: () => standardPrompt.type,
                   },
                   'ai.prompt.messages': {
                     input: () => JSON.stringify(promptMessages),
@@ -467,7 +465,7 @@ export async function generateObject<SCHEMA, RESULT>({
                     description: schemaDescription,
                   },
                   ...prepareCallSettings(settings),
-                  inputFormat,
+                  inputFormat: standardPrompt.type,
                   prompt: promptMessages,
                   providerMetadata,
                   abortSignal,

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -7,7 +7,7 @@ import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { Prompt } from '../prompt/prompt';
-import { validatePrompt } from '../prompt/validate-prompt';
+import { standardizePrompt } from '../prompt/standardize-prompt';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
 import { getTracer } from '../telemetry/get-tracer';
@@ -406,7 +406,7 @@ export async function generateObject<SCHEMA, RESULT>({
 
       switch (mode) {
         case 'json': {
-          const validatedPrompt = validatePrompt({
+          const validatedPrompt = standardizePrompt({
             system:
               outputStrategy.jsonSchema == null
                 ? injectJsonInstruction({ prompt: system })
@@ -533,7 +533,7 @@ export async function generateObject<SCHEMA, RESULT>({
         }
 
         case 'tool': {
-          const validatedPrompt = validatePrompt({
+          const validatedPrompt = standardizePrompt({
             system,
             prompt,
             messages,

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -33,7 +33,7 @@ describe('output = "object"', () => {
               },
             });
 
-            assert.deepStrictEqual(prompt, [
+            expect(prompt).toStrictEqual([
               {
                 role: 'system',
                 content:
@@ -41,7 +41,11 @@ describe('output = "object"', () => {
                   '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -96,10 +100,13 @@ describe('output = "object"', () => {
               },
             });
 
-            assert.deepStrictEqual(prompt, [
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            expect(prompt).toStrictEqual([
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
-
             return {
               stream: convertArrayToReadableStream([
                 { type: 'text-delta', textDelta: '{ ' },
@@ -152,8 +159,12 @@ describe('output = "object"', () => {
               },
             });
 
-            assert.deepStrictEqual(prompt, [
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            expect(prompt).toStrictEqual([
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -211,8 +222,12 @@ describe('output = "object"', () => {
                 },
               },
             });
-            assert.deepStrictEqual(prompt, [
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            expect(prompt).toStrictEqual([
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -304,8 +319,12 @@ describe('output = "object"', () => {
                 },
               },
             });
-            assert.deepStrictEqual(prompt, [
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+            expect(prompt).toStrictEqual([
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -1067,7 +1086,7 @@ describe('output = "object"', () => {
               }).jsonSchema,
             });
 
-            assert.deepStrictEqual(prompt, [
+            expect(prompt).toStrictEqual([
               {
                 role: 'system',
                 content:
@@ -1075,7 +1094,11 @@ describe('output = "object"', () => {
                   '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false}\n' +
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -1158,7 +1181,7 @@ describe('output = "array"', () => {
               },
             });
 
-            assert.deepStrictEqual(prompt, [
+            expect(prompt).toStrictEqual([
               {
                 role: 'system',
                 content:
@@ -1167,7 +1190,11 @@ describe('output = "array"', () => {
                   `\n` +
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -1309,7 +1336,7 @@ describe('output = "array"', () => {
               },
             });
 
-            assert.deepStrictEqual(prompt, [
+            expect(prompt).toStrictEqual([
               {
                 role: 'system',
                 content:
@@ -1318,7 +1345,11 @@ describe('output = "array"', () => {
                   `\n` +
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
-              { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
             ]);
 
             return {
@@ -1401,9 +1432,16 @@ describe('output = "no-schema"', () => {
             schema: undefined,
           });
 
-          assert.deepStrictEqual(prompt, [
-            { role: 'system', content: 'You MUST answer with JSON.' },
-            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+          expect(prompt).toStrictEqual([
+            {
+              role: 'system',
+              content: 'You MUST answer with JSON.',
+            },
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'prompt' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -21,7 +21,7 @@ import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { Prompt } from '../prompt/prompt';
-import { validatePrompt } from '../prompt/validate-prompt';
+import { standardizePrompt } from '../prompt/standardize-prompt';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
 import { getTracer } from '../telemetry/get-tracer';
@@ -430,7 +430,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
 
       switch (mode) {
         case 'json': {
-          const validatedPrompt = validatePrompt({
+          const validatedPrompt = standardizePrompt({
             system:
               outputStrategy.jsonSchema == null
                 ? injectJsonInstruction({ prompt: system })
@@ -481,7 +481,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
         }
 
         case 'tool': {
-          const validatedPrompt = validatePrompt({
+          const validatedPrompt = standardizePrompt({
             system,
             prompt,
             messages,

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -430,7 +430,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
 
       switch (mode) {
         case 'json': {
-          const validatedPrompt = standardizePrompt({
+          const standardPrompt = standardizePrompt({
             system:
               outputStrategy.jsonSchema == null
                 ? injectJsonInstruction({ prompt: system })
@@ -452,9 +452,9 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
               description: schemaDescription,
             },
             ...prepareCallSettings(settings),
-            inputFormat: validatedPrompt.type,
+            inputFormat: standardPrompt.type,
             prompt: await convertToLanguageModelPrompt({
-              prompt: validatedPrompt,
+              prompt: standardPrompt,
               modelSupportsImageUrls: model.supportsImageUrls,
             }),
             providerMetadata,

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -23,8 +23,13 @@ describe('result.text', () => {
             tools: undefined,
             toolChoice: undefined,
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'prompt' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -75,8 +80,13 @@ describe('result.toolCalls', () => {
               },
             ],
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -144,8 +154,13 @@ describe('result.toolResults', () => {
               },
             ],
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -307,6 +322,7 @@ describe('options.maxSteps', () => {
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                 ]);
 
@@ -359,12 +375,8 @@ describe('options.maxSteps', () => {
                 expect(prompt).toStrictEqual([
                   {
                     role: 'user',
-                    content: [
-                      {
-                        type: 'text',
-                        text: 'test-input',
-                      },
-                    ],
+                    content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                   {
                     role: 'assistant',
@@ -474,16 +486,18 @@ describe('options.maxSteps', () => {
         model: new MockLanguageModelV1({
           doGenerate: async ({ prompt, mode }) => {
             switch (responseCount++) {
-              case 0:
+              case 0: {
                 expect(mode).toStrictEqual({
                   type: 'regular',
                   toolChoice: undefined,
                   tools: undefined,
                 });
+
                 expect(prompt).toStrictEqual([
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                 ]);
 
@@ -498,16 +512,19 @@ describe('options.maxSteps', () => {
                     modelId: 'test-response-model-id',
                   },
                 };
-              case 1:
+              }
+              case 1: {
                 expect(mode).toStrictEqual({
                   type: 'regular',
                   toolChoice: undefined,
                   tools: undefined,
                 });
+
                 expect(prompt).toStrictEqual([
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                   {
                     role: 'assistant',
@@ -539,7 +556,8 @@ describe('options.maxSteps', () => {
                     },
                   },
                 };
-              case 2:
+              }
+              case 2: {
                 expect(mode).toStrictEqual({
                   type: 'regular',
                   toolChoice: undefined,
@@ -549,6 +567,7 @@ describe('options.maxSteps', () => {
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                   {
                     role: 'assistant',
@@ -579,6 +598,7 @@ describe('options.maxSteps', () => {
                   },
                   usage: { completionTokens: 2, promptTokens: 3 },
                 };
+              }
               default:
                 throw new Error(`Unexpected response count: ${responseCount}`);
             }
@@ -649,8 +669,13 @@ describe('result.response', () => {
             tools: undefined,
             toolChoice: undefined,
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'prompt' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'prompt' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -935,8 +960,13 @@ describe('tools with custom schema', () => {
               },
             ],
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -11,7 +11,7 @@ import {
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choice';
 import { Prompt } from '../prompt/prompt';
-import { validatePrompt } from '../prompt/validate-prompt';
+import { standardizePrompt } from '../prompt/standardize-prompt';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
 import { getTracer } from '../telemetry/get-tracer';
@@ -232,7 +232,7 @@ changing the tool call and result types in the result.
     tracer,
     fn: async span => {
       const retry = retryWithExponentialBackoff({ maxRetries });
-      const validatedPrompt = validatePrompt({
+      const validatedPrompt = standardizePrompt({
         system,
         prompt,
         messages,

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -2415,6 +2415,7 @@ describe('options.maxSteps', () => {
                   toolChoice: undefined,
                   tools: undefined,
                 });
+
                 expect(prompt).toStrictEqual([
                   {
                     role: 'user',
@@ -2432,6 +2433,7 @@ describe('options.maxSteps', () => {
                       {
                         type: 'text',
                         text: 'no-whitespace',
+                        providerMetadata: undefined,
                       },
                     ],
                     providerMetadata: undefined,

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -30,8 +30,13 @@ describe('result.textStream', () => {
             tools: undefined,
             toolChoice: undefined,
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -103,8 +108,13 @@ describe('result.fullStream', () => {
             tools: undefined,
             toolChoice: undefined,
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -146,8 +156,13 @@ describe('result.fullStream', () => {
             tools: undefined,
             toolChoice: undefined,
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -200,8 +215,13 @@ describe('result.fullStream', () => {
             ],
             toolChoice: { type: 'required' },
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -266,8 +286,13 @@ describe('result.fullStream', () => {
             ],
             toolChoice: { type: 'required' },
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -382,8 +407,13 @@ describe('result.fullStream', () => {
             ],
             toolChoice: { type: 'required' },
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -497,8 +527,13 @@ describe('result.fullStream', () => {
             ],
             toolChoice: { type: 'auto' },
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -563,8 +598,13 @@ describe('result.fullStream', () => {
             ],
             toolChoice: { type: 'auto' },
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -1597,8 +1637,13 @@ describe('result.text', () => {
             tools: undefined,
             toolChoice: undefined,
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -1650,8 +1695,13 @@ describe('result.toolCalls', () => {
             ],
             toolChoice: { type: 'auto' },
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -1719,8 +1769,13 @@ describe('result.toolResults', () => {
             ],
             toolChoice: { type: 'auto' },
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {
@@ -2042,7 +2097,7 @@ describe('options.maxSteps', () => {
         model: new MockLanguageModelV1({
           doStream: async ({ prompt, mode }) => {
             switch (responseCount++) {
-              case 0:
+              case 0: {
                 expect(mode).toStrictEqual({
                   type: 'regular',
                   tools: [
@@ -2066,6 +2121,7 @@ describe('options.maxSteps', () => {
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                 ]);
 
@@ -2093,7 +2149,8 @@ describe('options.maxSteps', () => {
                   ]),
                   rawCall: { rawPrompt: 'prompt', rawSettings: {} },
                 };
-              case 1:
+              }
+              case 1: {
                 expect(mode).toStrictEqual({
                   type: 'regular',
                   tools: [
@@ -2117,6 +2174,7 @@ describe('options.maxSteps', () => {
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                   {
                     role: 'assistant',
@@ -2166,6 +2224,7 @@ describe('options.maxSteps', () => {
                   rawCall: { rawPrompt: 'prompt', rawSettings: {} },
                   rawResponse: { headers: { call: '2' } },
                 };
+              }
               default:
                 throw new Error(`Unexpected response count: ${responseCount}`);
             }
@@ -2267,7 +2326,7 @@ describe('options.maxSteps', () => {
         model: new MockLanguageModelV1({
           doStream: async ({ prompt, mode }) => {
             switch (responseCount++) {
-              case 0:
+              case 0: {
                 expect(mode).toStrictEqual({
                   type: 'regular',
                   toolChoice: undefined,
@@ -2277,6 +2336,7 @@ describe('options.maxSteps', () => {
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                 ]);
 
@@ -2303,7 +2363,8 @@ describe('options.maxSteps', () => {
                   ]),
                   rawCall: { rawPrompt: 'prompt', rawSettings: {} },
                 };
-              case 1:
+              }
+              case 1: {
                 expect(mode).toStrictEqual({
                   type: 'regular',
                   toolChoice: undefined,
@@ -2313,6 +2374,7 @@ describe('options.maxSteps', () => {
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                   {
                     role: 'assistant',
@@ -2346,6 +2408,7 @@ describe('options.maxSteps', () => {
                   ]),
                   rawCall: { rawPrompt: 'prompt', rawSettings: {} },
                 };
+              }
               case 2: {
                 expect(mode).toStrictEqual({
                   type: 'regular',
@@ -2356,6 +2419,7 @@ describe('options.maxSteps', () => {
                   {
                     role: 'user',
                     content: [{ type: 'text', text: 'test-input' }],
+                    providerMetadata: undefined,
                   },
                   {
                     role: 'assistant',
@@ -2946,8 +3010,13 @@ describe('tools with custom schema', () => {
             ],
             toolChoice: { type: 'required' },
           });
-          assert.deepStrictEqual(prompt, [
-            { role: 'user', content: [{ type: 'text', text: 'test-input' }] },
+
+          expect(prompt).toStrictEqual([
+            {
+              role: 'user',
+              content: [{ type: 'text', text: 'test-input' }],
+              providerMetadata: undefined,
+            },
           ]);
 
           return {

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -24,7 +24,7 @@ import {
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choice';
 import { Prompt } from '../prompt/prompt';
-import { validatePrompt } from '../prompt/validate-prompt';
+import { standardizePrompt } from '../prompt/standardize-prompt';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
 import { getTracer } from '../telemetry/get-tracer';
@@ -388,7 +388,7 @@ need to be added separately.
       };
 
       const promptMessages = await convertToLanguageModelPrompt({
-        prompt: validatePrompt({ system, prompt, messages }),
+        prompt: standardizePrompt({ system, prompt, messages }),
         modelSupportsImageUrls: model.supportsImageUrls,
       });
 
@@ -397,7 +397,7 @@ need to be added separately.
         doStreamSpan,
         startTimestampMs,
       } = await startStep({
-        promptType: validatePrompt({ system, prompt, messages }).type,
+        promptType: standardizePrompt({ system, prompt, messages }).type,
         promptMessages,
       });
 

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -11,7 +11,6 @@ describe('convertToLanguageModelPrompt', () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
-            prompt: undefined,
             messages: [
               {
                 role: 'user',
@@ -52,7 +51,6 @@ describe('convertToLanguageModelPrompt', () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
-            prompt: undefined,
             messages: [
               {
                 role: 'user',
@@ -95,7 +93,6 @@ describe('convertToLanguageModelPrompt', () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
-            prompt: undefined,
             messages: [
               {
                 role: 'user',
@@ -131,7 +128,6 @@ describe('convertToLanguageModelPrompt', () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
-            prompt: undefined,
             messages: [
               {
                 role: 'user',
@@ -167,7 +163,6 @@ describe('convertToLanguageModelPrompt', () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
-            prompt: undefined,
             messages: [
               {
                 role: 'user',
@@ -202,7 +197,6 @@ describe('convertToLanguageModelPrompt', () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
-            prompt: undefined,
             messages: [
               {
                 role: 'user',
@@ -244,7 +238,6 @@ describe('convertToLanguageModelPrompt', () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
-            prompt: undefined,
             messages: [
               {
                 role: 'user',
@@ -288,7 +281,6 @@ describe('convertToLanguageModelPrompt', () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
-            prompt: undefined,
             messages: [
               {
                 role: 'user',

--- a/packages/ai/core/prompt/prompt.ts
+++ b/packages/ai/core/prompt/prompt.ts
@@ -1,7 +1,8 @@
 import { CoreMessage } from './message';
 
 /**
-Prompt part of the AI function options. It contains a system message, a simple text prompt, or a list of messages.
+Prompt part of the AI function options.
+It contains a system message, a simple text prompt, or a list of messages.
  */
 export type Prompt = {
   /**
@@ -15,7 +16,7 @@ A simple text prompt. You can either use `prompt` or `messages` but not both.
   prompt?: string;
 
   /**
-A list of messsages. You can either use `prompt` or `messages` but not both.
+A list of messages. You can either use `prompt` or `messages` but not both.
    */
   messages?: Array<CoreMessage>;
 };

--- a/packages/ai/core/prompt/standardize-prompt.test.ts
+++ b/packages/ai/core/prompt/standardize-prompt.test.ts
@@ -1,10 +1,10 @@
 import { InvalidPromptError } from '@ai-sdk/provider';
-import { validatePrompt } from './validate-prompt';
+import { standardizePrompt } from './standardize-prompt';
 
 describe('message prompt', () => {
   it('should throw InvalidPromptError when system message has parts', () => {
     expect(() => {
-      validatePrompt({
+      standardizePrompt({
         messages: [
           {
             role: 'system',

--- a/packages/ai/core/prompt/standardize-prompt.ts
+++ b/packages/ai/core/prompt/standardize-prompt.ts
@@ -4,21 +4,25 @@ import { z } from 'zod';
 import { CoreMessage, coreMessageSchema } from './message';
 import { Prompt } from './prompt';
 
-export type ValidatedPrompt =
-  | {
-      type: 'prompt';
-      prompt: string;
-      messages: undefined;
-      system?: string;
-    }
-  | {
-      type: 'messages';
-      prompt: undefined;
-      messages: CoreMessage[];
-      system?: string;
-    };
+export type StandardizedPrompt = {
+  /**
+   * Original prompt type. This is forwarded to the providers and can be used
+   * to write send raw text to providers that support it.
+   */
+  type: 'prompt' | 'messages';
 
-export function validatePrompt(prompt: Prompt): ValidatedPrompt {
+  /**
+   * System message.
+   */
+  system?: string;
+
+  /**
+   * Messages.
+   */
+  messages: CoreMessage[];
+};
+
+export function standardizePrompt(prompt: Prompt): StandardizedPrompt {
   if (prompt.prompt == null && prompt.messages == null) {
     throw new InvalidPromptError({
       prompt,
@@ -53,9 +57,13 @@ export function validatePrompt(prompt: Prompt): ValidatedPrompt {
 
     return {
       type: 'prompt',
-      prompt: prompt.prompt,
-      messages: undefined,
       system: prompt.system,
+      messages: [
+        {
+          role: 'user',
+          content: prompt.prompt,
+        },
+      ],
     };
   }
 
@@ -76,7 +84,6 @@ export function validatePrompt(prompt: Prompt): ValidatedPrompt {
 
     return {
       type: 'messages',
-      prompt: undefined,
       messages: prompt.messages!, // only possible case bc of checks above
       system: prompt.system,
     };

--- a/packages/ai/rsc/stream-ui/stream-ui.tsx
+++ b/packages/ai/rsc/stream-ui/stream-ui.tsx
@@ -7,7 +7,7 @@ import { convertToLanguageModelPrompt } from '../../core/prompt/convert-to-langu
 import { prepareCallSettings } from '../../core/prompt/prepare-call-settings';
 import { prepareToolsAndToolChoice } from '../../core/prompt/prepare-tools-and-tool-choice';
 import { Prompt } from '../../core/prompt/prompt';
-import { validatePrompt } from '../../core/prompt/validate-prompt';
+import { standardizePrompt } from '../../core/prompt/standardize-prompt';
 import {
   CallWarning,
   CoreToolChoice,
@@ -252,7 +252,7 @@ functionality that can be fully encapsulated in the provider.
   }
 
   const retry = retryWithExponentialBackoff({ maxRetries });
-  const validatedPrompt = validatePrompt({ system, prompt, messages });
+  const validatedPrompt = standardizePrompt({ system, prompt, messages });
   const result = await retry(async () =>
     model.doStream({
       mode: {


### PR DESCRIPTION
## Summary
* introduced standardized prompt that only consists of type, system, and messages by changing validatePrompt
* use the standardized prompt as the basis for multi-step calls

## Background
Multi-step calls current use intermediate language model level prompts that change between steps. This blocks advanced features like exposing tool call repair functions to users or switching instruction sets. With this refactoring, every step has an input that could also be used as input to streamText, generateText, etc.