### PR TITLE
chore (provider-utils): remove isParseableJson export

### DIFF
--- a/.changeset/tough-trees-rhyme.md
+++ b/.changeset/tough-trees-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': major
+---
+
+chore (provider-utils): remove isParseableJson export

--- a/packages/provider-utils/src/parse-json.ts
+++ b/packages/provider-utils/src/parse-json.ts
@@ -121,8 +121,3 @@ export function isParsableJson(input: string): boolean {
     return false;
   }
 }
-
-/**
-@deprecated Use `isParsableJson` instead.
- */
-export const isParseableJson = isParsableJson;


### PR DESCRIPTION
Note: since this is internal, not added to migration guide