### PR TITLE
fix (packages/codemod): Ignore code under dot-prefixed dirs.

### DIFF
--- a/.changeset/curly-mails-fix.md
+++ b/.changeset/curly-mails-fix.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+fix (packages/codemod): Ignore code under dot-prefixed dirs.

--- a/packages/codemod/src/lib/transform.ts
+++ b/packages/codemod/src/lib/transform.ts
@@ -4,6 +4,9 @@ import fs from 'fs';
 import path from 'path';
 import { TransformOptions } from './transform-options';
 
+const log = debug('codemod:transform');
+const error = debug('codemod:transform:error');
+
 function getJscodeshift(): string {
   const localJscodeshift = path.resolve(
     __dirname,
@@ -12,20 +15,18 @@ function getJscodeshift(): string {
   return fs.existsSync(localJscodeshift) ? localJscodeshift : 'jscodeshift';
 }
 
-const log = debug('codemod:transform');
-const error = debug('codemod:transform:error');
-
-export function transform(
-  codemod: string,
-  source: string,
+function buildCommand(
+  codemodPath: string,
+  targetPath: string,
+  jscodeshift: string,
   options: TransformOptions,
-) {
-  log(`Applying codemod '${codemod}': ${source}`);
-
-  const codemodPath = path.resolve(__dirname, `../codemods/${codemod}.js`);
-  const targetPath = path.resolve(source);
-  const jscodeshift = getJscodeshift();
-  let command = `${jscodeshift} -t ${codemodPath} ${targetPath} --parser tsx --ignore-pattern="**/node_modules/**" --ignore-pattern="**/.next/**"`;
+): string {
+  // Ignoring everything under `.*/` covers `.next/` along with any other
+  // framework build related or otherwise intended-to-be-hidden directories.
+  let command = `${jscodeshift} -t ${codemodPath} ${targetPath} \
+    --parser tsx \
+    --ignore-pattern="**/node_modules/**" \
+    --ignore-pattern="**/.*/**"`;
 
   if (options.dry) {
     command += ' --dry';
@@ -43,6 +44,19 @@ export function transform(
     command += ` ${options.jscodeshift}`;
   }
 
+  return command;
+}
+
+export function transform(
+  codemod: string,
+  source: string,
+  options: TransformOptions,
+) {
+  log(`Applying codemod '${codemod}': ${source}`);
+  const codemodPath = path.resolve(__dirname, `../codemods/${codemod}.js`);
+  const targetPath = path.resolve(source);
+  const jscodeshift = getJscodeshift();
+  const command = buildCommand(codemodPath, targetPath, jscodeshift, options);
   try {
     execSync(command, { stdio: 'inherit' });
     log('Codemod applied successfully.');


### PR DESCRIPTION
Some projects may place generated, processed, or otherwise unintended to be mutated code under directories prefixed with `.`. We see this, for example, in `ai-studio` with `.contentlayer`. We already had a filter for `.next`, so generalizing it seems a good approach.