### PR TITLE
feat (provider/bedrock): add file upload support

### DIFF
--- a/examples/ai-core/src/stream-text/amazon-bedrock-file.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-file.ts
@@ -1,0 +1,30 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { streamText } from 'ai';
+import 'dotenv/config';
+import fs from 'node:fs';
+
+async function main() {
+  const result = await streamText({
+    model: bedrock('anthropic.claude-3-haiku-20240307-v1:0'),
+    maxTokens: 512,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe the pdf in detail.' },
+          {
+            type: 'file',
+            data: fs.readFileSync('./data/ai.pdf'),
+            mimeType: 'application/pdf',
+          },
+        ],
+      },
+    ],
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+}
+
+main().catch(console.error);

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { convertToBedrockChatMessages } from './convert-to-bedrock-chat-messages';
 
 describe('system messages', () => {
@@ -21,7 +22,13 @@ describe('system messages', () => {
 });
 
 describe('user messages', () => {
-  it('should convert messages with image and text parts to multiple parts', async () => {
+  it('should convert messages with file, image, and text parts to multiple parts', async () => {
+    const fileData = new Uint8Array([0, 1, 2, 3]);
+    const fileBase64Data = Buffer.from(fileData).toString('base64');
+    const fileHash = crypto.createHash('sha256');
+    fileHash.update(fileBase64Data);
+    const fileName = fileHash.digest('hex');
+
     const { messages } = convertToBedrockChatMessages([
       {
         role: 'user',
@@ -31,6 +38,11 @@ describe('user messages', () => {
             type: 'image',
             image: new Uint8Array([0, 1, 2, 3]),
             mimeType: 'image/png',
+          },
+          {
+            type: 'file',
+            data: fileBase64Data,
+            mimeType: 'application/pdf',
           },
         ],
       },
@@ -45,6 +57,13 @@ describe('user messages', () => {
             image: {
               format: 'png',
               source: { bytes: new Uint8Array([0, 1, 2, 3]) },
+            },
+          },
+          {
+            document: {
+              format: 'pdf',
+              name: fileName,
+              source: { bytes: Buffer.from(fileData) },
             },
           },
         ],


### PR DESCRIPTION
# Summary
This PR adds support for file upload for the Amazon Bedrock provider.
- Add case to convert to Bedrock's document type from the file type
- Add basic check to the Bedrock message conversion test
- Add a file upload example for Bedrock.

_Note: For now the code generates the required document name by hashing the file contents, but it may be possible to default to a provider specific metadata option in the future._

Bedrock only supports file uploads for specific models. I found a page a while back that listed compatibility but cannot find it now. I know Claude 3 Sonnet and Claude 3 Haiku support it but Claude 3.5 Sonnet doesn't.