### PR TITLE
documentation: streamText should be awaited in app router quickstart

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -98,7 +98,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
-  const result = streamText({
+  const result = await streamText({
     model: openai('gpt-4-turbo'),
     messages,
   });


### PR DESCRIPTION
on the app router quickstart, `streamText` needs to be awaited so you can start streaming the result.  As written, you'd get something like `Property 'toDataStreamResponse' does not exist on type 'Promise<StreamTextResult<Record<string, CoreTool<any, any>>>>'.ts`