### PR TITLE
chore (packages): Standardize unsupported tool error type.

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -1,4 +1,8 @@
-import { LanguageModelV1, LanguageModelV1CallWarning } from '@ai-sdk/provider';
+import {
+  LanguageModelV1,
+  LanguageModelV1CallWarning,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
 import {
   Tool,
   ToolConfiguration,
@@ -80,7 +84,9 @@ export function prepareTools(
       };
     default: {
       const _exhaustiveCheck: never = type;
-      throw new Error(`Unsupported tool choice type: ${_exhaustiveCheck}`);
+      throw new UnsupportedFunctionalityError({
+        functionality: `Unsupported tool choice type: ${_exhaustiveCheck}`,
+      });
     }
   }
 }

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -1,4 +1,8 @@
-import { LanguageModelV1, LanguageModelV1CallWarning } from '@ai-sdk/provider';
+import {
+  LanguageModelV1,
+  LanguageModelV1CallWarning,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
 import { AnthropicTool, AnthropicToolChoice } from './anthropic-api-types';
 
 export function prepareTools(
@@ -96,7 +100,9 @@ export function prepareTools(
       };
     default: {
       const _exhaustiveCheck: never = type;
-      throw new Error(`Unsupported tool choice type: ${_exhaustiveCheck}`);
+      throw new UnsupportedFunctionalityError({
+        functionality: `Unsupported tool choice type: ${_exhaustiveCheck}`,
+      });
     }
   }
 }

--- a/packages/google-vertex/src/google-vertex-prepare-tools.ts
+++ b/packages/google-vertex/src/google-vertex-prepare-tools.ts
@@ -1,4 +1,8 @@
-import { LanguageModelV1, LanguageModelV1CallWarning } from '@ai-sdk/provider';
+import {
+  LanguageModelV1,
+  LanguageModelV1CallWarning,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
 import {
   FunctionCallingMode,
   FunctionDeclaration,
@@ -104,7 +108,9 @@ export function prepareTools({
       };
     default: {
       const _exhaustiveCheck: never = type;
-      throw new Error(`Unsupported tool choice type: ${_exhaustiveCheck}`);
+      throw new UnsupportedFunctionalityError({
+        functionality: `Unsupported tool choice type: ${_exhaustiveCheck}`,
+      });
     }
   }
 }

--- a/packages/groq/src/groq-prepare-tools.ts
+++ b/packages/groq/src/groq-prepare-tools.ts
@@ -1,4 +1,8 @@
-import { LanguageModelV1, LanguageModelV1CallWarning } from '@ai-sdk/provider';
+import {
+  LanguageModelV1,
+  LanguageModelV1CallWarning,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
 
 export function prepareTools({
   mode,
@@ -83,7 +87,9 @@ export function prepareTools({
       };
     default: {
       const _exhaustiveCheck: never = type;
-      throw new Error(`Unsupported tool choice type: ${_exhaustiveCheck}`);
+      throw new UnsupportedFunctionalityError({
+        functionality: `Unsupported tool choice type: ${_exhaustiveCheck}`,
+      });
     }
   }
 }

--- a/packages/mistral/src/mistral-prepare-tools.ts
+++ b/packages/mistral/src/mistral-prepare-tools.ts
@@ -1,4 +1,8 @@
-import { LanguageModelV1, LanguageModelV1CallWarning } from '@ai-sdk/provider';
+import {
+  LanguageModelV1,
+  LanguageModelV1CallWarning,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
 
 export function prepareTools(
   mode: Parameters<LanguageModelV1['doGenerate']>[0]['mode'] & {
@@ -82,7 +86,9 @@ export function prepareTools(
       };
     default: {
       const _exhaustiveCheck: never = type;
-      throw new Error(`Unsupported tool choice type: ${_exhaustiveCheck}`);
+      throw new UnsupportedFunctionalityError({
+        functionality: `Unsupported tool choice type: ${_exhaustiveCheck}`,
+      });
     }
   }
 }

--- a/packages/openai/src/openai-prepare-tools.ts
+++ b/packages/openai/src/openai-prepare-tools.ts
@@ -153,7 +153,9 @@ export function prepareTools({
       };
     default: {
       const _exhaustiveCheck: never = type;
-      throw new Error(`Unsupported tool choice type: ${_exhaustiveCheck}`);
+      throw new UnsupportedFunctionalityError({
+        functionality: `Unsupported tool choice type: ${_exhaustiveCheck}`,
+      });
     }
   }
 }


### PR DESCRIPTION
In the fallback case for "unsupported tool choice type" when preparing tools for various providers we were using `Error` in some places and `UnsupportedFunctionalityError` in others. The latter seems most semantically meaningful, so this change standardizes on that everywhere.