### PR TITLE
chore (dependencies): update typescript to 5.6.3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -28,6 +28,6 @@
   "devDependencies": {
     "@types/node": "20.11.20",
     "tsx": "4.7.1",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -16,6 +16,6 @@
     "@types/express": "5.0.0",
     "@types/node": "20.11.20",
     "tsx": "4.7.1",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@types/node": "20.11.20",
     "tsx": "4.7.1",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -15,6 +15,6 @@
   "devDependencies": {
     "@types/node": "20.11.20",
     "tsx": "4.7.1",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/next-fastapi/package.json
+++ b/examples/next-fastapi/package.json
@@ -28,6 +28,6 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/next-langchain/package.json
+++ b/examples/next-langchain/package.json
@@ -27,6 +27,6 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/next-openai-kasada-bot-protection/package.json
+++ b/examples/next-openai-kasada-bot-protection/package.json
@@ -26,6 +26,6 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/next-openai-telemetry-sentry/package.json
+++ b/examples/next-openai-telemetry-sentry/package.json
@@ -33,6 +33,6 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/next-openai-telemetry/package.json
+++ b/examples/next-openai-telemetry/package.json
@@ -31,6 +31,6 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/next-openai-upstash-rate-limits/package.json
+++ b/examples/next-openai-upstash-rate-limits/package.json
@@ -27,6 +27,6 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/next-openai/package.json
+++ b/examples/next-openai/package.json
@@ -30,6 +30,6 @@
     "eslint-config-next": "14.2.3",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/node-http-server/package.json
+++ b/examples/node-http-server/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/node": "20.11.20",
     "tsx": "4.7.1",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/examples/sveltekit-openai/package.json
+++ b/examples/sveltekit-openai/package.json
@@ -26,7 +26,7 @@
     "svelte": "^4",
     "svelte-check": "^3.7",
     "tslib": "^2.6.0",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "vite": "^5"
   },
   "type": "module"

--- a/examples/swarm/package.json
+++ b/examples/swarm/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/node": "20.11.20",
     "tsx": "4.7.1",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "19.0.0-rc-cc1ec60d0d-20240607",
     "react-dom": "19.0.0-rc-cc1ec60d0d-20240607",
     "turbo": "^1.10.13",
+    "typescript": "5.6.3",
     "vitest": "1.6.0"
   },
   "engines": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -89,7 +89,7 @@
     "react-dom": "^18",
     "react-server-dom-webpack": "18.3.0-canary-eb33bd747-20240312",
     "tsup": "^7.2.0",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/ai/rsc/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/ai/rsc/stream-ui/stream-ui.ui.test.tsx
