### PR TITLE
chore (ai/core): streamObject returns result immediately (no Promise)

### DIFF
--- a/.changeset/lucky-rings-behave.md
+++ b/.changeset/lucky-rings-behave.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai/core): streamObject returns result immediately (no Promise)

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -49,7 +49,7 @@ With the [`streamObject`](/docs/reference/ai-sdk-core/stream-object) function, y
 ```ts
 import { streamObject } from 'ai';
 
-const { partialObjectStream } = await streamObject({
+const { partialObjectStream } = streamObject({
   // ...
 });
 
@@ -81,7 +81,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
-const { elementStream } = await streamObject({
+const { elementStream } = streamObject({
   model: openai('gpt-4-turbo'),
   output: 'array',
   schema: z.object({

--- a/content/docs/03-ai-sdk-core/55-testing.mdx
+++ b/content/docs/03-ai-sdk-core/55-testing.mdx
@@ -102,7 +102,7 @@ import { streamObject } from 'ai';
 import { simulateReadableStream, MockLanguageModelV1 } from 'ai/test';
 import { z } from 'zod';
 
-const result = await streamObject({
+const result = streamObject({
   model: new MockLanguageModelV1({
     defaultObjectGenerationMode: 'json',
     doStream: async () => ({

--- a/content/docs/04-ai-sdk-ui/08-object-generation.mdx
+++ b/content/docs/04-ai-sdk-ui/08-object-generation.mdx
@@ -84,7 +84,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const context = await req.json();
 
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: notificationSchema,
     prompt:

--- a/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
+++ b/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
@@ -614,7 +614,7 @@ export async function generateSampleNotifications() {
   const stream = createStreamableValue();
 
   (async () => {
-    const { partialObjectStream } = await streamObject({
+    const { partialObjectStream } = streamObject({
       model: openai('gpt-4o'),
       system: 'generate sample ios messages for testing',
       prompt: 'messages from a family group chat during diwali, max 4',
@@ -679,7 +679,7 @@ import { notificationSchema } from '@/utils/schemas';
 export async function POST(req: Request) {
   const context = await req.json();
 
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: notificationSchema,
     prompt:

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -16,7 +16,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
-const { partialObjectStream } = await streamObject({
+const { partialObjectStream } = streamObject({
   model: openai('gpt-4-turbo'),
   schema: z.object({
     recipe: z.object({
@@ -44,7 +44,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
-const { elementStream } = await streamObject({
+const { elementStream } = streamObject({
   model: openai('gpt-4-turbo'),
   output: 'array',
   schema: z.object({
@@ -68,7 +68,7 @@ for await (const hero of elementStream) {
 import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 
-const { partialObjectStream } = await streamObject({
+const { partialObjectStream } = streamObject({
   model: openai('gpt-4-turbo'),
   output: 'no-schema',
   prompt: 'Generate a lasagna recipe.',

--- a/content/docs/08-troubleshooting/01-migration-guide/01-migration-guide-4-0.mdx
+++ b/content/docs/08-troubleshooting/01-migration-guide/01-migration-guide-4-0.mdx
@@ -106,6 +106,11 @@ The legacy `Tokens` RSC streaming from 2.x has been removed.
 
 ## AI SDK Core Changes
 
+### `streamObject` return immediately
+
+Instead of returning a Promise, the `streamObject` function now returns immediately.
+The `warnings` property on the result is now a Promise.
+
 ### Remove roundtrips
 
 The `maxToolRoundtrips` and `maxAutomaticRoundtrips` options have been removed from the `generateText` and `streamText` functions.

--- a/content/examples/01-next/01-basics/04-streaming-object-generation.mdx
+++ b/content/examples/01-next/01-basics/04-streaming-object-generation.mdx
@@ -106,7 +106,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const context = await req.json();
 
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: notificationSchema,
     prompt:

--- a/content/examples/03-node/02-streaming-structured-data/01-stream-object.mdx
+++ b/content/examples/03-node/02-streaming-structured-data/01-stream-object.mdx
@@ -17,7 +17,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
-const { partialObjectStream } = await streamObject({
+const { partialObjectStream } = streamObject({
   model: openai('gpt-4-turbo'),
   schema: z.object({
     recipe: z.object({

--- a/content/examples/03-node/02-streaming-structured-data/10-token-usage.mdx
+++ b/content/examples/03-node/02-streaming-structured-data/10-token-usage.mdx
@@ -18,7 +18,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
-const result = await streamObject({
+const result = streamObject({
   model: openai('gpt-4-turbo'),
   schema: z.object({
     recipe: z.object({
@@ -43,7 +43,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamObject, TokenUsage } from 'ai';
 import { z } from 'zod';
 
-const result = await streamObject({
+const result = streamObject({
   model: openai('gpt-4-turbo'),
   schema: z.object({
     recipe: z.object({

--- a/content/examples/03-node/02-streaming-structured-data/12-object.mdx
+++ b/content/examples/03-node/02-streaming-structured-data/12-object.mdx
@@ -20,7 +20,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
-const result = await streamObject({
+const result = streamObject({
   model: openai('gpt-4-turbo'),
   schema: z.object({
     recipe: z.object({
@@ -52,7 +52,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
-const result = await streamObject({
+const result = streamObject({
   model: openai('gpt-4-turbo'),
   schema: z.object({
     recipe: z.object({

--- a/content/examples/05-rsc/01-basics/04-streaming-object-generation.mdx
+++ b/content/examples/05-rsc/01-basics/04-streaming-object-generation.mdx
@@ -100,7 +100,7 @@ export async function generate(input: string) {
   const stream = createStreamableValue();
 
   (async () => {
-    const { partialObjectStream } = await streamObject({
+    const { partialObjectStream } = streamObject({
       model: openai('gpt-4-turbo'),
       system: 'You generate three notifications for a messages app.',
       prompt: input,

--- a/content/providers/03-community-providers/21-crosshatch.mdx
+++ b/content/providers/03-community-providers/21-crosshatch.mdx
@@ -99,7 +99,7 @@ const crosshatch = createCrosshatch();
 const itemSummaries = [...]; // list of items
 const ids = (itemSummaries?.map(({ itemId }) => itemId) ?? []) as string[];
 
-const { elementStream } = await streamObject({
+const { elementStream } = streamObject({
   output: "array",
   mode: "json",
   model: crosshatch.languageModel("gpt-4o-mini", {

--- a/examples/ai-core/src/stream-object/amazon-bedrock.ts
+++ b/examples/ai-core/src/stream-object/amazon-bedrock.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: bedrock('anthropic.claude-3-5-sonnet-20240620-v1:0'),
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/stream-object/anthropic.ts
+++ b/examples/ai-core/src/stream-object/anthropic.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: anthropic('claude-3-5-sonnet-20240620'),
     maxTokens: 2000,
     schema: z.object({

--- a/examples/ai-core/src/stream-object/azure.ts
+++ b/examples/ai-core/src/stream-object/azure.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: azure('v0-gpt-35-turbo'), // use your own deployment
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/stream-object/fireworks.ts
+++ b/examples/ai-core/src/stream-object/fireworks.ts
@@ -10,7 +10,7 @@ const fireworks = createOpenAI({
 });
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: fireworks('accounts/fireworks/models/firefunction-v1'),
     maxTokens: 2000,
     schema: z.object({

--- a/examples/ai-core/src/stream-object/google-vertex.ts
+++ b/examples/ai-core/src/stream-object/google-vertex.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: vertex('gemini-1.5-pro'),
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/stream-object/google.ts
+++ b/examples/ai-core/src/stream-object/google.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: google('gemini-1.5-pro-002'),
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/stream-object/groq.ts
+++ b/examples/ai-core/src/stream-object/groq.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: groq('llama-3.1-70b-versatile'),
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/stream-object/mistral-json.ts
+++ b/examples/ai-core/src/stream-object/mistral-json.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: mistral('open-mistral-7b'),
     maxTokens: 2000,
     schema: z.object({

--- a/examples/ai-core/src/stream-object/mistral-tool.ts
+++ b/examples/ai-core/src/stream-object/mistral-tool.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: mistral('mistral-large-latest'),
     maxTokens: 2000,
     schema: z.object({

--- a/examples/ai-core/src/stream-object/mistral.ts
+++ b/examples/ai-core/src/stream-object/mistral.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: mistral('open-mistral-7b'),
     maxTokens: 2000,
     schema: z.object({

--- a/examples/ai-core/src/stream-object/mock.ts
+++ b/examples/ai-core/src/stream-object/mock.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: new MockLanguageModelV1({
       defaultObjectGenerationMode: 'json',
       doStream: async () => ({

--- a/examples/ai-core/src/stream-object/openai-array.ts
+++ b/examples/ai-core/src/stream-object/openai-array.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const { elementStream: destinations } = await streamObject({
+  const { elementStream: destinations } = streamObject({
     model: openai('gpt-4o'),
     output: 'array',
     schema: z.object({

--- a/examples/ai-core/src/stream-object/openai-fullstream.ts
+++ b/examples/ai-core/src/stream-object/openai-fullstream.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo', { logprobs: 2 }),
     maxTokens: 2000,
     schema: z.object({

--- a/examples/ai-core/src/stream-object/openai-json.ts
+++ b/examples/ai-core/src/stream-object/openai-json.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     maxTokens: 2000,
     schema: z.object({

--- a/examples/ai-core/src/stream-object/openai-no-schema.ts
+++ b/examples/ai-core/src/stream-object/openai-no-schema.ts
@@ -3,7 +3,7 @@ import { streamObject } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4o-2024-08-06'),
     output: 'no-schema',
     prompt:

--- a/examples/ai-core/src/stream-object/openai-object.ts
+++ b/examples/ai-core/src/stream-object/openai-object.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: z.object({
       recipe: z.object({

--- a/examples/ai-core/src/stream-object/openai-on-finish.ts
+++ b/examples/ai-core/src/stream-object/openai-on-finish.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/stream-object/openai-raw-json-schema.ts
+++ b/examples/ai-core/src/stream-object/openai-raw-json-schema.ts
@@ -3,7 +3,7 @@ import { jsonSchema, streamObject } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: jsonSchema<{
       recipe: {

--- a/examples/ai-core/src/stream-object/openai-request-body.ts
+++ b/examples/ai-core/src/stream-object/openai-request-body.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4o-mini', { structuredOutputs: true }),
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/stream-object/openai-store-generation.ts
+++ b/examples/ai-core/src/stream-object/openai-store-generation.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/stream-object/openai-structured-outputs-name-description.ts
+++ b/examples/ai-core/src/stream-object/openai-structured-outputs-name-description.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4o-2024-08-06', {
       structuredOutputs: true,
     }),

--- a/examples/ai-core/src/stream-object/openai-structured-outputs.ts
+++ b/examples/ai-core/src/stream-object/openai-structured-outputs.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4o-2024-08-06', {
       structuredOutputs: true,
     }),

--- a/examples/ai-core/src/stream-object/openai-token-usage.ts
+++ b/examples/ai-core/src/stream-object/openai-token-usage.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: z.object({
       recipe: z.object({

--- a/examples/ai-core/src/stream-object/openai-tool.ts
+++ b/examples/ai-core/src/stream-object/openai-tool.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     maxTokens: 2000,
     schema: z.object({

--- a/examples/ai-core/src/stream-object/openai.ts
+++ b/examples/ai-core/src/stream-object/openai.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4o-mini', { structuredOutputs: true }),
     schema: z.object({
       characters: z.array(

--- a/examples/ai-core/src/telemetry/stream-object.ts
+++ b/examples/ai-core/src/telemetry/stream-object.ts
@@ -15,7 +15,7 @@ const sdk = new NodeSDK({
 sdk.start();
 
 async function main() {
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4o-mini', { structuredOutputs: true }),
     schema: z.object({
       recipe: z.object({

--- a/examples/next-openai-pages/app/api/stream-object/route.ts
+++ b/examples/next-openai-pages/app/api/stream-object/route.ts
@@ -7,7 +7,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const context = await req.json();
 
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     schema: z.object({
       notifications: z.array(

--- a/examples/next-openai/app/api/use-object-expense-tracker/route.ts
+++ b/examples/next-openai/app/api/use-object-expense-tracker/route.ts
@@ -8,7 +8,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const { expense }: { expense: string } = await req.json();
 
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     system:
       'You categorize expenses into one of the following categories: ' +

--- a/examples/next-openai/app/api/use-object/route.ts
+++ b/examples/next-openai/app/api/use-object/route.ts
@@ -8,7 +8,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const context = await req.json();
 
-  const result = await streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     prompt: `Generate 3 notifications for a messages app in this context: ${context}`,
     schema: notificationSchema,

--- a/examples/next-openai/app/stream-object/actions.ts
+++ b/examples/next-openai/app/stream-object/actions.ts
@@ -8,19 +8,19 @@ import { PartialNotification, notificationSchema } from './schema';
 export async function generateNotifications(context: string) {
   const notificationsStream = createStreamableValue<PartialNotification>();
 
-  streamObject({
+  const result = streamObject({
     model: openai('gpt-4-turbo'),
     prompt: `Generate 3 notifications for a messages app in this context: ${context}`,
     schema: notificationSchema,
-  })
-    .then(async ({ partialObjectStream }) => {
-      for await (const partialObject of partialObjectStream) {
-        notificationsStream.update(partialObject);
-      }
-    })
-    .finally(() => {
-      notificationsStream.done();
-    });
+  });
+
+  try {
+    for await (const partialObject of result.partialObjectStream) {
+      notificationsStream.update(partialObject);
+    }
+  } finally {
+    notificationsStream.done();
+  }
 
   return notificationsStream.value;
 }

--- a/packages/ai/core/generate-object/__snapshots__/stream-object.test.ts.snap
+++ b/packages/ai/core/generate-object/__snapshots__/stream-object.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`output = "object" > options.onFinish > should be called when a valid object is generated 1`] = `
+exports[`streamObject > output = "object" > options.onFinish > should be called when a valid object is generated 1`] = `
 {
   "error": undefined,
   "experimental_providerMetadata": {
@@ -26,7 +26,7 @@ exports[`output = "object" > options.onFinish > should be called when a valid ob
 }
 `;
 
-exports[`output = "object" > options.onFinish > should be called when object doesn't match the schema 1`] = `
+exports[`streamObject > output = "object" > options.onFinish > should be called when object doesn't match the schema 1`] = `
 {
   "error": [AI_TypeValidationError: Type validation failed: Value: {"invalid":"Hello, world!"}.
 Error message: [
@@ -57,7 +57,7 @@ Error message: [
 }
 `;
 
