### PR TITLE
fix (docs): corrected the default dimension for "amazon.titan-embed-text-v1"

### DIFF
--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -314,5 +314,5 @@ The following optional settings are available for Bedrock Titan embedding models
 
 | Model                          | Default Dimensions | Custom Dimensions   |
 | ------------------------------ | ------------------ | ------------------- |
-| `amazon.titan-embed-text-v1`   | 1024               | <Cross size={18} /> |
+| `amazon.titan-embed-text-v1`   | 1536               | <Cross size={18} /> |
 | `amazon.titan-embed-text-v2:0` | 1024               | <Check size={18} /> |


### PR DESCRIPTION
Hi,

Corrected the default dimension for "**amazon.titan-embed-text-v1**": 1536 vs 1024.
Ref: https://aws.amazon.com/jp/blogs/machine-learning/get-started-with-amazon-titan-text-embeddings-v2-a-new-state-of-the-art-embeddings-model-on-amazon-bedrock/