### PR TITLE
feat (ai): access raw request body

### DIFF
--- a/.changeset/kind-donkeys-hammer.md
+++ b/.changeset/kind-donkeys-hammer.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/groq': patch
+'ai': patch
+---
+
+feat (ai): access raw request body

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -173,35 +173,6 @@ const { object } = await generateObject({
 });
 ```
 
-## Schema Writing Tips
-
-The mapping from Zod schemas to LLM inputs (typically JSON schema) is not always straightforward, since the mapping is not one-to-one.
-Please checkout the following tips and the [Prompt Engineering with Tools](/docs/ai-sdk-core/tools-and-tool-calling#prompt-engineering-with-tools) guide.
-
-### Dates
-
-Zod expects JavaScript Date objects, but models return dates as strings.
-You can specify and validate the date format using `z.string().datetime()` or `z.string().date()`,
-and then use a Zod transformer to convert the string to a Date object.
-
-```ts highlight="7-10"
-const result = await generateObject({
-  model: openai('gpt-4-turbo'),
-  schema: z.object({
-    events: z.array(
-      z.object({
-        event: z.string(),
-        date: z
-          .string()
-          .date()
-          .transform(value => new Date(value)),
-      }),
-    ),
-  }),
-  prompt: 'List 5 important events from the the year 2000.',
-});
-```
-
 ## Error Handling
 
 When you use `generateObject`, errors are thrown when the model fails to generate proper JSON (`JSONParseError`)

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -294,22 +294,6 @@ const { text } = await generateText({
 });
 ```
 
-## Prompt Engineering with Tools
-
-When you create prompts that include tools, getting good results can be tricky as the number and complexity of your tools increases.
-
-Here are a few tips to help you get the best results:
-
-1. Use a model that is strong at tool calling, such as `gpt-4` or `gpt-4-turbo`. Weaker models will often struggle to call tools effectively and flawlessly.
-1. Keep the number of tools low, e.g. to 5 or less.
-1. Keep the complexity of the tool parameters low. Complex Zod schemas with many nested and optional elements, unions, etc. can be challenging for the model to work with.
-1. Use semantically meaningful names for your tools, parameters, parameter properties, etc. The more information you pass to the model, the better it can understand what you want.
-1. Add `.describe("...")` to your Zod schema properties to give the model hints about what a particular property is for.
-1. When the output of a tool might be unclear to the model and there are dependencies between tools, use the `description` field of a tool to provide information about the output of the tool execution.
-1. You can include example input/outputs of tool calls in your prompt to help the model understand how to use the tools. Keep in mind that the tools work with JSON objects, so the examples should use JSON.
-
-In general, the goal should be to give the model all information it needs in a clear way.
-
 ## Examples
 
 You can see tools in action using various frameworks in the following examples:

--- a/content/docs/03-ai-sdk-core/20-prompt-engineering.mdx
+++ b/content/docs/03-ai-sdk-core/20-prompt-engineering.mdx
@@ -1,0 +1,70 @@
+---
+title: Prompt Engineering
+description: Learn how to develop prompts with AI SDK Core.
+---
+
+# Prompt Engineering
+
+## Tips
+
+### Prompts for Tools
+
+When you create prompts that include tools, getting good results can be tricky as the number and complexity of your tools increases.
+
+Here are a few tips to help you get the best results:
+
+1. Use a model that is strong at tool calling, such as `gpt-4` or `gpt-4-turbo`. Weaker models will often struggle to call tools effectively and flawlessly.
+1. Keep the number of tools low, e.g. to 5 or less.
+1. Keep the complexity of the tool parameters low. Complex Zod schemas with many nested and optional elements, unions, etc. can be challenging for the model to work with.
+1. Use semantically meaningful names for your tools, parameters, parameter properties, etc. The more information you pass to the model, the better it can understand what you want.
+1. Add `.describe("...")` to your Zod schema properties to give the model hints about what a particular property is for.
+1. When the output of a tool might be unclear to the model and there are dependencies between tools, use the `description` field of a tool to provide information about the output of the tool execution.
+1. You can include example input/outputs of tool calls in your prompt to help the model understand how to use the tools. Keep in mind that the tools work with JSON objects, so the examples should use JSON.
+
+In general, the goal should be to give the model all information it needs in a clear way.
+
+### Tool & Structured Data Schemas
+
+The mapping from Zod schemas to LLM inputs (typically JSON schema) is not always straightforward, since the mapping is not one-to-one.
+
+#### Zod Dates
+
+Zod expects JavaScript Date objects, but models return dates as strings.
+You can specify and validate the date format using `z.string().datetime()` or `z.string().date()`,
+and then use a Zod transformer to convert the string to a Date object.
+
+```ts highlight="7-10"
+const result = await generateObject({
+  model: openai('gpt-4-turbo'),
+  schema: z.object({
+    events: z.array(
+      z.object({
+        event: z.string(),
+        date: z
+          .string()
+          .date()
+          .transform(value => new Date(value)),
+      }),
+    ),
+  }),
+  prompt: 'List 5 important events from the the year 2000.',
+});
+```
+
+## Debugging
+
+### HTTP Request Bodies
+
+You can inspect the raw HTTP request bodies for models that expose them, e.g. [OpenAI](/providers/ai-sdk-providers/openai).
+This allows you to inspect the exact payload that is sent to the model provider in the provider-specific way.
+
+Request bodies are available via the `request.body` property of the response:
+
+```ts highlight="6"
+const result = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'Hello, world!',
+});
+
+console.log(result.request.body);
+```