-exports[`output = "object" > result.fullStream > should send full stream data 1`] = `
+exports[`streamObject > output = "object" > result.fullStream > should send full stream data 1`] = `
 [
   {
     "object": {},
@@ -125,9 +125,9 @@ exports[`output = "object" > result.fullStream > should send full stream data 1`
 ]
 `;
 
-exports[`telemetry > should not record any telemetry data when not explicitly enabled 1`] = `[]`;
+exports[`streamObject > telemetry > should not record any telemetry data when not explicitly enabled 1`] = `[]`;
 
-exports[`telemetry > should not record telemetry inputs / outputs when disabled with mode "json" 1`] = `
+exports[`streamObject > telemetry > should not record telemetry inputs / outputs when disabled with mode "json" 1`] = `
 [
   {
     "attributes": {
@@ -180,7 +180,7 @@ exports[`telemetry > should not record telemetry inputs / outputs when disabled 
 ]
 `;
 
-exports[`telemetry > should not record telemetry inputs / outputs when disabled with mode "tool" 1`] = `
+exports[`streamObject > telemetry > should not record telemetry inputs / outputs when disabled with mode "tool" 1`] = `
 [
   {
     "attributes": {
@@ -233,7 +233,7 @@ exports[`telemetry > should not record telemetry inputs / outputs when disabled 
 ]
 `;
 
-exports[`telemetry > should record telemetry data when enabled with mode "json" 1`] = `
+exports[`streamObject > telemetry > should record telemetry data when enabled with mode "json" 1`] = `
 [
   {
     "attributes": {
@@ -321,7 +321,7 @@ exports[`telemetry > should record telemetry data when enabled with mode "json" 
 ]
 `;
 
-exports[`telemetry > should record telemetry data when enabled with mode "tool" 1`] = `
+exports[`streamObject > telemetry > should record telemetry data when enabled with mode "tool" 1`] = `
 [
   {
     "attributes": {

--- a/packages/ai/core/generate-object/stream-object-result.ts
+++ b/packages/ai/core/generate-object/stream-object-result.ts
@@ -17,7 +17,7 @@ export interface StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM> {
   /**
   Warnings from the model provider (e.g. unsupported settings)
      */
-  readonly warnings: CallWarning[] | undefined;
+  readonly warnings: Promise<CallWarning[] | undefined>;
 
   /**
   The token usage of the generated response. Resolved when the response is finished.

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -399,6 +399,23 @@ describe('streamObject', () => {
           ],
         );
       });
+
+      it('should handle error in doStream', async () => {
+        const result = streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => {
+              throw new Error('test error');
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        await expect(async () => {
+          await convertAsyncIterableToArray(result.partialObjectStream);
+        }).rejects.toThrow('test error');
+      });
     });
 
     describe('result.fullStream', () => {

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -84,7 +84,7 @@ describe('streamObject', () => {
       });
 
       it('should send object deltas with json mode when structured outputs are enabled', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             supportsStructuredOutputs: true,
             doStream: async ({ prompt, mode }) => {
@@ -143,7 +143,7 @@ describe('streamObject', () => {
       });
 
       it('should use name and description with json mode when structured outputs are enabled', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             supportsStructuredOutputs: true,
             doStream: async ({ prompt, mode }) => {
@@ -205,7 +205,7 @@ describe('streamObject', () => {
       });
 
       it('should send object deltas with tool mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ prompt, mode }) => {
               assert.deepStrictEqual(mode, {
@@ -302,7 +302,7 @@ describe('streamObject', () => {
       });
 
       it('should  use name and description with tool mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ prompt, mode }) => {
               assert.deepStrictEqual(mode, {
@@ -403,7 +403,7 @@ describe('streamObject', () => {
 
     describe('result.fullStream', () => {
       it('should send full stream data', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -442,7 +442,7 @@ describe('streamObject', () => {
 
     describe('result.textStream', () => {
       it('should send text stream', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -475,7 +475,7 @@ describe('streamObject', () => {
 
     describe('result.toTextStreamResponse', () => {
       it('should create a Response with a text stream', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -520,7 +520,7 @@ describe('streamObject', () => {
       it('should write text deltas to a Node.js response-like object', async () => {
         const mockResponse = createMockServerResponse();
 
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -564,7 +564,7 @@ describe('streamObject', () => {
 
     describe('result.usage', () => {
       it('should resolve with token usage', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -599,7 +599,7 @@ describe('streamObject', () => {
 
     describe('result.providerMetadata', () => {
       it('should resolve with provider metadata', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -635,7 +635,7 @@ describe('streamObject', () => {
 
     describe('result.response', () => {
       it('should resolve with response information in json mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -677,7 +677,7 @@ describe('streamObject', () => {
       });
 
       it('should resolve with response information in tool mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -724,7 +724,7 @@ describe('streamObject', () => {
 
     describe('result.request', () => {
       it('should contain request information with json mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -763,7 +763,7 @@ describe('streamObject', () => {
       });
 
       it('should contain request information with tool mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -807,7 +807,7 @@ describe('streamObject', () => {
 
     describe('result.object', () => {
       it('should resolve with typed object', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -840,7 +840,7 @@ describe('streamObject', () => {
       });
 
       it('should reject object promise when the streamed object does not match the schema', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -877,7 +877,7 @@ describe('streamObject', () => {
       });
 
       it('should not lead to unhandled promise rejections when the streamed object does not match the schema', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -914,7 +914,7 @@ describe('streamObject', () => {
           Required<Parameters<typeof streamObject>[0]>['onFinish']
         >[0];
 
-        const { partialObjectStream } = await streamObject({
+        const { partialObjectStream } = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -959,7 +959,7 @@ describe('streamObject', () => {
           Required<Parameters<typeof streamObject>[0]>['onFinish']
         >[0];
 
-        const { partialObjectStream, object } = await streamObject({
+        const { partialObjectStream, object } = streamObject({
           model: new MockLanguageModelV1({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
@@ -1004,7 +1004,7 @@ describe('streamObject', () => {
 
     describe('options.headers', () => {
       it('should pass headers to model in json mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ headers }) => {
               expect(headers).toStrictEqual({
@@ -1039,7 +1039,7 @@ describe('streamObject', () => {
       });
 
       it('should pass headers to model in tool mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ headers }) => {
               expect(headers).toStrictEqual({
@@ -1079,7 +1079,7 @@ describe('streamObject', () => {
 
     describe('options.providerMetadata', () => {
       it('should pass provider metadata to model in json mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ providerMetadata }) => {
               expect(providerMetadata).toStrictEqual({
@@ -1116,7 +1116,7 @@ describe('streamObject', () => {
       });
 
       it('should pass provider metadata to model in tool mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ providerMetadata }) => {
               expect(providerMetadata).toStrictEqual({
@@ -1158,7 +1158,7 @@ describe('streamObject', () => {
 
     describe('custom schema', () => {
       it('should send object deltas with json mode', async () => {
-        const result = await streamObject({
+        const result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ prompt, mode }) => {
               assert.deepStrictEqual(mode, {
@@ -1242,7 +1242,7 @@ describe('streamObject', () => {
       >[0];
 
       beforeEach(async () => {
-        result = await streamObject({
+        result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ prompt, mode }) => {
               assert.deepStrictEqual(mode, {
@@ -1397,7 +1397,7 @@ describe('streamObject', () => {
       >[0];
 
       beforeEach(async () => {
-        result = await streamObject({
+        result = streamObject({
           model: new MockLanguageModelV1({
             doStream: async ({ prompt, mode }) => {
               assert.deepStrictEqual(mode, {
@@ -1509,7 +1509,7 @@ describe('streamObject', () => {
 
   describe('output = "no-schema"', () => {
     it('should send object deltas with json mode', async () => {
-      const result = await streamObject({
+      const result = streamObject({
         model: new MockLanguageModelV1({
           doStream: async ({ prompt, mode }) => {
             assert.deepStrictEqual(mode, {
@@ -1573,7 +1573,7 @@ describe('streamObject', () => {
     });
 
     it('should not record any telemetry data when not explicitly enabled', async () => {
-      const result = await streamObject({
+      const result = streamObject({
         model: new MockLanguageModelV1({
           doStream: async () => ({
             stream: convertArrayToReadableStream([
@@ -1611,7 +1611,7 @@ describe('streamObject', () => {
     });
 
     it('should record telemetry data when enabled with mode "json"', async () => {
-      const result = await streamObject({
+      const result = streamObject({
         model: new MockLanguageModelV1({
           doStream: async () => ({
             stream: convertArrayToReadableStream([
@@ -1669,7 +1669,7 @@ describe('streamObject', () => {
     });
 
     it('should record telemetry data when enabled with mode "tool"', async () => {
-      const result = await streamObject({
+      const result = streamObject({
         model: new MockLanguageModelV1({
           doStream: async () => ({
             stream: convertArrayToReadableStream([
@@ -1763,7 +1763,7 @@ describe('streamObject', () => {
     });
 
     it('should not record telemetry inputs / outputs when disabled with mode "json"', async () => {
-      const result = await streamObject({
+      const result = streamObject({
         model: new MockLanguageModelV1({
           doStream: async () => ({
             stream: convertArrayToReadableStream([
@@ -1807,7 +1807,7 @@ describe('streamObject', () => {
     });
 
     it('should not record telemetry inputs / outputs when disabled with mode "tool"', async () => {
-      const result = await streamObject({
+      const result = streamObject({
         model: new MockLanguageModelV1({
           doStream: async () => ({
             stream: convertArrayToReadableStream([
@@ -1889,7 +1889,7 @@ describe('streamObject', () => {
 
   describe('options.messages', () => {
     it('should detect and convert ui messages', async () => {
-      const result = await streamObject({
+      const result = streamObject({
         model: new MockLanguageModelV1({
           doStream: async ({ prompt }) => {
             expect(prompt).toStrictEqual([

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -14,8 +14,1500 @@ import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { streamObject } from './stream-object';
 import { StreamObjectResult } from './stream-object-result';
 
-describe('output = "object"', () => {
-  describe('result.objectStream', () => {
+describe('streamObject', () => {
+  describe('output = "object"', () => {
+    describe('result.objectStream', () => {
+      it('should send object deltas with json mode', async () => {
+        const result = streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ prompt, mode }) => {
+              expect(mode).toStrictEqual({
+                type: 'object-json',
+                name: undefined,
+                description: undefined,
+                schema: {
+                  $schema: 'http://json-schema.org/draft-07/schema#',
+                  additionalProperties: false,
+                  properties: { content: { type: 'string' } },
+                  required: ['content'],
+                  type: 'object',
+                },
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'system',
+                  content:
+                    'JSON schema:\n' +
+                    '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
+                    'You MUST answer with a JSON object that matches the JSON schema above.',
+                },
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'text-delta', textDelta: '{ ' },
+                  { type: 'text-delta', textDelta: '"content": ' },
+                  { type: 'text-delta', textDelta: `"Hello, ` },
+                  { type: 'text-delta', textDelta: `world` },
+                  { type: 'text-delta', textDelta: `!"` },
+                  { type: 'text-delta', textDelta: ' }' },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+          [
+            {},
+            { content: 'Hello, ' },
+            { content: 'Hello, world' },
+            { content: 'Hello, world!' },
+          ],
+        );
+      });
+
+      it('should send object deltas with json mode when structured outputs are enabled', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            supportsStructuredOutputs: true,
+            doStream: async ({ prompt, mode }) => {
+              assert.deepStrictEqual(mode, {
+                type: 'object-json',
+                name: undefined,
+                description: undefined,
+                schema: {
+                  $schema: 'http://json-schema.org/draft-07/schema#',
+                  additionalProperties: false,
+                  properties: { content: { type: 'string' } },
+                  required: ['content'],
+                  type: 'object',
+                },
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'text-delta', textDelta: '{ ' },
+                  { type: 'text-delta', textDelta: '"content": ' },
+                  { type: 'text-delta', textDelta: `"Hello, ` },
+                  { type: 'text-delta', textDelta: `world` },
+                  { type: 'text-delta', textDelta: `!"` },
+                  { type: 'text-delta', textDelta: ' }' },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+          [
+            {},
+            { content: 'Hello, ' },
+            { content: 'Hello, world' },
+            { content: 'Hello, world!' },
+          ],
+        );
+      });
+
+      it('should use name and description with json mode when structured outputs are enabled', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            supportsStructuredOutputs: true,
+            doStream: async ({ prompt, mode }) => {
+              assert.deepStrictEqual(mode, {
+                type: 'object-json',
+                name: 'test-name',
+                description: 'test description',
+                schema: {
+                  $schema: 'http://json-schema.org/draft-07/schema#',
+                  additionalProperties: false,
+                  properties: { content: { type: 'string' } },
+                  required: ['content'],
+                  type: 'object',
+                },
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'text-delta', textDelta: '{ ' },
+                  { type: 'text-delta', textDelta: '"content": ' },
+                  { type: 'text-delta', textDelta: `"Hello, ` },
+                  { type: 'text-delta', textDelta: `world` },
+                  { type: 'text-delta', textDelta: `!"` },
+                  { type: 'text-delta', textDelta: ' }' },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          schemaName: 'test-name',
+          schemaDescription: 'test description',
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+          [
+            {},
+            { content: 'Hello, ' },
+            { content: 'Hello, world' },
+            { content: 'Hello, world!' },
+          ],
+        );
+      });
+
+      it('should send object deltas with tool mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ prompt, mode }) => {
+              assert.deepStrictEqual(mode, {
+                type: 'object-tool',
+                tool: {
+                  type: 'function',
+                  name: 'json',
+                  description: 'Respond with a JSON object.',
+                  parameters: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    additionalProperties: false,
+                    properties: { content: { type: 'string' } },
+                    required: ['content'],
+                    type: 'object',
+                  },
+                },
+              });
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: '{ ',
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: '"content": ',
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: `"Hello, `,
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: `world`,
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: `!"`,
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: ' }',
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'tool',
+          prompt: 'prompt',
+        });
+
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+          [
+            {},
+            { content: 'Hello, ' },
+            { content: 'Hello, world' },
+            { content: 'Hello, world!' },
+          ],
+        );
+      });
+
+      it('should  use name and description with tool mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ prompt, mode }) => {
+              assert.deepStrictEqual(mode, {
+                type: 'object-tool',
+                tool: {
+                  type: 'function',
+                  name: 'test-name',
+                  description: 'test description',
+                  parameters: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    additionalProperties: false,
+                    properties: { content: { type: 'string' } },
+                    required: ['content'],
+                    type: 'object',
+                  },
+                },
+              });
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: '{ ',
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: '"content": ',
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: `"Hello, `,
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: `world`,
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: `!"`,
+                  },
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: ' }',
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          schemaName: 'test-name',
+          schemaDescription: 'test description',
+          mode: 'tool',
+          prompt: 'prompt',
+        });
+
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+          [
+            {},
+            { content: 'Hello, ' },
+            { content: 'Hello, world' },
+            { content: 'Hello, world!' },
+          ],
+        );
+      });
+    });
+
+    describe('result.fullStream', () => {
+      it('should send full stream data', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"content": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 2 },
+                  logprobs: [{ token: '-', logprob: 1, topLogprobs: [] }],
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: { logprobs: 0 } },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        expect(
+          await convertAsyncIterableToArray(result.fullStream),
+        ).toMatchSnapshot();
+      });
+    });
+
+    describe('result.textStream', () => {
+      it('should send text stream', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"content": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 2 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.textStream),
+          ['{ ', '"content": "Hello, ', 'world', '!"', ' }'],
+        );
+      });
+    });
+
+    describe('result.toTextStreamResponse', () => {
+      it('should create a Response with a text stream', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"content": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 2 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        const response = result.toTextStreamResponse();
+
+        assert.strictEqual(response.status, 200);
+        assert.strictEqual(
+          response.headers.get('Content-Type'),
+          'text/plain; charset=utf-8',
+        );
+
+        assert.deepStrictEqual(
+          await convertReadableStreamToArray(
+            response.body!.pipeThrough(new TextDecoderStream()),
+          ),
+          ['{ ', '"content": "Hello, ', 'world', '!"', ' }'],
+        );
+      });
+    });
+
+    describe('result.pipeTextStreamToResponse', async () => {
+      it('should write text deltas to a Node.js response-like object', async () => {
+        const mockResponse = createMockServerResponse();
+
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"content": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 2 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        result.pipeTextStreamToResponse(mockResponse);
+
+        await mockResponse.waitForEnd();
+
+        expect(mockResponse.statusCode).toBe(200);
+        expect(mockResponse.headers).toEqual({
+          'Content-Type': 'text/plain; charset=utf-8',
+        });
+        expect(mockResponse.getDecodedChunks()).toEqual([
+          '{ ',
+          '"content": "Hello, ',
+          'world',
+          '!"',
+          ' }',
+        ]);
+      });
+    });
+
+    describe('result.usage', () => {
+      it('should resolve with token usage', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'text-delta',
+                  textDelta: '{ "content": "Hello, world!" }',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        convertAsyncIterableToArray(result.partialObjectStream);
+
+        assert.deepStrictEqual(await result.usage, {
+          completionTokens: 10,
+          promptTokens: 3,
+          totalTokens: 13,
+        });
+      });
+    });
+
+    describe('result.providerMetadata', () => {
+      it('should resolve with provider metadata', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'text-delta',
+                  textDelta: '{ "content": "Hello, world!" }',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                  providerMetadata: {
+                    testProvider: { testKey: 'testValue' },
+                  },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        convertAsyncIterableToArray(result.partialObjectStream);
+
+        assert.deepStrictEqual(await result.experimental_providerMetadata, {
+          testProvider: { testKey: 'testValue' },
+        });
+      });
+    });
+
+    describe('result.response', () => {
+      it('should resolve with response information in json mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                {
+                  type: 'text-delta',
+                  textDelta: '{"content": "Hello, world!"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  logprobs: undefined,
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              rawResponse: { headers: { call: '2' } },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        convertAsyncIterableToArray(result.partialObjectStream);
+
+        expect(await result.response).toStrictEqual({
+          id: 'id-0',
+          modelId: 'mock-model-id',
+          timestamp: new Date(0),
+          headers: { call: '2' },
+        });
+      });
+
+      it('should resolve with response information in tool mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                {
+                  type: 'tool-call-delta',
+                  toolCallType: 'function',
+                  toolCallId: 'tool-call-1',
+                  toolName: 'json',
+                  argsTextDelta: '{"content": "Hello, world!"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  logprobs: undefined,
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              rawResponse: { headers: { call: '2' } },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'tool',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        convertAsyncIterableToArray(result.partialObjectStream);
+
+        expect(await result.response).toStrictEqual({
+          id: 'id-0',
+          modelId: 'mock-model-id',
+          timestamp: new Date(0),
+          headers: { call: '2' },
+        });
+      });
+    });
+
+    describe('result.request', () => {
+      it('should contain request information with json mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                {
+                  type: 'text-delta',
+                  textDelta: '{"content": "Hello, world!"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  logprobs: undefined,
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              request: { body: 'test body' },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        await convertAsyncIterableToArray(result.partialObjectStream);
+
+        expect(await result.request).toStrictEqual({
+          body: 'test body',
+        });
+      });
+
+      it('should contain request information with tool mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                {
+                  type: 'tool-call-delta',
+                  toolCallType: 'function',
+                  toolCallId: 'tool-call-1',
+                  toolName: 'json',
+                  argsTextDelta: '{"content": "Hello, world!"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  logprobs: undefined,
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              request: { body: 'test body' },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'tool',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        await convertAsyncIterableToArray(result.partialObjectStream);
+
+        expect(await result.request).toStrictEqual({
+          body: 'test body',
+        });
+      });
+    });
+
+    describe('result.object', () => {
+      it('should resolve with typed object', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"content": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        convertAsyncIterableToArray(result.partialObjectStream);
+
+        assert.deepStrictEqual(await result.object, {
+          content: 'Hello, world!',
+        });
+      });
+
+      it('should reject object promise when the streamed object does not match the schema', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"invalid": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        convertAsyncIterableToArray(result.partialObjectStream);
+
+        await result.object
+          .then(() => {
+            assert.fail('Expected object promise to be rejected');
+          })
+          .catch(error => {
+            expect(TypeValidationError.isInstance(error)).toBeTruthy();
+          });
+      });
+
+      it('should not lead to unhandled promise rejections when the streamed object does not match the schema', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"invalid": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        // consume stream (runs in parallel)
+        convertAsyncIterableToArray(result.partialObjectStream);
+
+        // unhandled promise rejection should not be thrown (Vitest does this automatically)
+      });
+    });
+
+    describe('options.onFinish', () => {
+      it('should be called when a valid object is generated', async () => {
+        let result: Parameters<
+          Required<Parameters<typeof streamObject>[0]>['onFinish']
+        >[0];
+
+        const { partialObjectStream } = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                {
+                  type: 'text-delta',
+                  textDelta: '{ "content": "Hello, world!" }',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                  providerMetadata: {
+                    testProvider: { testKey: 'testValue' },
+                  },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+          onFinish: async event => {
+            result = event as unknown as typeof result;
+          },
+        });
+
+        // consume stream
+        await convertAsyncIterableToArray(partialObjectStream);
+
+        expect(result!).toMatchSnapshot();
+      });
+
+      it("should be called when object doesn't match the schema", async () => {
+        let result: Parameters<
+          Required<Parameters<typeof streamObject>[0]>['onFinish']
+        >[0];
+
+        const { partialObjectStream, object } = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"invalid": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+          onFinish: async event => {
+            result = event as unknown as typeof result;
+          },
+        });
+
+        // consume stream
+        await convertAsyncIterableToArray(partialObjectStream);
+
+        // consume expected error rejection
+        await object.catch(() => {});
+
+        expect(result!).toMatchSnapshot();
+      });
+    });
+
+    describe('options.headers', () => {
+      it('should pass headers to model in json mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ headers }) => {
+              expect(headers).toStrictEqual({
+                'custom-request-header': 'request-header-value',
+              });
+
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'text-delta',
+                    textDelta: `{ "content": "headers test" }`,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+          headers: { 'custom-request-header': 'request-header-value' },
+        });
+
+        expect(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+        ).toStrictEqual([{ content: 'headers test' }]);
+      });
+
+      it('should pass headers to model in tool mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ headers }) => {
+              expect(headers).toStrictEqual({
+                'custom-request-header': 'request-header-value',
+              });
+
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: `{ "content": "headers test" }`,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'tool',
+          prompt: 'prompt',
+          headers: { 'custom-request-header': 'request-header-value' },
+        });
+
+        expect(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+        ).toStrictEqual([{ content: 'headers test' }]);
+      });
+    });
+
+    describe('options.providerMetadata', () => {
+      it('should pass provider metadata to model in json mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ providerMetadata }) => {
+              expect(providerMetadata).toStrictEqual({
+                aProvider: { someKey: 'someValue' },
+              });
+
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'text-delta',
+                    textDelta: `{ "content": "provider metadata test" }`,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'json',
+          prompt: 'prompt',
+          experimental_providerMetadata: {
+            aProvider: { someKey: 'someValue' },
+          },
+        });
+
+        expect(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+        ).toStrictEqual([{ content: 'provider metadata test' }]);
+      });
+
+      it('should pass provider metadata to model in tool mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ providerMetadata }) => {
+              expect(providerMetadata).toStrictEqual({
+                aProvider: { someKey: 'someValue' },
+              });
+
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'tool-call-delta',
+                    toolCallType: 'function',
+                    toolCallId: 'tool-call-1',
+                    toolName: 'json',
+                    argsTextDelta: `{ "content": "provider metadata test" }`,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          mode: 'tool',
+          prompt: 'prompt',
+          experimental_providerMetadata: {
+            aProvider: { someKey: 'someValue' },
+          },
+        });
+
+        expect(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+        ).toStrictEqual([{ content: 'provider metadata test' }]);
+      });
+    });
+
+    describe('custom schema', () => {
+      it('should send object deltas with json mode', async () => {
+        const result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ prompt, mode }) => {
+              assert.deepStrictEqual(mode, {
+                type: 'object-json',
+                name: undefined,
+                description: undefined,
+                schema: jsonSchema({
+                  type: 'object',
+                  properties: { content: { type: 'string' } },
+                  required: ['content'],
+                  additionalProperties: false,
+                }).jsonSchema,
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'system',
+                  content:
+                    'JSON schema:\n' +
+                    '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false}\n' +
+                    'You MUST answer with a JSON object that matches the JSON schema above.',
+                },
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'text-delta', textDelta: '{ ' },
+                  { type: 'text-delta', textDelta: '"content": ' },
+                  { type: 'text-delta', textDelta: `"Hello, ` },
+                  { type: 'text-delta', textDelta: `world` },
+                  { type: 'text-delta', textDelta: `!"` },
+                  { type: 'text-delta', textDelta: ' }' },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: jsonSchema({
+            type: 'object',
+            properties: { content: { type: 'string' } },
+            required: ['content'],
+            additionalProperties: false,
+          }),
+          mode: 'json',
+          prompt: 'prompt',
+        });
+
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+          [
+            {},
+            { content: 'Hello, ' },
+            { content: 'Hello, world' },
+            { content: 'Hello, world!' },
+          ],
+        );
+      });
+    });
+  });
+
+  describe('output = "array"', () => {
+    describe('array with 3 elements', () => {
+      let result: StreamObjectResult<
+        { content: string }[],
+        { content: string }[],
+        AsyncIterableStream<{ content: string }>
+      >;
+
+      let onFinishResult: Parameters<
+        Required<Parameters<typeof streamObject>[0]>['onFinish']
+      >[0];
+
+      beforeEach(async () => {
+        result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ prompt, mode }) => {
+              assert.deepStrictEqual(mode, {
+                type: 'object-json',
+                name: undefined,
+                description: undefined,
+                schema: {
+                  $schema: 'http://json-schema.org/draft-07/schema#',
+                  additionalProperties: false,
+                  properties: {
+                    elements: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: { content: { type: 'string' } },
+                        required: ['content'],
+                        additionalProperties: false,
+                      },
+                    },
+                  },
+                  required: ['elements'],
+                  type: 'object',
+                },
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'system',
+                  content:
+                    'JSON schema:\n' +
+                    `{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"elements\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"content\":{\"type\":\"string\"}},\"required\":[\"content\"],\"additionalProperties\":false}}},\"required\":[\"elements\"],\"additionalProperties\":false}` +
+                    `\n` +
+                    'You MUST answer with a JSON object that matches the JSON schema above.',
+                },
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'text-delta', textDelta: '{"elements":[' },
+                  // first element:
+                  { type: 'text-delta', textDelta: '{' },
+                  { type: 'text-delta', textDelta: '"content":' },
+                  { type: 'text-delta', textDelta: `"element 1"` },
+                  { type: 'text-delta', textDelta: '},' },
+                  // second element:
+                  { type: 'text-delta', textDelta: '{ ' },
+                  { type: 'text-delta', textDelta: '"content": ' },
+                  { type: 'text-delta', textDelta: `"element 2"` },
+                  { type: 'text-delta', textDelta: '},' },
+                  // third element:
+                  { type: 'text-delta', textDelta: '{' },
+                  { type: 'text-delta', textDelta: '"content":' },
+                  { type: 'text-delta', textDelta: `"element 3"` },
+                  { type: 'text-delta', textDelta: '}' },
+                  // end of array
+                  { type: 'text-delta', textDelta: ']' },
+                  { type: 'text-delta', textDelta: '}' },
+                  // finish
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          output: 'array',
+          mode: 'json',
+          prompt: 'prompt',
+          onFinish: async event => {
+            onFinishResult = event as unknown as typeof onFinishResult;
+          },
+        });
+      });
+
+      it('should stream only complete objects in partialObjectStream', async () => {
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+          [
+            [],
+            [{ content: 'element 1' }],
+            [{ content: 'element 1' }, { content: 'element 2' }],
+            [
+              { content: 'element 1' },
+              { content: 'element 2' },
+              { content: 'element 3' },
+            ],
+          ],
+        );
+      });
+
+      it('should stream only complete objects in textStream', async () => {
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.textStream),
+          [
+            '[',
+            '{"content":"element 1"}',
+            ',{"content":"element 2"}',
+            ',{"content":"element 3"}]',
+          ],
+        );
+      });
+
+      it('should have the correct object result', async () => {
+        // consume stream
+        await convertAsyncIterableToArray(result.partialObjectStream);
+
+        expect(await result.object).toStrictEqual([
+          { content: 'element 1' },
+          { content: 'element 2' },
+          { content: 'element 3' },
+        ]);
+      });
+
+      it('should call onFinish callback with full array', async () => {
+        expect(onFinishResult.object).toStrictEqual([
+          { content: 'element 1' },
+          { content: 'element 2' },
+          { content: 'element 3' },
+        ]);
+      });
+
+      it('should stream elements individually in elementStream', async () => {
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.elementStream),
+          [
+            { content: 'element 1' },
+            { content: 'element 2' },
+            { content: 'element 3' },
+          ],
+        );
+      });
+    });
+
+    describe('array with 2 elements streamed in 1 chunk', () => {
+      let result: StreamObjectResult<
+        { content: string }[],
+        { content: string }[],
+        AsyncIterableStream<{ content: string }>
+      >;
+
+      let onFinishResult: Parameters<
+        Required<Parameters<typeof streamObject>[0]>['onFinish']
+      >[0];
+
+      beforeEach(async () => {
+        result = await streamObject({
+          model: new MockLanguageModelV1({
+            doStream: async ({ prompt, mode }) => {
+              assert.deepStrictEqual(mode, {
+                type: 'object-json',
+                name: undefined,
+                description: undefined,
+                schema: {
+                  $schema: 'http://json-schema.org/draft-07/schema#',
+                  additionalProperties: false,
+                  properties: {
+                    elements: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: { content: { type: 'string' } },
+                        required: ['content'],
+                        additionalProperties: false,
+                      },
+                    },
+                  },
+                  required: ['elements'],
+                  type: 'object',
+                },
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'system',
+                  content:
+                    'JSON schema:\n' +
+                    `{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"elements\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"content\":{\"type\":\"string\"}},\"required\":[\"content\"],\"additionalProperties\":false}}},\"required\":[\"elements\"],\"additionalProperties\":false}` +
+                    `\n` +
+                    'You MUST answer with a JSON object that matches the JSON schema above.',
+                },
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+
+              return {
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'text-delta',
+                    textDelta:
+                      '{"elements":[{"content":"element 1"},{"content":"element 2"}]}',
+                  },
+                  // finish
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { completionTokens: 10, promptTokens: 3 },
+                  },
+                ]),
+                rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          output: 'array',
+          mode: 'json',
+          prompt: 'prompt',
+          onFinish: async event => {
+            onFinishResult = event as unknown as typeof onFinishResult;
+          },
+        });
+      });
+
+      it('should stream only complete objects in partialObjectStream', async () => {
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.partialObjectStream),
+          [[{ content: 'element 1' }, { content: 'element 2' }]],
+        );
+      });
+
+      it('should stream only complete objects in textStream', async () => {
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.textStream),
+          ['[{"content":"element 1"},{"content":"element 2"}]'],
+        );
+      });
+
+      it('should have the correct object result', async () => {
+        // consume stream
+        await convertAsyncIterableToArray(result.partialObjectStream);
+
+        expect(await result.object).toStrictEqual([
+          { content: 'element 1' },
+          { content: 'element 2' },
+        ]);
+      });
+
+      it('should call onFinish callback with full array', async () => {
+        expect(onFinishResult.object).toStrictEqual([
+          { content: 'element 1' },
+          { content: 'element 2' },
+        ]);
+      });
+
+      it('should stream elements individually in elementStream', async () => {
+        assert.deepStrictEqual(
+          await convertAsyncIterableToArray(result.elementStream),
+          [{ content: 'element 1' }, { content: 'element 2' }],
+        );
+      });
+    });
+  });
+
+  describe('output = "no-schema"', () => {
     it('should send object deltas with json mode', async () => {
       const result = await streamObject({
         model: new MockLanguageModelV1({
@@ -24,15 +1516,382 @@ describe('output = "object"', () => {
               type: 'object-json',
               name: undefined,
               description: undefined,
-              schema: {
-                $schema: 'http://json-schema.org/draft-07/schema#',
-                additionalProperties: false,
-                properties: { content: { type: 'string' } },
-                required: ['content'],
-                type: 'object',
-              },
+              schema: undefined,
             });
 
+            expect(prompt).toStrictEqual([
+              {
+                role: 'system',
+                content: 'You MUST answer with JSON.',
+              },
+              {
+                role: 'user',
+                content: [{ type: 'text', text: 'prompt' }],
+                providerMetadata: undefined,
+              },
+            ]);
+
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'text-delta', textDelta: '{ ' },
+                { type: 'text-delta', textDelta: '"content": ' },
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { completionTokens: 10, promptTokens: 3 },
+                },
+              ]),
+              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+            };
+          },
+        }),
+        output: 'no-schema',
+        prompt: 'prompt',
+      });
+
+      assert.deepStrictEqual(
+        await convertAsyncIterableToArray(result.partialObjectStream),
+        [
+          {},
+          { content: 'Hello, ' },
+          { content: 'Hello, world' },
+          { content: 'Hello, world!' },
+        ],
+      );
+    });
+  });
+
+  describe('telemetry', () => {
+    let tracer: MockTracer;
+
+    beforeEach(() => {
+      tracer = new MockTracer();
+    });
+
+    it('should not record any telemetry data when not explicitly enabled', async () => {
+      const result = await streamObject({
+        model: new MockLanguageModelV1({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-delta', textDelta: '{ ' },
+              { type: 'text-delta', textDelta: '"content": ' },
+              { type: 'text-delta', textDelta: `"Hello, ` },
+              { type: 'text-delta', textDelta: `world` },
+              { type: 'text-delta', textDelta: `!"` },
+              { type: 'text-delta', textDelta: ' }' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        mode: 'json',
+        prompt: 'prompt',
+        _internal: { now: () => 0 },
+      });
+
+      // consume stream
+      await convertAsyncIterableToArray(result.partialObjectStream);
+
+      expect(tracer.jsonSpans).toMatchSnapshot();
+    });
+
+    it('should record telemetry data when enabled with mode "json"', async () => {
+      const result = await streamObject({
+        model: new MockLanguageModelV1({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-delta', textDelta: '{ ' },
+              { type: 'text-delta', textDelta: '"content": ' },
+              { type: 'text-delta', textDelta: `"Hello, ` },
+              { type: 'text-delta', textDelta: `world` },
+              { type: 'text-delta', textDelta: `!"` },
+              { type: 'text-delta', textDelta: ' }' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        schemaName: 'test-name',
+        schemaDescription: 'test description',
+        mode: 'json',
+        prompt: 'prompt',
+        topK: 0.1,
+        topP: 0.2,
+        frequencyPenalty: 0.3,
+        presencePenalty: 0.4,
+        temperature: 0.5,
+        headers: {
+          header1: 'value1',
+          header2: 'value2',
+        },
+        experimental_telemetry: {
+          isEnabled: true,
+          functionId: 'test-function-id',
+          metadata: {
+            test1: 'value1',
+            test2: false,
+          },
+          tracer,
+        },
+        _internal: { now: () => 0 },
+      });
+
+      // consume stream
+      await convertAsyncIterableToArray(result.partialObjectStream);
+
+      expect(tracer.jsonSpans).toMatchSnapshot();
+    });
+
+    it('should record telemetry data when enabled with mode "tool"', async () => {
+      const result = await streamObject({
+        model: new MockLanguageModelV1({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: '{ ',
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: '"content": ',
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `"Hello, `,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `world`,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `!"`,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: ' }',
+              },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        schemaName: 'test-name',
+        schemaDescription: 'test description',
+        mode: 'tool',
+        prompt: 'prompt',
+        topK: 0.1,
+        topP: 0.2,
+        frequencyPenalty: 0.3,
+        presencePenalty: 0.4,
+        temperature: 0.5,
+        headers: {
+          header1: 'value1',
+          header2: 'value2',
+        },
+        experimental_telemetry: {
+          isEnabled: true,
+          functionId: 'test-function-id',
+          metadata: {
+            test1: 'value1',
+            test2: false,
+          },
+          tracer,
+        },
+        _internal: { now: () => 0 },
+      });
+
+      // consume stream
+      await convertAsyncIterableToArray(result.partialObjectStream);
+
+      expect(tracer.jsonSpans).toMatchSnapshot();
+    });
+
+    it('should not record telemetry inputs / outputs when disabled with mode "json"', async () => {
+      const result = await streamObject({
+        model: new MockLanguageModelV1({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-delta', textDelta: '{ ' },
+              { type: 'text-delta', textDelta: '"content": ' },
+              { type: 'text-delta', textDelta: `"Hello, ` },
+              { type: 'text-delta', textDelta: `world` },
+              { type: 'text-delta', textDelta: `!"` },
+              { type: 'text-delta', textDelta: ' }' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        mode: 'json',
+        prompt: 'prompt',
+        experimental_telemetry: {
+          isEnabled: true,
+          recordInputs: false,
+          recordOutputs: false,
+          tracer,
+        },
+        _internal: { now: () => 0 },
+      });
+
+      // consume stream
+      await convertAsyncIterableToArray(result.partialObjectStream);
+
+      expect(tracer.jsonSpans).toMatchSnapshot();
+    });
+
+    it('should not record telemetry inputs / outputs when disabled with mode "tool"', async () => {
+      const result = await streamObject({
+        model: new MockLanguageModelV1({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: '{ ',
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: '"content": ',
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `"Hello, `,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `world`,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: `!"`,
+              },
+              {
+                type: 'tool-call-delta',
+                toolCallType: 'function',
+                toolCallId: 'tool-call-1',
+                toolName: 'json',
+                argsTextDelta: ' }',
+              },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        mode: 'tool',
+        prompt: 'prompt',
+        experimental_telemetry: {
+          isEnabled: true,
+          recordInputs: false,
+          recordOutputs: false,
+          tracer,
+        },
+        _internal: { now: () => 0 },
+      });
+
+      // consume stream
+      await convertAsyncIterableToArray(result.partialObjectStream);
+
+      expect(tracer.jsonSpans).toMatchSnapshot();
+    });
+  });
+
+  describe('options.messages', () => {
+    it('should detect and convert ui messages', async () => {
+      const result = await streamObject({
+        model: new MockLanguageModelV1({
+          doStream: async ({ prompt }) => {
             expect(prompt).toStrictEqual([
               {
                 role: 'system',
@@ -42,1263 +1901,55 @@ describe('output = "object"', () => {
                   'You MUST answer with a JSON object that matches the JSON schema above.',
               },
               {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
-                providerMetadata: undefined,
-              },
-            ]);
-
-            return {
-              stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-        [
-          {},
-          { content: 'Hello, ' },
-          { content: 'Hello, world' },
-          { content: 'Hello, world!' },
-        ],
-      );
-    });
-
-    it('should send object deltas with json mode when structured outputs are enabled', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          supportsStructuredOutputs: true,
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, {
-              type: 'object-json',
-              name: undefined,
-              description: undefined,
-              schema: {
-                $schema: 'http://json-schema.org/draft-07/schema#',
-                additionalProperties: false,
-                properties: { content: { type: 'string' } },
-                required: ['content'],
-                type: 'object',
-              },
-            });
-
-            expect(prompt).toStrictEqual([
-              {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
-                providerMetadata: undefined,
-              },
-            ]);
-            return {
-              stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-        [
-          {},
-          { content: 'Hello, ' },
-          { content: 'Hello, world' },
-          { content: 'Hello, world!' },
-        ],
-      );
-    });
-
-    it('should use name and description with json mode when structured outputs are enabled', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          supportsStructuredOutputs: true,
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, {
-              type: 'object-json',
-              name: 'test-name',
-              description: 'test description',
-              schema: {
-                $schema: 'http://json-schema.org/draft-07/schema#',
-                additionalProperties: false,
-                properties: { content: { type: 'string' } },
-                required: ['content'],
-                type: 'object',
-              },
-            });
-
-            expect(prompt).toStrictEqual([
-              {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
-                providerMetadata: undefined,
-              },
-            ]);
-
-            return {
-              stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        schemaName: 'test-name',
-        schemaDescription: 'test description',
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-        [
-          {},
-          { content: 'Hello, ' },
-          { content: 'Hello, world' },
-          { content: 'Hello, world!' },
-        ],
-      );
-    });
-
-    it('should send object deltas with tool mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, {
-              type: 'object-tool',
-              tool: {
-                type: 'function',
-                name: 'json',
-                description: 'Respond with a JSON object.',
-                parameters: {
-                  $schema: 'http://json-schema.org/draft-07/schema#',
-                  additionalProperties: false,
-                  properties: { content: { type: 'string' } },
-                  required: ['content'],
-                  type: 'object',
-                },
-              },
-            });
-            expect(prompt).toStrictEqual([
-              {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
-                providerMetadata: undefined,
-              },
-            ]);
-
-            return {
-              stream: convertArrayToReadableStream([
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: '{ ',
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: '"content": ',
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: `"Hello, `,
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: `world`,
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: `!"`,
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: ' }',
-                },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'tool',
-        prompt: 'prompt',
-      });
-
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-        [
-          {},
-          { content: 'Hello, ' },
-          { content: 'Hello, world' },
-          { content: 'Hello, world!' },
-        ],
-      );
-    });
-
-    it('should  use name and description with tool mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, {
-              type: 'object-tool',
-              tool: {
-                type: 'function',
-                name: 'test-name',
-                description: 'test description',
-                parameters: {
-                  $schema: 'http://json-schema.org/draft-07/schema#',
-                  additionalProperties: false,
-                  properties: { content: { type: 'string' } },
-                  required: ['content'],
-                  type: 'object',
-                },
-              },
-            });
-            expect(prompt).toStrictEqual([
-              {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
-                providerMetadata: undefined,
-              },
-            ]);
-
-            return {
-              stream: convertArrayToReadableStream([
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: '{ ',
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: '"content": ',
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: `"Hello, `,
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: `world`,
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: `!"`,
-                },
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: ' }',
-                },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        schemaName: 'test-name',
-        schemaDescription: 'test description',
-        mode: 'tool',
-        prompt: 'prompt',
-      });
-
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-        [
-          {},
-          { content: 'Hello, ' },
-          { content: 'Hello, world' },
-          { content: 'Hello, world!' },
-        ],
-      );
-    });
-  });
-
-  describe('result.fullStream', () => {
-    it('should send full stream data', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'response-metadata',
-                id: 'id-0',
-                modelId: 'mock-model-id',
-                timestamp: new Date(0),
-              },
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 2 },
-                logprobs: [{ token: '-', logprob: 1, topLogprobs: [] }],
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: { logprobs: 0 } },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      expect(
-        await convertAsyncIterableToArray(result.fullStream),
-      ).toMatchSnapshot();
-    });
-  });
-
-  describe('result.textStream', () => {
-    it('should send text stream', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 2 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.textStream),
-        ['{ ', '"content": "Hello, ', 'world', '!"', ' }'],
-      );
-    });
-  });
-
-  describe('result.toTextStreamResponse', () => {
-    it('should create a Response with a text stream', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 2 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      const response = result.toTextStreamResponse();
-
-      assert.strictEqual(response.status, 200);
-      assert.strictEqual(
-        response.headers.get('Content-Type'),
-        'text/plain; charset=utf-8',
-      );
-
-      assert.deepStrictEqual(
-        await convertReadableStreamToArray(
-          response.body!.pipeThrough(new TextDecoderStream()),
-        ),
-        ['{ ', '"content": "Hello, ', 'world', '!"', ' }'],
-      );
-    });
-  });
-
-  describe('result.pipeTextStreamToResponse', async () => {
-    it('should write text deltas to a Node.js response-like object', async () => {
-      const mockResponse = createMockServerResponse();
-
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 2 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      result.pipeTextStreamToResponse(mockResponse);
-
-      await mockResponse.waitForEnd();
-
-      expect(mockResponse.statusCode).toBe(200);
-      expect(mockResponse.headers).toEqual({
-        'Content-Type': 'text/plain; charset=utf-8',
-      });
-      expect(mockResponse.getDecodedChunks()).toEqual([
-        '{ ',
-        '"content": "Hello, ',
-        'world',
-        '!"',
-        ' }',
-      ]);
-    });
-  });
-
-  describe('result.usage', () => {
-    it('should resolve with token usage', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'text-delta',
-                textDelta: '{ "content": "Hello, world!" }',
-              },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      convertAsyncIterableToArray(result.partialObjectStream);
-
-      assert.deepStrictEqual(await result.usage, {
-        completionTokens: 10,
-        promptTokens: 3,
-        totalTokens: 13,
-      });
-    });
-  });
-
-  describe('result.providerMetadata', () => {
-    it('should resolve with provider metadata', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'text-delta',
-                textDelta: '{ "content": "Hello, world!" }',
-              },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-                providerMetadata: {
-                  testProvider: { testKey: 'testValue' },
-                },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      convertAsyncIterableToArray(result.partialObjectStream);
-
-      assert.deepStrictEqual(await result.experimental_providerMetadata, {
-        testProvider: { testKey: 'testValue' },
-      });
-    });
-  });
-
-  describe('result.response', () => {
-    it('should resolve with response information in json mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'response-metadata',
-                id: 'id-0',
-                modelId: 'mock-model-id',
-                timestamp: new Date(0),
-              },
-              { type: 'text-delta', textDelta: '{"content": "Hello, world!"}' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                logprobs: undefined,
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            rawResponse: { headers: { call: '2' } },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      convertAsyncIterableToArray(result.partialObjectStream);
-
-      expect(await result.response).toStrictEqual({
-        id: 'id-0',
-        modelId: 'mock-model-id',
-        timestamp: new Date(0),
-        headers: { call: '2' },
-      });
-    });
-
-    it('should resolve with response information in tool mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'response-metadata',
-                id: 'id-0',
-                modelId: 'mock-model-id',
-                timestamp: new Date(0),
-              },
-              {
-                type: 'tool-call-delta',
-                toolCallType: 'function',
-                toolCallId: 'tool-call-1',
-                toolName: 'json',
-                argsTextDelta: '{"content": "Hello, world!"}',
-              },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                logprobs: undefined,
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            rawResponse: { headers: { call: '2' } },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'tool',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      convertAsyncIterableToArray(result.partialObjectStream);
-
-      expect(await result.response).toStrictEqual({
-        id: 'id-0',
-        modelId: 'mock-model-id',
-        timestamp: new Date(0),
-        headers: { call: '2' },
-      });
-    });
-  });
-
-  describe('result.request', () => {
-    it('should contain request information with json mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'response-metadata',
-                id: 'id-0',
-                modelId: 'mock-model-id',
-                timestamp: new Date(0),
-              },
-              { type: 'text-delta', textDelta: '{"content": "Hello, world!"}' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                logprobs: undefined,
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            request: { body: 'test body' },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      await convertAsyncIterableToArray(result.partialObjectStream);
-
-      expect(await result.request).toStrictEqual({
-        body: 'test body',
-      });
-    });
-
-    it('should contain request information with tool mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'response-metadata',
-                id: 'id-0',
-                modelId: 'mock-model-id',
-                timestamp: new Date(0),
-              },
-              {
-                type: 'tool-call-delta',
-                toolCallType: 'function',
-                toolCallId: 'tool-call-1',
-                toolName: 'json',
-                argsTextDelta: '{"content": "Hello, world!"}',
-              },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                logprobs: undefined,
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            request: { body: 'test body' },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'tool',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      await convertAsyncIterableToArray(result.partialObjectStream);
-
-      expect(await result.request).toStrictEqual({
-        body: 'test body',
-      });
-    });
-  });
-
-  describe('result.object', () => {
-    it('should resolve with typed object', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      convertAsyncIterableToArray(result.partialObjectStream);
-
-      assert.deepStrictEqual(await result.object, {
-        content: 'Hello, world!',
-      });
-    });
-
-    it('should reject object promise when the streamed object does not match the schema', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"invalid": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      convertAsyncIterableToArray(result.partialObjectStream);
-
-      await result.object
-        .then(() => {
-          assert.fail('Expected object promise to be rejected');
-        })
-        .catch(error => {
-          expect(TypeValidationError.isInstance(error)).toBeTruthy();
-        });
-    });
-
-    it('should not lead to unhandled promise rejections when the streamed object does not match the schema', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"invalid": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      // consume stream (runs in parallel)
-      convertAsyncIterableToArray(result.partialObjectStream);
-
-      // unhandled promise rejection should not be thrown (Vitest does this automatically)
-    });
-  });
-
-  describe('options.onFinish', () => {
-    it('should be called when a valid object is generated', async () => {
-      let result: Parameters<
-        Required<Parameters<typeof streamObject>[0]>['onFinish']
-      >[0];
-
-      const { partialObjectStream } = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'response-metadata',
-                id: 'id-0',
-                modelId: 'mock-model-id',
-                timestamp: new Date(0),
-              },
-              {
-                type: 'text-delta',
-                textDelta: '{ "content": "Hello, world!" }',
-              },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-                providerMetadata: {
-                  testProvider: { testKey: 'testValue' },
-                },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-        onFinish: async event => {
-          result = event as unknown as typeof result;
-        },
-      });
-
-      // consume stream
-      await convertAsyncIterableToArray(partialObjectStream);
-
-      expect(result!).toMatchSnapshot();
-    });
-
-    it("should be called when object doesn't match the schema", async () => {
-      let result: Parameters<
-        Required<Parameters<typeof streamObject>[0]>['onFinish']
-      >[0];
-
-      const { partialObjectStream, object } = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async () => ({
-            stream: convertArrayToReadableStream([
-              {
-                type: 'response-metadata',
-                id: 'id-0',
-                modelId: 'mock-model-id',
-                timestamp: new Date(0),
-              },
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"invalid": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-        onFinish: async event => {
-          result = event as unknown as typeof result;
-        },
-      });
-
-      // consume stream
-      await convertAsyncIterableToArray(partialObjectStream);
-
-      // consume expected error rejection
-      await object.catch(() => {});
-
-      expect(result!).toMatchSnapshot();
-    });
-  });
-
-  describe('options.headers', () => {
-    it('should pass headers to model in json mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ headers }) => {
-            expect(headers).toStrictEqual({
-              'custom-request-header': 'request-header-value',
-            });
-
-            return {
-              stream: convertArrayToReadableStream([
-                {
-                  type: 'text-delta',
-                  textDelta: `{ "content": "headers test" }`,
-                },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-        headers: { 'custom-request-header': 'request-header-value' },
-      });
-
-      expect(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-      ).toStrictEqual([{ content: 'headers test' }]);
-    });
-
-    it('should pass headers to model in tool mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ headers }) => {
-            expect(headers).toStrictEqual({
-              'custom-request-header': 'request-header-value',
-            });
-
-            return {
-              stream: convertArrayToReadableStream([
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: `{ "content": "headers test" }`,
-                },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'tool',
-        prompt: 'prompt',
-        headers: { 'custom-request-header': 'request-header-value' },
-      });
-
-      expect(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-      ).toStrictEqual([{ content: 'headers test' }]);
-    });
-  });
-
-  describe('options.providerMetadata', () => {
-    it('should pass provider metadata to model in json mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ providerMetadata }) => {
-            expect(providerMetadata).toStrictEqual({
-              aProvider: { someKey: 'someValue' },
-            });
-
-            return {
-              stream: convertArrayToReadableStream([
-                {
-                  type: 'text-delta',
-                  textDelta: `{ "content": "provider metadata test" }`,
-                },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'json',
-        prompt: 'prompt',
-        experimental_providerMetadata: {
-          aProvider: { someKey: 'someValue' },
-        },
-      });
-
-      expect(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-      ).toStrictEqual([{ content: 'provider metadata test' }]);
-    });
-
-    it('should pass provider metadata to model in tool mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ providerMetadata }) => {
-            expect(providerMetadata).toStrictEqual({
-              aProvider: { someKey: 'someValue' },
-            });
-
-            return {
-              stream: convertArrayToReadableStream([
-                {
-                  type: 'tool-call-delta',
-                  toolCallType: 'function',
-                  toolCallId: 'tool-call-1',
-                  toolName: 'json',
-                  argsTextDelta: `{ "content": "provider metadata test" }`,
-                },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        mode: 'tool',
-        prompt: 'prompt',
-        experimental_providerMetadata: {
-          aProvider: { someKey: 'someValue' },
-        },
-      });
-
-      expect(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-      ).toStrictEqual([{ content: 'provider metadata test' }]);
-    });
-  });
-
-  describe('custom schema', () => {
-    it('should send object deltas with json mode', async () => {
-      const result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, {
-              type: 'object-json',
-              name: undefined,
-              description: undefined,
-              schema: jsonSchema({
-                type: 'object',
-                properties: { content: { type: 'string' } },
-                required: ['content'],
-                additionalProperties: false,
-              }).jsonSchema,
-            });
-
-            expect(prompt).toStrictEqual([
-              {
-                role: 'system',
-                content:
-                  'JSON schema:\n' +
-                  '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false}\n' +
-                  'You MUST answer with a JSON object that matches the JSON schema above.',
-              },
-              {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
-                providerMetadata: undefined,
-              },
-            ]);
-
-            return {
-              stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
-          },
-        }),
-        schema: jsonSchema({
-          type: 'object',
-          properties: { content: { type: 'string' } },
-          required: ['content'],
-          additionalProperties: false,
-        }),
-        mode: 'json',
-        prompt: 'prompt',
-      });
-
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-        [
-          {},
-          { content: 'Hello, ' },
-          { content: 'Hello, world' },
-          { content: 'Hello, world!' },
-        ],
-      );
-    });
-  });
-});
-
-describe('output = "array"', () => {
-  describe('array with 3 elements', () => {
-    let result: StreamObjectResult<
-      { content: string }[],
-      { content: string }[],
-      AsyncIterableStream<{ content: string }>
-    >;
-
-    let onFinishResult: Parameters<
-      Required<Parameters<typeof streamObject>[0]>['onFinish']
-    >[0];
-
-    beforeEach(async () => {
-      result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, {
-              type: 'object-json',
-              name: undefined,
-              description: undefined,
-              schema: {
-                $schema: 'http://json-schema.org/draft-07/schema#',
-                additionalProperties: false,
-                properties: {
-                  elements: {
-                    type: 'array',
-                    items: {
-                      type: 'object',
-                      properties: { content: { type: 'string' } },
-                      required: ['content'],
-                      additionalProperties: false,
-                    },
+                content: [
+                  {
+                    text: 'prompt',
+                    type: 'text',
                   },
-                },
-                required: ['elements'],
-                type: 'object',
-              },
-            });
-
-            expect(prompt).toStrictEqual([
-              {
-                role: 'system',
-                content:
-                  'JSON schema:\n' +
-                  `{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"elements\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"content\":{\"type\":\"string\"}},\"required\":[\"content\"],\"additionalProperties\":false}}},\"required\":[\"elements\"],\"additionalProperties\":false}` +
-                  `\n` +
-                  'You MUST answer with a JSON object that matches the JSON schema above.',
-              },
-              {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
+                ],
                 providerMetadata: undefined,
+                role: 'user',
+              },
+              {
+                content: [
+                  {
+                    args: {
+                      value: 'test-value',
+                    },
+                    providerMetadata: undefined,
+                    toolCallId: 'call-1',
+                    toolName: 'test-tool',
+                    type: 'tool-call',
+                  },
+                ],
+                providerMetadata: undefined,
+                role: 'assistant',
+              },
+              {
+                content: [
+                  {
+                    content: undefined,
+                    isError: undefined,
+                    providerMetadata: undefined,
+                    result: 'test result',
+                    toolCallId: 'call-1',
+                    toolName: 'test-tool',
+                    type: 'tool-result',
+                  },
+                ],
+                providerMetadata: undefined,
+                role: 'tool',
               },
             ]);
 
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{"elements":[' },
-                // first element:
-                { type: 'text-delta', textDelta: '{' },
-                { type: 'text-delta', textDelta: '"content":' },
-                { type: 'text-delta', textDelta: `"element 1"` },
-                { type: 'text-delta', textDelta: '},' },
-                // second element:
                 { type: 'text-delta', textDelta: '{ ' },
                 { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"element 2"` },
-                { type: 'text-delta', textDelta: '},' },
-                // third element:
-                { type: 'text-delta', textDelta: '{' },
-                { type: 'text-delta', textDelta: '"content":' },
-                { type: 'text-delta', textDelta: `"element 3"` },
-                { type: 'text-delta', textDelta: '}' },
-                // end of array
-                { type: 'text-delta', textDelta: ']' },
-                { type: 'text-delta', textDelta: '}' },
-                // finish
+                { type: 'text-delta', textDelta: `"Hello, ` },
+                { type: 'text-delta', textDelta: `world` },
+                { type: 'text-delta', textDelta: `!"` },
+                { type: 'text-delta', textDelta: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -1310,679 +1961,36 @@ describe('output = "array"', () => {
           },
         }),
         schema: z.object({ content: z.string() }),
-        output: 'array',
         mode: 'json',
-        prompt: 'prompt',
-        onFinish: async event => {
-          onFinishResult = event as unknown as typeof onFinishResult;
-        },
-      });
-    });
-
-    it('should stream only complete objects in partialObjectStream', async () => {
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-        [
-          [],
-          [{ content: 'element 1' }],
-          [{ content: 'element 1' }, { content: 'element 2' }],
-          [
-            { content: 'element 1' },
-            { content: 'element 2' },
-            { content: 'element 3' },
-          ],
-        ],
-      );
-    });
-
-    it('should stream only complete objects in textStream', async () => {
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.textStream),
-        [
-          '[',
-          '{"content":"element 1"}',
-          ',{"content":"element 2"}',
-          ',{"content":"element 3"}]',
-        ],
-      );
-    });
-
-    it('should have the correct object result', async () => {
-      // consume stream
-      await convertAsyncIterableToArray(result.partialObjectStream);
-
-      expect(await result.object).toStrictEqual([
-        { content: 'element 1' },
-        { content: 'element 2' },
-        { content: 'element 3' },
-      ]);
-    });
-
-    it('should call onFinish callback with full array', async () => {
-      expect(onFinishResult.object).toStrictEqual([
-        { content: 'element 1' },
-        { content: 'element 2' },
-        { content: 'element 3' },
-      ]);
-    });
-
-    it('should stream elements individually in elementStream', async () => {
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.elementStream),
-        [
-          { content: 'element 1' },
-          { content: 'element 2' },
-          { content: 'element 3' },
-        ],
-      );
-    });
-  });
-
-  describe('array with 2 elements streamed in 1 chunk', () => {
-    let result: StreamObjectResult<
-      { content: string }[],
-      { content: string }[],
-      AsyncIterableStream<{ content: string }>
-    >;
-
-    let onFinishResult: Parameters<
-      Required<Parameters<typeof streamObject>[0]>['onFinish']
-    >[0];
-
-    beforeEach(async () => {
-      result = await streamObject({
-        model: new MockLanguageModelV1({
-          doStream: async ({ prompt, mode }) => {
-            assert.deepStrictEqual(mode, {
-              type: 'object-json',
-              name: undefined,
-              description: undefined,
-              schema: {
-                $schema: 'http://json-schema.org/draft-07/schema#',
-                additionalProperties: false,
-                properties: {
-                  elements: {
-                    type: 'array',
-                    items: {
-                      type: 'object',
-                      properties: { content: { type: 'string' } },
-                      required: ['content'],
-                      additionalProperties: false,
-                    },
-                  },
-                },
-                required: ['elements'],
-                type: 'object',
-              },
-            });
-
-            expect(prompt).toStrictEqual([
-              {
-                role: 'system',
-                content:
-                  'JSON schema:\n' +
-                  `{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"elements\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"content\":{\"type\":\"string\"}},\"required\":[\"content\"],\"additionalProperties\":false}}},\"required\":[\"elements\"],\"additionalProperties\":false}` +
-                  `\n` +
-                  'You MUST answer with a JSON object that matches the JSON schema above.',
-              },
-              {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
-                providerMetadata: undefined,
-              },
-            ]);
-
-            return {
-              stream: convertArrayToReadableStream([
-                {
-                  type: 'text-delta',
-                  textDelta:
-                    '{"elements":[{"content":"element 1"},{"content":"element 2"}]}',
-                },
-                // finish
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { completionTokens: 10, promptTokens: 3 },
-                },
-              ]),
-              rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-            };
+        messages: [
+          {
+            role: 'user',
+            content: 'prompt',
           },
-        }),
-        schema: z.object({ content: z.string() }),
-        output: 'array',
-        mode: 'json',
-        prompt: 'prompt',
-        onFinish: async event => {
-          onFinishResult = event as unknown as typeof onFinishResult;
-        },
-      });
-    });
-
-    it('should stream only complete objects in partialObjectStream', async () => {
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.partialObjectStream),
-        [[{ content: 'element 1' }, { content: 'element 2' }]],
-      );
-    });
-
-    it('should stream only complete objects in textStream', async () => {
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.textStream),
-        ['[{"content":"element 1"},{"content":"element 2"}]'],
-      );
-    });
-
-    it('should have the correct object result', async () => {
-      // consume stream
-      await convertAsyncIterableToArray(result.partialObjectStream);
-
-      expect(await result.object).toStrictEqual([
-        { content: 'element 1' },
-        { content: 'element 2' },
-      ]);
-    });
-
-    it('should call onFinish callback with full array', async () => {
-      expect(onFinishResult.object).toStrictEqual([
-        { content: 'element 1' },
-        { content: 'element 2' },
-      ]);
-    });
-
-    it('should stream elements individually in elementStream', async () => {
-      assert.deepStrictEqual(
-        await convertAsyncIterableToArray(result.elementStream),
-        [{ content: 'element 1' }, { content: 'element 2' }],
-      );
-    });
-  });
-});
-
-describe('output = "no-schema"', () => {
-  it('should send object deltas with json mode', async () => {
-    const result = await streamObject({
-      model: new MockLanguageModelV1({
-        doStream: async ({ prompt, mode }) => {
-          assert.deepStrictEqual(mode, {
-            type: 'object-json',
-            name: undefined,
-            description: undefined,
-            schema: undefined,
-          });
-
-          expect(prompt).toStrictEqual([
-            {
-              role: 'system',
-              content: 'You MUST answer with JSON.',
-            },
-            {
-              role: 'user',
-              content: [{ type: 'text', text: 'prompt' }],
-              providerMetadata: undefined,
-            },
-          ]);
-
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
+          {
+            role: 'assistant',
+            content: '',
+            toolInvocations: [
               {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'test-tool',
+                args: { value: 'test-value' },
+                result: 'test result',
               },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
-      }),
-      output: 'no-schema',
-      prompt: 'prompt',
-    });
+            ],
+          },
+        ],
+      });
 
-    assert.deepStrictEqual(
-      await convertAsyncIterableToArray(result.partialObjectStream),
-      [
+      expect(
+        await convertAsyncIterableToArray(result.partialObjectStream),
+      ).toStrictEqual([
         {},
         { content: 'Hello, ' },
         { content: 'Hello, world' },
         { content: 'Hello, world!' },
-      ],
-    );
-  });
-});
-
-describe('telemetry', () => {
-  let tracer: MockTracer;
-
-  beforeEach(() => {
-    tracer = new MockTracer();
-  });
-
-  it('should not record any telemetry data when not explicitly enabled', async () => {
-    const result = await streamObject({
-      model: new MockLanguageModelV1({
-        doStream: async () => ({
-          stream: convertArrayToReadableStream([
-            {
-              type: 'response-metadata',
-              id: 'id-0',
-              modelId: 'mock-model-id',
-              timestamp: new Date(0),
-            },
-            { type: 'text-delta', textDelta: '{ ' },
-            { type: 'text-delta', textDelta: '"content": ' },
-            { type: 'text-delta', textDelta: `"Hello, ` },
-            { type: 'text-delta', textDelta: `world` },
-            { type: 'text-delta', textDelta: `!"` },
-            { type: 'text-delta', textDelta: ' }' },
-            {
-              type: 'finish',
-              finishReason: 'stop',
-              usage: { completionTokens: 10, promptTokens: 3 },
-            },
-          ]),
-          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-        }),
-      }),
-      schema: z.object({ content: z.string() }),
-      mode: 'json',
-      prompt: 'prompt',
-      _internal: { now: () => 0 },
+      ]);
     });
-
-    // consume stream
-    await convertAsyncIterableToArray(result.partialObjectStream);
-
-    expect(tracer.jsonSpans).toMatchSnapshot();
-  });
-
-  it('should record telemetry data when enabled with mode "json"', async () => {
-    const result = await streamObject({
-      model: new MockLanguageModelV1({
-        doStream: async () => ({
-          stream: convertArrayToReadableStream([
-            {
-              type: 'response-metadata',
-              id: 'id-0',
-              modelId: 'mock-model-id',
-              timestamp: new Date(0),
-            },
-            { type: 'text-delta', textDelta: '{ ' },
-            { type: 'text-delta', textDelta: '"content": ' },
-            { type: 'text-delta', textDelta: `"Hello, ` },
-            { type: 'text-delta', textDelta: `world` },
-            { type: 'text-delta', textDelta: `!"` },
-            { type: 'text-delta', textDelta: ' }' },
-            {
-              type: 'finish',
-              finishReason: 'stop',
-              usage: { completionTokens: 10, promptTokens: 3 },
-            },
-          ]),
-          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-        }),
-      }),
-      schema: z.object({ content: z.string() }),
-      schemaName: 'test-name',
-      schemaDescription: 'test description',
-      mode: 'json',
-      prompt: 'prompt',
-      topK: 0.1,
-      topP: 0.2,
-      frequencyPenalty: 0.3,
-      presencePenalty: 0.4,
-      temperature: 0.5,
-      headers: {
-        header1: 'value1',
-        header2: 'value2',
-      },
-      experimental_telemetry: {
-        isEnabled: true,
-        functionId: 'test-function-id',
-        metadata: {
-          test1: 'value1',
-          test2: false,
-        },
-        tracer,
-      },
-      _internal: { now: () => 0 },
-    });
-
-    // consume stream
-    await convertAsyncIterableToArray(result.partialObjectStream);
-
-    expect(tracer.jsonSpans).toMatchSnapshot();
-  });
-
-  it('should record telemetry data when enabled with mode "tool"', async () => {
-    const result = await streamObject({
-      model: new MockLanguageModelV1({
-        doStream: async () => ({
-          stream: convertArrayToReadableStream([
-            {
-              type: 'response-metadata',
-              id: 'id-0',
-              modelId: 'mock-model-id',
-              timestamp: new Date(0),
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: '{ ',
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: '"content": ',
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: `"Hello, `,
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: `world`,
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: `!"`,
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: ' }',
-            },
-            {
-              type: 'finish',
-              finishReason: 'stop',
-              usage: { completionTokens: 10, promptTokens: 3 },
-            },
-          ]),
-          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-        }),
-      }),
-      schema: z.object({ content: z.string() }),
-      schemaName: 'test-name',
-      schemaDescription: 'test description',
-      mode: 'tool',
-      prompt: 'prompt',
-      topK: 0.1,
-      topP: 0.2,
-      frequencyPenalty: 0.3,
-      presencePenalty: 0.4,
-      temperature: 0.5,
-      headers: {
-        header1: 'value1',
-        header2: 'value2',
-      },
-      experimental_telemetry: {
-        isEnabled: true,
-        functionId: 'test-function-id',
-        metadata: {
-          test1: 'value1',
-          test2: false,
-        },
-        tracer,
-      },
-      _internal: { now: () => 0 },
-    });
-
-    // consume stream
-    await convertAsyncIterableToArray(result.partialObjectStream);
-
-    expect(tracer.jsonSpans).toMatchSnapshot();
-  });
-
-  it('should not record telemetry inputs / outputs when disabled with mode "json"', async () => {
-    const result = await streamObject({
-      model: new MockLanguageModelV1({
-        doStream: async () => ({
-          stream: convertArrayToReadableStream([
-            {
-              type: 'response-metadata',
-              id: 'id-0',
-              modelId: 'mock-model-id',
-              timestamp: new Date(0),
-            },
-            { type: 'text-delta', textDelta: '{ ' },
-            { type: 'text-delta', textDelta: '"content": ' },
-            { type: 'text-delta', textDelta: `"Hello, ` },
-            { type: 'text-delta', textDelta: `world` },
-            { type: 'text-delta', textDelta: `!"` },
-            { type: 'text-delta', textDelta: ' }' },
-            {
-              type: 'finish',
-              finishReason: 'stop',
-              usage: { completionTokens: 10, promptTokens: 3 },
-            },
-          ]),
-          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-        }),
-      }),
-      schema: z.object({ content: z.string() }),
-      mode: 'json',
-      prompt: 'prompt',
-      experimental_telemetry: {
-        isEnabled: true,
-        recordInputs: false,
-        recordOutputs: false,
-        tracer,
-      },
-      _internal: { now: () => 0 },
-    });
-
-    // consume stream
-    await convertAsyncIterableToArray(result.partialObjectStream);
-
-    expect(tracer.jsonSpans).toMatchSnapshot();
-  });
-
-  it('should not record telemetry inputs / outputs when disabled with mode "tool"', async () => {
-    const result = await streamObject({
-      model: new MockLanguageModelV1({
-        doStream: async () => ({
-          stream: convertArrayToReadableStream([
-            {
-              type: 'response-metadata',
-              id: 'id-0',
-              modelId: 'mock-model-id',
-              timestamp: new Date(0),
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: '{ ',
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: '"content": ',
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: `"Hello, `,
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: `world`,
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: `!"`,
-            },
-            {
-              type: 'tool-call-delta',
-              toolCallType: 'function',
-              toolCallId: 'tool-call-1',
-              toolName: 'json',
-              argsTextDelta: ' }',
-            },
-            {
-              type: 'finish',
-              finishReason: 'stop',
-              usage: { completionTokens: 10, promptTokens: 3 },
-            },
-          ]),
-          rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-        }),
-      }),
-      schema: z.object({ content: z.string() }),
-      mode: 'tool',
-      prompt: 'prompt',
-      experimental_telemetry: {
-        isEnabled: true,
-        recordInputs: false,
-        recordOutputs: false,
-        tracer,
-      },
-      _internal: { now: () => 0 },
-    });
-
-    // consume stream
-    await convertAsyncIterableToArray(result.partialObjectStream);
-
-    expect(tracer.jsonSpans).toMatchSnapshot();
-  });
-});
-
-describe('options.messages', () => {
-  it('should detect and convert ui messages', async () => {
-    const result = await streamObject({
-      model: new MockLanguageModelV1({
-        doStream: async ({ prompt }) => {
-          expect(prompt).toStrictEqual([
-            {
-              role: 'system',
-              content:
-                'JSON schema:\n' +
-                '{"type":"object","properties":{"content":{"type":"string"}},"required":["content"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}\n' +
-                'You MUST answer with a JSON object that matches the JSON schema above.',
-            },
-            {
-              content: [
-                {
-                  text: 'prompt',
-                  type: 'text',
-                },
-              ],
-              providerMetadata: undefined,
-              role: 'user',
-            },
-            {
-              content: [
-                {
-                  args: {
-                    value: 'test-value',
-                  },
-                  providerMetadata: undefined,
-                  toolCallId: 'call-1',
-                  toolName: 'test-tool',
-                  type: 'tool-call',
-                },
-              ],
-              providerMetadata: undefined,
-              role: 'assistant',
-            },
-            {
-              content: [
-                {
-                  content: undefined,
-                  isError: undefined,
-                  providerMetadata: undefined,
-                  result: 'test result',
-                  toolCallId: 'call-1',
-                  toolName: 'test-tool',
-                  type: 'tool-result',
-                },
-              ],
-              providerMetadata: undefined,
-              role: 'tool',
-            },
-          ]);
-
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { completionTokens: 10, promptTokens: 3 },
-              },
-            ]),
-            rawCall: { rawPrompt: 'prompt', rawSettings: {} },
-          };
-        },
-      }),
-      schema: z.object({ content: z.string() }),
-      mode: 'json',
-      messages: [
-        {
-          role: 'user',
-          content: 'prompt',
-        },
-        {
-          role: 'assistant',
-          content: '',
-          toolInvocations: [
-            {
-              state: 'result',
-              toolCallId: 'call-1',
-              toolName: 'test-tool',
-              args: { value: 'test-value' },
-              result: 'test result',
-            },
-          ],
-        },
-      ],
-    });
-
-    expect(
-      await convertAsyncIterableToArray(result.partialObjectStream),
-    ).toStrictEqual([
-      {},
-      { content: 'Hello, ' },
-      { content: 'Hello, world' },
-      { content: 'Hello, world!' },
-    ]);
   });
 });

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -11,10 +11,8 @@ import {
   isDeepEqualData,
   parsePartialJson,
 } from '@ai-sdk/ui-utils';
