### PR TITLE
fix (release): remove clean task from google-vertex example

### DIFF
--- a/examples/next-google-vertex/package.json
+++ b/examples/next-google-vertex/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "clean": "rm -rf .next node_modules",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## Background
We seem to have a build bug where `clean` tasks in examples interfere with our release publishing. Removing the `clean` task from the example for now. We eventually need to find the deeper issue.