### PR TITLE
docs: remove deprecated models for Groq

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -84,8 +84,7 @@ Here are the capabilities of popular models:
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex)               | `gemini-1.5-pro`             | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-beta`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-vision-beta`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [Groq](/providers/ai-sdk-providers/groq)                                 | `llama-3.1-405b-reasoning`   | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [Groq](/providers/ai-sdk-providers/groq)                                 | `llama-3.1-70b-versatile`    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [Groq](/providers/ai-sdk-providers/groq)                                 | `llama-3.3-70b-versatile`    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Groq](/providers/ai-sdk-providers/groq)                                 | `llama-3.1-8b-instant`       | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Groq](/providers/ai-sdk-providers/groq)                                 | `mixtral-8x7b-32768`         | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Groq](/providers/ai-sdk-providers/groq)                                 | `gemma2-9b-it`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/50-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/50-groq.mdx
@@ -95,7 +95,7 @@ Groq offers [a variety of models with different capabilities](https://console.gr
 
 | Model                     | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | ------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `llama-3.1-70b-versatile` | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `llama-3.3-70b-versatile` | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `llama-3.1-8b-instant`    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemma2-9b-it`            | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `mixtral-8x7b-32768`      | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -38,8 +38,7 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex)               | `gemini-1.5-pro`             | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-beta`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [xAI Grok](/providers/ai-sdk-providers/xai)                              | `grok-vision-beta`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [Groq](/providers/ai-sdk-providers/groq)                                 | `llama-3.1-405b-reasoning`   | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [Groq](/providers/ai-sdk-providers/groq)                                 | `llama-3.1-70b-versatile`    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [Groq](/providers/ai-sdk-providers/groq)                                 | `llama-3.3-70b-versatile`    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Groq](/providers/ai-sdk-providers/groq)                                 | `llama-3.1-8b-instant`       | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Groq](/providers/ai-sdk-providers/groq)                                 | `mixtral-8x7b-32768`         | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Groq](/providers/ai-sdk-providers/groq)                                 | `gemma2-9b-it`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |


### PR DESCRIPTION
Hi,

Updated list of available models for Groq: 
- [https://console.groq.com/docs/models](https://console.groq.com/docs/models)
- [https://console.groq.com/docs/deprecations](https://console.groq.com/docs/deprecations)