### PR TITLE
feat (docs): Add Laminar provider to telemetry docs

### DIFF
--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -20,6 +20,7 @@ The following observability integrations support AI SDK Telemetry data:
 - [Langfuse](https://langfuse.com/docs/integrations/vercel-ai-sdk)
 - [LangSmith](https://docs.smith.langchain.com/observability/how_to_guides/tracing/trace_with_vercel_ai_sdk)
 - [Braintrust](https://www.braintrust.dev/docs/cookbook/recipes/OTEL-logging)
+- [Laminar](https://docs.lmnr.ai/tracing/vercel-ai-sdk)
 
 <Note>
   Do you have an observability integration that supports AI SDK Telemetry data


### PR DESCRIPTION
[Laminar](https://github.com/lmnr-ai/lmnr) is an open-source all-in-one platform for engineering AI products. Laminar tracing is based on OpenTelemetry and easily integrates with AI SDK's telemetry. With this PR I added direct link to our docs explaining how to start tracing AI SDK with Laminar.