### PR TITLE
fix (ai/core): change default error message for data streams to "An error occurred."

### DIFF
--- a/.changeset/chilly-elephants-check.md
+++ b/.changeset/chilly-elephants-check.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai/core): change default error message for data streams to "An error occurred."

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -369,7 +369,9 @@ With `streamText`, you can control how error messages and usage information are 
 
 ### Error Messages
 
-By default, the error message is suppressed for security reasons. You can forward it or send your own error message by providing a `getErrorMessage` function:
+By default, the error message is masked for security reasons.
+The default error message is "An error occurred."
+You can forward error messages or send your own error message by providing a `getErrorMessage` function:
 
 ```ts filename="app/api/chat/route.ts" highlight="13-27"
 import { openai } from '@ai-sdk/openai';

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -2368,7 +2368,7 @@ exports[`streamText > result.pipeDataStreamToResponse > should create a Response
 
 exports[`streamText > result.pipeDataStreamToResponse > should mask error messages by default 1`] = `
 [
-  "3:""
+  "3:"An error occurred."
 ",
   "e:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0},"isContinued":false}
 ",
@@ -2517,7 +2517,7 @@ exports[`streamText > result.toDataStream > should create a data stream 1`] = `
 
 exports[`streamText > result.toDataStream > should mask error messages by default 1`] = `
 [
-  "3:""
+  "3:"An error occurred."
 ",
   "e:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0},"isContinued":false}
 ",
@@ -2629,7 +2629,7 @@ exports[`streamText > result.toDataStreamResponse > should create a Response wit
 
 exports[`streamText > result.toDataStreamResponse > should mask error messages by default 1`] = `
 [
-  "3:""
+  "3:"An error occurred."
 ",
   "e:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0},"isContinued":false}
 ",

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1050,7 +1050,7 @@ However, the LLM results are expected to be small enough to not cause issues.
   }
 
   private toDataStreamInternal({
-    getErrorMessage = () => '', // mask error messages for safety by default
+    getErrorMessage = () => 'An error occurred.', // mask error messages for safety by default
     sendUsage = true,
   }: {
     getErrorMessage?: (error: unknown) => string;


### PR DESCRIPTION
## Background
We currently send empty strings as error message by default. This can lead to swallowed error messages in the frontend, because the empty string is falsy. Changing to "An error occurred." to prevent this while retaining masking.