### PR TITLE
chore (docs):  Update providers-and-models page

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -32,6 +32,7 @@ The AI SDK comes with several providers that you can use to interact with differ
 - [Google Vertex Provider](/providers/ai-sdk-providers/google-vertex) (`@ai-sdk/google-vertex`)
 - [Mistral Provider](/providers/ai-sdk-providers/mistral) (`@ai-sdk/mistral`)
 - [xAI Grok Provider](/providers/ai-sdk-providers/xai) (`@ai-sdk/xai`)
+- [Together.ai Provider](/providers/ai-sdk-providers/togetherai) (`@ai-sdk/togetherai`)
 - [Cohere Provider](/providers/ai-sdk-providers/cohere) (`@ai-sdk/cohere`)
 - [Groq](/providers/ai-sdk-providers/groq) (`@ai-sdk/groq`)
 
@@ -46,11 +47,16 @@ Our [language model specification](https://github.com/vercel/ai/tree/main/packag
 
 The open-source community has created the following providers:
 
-- [LLamaCpp Provider](/providers/community-providers/llama-cpp) (`nnance/llamacpp-ai-provider `)
-- [Ollama Provider](/providers/community-providers/ollama) (`sgomez/ollama-ai-provider`)
-- [ChromeAI Provider](/providers/community-providers/chrome-ai) (`jeasonstudio/chrome-ai`)
+- [Ollama Provider](/providers/community-providers/ollama) (`ollama-ai-provider`)
+- [ChromeAI Provider](/providers/community-providers/chrome-ai) (`chrome-ai`)
+- [AnthropicVertex Provider](/providers/community-providers/anthropic-vertex-ai) (`anthropic-vertex-ai`)
+- [FriendliAI Provider](/providers/community-providers/friendliai) (`@friendliai/ai-provider`)
 - [Portkey Provider](/providers/community-providers/portkey) (`@portkey-ai/vercel-provider`)
-- [AnthropicVertex Provider](/providers/community-providers/anthropic-vertex-ai) (`nalaso/anthropic-vertex-ai`)
+- [Cloudflare Workers AI Provider](/providers/community-providers/cloudflare-workers-ai) (`workers-ai-provider`)
+- [Crosshatch Provider](/providers/community-providers/crosshatch) (`@crosshatch/ai-provider`)
+- [Mixedbread Provider](/providers/community-providers/mixedbread) (`mixedbread-ai-provider`)
+- [Voyage AI Provider](/providers/community-providers/voyage-ai) (`voyage-ai-provider`)
+- [LLamaCpp Provider](/providers/community-providers/llama-cpp) (`llamacpp-ai-provider`)
 
 ## Model Capabilities
 


### PR DESCRIPTION
Updated the https://sdk.vercel.ai/docs/foundations/providers-and-models page

- Added missing items. (friendliai, togehterai, cloudflare workers ai, crosshatch, mixedbread, voyage)
- The text on the right of the community provider has been unified as the package name.
- Sorted the order (same as document order)

It would also be nice if the `<CommunityModelCards />` component were updated.