-import { Span } from '@opentelemetry/api';
 import { ServerResponse } from 'http';
 import { z } from 'zod';
-import { createResolvablePromise } from '../../util/create-resolvable-promise';
 import { DelayedPromise } from '../../util/delayed-promise';
 import { retryWithExponentialBackoff } from '../../util/retry-with-exponential-backoff';
 import { CallSettings } from '../prompt/call-settings';
@@ -32,10 +30,11 @@ import {
   CallWarning,
   FinishReason,
   LanguageModel,
-  LanguageModelResponseMetadata,
   LogProbs,
-  ProviderMetadata,
-} from '../types';
+} from '../types/language-model';
+import { LanguageModelRequestMetadata } from '../types/language-model-request-metadata';
+import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
+import { ProviderMetadata } from '../types/provider-metadata';
 import {
   LanguageModelUsage,
   calculateLanguageModelUsage,
@@ -52,6 +51,7 @@ import { injectJsonInstruction } from './inject-json-instruction';
 import { OutputStrategy, getOutputStrategy } from './output-strategy';
 import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
+import { createStitchableStream } from '../util/create-stitchable-stream';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -97,7 +97,7 @@ This function streams the output. If you do not want to stream the output, use `
 @return
 A result object for accessing the partial object stream and additional information.
  */
-export async function streamObject<OBJECT>(
+export function streamObject<OBJECT>(
   options: Omit<CallSettings, 'stopSequences'> &
     Prompt & {
       output?: 'object' | undefined;
@@ -167,7 +167,7 @@ Callback that is called when the LLM response and the final object validation ar
         now?: () => number;
       };
     },
-): Promise<StreamObjectResult<DeepPartial<OBJECT>, OBJECT, never>>;
+): StreamObjectResult<DeepPartial<OBJECT>, OBJECT, never>;
 /**
 Generate an array with structured, typed elements for a given prompt and element schema using a language model.
 
@@ -176,7 +176,7 @@ This function streams the output. If you do not want to stream the output, use `
 @return
 A result object for accessing the partial object stream and additional information.
  */
-export async function streamObject<ELEMENT>(
+export function streamObject<ELEMENT>(
   options: Omit<CallSettings, 'stopSequences'> &
     Prompt & {
       output: 'array';
@@ -246,12 +246,10 @@ Callback that is called when the LLM response and the final object validation ar
         now?: () => number;
       };
     },
-): Promise<
-  StreamObjectResult<
-    Array<ELEMENT>,
-    Array<ELEMENT>,
-    AsyncIterableStream<ELEMENT>
-  >
+): StreamObjectResult<
+  Array<ELEMENT>,
+  Array<ELEMENT>,
+  AsyncIterableStream<ELEMENT>
 >;
 /**
 Generate JSON with any schema for a given prompt using a language model.
@@ -261,7 +259,7 @@ This function streams the output. If you do not want to stream the output, use `
 @return
 A result object for accessing the partial object stream and additional information.
  */
