### PR TITLE
feat (ai/core): expose response message for each step

### DIFF
--- a/.changeset/silver-guests-attack.md
+++ b/.changeset/silver-guests-attack.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai/core): expose response message for each step

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -679,6 +679,12 @@ To see `generateText` in action, check out [these examples](#examples).
               type: 'Record<string, string>',
               description: 'Optional response headers.',
             },
+            {
+              name: 'messages',
+              type: 'Array<CoreAssistantMessage | CoreToolMessage>',
+              description:
+                'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+            },
           ],
         },
       ],
@@ -694,12 +700,6 @@ To see `generateText` in action, check out [these examples](#examples).
       type: 'Record<string,Record<string,JSONValue>> | undefined',
       description:
         'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
-    },
-    {
-      name: 'responseMessages',
-      type: 'Array<CoreAssistantMessage | CoreToolMessage>',
-      description:
-        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
     },
     {
       name: 'steps',
@@ -816,6 +816,12 @@ To see `generateText` in action, check out [these examples](#examples).
                       isOptional: true,
                       type: 'Record<string, string>',
                       description: 'Optional response headers.',
+                    },
+                    {
+                      name: 'messages',
+                      type: 'Array<CoreAssistantMessage | CoreToolMessage>',
+                      description:
+                        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
                     },
                   ],
                 },

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -833,6 +833,12 @@ To see `streamText` in action, check out [these examples](#examples).
                       type: 'Record<string, string>',
                       description: 'Optional response headers.',
                     },
+                    {
+                      name: 'messages',
+                      type: 'Array<CoreAssistantMessage | CoreToolMessage>',
+                      description:
+                        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+                    },
                   ],
                 },
               ],
@@ -842,12 +848,6 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'Array<StepResult>',
               description:
                 'Response information for every step. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
-            },
-            {
-              name: 'responseMessages',
-              type: 'Array<CoreAssistantMessage | CoreToolMessage>',
-              description:
-                'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
             },
           ],
         },
@@ -976,6 +976,12 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'Record<string, string>',
               description: 'Optional response headers.',
             },
+            {
+              name: 'messages',
+              type: 'Array<CoreAssistantMessage | CoreToolMessage>',
+              description:
+                'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+            },
           ],
         },
       ],
@@ -1101,6 +1107,12 @@ To see `streamText` in action, check out [these examples](#examples).
                       isOptional: true,
                       type: 'Record<string, string>',
                       description: 'Optional response headers.',
+                    },
+                    {
+                      name: 'messages',
+                      type: 'Array<CoreAssistantMessage | CoreToolMessage>',
+                      description:
+                        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
                     },
                   ],
                 },

--- a/packages/ai/core/generate-object/generate-object-result.ts
+++ b/packages/ai/core/generate-object/generate-object-result.ts
@@ -2,7 +2,7 @@ import {
   CallWarning,
   FinishReason,
   LanguageModelRequestMetadata,
-  LanguageModelResponseMetadataWithHeaders,
+  LanguageModelResponseMetadata,
   LogProbs,
   ProviderMetadata,
 } from '../types';
@@ -52,7 +52,7 @@ Additional request information.
   /**
 Additional response information.
    */
-  readonly response: LanguageModelResponseMetadataWithHeaders;
+  readonly response: LanguageModelResponseMetadata;
 
   /**
  Logprobs for the completion.

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -18,11 +18,11 @@ import {
   CallWarning,
   FinishReason,
   LanguageModel,
-  LanguageModelRequestMetadata,
-  LanguageModelResponseMetadata,
   LogProbs,
   ProviderMetadata,
 } from '../types';
+import { LanguageModelRequestMetadata } from '../types/language-model-request-metadata';
+import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
 import { calculateLanguageModelUsage } from '../types/usage';
 import { prepareResponseHeaders } from '../util/prepare-response-headers';
 import { GenerateObjectResult } from './generate-object-result';

--- a/packages/ai/core/generate-object/stream-object-result.ts
+++ b/packages/ai/core/generate-object/stream-object-result.ts
@@ -4,7 +4,6 @@ import {
   FinishReason,
   LanguageModelRequestMetadata,
   LanguageModelResponseMetadata,
-  LanguageModelResponseMetadataWithHeaders,
   LogProbs,
   ProviderMetadata,
 } from '../types';
@@ -53,7 +52,7 @@ Additional request information from the last step.
   /**
 Additional response information.
  */
