### PR TITLE
docs: await streamText call

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -98,7 +98,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
-  const result = streamText({
+  const result = await streamText({
     model: openai('gpt-4-turbo'),
     messages,
   });


### PR DESCRIPTION
Was going through the tut and noticed that `streamText` needed to be awaited!