### PR TITLE
fix: missing trigger onFinal callback

### DIFF
--- a/packages/ai/streams/stream-callbacks.ts
+++ b/packages/ai/streams/stream-callbacks.ts
@@ -62,6 +62,9 @@ export function createCallbacksTransformer(
       if (callbacks.onCompletion) {
         await callbacks.onCompletion(aggregatedResponse);
       }
+      if (callbacks.onFinal) {
+        await callbacks.onFinal(aggregatedResponse);
+      }
     },
   });
 }


### PR DESCRIPTION
Hi @lgrammel, I'm not sure why onFinal is removed in this PR:
https://github.com/vercel/ai/pull/3479/files#r1853548735

However, it is still an option in StreamCallbacks. 
https://github.com/vercel/ai/blob/d10ed1c2dce4313f75b414b871cf984c7a9bcf90/packages/ai/streams/stream-callbacks.ts#L10

You should either remove it from the StreamCallbacks options or ensure that it is triggered.