-  readonly response: Promise<LanguageModelResponseMetadataWithHeaders>;
+  readonly response: Promise<LanguageModelResponseMetadata>;
 
   /**
   The generated object (typed according to the schema). Resolved when the response is finished.

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -32,7 +32,7 @@ import {
   CallWarning,
   FinishReason,
   LanguageModel,
-  LanguageModelResponseMetadataWithHeaders,
+  LanguageModelResponseMetadata,
   LogProbs,
   ProviderMetadata,
 } from '../types';
@@ -86,7 +86,7 @@ Response headers.
   /**
 Response metadata.
  */
-  response: LanguageModelResponseMetadataWithHeaders;
+  response: LanguageModelResponseMetadata;
 
   /**
 Warnings from the model provider (e.g. unsupported settings).
@@ -691,7 +691,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
 
     // initialize response promise
     const { resolve: resolveResponse, promise: responsePromise } =
-      createResolvablePromise<LanguageModelResponseMetadataWithHeaders>();
+      createResolvablePromise<LanguageModelResponseMetadata>();
     this.response = responsePromise;
 
     // initialize experimental_providerMetadata promise

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -340,6 +340,28 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > result.steps 
 ]
 `;
 
+exports[`result.response > should contain response information 1`] = `
+{
+  "headers": {
+    "custom-response-header": "response-header-value",
+  },
+  "id": "test-id-from-model",
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "Hello, world!",
+          "type": "text",
+        },
+      ],
+      "role": "assistant",
+    },
+  ],
+  "modelId": "test-response-model-id",
+  "timestamp": 1970-01-01T00:00:10.000Z,
+}
+`;
+
 exports[`result.responseMessages > should contain assistant response message and tool message when there are tool calls with results 1`] = `
 [
   {

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -11,6 +11,36 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
     "response": {
       "headers": undefined,
       "id": "test-id-1-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "",
+              "type": "text",
+            },
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -54,6 +84,45 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
         "custom-response-header": "response-header-value",
       },
       "id": "test-id-2-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "",
+              "type": "text",
+            },
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello, world!",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
@@ -124,6 +193,36 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
     "response": {
       "headers": undefined,
       "id": "test-id-1-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "",
+              "type": "text",
+            },
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -167,6 +266,45 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
         "custom-response-header": "response-header-value",
       },
       "id": "test-id-2-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "",
+              "type": "text",
+            },
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello, world!",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
@@ -195,6 +333,18 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > onStepFinish 
     "response": {
       "headers": undefined,
       "id": "test-id-1-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -221,6 +371,22 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > onStepFinish 
         "custom-response-header": "response-header-value",
       },
       "id": "test-id-2-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+            {
+              "text": "no-whitespace",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
@@ -244,6 +410,27 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > onStepFinish 
     "response": {
       "headers": undefined,
       "id": "test-id-3-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+            {
+              "text": "no-whitespace",
+              "type": "text",
+            },
+            {
+              "text": "final value keep all whitespace
+ end",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:20.000Z,
     },
@@ -273,6 +460,18 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > result.steps 
     "response": {
       "headers": undefined,
       "id": "test-id-1-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -299,6 +498,22 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > result.steps 
         "custom-response-header": "response-header-value",
       },
       "id": "test-id-2-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+            {
+              "text": "no-whitespace",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
@@ -322,6 +537,27 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > result.steps 
     "response": {
       "headers": undefined,
       "id": "test-id-3-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+            {
+              "text": "no-whitespace",
+              "type": "text",
+            },
+            {
+              "text": "final value keep all whitespace
+ end",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:20.000Z,
     },

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -85,6 +85,45 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onFinish
       "call": "1",
     },
     "id": "id-1",
+    "messages": [
+      {
+        "content": [
+          {
+            "text": "",
+            "type": "text",
+          },
+          {
+            "args": {
+              "value": "value",
+            },
+            "toolCallId": "call-1",
+            "toolName": "tool1",
+            "type": "tool-call",
+          },
+        ],
+        "role": "assistant",
+      },
+      {
+        "content": [
+          {
+            "result": "result1",
+            "toolCallId": "call-1",
+            "toolName": "tool1",
+            "type": "tool-result",
+          },
+        ],
+        "role": "tool",
+      },
+      {
+        "content": [
+          {
+            "text": "Hello, world!",
+            "type": "text",
+          },
+        ],
+        "role": "assistant",
+      },
+    ],
     "modelId": "mock-model-id",
     "timestamp": 1970-01-01T00:00:01.000Z,
   },
@@ -144,6 +183,36 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onFinish
           "call": "1",
         },
         "id": "id-0",
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "",
+                "type": "text",
+              },
+              {
+                "args": {
+                  "value": "value",
+                },
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "result": "result1",
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
@@ -193,6 +262,45 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onFinish
           "call": "2",
         },
         "id": "id-1",
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "",
+                "type": "text",
+              },
+              {
+                "args": {
+                  "value": "value",
+                },
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "result": "result1",
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+          {
+            "content": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
@@ -238,6 +346,36 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onStepFi
         "call": "1",
       },
       "id": "id-0",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "",
+              "type": "text",
+            },
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -287,6 +425,45 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > callbacks > onStepFi
         "call": "2",
       },
       "id": "id-1",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "",
+              "type": "text",
+            },
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello, world!",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -573,6 +750,36 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > value promises > res
         "call": "1",
       },
       "id": "id-0",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "",
+              "type": "text",
+            },
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -622,6 +829,45 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > value promises > res
         "call": "2",
       },
       "id": "id-1",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "",
+              "type": "text",
+            },
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "role": "tool",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello, world!",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -649,6 +895,27 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
   "response": {
     "headers": undefined,
     "id": "id-1",
+    "messages": [
+      {
+        "content": [
+          {
+            "text": "part 1 
+ ",
+            "type": "text",
+          },
+          {
+            "text": "no-whitespace",
+            "type": "text",
+          },
+          {
+            "text": "final value keep all whitespace
+ end",
+            "type": "text",
+          },
+        ],
+        "role": "assistant",
+      },
+    ],
     "modelId": "mock-model-id",
     "timestamp": 1970-01-01T00:00:01.000Z,
   },
@@ -684,6 +951,18 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
       "response": {
         "headers": undefined,
         "id": "id-0",
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "part 1 
+ ",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
@@ -709,6 +988,22 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
       "response": {
         "headers": undefined,
         "id": "id-1",
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "part 1 
+ ",
+                "type": "text",
+              },
+              {
+                "text": "no-whitespace",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
@@ -739,6 +1034,27 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
           "call": "3",
         },
         "id": "id-1",
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "part 1 
+ ",
+                "type": "text",
+              },
+              {
+                "text": "no-whitespace",
+                "type": "text",
+              },
+              {
+                "text": "final value keep all whitespace
+ end",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
@@ -781,6 +1097,18 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
     "response": {
       "headers": undefined,
       "id": "id-0",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -806,6 +1134,22 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
     "response": {
       "headers": undefined,
       "id": "id-1",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+            {
+              "text": "no-whitespace",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -836,6 +1180,27 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > callbacks > o
         "call": "3",
       },
       "id": "id-1",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+            {
+              "text": "no-whitespace",
+              "type": "text",
+            },
+            {
+              "text": "final value keep all whitespace
+ end",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -1064,6 +1429,18 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > value promise
     "response": {
       "headers": undefined,
       "id": "id-0",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -1089,6 +1466,22 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > value promise
     "response": {
       "headers": undefined,
       "id": "id-1",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+            {
+              "text": "no-whitespace",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -1119,6 +1512,27 @@ exports[`options.maxSteps > 3 steps: initial, continue, continue > value promise
         "call": "3",
       },
       "id": "id-1",
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+            {
+              "text": "no-whitespace",
+              "type": "text",
+            },
+            {
+              "text": "final value keep all whitespace
+ end",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -1157,6 +1571,36 @@ exports[`options.onFinish > options.onFinish should send correct information 1`]
       "call": "2",
     },
     "id": "id-0",
+    "messages": [
+      {
+        "content": [
+          {
+            "text": "Hello, world!",
+            "type": "text",
+          },
+          {
+            "args": {
+              "value": "value",
+            },
+            "toolCallId": "call-1",
+            "toolName": "tool1",
+            "type": "tool-call",
+          },
+        ],
+        "role": "assistant",
+      },
+      {
+        "content": [
+          {
+            "result": "value-result",
+            "toolCallId": "call-1",
+            "toolName": "tool1",
+            "type": "tool-result",
+          },
+        ],
+        "role": "tool",
+      },
+    ],
     "modelId": "mock-model-id",
     "timestamp": 1970-01-01T00:00:00.000Z,
   },
@@ -1211,6 +1655,36 @@ exports[`options.onFinish > options.onFinish should send correct information 1`]
           "call": "2",
         },
         "id": "id-0",
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+              {
+                "args": {
+                  "value": "value",
+                },
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "result": "value-result",
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -3,11 +3,11 @@ import { CoreTool } from '../tool/tool';
 import {
   CallWarning,
   FinishReason,
-  LanguageModelRequestMetadata,
-  LanguageModelResponseMetadataWithHeaders,
   LogProbs,
   ProviderMetadata,
 } from '../types';
+import { LanguageModelRequestMetadata } from '../types/language-model-request-metadata';
+import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
 import { LanguageModelUsage } from '../types/usage';
 import { StepResult } from './step-result';
 import { ToolCallArray } from './tool-call';
@@ -49,12 +49,7 @@ export interface GenerateTextResult<TOOLS extends Record<string, CoreTool>> {
   readonly warnings: CallWarning[] | undefined;
 
   /**
-The response messages that were generated during the call. It consists of an assistant message,
-potentially containing tool calls.
-
-When there are tool results, there is an additional tool message with the tool results that are available.
-If there are tools that do not have execute functions, they are not included in the tool results and
-need to be added separately.
+@deprecated use `response.messages` instead.
      */
   readonly responseMessages: Array<CoreAssistantMessage | CoreToolMessage>;
 
