### PR TITLE
chore (package): Specify Node version and document versions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,9 @@ To set up the repository on your local machine, follow these steps:
 
 1. **Fork the Repository**: Make a copy of the repository to your GitHub account.
 2. **Clone the Repository**: Clone the repository to your local machine, e.g. using `git clone`.
-3. **Install pnpm**: If you haven't already, install `pnpm`. You can do this by running `npm install -g pnpm` if you're using npm. Alternatively, if you're using Homebrew (Mac), you can run `brew install pnpm`.
-4. **Install Dependencies**: Navigate to the project directory and run `pnpm install` to install all necessary dependencies.
+3. **Install Node**: If you haven't already, install Node `v18` or `v20`. We recommend managing Node installation and versions with [fnm](https://github.com/Schniz/fnm) or [nvm](https://github.com/nvm-sh/nvm).
+4. **Install pnpm**: If you haven't already, install `pnpm` `v8`. You can do this by running `npm install -g pnpm@8` if you're using npm. Alternatively, if you're using Homebrew (Mac), you can run `brew install pnpm@8`. For more see [the pnpm site](https://pnpm.io/installation).
+5. **Install Dependencies**: Navigate to the project directory and run `pnpm install` to install all necessary dependencies.
 
 ### Submitting Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "turbo": "^1.10.13",
     "vitest": "1.6.0"
   },
+  "engines": {
+    "node": "^18.0.0 || ^20.0.0"
+  },
   "homepage": "https://sdk.vercel.ai/docs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
chore (package): Specify Node version and document versions.

Contributing developers can unintentionally install and build with Node or
`pnpm` versions we don't officially support. Currently our CI runs with Node
v18 and v20, and we're using `pnpm` v8.

This change adds an `engines` field to the top level `package.json`
file. This will output a warning on install/build if the engine
version doesn't match the specified range.

The `pnpm` version is already specified in `packageManager` to reflect
the version we use in CI, although it is not enforced or warned if,
for example, the developer is on v9.

This change also updates contributing docs to note the supported Node
engine and `pnpm` versions.

We can consider for the future but choose not to pursue for now:
- placing `engine-strict=true` in the top level `.npmrc` to
  hard-fail on incompatible engine versions
- adding a preinstall/prebuild command that checks versions with
  more explicit failures, messaging, etc.
