### PR TITLE
docs: fix nuxt instructions to use properly cased environment variable

### DIFF
--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -193,7 +193,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { z } from 'zod';
 
 export default defineLazyEventHandler(async () => {
-  const apiKey = useRuntimeConfig().openaiApiKey;
+  const apiKey = useRuntimeConfig().OPENAI_API_KEY;
   if (!apiKey) throw new Error('Missing OpenAI API key');
   const openai = createOpenAI({
     apiKey: apiKey,


### PR DESCRIPTION
Instructions are currently broken. Nuxt environment variables configured in `runtimeConfig` within `nuxt.config.ts` will retain case. We configured the process.env var to be called `OPENAI_API_KEY`, so the eventHandler needs to call it the same thing.

To reproduce, follow the docs:

```ts
// server/event.ts - some file with an event handler, from this tutorial
import { streamText } from 'ai';
import { createOpenAI } from '@ai-sdk/openai';

export default defineLazyEventHandler(async () => {
  debugger; // Inspect `useRuntimeConfig()`
  const apiKey = useRuntimeConfig().openaiApiKey;
  if (!apiKey) throw new Error('Missing OpenAI API key');
  const openai = createOpenAI({
    apiKey: apiKey,
  });

  return defineEventHandler(async (event: any) => {
    const { messages } = await readBody(event);

    const result = streamText({
      model: openai('gpt-4o'),
      messages,
    });

    return result.toDataStreamResponse();
  });
});
```