### PR TITLE
fix(gemini): fix functionResponse format

### DIFF
--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -133,7 +133,10 @@ export function convertToGoogleGenerativeAIMessages(
           parts: content.map(part => ({
             functionResponse: {
               name: part.toolName,
-              response: part.result,
+              response: {
+                name: part.toolName,
+                content: part.result,
+              },
             },
           })),
         });


### PR DESCRIPTION
I'm currently getting the following error when using tools with gemini:

```
Invalid JSON payload received. 
Unknown name \"response\" at 'contents[2].parts[0].function_response': 
Proto field is not repeating, cannot start list.
```

According to https://ai.google.dev/gemini-api/docs/function-calling

The correct format of `functionResponse`:

![CleanShot 2024-11-10 at 15 11 28@2x](https://github.com/user-attachments/assets/9aef4cb2-1bd3-4ca9-b369-bacbf93cf517)
