### PR TITLE
fix (docs): point perplexity example/docs to newest model

### DIFF
--- a/content/providers/02-openai-compatible-providers/10-perplexity.mdx
+++ b/content/providers/02-openai-compatible-providers/10-perplexity.mdx
@@ -42,10 +42,10 @@ const perplexity = createOpenAI({
 ## Language Models
 
 You can create [Perplexity models](https://docs.perplexity.ai/docs/model-cards) using a provider instance.
-The first argument is the model id, e.g. `llama-3-sonar-large-32k-online`.
+The first argument is the model id, e.g. `llama-3.1-sonar-large-32k-online`.
 
 ```ts
-const model = perplexity('llama-3-sonar-large-32k-online');
+const model = perplexity('llama-3.1-sonar-large-32k-online');
 ```
 
 ### Example
@@ -63,7 +63,7 @@ const perplexity = createOpenAI({
 });
 
 const { text } = await generateText({
-  model: perplexity('llama-3-sonar-large-32k-online'),
+  model: perplexity('llama-3.1-sonar-large-32k-online'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```

--- a/examples/ai-core/src/stream-text/perplexity.ts
+++ b/examples/ai-core/src/stream-text/perplexity.ts
@@ -10,7 +10,7 @@ const perplexity = createOpenAI({
 
 async function main() {
   const result = streamText({
-    model: perplexity('llama-3-sonar-large-32k-online'),
+    model: perplexity('llama-3.1-sonar-large-32k-online'),
     prompt:
       'List the top 5 San Francisco news from the past week.' +
       'You must include the date of each article.',


### PR DESCRIPTION
Perplexity is not hosting the llama 3 version of their model anymore, so let's update to 3.1

src: https://docs.perplexity.ai/guides/model-cards