-export async function streamObject(
+export function streamObject(
   options: Omit<CallSettings, 'stopSequences'> &
     Prompt & {
       output: 'no-schema';
@@ -302,8 +300,8 @@ Callback that is called when the LLM response and the final object validation ar
         now?: () => number;
       };
     },
-): Promise<StreamObjectResult<JSONValue, JSONValue, never>>;
-export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
+): StreamObjectResult<JSONValue, JSONValue, never>;
+export function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
   model,
   schema: inputSchema,
   schemaName,
@@ -351,7 +349,7 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
       currentDate?: () => Date;
       now?: () => number;
     };
-  }): Promise<StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>> {
+  }): StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM> {
   validateObjectGenerationInput({
     output,
     mode,
@@ -367,551 +365,571 @@ export async function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
     mode = 'json';
   }
 
-  const baseTelemetryAttributes = getBaseTelemetryAttributes({
+  return new DefaultStreamObjectResult({
     model,
     telemetry,
     headers,
-    settings: { ...settings, maxRetries },
-  });
-
-  const tracer = getTracer(telemetry);
-
-  const retry = retryWithExponentialBackoff({ maxRetries });
-
-  return recordSpan({
-    name: 'ai.streamObject',
-    attributes: selectTelemetryAttributes({
-      telemetry,
-      attributes: {
-        ...assembleOperationName({
-          operationId: 'ai.streamObject',
-          telemetry,
-        }),
-        ...baseTelemetryAttributes,
-        // specific settings that only make sense on the outer level:
-        'ai.prompt': {
-          input: () => JSON.stringify({ system, prompt, messages }),
-        },
-        'ai.schema':
-          outputStrategy.jsonSchema != null
-            ? { input: () => JSON.stringify(outputStrategy.jsonSchema) }
-            : undefined,
-        'ai.schema.name': schemaName,
-        'ai.schema.description': schemaDescription,
-        'ai.settings.output': outputStrategy.type,
-        'ai.settings.mode': mode,
-      },
-    }),
-    tracer,
-    endWhenDone: false,
-    fn: async rootSpan => {
-      // use the default provider mode when the mode is set to 'auto' or unspecified
-      if (mode === 'auto' || mode == null) {
-        mode = model.defaultObjectGenerationMode;
-      }
-
-      let callOptions: LanguageModelV1CallOptions;
-      let transformer: Transformer<
-        LanguageModelV1StreamPart,
-        string | Omit<LanguageModelV1StreamPart, 'text-delta'>
-      >;
-
-      switch (mode) {
-        case 'json': {
-          const standardizedPrompt = standardizePrompt({
-            prompt: {
-              system:
-                outputStrategy.jsonSchema == null
-                  ? injectJsonInstruction({ prompt: system })
-                  : model.supportsStructuredOutputs
-                  ? system
-                  : injectJsonInstruction({
-                      prompt: system,
-                      schema: outputStrategy.jsonSchema,
-                    }),
-              prompt,
-              messages,
-            },
-            tools: undefined,
-          });
-
-          callOptions = {
-            mode: {
-              type: 'object-json',
-              schema: outputStrategy.jsonSchema,
-              name: schemaName,
-              description: schemaDescription,
-            },
-            ...prepareCallSettings(settings),
-            inputFormat: standardizedPrompt.type,
-            prompt: await convertToLanguageModelPrompt({
-              prompt: standardizedPrompt,
-              modelSupportsImageUrls: model.supportsImageUrls,
-              modelSupportsUrl: model.supportsUrl,
-            }),
-            providerMetadata,
-            abortSignal,
-            headers,
-          };
-
-          transformer = {
-            transform: (chunk, controller) => {
-              switch (chunk.type) {
-                case 'text-delta':
-                  controller.enqueue(chunk.textDelta);
-                  break;
-                case 'response-metadata':
-                case 'finish':
-                case 'error':
-                  controller.enqueue(chunk);
-                  break;
-              }
-            },
-          };
-
-          break;
-        }
-
-        case 'tool': {
-          const standardizedPrompt = standardizePrompt({
-            prompt: { system, prompt, messages },
-            tools: undefined,
-          });
-
-          callOptions = {
-            mode: {
-              type: 'object-tool',
-              tool: {
-                type: 'function',
-                name: schemaName ?? 'json',
-                description: schemaDescription ?? 'Respond with a JSON object.',
-                parameters: outputStrategy.jsonSchema!,
-              },
-            },
-            ...prepareCallSettings(settings),
-            inputFormat: standardizedPrompt.type,
-            prompt: await convertToLanguageModelPrompt({
-              prompt: standardizedPrompt,
-              modelSupportsImageUrls: model.supportsImageUrls,
-              modelSupportsUrl: model.supportsUrl,
-            }),
-            providerMetadata,
-            abortSignal,
-            headers,
-          };
-
-          transformer = {
-            transform(chunk, controller) {
-              switch (chunk.type) {
-                case 'tool-call-delta':
-                  controller.enqueue(chunk.argsTextDelta);
-                  break;
-                case 'response-metadata':
-                case 'finish':
-                case 'error':
-                  controller.enqueue(chunk);
-                  break;
-              }
-            },
-          };
-
-          break;
-        }
-
-        case undefined: {
-          throw new Error(
-            'Model does not have a default object generation mode.',
-          );
-        }
-
-        default: {
-          const _exhaustiveCheck: never = mode;
-          throw new Error(`Unsupported mode: ${_exhaustiveCheck}`);
-        }
-      }
-
-      const {
-        result: { stream, warnings, rawResponse, request },
-        doStreamSpan,
-        startTimestampMs,
-      } = await retry(() =>
-        recordSpan({
-          name: 'ai.streamObject.doStream',
-          attributes: selectTelemetryAttributes({
-            telemetry,
-            attributes: {
-              ...assembleOperationName({
-                operationId: 'ai.streamObject.doStream',
-                telemetry,
-              }),
-              ...baseTelemetryAttributes,
-              'ai.prompt.format': {
-                input: () => callOptions.inputFormat,
-              },
-              'ai.prompt.messages': {
-                input: () => JSON.stringify(callOptions.prompt),
-              },
-              'ai.settings.mode': mode,
-
-              // standardized gen-ai llm span attributes:
-              'gen_ai.system': model.provider,
-              'gen_ai.request.model': model.modelId,
-              'gen_ai.request.frequency_penalty': settings.frequencyPenalty,
-              'gen_ai.request.max_tokens': settings.maxTokens,
-              'gen_ai.request.presence_penalty': settings.presencePenalty,
-              'gen_ai.request.temperature': settings.temperature,
-              'gen_ai.request.top_k': settings.topK,
-              'gen_ai.request.top_p': settings.topP,
-            },
-          }),
-          tracer,
-          endWhenDone: false,
-          fn: async doStreamSpan => ({
-            startTimestampMs: now(),
-            doStreamSpan,
-            result: await model.doStream(callOptions),
-          }),
-        }),
-      );
-
-      return new DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>({
-        outputStrategy,
-        stream: stream.pipeThrough(new TransformStream(transformer)),
-        warnings,
-        rawResponse,
-        request: request ?? {},
-        onFinish,
-        rootSpan,
-        doStreamSpan,
-        telemetry,
-        startTimestampMs,
-        modelId: model.modelId,
-        now,
-        currentDate,
-        generateId,
-      });
-    },
+    settings,
+    maxRetries,
+    abortSignal,
+    outputStrategy,
+    system,
+    prompt,
+    messages,
+    schemaName,
+    schemaDescription,
+    inputProviderMetadata: providerMetadata,
+    mode,
+    onFinish,
+    generateId,
+    currentDate,
+    now,
   });
 }
 
 class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
   implements StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
 {
-  private readonly originalStream: ReadableStream<ObjectStreamPart<PARTIAL>>;
-  private readonly objectPromise: DelayedPromise<RESULT>;
+  private readonly objectPromise = new DelayedPromise<RESULT>();
+  private readonly usagePromise = new DelayedPromise<LanguageModelUsage>();
+  private readonly providerMetadataPromise = new DelayedPromise<
+    ProviderMetadata | undefined
+  >();
+  private readonly warningsPromise = new DelayedPromise<
+    CallWarning[] | undefined
+  >();
+  private readonly requestPromise =
+    new DelayedPromise<LanguageModelRequestMetadata>();
+  private readonly responsePromise =
+    new DelayedPromise<LanguageModelResponseMetadata>();
+  private readonly stitchableStream =
+    createStitchableStream<ObjectStreamPart<PARTIAL>>();
 
-  readonly request: StreamObjectResult<
+  private readonly outputStrategy: OutputStrategy<
     PARTIAL,
     RESULT,
     ELEMENT_STREAM
-  >['request'];
-
-  readonly warnings: StreamObjectResult<
-    PARTIAL,
-    RESULT,
-    ELEMENT_STREAM
-  >['warnings'];
-  readonly usage: StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>['usage'];
-  readonly experimental_providerMetadata: StreamObjectResult<
-    PARTIAL,
-    RESULT,
-    ELEMENT_STREAM
-  >['experimental_providerMetadata'];
-  readonly outputStrategy: OutputStrategy<PARTIAL, RESULT, ELEMENT_STREAM>;
-  readonly response: StreamObjectResult<
-    PARTIAL,
-    RESULT,
-    ELEMENT_STREAM
-  >['response'];
+  >;
 
   constructor({
-    stream,
-    warnings,
-    rawResponse,
-    request,
-    outputStrategy,
-    onFinish,
-    rootSpan,
-    doStreamSpan,
+    model,
+    headers,
     telemetry,
-    startTimestampMs,
-    modelId,
-    now,
-    currentDate,
+    settings,
+    maxRetries,
+    abortSignal,
+    outputStrategy,
+    system,
+    prompt,
+    messages,
+    schemaName,
+    schemaDescription,
+    inputProviderMetadata,
+    mode,
+    onFinish,
     generateId,
+    currentDate,
+    now,
   }: {
-    stream: ReadableStream<
-      string | Omit<LanguageModelV1StreamPart, 'text-delta'>
-    >;
-    warnings: StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>['warnings'];
-    rawResponse: { headers?: Record<string, string> } | undefined;
-    request: Awaited<
-      StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>['request']
-    >;
-    outputStrategy: OutputStrategy<PARTIAL, RESULT, ELEMENT_STREAM>;
-    onFinish: OnFinishCallback<RESULT> | undefined;
-    rootSpan: Span;
-    doStreamSpan: Span;
+    model: LanguageModel;
     telemetry: TelemetrySettings | undefined;
-    startTimestampMs: number;
-    modelId: string;
-    now: () => number;
-    currentDate: () => Date;
+    headers: Record<string, string | undefined> | undefined;
+    settings: Omit<CallSettings, 'abortSignal' | 'headers'>;
+    maxRetries: number | undefined;
+    abortSignal: AbortSignal | undefined;
+    outputStrategy: OutputStrategy<PARTIAL, RESULT, ELEMENT_STREAM>;
+    system: Prompt['system'];
+    prompt: Prompt['prompt'];
+    messages: Prompt['messages'];
+    schemaName: string | undefined;
+    schemaDescription: string | undefined;
+    inputProviderMetadata: ProviderMetadata | undefined;
+    mode: 'auto' | 'json' | 'tool' | undefined;
+    onFinish: OnFinishCallback<RESULT> | undefined;
     generateId: () => string;
+    currentDate: () => Date;
+    now: () => number;
   }) {
-    this.warnings = warnings;
-    this.outputStrategy = outputStrategy;
-    this.request = Promise.resolve(request);
+    const baseTelemetryAttributes = getBaseTelemetryAttributes({
+      model,
+      telemetry,
+      headers,
+      settings: { ...settings, maxRetries },
+    });
 
-    // initialize object promise
-    this.objectPromise = new DelayedPromise<RESULT>();
-
-    // initialize usage promise
-    const { resolve: resolveUsage, promise: usagePromise } =
-      createResolvablePromise<LanguageModelUsage>();
-    this.usage = usagePromise;
-
-    // initialize response promise
-    const { resolve: resolveResponse, promise: responsePromise } =
-      createResolvablePromise<LanguageModelResponseMetadata>();
-    this.response = responsePromise;
-
-    // initialize experimental_providerMetadata promise
-    const {
-      resolve: resolveProviderMetadata,
-      promise: providerMetadataPromise,
-    } = createResolvablePromise<ProviderMetadata | undefined>();
-    this.experimental_providerMetadata = providerMetadataPromise;
-
-    // store information for onFinish callback:
-    let usage: LanguageModelUsage | undefined;
-    let finishReason: LanguageModelV1FinishReason | undefined;
-    let providerMetadata: ProviderMetadata | undefined;
-    let object: RESULT | undefined;
-    let error: unknown | undefined;
-
-    // pipe chunks through a transformation stream that extracts metadata:
-    let accumulatedText = '';
-    let textDelta = '';
-    let response: {
-      id: string;
-      timestamp: Date;
-      modelId: string;
-    } = {
-      id: generateId(),
-      timestamp: currentDate(),
-      modelId,
-    };
-
-    // Keep track of raw parse result before type validation, since e.g. Zod might
-    // change the object by mapping properties.
-    let latestObjectJson: JSONValue | undefined = undefined;
-    let latestObject: PARTIAL | undefined = undefined;
-    let isFirstChunk = true;
-    let isFirstDelta = true;
-
+    const tracer = getTracer(telemetry);
+    const retry = retryWithExponentialBackoff({ maxRetries });
     const self = this;
-    this.originalStream = stream.pipeThrough(
-      new TransformStream<
-        string | ObjectStreamInputPart,
-        ObjectStreamPart<PARTIAL>
-      >({
-        async transform(chunk, controller): Promise<void> {
-          // Telemetry event for first chunk:
-          if (isFirstChunk) {
-            const msToFirstChunk = now() - startTimestampMs;
 
-            isFirstChunk = false;
-
-            doStreamSpan.addEvent('ai.stream.firstChunk', {
-              'ai.stream.msToFirstChunk': msToFirstChunk,
-            });
-
-            doStreamSpan.setAttributes({
-              'ai.stream.msToFirstChunk': msToFirstChunk,
-            });
-          }
-
-          // process partial text chunks
-          if (typeof chunk === 'string') {
-            accumulatedText += chunk;
-            textDelta += chunk;
-
-            const { value: currentObjectJson, state: parseState } =
-              parsePartialJson(accumulatedText);
-
-            if (
-              currentObjectJson !== undefined &&
-              !isDeepEqualData(latestObjectJson, currentObjectJson)
-            ) {
-              const validationResult = outputStrategy.validatePartialResult({
-                value: currentObjectJson,
-                textDelta,
-                latestObject,
-                isFirstDelta,
-                isFinalDelta: parseState === 'successful-parse',
-              });
-
-              if (
-                validationResult.success &&
-                !isDeepEqualData(latestObject, validationResult.value.partial)
-              ) {
-                // inside inner check to correctly parse the final element in array mode:
-                latestObjectJson = currentObjectJson;
-                latestObject = validationResult.value.partial;
-
-                controller.enqueue({
-                  type: 'object',
-                  object: latestObject,
-                });
-
-                controller.enqueue({
-                  type: 'text-delta',
-                  textDelta: validationResult.value.textDelta,
-                });
-
-                textDelta = '';
-                isFirstDelta = false;
-              }
-            }
-
-            return;
-          }
-
-          switch (chunk.type) {
-            case 'response-metadata': {
-              response = {
-                id: chunk.id ?? response.id,
-                timestamp: chunk.timestamp ?? response.timestamp,
-                modelId: chunk.modelId ?? response.modelId,
-              };
-              break;
-            }
-
-            case 'finish': {
-              // send final text delta:
-              if (textDelta !== '') {
-                controller.enqueue({ type: 'text-delta', textDelta });
-              }
-
-              // store finish reason for telemetry:
-              finishReason = chunk.finishReason;
-
-              // store usage and metadata for promises and onFinish callback:
-              usage = calculateLanguageModelUsage(chunk.usage);
-              providerMetadata = chunk.providerMetadata;
-
-              controller.enqueue({ ...chunk, usage, response });
-
-              // resolve promises that can be resolved now:
-              resolveUsage(usage);
-              resolveProviderMetadata(providerMetadata);
-              resolveResponse({
-                ...response,
-                headers: rawResponse?.headers,
-              });
-
-              // resolve the object promise with the latest object:
-              const validationResult =
-                outputStrategy.validateFinalResult(latestObjectJson);
-
-              if (validationResult.success) {
-                object = validationResult.value;
-                self.objectPromise.resolve(object);
-              } else {
-                error = validationResult.error;
-                self.objectPromise.reject(error);
-              }
-
-              break;
-            }
-
-            default: {
-              controller.enqueue(chunk);
-              break;
-            }
-          }
-        },
-
-        // invoke onFinish callback and resolve toolResults promise when the stream is about to close:
-        async flush(controller) {
-          try {
-            const finalUsage = usage ?? {
-              promptTokens: NaN,
-              completionTokens: NaN,
-              totalTokens: NaN,
-            };
-
-            doStreamSpan.setAttributes(
-              selectTelemetryAttributes({
-                telemetry,
-                attributes: {
-                  'ai.response.finishReason': finishReason,
-                  'ai.response.object': {
-                    output: () => JSON.stringify(object),
-                  },
-                  'ai.response.id': response.id,
-                  'ai.response.model': response.modelId,
-                  'ai.response.timestamp': response.timestamp.toISOString(),
-
-                  'ai.usage.promptTokens': finalUsage.promptTokens,
-                  'ai.usage.completionTokens': finalUsage.completionTokens,
-
-                  // standardized gen-ai llm span attributes:
-                  'gen_ai.response.finish_reasons': [finishReason],
-                  'gen_ai.response.id': response.id,
-                  'gen_ai.response.model': response.modelId,
-                  'gen_ai.usage.input_tokens': finalUsage.promptTokens,
-                  'gen_ai.usage.output_tokens': finalUsage.completionTokens,
-                },
-              }),
-            );
-
-            // finish doStreamSpan before other operations for correct timing:
-            doStreamSpan.end();
-
-            // Add response information to the root span:
-            rootSpan.setAttributes(
-              selectTelemetryAttributes({
-                telemetry,
-                attributes: {
-                  'ai.usage.promptTokens': finalUsage.promptTokens,
-                  'ai.usage.completionTokens': finalUsage.completionTokens,
-                  'ai.response.object': {
-                    output: () => JSON.stringify(object),
-                  },
-                },
-              }),
-            );
-
-            // call onFinish callback:
-            await onFinish?.({
-              usage: finalUsage,
-              object,
-              error,
-              response: {
-                ...response,
-                headers: rawResponse?.headers,
-              },
-              warnings,
-              experimental_providerMetadata: providerMetadata,
-            });
-          } catch (error) {
-            controller.error(error);
-          } finally {
-            rootSpan.end();
-          }
+    // TODO stream closing
+    // TODO catch error / error handling
+    recordSpan({
+      name: 'ai.streamObject',
+      attributes: selectTelemetryAttributes({
+        telemetry,
+        attributes: {
+          ...assembleOperationName({
+            operationId: 'ai.streamObject',
+            telemetry,
+          }),
+          ...baseTelemetryAttributes,
+          // specific settings that only make sense on the outer level:
+          'ai.prompt': {
+            input: () => JSON.stringify({ system, prompt, messages }),
+          },
+          'ai.schema':
+            outputStrategy.jsonSchema != null
+              ? { input: () => JSON.stringify(outputStrategy.jsonSchema) }
+              : undefined,
+          'ai.schema.name': schemaName,
+          'ai.schema.description': schemaDescription,
+          'ai.settings.output': outputStrategy.type,
+          'ai.settings.mode': mode,
         },
       }),
-    );
+      tracer,
+      endWhenDone: false,
+      fn: async rootSpan => {
+        // use the default provider mode when the mode is set to 'auto' or unspecified
+        if (mode === 'auto' || mode == null) {
+          mode = model.defaultObjectGenerationMode;
+        }
+
+        let callOptions: LanguageModelV1CallOptions;
+        let transformer: Transformer<
+          LanguageModelV1StreamPart,
+          string | Omit<LanguageModelV1StreamPart, 'text-delta'>
+        >;
+
+        switch (mode) {
+          case 'json': {
+            const standardizedPrompt = standardizePrompt({
+              prompt: {
+                system:
+                  outputStrategy.jsonSchema == null
+                    ? injectJsonInstruction({ prompt: system })
+                    : model.supportsStructuredOutputs
+                    ? system
+                    : injectJsonInstruction({
+                        prompt: system,
+                        schema: outputStrategy.jsonSchema,
+                      }),
+                prompt,
+                messages,
+              },
+              tools: undefined,
+            });
+
+            callOptions = {
+              mode: {
+                type: 'object-json',
+                schema: outputStrategy.jsonSchema,
+                name: schemaName,
+                description: schemaDescription,
+              },
+              ...prepareCallSettings(settings),
+              inputFormat: standardizedPrompt.type,
+              prompt: await convertToLanguageModelPrompt({
+                prompt: standardizedPrompt,
+                modelSupportsImageUrls: model.supportsImageUrls,
+                modelSupportsUrl: model.supportsUrl,
+              }),
+              providerMetadata: inputProviderMetadata,
+              abortSignal,
+              headers,
+            };
+
+            transformer = {
+              transform: (chunk, controller) => {
+                switch (chunk.type) {
+                  case 'text-delta':
+                    controller.enqueue(chunk.textDelta);
+                    break;
+                  case 'response-metadata':
+                  case 'finish':
+                  case 'error':
+                    controller.enqueue(chunk);
+                    break;
+                }
+              },
+            };
+
+            break;
+          }
+
+          case 'tool': {
+            const standardizedPrompt = standardizePrompt({
+              prompt: { system, prompt, messages },
+              tools: undefined,
+            });
+
+            callOptions = {
+              mode: {
+                type: 'object-tool',
+                tool: {
+                  type: 'function',
+                  name: schemaName ?? 'json',
+                  description:
+                    schemaDescription ?? 'Respond with a JSON object.',
+                  parameters: outputStrategy.jsonSchema!,
+                },
+              },
+              ...prepareCallSettings(settings),
+              inputFormat: standardizedPrompt.type,
+              prompt: await convertToLanguageModelPrompt({
+                prompt: standardizedPrompt,
+                modelSupportsImageUrls: model.supportsImageUrls,
+                modelSupportsUrl: model.supportsUrl,
+              }),
+              providerMetadata: inputProviderMetadata,
+              abortSignal,
+              headers,
+            };
+
+            transformer = {
+              transform(chunk, controller) {
+                switch (chunk.type) {
+                  case 'tool-call-delta':
+                    controller.enqueue(chunk.argsTextDelta);
+                    break;
+                  case 'response-metadata':
+                  case 'finish':
+                  case 'error':
+                    controller.enqueue(chunk);
+                    break;
+                }
+              },
+            };
+
+            break;
+          }
+
+          case undefined: {
+            throw new Error(
+              'Model does not have a default object generation mode.',
+            );
+          }
+
+          default: {
+            const _exhaustiveCheck: never = mode;
+            throw new Error(`Unsupported mode: ${_exhaustiveCheck}`);
+          }
+        }
+
+        const {
+          result: { stream, warnings, rawResponse, request },
+          doStreamSpan,
+          startTimestampMs,
+        } = await retry(() =>
+          recordSpan({
+            name: 'ai.streamObject.doStream',
+            attributes: selectTelemetryAttributes({
+              telemetry,
+              attributes: {
+                ...assembleOperationName({
+                  operationId: 'ai.streamObject.doStream',
+                  telemetry,
+                }),
+                ...baseTelemetryAttributes,
+                'ai.prompt.format': {
+                  input: () => callOptions.inputFormat,
+                },
+                'ai.prompt.messages': {
+                  input: () => JSON.stringify(callOptions.prompt),
+                },
+                'ai.settings.mode': mode,
+
+                // standardized gen-ai llm span attributes:
+                'gen_ai.system': model.provider,
+                'gen_ai.request.model': model.modelId,
+                'gen_ai.request.frequency_penalty': settings.frequencyPenalty,
+                'gen_ai.request.max_tokens': settings.maxTokens,
+                'gen_ai.request.presence_penalty': settings.presencePenalty,
+                'gen_ai.request.temperature': settings.temperature,
+                'gen_ai.request.top_k': settings.topK,
+                'gen_ai.request.top_p': settings.topP,
+              },
+            }),
+            tracer,
+            endWhenDone: false,
+            fn: async doStreamSpan => ({
+              startTimestampMs: now(),
+              doStreamSpan,
+              result: await model.doStream(callOptions),
+            }),
+          }),
+        );
+
+        self.requestPromise.resolve(request ?? {});
+
+        // store information for onFinish callback:
+        let usage: LanguageModelUsage | undefined;
+        let finishReason: LanguageModelV1FinishReason | undefined;
+        let providerMetadata: ProviderMetadata | undefined;
+        let object: RESULT | undefined;
+        let error: unknown | undefined;
+
+        // pipe chunks through a transformation stream that extracts metadata:
+        let accumulatedText = '';
+        let textDelta = '';
+        let response: {
+          id: string;
+          timestamp: Date;
+          modelId: string;
+        } = {
+          id: generateId(),
+          timestamp: currentDate(),
+          modelId: model.modelId,
+        };
+
+        // Keep track of raw parse result before type validation, since e.g. Zod might
+        // change the object by mapping properties.
+        let latestObjectJson: JSONValue | undefined = undefined;
+        let latestObject: PARTIAL | undefined = undefined;
+        let isFirstChunk = true;
+        let isFirstDelta = true;
+
+        const transformedStream = stream
+          .pipeThrough(new TransformStream(transformer))
+          .pipeThrough(
+            new TransformStream<
+              string | ObjectStreamInputPart,
+              ObjectStreamPart<PARTIAL>
+            >({
+              async transform(chunk, controller): Promise<void> {
+                // Telemetry event for first chunk:
+                if (isFirstChunk) {
+                  const msToFirstChunk = now() - startTimestampMs;
+
+                  isFirstChunk = false;
+
+                  doStreamSpan.addEvent('ai.stream.firstChunk', {
+                    'ai.stream.msToFirstChunk': msToFirstChunk,
+                  });
+
+                  doStreamSpan.setAttributes({
+                    'ai.stream.msToFirstChunk': msToFirstChunk,
+                  });
+                }
+
+                // process partial text chunks
+                if (typeof chunk === 'string') {
+                  accumulatedText += chunk;
+                  textDelta += chunk;
+
+                  const { value: currentObjectJson, state: parseState } =
+                    parsePartialJson(accumulatedText);
+
+                  if (
+                    currentObjectJson !== undefined &&
+                    !isDeepEqualData(latestObjectJson, currentObjectJson)
+                  ) {
+                    const validationResult =
+                      outputStrategy.validatePartialResult({
+                        value: currentObjectJson,
+                        textDelta,
+                        latestObject,
+                        isFirstDelta,
+                        isFinalDelta: parseState === 'successful-parse',
+                      });
+
+                    if (
+                      validationResult.success &&
+                      !isDeepEqualData(
+                        latestObject,
+                        validationResult.value.partial,
+                      )
+                    ) {
+                      // inside inner check to correctly parse the final element in array mode:
+                      latestObjectJson = currentObjectJson;
+                      latestObject = validationResult.value.partial;
+
+                      controller.enqueue({
+                        type: 'object',
+                        object: latestObject,
+                      });
+
+                      controller.enqueue({
+                        type: 'text-delta',
+                        textDelta: validationResult.value.textDelta,
+                      });
+
+                      textDelta = '';
+                      isFirstDelta = false;
+                    }
+                  }
+
+                  return;
+                }
+
+                switch (chunk.type) {
+                  case 'response-metadata': {
+                    response = {
+                      id: chunk.id ?? response.id,
+                      timestamp: chunk.timestamp ?? response.timestamp,
+                      modelId: chunk.modelId ?? response.modelId,
+                    };
+                    break;
+                  }
+
+                  case 'finish': {
+                    // send final text delta:
+                    if (textDelta !== '') {
+                      controller.enqueue({ type: 'text-delta', textDelta });
+                    }
+
+                    // store finish reason for telemetry:
+                    finishReason = chunk.finishReason;
+
+                    // store usage and metadata for promises and onFinish callback:
+                    usage = calculateLanguageModelUsage(chunk.usage);
+                    providerMetadata = chunk.providerMetadata;
+
+                    controller.enqueue({ ...chunk, usage, response });
+
+                    // resolve promises that can be resolved now:
+                    self.usagePromise.resolve(usage);
+                    self.providerMetadataPromise.resolve(providerMetadata);
+                    self.responsePromise.resolve({
+                      ...response,
+                      headers: rawResponse?.headers,
+                    });
+
+                    // resolve the object promise with the latest object:
+                    const validationResult =
+                      outputStrategy.validateFinalResult(latestObjectJson);
+
+                    if (validationResult.success) {
+                      object = validationResult.value;
+                      self.objectPromise.resolve(object);
+                    } else {
+                      error = validationResult.error;
+                      self.objectPromise.reject(error);
+                    }
+
+                    break;
+                  }
+
+                  default: {
+                    controller.enqueue(chunk);
+                    break;
+                  }
+                }
+              },
+
+              // invoke onFinish callback and resolve toolResults promise when the stream is about to close:
+              async flush(controller) {
+                try {
+                  const finalUsage = usage ?? {
+                    promptTokens: NaN,
+                    completionTokens: NaN,
+                    totalTokens: NaN,
+                  };
+
+                  doStreamSpan.setAttributes(
+                    selectTelemetryAttributes({
+                      telemetry,
+                      attributes: {
+                        'ai.response.finishReason': finishReason,
+                        'ai.response.object': {
+                          output: () => JSON.stringify(object),
+                        },
+                        'ai.response.id': response.id,
+                        'ai.response.model': response.modelId,
+                        'ai.response.timestamp':
+                          response.timestamp.toISOString(),
+
+                        'ai.usage.promptTokens': finalUsage.promptTokens,
+                        'ai.usage.completionTokens':
+                          finalUsage.completionTokens,
+
+                        // standardized gen-ai llm span attributes:
+                        'gen_ai.response.finish_reasons': [finishReason],
+                        'gen_ai.response.id': response.id,
+                        'gen_ai.response.model': response.modelId,
+                        'gen_ai.usage.input_tokens': finalUsage.promptTokens,
+                        'gen_ai.usage.output_tokens':
+                          finalUsage.completionTokens,
+                      },
+                    }),
+                  );
+
+                  // finish doStreamSpan before other operations for correct timing:
+                  doStreamSpan.end();
+
+                  // Add response information to the root span:
+                  rootSpan.setAttributes(
+                    selectTelemetryAttributes({
+                      telemetry,
+                      attributes: {
+                        'ai.usage.promptTokens': finalUsage.promptTokens,
+                        'ai.usage.completionTokens':
+                          finalUsage.completionTokens,
+                        'ai.response.object': {
+                          output: () => JSON.stringify(object),
+                        },
+                      },
+                    }),
+                  );
+
+                  // call onFinish callback:
+                  await onFinish?.({
+                    usage: finalUsage,
+                    object,
+                    error,
+                    response: {
+                      ...response,
+                      headers: rawResponse?.headers,
+                    },
+                    warnings,
+                    experimental_providerMetadata: providerMetadata,
+                  });
+                } catch (error) {
+                  controller.error(error);
+                } finally {
+                  rootSpan.end();
+                }
+              },
+            }),
+          );
+
+        self.stitchableStream.addStream(transformedStream);
+        self.stitchableStream.close();
+      },
+    }).catch(error => {
+      console.log(error);
+      // TODO need to break streams
+    });
+
+    this.outputStrategy = outputStrategy;
   }
 
   get object(): Promise<RESULT> {
     return this.objectPromise.value;
   }
 
+  get usage(): Promise<LanguageModelUsage> {
+    return this.usagePromise.value;
+  }
+
+  get experimental_providerMetadata(): Promise<ProviderMetadata | undefined> {
+    return this.providerMetadataPromise.value;
+  }
+
+  get warnings(): Promise<CallWarning[] | undefined> {
+    return this.warningsPromise.value;
+  }
+
+  get request(): Promise<LanguageModelRequestMetadata> {
+    return this.requestPromise.value;
+  }
+
+  get response(): Promise<LanguageModelResponseMetadata> {
+    return this.responsePromise.value;
+  }
+
   get partialObjectStream(): AsyncIterableStream<PARTIAL> {
-    return createAsyncIterableStream(this.originalStream, {
+    return createAsyncIterableStream(this.stitchableStream.stream, {
       transform(chunk, controller) {
         switch (chunk.type) {
           case 'object':
@@ -936,11 +954,13 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
   }
 
   get elementStream(): ELEMENT_STREAM {
-    return this.outputStrategy.createElementStream(this.originalStream);
+    return this.outputStrategy.createElementStream(
+      this.stitchableStream.stream,
+    );
   }
 
   get textStream(): AsyncIterableStream<string> {
-    return createAsyncIterableStream(this.originalStream, {
+    return createAsyncIterableStream(this.stitchableStream.stream, {
       transform(chunk, controller) {
         switch (chunk.type) {
           case 'text-delta':
@@ -965,7 +985,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
   }
 
   get fullStream(): AsyncIterableStream<ObjectStreamPart<PARTIAL>> {
-    return createAsyncIterableStream(this.originalStream, {
+    return createAsyncIterableStream(this.stitchableStream.stream, {
       transform(chunk, controller) {
         controller.enqueue(chunk);
       },

--- a/packages/ai/core/util/create-stitchable-stream.test.ts
+++ b/packages/ai/core/util/create-stitchable-stream.test.ts
@@ -5,157 +5,179 @@ import {
 import { expect } from 'vitest';
 import { createStitchableStream } from './create-stitchable-stream';
 
-describe('read full streams after they are added', () => {
-  it('should return no stream when immediately closed', async () => {
-    const { stream, close } = createStitchableStream<number>();
+describe('createStitchableStream', () => {
+  describe('read full streams after they are added', () => {
+    it('should return no stream when immediately closed', async () => {
+      const { stream, close } = createStitchableStream<number>();
 
-    close();
+      close();
 
-    expect(await convertReadableStreamToArray(stream)).toEqual([]);
-  });
+      expect(await convertReadableStreamToArray(stream)).toEqual([]);
+    });
 
-  it('should return all values from a single inner stream', async () => {
-    const { stream, addStream, close } = createStitchableStream<number>();
+    it('should return all values from a single inner stream', async () => {
+      const { stream, addStream, close } = createStitchableStream<number>();
 
-    addStream(convertArrayToReadableStream([1, 2, 3]));
-    close();
+      addStream(convertArrayToReadableStream([1, 2, 3]));
+      close();
 
-    expect(await convertReadableStreamToArray(stream)).toEqual([1, 2, 3]);
-  });
+      expect(await convertReadableStreamToArray(stream)).toEqual([1, 2, 3]);
+    });
 
-  it('should return all values from 2 inner streams', async () => {
-    const { stream, addStream, close } = createStitchableStream<number>();
+    it('should return all values from 2 inner streams', async () => {
+      const { stream, addStream, close } = createStitchableStream<number>();
 
-    addStream(convertArrayToReadableStream([1, 2, 3]));
-    addStream(convertArrayToReadableStream([4, 5, 6]));
-    close();
+      addStream(convertArrayToReadableStream([1, 2, 3]));
+      addStream(convertArrayToReadableStream([4, 5, 6]));
+      close();
 
-    expect(await convertReadableStreamToArray(stream)).toEqual([
-      1, 2, 3, 4, 5, 6,
-    ]);
-  });
+      expect(await convertReadableStreamToArray(stream)).toEqual([
+        1, 2, 3, 4, 5, 6,
+      ]);
+    });
 
-  it('should return all values from 3 inner streams', async () => {
-    const { stream, addStream, close } = createStitchableStream<number>();
+    it('should return all values from 3 inner streams', async () => {
+      const { stream, addStream, close } = createStitchableStream<number>();
 
-    addStream(convertArrayToReadableStream([1, 2, 3]));
-    addStream(convertArrayToReadableStream([4, 5, 6]));
-    addStream(convertArrayToReadableStream([7, 8, 9]));
-    close();
+      addStream(convertArrayToReadableStream([1, 2, 3]));
+      addStream(convertArrayToReadableStream([4, 5, 6]));
+      addStream(convertArrayToReadableStream([7, 8, 9]));
+      close();
 
-    expect(await convertReadableStreamToArray(stream)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9,
-    ]);
-  });
+      expect(await convertReadableStreamToArray(stream)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9,
+      ]);
+    });
 
-  it('should handle empty inner streams', async () => {
-    const { stream, addStream, close } = createStitchableStream<number>();
+    it('should handle empty inner streams', async () => {
+      const { stream, addStream, close } = createStitchableStream<number>();
 
-    addStream(convertArrayToReadableStream([]));
-    addStream(convertArrayToReadableStream([1, 2]));
-    addStream(convertArrayToReadableStream([]));
-    addStream(convertArrayToReadableStream([3, 4]));
-    close();
+      addStream(convertArrayToReadableStream([]));
+      addStream(convertArrayToReadableStream([1, 2]));
+      addStream(convertArrayToReadableStream([]));
+      addStream(convertArrayToReadableStream([3, 4]));
+      close();
 
-    expect(await convertReadableStreamToArray(stream)).toEqual([1, 2, 3, 4]);
-  });
-});
+      expect(await convertReadableStreamToArray(stream)).toEqual([1, 2, 3, 4]);
+    });
 
-describe('read from partial stream and with interruptions', async () => {
-  it('should return all values from 2 inner streams', async () => {
-    const { stream, addStream, close } = createStitchableStream<number>();
+    it('should handle reading a single value before it is added', async () => {
+      const { stream, addStream, close } = createStitchableStream<number>();
 
-    // read 5 values from the stream before they are added
-    // (added asynchronously)
-    const reader = stream.getReader();
-    const results: Array<{ done: boolean; value?: number }> = [];
-    for (let i = 0; i < 5; i++) {
-      reader.read().then(result => {
-        results.push(result);
+      // Start reading before any values are added
+      const reader = stream.getReader();
+      const readPromise = reader.read();
+
+      // Add value with delay after starting read
+      Promise.resolve().then(() => {
+        addStream(convertArrayToReadableStream([42]));
+        close();
       });
-    }
 
-    addStream(convertArrayToReadableStream([1, 2, 3]));
-    addStream(convertArrayToReadableStream([4, 5]));
-    close();
+      // Value should be returned once available
+      expect(await readPromise).toEqual({ done: false, value: 42 });
 
-    // wait for the stream to finish via await:
-    expect(await reader.read()).toEqual({ done: true, value: undefined });
-
-    expect(results).toEqual([
-      { done: false, value: 1 },
-      { done: false, value: 2 },
-      { done: false, value: 3 },
-      { done: false, value: 4 },
-      { done: false, value: 5 },
-    ]);
-  });
-});
-
-describe('error handling', () => {
-  it('should handle errors from inner streams', async () => {
-    const { stream, addStream, close } = createStitchableStream<number>();
-
-    const errorStream = new ReadableStream({
-      start(controller) {
-        controller.error(new Error('Test error'));
-      },
+      // Stream should complete after value is read
+      expect(await reader.read()).toEqual({ done: true, value: undefined });
     });
-
-    addStream(convertArrayToReadableStream([1, 2]));
-    addStream(errorStream);
-    addStream(convertArrayToReadableStream([3, 4]));
-    close();
-
-    await expect(convertReadableStreamToArray(stream)).rejects.toThrow(
-      'Test error',
-    );
-  });
-});
-
-describe('cancellation & closing', () => {
-  it('should cancel all inner streams when cancelled', async () => {
-    const { stream, addStream } = createStitchableStream<number>();
-
-    let stream1Cancelled = false;
-    let stream2Cancelled = false;
-
-    const mockStream1 = new ReadableStream({
-      start(controller) {
-        controller.enqueue(1);
-        controller.enqueue(2);
-      },
-      cancel() {
-        stream1Cancelled = true;
-      },
-    });
-
-    const mockStream2 = new ReadableStream({
-      start(controller) {
-        controller.enqueue(3);
-        controller.enqueue(4);
-      },
-      cancel() {
-        stream2Cancelled = true;
-      },
-    });
-
-    addStream(mockStream1);
-    addStream(mockStream2);
-
-    await stream.cancel();
-
-    expect(stream1Cancelled).toBe(true);
-    expect(stream2Cancelled).toBe(true);
   });
 
-  it('should throw an error when adding a stream after closing', async () => {
-    const { addStream, close } = createStitchableStream<number>();
+  describe('read from partial stream and with interruptions', async () => {
+    it('should return all values from 2 inner streams', async () => {
+      const { stream, addStream, close } = createStitchableStream<number>();
 
-    close();
+      // read 5 values from the stream before they are added
+      // (added asynchronously)
+      const reader = stream.getReader();
+      const results: Array<{ done: boolean; value?: number }> = [];
+      for (let i = 0; i < 5; i++) {
+        reader.read().then(result => {
+          results.push(result);
+        });
+      }
 
-    expect(() => addStream(convertArrayToReadableStream([1, 2]))).toThrow(
-      'Cannot add inner stream: outer stream is closed',
-    );
+      addStream(convertArrayToReadableStream([1, 2, 3]));
+      addStream(convertArrayToReadableStream([4, 5]));
+      close();
+
+      // wait for the stream to finish via await:
+      expect(await reader.read()).toEqual({ done: true, value: undefined });
+
+      expect(results).toEqual([
+        { done: false, value: 1 },
+        { done: false, value: 2 },
+        { done: false, value: 3 },
+        { done: false, value: 4 },
+        { done: false, value: 5 },
+      ]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle errors from inner streams', async () => {
+      const { stream, addStream, close } = createStitchableStream<number>();
+
+      const errorStream = new ReadableStream({
+        start(controller) {
+          controller.error(new Error('Test error'));
+        },
+      });
+
+      addStream(convertArrayToReadableStream([1, 2]));
+      addStream(errorStream);
+      addStream(convertArrayToReadableStream([3, 4]));
+      close();
+
+      await expect(convertReadableStreamToArray(stream)).rejects.toThrow(
+        'Test error',
+      );
+    });
+  });
+
+  describe('cancellation & closing', () => {
+    it('should cancel all inner streams when cancelled', async () => {
+      const { stream, addStream } = createStitchableStream<number>();
+
+      let stream1Cancelled = false;
+      let stream2Cancelled = false;
+
+      const mockStream1 = new ReadableStream({
+        start(controller) {
+          controller.enqueue(1);
+          controller.enqueue(2);
+        },
+        cancel() {
+          stream1Cancelled = true;
+        },
+      });
+
+      const mockStream2 = new ReadableStream({
+        start(controller) {
+          controller.enqueue(3);
+          controller.enqueue(4);
+        },
+        cancel() {
+          stream2Cancelled = true;
+        },
+      });
+
+      addStream(mockStream1);
+      addStream(mockStream2);
+
+      await stream.cancel();
+
+      expect(stream1Cancelled).toBe(true);
+      expect(stream2Cancelled).toBe(true);
+    });
+
+    it('should throw an error when adding a stream after closing', async () => {
+      const { addStream, close } = createStitchableStream<number>();
+
+      close();
+
+      expect(() => addStream(convertArrayToReadableStream([1, 2]))).toThrow(
+        'Cannot add inner stream: outer stream is closed',
+      );
+    });
   });
 });

--- a/packages/codemod/src/test/__testfixtures__/remove-experimental-ai-fn-exports.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/remove-experimental-ai-fn-exports.output.ts
@@ -17,7 +17,7 @@ async function main() {
     prompt: 'Hello',
   });
 
-  const objStream = streamObject({
+  const objStream = await streamObject({
     model: provider('model-name'),
     prompt: 'Hello',
   });

--- a/packages/codemod/src/test/__testfixtures__/remove-experimental-ai-fn-exports.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/remove-experimental-ai-fn-exports.output.ts
@@ -17,7 +17,7 @@ async function main() {
     prompt: 'Hello',
   });
 
-  const objStream = await streamObject({
+  const objStream = streamObject({
     model: provider('model-name'),
     prompt: 'Hello',
   });


### PR DESCRIPTION
## Background

The need to await the initial call result prevents streaming additional data such as status information immediately. This will apply to `streamObject` in the future and to keep things aligned we need to make the breaking change now.

## Tasks

- [x] implementation
- [x] error handling
- [x] replace occurences
- [x] docs: migration guide
- [x] manual testing
- [x] changeset