### PR TITLE
fix (docs): Correct missing close-backtick breaking Anthropic text.

### DIFF
--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -201,7 +201,7 @@ const result = await generateText({
   Generative AI](/providers/ai-sdk-providers/google-generative-ai), [Google
   Vertex AI](/providers/ai-sdk-providers/google-vertex),
   [OpenAI](/providers/ai-sdk-providers/openai) (for `wav` and `mp3` audio with
-  `gpt-4o-audio-preview), [Anthropic](/providers/ai-sdk-providers/anthropic)
+  `gpt-4o-audio-preview`), [Anthropic](/providers/ai-sdk-providers/anthropic)
   (for `pdf`).
 </Note>
 


### PR DESCRIPTION
The note on file parts has a broken section intended to link to Anthropic due to an absent closing backtick in the preceding GPT 4o text.