### PR TITLE
chore (docs): update FriendliAI baseURL

### DIFF
--- a/content/providers/03-community-providers/08-friendliai.mdx
+++ b/content/providers/03-community-providers/08-friendliai.mdx
@@ -139,7 +139,7 @@ You can also use `@ai-sdk/openai` as the APIs are OpenAI-compatible.
 import { createOpenAI } from '@ai-sdk/openai';
 
 const friendli = createOpenAI({
-  baseURL: 'https://inference.friendli.ai/v1',
+  baseURL: 'https://api.friendli.ai/serverless/v1',
   apiKey: process.env.FRIENDLI_TOKEN,
 });
 ```

--- a/content/providers/03-community-providers/08-friendliai.mdx
+++ b/content/providers/03-community-providers/08-friendliai.mdx
@@ -143,3 +143,14 @@ const friendli = createOpenAI({
   apiKey: process.env.FRIENDLI_TOKEN,
 });
 ```
+
+If you are using dedicated endpoints
+
+```ts
+import { createOpenAI } from '@ai-sdk/openai';
+
+const friendli = createOpenAI({
+  baseURL: 'https://api.friendli.ai/dedicated/v1',
+  apiKey: process.env.FRIENDLI_TOKEN,
+});
+```


### PR DESCRIPTION
The endpoint URL has changed.

```diff
- https://inference.friendli.ai/v1
+ https://api.friendli.ai/serverless/v1
```

For the previous URL, we plan to maintain it for 6 months and then decommission it.


Additionally, we added an OpenAI Compatibility example for dedicated endpoints.

