### PR TITLE
feat (provider): Define type for ObjectGenerationMode.

### DIFF
--- a/.changeset/tame-paws-laugh.md
+++ b/.changeset/tame-paws-laugh.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+feat (provider): Define type for ObjectGenerationMode.

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -36,7 +36,7 @@ model. `undefined` can be returned if object generation is not supported.
 This is needed to generate the best objects possible w/o requiring the
 user to explicitly specify the object generation mode.
    */
-  readonly defaultObjectGenerationMode: 'json' | 'tool' | undefined;
+  readonly defaultObjectGenerationMode: LanguageModelV1ObjectGenerationMode;
 
   /**
 Flag whether this model supports image URLs. Default is `true`.
@@ -280,3 +280,9 @@ export type LanguageModelV1StreamPart =
 
   // error parts are streamed, allowing for multiple errors
   | { type: 'error'; error: unknown };
+
+/**
+The object generation modes available for use with a model. `undefined`
+represents no support for object generation.
+   */
+export type LanguageModelV1ObjectGenerationMode = 'json' | 'tool' | undefined;


### PR DESCRIPTION
As we generalize an OpenAI-compatible base provider we need to surface this mode setting to a concrete provider implementation, catalyzing the need to define and export a named type for the possible values. See one [sample usage](https://github.com/vercel/ai/blob/90b9c52bea5cd6dc3c454fb70ca976d31112bc43/packages/openai-compatible/src/openai-compatible-chat-language-model.ts#L44) site.