--- a/content/docs/03-ai-sdk-core/index.mdx
+++ b/content/docs/03-ai-sdk-core/index.mdx
@@ -34,6 +34,11 @@ description: Learn about AI SDK Core.
       href: '/docs/ai-sdk-core/agents',
     },
     {
+      title: 'Prompt Engineering',
+      description: 'Learn how to write prompts with AI SDK Core.',
+      href: '/docs/ai-sdk-core/prompt-engineering',
+    },
+    {
       title: 'Settings',
       description:
         'Learn how to set up settings for language models generations.',

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -628,13 +628,32 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
+      name: 'request',
+      type: 'RequestMetadata',
+      isOptional: true,
+      description: 'Request metadata.',
+      properties: [
+        {
+          type: 'RequestMetadata',
+          parameters: [
+            {
+              name: 'body',
+              type: 'string',
+              description:
+                'Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).',
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'response',
-      type: 'Response',
+      type: 'ResponseMetadata',
       isOptional: true,
       description: 'Response metadata.',
       properties: [
         {
-          type: 'Response',
+          type: 'ResponseMetadata',
           parameters: [
             {
               name: 'id',
@@ -747,13 +766,32 @@ To see `generateText` in action, check out [these examples](#examples).
               ],
             },
             {
+              name: 'request',
+              type: 'RequestMetadata',
+              isOptional: true,
+              description: 'Request metadata.',
+              properties: [
+                {
+                  type: 'RequestMetadata',
+                  parameters: [
+                    {
+                      name: 'body',
+                      type: 'string',
+                      description:
+                        'Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
               name: 'response',
-              type: 'Response',
+              type: 'ResponseMetadata',
               isOptional: true,
               description: 'Response metadata.',
               properties: [
                 {
-                  type: 'Response',
+                  type: 'ResponseMetadata',
                   parameters: [
                     {
                       name: 'id',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -926,7 +926,7 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'request',
-      type: 'RequestMetadata',
+      type: 'Promise<RequestMetadata>',
       isOptional: true,
       description: 'Request metadata.',
       properties: [

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -925,13 +925,32 @@ To see `streamText` in action, check out [these examples](#examples).
         'The tool results that have been generated. Resolved when the all tool executions are finished.',
     },
     {
+      name: 'request',
+      type: 'RequestMetadata',
+      isOptional: true,
+      description: 'Request metadata.',
+      properties: [
+        {
+          type: 'RequestMetadata',
+          parameters: [
+            {
+              name: 'body',
+              type: 'string',
+              description:
+                'Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).',
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'response',
-      type: 'Promise<Response>',
+      type: 'Promise<ResponseMetadata>',
       isOptional: true,
       description: 'Response metadata. Resolved when the response is finished.',
       properties: [
         {
-          type: 'Response',
+          type: 'ResponseMetadata',
           parameters: [
             {
               name: 'id',
@@ -1032,13 +1051,32 @@ To see `streamText` in action, check out [these examples](#examples).
               ],
             },
             {
+              name: 'request',
+              type: 'RequestMetadata',
+              isOptional: true,
+              description: 'Request metadata.',
+              properties: [
+                {
+                  type: 'RequestMetadata',
+                  parameters: [
+                    {
+                      name: 'body',
+                      type: 'string',
+                      description:
+                        'Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
               name: 'response',
-              type: 'Response',
+              type: 'ResponseMetadata',
               isOptional: true,
               description: 'Response metadata.',
               properties: [
                 {
-                  type: 'Response',
+                  type: 'ResponseMetadata',
                   parameters: [
                     {
                       name: 'id',

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -538,13 +538,32 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
       ],
     },
     {
+      name: 'request',
+      type: 'RequestMetadata',
+      isOptional: true,
+      description: 'Request metadata.',
+      properties: [
+        {
+          type: 'RequestMetadata',
+          parameters: [
+            {
+              name: 'body',
+              type: 'string',
+              description:
+                'Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).',
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'response',
-      type: 'Response',
+      type: 'ResponseMetadata',
       isOptional: true,
       description: 'Response metadata.',
       properties: [
         {
-          type: 'Response',
+          type: 'ResponseMetadata',
           parameters: [
             {
               name: 'id',

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -751,13 +751,32 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
       ],
     },
     {
+      name: 'request',
+      type: 'Promise<RequestMetadata>',
+      isOptional: true,
+      description: 'Request metadata.',
+      properties: [
+        {
+          type: 'RequestMetadata',
+          parameters: [
+            {
+              name: 'body',
+              type: 'string',
+              description:
+                'Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).',
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'response',
-      type: 'Promise<Response>',
+      type: 'Promise<ResponseMetadata>',
       isOptional: true,
       description: 'Response metadata. Resolved when the response is finished.',
       properties: [
         {
-          type: 'Response',
+          type: 'ResponseMetadata',
           parameters: [
             {
               name: 'id',

--- a/examples/ai-core/src/generate-object/openai-request-body.ts
+++ b/examples/ai-core/src/generate-object/openai-request-body.ts
@@ -1,0 +1,28 @@
+import { openai } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const { request } = await generateObject({
+    model: openai('gpt-4o-mini', { structuredOutputs: true }),
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({
+            name: z.string(),
+            amount: z.string(),
+          }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log('REQUEST BODY');
+  console.log(request.body);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-request-body.ts
+++ b/examples/ai-core/src/generate-text/openai-request-body.ts
@@ -1,0 +1,15 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const { request } = await generateText({
+    model: openai('gpt-4o-mini'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log('REQUEST BODY');
+  console.log(request.body);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-object/openai-request-body.ts
+++ b/examples/ai-core/src/stream-object/openai-request-body.ts
@@ -21,10 +21,12 @@ async function main() {
       'Generate 3 character descriptions for a fantasy role playing game.',
   });
 
-  for await (const partialObject of result.partialObjectStream) {
-    console.clear();
-    console.log(partialObject);
+  // consume stream
+  for await (const part of result.partialObjectStream) {
   }
+
+  console.log('REQUEST BODY');
+  console.log((await result.request).body);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-request-body.ts
+++ b/examples/ai-core/src/stream-text/openai-request-body.ts
@@ -1,0 +1,19 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await streamText({
+    model: openai('gpt-4o-mini'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  // consume stream
+  for await (const textPart of result.textStream) {
+  }
+
+  console.log('REQUEST BODY');
+  console.log((await result.request).body);
+}
+
+main().catch(console.error);

--- a/packages/ai/core/generate-object/generate-object-result.ts
+++ b/packages/ai/core/generate-object/generate-object-result.ts
@@ -1,6 +1,7 @@
 import {
   CallWarning,
   FinishReason,
+  LanguageModelRequestMetadata,
   LanguageModelResponseMetadataWithHeaders,
   LogProbs,
   ProviderMetadata,
@@ -42,6 +43,11 @@ export interface GenerateObjectResult<T> {
    */
     headers?: Record<string, string>;
   };
+
+  /**
+Additional request information.
+   */
+  readonly request: LanguageModelRequestMetadata;
 
   /**
 Additional response information.

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -242,6 +242,57 @@ describe('output = "object"', () => {
     });
   });
 
+  describe('result.request', () => {
+    it('should contain request information with json mode', async () => {
+      const result = await generateObject({
+        model: new MockLanguageModelV1({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            text: `{ "content": "Hello, world!" }`,
+            request: {
+              body: 'test body',
+            },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        mode: 'json',
+        prompt: 'prompt',
+      });
+
+      expect(result.request).toStrictEqual({
+        body: 'test body',
+      });
+    });
+
+    it('should contain request information with tool mode', async () => {
+      const result = await generateObject({
+        model: new MockLanguageModelV1({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            toolCalls: [
+              {
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                args: `{ "content": "Hello, world!" }`,
+              },
+            ],
+            request: {
+              body: 'test body',
+            },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        mode: 'tool',
+        prompt: 'prompt',
+      });
+
+      expect(result.request).toStrictEqual({
+        body: 'test body',
+      });
+    });
+  });
+
   describe('result.response', () => {
     it('should contain response information with json mode', async () => {
       const result = await generateObject({

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -18,6 +18,7 @@ import {
   CallWarning,
   FinishReason,
   LanguageModel,
+  LanguageModelRequestMetadata,
   LanguageModelResponseMetadata,
   LogProbs,
   ProviderMetadata,
@@ -401,6 +402,7 @@ export async function generateObject<SCHEMA, RESULT>({
       let warnings: CallWarning[] | undefined;
       let rawResponse: { headers?: Record<string, string> } | undefined;
       let response: LanguageModelResponseMetadata;
+      let request: LanguageModelRequestMetadata;
       let logprobs: LogProbs | undefined;
       let resultProviderMetadata: ProviderMetadata | undefined;
 
@@ -525,6 +527,7 @@ export async function generateObject<SCHEMA, RESULT>({
           rawResponse = generateResult.rawResponse;
           logprobs = generateResult.logprobs;
           resultProviderMetadata = generateResult.providerMetadata;
+          request = generateResult.request ?? {};
           response = generateResult.responseData;
 
           break;
@@ -649,6 +652,7 @@ export async function generateObject<SCHEMA, RESULT>({
           rawResponse = generateResult.rawResponse;
           logprobs = generateResult.logprobs;
           resultProviderMetadata = generateResult.providerMetadata;
+          request = generateResult.request ?? {};
           response = generateResult.responseData;
 
           break;
@@ -707,6 +711,7 @@ export async function generateObject<SCHEMA, RESULT>({
         finishReason,
         usage: calculateLanguageModelUsage(usage),
         warnings,
+        request,
         response: {
           ...response,
           headers: rawResponse?.headers,
@@ -727,6 +732,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
   readonly logprobs: GenerateObjectResult<T>['logprobs'];
   readonly experimental_providerMetadata: GenerateObjectResult<T>['experimental_providerMetadata'];
   readonly response: GenerateObjectResult<T>['response'];
+  readonly request: GenerateObjectResult<T>['request'];
 
   constructor(options: {
     object: GenerateObjectResult<T>['object'];
@@ -736,6 +742,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
     logprobs: GenerateObjectResult<T>['logprobs'];
     providerMetadata: GenerateObjectResult<T>['experimental_providerMetadata'];
     response: GenerateObjectResult<T>['response'];
+    request: GenerateObjectResult<T>['request'];
   }) {
     this.object = options.object;
     this.finishReason = options.finishReason;
@@ -743,7 +750,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
     this.warnings = options.warnings;
     this.experimental_providerMetadata = options.providerMetadata;
     this.response = options.response;
-
+    this.request = options.request;
     // deprecated:
     this.rawResponse = {
       headers: options.response.headers,

--- a/packages/ai/core/generate-object/stream-object-result.ts
+++ b/packages/ai/core/generate-object/stream-object-result.ts
@@ -2,6 +2,7 @@ import { ServerResponse } from 'http';
 import {
   CallWarning,
   FinishReason,
+  LanguageModelRequestMetadata,
   LanguageModelResponseMetadata,
   LanguageModelResponseMetadataWithHeaders,
   LogProbs,
@@ -43,6 +44,11 @@ Optional raw response data.
    */
     headers?: Record<string, string>;
   };
+
+  /**
+Additional request information from the last step.
+ */
+  readonly request: Promise<LanguageModelRequestMetadata>;
 
   /**
 Additional response information.

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -539,7 +539,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
       }
 
       const {
-        result: { stream, warnings, rawResponse },
+        result: { stream, warnings, rawResponse, request },
         doStreamSpan,
         startTimestampMs,
       } = await retry(() =>
@@ -587,6 +587,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
         stream: stream.pipeThrough(new TransformStream(transformer)),
         warnings,
         rawResponse,
+        request: request ?? {},
         onFinish,
         rootSpan,
         doStreamSpan,
@@ -606,6 +607,12 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
 {
   private readonly originalStream: ReadableStream<ObjectStreamPart<PARTIAL>>;
   private readonly objectPromise: DelayedPromise<RESULT>;
+
+  readonly request: StreamObjectResult<
+    PARTIAL,
+    RESULT,
+    ELEMENT_STREAM
+  >['request'];
 
   readonly warnings: StreamObjectResult<
     PARTIAL,
@@ -634,6 +641,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
     stream,
     warnings,
     rawResponse,
+    request,
     outputStrategy,
     onFinish,
     rootSpan,
@@ -654,6 +662,9 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
       RESULT,
       ELEMENT_STREAM
     >['rawResponse'];
+    request: Awaited<
+      StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>['request']
+    >;
     outputStrategy: OutputStrategy<PARTIAL, RESULT, ELEMENT_STREAM>;
     onFinish: OnFinishCallback<RESULT> | undefined;
     rootSpan: Span;
@@ -668,6 +679,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
     this.warnings = warnings;
     this.rawResponse = rawResponse;
     this.outputStrategy = outputStrategy;
+    this.request = Promise.resolve(request);
 
     // initialize object promise
     this.objectPromise = new DelayedPromise<RESULT>();

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -7,6 +7,7 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
     "finishReason": "tool-calls",
     "isContinued": false,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": undefined,
       "id": "test-id-1-from-model",
@@ -47,6 +48,7 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
     "finishReason": "stop",
     "isContinued": false,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": {
         "custom-response-header": "response-header-value",
@@ -118,6 +120,7 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
     "finishReason": "tool-calls",
     "isContinued": false,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": undefined,
       "id": "test-id-1-from-model",
@@ -158,6 +161,7 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
     "finishReason": "stop",
     "isContinued": false,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": {
         "custom-response-header": "response-header-value",
@@ -187,6 +191,7 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > onStepFinish 
     "finishReason": "length",
     "isContinued": true,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": undefined,
       "id": "test-id-1-from-model",
@@ -210,6 +215,7 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > onStepFinish 
     "finishReason": "length",
     "isContinued": true,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": {
         "custom-response-header": "response-header-value",
@@ -234,6 +240,7 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > onStepFinish 
     "finishReason": "stop",
     "isContinued": false,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": undefined,
       "id": "test-id-3-from-model",
@@ -262,6 +269,7 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > result.steps 
     "finishReason": "length",
     "isContinued": true,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": undefined,
       "id": "test-id-1-from-model",
@@ -285,6 +293,7 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > result.steps 
     "finishReason": "length",
     "isContinued": true,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": {
         "custom-response-header": "response-header-value",
@@ -309,6 +318,7 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > result.steps 
     "finishReason": "stop",
     "isContinued": false,
     "logprobs": undefined,
+    "request": {},
     "response": {
       "headers": undefined,
       "id": "test-id-3-from-model",

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -74,9 +74,16 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onFinish
   "experimental_providerMetadata": undefined,
   "finishReason": "stop",
   "logprobs": undefined,
-  "rawResponse": undefined,
+  "rawResponse": {
+    "headers": {
+      "call": "1",
+    },
+  },
+  "request": {},
   "response": {
-    "headers": undefined,
+    "headers": {
+      "call": "1",
+    },
     "id": "id-1",
     "modelId": "mock-model-id",
     "timestamp": 1970-01-01T00:00:01.000Z,
@@ -126,8 +133,16 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onFinish
       "finishReason": "tool-calls",
       "isContinued": false,
       "logprobs": undefined,
-      "rawResponse": undefined,
+      "rawResponse": {
+        "headers": {
+          "call": "1",
+        },
+      },
+      "request": {},
       "response": {
+        "headers": {
+          "call": "1",
+        },
         "id": "id-0",
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
@@ -172,7 +187,11 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onFinish
           "call": "2",
         },
       },
+      "request": {},
       "response": {
+        "headers": {
+          "call": "2",
+        },
         "id": "id-1",
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
@@ -208,8 +227,16 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onStepFi
     "finishReason": "tool-calls",
     "isContinued": false,
     "logprobs": undefined,
-    "rawResponse": undefined,
+    "rawResponse": {
+      "headers": {
+        "call": "1",
+      },
+    },
+    "request": {},
     "response": {
+      "headers": {
+        "call": "1",
+      },
       "id": "id-0",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
@@ -254,7 +281,11 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onStepFi
         "call": "2",
       },
     },
+    "request": {},
     "response": {
+      "headers": {
+        "call": "2",
+      },
       "id": "id-1",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
@@ -531,8 +562,16 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > value promises > res
     "finishReason": "tool-calls",
     "isContinued": false,
     "logprobs": undefined,
-    "rawResponse": undefined,
+    "rawResponse": {
+      "headers": {
+        "call": "1",
+      },
+    },
+    "request": {},
     "response": {
+      "headers": {
+        "call": "1",
+      },
       "id": "id-0",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
@@ -577,7 +616,11 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > value promises > res
         "call": "2",
       },
     },
+    "request": {},
     "response": {
+      "headers": {
+        "call": "2",
+      },
       "id": "id-1",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
@@ -602,6 +645,7 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
   "finishReason": "stop",
   "logprobs": undefined,
   "rawResponse": undefined,
+  "request": {},
   "response": {
     "headers": undefined,
     "id": "id-1",
@@ -636,7 +680,9 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
       "isContinued": true,
       "logprobs": undefined,
       "rawResponse": undefined,
+      "request": {},
       "response": {
+        "headers": undefined,
         "id": "id-0",
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
@@ -659,7 +705,9 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
       "isContinued": true,
       "logprobs": undefined,
       "rawResponse": undefined,
+      "request": {},
       "response": {
+        "headers": undefined,
         "id": "id-1",
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
@@ -685,7 +733,11 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
           "call": "3",
         },
       },
+      "request": {},
       "response": {
+        "headers": {
+          "call": "3",
+        },
         "id": "id-1",
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
@@ -725,7 +777,9 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
     "isContinued": true,
     "logprobs": undefined,
     "rawResponse": undefined,
+    "request": {},
     "response": {
+      "headers": undefined,
       "id": "id-0",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
@@ -748,7 +802,9 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
     "isContinued": true,
     "logprobs": undefined,
     "rawResponse": undefined,
+    "request": {},
     "response": {
+      "headers": undefined,
       "id": "id-1",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
@@ -774,7 +830,11 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
         "call": "3",
       },
     },
+    "request": {},
     "response": {
+      "headers": {
+        "call": "3",
+      },
       "id": "id-1",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
@@ -1000,7 +1060,9 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > value promise
     "isContinued": true,
     "logprobs": undefined,
     "rawResponse": undefined,
+    "request": {},
     "response": {
+      "headers": undefined,
       "id": "id-0",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
@@ -1023,7 +1085,9 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > value promise
     "isContinued": true,
     "logprobs": undefined,
     "rawResponse": undefined,
+    "request": {},
     "response": {
+      "headers": undefined,
       "id": "id-1",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
@@ -1049,7 +1113,11 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > value promise
         "call": "3",
       },
     },
+    "request": {},
     "response": {
+      "headers": {
+        "call": "3",
+      },
       "id": "id-1",
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
@@ -1083,6 +1151,7 @@ exports[`options.onFinish > options.onFinish should send correct information 1`]
       "call": "2",
     },
   },
+  "request": {},
   "response": {
     "headers": {
       "call": "2",
@@ -1136,7 +1205,11 @@ exports[`options.onFinish > options.onFinish should send correct information 1`]
           "call": "2",
         },
       },
+      "request": {},
       "response": {
+        "headers": {
+          "call": "2",
+        },
         "id": "id-0",
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -3,6 +3,7 @@ import { CoreTool } from '../tool/tool';
 import {
   CallWarning,
   FinishReason,
+  LanguageModelRequestMetadata,
   LanguageModelResponseMetadataWithHeaders,
   LogProbs,
   ProviderMetadata,
@@ -83,6 +84,11 @@ Optional raw response data.
    */
     readonly headers?: Record<string, string>;
   };
+
+  /**
+Additional request information.
+   */
+  readonly request: LanguageModelRequestMetadata;
 
   /**
 Additional response information.

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -285,6 +285,60 @@ describe('result.responseMessages', () => {
   });
 });
 
+describe('result.request', () => {
+  it('should contain request information', async () => {
+    const result = await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({}) => ({
+          ...dummyResponseValues,
+          text: `Hello, world!`,
+          request: {
+            body: 'test body',
+          },
+        }),
+      }),
+      prompt: 'prompt',
+    });
+
+    expect(result.request).toStrictEqual({
+      body: 'test body',
+    });
+  });
+});
+
+describe('result.response', () => {
+  it('should contain response information', async () => {
+    const result = await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async ({}) => ({
+          ...dummyResponseValues,
+          text: `Hello, world!`,
+          response: {
+            id: 'test-id-from-model',
+            timestamp: new Date(10000),
+            modelId: 'test-response-model-id',
+          },
+          rawResponse: {
+            headers: {
+              'custom-response-header': 'response-header-value',
+            },
+          },
+        }),
+      }),
+      prompt: 'prompt',
+    });
+
+    expect(result.response).toStrictEqual({
+      id: 'test-id-from-model',
+      timestamp: new Date(10000),
+      modelId: 'test-response-model-id',
+      headers: {
+        'custom-response-header': 'response-header-value',
+      },
+    });
+  });
+});
+
 describe('options.maxSteps', () => {
   describe('2 steps: initial, tool-result', () => {
     let result: GenerateTextResult<any>;
@@ -655,55 +709,6 @@ describe('options.maxSteps', () => {
 
     it('onStepFinish should be called for each step', () => {
       expect(onStepFinishResults).toMatchSnapshot();
-    });
-  });
-});
-
-describe('result.response', () => {
-  it('should contain response information', async () => {
-    const result = await generateText({
-      model: new MockLanguageModelV1({
-        doGenerate: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, {
-            type: 'regular',
-            tools: undefined,
-            toolChoice: undefined,
-          });
-
-          expect(prompt).toStrictEqual([
-            {
-              role: 'user',
-              content: [{ type: 'text', text: 'prompt' }],
-              providerMetadata: undefined,
-            },
-          ]);
-
-          return {
-            ...dummyResponseValues,
-            text: `Hello, world!`,
-            response: {
-              id: 'test-id-from-model',
-              timestamp: new Date(10000),
-              modelId: 'test-response-model-id',
-            },
-            rawResponse: {
-              headers: {
-                'custom-response-header': 'response-header-value',
-              },
-            },
-          };
-        },
-      }),
-      prompt: 'prompt',
-    });
-
-    expect(result.response).toStrictEqual({
-      id: 'test-id-from-model',
-      timestamp: new Date(10000),
-      modelId: 'test-response-model-id',
-      headers: {
-        'custom-response-header': 'response-header-value',
-      },
     });
   });
 });

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -4,10 +4,7 @@ import { InvalidArgumentError } from '../../errors';
 import { retryWithExponentialBackoff } from '../../util/retry-with-exponential-backoff';
 import { CoreAssistantMessage, CoreToolMessage } from '../prompt';
 import { CallSettings } from '../prompt/call-settings';
-import {
-  convertToLanguageModelMessage,
-  convertToLanguageModelPrompt,
-} from '../prompt/convert-to-language-model-prompt';
+import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choice';
 import { Prompt } from '../prompt/prompt';
@@ -511,6 +508,10 @@ changing the tool call and result types in the result.
         finishReason: currentModelResponse.finishReason,
         usage,
         warnings: currentModelResponse.warnings,
+        request: {
+          // TODO add to every step result
+          body: currentModelResponse.request?.body,
+        },
         response: {
           ...currentModelResponse.response,
           headers: currentModelResponse.rawResponse?.headers,
@@ -617,7 +618,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
   readonly logprobs: GenerateTextResult<TOOLS>['logprobs'];
   readonly experimental_providerMetadata: GenerateTextResult<TOOLS>['experimental_providerMetadata'];
   readonly response: GenerateTextResult<TOOLS>['response'];
-
+  readonly request: GenerateTextResult<TOOLS>['request'];
   constructor(options: {
     text: GenerateTextResult<TOOLS>['text'];
     toolCalls: GenerateTextResult<TOOLS>['toolCalls'];
@@ -630,6 +631,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
     steps: GenerateTextResult<TOOLS>['steps'];
     providerMetadata: GenerateTextResult<TOOLS>['experimental_providerMetadata'];
     response: GenerateTextResult<TOOLS>['response'];
+    request: GenerateTextResult<TOOLS>['request'];
   }) {
     this.text = options.text;
     this.toolCalls = options.toolCalls;
@@ -637,6 +639,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>>
     this.finishReason = options.finishReason;
     this.usage = options.usage;
     this.warnings = options.warnings;
+    this.request = options.request;
     this.response = options.response;
     this.responseMessages = options.responseMessages;
     this.roundtrips = options.steps;

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -426,6 +426,7 @@ changing the tool call and result types in the result.
           usage: currentUsage,
           warnings: currentModelResponse.warnings,
           logprobs: currentModelResponse.logprobs,
+          request: currentModelResponse.request ?? {},
           response: {
             ...currentModelResponse.response,
             headers: currentModelResponse.rawResponse?.headers,
@@ -508,10 +509,7 @@ changing the tool call and result types in the result.
         finishReason: currentModelResponse.finishReason,
         usage,
         warnings: currentModelResponse.warnings,
-        request: {
-          // TODO add to every step result
-          body: currentModelResponse.request?.body,
-        },
+        request: currentModelResponse.request ?? {},
         response: {
           ...currentModelResponse.response,
           headers: currentModelResponse.rawResponse?.headers,

--- a/packages/ai/core/generate-text/step-result.ts
+++ b/packages/ai/core/generate-text/step-result.ts
@@ -2,6 +2,7 @@ import { CoreTool } from '../tool';
 import {
   CallWarning,
   FinishReason,
+  LanguageModelRequestMetadata,
   LanguageModelResponseMetadataWithHeaders,
   LogProbs,
   ProviderMetadata,
@@ -61,6 +62,11 @@ Response headers.
 */
     readonly headers?: Record<string, string>;
   };
+
+  /**
+Additional request information.
+   */
+  readonly request: LanguageModelRequestMetadata;
 
   /**
 Additional response information.

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -9,6 +9,7 @@ import { CoreTool } from '../tool';
 import {
   CallWarning,
   FinishReason,
+  LanguageModelRequestMetadata,
   LanguageModelResponseMetadata,
   LanguageModelResponseMetadataWithHeaders,
   LogProbs,
@@ -108,7 +109,12 @@ such as the tool calls or the response headers.
   readonly steps: Promise<Array<StepResult<TOOLS>>>;
 
   /**
-Additional response information.
+Additional request information from the last step.
+ */
+  readonly request: Promise<LanguageModelRequestMetadata>;
+
+  /**
+Additional response information from the last step.
  */
   readonly response: Promise<LanguageModelResponseMetadataWithHeaders>;
 

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1588,6 +1588,42 @@ describe('result.providerMetadata', () => {
   });
 });
 
+describe('result.request', () => {
+  it('should resolve with response information', async () => {
+    const result = await streamText({
+      model: new MockLanguageModelV1({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text-delta', textDelta: 'Hello' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              logprobs: undefined,
+              usage: { completionTokens: 10, promptTokens: 3 },
+            },
+          ]),
+          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          request: { body: 'test body' },
+        }),
+      }),
+      prompt: 'test-input',
+    });
+
+    // consume stream (runs in parallel)
+    convertAsyncIterableToArray(result.textStream);
+
+    expect(await result.request).toStrictEqual({
+      body: 'test body',
+    });
+  });
+});
+
 describe('result.response', () => {
   it('should resolve with response information', async () => {
     const result = await streamText({
@@ -2148,6 +2184,7 @@ describe('options.maxSteps', () => {
                     },
                   ]),
                   rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+                  rawResponse: { headers: { call: '1' } },
                 };
               }
               case 1: {

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -62,7 +62,7 @@ export type CoreToolChoice<TOOLS extends Record<string, unknown>> =
 export type LanguageModelResponseMetadata = {
   /**
 ID for the generated response.
-     */
+   */
   id: string;
 
   /**
@@ -80,3 +80,10 @@ export type LanguageModelResponseMetadataWithHeaders =
   LanguageModelResponseMetadata & {
     headers?: Record<string, string>;
   };
+
+export type LanguageModelRequestMetadata = {
+  /**
+Request body as string (JSON should be stringified).
+   */
+  body?: string;
+};

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -83,7 +83,7 @@ export type LanguageModelResponseMetadataWithHeaders =
 
 export type LanguageModelRequestMetadata = {
   /**
-Request body as string (JSON should be stringified).
+Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).
    */
   body?: string;
 };

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -392,6 +392,20 @@ describe('doGenerate', () => {
       },
     });
   });
+
+  it('should send request body', async () => {
+    prepareJsonResponse({ content: [] });
+
+    const { request } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"claude-3-haiku-20240307","max_tokens":4096,"messages":[{"role":"user","content":[{"type":"text","text":"Hello"}]}]}',
+    });
+  });
 });
 
 describe('doStream', () => {
@@ -695,5 +709,19 @@ describe('doStream', () => {
         },
       },
     ]);
+  });
+
+  it('should send request body', async () => {
+    prepareStreamResponse({ content: [] });
+
+    const { request } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"claude-3-haiku-20240307","max_tokens":4096,"messages":[{"role":"user","content":[{"type":"text","text":"Hello"}]}],"stream":true}',
+    });
   });
 });

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -239,6 +239,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
               },
             }
           : undefined,
+      request: { body: JSON.stringify(args) },
     };
   }
 
@@ -247,10 +248,12 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doStream']>>> {
     const { args, warnings } = await this.getArgs(options);
 
+    const body = { ...args, stream: true };
+
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/messages`,
       headers: this.getHeaders(options.headers),
-      body: { ...args, stream: true },
+      body,
       failedResponseHandler: anthropicFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(
         anthropicMessagesChunkSchema,
@@ -437,6 +440,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
       rawCall: { rawPrompt, rawSettings },
       rawResponse: { headers: responseHeaders },
       warnings,
+      request: { body: JSON.stringify(body) },
     };
   }
 }

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -428,6 +428,20 @@ describe('doGenerate', () => {
       },
     });
   });
+
+  it('should send request body', async () => {
+    prepareJsonResponse({ text: '' });
+
+    const { request } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"command-r-plus","chat_history":[{"role":"SYSTEM","message":"you are a friendly bot!"}],"message":"Hello"}',
+    });
+  });
 });
 
 describe('doStream', () => {
@@ -1013,6 +1027,20 @@ describe('doStream', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
+    });
+  });
+
+  it('should send request body', async () => {
+    prepareStreamResponse({ content: [] });
+
+    const { request } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"command-r-plus","chat_history":[{"role":"SYSTEM","message":"you are a friendly bot!"}],"message":"Hello","stream":true}',
     });
   });
 });

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -179,6 +179,7 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
       },
       rawResponse: { headers: responseHeaders },
       warnings: undefined,
+      request: { body: JSON.stringify(args) },
     };
   }
 
@@ -186,14 +187,12 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
     options: Parameters<LanguageModelV1['doStream']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV1['doStream']>>> {
     const args = this.getArgs(options);
+    const body = { ...args, stream: true };
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/chat`,
       headers: combineHeaders(this.config.headers(), options.headers),
-      body: {
-        ...args,
-        stream: true,
-      },
+      body,
       failedResponseHandler: cohereFailedResponseHandler,
       successfulResponseHandler: createJsonStreamResponseHandler(
         cohereChatChunkSchema,
@@ -337,6 +336,7 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
       },
       rawResponse: { headers: responseHeaders },
       warnings: [],
+      request: { body: JSON.stringify(body) },
     };
   }
 }

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -488,6 +488,21 @@ describe('doGenerate', () => {
       });
     }),
   );
+
+  it(
+    'should send request body',
+    withTestServer(prepareJsonResponse({}), async () => {
+      const { request } = await model.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+      });
+
+      expect(request).toStrictEqual({
+        body: '{"generationConfig":{},"contents":[{"role":"user","parts":[{"text":"Hello"}]}]}',
+      });
+    }),
+  );
 });
 
 describe('doStream', () => {
@@ -637,5 +652,20 @@ describe('doStream', () => {
         });
       },
     ),
+  );
+
+  it(
+    'should send request body',
+    withTestServer(prepareStreamResponse({ content: [''] }), async () => {
+      const { request } = await model.doStream({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+      });
+
+      expect(request).toStrictEqual({
+        body: '{"generationConfig":{},"contents":[{"role":"user","parts":[{"text":"Hello"}]}]}',
+      });
+    }),
   );
 });

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -184,6 +184,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args, warnings } = await this.getArgs(options);
 
+    const body = JSON.stringify(args);
+
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/${getModelPath(
         this.modelId,
@@ -220,6 +222,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       rawCall: { rawPrompt, rawSettings },
       rawResponse: { headers: responseHeaders },
       warnings,
+      request: { body },
     };
   }
 
@@ -227,6 +230,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
     options: Parameters<LanguageModelV1['doStream']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV1['doStream']>>> {
     const { args, warnings } = await this.getArgs(options);
+
+    const body = JSON.stringify(args);
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/${getModelPath(
@@ -333,6 +338,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       rawCall: { rawPrompt, rawSettings },
       rawResponse: { headers: responseHeaders },
       warnings,
+      request: { body },
     };
   }
 }

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -420,6 +420,20 @@ describe('doGenerate', () => {
       },
     });
   });
+
+  it('should send request body', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const { request } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"gemma2-9b-it","messages":[{"role":"user","content":"Hello"}]}',
+    });
+  });
 });
 
 describe('doStream', () => {
@@ -930,6 +944,20 @@ describe('doStream', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
+    });
+  });
+
+  it('should send request body', async () => {
+    prepareStreamResponse({ content: [] });
+
+    const { request } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"gemma2-9b-it","messages":[{"role":"user","content":"Hello"}],"stream":true}',
     });
   });
 });

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -185,6 +185,8 @@ export class GroqChatLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args, warnings } = this.getArgs({ ...options, stream: false });
 
+    const body = JSON.stringify(args);
+
     const { responseHeaders, value: response } = await postJsonToApi({
       url: this.config.url({
         path: '/chat/completions',
@@ -220,6 +222,7 @@ export class GroqChatLanguageModel implements LanguageModelV1 {
       rawResponse: { headers: responseHeaders },
       response: getResponseMetadata(response),
       warnings,
+      request: { body },
     };
   }
 
@@ -227,6 +230,8 @@ export class GroqChatLanguageModel implements LanguageModelV1 {
     options: Parameters<LanguageModelV1['doStream']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV1['doStream']>>> {
     const { args, warnings } = this.getArgs({ ...options, stream: true });
+
+    const body = JSON.stringify({ ...args, stream: true });
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: this.config.url({
@@ -445,6 +450,7 @@ export class GroqChatLanguageModel implements LanguageModelV1 {
       rawCall: { rawPrompt, rawSettings },
       rawResponse: { headers: responseHeaders },
       warnings,
+      request: { body },
     };
   }
 }

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -291,6 +291,20 @@ describe('doGenerate', () => {
       'custom-request-header': 'request-header-value',
     });
   });
+
+  it('should send request body', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const { request } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"mistral-small-latest","messages":[{"role":"user","content":[{"type":"text","text":"Hello"}]}]}',
+    });
+  });
 });
 
 describe('doStream', () => {
@@ -515,6 +529,20 @@ describe('doStream', () => {
       'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
+    });
+  });
+
+  it('should send request body', async () => {
+    prepareStreamResponse({ content: [] });
+
+    const { request } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"mistral-small-latest","messages":[{"role":"user","content":[{"type":"text","text":"Hello"}]}],"stream":true}',
     });
   });
 });

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -214,6 +214,7 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
       },
       rawCall: { rawPrompt, rawSettings },
       rawResponse: { headers: responseHeaders },
