### PR TITLE
fix (docs): updating rag to match latest code to guide

### DIFF
--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -355,7 +355,7 @@ export const createResource = async (input: NewResourceParams) => {
       .values({ content: contentWithoutLineBreaks })
       .returning();
 
-    const embeddings = await generateEmbeddings(content);
+    const embeddings = await generateEmbeddings(contentWithoutLineBreaks);
     await db.insert(embeddingsTable).values(
       embeddings.map(embedding => ({
         resourceId: resource.id,

--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -315,9 +315,10 @@ export const createResource = async (input: NewResourceParams) => {
   try {
     const { content } = insertResourceSchema.parse(input);
 
+    const contentWithoutLineBreaks = payload.content.replace("\n", " ");
     const [resource] = await db
       .insert(resources)
-      .values({ content })
+      .values({ content: contentWithoutLineBreaks })
       .returning();
 
     return 'Resource successfully created.';
@@ -332,7 +333,7 @@ This function is a [Server Action](https://nextjs.org/docs/app/building-your-app
 
 Update the file with the following code:
 
-```tsx filename="lib/actions/resources.ts" highlight="9-10,21-27,29"
+```tsx filename="lib/actions/resources.ts" highlight="9-10,22-28,30"
 'use server';
 
 import {
@@ -348,9 +349,10 @@ export const createResource = async (input: NewResourceParams) => {
   try {
     const { content } = insertResourceSchema.parse(input);
 
+    const contentWithoutLineBreaks = payload.content.replace("\n", " ");
     const [resource] = await db
       .insert(resources)
-      .values({ content })
+      .values({ content: contentWithoutLineBreaks })
       .returning();
 
     const embeddings = await generateEmbeddings(content);

--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -315,7 +315,7 @@ export const createResource = async (input: NewResourceParams) => {
   try {
     const { content } = insertResourceSchema.parse(input);
 
-    const contentWithoutLineBreaks = payload.content.replace("\n", " ");
+    const contentWithoutLineBreaks = payload.content.replace('\n', ' ');
     const [resource] = await db
       .insert(resources)
       .values({ content: contentWithoutLineBreaks })
@@ -349,7 +349,7 @@ export const createResource = async (input: NewResourceParams) => {
   try {
     const { content } = insertResourceSchema.parse(input);
 
-    const contentWithoutLineBreaks = payload.content.replace("\n", " ");
+    const contentWithoutLineBreaks = payload.content.replace('\n', ' ');
     const [resource] = await db
       .insert(resources)
       .values({ content: contentWithoutLineBreaks })


### PR DESCRIPTION
As I followed through the guide, the latest code didn't matched the docs. This updates it to match it properly.

### Latest Code
<img width="712" alt="image" src="https://github.com/user-attachments/assets/a3744d69-758e-4c05-9f16-6f42ef08d178">

### Latest in the [docs](https://sdk.vercel.ai/docs/guides/rag-chatbot#update-server-action)
<img width="844" alt="CleanShot 2024-10-24 at 10 30 24@2x" src="https://github.com/user-attachments/assets/326f5d8e-9910-48ec-a774-bf5365b8d018">
