### PR TITLE
Add description on how to use own models

### DIFF
--- a/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
@@ -48,6 +48,7 @@ const vertex = createVertex({
   location: 'us-central1', // optional
 });
 ```
+> If you are using your [own models](https://cloud.google.com/vertex-ai/docs/training-overview) remember that the name of your model should start with `projects/`
 
 You can use the following optional settings to customize the Google Generative AI provider instance:
 


### PR DESCRIPTION
This took a lot of digging, the generated REST API by vertex is not clear, and the docs did not make it clear on how to pass a URL.