### PR TITLE
fix (packages/codemod): Only replace ai-sdk provider ctors.

### DIFF
--- a/.changeset/sixty-keys-rhyme.md
+++ b/.changeset/sixty-keys-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+fix (packages/codemod): Only replace ai-sdk provider ctors.

--- a/packages/codemod/src/test/__testfixtures__/remove-openai-facade-as.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/remove-openai-facade-as.input.ts
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import OpenAI from 'openai';
+import { OpenAI as AiOpenAI } from '@ai-sdk/openai';
+
+const client1 = new OpenAI();
+const client2 = new AiOpenAI();

--- a/packages/codemod/src/test/__testfixtures__/remove-openai-facade-as.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/remove-openai-facade-as.output.ts
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import OpenAI from 'openai';
+import { createOpenAI } from '@ai-sdk/openai';
+
+const client1 = new OpenAI();
+const client2 = createOpenAI();

--- a/packages/codemod/src/test/__testfixtures__/remove-openai-facade-corp.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/remove-openai-facade-corp.input.ts
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import OpenAI from 'openai';
+
+const openaiClient = new OpenAI({
+  apiKey: 'key2'
+});

--- a/packages/codemod/src/test/__testfixtures__/remove-openai-facade-corp.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/remove-openai-facade-corp.output.ts
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import OpenAI from 'openai';
+
+const openaiClient = new OpenAI({
+  apiKey: 'key2'
+});

--- a/packages/codemod/src/test/remove-openai-facade.test.ts
+++ b/packages/codemod/src/test/remove-openai-facade.test.ts
@@ -6,4 +6,12 @@ describe('remove-openai-facade', () => {
   it('transforms correctly', () => {
     testTransform(transformer, 'remove-openai-facade');
   });
+
+  it('does not transform openai corporate', () => {
+    testTransform(transformer, 'remove-openai-facade-corp');
+  });
+
+  it('does transform openai import with as', () => {
+    testTransform(transformer, 'remove-openai-facade-as');
+  });
 });


### PR DESCRIPTION
Prior to this change (for example) the corporate OpenAI package's associated ctor would be incorrectly renamed to `createOpenAI`.

We now only rename for targets validated as imported from '@ai-sdk/...'.