@@ -93,7 +88,17 @@ Additional request information.
   /**
 Additional response information.
    */
-  readonly response: LanguageModelResponseMetadataWithHeaders;
+  readonly response: LanguageModelResponseMetadata & {
+    /**
+The response messages that were generated during the call. It consists of an assistant message,
+potentially containing tool calls.
+
+When there are tool results, there is an additional tool message with the tool results that are available.
+If there are tools that do not have execute functions, they are not included in the tool results and
+need to be added separately.
+       */
+    messages: Array<CoreAssistantMessage | CoreToolMessage>;
+  };
 
   /**
 Logprobs for the completion.

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -328,14 +328,7 @@ describe('result.response', () => {
       prompt: 'prompt',
     });
 
-    expect(result.response).toStrictEqual({
-      id: 'test-id-from-model',
-      timestamp: new Date(10000),
-      modelId: 'test-response-model-id',
-      headers: {
-        'custom-response-header': 'response-header-value',
-      },
-    });
+    expect(result.response).toMatchSnapshot();
   });
 });
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -458,9 +458,6 @@ changing the tool call and result types in the result.
               type: 'text',
             });
           }
-
-          // update the last message in the prompt:
-          responseMessages[responseMessages.length - 1] = lastMessage;
         } else {
           responseMessages.push(
             ...toResponseMessages({

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -513,6 +513,7 @@ changing the tool call and result types in the result.
         response: {
           ...currentModelResponse.response,
           headers: currentModelResponse.rawResponse?.headers,
+          messages: responseMessages,
         },
         logprobs: currentModelResponse.logprobs,
         responseMessages,

--- a/packages/ai/core/generate-text/step-result.ts
+++ b/packages/ai/core/generate-text/step-result.ts
@@ -1,3 +1,4 @@
+import { CoreAssistantMessage, CoreToolMessage } from '../prompt/message';
 import { CoreTool } from '../tool';
 import {
   CallWarning,
@@ -71,7 +72,13 @@ Additional request information.
   /**
 Additional response information.
 */
