### PR TITLE
fix (ai/ui): update latest message with stream data message annotations until new message starts

### DIFF
--- a/.changeset/swift-donkeys-talk.md
+++ b/.changeset/swift-donkeys-talk.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/ui-utils': patch
+---
+
+fix (ai/ui): update latest message with stream data message annotations until new message starts

--- a/packages/ui-utils/src/process-data-protocol-response.ts
+++ b/packages/ui-utils/src/process-data-protocol-response.ts
@@ -119,19 +119,31 @@ export async function processDataProtocolResponse({
       continue;
     }
 
-    if (nextPrefixMap) {
-      if (prefixMap.text) {
-        previousMessages.push(prefixMap.text);
-      }
-      if (prefixMap.function_call) {
-        previousMessages.push(prefixMap.function_call);
-      }
-      if (prefixMap.tool_calls) {
-        previousMessages.push(prefixMap.tool_calls);
-      }
+    // switch to the next prefix map once we start receiving
+    // content of the next message. Stream data annotations
+    // are associated with the previous message until then to
+    // support sending them in onFinish and onStepFinish:
+    if (
+      type === 'text' ||
+      type === 'tool_call' ||
+      type === 'tool_call_streaming_start' ||
+      type === 'tool_call_delta' ||
+      type === 'tool_result'
+    ) {
+      if (nextPrefixMap) {
+        if (prefixMap.text) {
+          previousMessages.push(prefixMap.text);
+        }
+        if (prefixMap.function_call) {
+          previousMessages.push(prefixMap.function_call);
+        }
+        if (prefixMap.tool_calls) {
+          previousMessages.push(prefixMap.tool_calls);
+        }
 
-      prefixMap = nextPrefixMap;
-      nextPrefixMap = undefined;
+        prefixMap = nextPrefixMap;
+        nextPrefixMap = undefined;
+      }
     }
 
     if (type === 'text') {
@@ -320,6 +332,10 @@ export async function processDataProtocolResponse({
         prefixMap['text'],
         message_annotations,
       );
+
+      // trigger update for streaming by copying adding a update id that changes
+      // (without it, the changes get stuck in SWR and are not forwarded to rendering):
+      (prefixMap.text! as any).internalUpdateId = generateId();
     }
 
     // keeps the prefixMap up to date with the latest annotations, even if annotations preceded the message

--- a/packages/ui-utils/src/process-data-protocol-response.ts
+++ b/packages/ui-utils/src/process-data-protocol-response.ts
@@ -124,26 +124,25 @@ export async function processDataProtocolResponse({
     // are associated with the previous message until then to
     // support sending them in onFinish and onStepFinish:
     if (
-      type === 'text' ||
-      type === 'tool_call' ||
-      type === 'tool_call_streaming_start' ||
-      type === 'tool_call_delta' ||
-      type === 'tool_result'
+      nextPrefixMap &&
+      (type === 'text' ||
+        type === 'tool_call' ||
+        type === 'tool_call_streaming_start' ||
+        type === 'tool_call_delta' ||
+        type === 'tool_result')
     ) {
-      if (nextPrefixMap) {
-        if (prefixMap.text) {
-          previousMessages.push(prefixMap.text);
-        }
-        if (prefixMap.function_call) {
-          previousMessages.push(prefixMap.function_call);
-        }
-        if (prefixMap.tool_calls) {
-          previousMessages.push(prefixMap.tool_calls);
-        }
-
-        prefixMap = nextPrefixMap;
-        nextPrefixMap = undefined;
+      if (prefixMap.text) {
+        previousMessages.push(prefixMap.text);
       }
+      if (prefixMap.function_call) {
+        previousMessages.push(prefixMap.function_call);
+      }
+      if (prefixMap.tool_calls) {
+        previousMessages.push(prefixMap.tool_calls);
+      }
+
+      prefixMap = nextPrefixMap;
+      nextPrefixMap = undefined;
     }
 
     if (type === 'text') {


### PR DESCRIPTION
## Summary

Associates stream data message annotations after the step finish event with the previous step until tool calls or text from the next message arrive. Adds update marker to message for triggering update when there are new stream data annotations.

## Tasks

- [x] fix
- [x] tests
- [x] changeset