### PR TITLE
chore (turbo): Fix turbo build output warning for three examples.

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -31,7 +31,14 @@
         "NEXT_RUNTIME",
         "XAI_API_KEY"
       ],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "!.next/cache/**",
+        ".nuxt/**",
+        ".svelte-kit/**",
+        ".vinxi/**"
+      ]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
This is likely a follow-up from the turbo 2 upgrade. Fixes the warnings at the end of build:

```
WARNING  no output files found for task nuxt-openai#build. Please check your `outputs` key in `turbo.json`
WARNING  no output files found for task solidstart-openai#build. Please check your `outputs` key in `turbo.json`
WARNING  no output files found for task sveltekit-openai#build. Please check your `outputs` key in `turbo.json`
```