### PR TITLE
chore (provider/openai): Standardize internal schema case as 'openai'.

### DIFF
--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -24,7 +24,7 @@ import { mapOpenAIChatLogProbsOutput } from './map-openai-chat-logprobs';
 import { mapOpenAIFinishReason } from './map-openai-finish-reason';
 import { OpenAIChatModelId, OpenAIChatSettings } from './openai-chat-settings';
 import {
-  openAIErrorDataSchema,
+  openaiErrorDataSchema,
   openaiFailedResponseHandler,
 } from './openai-error';
 import { getResponseMetadata } from './get-response-metadata';
@@ -290,7 +290,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
       body,
       failedResponseHandler: openaiFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
-        openAIChatResponseSchema,
+        openaiChatResponseSchema,
       ),
       abortSignal: options.abortSignal,
       fetch: this.config.fetch,
@@ -628,7 +628,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
   }
 }
 
-const openAITokenUsageSchema = z
+const openaiTokenUsageSchema = z
   .object({
     prompt_tokens: z.number().nullish(),
     completion_tokens: z.number().nullish(),
@@ -647,7 +647,7 @@ const openAITokenUsageSchema = z
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const openAIChatResponseSchema = z.object({
+const openaiChatResponseSchema = z.object({
   id: z.string().nullish(),
   created: z.number().nullish(),
   model: z.string().nullish(),
@@ -697,7 +697,7 @@ const openAIChatResponseSchema = z.object({
       finish_reason: z.string().nullish(),
     }),
   ),
-  usage: openAITokenUsageSchema,
+  usage: openaiTokenUsageSchema,
 });
 
 // limited version of the schema, focussed on what is needed for the implementation
@@ -756,9 +756,9 @@ const openaiChatChunkSchema = z.union([
         index: z.number(),
       }),
     ),
-    usage: openAITokenUsageSchema,
+    usage: openaiTokenUsageSchema,
   }),
-  openAIErrorDataSchema,
+  openaiErrorDataSchema,
 ]);
 
 function isReasoningModel(modelId: string) {

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -23,7 +23,7 @@ import {
   OpenAICompletionSettings,
 } from './openai-completion-settings';
 import {
-  openAIErrorDataSchema,
+  openaiErrorDataSchema,
   openaiFailedResponseHandler,
 } from './openai-error';
 import { getResponseMetadata } from './get-response-metadata';
@@ -180,7 +180,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
       body: args,
       failedResponseHandler: openaiFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
-        openAICompletionResponseSchema,
+        openaiCompletionResponseSchema,
       ),
       abortSignal: options.abortSignal,
       fetch: this.config.fetch,
@@ -327,7 +327,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const openAICompletionResponseSchema = z.object({
+const openaiCompletionResponseSchema = z.object({
   id: z.string().nullish(),
   created: z.number().nullish(),
   model: z.string().nullish(),
@@ -378,5 +378,5 @@ const openaiCompletionChunkSchema = z.union([
       })
       .nullish(),
   }),
-  openAIErrorDataSchema,
+  openaiErrorDataSchema,
 ]);

--- a/packages/openai/src/openai-error.test.ts
+++ b/packages/openai/src/openai-error.test.ts
@@ -1,7 +1,7 @@
 import { safeParseJSON } from '@ai-sdk/provider-utils';
-import { openAIErrorDataSchema } from './openai-error';
+import { openaiErrorDataSchema } from './openai-error';
 
-describe('openAIErrorDataSchema', () => {
+describe('openaiErrorDataSchema', () => {
   it('should parse OpenRouter resource exhausted error', () => {
     const error = `
 {"error":{"message":"{\\n  \\"error\\": {\\n    \\"code\\": 429,\\n    \\"message\\": \\"Resource has been exhausted (e.g. check quota).\\",\\n    \\"status\\": \\"RESOURCE_EXHAUSTED\\"\\n  }\\n}\\n","code":429}}
@@ -9,7 +9,7 @@ describe('openAIErrorDataSchema', () => {
 
     const result = safeParseJSON({
       text: error,
-      schema: openAIErrorDataSchema,
+      schema: openaiErrorDataSchema,
     });
 
     expect(result).toStrictEqual({

--- a/packages/openai/src/openai-error.ts
+++ b/packages/openai/src/openai-error.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
-export const openAIErrorDataSchema = z.object({
+export const openaiErrorDataSchema = z.object({
   error: z.object({
     message: z.string(),
 
@@ -14,9 +14,9 @@ export const openAIErrorDataSchema = z.object({
   }),
 });
 
-export type OpenAIErrorData = z.infer<typeof openAIErrorDataSchema>;
+export type OpenAIErrorData = z.infer<typeof openaiErrorDataSchema>;
 
 export const openaiFailedResponseHandler = createJsonErrorResponseHandler({
-  errorSchema: openAIErrorDataSchema,
+  errorSchema: openaiErrorDataSchema,
   errorToMessage: data => data.error.message,
 });


### PR DESCRIPTION
It was already this way in a majority of other schema definitions, and it reads better to my eye. We should be consistent.