### PR TITLE
fix (provider/google): send json schema into provider

### DIFF
--- a/.changeset/silent-pugs-bake.md
+++ b/.changeset/silent-pugs-bake.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/google': patch
+---
+
+fix (provider/google): send json schema into provider

--- a/packages/google-vertex/src/google-vertex-language-model.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.ts
@@ -37,7 +37,7 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
   readonly defaultObjectGenerationMode = 'json';
   readonly supportsImageUrls = false;
 
-  get supportsObjectGeneration() {
+  get supportsStructuredOutputs() {
     return this.settings.structuredOutputs !== false;
   }
 
@@ -110,7 +110,7 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
         responseFormat.schema != null &&
         // Google Vertex does not support all OpenAPI Schema features,
         // so this is needed as an escape hatch:
-        this.supportsObjectGeneration
+        this.supportsStructuredOutputs
           ? (convertJSONSchemaToOpenAPISchema(
               responseFormat.schema,
             ) as ResponseSchema)
@@ -154,7 +154,7 @@ export class GoogleVertexLanguageModel implements LanguageModelV1 {
                 mode.schema != null &&
                 // Google Vertex does not support all OpenAPI Schema features,
                 // so this is needed as an escape hatch:
-                this.supportsObjectGeneration
+                this.supportsStructuredOutputs
                   ? (convertJSONSchemaToOpenAPISchema(
                       mode.schema,
                     ) as ResponseSchema)

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -38,7 +38,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
   readonly defaultObjectGenerationMode = 'json';
   readonly supportsImageUrls = false;
 
-  get supportsObjectGeneration() {
+  get supportsStructuredOutputs() {
     return this.settings.structuredOutputs !== false;
   }
 
@@ -103,7 +103,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
         responseFormat.schema != null &&
         // Google GenAI does not support all OpenAPI Schema features,
         // so this is needed as an escape hatch:
-        this.supportsObjectGeneration
+        this.supportsStructuredOutputs
           ? convertJSONSchemaToOpenAPISchema(responseFormat.schema)
           : undefined,
     };
@@ -139,7 +139,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
                 mode.schema != null &&
                 // Google GenAI does not support all OpenAPI Schema features,
                 // so this is needed as an escape hatch:
-                this.supportsObjectGeneration
+                this.supportsStructuredOutputs
                   ? convertJSONSchemaToOpenAPISchema(mode.schema)
                   : undefined,
             },


### PR DESCRIPTION
## Background
The name of the setting was incorrect, so the AI SDK functions did not send the schema.