### PR TITLE
fix: update OpenAICompatibleChatChunkSchema to allow nullish index

### DIFF
--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -568,7 +568,7 @@ const OpenAICompatibleChatChunkSchema = z.union([
           })
           .nullish(),
         finish_reason: z.string().nullable().optional(),
-        index: z.number(),
+        index: z.number().nullish(),
       }),
     ),
     usage: z


### PR DESCRIPTION
This PR fixes the validation error when streaming text from [Cloudflare Workers AI OpenAI compatible API endpoints](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/).

```bash
Cause: AI_TypeValidationError: Type validation failed: Value: {"id":"id-1733737971956","object":"chat.completion.chunk","created":1733737971,"model":"@cf/meta/llama-3.1-8b-instruct-fast","choices":[{"delta":{"content":"**"}}]}.
Error message: [
  {
    "code": "invalid_union",
    "unionErrors": [
      {
        "issues": [
          {
            "code": "invalid_type",
            "expected": "number",
            "received": "undefined",
            "path": [
              "choices",
              0,
              "index"
            ],
            "message": "Required"
          }
        ],
        "name": "ZodError"
      },
      {
        "issues": [
          {
            "code": "invalid_type",
            "expected": "object",
            "received": "undefined",
            "path": [
              "error"
            ],
            "message": "Required"
          }
        ],
        "name": "ZodError"
      }
    ],
    "path": [],
    "message": "Invalid input"
  }
]
```