-  readonly response: LanguageModelResponseMetadata;
+  readonly response: LanguageModelResponseMetadata & {
+    /**
+The response messages that were generated during the call. It consists of an assistant message,
+potentially containing tool calls.
+*/
+    readonly messages: Array<CoreAssistantMessage | CoreToolMessage>;
+  };
 
   /**
 Additional provider-specific metadata. They are passed through

--- a/packages/ai/core/generate-text/step-result.ts
+++ b/packages/ai/core/generate-text/step-result.ts
@@ -3,7 +3,7 @@ import {
   CallWarning,
   FinishReason,
   LanguageModelRequestMetadata,
-  LanguageModelResponseMetadataWithHeaders,
+  LanguageModelResponseMetadata,
   LogProbs,
   ProviderMetadata,
 } from '../types';
@@ -71,7 +71,7 @@ Additional request information.
   /**
 Additional response information.
 */
-  readonly response: LanguageModelResponseMetadataWithHeaders;
+  readonly response: LanguageModelResponseMetadata;
 
   /**
 Additional provider-specific metadata. They are passed through

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -10,11 +10,13 @@ import {
   CallWarning,
   FinishReason,
   LanguageModelRequestMetadata,
-  LanguageModelResponseMetadata,
-  LanguageModelResponseMetadataWithHeaders,
   LogProbs,
   ProviderMetadata,
 } from '../types';
+import {
+  LanguageModelResponseMetadata,
+  LanguageModelResponseMetadataWithHeaders,
+} from '../types/language-model-response-metadata';
 import { LanguageModelUsage } from '../types/usage';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { StepResult } from './step-result';
@@ -88,14 +90,7 @@ Optional raw response data.
   };
 
   /**
-The response messages that were generated during the call. It consists of an assistant message,
-potentially containing tool calls.
-
-When there are tool results, there is an additional tool message with the tool results that are available.
-If there are tools that do not have execute functions, they are not included in the tool results and
-need to be added separately.
-
-Resolved when the response is finished.
+@deprecated use `response.messages` instead.
      */
   readonly responseMessages: Promise<
     Array<CoreAssistantMessage | CoreToolMessage>

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1,7 +1,3 @@
-import {
-  LanguageModelV1Message,
-  LanguageModelV1Prompt,
-} from '@ai-sdk/provider';
 import { createIdGenerator } from '@ai-sdk/provider-utils';
 import { Span } from '@opentelemetry/api';
 import { ServerResponse } from 'node:http';
