### PR TITLE
chore (npmrc): Remove strict-peer-dependencies config disable.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 auto-install-peers = true
-# necessary for a PNPM bug: https://github.com/pnpm/pnpm/issues/5152#issuecomment-1223449173
-strict-peer-dependencies = false


### PR DESCRIPTION
This config setting is old and looks like it may be a workaround from pre-v8 pnpm versions. Removing both to reduce complexity and in case it has any ramification for the work we're doing to move to pnpm v9.