### PR TITLE
Fix computer use handling of experimental_toToolResultContent

### DIFF
--- a/.changeset/silver-donuts-dress.md
+++ b/.changeset/silver-donuts-dress.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+(experimental) fix passing "experimental_toToolResultContent" into PoolResultPart

--- a/packages/ai/core/generate-text/to-response-messages.test.ts
+++ b/packages/ai/core/generate-text/to-response-messages.test.ts
@@ -191,7 +191,7 @@ it('should handle multipart tool results', () => {
           result: [
             { type: 'image', data: 'image-base64', mimeType: 'image/png' },
           ],
-          content: [
+          experimental_content: [
             { type: 'image', data: 'image-base64', mimeType: 'image/png' },
           ],
         },

--- a/packages/ai/core/generate-text/to-response-messages.ts
+++ b/packages/ai/core/generate-text/to-response-messages.ts
@@ -1,4 +1,8 @@
-import { CoreAssistantMessage, CoreToolMessage } from '../prompt';
+import {
+  CoreAssistantMessage,
+  CoreToolMessage,
+  ToolResultPart,
+} from '../prompt';
 import { CoreTool } from '../tool/tool';
 import { ToolCallArray } from './tool-call';
 import { ToolResultArray } from './tool-result';
@@ -27,16 +31,17 @@ export function toResponseMessages<TOOLS extends Record<string, CoreTool>>({
   if (toolResults.length > 0) {
     responseMessages.push({
       role: 'tool',
-      content: toolResults.map(toolResult => {
+      content: toolResults.map((toolResult): ToolResultPart => {
         const tool = tools[toolResult.toolName];
-
         return tool?.experimental_toToolResultContent != null
           ? {
               type: 'tool-result',
               toolCallId: toolResult.toolCallId,
               toolName: toolResult.toolName,
               result: tool.experimental_toToolResultContent(toolResult.result),
-              content: tool.experimental_toToolResultContent(toolResult.result),
+              experimental_content: tool.experimental_toToolResultContent(
+                toolResult.result,
+              ),
             }
           : {
               type: 'tool-result',


### PR DESCRIPTION
`experimental_content` is what `convert-to-language-model-prompt` expects. `content` isn't used and the value is silently disregarded, leading to `part.result` being stringified (see screenshot)

![CleanShot 2024-10-27 at 15 33 53@2x](https://github.com/user-attachments/assets/5c553815-5525-45c9-85e6-260413ef5903)

Fixes #3370