@@ -17,10 +13,7 @@ import {
 import { createResolvablePromise } from '../../util/create-resolvable-promise';
 import { retryWithExponentialBackoff } from '../../util/retry-with-exponential-backoff';
 import { CallSettings } from '../prompt/call-settings';
-import {
-  convertToLanguageModelMessage,
-  convertToLanguageModelPrompt,
-} from '../prompt/convert-to-language-model-prompt';
+import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
 import { prepareToolsAndToolChoice } from '../prompt/prepare-tools-and-tool-choice';
 import { Prompt } from '../prompt/prompt';
@@ -869,7 +862,9 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
                 usage: stepUsage,
                 experimental_providerMetadata: stepProviderMetadata,
                 logprobs: stepLogProbs,
-                response: stepResponse,
+                response: {
+                  ...stepResponse,
+                },
                 isContinued: nextStepType === 'continue',
               });
 
@@ -975,7 +970,9 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
                   usage: combinedUsage,
                   experimental_providerMetadata: stepProviderMetadata,
                   logprobs: stepLogProbs,
-                  response: stepResponse,
+                  response: {
+                    ...stepResponse,
+                  },
                 });
 
                 // close the stitchable stream

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1003,39 +1003,6 @@ class DefaultStreamTextResult<TOOLS extends Record<string, CoreTool>>
                   }),
                 );
 
