### PR TITLE
Add support apiVersion argument to azure provider

### DIFF
--- a/content/providers/01-ai-sdk-providers/02-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/02-azure.mdx
@@ -77,6 +77,11 @@ You can use the following optional settings to customize the OpenAI provider ins
   You can use it as a middleware to intercept requests,
   or to provide a custom fetch implementation for e.g. testing.
 
+- **apiVersion** _string_
+
+  Custom [api version](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation) to use. 
+  Defaults to `2024-10-01-preview`.
+
 ## Language Models
 
 The Azure OpenAI provider instance is a function that you can invoke to create a language model:
@@ -114,7 +119,7 @@ OpenAI language models can also be used in the `streamText`, `generateObject`, `
 
 <Note>
   The URL for calling Azure chat models will be constructed as follows:
-  `https://RESOURCE_NAME.openai.azure.com/openai/deployments/DEPLOYMENT_NAME/chat/completions?api-version=2024-10-01-preview`
+  `https://RESOURCE_NAME.openai.azure.com/openai/deployments/DEPLOYMENT_NAME/chat/completions?api-version=API_VERSION`
 </Note>
 
 Azure OpenAI chat models support also some model specific settings that are not part of the [standard call settings](/docs/ai-sdk-core/settings).

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -14,6 +14,12 @@ const provider = createAzure({
   apiKey: 'test-api-key',
 });
 
+const providerApiVersionChanged = createAzure({
+  resourceName: 'test-resource',
+  apiKey: 'test-api-key',
+  apiVersion: '2024-08-01-preview',
+});
+
 describe('chat', () => {
   describe('doGenerate', () => {
     const server = new JsonTestServer(
@@ -47,7 +53,7 @@ describe('chat', () => {
       };
     }
 
-    it('should set the correct api version', async () => {
+    it('should set the correct default api version', async () => {
       prepareJsonResponse();
 
       await provider('test-deployment').doGenerate({
@@ -59,6 +65,21 @@ describe('chat', () => {
       const searchParams = await server.getRequestUrlSearchParams();
       expect(searchParams.get('api-version')).toStrictEqual(
         '2024-10-01-preview',
+      );
+    });
+
+    it('should set the correct modified api version', async () => {
+      prepareJsonResponse();
+
+      await providerApiVersionChanged('test-deployment').doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+      });
+
+      const searchParams = await server.getRequestUrlSearchParams();
+      expect(searchParams.get('api-version')).toStrictEqual(
+        '2024-08-01-preview',
       );
     });
 

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -93,6 +93,11 @@ Custom fetch implementation. You can use it as a middleware to intercept request
 or to provide a custom fetch implementation for e.g. testing.
     */
   fetch?: FetchFunction;
+
+  /**
+Custom api version to use. Defaults to `2024-10-01-preview`.
+    */
+   apiVersion?: string;
 }
 
 /**
@@ -118,10 +123,12 @@ export function createAzure(
       description: 'Azure OpenAI resource name',
     });
 
+  const apiVersion = options.apiVersion? options.apiVersion : '2024-10-01-preview';
+
   const url = ({ path, modelId }: { path: string; modelId: string }) =>
     options.baseURL
-      ? `${options.baseURL}/${modelId}${path}?api-version=2024-10-01-preview`
-      : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=2024-10-01-preview`;
+      ? `${options.baseURL}/${modelId}${path}?api-version=${apiVersion}`
+      : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=${apiVersion}`;
 
   const createChatModel = (
     deploymentName: string,


### PR DESCRIPTION
Not every region support all api version, hence adding `apiVersion` to azure provider will allow wider usecase. I personally have problem with this hardcoded api-version, since my model deployment is in europe, currently I can't bump the version to 2024-10-01.

+ added to the docs
+ added new test