@@ -29,7 +29,7 @@ async function simulateFlightServerRender(node: React.ReactNode) {
     if (!node) return {};
 
     // Let's only do one level of promise resolution here. As it's only for testing purposes.
-    const props = await recursiveResolve({ ...node.props } || {});
+    const props = await recursiveResolve({ ...node.props });
 
     const { type } = node;
     const { children, ...otherProps } = props;

--- a/packages/ai/rsc/streamable-ui/create-streamable-ui.ui.test.tsx
+++ b/packages/ai/rsc/streamable-ui/create-streamable-ui.ui.test.tsx
@@ -66,7 +66,7 @@ async function simulateFlightServerRender(node: React.ReactNode) {
     if (!node) return {};
 
     // Let's only do one level of promise resolution here. As it's only for testing purposes.
-    const props = await recursiveResolve({ ...node.props } || {});
+    const props = await recursiveResolve({ ...node.props });
 
     const { type } = node;
     const { children, ...otherProps } = props;

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -40,7 +40,7 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "aws-sdk-client-mock": "^4.0.2",
     "tsup": "^8.3.0",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/cohere/package.json
+++ b/packages/cohere/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/mistral/package.json
+++ b/packages/mistral/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -47,7 +47,7 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "msw": "2.3.1",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   },
   "engines": {
     "node": ">=18"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,7 @@
     "msw": "2.3.1",
     "react-dom": "^18",
     "tsup": "^7.2.0",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -44,7 +44,7 @@
     "jsdom": "^24.0.0",
     "msw": "2.3.1",
     "tsup": "^7.2.0",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "vite-plugin-solid": "2.7.2"
   },
   "peerDependencies": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -37,7 +37,7 @@
     "eslint": "^7.32.0",
     "eslint-config-vercel-ai": "workspace:*",
     "tsup": "^7.2.0",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   },
   "peerDependencies": {
     "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0"

--- a/packages/swarm/package.json
+++ b/packages/swarm/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   },
   "engines": {
     "node": ">=18"

--- a/packages/ui-utils/package.json
+++ b/packages/ui-utils/package.json
@@ -49,7 +49,7 @@
     "@types/react": "^18",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "zod": "3.23.8"
   },
   "peerDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -45,7 +45,7 @@
     "jsdom": "^24.0.0",
     "msw": "2.3.1",
     "tsup": "^7.2.0",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   },
   "peerDependencies": {
     "vue": "^3.3.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: 4.7.1
         version: 4.7.1
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/express:
     dependencies:
@@ -146,8 +146,8 @@ importers:
         specifier: 4.7.1
         version: 4.7.1
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/fastify:
     dependencies:
@@ -171,8 +171,8 @@ importers:
         specifier: 4.7.1
         version: 4.7.1
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/hono:
     dependencies:
@@ -199,8 +199,8 @@ importers:
         specifier: 4.7.1
         version: 4.7.1
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/nest:
     dependencies:
@@ -331,7 +331,7 @@ importers:
         version: 7.32.0
       eslint-config-next:
         specifier: 14.2.3
-        version: 14.2.3(eslint@7.32.0)(typescript@5.5.4)
+        version: 14.2.3(eslint@7.32.0)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.23
         version: 8.4.38
@@ -339,8 +339,8 @@ importers:
         specifier: ^3.3.2
         version: 3.4.4
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/next-langchain:
     dependencies:
@@ -386,7 +386,7 @@ importers:
         version: 7.32.0
       eslint-config-next:
         specifier: 14.2.3
-        version: 14.2.3(eslint@7.32.0)(typescript@5.5.4)
+        version: 14.2.3(eslint@7.32.0)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.23
         version: 8.4.31
@@ -394,8 +394,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.5
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/next-openai:
     dependencies:
@@ -450,7 +450,7 @@ importers:
         version: 7.32.0
       eslint-config-next:
         specifier: 14.2.3
-        version: 14.2.3(eslint@7.32.0)(typescript@5.5.4)
+        version: 14.2.3(eslint@7.32.0)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.23
         version: 8.4.41
@@ -458,8 +458,8 @@ importers:
         specifier: ^3.3.2
         version: 3.4.7
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/next-openai-kasada-bot-protection:
     dependencies:
@@ -502,7 +502,7 @@ importers:
         version: 7.32.0
       eslint-config-next:
         specifier: 14.2.3
-        version: 14.2.3(eslint@7.32.0)(typescript@5.5.4)
+        version: 14.2.3(eslint@7.32.0)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.23
         version: 8.4.47
@@ -510,8 +510,8 @@ importers:
         specifier: ^3.3.2
         version: 3.4.7
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/next-openai-pages:
     dependencies:
@@ -624,7 +624,7 @@ importers:
         version: 7.32.0
       eslint-config-next:
         specifier: 14.2.3
-        version: 14.2.3(eslint@7.32.0)(typescript@5.5.4)
+        version: 14.2.3(eslint@7.32.0)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.23
         version: 8.4.39
@@ -632,8 +632,8 @@ importers:
         specifier: ^3.3.2
         version: 3.4.4
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/next-openai-telemetry-sentry:
     dependencies:
@@ -697,7 +697,7 @@ importers:
         version: 7.32.0
       eslint-config-next:
         specifier: 14.2.3
-        version: 14.2.3(eslint@7.32.0)(typescript@5.5.4)
+        version: 14.2.3(eslint@7.32.0)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.23
         version: 8.4.39
@@ -705,8 +705,8 @@ importers:
         specifier: ^3.3.2
         version: 3.4.4
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/next-openai-upstash-rate-limits:
     dependencies:
@@ -752,7 +752,7 @@ importers:
         version: 7.32.0
       eslint-config-next:
         specifier: 14.2.3
-        version: 14.2.3(eslint@7.32.0)(typescript@5.5.4)
+        version: 14.2.3(eslint@7.32.0)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.23
         version: 8.4.47
@@ -760,8 +760,8 @@ importers:
         specifier: ^3.3.2
         version: 3.4.7
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/node-http-server:
     dependencies:
@@ -797,8 +797,8 @@ importers:
         specifier: 4.7.1
         version: 4.7.1
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   examples/nuxt-openai:
     dependencies:
@@ -947,8 +947,8 @@ importers:
         specifier: ^2.6.0
         version: 2.6.2
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       vite:
         specifier: ^5
         version: 5.2.11(@types/node@18.18.9)
@@ -999,8 +999,8 @@ importers:
         specifier: 4.7.1
         version: 4.7.1
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   packages/ai:
     dependencies:
@@ -1079,7 +1079,7 @@ importers:
         version: 24.1.1
       msw:
         specifier: 2.3.1
-        version: 2.3.1(typescript@5.5.4)
+        version: 2.3.1(typescript@5.6.3)
       openai:
         specifier: 4.52.6
         version: 4.52.6
@@ -1091,10 +1091,10 @@ importers:
         version: 18.3.0-canary-eb33bd747-20240312(react-dom@18.3.1)(react@18.3.1)(webpack@5.95.0)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(typescript@5.5.4)
+        version: 7.2.0(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1140,10 +1140,10 @@ importers:
         version: 4.0.2
       tsup:
         specifier: ^8.3.0
-        version: 8.3.0(typescript@5.5.4)
+        version: 8.3.0(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1165,10 +1165,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1193,10 +1193,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1218,10 +1218,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1243,10 +1243,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1271,10 +1271,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1296,10 +1296,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.3.0(typescript@5.5.4)
+        version: 8.3.0(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1321,10 +1321,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1346,10 +1346,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.2.4(typescript@5.5.4)
+        version: 8.2.4(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1371,10 +1371,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   packages/provider-utils:
     dependencies:
@@ -1399,13 +1399,13 @@ importers:
         version: link:../../tools/tsconfig
       msw:
         specifier: 2.3.1
-        version: 2.3.1(typescript@5.5.4)
+        version: 2.3.1(typescript@5.6.3)
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1460,16 +1460,16 @@ importers:
         version: 24.0.0
       msw:
         specifier: 2.3.1
-        version: 2.3.1(typescript@5.5.4)
+        version: 2.3.1(typescript@5.6.3)
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.3.1)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(typescript@5.5.4)
+        version: 7.2.0(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1515,13 +1515,13 @@ importers:
         version: 24.0.0
       msw:
         specifier: 2.3.1
-        version: 2.3.1(typescript@5.5.4)
+        version: 2.3.1(typescript@5.6.3)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(typescript@5.5.4)
+        version: 7.2.0(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       vite-plugin-solid:
         specifier: 2.7.2
         version: 2.7.2(solid-js@1.8.7)(vite@4.5.5)
@@ -1555,10 +1555,10 @@ importers:
         version: link:../../tools/eslint-config
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(typescript@5.5.4)
+        version: 7.2.0(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   packages/swarm:
     dependencies:
@@ -1577,10 +1577,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.3.0(typescript@5.5.4)
+        version: 8.3.0(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   packages/ui-utils:
     dependencies:
@@ -1614,10 +1614,10 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: ^8
-        version: 8.0.2(typescript@5.5.4)
+        version: 8.0.2(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -1635,7 +1635,7 @@ importers:
         version: 1.0.4(vue@3.3.8)
       vue:
         specifier: ^3.3.4
-        version: 3.3.8(typescript@5.5.4)
+        version: 3.3.8(typescript@5.6.3)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.4.5
@@ -1666,19 +1666,19 @@ importers:
         version: 24.0.0
       msw:
         specifier: 2.3.1
-        version: 2.3.1(typescript@5.5.4)
+        version: 2.3.1(typescript@5.6.3)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(typescript@5.5.4)
+        version: 7.2.0(typescript@5.6.3)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.6.3
+        version: 5.6.3
 
   tools/eslint-config:
     dependencies:
       eslint-config-next:
         specifier: ^14.2.3
-        version: 14.2.3(eslint@8.57.1)(typescript@5.5.4)
+        version: 14.2.3(eslint@8.57.1)(typescript@5.6.3)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.10.0(eslint@8.57.1)
@@ -9986,7 +9986,7 @@ packages:
       '@testing-library/dom': 9.3.3
       '@vue/compiler-sfc': 3.5.10
       '@vue/test-utils': 2.4.2(vue@3.3.8)
-      vue: 3.3.8(typescript@5.5.4)
+      vue: 3.3.8(typescript@5.6.3)
     transitivePeerDependencies:
       - '@vue/server-renderer'
     dev: true
@@ -10538,7 +10538,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@7.2.0(eslint@7.32.0)(typescript@5.5.4):
+  /@typescript-eslint/parser@7.2.0(eslint@7.32.0)(typescript@5.6.3):
     resolution: {integrity: sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -10550,16 +10550,16 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.3.6
       eslint: 7.32.0
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.5.4):
+  /@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3):
     resolution: {integrity: sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -10571,11 +10571,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.3.6
       eslint: 8.57.1
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -10666,7 +10666,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@7.2.0(typescript@5.5.4):
+  /@typescript-eslint/typescript-estree@7.2.0(typescript@5.6.3):
     resolution: {integrity: sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -10682,8 +10682,8 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 1.3.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10988,7 +10988,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 4.5.5(@types/node@18.18.9)
-      vue: 3.5.10(typescript@5.5.4)
+      vue: 3.5.10(typescript@5.6.3)
     dev: true
 
   /@vitejs/plugin-vue@4.5.0(vite@5.4.8)(vue@3.3.8):
@@ -10999,7 +10999,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 5.4.8(@types/node@18.18.9)
-      vue: 3.3.8(typescript@5.5.4)
+      vue: 3.3.8(typescript@5.6.3)
     dev: true
 
   /@vitejs/plugin-vue@5.0.5(vite@5.3.3)(vue@3.4.31):
@@ -11377,7 +11377,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.3.8
       '@vue/shared': 3.3.8
-      vue: 3.3.8(typescript@5.5.4)
+      vue: 3.3.8(typescript@5.6.3)
 
   /@vue/server-renderer@3.4.31(vue@3.4.31):
     resolution: {integrity: sha512-D5BLbdvrlR9PE3by9GaUp1gQXlCNadIZytMIb8H2h3FMWJd4oUfkUTEH2wAr3qxoRz25uxbTcbqd3WKlm9EHQA==}
@@ -11396,7 +11396,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.5.10
       '@vue/shared': 3.5.10
-      vue: 3.5.10(typescript@5.5.4)
+      vue: 3.5.10(typescript@5.6.3)
     dev: true
 
   /@vue/shared@3.3.8:
@@ -11420,7 +11420,7 @@ packages:
         optional: true
     dependencies:
       js-beautify: 1.14.11
-      vue: 3.3.8(typescript@5.5.4)
+      vue: 3.3.8(typescript@5.6.3)
       vue-component-type-helpers: 1.8.22
     dev: true
 
@@ -14321,7 +14321,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-next@14.2.3(eslint@7.32.0)(typescript@5.5.4):
+  /eslint-config-next@14.2.3(eslint@7.32.0)(typescript@5.6.3):
     resolution: {integrity: sha512-ZkNztm3Q7hjqvB1rRlOX8P9E/cXRL9ajRcs8jufEtwMfTVYRqnmtnaSu57QqHyBlovMuiB8LEzfLBkh5RYV6Fg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -14332,7 +14332,7 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 14.2.3
       '@rushstack/eslint-patch': 1.10.4
-      '@typescript-eslint/parser': 7.2.0(eslint@7.32.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.2.0(eslint@7.32.0)(typescript@5.6.3)
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@7.32.0)
@@ -14340,13 +14340,13 @@ packages:
       eslint-plugin-jsx-a11y: 6.9.0(eslint@7.32.0)
       eslint-plugin-react: 7.35.0(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
-  /eslint-config-next@14.2.3(eslint@8.57.1)(typescript@5.5.4):
+  /eslint-config-next@14.2.3(eslint@8.57.1)(typescript@5.6.3):
     resolution: {integrity: sha512-ZkNztm3Q7hjqvB1rRlOX8P9E/cXRL9ajRcs8jufEtwMfTVYRqnmtnaSu57QqHyBlovMuiB8LEzfLBkh5RYV6Fg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -14357,7 +14357,7 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 14.2.3
       '@rushstack/eslint-patch': 1.10.4
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1)
@@ -14365,7 +14365,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.1)
       eslint-plugin-react: 7.35.0(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -14474,7 +14474,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@7.32.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.2.0(eslint@7.32.0)(typescript@5.6.3)
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
@@ -14504,7 +14504,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.6.3)
       debug: 3.2.7
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
@@ -14534,7 +14534,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@7.32.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.2.0(eslint@7.32.0)(typescript@5.6.3)
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
@@ -14564,7 +14564,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.6.3)
       debug: 3.2.7
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
@@ -14583,7 +14583,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@7.32.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.2.0(eslint@7.32.0)(typescript@5.6.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -14618,7 +14618,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.6.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -18947,7 +18947,7 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  /msw@2.3.1(typescript@5.5.4):
+  /msw@2.3.1(typescript@5.6.3):
     resolution: {integrity: sha512-ocgvBCLn/5l3jpl1lssIb3cniuACJLoOfZu01e3n5dbJrpA5PeeWn28jCLgQDNt6d7QT8tF2fYRzm9JoEHtiig==}
     engines: {node: '>=18'}
     hasBin: true
@@ -18974,7 +18974,7 @@ packages:
       path-to-regexp: 6.2.2
       strict-event-emitter: 0.5.1
       type-fest: 4.23.0
-      typescript: 5.5.4
+      typescript: 5.6.3
       yargs: 17.7.2
     dev: true
 
@@ -22785,8 +22785,8 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.2.3
-      svelte-preprocess: 5.1.4(svelte@4.2.3)(typescript@5.5.4)
-      typescript: 5.5.4
+      svelte-preprocess: 5.1.4(svelte@4.2.3)(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -22808,7 +22808,7 @@ packages:
       svelte: 4.2.3
     dev: true
 
-  /svelte-preprocess@5.1.4(svelte@4.2.3)(typescript@5.5.4):
+  /svelte-preprocess@5.1.4(svelte@4.2.3)(typescript@5.6.3):
     resolution: {integrity: sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==}
     engines: {node: '>= 16.0.0'}
     requiresBuild: true
@@ -22852,7 +22852,7 @@ packages:
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 4.2.3
-      typescript: 5.5.4
+      typescript: 5.6.3
     dev: true
 
   /svelte@4.2.18:
@@ -22931,7 +22931,7 @@ packages:
     peerDependencies:
       vue: '>=3.2.26 < 4'
     dependencies:
-      vue: 3.3.8(typescript@5.5.4)
+      vue: 3.3.8(typescript@5.6.3)
     dev: false
 
   /symbol-observable@4.0.0:
@@ -23389,6 +23389,15 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.5.4
+    dev: true
+
+  /ts-api-utils@1.3.0(typescript@5.6.3):
+    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.6.3
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -23519,7 +23528,7 @@ packages:
     engines: {node: '>=0.6.x'}
     dev: true
 
-  /tsup@7.2.0(typescript@5.5.4):
+  /tsup@7.2.0(typescript@5.6.3):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -23549,13 +23558,13 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsup@8.0.2(typescript@5.5.4):
+  /tsup@8.0.2(typescript@5.6.3):
     resolution: {integrity: sha512-NY8xtQXdH7hDUAZwcQdY/Vzlw9johQsaqf7iwZ6g1DOUlFYQ5/AtVAjTvihhEyeRlGo4dLRVHtrRaL35M1daqQ==}
     engines: {node: '>=18'}
     hasBin: true
@@ -23588,13 +23597,13 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsup@8.2.4(typescript@5.5.4):
+  /tsup@8.2.4(typescript@5.6.3):
     resolution: {integrity: sha512-akpCPePnBnC/CXgRrcy72ZSntgIEUa1jN0oJbbvpALWKNOz1B7aM+UVDWGRGIO/T/PZugAESWDJUAb5FD48o8Q==}
     engines: {node: '>=18'}
     hasBin: true
@@ -23629,7 +23638,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -23637,7 +23646,7 @@ packages:
       - yaml
     dev: true
 
-  /tsup@8.3.0(typescript@5.5.4):
+  /tsup@8.3.0(typescript@5.6.3):
     resolution: {integrity: sha512-ALscEeyS03IomcuNdFdc0YWGVIkwH1Ws7nfTbAPuoILvEV2hpGQAY72LIOjglGo4ShWpZfpBqP/jpQVCzqYQag==}
     engines: {node: '>=18'}
     hasBin: true
@@ -23672,7 +23681,7 @@ packages:
       sucrase: 3.35.0
       tinyglobby: 0.2.9
       tree-kill: 1.2.2
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -23872,6 +23881,12 @@ packages:
 
   /typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -24991,7 +25006,7 @@ packages:
       vue: 3.4.31
     dev: true
 
-  /vue@3.3.8(typescript@5.5.4):
+  /vue@3.3.8(typescript@5.6.3):
     resolution: {integrity: sha512-5VSX/3DabBikOXMsxzlW8JyfeLKlG9mzqnWgLQLty88vdZL7ZJgrdgBOmrArwxiLtmS+lNNpPcBYqrhE6TQW5w==}
     peerDependencies:
       typescript: '*'
@@ -25004,7 +25019,7 @@ packages:
       '@vue/runtime-dom': 3.3.8
       '@vue/server-renderer': 3.3.8(vue@3.3.8)
       '@vue/shared': 3.3.8
-      typescript: 5.5.4
+      typescript: 5.6.3
 
   /vue@3.4.31:
     resolution: {integrity: sha512-njqRrOy7W3YLAlVqSKpBebtZpDVg21FPoaq1I7f/+qqBThK9ChAIjkRWgeP6Eat+8C+iia4P3OYqpATP21BCoQ==}
@@ -25021,7 +25036,7 @@ packages:
       '@vue/shared': 3.4.31
     dev: true
 
-  /vue@3.5.10(typescript@5.5.4):
+  /vue@3.5.10(typescript@5.6.3):
     resolution: {integrity: sha512-Vy2kmJwHPlouC/tSnIgXVg03SG+9wSqT1xu1Vehc+ChsXsRd7jLkKgMltVEFOzUdBr3uFwBCG+41LJtfAcBRng==}
     peerDependencies:
       typescript: '*'
@@ -25034,7 +25049,7 @@ packages:
       '@vue/runtime-dom': 3.5.10
       '@vue/server-renderer': 3.5.10(vue@3.5.10)
       '@vue/shared': 3.5.10
-      typescript: 5.5.4
+      typescript: 5.6.3
     dev: true
 
   /w3c-xmlserializer@5.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       turbo:
         specifier: ^1.10.13
         version: 1.13.4
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
       vitest:
         specifier: 1.6.0
         version: 1.6.0
@@ -841,7 +844,7 @@ importers:
         version: 3.4.31
       nuxt:
         specifier: ^3.12.3
-        version: 3.12.3(@opentelemetry/api@1.9.0)(@types/node@18.18.9)(eslint@7.32.0)(vite@5.3.3)
+        version: 3.12.3(@opentelemetry/api@1.9.0)(@types/node@18.18.9)(eslint@7.32.0)(typescript@5.6.3)(vite@5.3.3)
       openai:
         specifier: 4.52.6
         version: 4.52.6
@@ -856,7 +859,7 @@ importers:
         version: 2.3.1
       vue:
         specifier: ^3.4.31
-        version: 3.4.31
+        version: 3.4.31(typescript@5.6.3)
       vue-router:
         specifier: 4.4.0
         version: 4.4.0(vue@3.4.31)
@@ -6542,7 +6545,7 @@ packages:
     resolution: {integrity: sha512-zjuslnkj5zboZGis5QpmR5gvRTx5N8Ha/Rll+RRT8YZhXVNBincifhZ9apUQ9f6T0xJE8IHPyVyPx6WokomdYw==}
     dev: true
 
-  /@nuxt/vite-builder@3.12.3(@types/node@18.18.9)(eslint@7.32.0)(vue@3.4.31):
+  /@nuxt/vite-builder@3.12.3(@types/node@18.18.9)(eslint@7.32.0)(typescript@5.6.3)(vue@3.4.31):
     resolution: {integrity: sha512-8xfeOgSUaXTYgLx1DA5qEFwU3/vL5DVAIv8sgPn2rnmB50nPJVXrVa+tXhO0I1Q8L4ycXRqq2dxOPGq8CSYo+A==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
@@ -6579,8 +6582,8 @@ packages:
       unplugin: 1.11.0
       vite: 5.3.3(@types/node@18.18.9)
       vite-node: 1.6.0(@types/node@18.18.9)
-      vite-plugin-checker: 0.7.0(eslint@7.32.0)(vite@5.3.3)
-      vue: 3.4.31
+      vite-plugin-checker: 0.7.0(eslint@7.32.0)(typescript@5.6.3)(vite@5.3.3)
+      vue: 3.4.31(typescript@5.6.3)
       vue-bundle-renderer: 2.1.0
     transitivePeerDependencies:
       - '@types/node'
@@ -10779,7 +10782,7 @@ packages:
       '@unhead/shared': 1.9.15
       hookable: 5.5.3
       unhead: 1.9.15
-      vue: 3.4.31
+      vue: 3.4.31(typescript@5.6.3)
     dev: true
 
   /@upstash/core-analytics@0.0.6:
@@ -10975,7 +10978,7 @@ packages:
       '@babel/plugin-transform-typescript': 7.24.7(@babel/core@7.24.7)
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.24.7)
       vite: 5.3.3(@types/node@18.18.9)
-      vue: 3.4.31
+      vue: 3.4.31(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11010,7 +11013,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 5.3.3(@types/node@18.18.9)
-      vue: 3.4.31
+      vue: 3.4.31(typescript@5.6.3)
     dev: true
 
   /@vitest/expect@1.6.0:
@@ -11085,7 +11088,7 @@ packages:
       ast-kit: 0.12.2
       local-pkg: 0.5.0
       magic-string-ast: 0.6.2
-      vue: 3.4.31
+      vue: 3.4.31(typescript@5.6.3)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -11386,7 +11389,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.4.31
       '@vue/shared': 3.4.31
-      vue: 3.4.31
+      vue: 3.4.31(typescript@5.6.3)
     dev: true
 
   /@vue/server-renderer@3.5.10(vue@3.5.10):
@@ -19624,7 +19627,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /nuxt@3.12.3(@opentelemetry/api@1.9.0)(@types/node@18.18.9)(eslint@7.32.0)(vite@5.3.3):
+  /nuxt@3.12.3(@opentelemetry/api@1.9.0)(@types/node@18.18.9)(eslint@7.32.0)(typescript@5.6.3)(vite@5.3.3):
     resolution: {integrity: sha512-Qdkc+ucWwFcKsiL/OTF87jbgyFSymwPRKiiu0mvzsd/RXTn4hGiBduAlF3f7Yy0F9pDjSj8XHKDSnHYsDzm6rA==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -19642,7 +19645,7 @@ packages:
       '@nuxt/kit': 3.12.3(magicast@0.3.4)
       '@nuxt/schema': 3.12.3
       '@nuxt/telemetry': 2.5.4
-      '@nuxt/vite-builder': 3.12.3(@types/node@18.18.9)(eslint@7.32.0)(vue@3.4.31)
+      '@nuxt/vite-builder': 3.12.3(@types/node@18.18.9)(eslint@7.32.0)(typescript@5.6.3)(vue@3.4.31)
       '@types/node': 18.18.9
       '@unhead/dom': 1.9.15
       '@unhead/ssr': 1.9.15
@@ -19692,7 +19695,7 @@ packages:
       unplugin-vue-router: 0.10.0(vue-router@4.4.0)(vue@3.4.31)
       unstorage: 1.10.2(ioredis@5.3.2)
       untyped: 1.4.2
-      vue: 3.4.31
+      vue: 3.4.31(typescript@5.6.3)
       vue-bundle-renderer: 2.1.0
       vue-devtools-stub: 0.1.0
       vue-router: 4.4.0(vue@3.4.31)
@@ -24476,7 +24479,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-checker@0.7.0(eslint@7.32.0)(vite@5.3.3):
+  /vite-plugin-checker@0.7.0(eslint@7.32.0)(typescript@5.6.3)(vite@5.3.3):
     resolution: {integrity: sha512-F3MdUORNLcPC0oDB9zxmPDhUC8X/3fzDShU5Izk4bqE4uTgxbQdOuOCa99bS6OSyWVC0uhHG4yAtWUXM2jOx9A==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -24519,6 +24522,7 @@ packages:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
+      typescript: 5.6.3
       vite: 5.3.3(@types/node@18.18.9)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
@@ -25003,7 +25007,7 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.5.1
-      vue: 3.4.31
+      vue: 3.4.31(typescript@5.6.3)
     dev: true
 
   /vue@3.3.8(typescript@5.6.3):
@@ -25021,7 +25025,7 @@ packages:
       '@vue/shared': 3.3.8
       typescript: 5.6.3
 
-  /vue@3.4.31:
+  /vue@3.4.31(typescript@5.6.3):
     resolution: {integrity: sha512-njqRrOy7W3YLAlVqSKpBebtZpDVg21FPoaq1I7f/+qqBThK9ChAIjkRWgeP6Eat+8C+iia4P3OYqpATP21BCoQ==}
     peerDependencies:
       typescript: '*'
@@ -25034,6 +25038,7 @@ packages:
       '@vue/runtime-dom': 3.4.31
       '@vue/server-renderer': 3.4.31(vue@3.4.31)
       '@vue/shared': 3.4.31
+      typescript: 5.6.3
     dev: true
 
   /vue@3.5.10(typescript@5.6.3):


### PR DESCRIPTION
## Summary
- opt into typescript workspace version in vscode / cursor
- upgrade typescript to 5.6.3