-                // // Collect responseMessages from all steps:
-                // const responseMessages = stepResults.reduce<
-                //   Array<CoreAssistantMessage | CoreToolMessage>
-                // >((responseMessages, step) => {
-                //   if (step.stepType === 'continue') {
-                //     // continue step: update the last assistant message
-                //     // continue is only possible when there are no tool calls,
-                //     // so we can assume that there is a single last assistant message:
-                //     const lastResponseMessage =
-                //       responseMessages.pop() as CoreAssistantMessage;
-
-                //     if (typeof lastResponseMessage.content === 'string') {
-                //       lastResponseMessage.content += step.text;
-                //     } else {
-                //       lastResponseMessage.content.push({
-                //         text: step.text,
-                //         type: 'text',
-                //       });
-                //     }
-
-                //     return [...responseMessages, lastResponseMessage];
-                //   }
-
-                //   return [
-                //     ...responseMessages,
-                //     ...toResponseMessages({
-                //       text: step.text,
-                //       toolCalls: step.toolCalls,
-                //       toolResults: step.toolResults,
-                //     }),
-                //   ];
-                // }, []);
-
                 // resolve promises:
                 resolveUsage(combinedUsage);
                 resolveFinishReason(stepFinishReason!);

--- a/packages/ai/core/types/index.ts
+++ b/packages/ai/core/types/index.ts
@@ -5,6 +5,13 @@ import type {
 
 export * from './embedding-model';
 export * from './language-model';
+
+export type { LanguageModelRequestMetadata } from './language-model-request-metadata';
+export type {
+  LanguageModelResponseMetadata,
+  LanguageModelResponseMetadataWithHeaders,
+} from './language-model-response-metadata';
+
 export type { Provider } from './provider';
 export type { ProviderMetadata } from './provider-metadata';
 

--- a/packages/ai/core/types/language-model-request-metadata.ts
+++ b/packages/ai/core/types/language-model-request-metadata.ts
@@ -1,0 +1,6 @@
+export type LanguageModelRequestMetadata = {
+  /**
+  Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).
+     */
+  body?: string;
+};

--- a/packages/ai/core/types/language-model-response-metadata.ts
+++ b/packages/ai/core/types/language-model-response-metadata.ts
@@ -1,0 +1,27 @@
+export type LanguageModelResponseMetadata = {
+  /**
+  ID for the generated response.
+     */
+  id: string;
+
+  /**
+  Timestamp for the start of the generated response.
+  */
+  timestamp: Date;
+
+  /**
+  The ID of the response model that was used to generate the response.
+  */
+  modelId: string;
+
+  /**
+Response headers.
+     */
+  headers?: Record<string, string>;
+};
+
+/**
+@deprecated Use `LanguageModelResponseMetadata` instead.
+ */
+export type LanguageModelResponseMetadataWithHeaders =
+  LanguageModelResponseMetadata;

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -58,32 +58,3 @@ export type CoreToolChoice<TOOLS extends Record<string, unknown>> =
   | 'none'
   | 'required'
   | { type: 'tool'; toolName: keyof TOOLS };
-
-export type LanguageModelResponseMetadata = {
-  /**
-ID for the generated response.
-   */
-  id: string;
-
-  /**
-Timestamp for the start of the generated response.
-*/
-  timestamp: Date;
-
-  /**
-The ID of the response model that was used to generate the response.
-*/
-  modelId: string;
-};
-
-export type LanguageModelResponseMetadataWithHeaders =
-  LanguageModelResponseMetadata & {
-    headers?: Record<string, string>;
-  };
-
-export type LanguageModelRequestMetadata = {
-  /**
-Raw request HTTP body that was sent to the provider API as a string (JSON should be stringified).
-   */
-  body?: string;
-};


### PR DESCRIPTION
## Summary
* Add headers to `LanguageModelMetadata` and deprecate `LanguageModelResponseMetadata`
* Add `messages` to `response` for `streamText` and `generatetext`, and deprecate `responseMessages`
* Add `response.messages` to `StepResult` (messages for each step are availalbe)
* Refactor implementation to use changing `responseMessages` and fixed `initialPrompt`

## Tasks

- [x] implementation
- [x] reference docs updates `generateText`
- [x] reference docs updates `streamText`
- [x] changeset