### PR TITLE
fix (packages/codemod): Only rename baseUrl in create-provider calls.

### DIFF
--- a/.changeset/good-dots-hear.md
+++ b/.changeset/good-dots-hear.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+fix (packages/codemod): Only rename baseUrl in create-provider calls.

--- a/packages/codemod/src/test/__testfixtures__/replace-baseurl.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/replace-baseurl.input.ts
@@ -1,14 +1,26 @@
 // @ts-nocheck
-import { createAnthropicClientOptions } from 'ai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createMistral } from '@ai-sdk/mistral';
 
-const opts = {
-  baseUrl: 'https://api.anthropic.com',
-};
+const anthropic = createAnthropic({
+  baseUrl: 'https://api.anthropic.com'
+});
 
-const otherOpts = {
-  baseUrl,
-};
+const openai = createOpenAI({
+  baseUrl: 'https://api.openai.com'
+});
 
+const mistral = createMistral({
+  baseUrl: 'https://api.mistral.ai'
+});
+
+// Should NOT rename - not in provider creation
 const config = {
-  something: baseUrl,
+  baseUrl: 'https://example.com'
 };
+
+// Should NOT rename - not a provider
+function someOtherFunction({ baseUrl }) {
+  return baseUrl;
+}

--- a/packages/codemod/src/test/__testfixtures__/replace-baseurl.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/replace-baseurl.output.ts
@@ -1,14 +1,26 @@
 // @ts-nocheck
-import { createAnthropicClientOptions } from 'ai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createMistral } from '@ai-sdk/mistral';
 
-const opts = {
-  baseURL: 'https://api.anthropic.com',
-};
+const anthropic = createAnthropic({
+  baseURL: 'https://api.anthropic.com'
+});
 
-const otherOpts = {
-  baseURL,
-};
+const openai = createOpenAI({
+  baseURL: 'https://api.openai.com'
+});
 
+const mistral = createMistral({
+  baseURL: 'https://api.mistral.ai'
+});
+
+// Should NOT rename - not in provider creation
 const config = {
-  something: baseURL,
+  baseUrl: 'https://example.com'
 };
+
+// Should NOT rename - not a provider
+function someOtherFunction({ baseUrl }) {
+  return baseUrl;
+}


### PR DESCRIPTION
Two notes:
- this is the first case I've come across where specifying codemod ordering could be beneficial (run this only after we've run the `remove-xxx-facade` codemods, which could introduce new `createXxx` calls). I am not actually sure we had the `baseUrl` option in the old provider facades, though. In any case, doing such work is a nice-to-have priority-wise currently IMO and we can live without the perfection.
- here we add more test cases to the single existing fixture set. In some cases we can do this, in others we can't (e.g. invalid TS if multiple imports with the same name). I think we will continue to have a mix like this, though my preference in general would be to separate into different files and test cases so that we get informative and granular failures.