### PR TITLE
'100vh' is not a valid DimensionValue in React Native

### DIFF
--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -129,7 +129,7 @@ export default function App() {
   if (error) return <Text>{error.message}</Text>;
 
   return (
-    <SafeAreaView style={{ height: '100vh' }}>
+    <SafeAreaView style={{ height: '100%' }}>
       <View
         style={{
           height: '95%',


### PR DESCRIPTION
## Description
I just fix the error by changing the old ``100vh`` to ``100%``

```ts
height?: DimensionValue | undefined;

// ...

export type DimensionValue =
  | number
  | 'auto'
  | `${number}%`
  | Animated.AnimatedNode
  | null;
```