### PR TITLE
feat: Add support for Google Gemini files and Google Storage on Vertex

### DIFF
--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -19,7 +19,8 @@
     "dotenv": "16.4.5",
     "mathjs": "12.4.2",
     "zod": "3.23.8",
-    "zod-to-json-schema": "3.23.2"
+    "zod-to-json-schema": "3.23.2",
+    "@google/generative-ai": "0.21.0"
   },
   "scripts": {
     "type-check": "tsc --noEmit"

--- a/examples/ai-core/src/generate-object/google-gemini-files.ts
+++ b/examples/ai-core/src/generate-object/google-gemini-files.ts
@@ -1,5 +1,5 @@
 import { GoogleAIFileManager } from '@google/generative-ai/server';
-import { google } from '../../../../packages/google';
+import { google } from '@ai-sdk/google';
 import { generateObject } from 'ai';
 import path from 'path';
 import 'dotenv/config';

--- a/examples/ai-core/src/generate-object/google-gemini-files.ts
+++ b/examples/ai-core/src/generate-object/google-gemini-files.ts
@@ -1,0 +1,47 @@
+import { GoogleAIFileManager } from '@google/generative-ai/server';
+import { google } from '../../../../packages/google';
+import { generateObject } from 'ai';
+import path from 'path';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const fileManager = new GoogleAIFileManager(
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY!,
+  );
+
+  const filePath = path.resolve(__dirname, '../../data/ai.pdf');
+
+  const geminiFile = await fileManager.uploadFile(filePath, {
+    name: `ai-${Math.random().toString(36).substring(7)}`,
+    mimeType: 'application/pdf',
+  });
+
+  const { object: summary } = await generateObject({
+    model: google('gemini-1.5-pro-latest'),
+    schema: z.object({
+      title: z.string(),
+      keyPoints: z.array(z.string()),
+    }),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Extract title and key points from the PDF.',
+          },
+          {
+            type: 'file',
+            data: geminiFile.file.uri,
+            mimeType: geminiFile.file.mimeType,
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(summary);
+}
+
+main().catch(console.error);

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -425,6 +425,7 @@ export async function generateObject<SCHEMA, RESULT>({
           const promptMessages = await convertToLanguageModelPrompt({
             prompt: standardPrompt,
             modelSupportsImageUrls: model.supportsImageUrls,
+            modelSupportsUrl: model.supportsUrl,
           });
 
           const generateResult = await retry(() =>
@@ -543,6 +544,7 @@ export async function generateObject<SCHEMA, RESULT>({
           const promptMessages = await convertToLanguageModelPrompt({
             prompt: validatedPrompt,
             modelSupportsImageUrls: model.supportsImageUrls,
+            modelSupportsUrl: model.supportsUrl,
           });
           const inputFormat = validatedPrompt.type;
 

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -456,6 +456,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
             prompt: await convertToLanguageModelPrompt({
               prompt: standardPrompt,
               modelSupportsImageUrls: model.supportsImageUrls,
+              modelSupportsUrl: model.supportsUrl,
             }),
             providerMetadata,
             abortSignal,
@@ -502,6 +503,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
             prompt: await convertToLanguageModelPrompt({
               prompt: validatedPrompt,
               modelSupportsImageUrls: model.supportsImageUrls,
+              modelSupportsUrl: model.supportsUrl,
             }),
             providerMetadata,
             abortSignal,

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -272,6 +272,7 @@ changing the tool call and result types in the result.
             messages: [...initialPrompt.messages, ...responseMessages],
           },
           modelSupportsImageUrls: model.supportsImageUrls,
+          modelSupportsUrl: model.supportsUrl,
         });
 
         currentModelResponse = await retry(() =>

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -318,6 +318,7 @@ need to be added separately.
             messages: [...initialPrompt.messages, ...responseMessages],
           },
           modelSupportsImageUrls: model.supportsImageUrls,
+          modelSupportsUrl: model.supportsUrl,
         });
 
         const {

--- a/packages/ai/core/middleware/wrap-language-model.test.ts
+++ b/packages/ai/core/middleware/wrap-language-model.test.ts
@@ -1,7 +1,6 @@
 import { LanguageModelV1CallOptions } from '@ai-sdk/provider';
 import { experimental_wrapLanguageModel } from '../middleware/wrap-language-model';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
-import exp from 'constants';
 
 it('should pass through model properties', () => {
   const wrappedModel = experimental_wrapLanguageModel({

--- a/packages/ai/core/middleware/wrap-language-model.test.ts
+++ b/packages/ai/core/middleware/wrap-language-model.test.ts
@@ -1,6 +1,7 @@
 import { LanguageModelV1CallOptions } from '@ai-sdk/provider';
 import { experimental_wrapLanguageModel } from '../middleware/wrap-language-model';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
+import exp from 'constants';
 
 it('should pass through model properties', () => {
   const wrappedModel = experimental_wrapLanguageModel({
@@ -148,4 +149,43 @@ it('should call wrapStream middleware', async () => {
     params,
     model: mockModel,
   });
+});
+
+it('should default to a model that does not support any native URLs', async () => {
+  const mockModel = new MockLanguageModelV1({
+    doGenerate: vi.fn().mockResolvedValue('mock result'),
+  });
+
+  const wrappedModel = experimental_wrapLanguageModel({
+    model: mockModel,
+    middleware: {},
+  });
+
+  if (wrappedModel.supportsUrl) {
+    expect(
+      wrappedModel.supportsUrl(new URL('https://example.com/test.jpg')),
+    ).toBe(false);
+  } else {
+    throw new Error('supportsUrl is not defined');
+  }
+});
+
+it('passes on supportsUrl when it is defined on the model', async () => {
+  const mockModel = new MockLanguageModelV1({
+    doGenerate: vi.fn().mockResolvedValue('mock result'),
+    supportsUrl: vi.fn().mockReturnValue(true),
+  });
+
+  const wrappedModel = experimental_wrapLanguageModel({
+    model: mockModel,
+    middleware: {},
+  });
+
+  if (wrappedModel.supportsUrl) {
+    expect(
+      wrappedModel.supportsUrl(new URL('https://example.com/test.jpg')),
+    ).toBe(true);
+  } else {
+    throw new Error('supportsUrl is not defined');
+  }
 });

--- a/packages/ai/core/middleware/wrap-language-model.ts
+++ b/packages/ai/core/middleware/wrap-language-model.ts
@@ -42,6 +42,7 @@ export const experimental_wrapLanguageModel = ({
 
     defaultObjectGenerationMode: model.defaultObjectGenerationMode,
     supportsImageUrls: model.supportsImageUrls,
+    supportsUrl: model.supportsUrl ? model.supportsUrl : () => false,
     supportsStructuredOutputs: model.supportsStructuredOutputs,
 
     async doGenerate(

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -89,7 +89,7 @@ describe('convertToLanguageModelPrompt', () => {
     });
 
     describe('file parts', () => {
-      it('should handle file parts with URL data', async () => {
+      it('should pass through URLs when the model supports a particular URL', async () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {
             type: 'messages',
@@ -107,6 +107,7 @@ describe('convertToLanguageModelPrompt', () => {
             ],
           },
           modelSupportsImageUrls: true,
+          modelSupportsUrl: () => true,
         });
 
         expect(result).toEqual([

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -124,6 +124,48 @@ describe('convertToLanguageModelPrompt', () => {
         ]);
       });
 
+      it('should download the URL as an asset when the model does not support a URL', async () => {
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            type: 'messages',
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: new URL('https://example.com/document.pdf'),
+                    mimeType: 'application/pdf',
+                  },
+                ],
+              },
+            ],
+          },
+          modelSupportsImageUrls: true,
+          modelSupportsUrl: () => false,
+          downloadImplementation: async ({ url }) => {
+            expect(url).toEqual(new URL('https://example.com/document.pdf'));
+            return {
+              data: new Uint8Array([0, 1, 2, 3]),
+              mimeType: 'application/pdf',
+            };
+          },
+        });
+
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mimeType: 'application/pdf',
+                data: convertUint8ArrayToBase64(new Uint8Array([0, 1, 2, 3])),
+              },
+            ],
+          },
+        ]);
+      });
+
       it('should handle file parts with base64 string data', async () => {
         const base64Data = 'SGVsbG8sIFdvcmxkIQ=='; // "Hello, World!" in base64
         const result = await convertToLanguageModelPrompt({

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -318,6 +318,85 @@ describe('convertToLanguageModelPrompt', () => {
         ]);
       });
 
+      it('should download files for user file parts with string URLs when model does not support the particular URL', async () => {
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            type: 'messages',
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: 'https://example.com/document.pdf',
+                    mimeType: 'application/pdf',
+                  },
+                ],
+              },
+            ],
+          },
+          modelSupportsImageUrls: false,
+          modelSupportsUrl: url =>
+            url.toString() !== 'https://example.com/document.pdf',
+          downloadImplementation: async ({ url }) => {
+            expect(url).toEqual(new URL('https://example.com/document.pdf'));
+            return {
+              data: new Uint8Array([0, 1, 2, 3]),
+              mimeType: 'application/pdf',
+            };
+          },
+        });
+
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mimeType: 'application/pdf',
+                data: convertUint8ArrayToBase64(new Uint8Array([0, 1, 2, 3])),
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('does not download URLs for user file parts for URL objects when model does support the URL', async () => {
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            type: 'messages',
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: new URL('https://example.com/document.pdf'),
+                    mimeType: 'application/pdf',
+                  },
+                ],
+              },
+            ],
+          },
+          modelSupportsImageUrls: false,
+          modelSupportsUrl: url =>
+            url.toString() === 'https://example.com/document.pdf',
+        });
+
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mimeType: 'application/pdf',
+                data: new URL('https://example.com/document.pdf'),
+              },
+            ],
+          },
+        ]);
+      });
+
       it('it should default to downloading the URL when the model does not provider a supportsUrl function', async () => {
         const result = await convertToLanguageModelPrompt({
           prompt: {

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -317,6 +317,47 @@ describe('convertToLanguageModelPrompt', () => {
           },
         ]);
       });
+
+      it('it should default to downloading the URL when the model does not provider a supportsUrl function', async () => {
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            type: 'messages',
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    data: 'https://example.com/document.pdf',
+                    mimeType: 'application/pdf',
+                  },
+                ],
+              },
+            ],
+          },
+          modelSupportsImageUrls: false,
+          downloadImplementation: async ({ url }) => {
+            expect(url).toEqual(new URL('https://example.com/document.pdf'));
+            return {
+              data: new Uint8Array([0, 1, 2, 3]),
+              mimeType: 'application/pdf',
+            };
+          },
+        });
+
+        expect(result).toEqual([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mimeType: 'application/pdf',
+                data: convertUint8ArrayToBase64(new Uint8Array([0, 1, 2, 3])),
+              },
+            ],
+          },
+        ]);
+      });
     });
 
     describe('provider metadata', async () => {

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -5,10 +5,6 @@ import {
   LanguageModelV1Prompt,
   LanguageModelV1TextPart,
 } from '@ai-sdk/provider';
-import {
-  convertUint8ArrayToBase64,
-  getErrorMessage,
-} from '@ai-sdk/provider-utils';
 import { download } from '../../util/download';
 import { CoreMessage } from '../prompt/message';
 import { detectImageMimeType } from '../util/detect-image-mimetype';
@@ -16,6 +12,7 @@ import { FilePart, ImagePart, TextPart } from './content-part';
 import {
   convertDataContentToBase64String,
   convertDataContentToUint8Array,
+  DataContent,
 } from './data-content';
 import { InvalidMessageRoleError } from './invalid-message-role-error';
 import { splitDataUrl } from './split-data-url';
@@ -24,16 +21,23 @@ import { StandardizedPrompt } from './standardize-prompt';
 export async function convertToLanguageModelPrompt({
   prompt,
   modelSupportsImageUrls = true,
+  modelSupportsUrl = () => false,
   downloadImplementation = download,
 }: {
   prompt: StandardizedPrompt;
   modelSupportsImageUrls: boolean | undefined;
+  modelSupportsUrl?: (url: URL) => boolean;
   downloadImplementation?: typeof download;
 }): Promise<LanguageModelV1Prompt> {
   const downloadedAssets =
-    modelSupportsImageUrls || prompt.messages == null
+    prompt.messages == null
       ? null
-      : await downloadAssets(prompt.messages, downloadImplementation);
+      : await downloadAssets(
+          prompt.messages,
+          downloadImplementation,
+          modelSupportsImageUrls,
+          modelSupportsUrl,
+        );
 
   const languageModelMessages: LanguageModelV1Prompt = [];
 
@@ -87,213 +91,7 @@ export function convertToLanguageModelMessage(
       return {
         role: 'user',
         content: message.content
-          .map(
-            (
-              part,
-            ):
-              | LanguageModelV1TextPart
-              | LanguageModelV1ImagePart
-              | LanguageModelV1FilePart => {
-              switch (part.type) {
-                case 'text': {
-                  return {
-                    type: 'text',
-                    text: part.text,
-                    providerMetadata: part.experimental_providerMetadata,
-                  };
-                }
-
-                case 'image': {
-                  if (part.image instanceof URL) {
-                    if (downloadedAssets == null) {
-                      return {
-                        type: 'image',
-                        image: part.image,
-                        mimeType: part.mimeType,
-                        providerMetadata: part.experimental_providerMetadata,
-                      };
-                    } else {
-                      const downloadedImage =
-                        downloadedAssets[part.image.toString()];
-                      return {
-                        type: 'image',
-                        image: downloadedImage.data,
-                        mimeType: part.mimeType ?? downloadedImage.mimeType,
-                        providerMetadata: part.experimental_providerMetadata,
-                      };
-                    }
-                  }
-
-                  // try to convert string image parts to urls
-                  if (typeof part.image === 'string') {
-                    try {
-                      const url = new URL(part.image);
-
-                      switch (url.protocol) {
-                        case 'http:':
-                        case 'https:': {
-                          if (downloadedAssets == null) {
-                            return {
-                              type: 'image',
-                              image: url,
-                              mimeType: part.mimeType,
-                              providerMetadata:
-                                part.experimental_providerMetadata,
-                            };
-                          } else {
-                            const downloadedImage =
-                              downloadedAssets[url.toString()];
-                            return {
-                              type: 'image',
-                              image: downloadedImage.data,
-                              mimeType:
-                                part.mimeType ?? downloadedImage.mimeType,
-                              providerMetadata:
-                                part.experimental_providerMetadata,
-                            };
-                          }
-                        }
-                        case 'data:': {
-                          try {
-                            const { mimeType, base64Content } = splitDataUrl(
-                              part.image,
-                            );
-
-                            if (mimeType == null || base64Content == null) {
-                              throw new Error('Invalid data URL format');
-                            }
-
-                            return {
-                              type: 'image',
-                              image:
-                                convertDataContentToUint8Array(base64Content),
-                              mimeType,
-                              providerMetadata:
-                                part.experimental_providerMetadata,
-                            };
-                          } catch (error) {
-                            throw new Error(
-                              `Error processing data URL: ${getErrorMessage(
-                                message,
-                              )}`,
-                            );
-                          }
-                        }
-                      }
-                    } catch (_ignored) {
-                      // not a URL
-                    }
-                  }
-
-                  const imageUint8 = convertDataContentToUint8Array(part.image);
-
-                  return {
-                    type: 'image',
-                    image: imageUint8,
-                    mimeType: part.mimeType ?? detectImageMimeType(imageUint8),
-                    providerMetadata: part.experimental_providerMetadata,
-                  };
-                }
-
-                case 'file': {
-                  if (part.data instanceof URL) {
-                    if (downloadedAssets == null) {
-                      return {
-                        type: 'file',
-                        data: part.data,
-                        mimeType: part.mimeType,
-                        providerMetadata: part.experimental_providerMetadata,
-                      };
-                    } else {
-                      const downloadedImage =
-                        downloadedAssets[part.data.toString()];
-                      return {
-                        type: 'file',
-                        data: convertUint8ArrayToBase64(downloadedImage.data),
-                        mimeType: part.mimeType ?? downloadedImage.mimeType,
-                        providerMetadata: part.experimental_providerMetadata,
-                      };
-                    }
-                  }
-
-                  // try to convert string image parts to urls
-                  if (typeof part.data === 'string') {
-                    try {
-                      const url = new URL(part.data);
-
-                      switch (url.protocol) {
-                        case 'http:':
-                        case 'https:': {
-                          if (downloadedAssets == null) {
-                            return {
-                              type: 'file',
-                              data: url,
-                              mimeType: part.mimeType,
-                              providerMetadata:
-                                part.experimental_providerMetadata,
-                            };
-                          } else {
-                            const downloadedImage =
-                              downloadedAssets[url.toString()];
-                            return {
-                              type: 'file',
-                              data: convertUint8ArrayToBase64(
-                                downloadedImage.data,
-                              ),
-                              mimeType:
-                                part.mimeType ?? downloadedImage.mimeType,
-                              providerMetadata:
-                                part.experimental_providerMetadata,
-                            };
-                          }
-                        }
-                        case 'data:': {
-                          try {
-                            const { mimeType, base64Content } = splitDataUrl(
-                              part.data,
-                            );
-
-                            if (mimeType == null || base64Content == null) {
-                              throw new Error('Invalid data URL format');
-                            }
-
-                            return {
-                              type: 'file',
-                              data: convertDataContentToBase64String(
-                                base64Content,
-                              ),
-                              mimeType,
-                              providerMetadata:
-                                part.experimental_providerMetadata,
-                            };
-                          } catch (error) {
-                            throw new Error(
-                              `Error processing data URL: ${getErrorMessage(
-                                message,
-                              )}`,
-                            );
-                          }
-                        }
-                      }
-                    } catch (_ignored) {
-                      // not a URL
-                    }
-                  }
-
-                  const imageBase64 = convertDataContentToBase64String(
-                    part.data,
-                  );
-
-                  return {
-                    type: 'file',
-                    data: imageBase64,
-                    mimeType: part.mimeType,
-                    providerMetadata: part.experimental_providerMetadata,
-                  };
-                }
-              }
-            },
-          )
+          .map(part => convertPartToLanguageModelPart(part, downloadedAssets))
           // remove empty text parts:
           .filter(part => part.type !== 'text' || part.text !== ''),
         providerMetadata: message.experimental_providerMetadata,
@@ -354,6 +152,8 @@ export function convertToLanguageModelMessage(
 async function downloadAssets(
   messages: CoreMessage[],
   downloadImplementation: typeof download,
+  modelSupportsImageUrls: boolean | undefined,
+  modelSupportsUrl: (url: URL) => boolean,
 ): Promise<Record<string, { mimeType: string | undefined; data: Uint8Array }>> {
   const urls = messages
     .filter(message => message.role === 'user')
@@ -366,6 +166,14 @@ async function downloadAssets(
       (part): part is ImagePart | FilePart =>
         part.type === 'image' || part.type === 'file',
     )
+    /**
+     * Filter out image parts if the model supports image URLs, before letting it
+     * decide if it supports a particular URL.
+     */
+    .filter(
+      (part): part is ImagePart | FilePart =>
+        !(part.type === 'image' && modelSupportsImageUrls === true),
+    )
     .map(part => (part.type === 'image' ? part.image : part.data))
     .map(part =>
       // support string urls:
@@ -374,7 +182,11 @@ async function downloadAssets(
         ? new URL(part)
         : part,
     )
-    .filter((image): image is URL => image instanceof URL);
+    .filter((image): image is URL => image instanceof URL)
+    /**
+     * Filter out URLs that the model supports natively, so we don't download them.
+     */
+    .filter(url => !modelSupportsUrl(url));
 
   // download in parallel:
   const downloadedImages = await Promise.all(
@@ -387,4 +199,132 @@ async function downloadAssets(
   return Object.fromEntries(
     downloadedImages.map(({ url, data }) => [url.toString(), data]),
   );
+}
+
+/**
+ * Convert part of a message to a LanguageModelV1Part.
+ * @param part The part to convert.
+ * @param downloadedAssets A map of URLs to their downloaded data. Only
+ *  available if the model does not support URLs, null otherwise.
+ *
+ * @returns The converted part.
+ */
+function convertPartToLanguageModelPart(
+  part: TextPart | ImagePart | FilePart,
+  downloadedAssets: Record<
+    string,
+    { mimeType: string | undefined; data: Uint8Array }
+  > | null,
+):
+  | LanguageModelV1TextPart
+  | LanguageModelV1ImagePart
+  | LanguageModelV1FilePart {
+  if (part.type === 'text') {
+    return {
+      type: 'text',
+      text: part.text,
+      providerMetadata: part.experimental_providerMetadata,
+    };
+  }
+
+  const type = part.type;
+  let mimeType: string | undefined = part.mimeType;
+  let data: DataContent | URL;
+  let content: URL | ArrayBuffer | string;
+  let normalizedData: Uint8Array | URL;
+
+  switch (type) {
+    case 'image':
+      data = part.image;
+      break;
+    case 'file':
+      data = part.data;
+      break;
+    default:
+      throw new Error(`Unsupported part type: ${type}`);
+  }
+
+  // Attempt to create a URL from the data. If it fails, we can assume the data
+  // is not a URL and likely some other sort of data.
+  try {
+    content = typeof data === 'string' ? new URL(data) : data;
+  } catch (error) {
+    content = data;
+  }
+
+  // If we successfully created a URL, we can use that to normalize the data
+  // either by passing it through or converting normalizing the base64 content
+  // to a Uint8Array.
+  if (content instanceof URL) {
+    // If the content is a data URL, we want to convert that to a Uint8Array
+    if (content.protocol === 'data:') {
+      const { mimeType: dataUrlMimeType, base64Content } = splitDataUrl(
+        content.toString(),
+      );
+
+      if (dataUrlMimeType == null || base64Content == null) {
+        throw new Error(`Invalid data URL format in part ${type}`);
+      }
+
+      mimeType = dataUrlMimeType;
+      normalizedData = convertDataContentToUint8Array(base64Content);
+    } else {
+      /**
+       * If the content is a URL, we should first see if it was downloaded. And if not,
+       * we can let the model decide if it wants to support the URL. This also allows
+       * for non-HTTP URLs to be passed through (e.g. gs://).
+       */
+      const downloadedFile = downloadedAssets?.[content.toString()];
+      if (downloadedFile) {
+        normalizedData = downloadedFile.data;
+
+        if (!mimeType) {
+          mimeType = downloadedFile.mimeType;
+        }
+      } else {
+        normalizedData = content;
+      }
+    }
+  } else {
+    // Since we know know the content is not a URL, we can attempt to normalize the data
+    // assuming it is some sort of data.
+    normalizedData = convertDataContentToUint8Array(content);
+  }
+
+  // Now that we have the normalized data either as a URL or a Uint8Array,
+  // we can create the LanguageModelV1Part.
+  switch (type) {
+    case 'image':
+      // We give a best effort to detect the mime type if it is not provided.
+      // otherwise, we use the provided mime type.
+      if (!mimeType && normalizedData instanceof Uint8Array) {
+        mimeType = detectImageMimeType(normalizedData);
+      }
+
+      if (!mimeType) {
+        mimeType = part.mimeType;
+      }
+
+      return {
+        type: 'image',
+        image: normalizedData,
+        mimeType: mimeType,
+        providerMetadata: part.experimental_providerMetadata,
+      };
+    case 'file':
+      // We should have a mimeType at this point, if not, throw an error.
+      if (!mimeType) {
+        throw new Error('Mime type is missing for file');
+      }
+
+      return {
+        type: 'file',
+        data:
+          normalizedData instanceof Uint8Array
+            ? convertDataContentToBase64String(normalizedData)
+            : normalizedData,
+        mimeType: mimeType,
+        providerMetadata: part.experimental_providerMetadata,
+      };
+  }
 }

--- a/packages/ai/core/test/mock-language-model-v1.ts
+++ b/packages/ai/core/test/mock-language-model-v1.ts
@@ -6,6 +6,7 @@ export class MockLanguageModelV1 implements LanguageModelV1 {
   readonly provider: LanguageModelV1['provider'];
   readonly modelId: LanguageModelV1['modelId'];
 
+  supportsUrl: LanguageModelV1['supportsUrl'];
   doGenerate: LanguageModelV1['doGenerate'];
   doStream: LanguageModelV1['doStream'];
 
@@ -14,6 +15,7 @@ export class MockLanguageModelV1 implements LanguageModelV1 {
   constructor({
     provider = 'mock-provider',
     modelId = 'mock-model-id',
+    supportsUrl = undefined,
     doGenerate = notImplemented,
     doStream = notImplemented,
     defaultObjectGenerationMode = undefined,
@@ -21,6 +23,7 @@ export class MockLanguageModelV1 implements LanguageModelV1 {
   }: {
     provider?: LanguageModelV1['provider'];
     modelId?: LanguageModelV1['modelId'];
+    supportsUrl?: LanguageModelV1['supportsUrl'];
     doGenerate?: LanguageModelV1['doGenerate'];
     doStream?: LanguageModelV1['doStream'];
     defaultObjectGenerationMode?: LanguageModelV1['defaultObjectGenerationMode'];
@@ -30,6 +33,7 @@ export class MockLanguageModelV1 implements LanguageModelV1 {
     this.modelId = modelId;
     this.doGenerate = doGenerate;
     this.doStream = doStream;
+    this.supportsUrl = supportsUrl;
 
     this.defaultObjectGenerationMode = defaultObjectGenerationMode;
     this.supportsStructuredOutputs = supportsStructuredOutputs;

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -101,7 +101,7 @@
     "@anthropic-ai/sdk": "0.18.0",
     "@aws-sdk/client-bedrock-runtime": "3.451.0",
     "@edge-runtime/vm": "^3.2.0",
-    "@google/generative-ai": "0.1.1",
+    "@google/generative-ai": "0.21.0",
     "@huggingface/inference": "2.6.4",
     "@mistralai/mistralai": "0.1.3",
     "@testing-library/jest-dom": "^6.4.5",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -101,7 +101,7 @@
     "@anthropic-ai/sdk": "0.18.0",
     "@aws-sdk/client-bedrock-runtime": "3.451.0",
     "@edge-runtime/vm": "^3.2.0",
-    "@google/generative-ai": "0.21.0",
+    "@google/generative-ai": "0.1.1",
     "@huggingface/inference": "2.6.4",
     "@mistralai/mistralai": "0.1.3",
     "@testing-library/jest-dom": "^6.4.5",

--- a/packages/ai/rsc/stream-ui/stream-ui.tsx
+++ b/packages/ai/rsc/stream-ui/stream-ui.tsx
@@ -268,6 +268,7 @@ functionality that can be fully encapsulated in the provider.
       prompt: await convertToLanguageModelPrompt({
         prompt: validatedPrompt,
         modelSupportsImageUrls: model.supportsImageUrls,
+        modelSupportsUrl: model.supportsUrl,
       }),
       providerMetadata,
       abortSignal,

--- a/packages/ai/streams/google-generative-ai-stream.ts
+++ b/packages/ai/streams/google-generative-ai-stream.ts
@@ -19,7 +19,7 @@ interface Content {
   parts: Part[];
 }
 
-type Part = TextPart | InlineDataPart | FileDataPart;
+type Part = TextPart | InlineDataPart;
 
 interface InlineDataPart {
   text?: never;
@@ -29,13 +29,6 @@ interface TextPart {
   text: string;
   inlineData?: never;
 }
-
-interface FileDataPart {
-  text?: never;
-  mimeType: string;
-  fileUri: string;
-}
-
 async function* streamable(response: {
   stream: AsyncIterable<GenerateContentResponse>;
 }) {

--- a/packages/ai/streams/google-generative-ai-stream.ts
+++ b/packages/ai/streams/google-generative-ai-stream.ts
@@ -19,7 +19,7 @@ interface Content {
   parts: Part[];
 }
 
-type Part = TextPart | InlineDataPart;
+type Part = TextPart | InlineDataPart | FileDataPart;
 
 interface InlineDataPart {
   text?: never;
@@ -28,6 +28,12 @@ interface InlineDataPart {
 interface TextPart {
   text: string;
   inlineData?: never;
+}
+
+interface FileDataPart {
+  text?: never;
+  mimeType: string;
+  fileUri: string;
 }
 
 async function* streamable(response: {

--- a/packages/google-vertex/src/convert-to-google-vertex-content-request.ts
+++ b/packages/google-vertex/src/convert-to-google-vertex-content-request.ts
@@ -38,33 +38,37 @@ export function convertToGoogleVertexContentRequest(
 
             case 'image': {
               if (part.image instanceof URL) {
-                // The AI SDK automatically downloads images for user image parts with URLs
-                throw new UnsupportedFunctionalityError({
-                  functionality: 'Image URLs in user messages',
+                parts.push({
+                  fileData: {
+                    mimeType: part.mimeType ?? 'image/jpeg',
+                    fileUri: part.image.toString(),
+                  },
+                });
+              } else {
+                parts.push({
+                  inlineData: {
+                    mimeType: part.mimeType ?? 'image/jpeg',
+                    data: convertUint8ArrayToBase64(part.image),
+                  },
                 });
               }
-
-              parts.push({
-                inlineData: {
-                  mimeType: part.mimeType ?? 'image/jpeg',
-                  data: convertUint8ArrayToBase64(part.image),
-                },
-              });
 
               break;
             }
 
             case 'file': {
               if (part.data instanceof URL) {
-                // The AI SDK automatically downloads files for user file parts with URLs
-                throw new UnsupportedFunctionalityError({
-                  functionality: 'File URLs in user messages',
+                parts.push({
+                  fileData: {
+                    mimeType: part.mimeType,
+                    fileUri: part.data.toString(),
+                  },
+                });
+              } else {
+                parts.push({
+                  inlineData: { mimeType: part.mimeType, data: part.data },
                 });
               }
-
-              parts.push({
-                inlineData: { mimeType: part.mimeType, data: part.data },
-              });
 
               break;
             }

--- a/packages/google-vertex/src/google-vertex-language-model.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.ts
@@ -207,6 +207,14 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
     }
   }
 
+  supportsUrl(url: URL): boolean {
+    if (url.protocol === 'gs:') {
+      return true;
+    }
+
+    return false;
+  }
+
   async doGenerate(
     options: Parameters<LanguageModelV1['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {

--- a/packages/google-vertex/src/google-vertex-language-model.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.ts
@@ -208,11 +208,7 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
   }
 
   supportsUrl(url: URL): boolean {
-    if (url.protocol === 'gs:') {
-      return true;
-    }
-
-    return false;
+    return url.protocol === 'gs:';
   }
 
   async doGenerate(

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -35,6 +35,34 @@ const provider = createGoogleGenerativeAI({
 });
 const model = provider.chat('gemini-pro');
 
+describe('supportsUrl', () => {
+  it('should return false if it is not a Gemini files URL', () => {
+    if (model.supportsUrl) {
+      // Check if the method is defined
+      expect(
+        model.supportsUrl(new URL('https://example.com/foo/bar')),
+      ).toStrictEqual(false);
+    } else {
+      throw new Error('supportsUrl method is not defined');
+    }
+  });
+
+  it('should return true if it is a Gemini files URL', () => {
+    expect(model.supportsUrl).toBeDefined();
+    if (model.supportsUrl) {
+      expect(
+        model.supportsUrl(
+          new URL(
+            'https://generativelanguage.googleapis.com/v1beta/files/00000000-00000000-00000000-00000000',
+          ),
+        ),
+      ).toStrictEqual(true);
+    } else {
+      throw new Error('supportsUrl method is not defined');
+    }
+  });
+});
+
 describe('doGenerate', () => {
   const prepareJsonResponse = ({
     content = '',

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -179,6 +179,18 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
     }
   }
 
+  supportsUrl(url: URL): boolean {
+    if (
+      url
+        .toString()
+        .startsWith('https://generativelanguage.googleapis.com/v1beta/files/')
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   async doGenerate(
     options: Parameters<LanguageModelV1['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -180,15 +180,9 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
   }
 
   supportsUrl(url: URL): boolean {
-    if (
-      url
-        .toString()
-        .startsWith('https://generativelanguage.googleapis.com/v1beta/files/')
-    ) {
-      return true;
-    }
-
-    return false;
+    return url
+      .toString()
+      .startsWith('https://generativelanguage.googleapis.com/v1beta/files/');
   }
 
   async doGenerate(

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -67,6 +67,16 @@ Defaults to `false`.
   readonly supportsStructuredOutputs?: boolean;
 
   /**
+   * Checks if the model supports the given URL in the context of a language model call where a URL is
+   * passed as a file part. If the model does not support the URL, the AI SDK will download the file
+   * and pass the file data to the model.
+   *
+   * Default to `false`.
+   * @param url
+   */
+  supportsUrl?(url: URL): boolean;
+
+  /**
 Generates a language model output (non-streaming).
 
 Naming: "do" prefix to prevent accidental direct usage of the method

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1045,8 +1045,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
       '@google/generative-ai':
-        specifier: 0.1.1
-        version: 0.1.1
+        specifier: 0.21.0
+        version: 0.21.0
       '@huggingface/inference':
         specifier: 2.6.4
         version: 2.6.4
@@ -6061,8 +6061,8 @@ packages:
       - supports-color
     dev: true
 
-  /@google/generative-ai@0.1.1:
-    resolution: {integrity: sha512-cbzKa8mT9YkTrT4XUuENIuvlqiJjwDgcD2Ks4L99Az9dWLgdXn8xnETEAZLOpqzoGx+1PuATZqlUnVRAeLbMgA==}
+  /@google/generative-ai@0.21.0:
+    resolution: {integrity: sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==}
     engines: {node: '>=18.0.0'}
     dev: true
 
@@ -7610,7 +7610,7 @@ packages:
       semver: 7.6.2
       simple-git: 3.25.0
       sirv: 2.0.4
-      unimport: 3.7.2(rollup@4.18.0)
+      unimport: 3.7.2
       vite: 5.3.3(@types/node@18.18.9)
       vite-plugin-inspect: 0.8.4(@nuxt/kit@3.12.3)(vite@5.3.3)
       vite-plugin-vue-inspector: 5.1.2(vite@5.3.3)
@@ -7645,7 +7645,7 @@ packages:
       semver: 7.6.3
       ufo: 1.5.3
       unctx: 2.3.1
-      unimport: 3.7.2(rollup@4.18.0)
+      unimport: 3.7.2
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -7667,7 +7667,7 @@ packages:
       std-env: 3.7.0
       ufo: 1.5.3
       uncrypto: 0.1.3
-      unimport: 3.7.2(rollup@4.18.0)
+      unimport: 3.7.2
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -7712,7 +7712,7 @@ packages:
       vue: ^3.3.4
     dependencies:
       '@nuxt/kit': 3.12.3(magicast@0.3.4)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.18.0)
+      '@rollup/plugin-replace': 5.0.7
       '@vitejs/plugin-vue': 5.0.5(vite@5.3.3)(vue@3.4.31)
       '@vitejs/plugin-vue-jsx': 4.0.0(vite@5.3.3)(vue@3.4.31)
       autoprefixer: 10.4.20(postcss@8.4.47)
@@ -9492,6 +9492,19 @@ packages:
       magic-string: 0.30.10
       rollup: 4.18.0
 
+  /@rollup/plugin-replace@5.0.7:
+    resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      magic-string: 0.30.10
+    dev: true
+
   /@rollup/plugin-replace@5.0.7(rollup@4.18.0):
     resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
     engines: {node: '>=14.0.0'}
@@ -9540,7 +9553,6 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.29.4
-    dev: false
 
   /@rollup/pluginutils@5.1.0(rollup@4.18.0):
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
@@ -12615,7 +12627,7 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.24.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       '@vue/compiler-sfc': 3.4.31
       ast-kit: 0.12.2
       local-pkg: 0.5.0
@@ -21259,7 +21271,7 @@ packages:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.2(rollup@4.18.0)
+      unimport: 3.7.2
       unplugin: 1.11.0
       unplugin-vue-router: 0.10.0(vue-router@4.4.0)(vue@3.4.31)
       unstorage: 1.10.2(ioredis@5.3.2)
@@ -25484,6 +25496,26 @@ packages:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
 
+  /unimport@3.7.2:
+    resolution: {integrity: sha512-91mxcZTadgXyj3lFWmrGT8GyoRHWuE5fqPOjg5RVtF6vj+OfM5G6WCzXjuYtSgELE5ggB34RY4oiCSEP8I3AHw==}
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      acorn: 8.12.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      fast-glob: 3.3.2
+      local-pkg: 0.5.0
+      magic-string: 0.30.10
+      mlly: 1.7.1
+      pathe: 1.1.2
+      pkg-types: 1.1.1
+      scule: 1.3.0
+      strip-literal: 2.1.0
+      unplugin: 1.11.0
+    transitivePeerDependencies:
+      - rollup
+    dev: true
+
   /unimport@3.7.2(rollup@4.18.0):
     resolution: {integrity: sha512-91mxcZTadgXyj3lFWmrGT8GyoRHWuE5fqPOjg5RVtF6vj+OfM5G6WCzXjuYtSgELE5ggB34RY4oiCSEP8I3AHw==}
     dependencies:
@@ -25530,7 +25562,7 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.24.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       '@vue-macros/common': 1.10.4(vue@3.4.31)
       ast-walker-scope: 0.6.1
       chokidar: 3.6.0
@@ -26027,7 +26059,7 @@ packages:
         optional: true
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       debug: 4.3.5
       error-stack-parser-es: 0.1.4
       fs-extra: 11.2.0
@@ -26052,7 +26084,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.10
       '@nuxt/kit': 3.12.3(magicast@0.3.4)
-      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       debug: 4.3.5
       error-stack-parser-es: 0.1.4
       fs-extra: 11.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@ai-sdk/openai':
         specifier: latest
         version: link:../../packages/openai
+      '@google/generative-ai':
+        specifier: 0.21.0
+        version: 0.21.0
       '@opentelemetry/auto-instrumentations-node':
         specifier: 0.47.0
         version: 0.47.0(@opentelemetry/api@1.9.0)
@@ -6064,7 +6067,6 @@ packages:
   /@google/generative-ai@0.21.0:
     resolution: {integrity: sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==}
     engines: {node: '>=18.0.0'}
-    dev: true
 
   /@grpc/grpc-js@1.10.10:
     resolution: {integrity: sha512-HPa/K5NX6ahMoeBv15njAc/sfF4/jmiXLar9UlC2UfHFKZzsCVLc3wbe7+7qua7w9VPh2/L6EBxyAV7/E8Wftg==}
@@ -7610,7 +7612,7 @@ packages:
       semver: 7.6.2
       simple-git: 3.25.0
       sirv: 2.0.4
-      unimport: 3.7.2
+      unimport: 3.7.2(rollup@4.18.0)
       vite: 5.3.3(@types/node@18.18.9)
       vite-plugin-inspect: 0.8.4(@nuxt/kit@3.12.3)(vite@5.3.3)
       vite-plugin-vue-inspector: 5.1.2(vite@5.3.3)
@@ -7645,7 +7647,7 @@ packages:
       semver: 7.6.3
       ufo: 1.5.3
       unctx: 2.3.1
-      unimport: 3.7.2
+      unimport: 3.7.2(rollup@4.18.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -7667,7 +7669,7 @@ packages:
       std-env: 3.7.0
       ufo: 1.5.3
       uncrypto: 0.1.3
-      unimport: 3.7.2
+      unimport: 3.7.2(rollup@4.18.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -7712,7 +7714,7 @@ packages:
       vue: ^3.3.4
     dependencies:
       '@nuxt/kit': 3.12.3(magicast@0.3.4)
-      '@rollup/plugin-replace': 5.0.7
+      '@rollup/plugin-replace': 5.0.7(rollup@4.18.0)
       '@vitejs/plugin-vue': 5.0.5(vite@5.3.3)(vue@3.4.31)
       '@vitejs/plugin-vue-jsx': 4.0.0(vite@5.3.3)(vue@3.4.31)
       autoprefixer: 10.4.20(postcss@8.4.47)
@@ -9492,19 +9494,6 @@ packages:
       magic-string: 0.30.10
       rollup: 4.18.0
 
-  /@rollup/plugin-replace@5.0.7:
-    resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      magic-string: 0.30.10
-    dev: true
-
   /@rollup/plugin-replace@5.0.7(rollup@4.18.0):
     resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
     engines: {node: '>=14.0.0'}
@@ -9553,6 +9542,7 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.29.4
+    dev: false
 
   /@rollup/pluginutils@5.1.0(rollup@4.18.0):
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
@@ -12627,7 +12617,7 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.24.7
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
       '@vue/compiler-sfc': 3.4.31
       ast-kit: 0.12.2
       local-pkg: 0.5.0
@@ -21271,7 +21261,7 @@ packages:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.2
+      unimport: 3.7.2(rollup@4.18.0)
       unplugin: 1.11.0
       unplugin-vue-router: 0.10.0(vue-router@4.4.0)(vue@3.4.31)
       unstorage: 1.10.2(ioredis@5.3.2)
@@ -25122,7 +25112,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.4.31)
+      postcss-load-config: 4.0.1(postcss@8.4.38)
       resolve-from: 5.0.0
       rollup: 4.14.1
       source-map: 0.8.0-beta.0
@@ -25496,26 +25486,6 @@ packages:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
 
-  /unimport@3.7.2:
-    resolution: {integrity: sha512-91mxcZTadgXyj3lFWmrGT8GyoRHWuE5fqPOjg5RVtF6vj+OfM5G6WCzXjuYtSgELE5ggB34RY4oiCSEP8I3AHw==}
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      acorn: 8.12.0
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.1.1
-      scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.11.0
-    transitivePeerDependencies:
-      - rollup
-    dev: true
-
   /unimport@3.7.2(rollup@4.18.0):
     resolution: {integrity: sha512-91mxcZTadgXyj3lFWmrGT8GyoRHWuE5fqPOjg5RVtF6vj+OfM5G6WCzXjuYtSgELE5ggB34RY4oiCSEP8I3AHw==}
     dependencies:
@@ -25562,7 +25532,7 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.24.7
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
       '@vue-macros/common': 1.10.4(vue@3.4.31)
       ast-walker-scope: 0.6.1
       chokidar: 3.6.0
@@ -26059,7 +26029,7 @@ packages:
         optional: true
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
       debug: 4.3.5
       error-stack-parser-es: 0.1.4
       fs-extra: 11.2.0
@@ -26084,7 +26054,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.10
       '@nuxt/kit': 3.12.3(magicast@0.3.4)
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
       debug: 4.3.5
       error-stack-parser-es: 0.1.4
       fs-extra: 11.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1048,8 +1048,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
       '@google/generative-ai':
-        specifier: 0.21.0
-        version: 0.21.0
+        specifier: 0.1.1
+        version: 0.1.1
       '@huggingface/inference':
         specifier: 2.6.4
         version: 2.6.4
@@ -6064,9 +6064,15 @@ packages:
       - supports-color
     dev: true
 
+  /@google/generative-ai@0.1.1:
+    resolution: {integrity: sha512-cbzKa8mT9YkTrT4XUuENIuvlqiJjwDgcD2Ks4L99Az9dWLgdXn8xnETEAZLOpqzoGx+1PuATZqlUnVRAeLbMgA==}
+    engines: {node: '>=18.0.0'}
+    dev: true
+
   /@google/generative-ai@0.21.0:
     resolution: {integrity: sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==}
     engines: {node: '>=18.0.0'}
+    dev: false
 
   /@grpc/grpc-js@1.10.10:
     resolution: {integrity: sha512-HPa/K5NX6ahMoeBv15njAc/sfF4/jmiXLar9UlC2UfHFKZzsCVLc3wbe7+7qua7w9VPh2/L6EBxyAV7/E8Wftg==}
@@ -25112,7 +25118,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.4.38)
+      postcss-load-config: 4.0.1(postcss@8.4.31)
       resolve-from: 5.0.0
       rollup: 4.14.1
       source-map: 0.8.0-beta.0

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
         "DEEPSEEK_API_KEY",
         "FIREWORKS_API_KEY",
         "GOOGLE_API_KEY",
+        "GOOGLE_GENERATIVE_AI_API_KEY",
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
         "MISTRAL_API_KEY",


### PR DESCRIPTION
Currently the AI SDK does not support Gemini files https://ai.google.dev/api/files, which means that even though Gemini supports it, you cannot use files larger than a certain size or reuse files from previous requests.

When using Gemini files, the Generative AI SDK expects that the file part will look like the following:

```json
{
   "fileData": {
       "mimeType": "application/pdf",
       "fileUri": "https://generativelanguage.googleapis.com/v1beta/files/00000000-00000000-00000000-00000000"
   }
}
```

However, the current behavior of the SDK is to attempt to download any URL it sees. This of course fails here since the URL is not public. This results in a very cryptic error from the SDK and an unnecessary loss in functionality for the developer since passing through a URL is so trivial.

This PR addresses this shortcoming by:
- Adding generic support for models to opt-out of downloading assets if they support a URL.
- Opting out of asset downloading for certain URLs and supporting URLs as fileData for both Gemini and Vertex
- Simplifying the normalization of message parts after the assets are downloaded to improve readability and support non-downloaded URLs.

In the Vercel AI SDK the message part, using a Gemini file should now look like:
```js
{
   type: "file",
   data: "https://generativelanguage.googleapis.com/v1beta/files/00000000-00000000-00000000-00000000",
   mimeType: "application/pdf"
}
```


What isn't in this PR:
- A generic way to upload files to a provider.