### PR TITLE
feat (provider/azure): add support for azure managed identity.

### DIFF
--- a/content/providers/01-ai-sdk-providers/02-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/02-azure.mdx
@@ -57,6 +57,13 @@ You can use the following optional settings to customize the OpenAI provider ins
   API key that is being sent using the `api-key` header.
   It defaults to the `AZURE_API_KEY` environment variable.
 
+- **identityTokenProvider** _Promise&lt;string&gt;_
+
+  A function that returns a promise resolving to a token to be sent using the `Authorization` header.
+  This can be used with the `@azure/identity` package and `getBearerTokenProvider` function to authenticate with Azure Managed Identity.
+
+  If both `apiKey` and `identityTokenProvider` are provided, the `identityTokenProvider` takes precedence.
+
 - **apiVersion** _string_
 
   Sets a custom [api version](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation).

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -98,6 +98,11 @@ or to provide a custom fetch implementation for e.g. testing.
 Custom api version to use. Defaults to `2024-10-01-preview`.
     */
   apiVersion?: string;
+
+  /**
+  Function to fetch an authorization token using Azure Managed Identity using the `@azure/identity` package. If provided, the `apiKey` is ignored.
+   */
+  identityTokenProvider?: () => Promise<string>;
 }
 
 /**
@@ -107,11 +112,15 @@ export function createAzure(
   options: AzureOpenAIProviderSettings = {},
 ): AzureOpenAIProvider {
   const getHeaders = () => ({
-    'api-key': loadApiKey({
-      apiKey: options.apiKey,
-      environmentVariableName: 'AZURE_API_KEY',
-      description: 'Azure OpenAI',
-    }),
+    ...(options.identityTokenProvider
+      ? {}
+      : {
+          'api-key': loadApiKey({
+            apiKey: options.apiKey,
+            environmentVariableName: 'AZURE_API_KEY',
+            description: 'Azure OpenAI',
+          }),
+        }),
     ...options.headers,
   });
 
@@ -129,6 +138,36 @@ export function createAzure(
       ? `${options.baseURL}/${modelId}${path}?api-version=${apiVersion}`
       : `https://${getResourceName()}.openai.azure.com/openai/deployments/${modelId}${path}?api-version=${apiVersion}`;
 
+  const wrappedFetch = async function (...args: Parameters<FetchFunction>) {
+    if (options.identityTokenProvider) {
+      const [input, init] = args;
+      let token: string;
+
+      try {
+        token = await options.identityTokenProvider();
+      } catch (error) {
+        throw new Error(
+          'Failed to fetch Azure Managed Identity token: ' +
+            (error as Error).message,
+        );
+      }
+      if (!token || typeof token !== 'string') {
+        throw new Error(
+          `Invalid Azure Managed Identity token format: token must be a non-empty string. Received: ${token}`,
+        );
+      }
+
+      return (options.fetch || fetch)(input, {
+        ...init,
+        headers: {
+          ...init?.headers,
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    }
+    return (options.fetch || fetch)(...args);
+  } as FetchFunction;
+
   const createChatModel = (
     deploymentName: string,
     settings: OpenAIChatSettings = {},
@@ -138,7 +177,7 @@ export function createAzure(
       url,
       headers: getHeaders,
       compatibility: 'strict',
-      fetch: options.fetch,
+      fetch: wrappedFetch,
     });
 
   const createCompletionModel = (
@@ -150,7 +189,7 @@ export function createAzure(
       url,
       compatibility: 'strict',
       headers: getHeaders,
-      fetch: options.fetch,
+      fetch: wrappedFetch,
     });
 
   const createEmbeddingModel = (
@@ -161,7 +200,7 @@ export function createAzure(
       provider: 'azure-openai.embeddings',
       headers: getHeaders,
       url,
-      fetch: options.fetch,
+      fetch: wrappedFetch,
     });
 
   const provider = function (


### PR DESCRIPTION
Fixes: #3124 

Similar to my last PR, #3463 but updated to v4 and cleaned up the code. Had to close the previous PR as it was too far behind and easier to start over than rebase.

- added option for a token provider to be sent
- added new tests
- added to the docs

Made it a fetch wrapper to grab a new token on new requests, similar to how [OpenAI package does it](https://github.com/openai/openai-node/blob/3f8634ed111782e3090a25d1d8640e050fb2c45b/src/index.ts#L610).

Please let me know what else I can add or change.