### PR TITLE
fix (provider/google-vertex): Remove unsupported cache ctl setting.

### DIFF
--- a/.changeset/few-badgers-glow.md
+++ b/.changeset/few-badgers-glow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix (provider/google-vertex): Remove unsupported cache control setting from Vertex Anthropic.

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts
@@ -11,4 +11,4 @@ export type GoogleVertexAnthropicMessagesModelId =
   | (string & {});
 
 export interface GoogleVertexAnthropicMessagesSettings
-  extends AnthropicMessagesSettings {}
+  extends Omit<AnthropicMessagesSettings, 'cacheControl'> {}

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -13,7 +13,6 @@ import {
   anthropicTools,
   AnthropicMessagesLanguageModel,
   AnthropicMessagesModelId,
-  AnthropicMessagesSettings,
 } from '@ai-sdk/anthropic/internal';
 import {
   GoogleVertexAnthropicMessagesModelId,
@@ -25,7 +24,7 @@ Creates a model for text generation.
 */
   (
     modelId: GoogleVertexAnthropicMessagesModelId,
-    settings?: AnthropicMessagesSettings,
+    settings?: GoogleVertexAnthropicMessagesSettings,
   ): LanguageModelV1;
 
   /**
@@ -33,7 +32,7 @@ Creates a model for text generation.
 */
   languageModel(
     modelId: GoogleVertexAnthropicMessagesModelId,
-    settings?: AnthropicMessagesSettings,
+    settings?: GoogleVertexAnthropicMessagesSettings,
   ): LanguageModelV1;
 
   /**


### PR DESCRIPTION
Vertex Anthropic does not currently appear to support the beta cache-control feature.