### PR TITLE
feat (packages/codemods): Allow null transforms to represent no-ops.

### DIFF
--- a/packages/codemod/src/test/test-utils.test.ts
+++ b/packages/codemod/src/test/test-utils.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { API, FileInfo } from 'jscodeshift';
+import * as testUtils from './test-utils';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('path', () => ({
+  join: vi.fn((...args) => args.join('/')),
+}));
+
+describe('test-utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('applyTransform', () => {
+    it('should apply transform and return modified source when transform returns string', () => {
+      const mockTransform = vi.fn().mockReturnValue('modified source');
+      const input = 'original source';
+
+      const result = testUtils.applyTransform(mockTransform, input);
+
+      expect(result).toBe('modified source');
+      expect(mockTransform).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: 'test.tsx',
+          source: input,
+        }),
+        expect.objectContaining({
+          j: expect.any(Function),
+          jscodeshift: expect.any(Function),
+          stats: expect.any(Function),
+          report: console.log,
+        }),
+      );
+    });
+
+    it('should return original source when transform returns null', () => {
+      const mockTransform = vi.fn().mockReturnValue(null);
+      const input = 'original source';
+
+      const result = testUtils.applyTransform(mockTransform, input);
+
+      expect(result).toBe(input);
+    });
+
+    it('should pass additional options to transform', () => {
+      const mockTransform = vi.fn().mockReturnValue('modified');
+      const options = { dry: true };
+
+      testUtils.applyTransform(mockTransform, 'input', options);
+
+      expect(mockTransform).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining(options),
+      );
+    });
+  });
+
+  describe('readFixture', () => {
+    const mockExistsSync = existsSync as unknown as ReturnType<typeof vi.fn>;
+    const mockReadFileSync = readFileSync as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    const mockJoin = join as unknown as ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockJoin.mockImplementation((...parts) => parts.join('/'));
+    });
+
+    it('should read .ts fixture when it exists', () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith('.ts'));
+      mockReadFileSync.mockReturnValue('ts content');
+
+      const result = testUtils.readFixture('test', 'input');
+
+      expect(result).toBe('ts content');
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('test.input.ts'),
+        'utf8',
+      );
+    });
+
+    it('should read .tsx fixture when .ts does not exist', () => {
+      mockExistsSync.mockImplementation((path: string) =>
+        path.endsWith('.tsx'),
+      );
+      mockReadFileSync.mockReturnValue('tsx content');
+
+      const result = testUtils.readFixture('test', 'input');
+
+      expect(result).toBe('tsx content');
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('test.input.tsx'),
+        'utf8',
+      );
+    });
+
+    it('should throw error when no fixture exists', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      expect(() => testUtils.readFixture('test', 'input')).toThrow(
+        'Fixture not found: test.input',
+      );
+    });
+  });
+
+  describe('testTransform', () => {
+    it('should compare transform output with fixture', () => {
+      const mockTransform = vi.fn().mockReturnValue('transformed');
+
+      // Mock filesystem for this test
+      (existsSync as any).mockImplementation((path: string) =>
+        path.endsWith('.ts'),
+      );
+      (readFileSync as any)
+        .mockReturnValueOnce('input content') // First call for input
+        .mockReturnValueOnce('transformed'); // Second call for output
+
+      testUtils.testTransform(mockTransform, 'test');
+
+      expect(mockTransform).toHaveBeenCalled();
+      expect(readFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw when transform output does not match fixture', () => {
+      const mockTransform = vi.fn().mockReturnValue('wrong output');
+
+      // Mock filesystem for this test
+      (existsSync as any).mockImplementation((path: string) =>
+        path.endsWith('.ts'),
+      );
+      (readFileSync as any)
+        .mockReturnValueOnce('input') // First call for input
+        .mockReturnValueOnce('expected output'); // Second call for output
+
+      expect(() => testUtils.testTransform(mockTransform, 'test')).toThrow();
+    });
+  });
+});

--- a/packages/codemod/src/test/test-utils.ts
+++ b/packages/codemod/src/test/test-utils.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 
 export function applyTransform(
-  transform: (fileInfo: FileInfo, api: API) => string,
+  transform: (fileInfo: FileInfo, api: API) => string | null,
   input: string,
   options = {},
 ): string {
@@ -19,7 +19,9 @@ export function applyTransform(
     stats: () => {},
     report: console.log,
   };
-  return transform(fileInfo, { ...api, ...options });
+  // A null result indicates no changes were made.
+  const result = transform(fileInfo, { ...api, ...options });
+  return result === null ? input : result;
 }
 
 export function readFixture(name: string, type: 'input' | 'output'): string {
@@ -37,7 +39,7 @@ export function readFixture(name: string, type: 'input' | 'output'): string {
 }
 
 export function testTransform(
-  transformer: (fileInfo: FileInfo, api: API) => string,
+  transformer: (fileInfo: FileInfo, api: API) => string | null,
   fixtureName: string,
 ) {
   const input = readFixture(fixtureName, 'input');


### PR DESCRIPTION
`jscodeshift` treats transforms that return null as having performed no code mutations. This can improve performance and avoid unnecessary rewriting of input code.

This change updates our test utility to treat codemods similar to `jscodeshift`.

In an upcoming change we'll update our codemod base to take advantage of this to reduce unnecessary transformations we currently see when running on larger codebases.