+      request: { body: JSON.stringify(args) },
       response: getResponseMetadata(response),
       warnings,
     };
@@ -224,10 +225,12 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doStream']>>> {
     const { args, warnings } = this.getArgs(options);
 
+    const body = { ...args, stream: true };
+
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/chat/completions`,
       headers: combineHeaders(this.config.headers(), options.headers),
-      body: { ...args, stream: true },
+      body,
       failedResponseHandler: mistralFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(
         mistralChatChunkSchema,
@@ -348,6 +351,7 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
       ),
       rawCall: { rawPrompt, rawSettings },
       rawResponse: { headers: responseHeaders },
+      request: { body: JSON.stringify(body) },
       warnings,
     };
   }

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -247,6 +247,24 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should send request body', async () => {
+    prepareJsonResponse({
+      id: 'test-id',
+      created: 123,
+      model: 'test-model',
+    });
+
+    const { request } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello"}]}',
+    });
+  });
+
   it('should send additional response information', async () => {
     prepareJsonResponse({
       id: 'test-id',
@@ -1683,6 +1701,20 @@ describe('doStream', () => {
         completionTokens: NaN,
         promptTokens: NaN,
       },
+    });
+  });
+
+  it('should send request body', async () => {
+    prepareStreamResponse({ content: [] });
+
+    const { request } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello"}],"stream":true,"stream_options":{"include_usage":true}}',
     });
   });
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -248,11 +248,7 @@ describe('doGenerate', () => {
   });
 
   it('should send request body', async () => {
-    prepareJsonResponse({
-      id: 'test-id',
-      created: 123,
-      model: 'test-model',
-    });
+    prepareJsonResponse({});
 
     const { request } = await model.doGenerate({
       inputFormat: 'prompt',

--- a/packages/openai/src/openai-completion-language-model.test.ts
+++ b/packages/openai/src/openai-completion-language-model.test.ts
@@ -126,6 +126,20 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should send request body', async () => {
+    prepareJsonResponse({});
+
+    const { request } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"gpt-3.5-turbo-instruct","prompt":"Hello"}',
+    });
+  });
+
   it('should send additional response information', async () => {
     prepareJsonResponse({
       id: 'test-id',
@@ -416,6 +430,20 @@ describe('doStream', () => {
         completionTokens: NaN,
         promptTokens: NaN,
       },
+    });
+  });
+
+  it('should send request body', async () => {
+    prepareStreamResponse({ content: [] });
+
+    const { request } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(request).toStrictEqual({
+      body: '{"model":"gpt-3.5-turbo-instruct","prompt":"Hello","stream":true,"stream_options":{"include_usage":true}}',
     });
   });
 

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -101,6 +101,7 @@ Finish reason.
     /**
 Raw prompt and setting information for observability provider integration.
      */
+    // TODO remove in v2 (there is now request)
     rawCall: {
       /**
 Raw prompt after expansion and conversion to the format that the
@@ -126,6 +127,19 @@ Response headers.
       headers?: Record<string, string>;
     };
 
+    /**
+Optional request information for telemetry and debugging purposes.
+     */
+    request?: {
+      /**
+Request body as string (JSON should be stringified).
+       */
+      body?: string;
+    };
+
+    /**
+Optional response information for telemetry and debugging purposes.
+     */
     response?: {
       /**
 ID for the generated response, if the provider sends one.
@@ -175,6 +189,7 @@ by the user.
     /**
 Raw prompt and setting information for observability provider integration.
      */
+    // TODO remove in v2 (there is now request)
     rawCall: {
       /**
 Raw prompt after expansion and conversion to the format that the
@@ -192,11 +207,22 @@ settings.
     /**
 Optional raw response data.
      */
+    // TODO rename to response in v2
     rawResponse?: {
       /**
 Response headers.
        */
       headers?: Record<string, string>;
+    };
+
+    /**
+Optional request information for telemetry and debugging purposes.
+     */
+    request?: {
+      /**
+Request body as string (JSON should be stringified).
+   */
+      body?: string;
     };
 
     warnings?: LanguageModelV1CallWarning[];

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -132,7 +132,8 @@ Optional request information for telemetry and debugging purposes.
      */
     request?: {
       /**
-Request body as string (JSON should be stringified).
+Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).
+Non-HTTP(s) providers should not set this.
        */
       body?: string;
     };
@@ -220,7 +221,8 @@ Optional request information for telemetry and debugging purposes.
      */
     request?: {
       /**
-Request body as string (JSON should be stringified).
+Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).
+Non-HTTP(s) providers should not set this.
    */
       body?: string;
     };


### PR DESCRIPTION
## Summary
* add `request.body` to return value of language model `doGenerate` and `doStream` functions
* add `request.body` to result of `generateText`, `streamText`, `generateObject`, `streamObject`
* add `request.body` to `StepResult`
* implement in various providers

## Background
For better debugging and troubleshooting, it is often required to access the raw HTTP request body.

## Tasks

- [x] implementation
   - [x] add to provider specification
   - [x] ai/core implementation
      - [x] generateText
      - [x] streamText
      - [x] generateObject
      - [x] streamObject
   - [x] providers
      - [x] anthropic
      - [x] cohere
      - [x] google
      - [x] groq
      - [x] mistral
      - [x] openai chat
      - [x] openai completion
- [x] examples
- [x] documentation 
    - [x] generateText reference
    - [x] streamText reference
    - [x] generateObject reference
    - [x] streamObject reference
    - [x] guide
- [x] changeset