### PR TITLE
feat (provider/vertex): expose search grounding metadata

### DIFF
--- a/.changeset/breezy-eels-sip.md
+++ b/.changeset/breezy-eels-sip.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+feat (provider/vertex): expose search grounding metadata

--- a/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
@@ -215,11 +215,11 @@ With [search grounding](https://cloud.google.com/vertex-ai/generative-ai/docs/gr
 the model has access to the latest information using Google search.
 Search grounding can e.g. be used to provide answers around current events:
 
-```ts highlight="6"
+```ts highlight="6,13-15"
 import { vertex } from '@ai-sdk/google-vertex';
 import { generateText } from 'ai';
 
-const { text } = await generateText({
+const { text, experimental_providerMetadata } = await generateText({
   model: vertex('gemini-1.5-pro', {
     useSearchGrounding: true,
   }),
@@ -227,6 +227,10 @@ const { text } = await generateText({
     'List the top 5 San Francisco news from the past week.' +
     'You must include the date of each article.',
 });
+
+// access the grounding metadata
+const groundingMetadata =
+  experimental_providerMetadata?.vertex.groundingMetadata;
 ```
 
 ### Troubleshooting

--- a/examples/ai-core/src/generate-text/google-vertex-grounding.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-grounding.ts
@@ -1,0 +1,22 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: vertex('gemini-1.5-pro', {
+      useSearchGrounding: true,
+    }),
+    prompt:
+      'List the top 5 San Francisco news from the past week.' +
+      'You must include the date of each article.',
+  });
+
+  console.log(result.text);
+  console.log(result.experimental_providerMetadata?.vertex);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/google-vertex-grounding.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-grounding.ts
@@ -16,6 +16,7 @@ async function main() {
     process.stdout.write(textPart);
   }
 
+  console.log((await result.experimental_providerMetadata)?.vertex);
   console.log();
   console.log('Token usage:', await result.usage);
   console.log('Finish reason:', await result.finishReason);

--- a/packages/google-vertex/src/google-vertex-language-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.test.ts
@@ -619,6 +619,72 @@ describe('doStream', () => {
         type: 'finish',
         finishReason: 'stop',
         usage: { promptTokens: 9, completionTokens: 403 },
+        providerMetadata: undefined,
+      },
+    ]);
+  });
+
+  it('should include grounding metadata in stream when useSearchGrounding is enabled', async () => {
+    const mockGroundingMetadata = {
+      webSearchQueries: ['test query'],
+      webSearchResults: [
+        {
+          url: 'https://example.com',
+          title: 'Example Result',
+          snippet: 'Example snippet',
+        },
+      ],
+    };
+
+    const { model } = createModel({
+      settings: {
+        useSearchGrounding: true,
+      },
+      generateContentStream: async function* () {
+        yield {
+          candidates: [
+            {
+              content: { parts: [{ text: 'Response ' }], role: 'model' },
+              index: 0,
+            },
+          ],
+        };
+        yield {
+          candidates: [
+            {
+              content: { parts: [{ text: 'with grounding' }], role: 'model' },
+              index: 0,
+              groundingMetadata: mockGroundingMetadata,
+              finishReason: 'STOP' as FinishReason,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 20,
+            totalTokenCount: 30,
+          },
+        };
+      },
+    });
+
+    const { stream } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+      { type: 'text-delta', textDelta: 'Response ' },
+      { type: 'text-delta', textDelta: 'with grounding' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { promptTokens: 10, completionTokens: 20 },
+        providerMetadata: {
+          vertex: {
+            groundingMetadata: mockGroundingMetadata,
+          },
+        },
       },
     ]);
   });

--- a/packages/google-vertex/src/google-vertex-language-model.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.ts
@@ -249,6 +249,13 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
         rawPrompt: contentRequest,
         rawSettings: {},
       },
+      providerMetadata: this.settings.useSearchGrounding
+        ? {
+            vertex: {
+              groundingMetadata: firstCandidate.groundingMetadata as any,
+            },
+          }
+        : undefined,
       warnings,
     };
   }

--- a/packages/google-vertex/src/google-vertex-language-model.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.ts
@@ -274,6 +274,7 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
 
     const generateId = this.config.generateId;
     let hasToolCalls = false;
+    let providerMetadata: { vertex: { groundingMetadata: any } } | undefined;
 
     return {
       stream: convertAsyncGeneratorToReadableStream(stream).pipeThrough(
@@ -299,6 +300,14 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
                   finishReason: candidate.finishReason,
                   hasToolCalls,
                 });
+              }
+
+              if (candidate.groundingMetadata != null) {
+                providerMetadata = {
+                  vertex: {
+                    groundingMetadata: candidate.groundingMetadata as any,
+                  },
+                };
               }
 
               const content = candidate.content;
@@ -344,6 +353,7 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
                 type: 'finish',
                 finishReason,
                 usage,
+                providerMetadata,
               });
             },
           },


### PR DESCRIPTION
## Tasks

- [x] implementation
   - [x] generate text
   - [x] generate text test
   - [x] stream text
   - [x] stream text test
- [x] examples
   - [x] generate text grounding
   - [x] stream text grounding
- [x] docs (google vertex provider guide)
- [x] changeset