### PR TITLE
fix (docs): add link in langfuse docs and add learn more

### DIFF
--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -221,7 +221,7 @@ new LangfuseExporter({ debug: true });
   - set `skipOpenTelemetrySetup: true` in Sentry.init
   - follow Sentry's docs on how to manually set up Sentry with OTEL
 
-## Learn more  
+## Learn more
 
 - After setting up Langfuse Tracing for the AI SDK, you can utilize any of the other Langfuse [platform features](https://langfuse.com/docs):  
   - [Prompt Management](https://langfuse.com/docs/prompts): Collaboratively manage and iterate on prompts, use them with low-latency in production.  

--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -223,8 +223,8 @@ new LangfuseExporter({ debug: true });
 
 ## Learn more
 
-- After setting up Langfuse Tracing for the AI SDK, you can utilize any of the other Langfuse [platform features](https://langfuse.com/docs):  
-  - [Prompt Management](https://langfuse.com/docs/prompts): Collaboratively manage and iterate on prompts, use them with low-latency in production.  
-  - [Evaluations](https://langfuse.com/docs/scores): Test the application holistically in development and production using user feedback, LLM-as-a-judge evaluators, manual reviews, or custom evaluation pipelines.  
-  - [Experiments](https://langfuse.com/docs/datasets): Iterate on prompts, models, and application design in a structured manner with datasets and evaluations.  
+- After setting up Langfuse Tracing for the AI SDK, you can utilize any of the other Langfuse [platform features](https://langfuse.com/docs):
+  - [Prompt Management](https://langfuse.com/docs/prompts): Collaboratively manage and iterate on prompts, use them with low-latency in production.
+  - [Evaluations](https://langfuse.com/docs/scores): Test the application holistically in development and production using user feedback, LLM-as-a-judge evaluators, manual reviews, or custom evaluation pipelines.
+  - [Experiments](https://langfuse.com/docs/datasets): Iterate on prompts, models, and application design in a structured manner with datasets and evaluations.
 - For more information, see the [telemetry documentation](/docs/ai-sdk-core/telemetry) of the Vercel AI SDK.

--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -221,7 +221,10 @@ new LangfuseExporter({ debug: true });
   - set `skipOpenTelemetrySetup: true` in Sentry.init
   - follow Sentry's docs on how to manually set up Sentry with OTEL
 
-## Learn more
+## Learn more  
 
-- Watch the video tutorial in the Langfuse [docs](https://langfuse.com/blog/langfuse-vercel-ai-sdk).
-- See the [telemetry documentation](/docs/ai-sdk-core/telemetry) of the Vercel AI SDK for more information.
+- After setting up Langfuse Tracing for the AI SDK, you can utilize any of the other Langfuse [platform features](https://langfuse.com/docs):  
+  - [Prompt Management](https://langfuse.com/docs/prompts): Collaboratively manage and iterate on prompts, use them with low-latency in production.  
+  - [Evaluations](https://langfuse.com/docs/scores): Test the application holistically in development and production using user feedback, LLM-as-a-judge evaluators, manual reviews, or custom evaluation pipelines.  
+  - [Experiments](https://langfuse.com/docs/datasets): Iterate on prompts, models, and application design in a structured manner with datasets and evaluations.  
+- For more information, see the [telemetry documentation](/docs/ai-sdk-core/telemetry) of the Vercel AI SDK.

--- a/content/providers/05-observability/langfuse.mdx
+++ b/content/providers/05-observability/langfuse.mdx
@@ -227,4 +227,4 @@ new LangfuseExporter({ debug: true });
   - [Prompt Management](https://langfuse.com/docs/prompts): Collaboratively manage and iterate on prompts, use them with low-latency in production.
   - [Evaluations](https://langfuse.com/docs/scores): Test the application holistically in development and production using user feedback, LLM-as-a-judge evaluators, manual reviews, or custom evaluation pipelines.
   - [Experiments](https://langfuse.com/docs/datasets): Iterate on prompts, models, and application design in a structured manner with datasets and evaluations.
-- For more information, see the [telemetry documentation](/docs/ai-sdk-core/telemetry) of the Vercel AI SDK.
+- For more information, see the [telemetry documentation](/docs/ai-sdk-core/telemetry) of the AI SDK.


### PR DESCRIPTION
Existing link was broken, replaced it with correct links to langfuse documentation