### PR TITLE
fix (examples): Remove `NextRequest.ip` references as it's now deleted.

### DIFF
--- a/examples/next-openai-kasada-bot-protection/kasada/kasada-server.tsx
+++ b/examples/next-openai-kasada-bot-protection/kasada/kasada-server.tsx
@@ -59,7 +59,7 @@ async function getKasadaMetadata(request: NextRequest): Promise<{
   }));
 
   const kasadaPayload: APIRequest = {
-    clientIp: String(request.headers.get('x-real-ip') || request.ip),
+    clientIp: String(request.headers.get('x-real-ip')),
     headers: headersArray,
     method: request.method as APIRequest['method'],
     protocol: url.protocol.slice(0, -1).toUpperCase() as APIRequest['protocol'],

--- a/examples/next-openai-rate-limits/kasada/kasada-server.ts
+++ b/examples/next-openai-rate-limits/kasada/kasada-server.ts
@@ -62,7 +62,7 @@ async function getKasadaMetadata(request: NextRequest): Promise<{
     clientIp:
       process.env.NODE_ENV === 'development'
         ? '65.204.128.202'
-        : String(request.headers.get('x-real-ip') || request.ip),
+        : String(request.headers.get('x-real-ip')),
     headers: headersArray,
     method: request.method as APIRequest['method'],
     protocol: url.protocol.slice(0, -1).toUpperCase() as APIRequest['protocol'],


### PR DESCRIPTION
The build is broken for these two examples that specify `latest` for the `next` dependency. Next.js 15 deleted the `NextRequest.ip` field per:

https://nextjs.org/docs/app/api-reference/functions/next-request#version-history

Note that developers might want to also fall back to include `request.headers.get('x-forwarded-for')` but we do not do so in this change.