### PR TITLE
feat (ai/core): add experimental generateImage function

### DIFF
--- a/.changeset/chilly-dragons-count.md
+++ b/.changeset/chilly-dragons-count.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider': patch
+'@ai-sdk/openai': patch
+'ai': patch
+---
+
+feat (ai/core): add experimental generateImage function

--- a/content/docs/03-ai-sdk-core/35-image-generation.mdx
+++ b/content/docs/03-ai-sdk-core/35-image-generation.mdx
@@ -1,0 +1,99 @@
+---
+title: Image Generation
+description: Learn how to generate images with the AI SDK.
+---
+
+# Image Generation
+
+<Note type="warning">Image generation is an experimental feature.</Note>
+
+The AI SDK provides the [`generateImage`](/docs/reference/ai-sdk-core/generate-image)
+function to generate images based on a given prompt using an image model.
+
+```tsx
+import { experimental_generateImage as generateImage } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const { image } = await generateImage({
+  model: openai.image('dall-e-3'),
+  prompt: 'Santa Claus driving a Cadillac',
+  size: '1024x1024',
+});
+```
+
+You can access the image data using the `base64` or `uint8Array` properties:
+
+```tsx
+const base64 = image.base64; // base64 image data
+const uint8Array = image.uint8Array; // Uint8Array image data
+```
+
+### Generating Multiple Images
+
+`generateImage` also supports generating multiple images at once:
+
+```tsx highlight={"4"}
+const { images } = await generateImage({
+  model: openai.image('dall-e-3'),
+  prompt: 'Santa Claus driving a Cadillac',
+  n: 4, // number of images to generate
+});
+```
+
+### Provider-specific Settings
+
+Image models often have provider- or even model-specific settings.
+You can pass such settings to the `generateImage` function
+using the `providerOptions` parameter. The options for the provider
+(`openai` in the example below) become request body properties.
+
+```tsx highlight={"5-7"}
+const { image } = await generateImage({
+  model: openai.image('dall-e-3'),
+  prompt: 'Santa Claus driving a Cadillac',
+  size: '1024x1024',
+  providerOptions: {
+    openai: { style: 'vivid', quality: 'hd' },
+  },
+});
+```
+
+### Abort Signals and Timeouts
+
+`generateImage` accepts an optional `abortSignal` parameter of
+type [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+that you can use to abort the image generation process or set a timeout.
+
+```ts highlight={"7"}
+import { openai } from '@ai-sdk/openai';
+import { experimental_generateImage as generateImage } from 'ai';
+
+const { image } = await generateImage({
+  model: openai.image('dall-e-3'),
+  prompt: 'Santa Claus driving a Cadillac',
+  abortSignal: AbortSignal.timeout(1000), // Abort after 1 second
+});
+```
+
+### Custom Headers
+
+`generateImage` accepts an optional `headers` parameter of type `Record<string, string>`
+that you can use to add custom headers to the image generation request.
+
+```ts highlight={"7"}
+import { openai } from '@ai-sdk/openai';
+import { experimental_generateImage as generateImage } from 'ai';
+
+const { image } = await generateImage({
+  model: openai.image('dall-e-3'),
+  value: 'sunny day at the beach',
+  headers: { 'X-Custom-Header': 'custom-value' },
+});
+```
+
+## Image Models
+
+| Provider                                                  | Model      | Supported Sizes                 |
+| --------------------------------------------------------- | ---------- | ------------------------------- |
+| [OpenAI](/providers/ai-sdk-providers/openai#image-models) | `dall-e-3` | 1024x1024, 1792x1024, 1024x1792 |
+| [OpenAI](/providers/ai-sdk-providers/openai#image-models) | `dall-e-2` | 256x256, 512x512, 1024x1024     |

--- a/content/docs/03-ai-sdk-core/index.mdx
+++ b/content/docs/03-ai-sdk-core/index.mdx
@@ -50,6 +50,11 @@ description: Learn about AI SDK Core.
       href: '/docs/ai-sdk-core/embeddings',
     },
     {
+      title: 'Image Generation',
+      description: 'Learn how to generate images with AI SDK Core.',
+      href: '/docs/ai-sdk-core/image-generation',
+    },
+    {
       title: 'Provider Management',
       description: 'Learn how to work with multiple providers.',
       href: '/docs/ai-sdk-core/provider-management',

--- a/content/docs/07-reference/01-ai-sdk-core/10-generate-image.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/10-generate-image.mdx
@@ -1,0 +1,140 @@
+---
+title: generateImage
+description: API Reference for generateImage.
+---
+
+# `generateImage()`
+
+<Note type="warning">`generateImage` is an experimental feature.</Note>
+
+Generates images based on a given prompt using an image model.
+
+It is ideal for use cases where you need to generate images programmatically,
+such as creating visual content or generating images for data augmentation.
+
+```ts
+import { experimental_generateImage as generateImage } from 'ai';
+
+const { images } = await generateImage({
+  model: openai.image('dall-e-3'),
+  prompt: 'A futuristic cityscape at sunset',
+  n: 3,
+  size: '1024x1024',
+});
+
+console.log(images);
+```
+
+## Import
+
+<Snippet
+  text={`import { experimental_generateImage as generateImage } from "ai"`}
+  prompt={false}
+/>
+
+## API Signature
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'model',
+      type: 'ImageModelV1',
+      description: 'The image model to use.',
+    },
+    {
+      name: 'prompt',
+      type: 'string',
+      description: 'The input prompt to generate the image from.',
+    },
+    {
+      name: 'n',
+      type: 'number',
+      isOptional: true,
+      description: 'Number of images to generate.',
+    },
+    {
+      name: 'size',
+      type: 'string',
+      isOptional: true,
+      description:
+        'Size of the images to generate. Format: `{width}x{height}`.',
+    },
+    {
+      name: 'providerOptions',
+      type: 'Record<string, Record<string, JSONValue>>',
+      isOptional: true,
+      description: 'Additional provider-specific options.',
+    },
+    {
+      name: 'maxRetries',
+      type: 'number',
+      isOptional: true,
+      description: 'Maximum number of retries. Default: 2.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal',
+      isOptional: true,
+      description: 'An optional abort signal to cancel the call.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description: 'Additional HTTP headers for the request.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'image',
+      type: 'GeneratedImage',
+      description: 'The first image that was generated.',
+      properties: [
+        {
+          type: 'GeneratedImage',
+          parameters: [
+            {
+              name: 'base64',
+              type: 'string',
+              description: 'Image as a base64 encoded string.',
+            },
+            {
+              name: 'uint8Array',
+              type: 'Uint8Array',
+              description: 'Image as a Uint8Array.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'images',
+      type: 'Array<GeneratedImage>',
+      description: 'All images that were generated.',
+      properties: [
+        {
+          type: 'GeneratedImage',
+          parameters: [
+            {
+              name: 'base64',
+              type: 'string',
+              description: 'Image as a base64 encoded string.',
+            },
+            {
+              name: 'uint8Array',
+              type: 'Uint8Array',
+              description: 'Image as a Uint8Array.',
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -46,6 +46,12 @@ AI SDK Core contains the following main functions:
         'Generate embeddings for several values using an embedding model (batch embedding).',
       href: '/docs/reference/ai-sdk-core/embed-many',
     },
+    {
+      title: 'generateImage()',
+      description:
+        'Generate images based on a given prompt using an image model.',
+      href: '/docs/reference/ai-sdk-core/generate-image',
+    },
   ]}
 />
 

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -517,8 +517,10 @@ The following optional settings are available for OpenAI completion models:
 | `o1-mini`              | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 
 <Note>
-  The table above lists popular models. You can also pass any available provider
-  model ID as a string if needed.
+  The table above lists popular models. Please see the [OpenAI
+  docs](https://platform.openai.com/docs/models) for a full list of available
+  models. The table above lists popular models. You can also pass any available
+  provider model ID as a string if needed.
 </Note>
 
 ## Embedding Models

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -517,10 +517,8 @@ The following optional settings are available for OpenAI completion models:
 | `o1-mini`              | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 
 <Note>
-  The table above lists popular models. Please see the [OpenAI
-  docs](https://platform.openai.com/docs/models) for a full list of available
-  models. The table above lists popular models. You can also pass any available
-  provider model ID as a string if needed.
+  The table above lists popular models. You can also pass any available provider
+  model ID as a string if needed.
 </Note>
 
 ## Embedding Models
@@ -561,3 +559,19 @@ The following optional settings are available for OpenAI embedding models:
 | `text-embedding-3-large` | 3072               | <Check size={18} /> |
 | `text-embedding-3-small` | 1536               | <Check size={18} /> |
 | `text-embedding-ada-002` | 1536               | <Cross size={18} /> |
+
+## Image Models
+
+You can create models that call the [OpenAI image generation API](https://platform.openai.com/docs/api-reference/images)
+using the `.image()` factory method.
+
+```ts
+const model = openai.image('dall-e-3');
+```
+
+### Model Capabilities
+
+| Model      | Supported Sizes                 |
+| ---------- | ------------------------------- |
+| `dall-e-3` | 1024x1024, 1792x1024, 1024x1792 |
+| `dall-e-2` | 256x256, 512x512, 1024x1024     |

--- a/examples/ai-core/src/generate-image/openai.ts
+++ b/examples/ai-core/src/generate-image/openai.ts
@@ -5,9 +5,12 @@ import fs from 'fs';
 
 async function main() {
   const { imageAsUint8Array: image } = await generateImage({
-    model: openai.image('dall-e-2'),
+    model: openai.image('dall-e-3'),
     prompt: 'Santa Claus driving a Cadillac',
-    size: '512x512',
+    size: '1024x1024',
+    providerOptions: {
+      openai: { style: 'vivid', quality: 'hd' },
+    },
   });
 
   const filename = `image-${Date.now()}.png`;

--- a/examples/ai-core/src/generate-image/openai.ts
+++ b/examples/ai-core/src/generate-image/openai.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateImage } from 'ai';
+import { experimental_generateImage as generateImage } from 'ai';
 import 'dotenv/config';
 import fs from 'fs';
 
@@ -8,7 +8,6 @@ async function main() {
     model: openai.image('dall-e-2'),
     prompt: 'Santa Claus driving a Cadillac',
     size: '512x512',
-    maxRetries: 0,
   });
 
   const filename = `image-${Date.now()}.png`;

--- a/examples/ai-core/src/generate-image/openai.ts
+++ b/examples/ai-core/src/generate-image/openai.ts
@@ -1,15 +1,19 @@
 import { openai } from '@ai-sdk/openai';
 import { generateImage } from 'ai';
 import 'dotenv/config';
+import fs from 'fs';
 
 async function main() {
-  const { images } = await generateImage({
-    model: openai.image('dall-e-3'),
+  const { imageAsUint8Array: image } = await generateImage({
+    model: openai.image('dall-e-2'),
     prompt: 'Santa Claus driving a Cadillac',
+    size: '512x512',
     maxRetries: 0,
   });
 
-  console.log(images);
+  const filename = `image-${Date.now()}.png`;
+  fs.writeFileSync(filename, image);
+  console.log(`Image saved to ${filename}`);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-image/openai.ts
+++ b/examples/ai-core/src/generate-image/openai.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import fs from 'fs';
 
 async function main() {
-  const { imageAsUint8Array: image } = await generateImage({
+  const { image } = await generateImage({
     model: openai.image('dall-e-3'),
     prompt: 'Santa Claus driving a Cadillac',
     size: '1024x1024',
@@ -14,7 +14,7 @@ async function main() {
   });
 
   const filename = `image-${Date.now()}.png`;
-  fs.writeFileSync(filename, image);
+  fs.writeFileSync(filename, image.uint8Array);
   console.log(`Image saved to ${filename}`);
 }
 

--- a/examples/ai-core/src/generate-image/openai.ts
+++ b/examples/ai-core/src/generate-image/openai.ts
@@ -1,0 +1,15 @@
+import { openai } from '@ai-sdk/openai';
+import { generateImage } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const { images } = await generateImage({
+    model: openai.image('dall-e-3'),
+    prompt: 'Santa Claus driving a Cadillac',
+    maxRetries: 0,
+  });
+
+  console.log(images);
+}
+
+main().catch(console.error);

--- a/examples/next-openai/app/api/generate-image/route.ts
+++ b/examples/next-openai/app/api/generate-image/route.ts
@@ -1,0 +1,19 @@
+import { openai } from '@ai-sdk/openai';
+import { experimental_generateImage as generateImage } from 'ai';
+
+export const runtime = 'edge';
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json();
+
+  const { image } = await generateImage({
+    model: openai.image('dall-e-3'),
+    prompt,
+    size: '1024x1024',
+    providerOptions: {
+      openai: { style: 'vivid', quality: 'hd' },
+    },
+  });
+
+  return Response.json(image.base64);
+}

--- a/examples/next-openai/app/api/generate-image/route.ts
+++ b/examples/next-openai/app/api/generate-image/route.ts
@@ -1,7 +1,8 @@
 import { openai } from '@ai-sdk/openai';
 import { experimental_generateImage as generateImage } from 'ai';
 
-export const runtime = 'edge';
+// Allow responses up to 60 seconds
+export const maxDuration = 60;
 
 export async function POST(req: Request) {
   const { prompt } = await req.json();

--- a/examples/next-openai/app/generate-image/page.tsx
+++ b/examples/next-openai/app/generate-image/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function Page() {
+  const [inputValue, setInputValue] = useState('');
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    setIsLoading(true);
+    setImageSrc(null);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/generate-image', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: inputValue }),
+      });
+
+      if (response.ok) {
+        const image = await response.json();
+        setImageSrc(`data:image/png;base64,${image}`);
+        return;
+      }
+
+      setError(await response.text());
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center min-h-screen p-24">
+      <div className="space-y-2">
+        <h2 className="text-3xl font-bold tracking-tighter text-center sm:text-4xl md:text-5xl">
+          Image Generator
+        </h2>
+        <p className="max-w-[600px] text-gray-500 md:text-xl/relaxed lg:text-base/relaxed xl:text-xl/relaxed dark:text-gray-400">
+          Generate images.
+        </p>
+      </div>
+
+      <div className="w-full max-w-sm pt-6 pb-8 space-y-2">
+        <form className="flex space-x-2" onSubmit={handleSubmit}>
+          <input
+            className="flex-1 max-w-lg px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed"
+            placeholder="Describe the image"
+            type="text"
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            disabled={isLoading}
+          />
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-4 py-2 text-white bg-blue-500 rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:bg-blue-300 disabled:cursor-not-allowed"
+          >
+            Generate
+          </button>
+        </form>
+      </div>
+
+      {error && (
+        <div className="p-4 mb-4 text-red-700 bg-red-100 border border-red-400 rounded-lg">
+          {error}
+        </div>
+      )}
+
+      <div className="w-[512px] h-[512px] space-y-2">
+        {isLoading ? (
+          <div className="h-[512px] w-[512px] animate-pulse bg-gray-200 rounded-lg" />
+        ) : (
+          imageSrc && (
+            <img
+              alt="Generated Image"
+              className="object-cover overflow-hidden rounded-lg"
+              src={imageSrc}
+            />
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ai/core/generate-image/generate-image-result.ts
+++ b/packages/ai/core/generate-image/generate-image-result.ts
@@ -4,22 +4,24 @@ It contains the images and additional information.
  */
 export interface GenerateImageResult {
   /**
-The first image that was generated (base64 encoded).
+The first image that was generated.
    */
-  readonly image: string;
+  readonly image: GeneratedImage;
 
   /**
-The first image that was generated, as a Uint8Array.
-   */
-  readonly imageAsUint8Array: Uint8Array;
-
-  /**
-The images that were generated (base64 encoded).
+The images that were generated.
      */
-  readonly images: Array<string>;
+  readonly images: Array<GeneratedImage>;
+}
+
+export interface GeneratedImage {
+  /**
+Image as a base64 encoded string.
+   */
+  readonly base64: string;
 
   /**
-The images that were generated as Uint8Array objects.
+Image as a Uint8Array.
    */
-  readonly imagesAsUint8Arrays: Array<Uint8Array>;
+  readonly uint8Array: Uint8Array;
 }

--- a/packages/ai/core/generate-image/generate-image-result.ts
+++ b/packages/ai/core/generate-image/generate-image-result.ts
@@ -4,6 +4,11 @@ It contains the images and additional information.
  */
 export interface GenerateImageResult {
   /**
+The first image that was generated.
+   */
+  readonly image: string;
+
+  /**
 The images that were generated (base64 encoded).
      */
   readonly images: Array<string>;

--- a/packages/ai/core/generate-image/generate-image-result.ts
+++ b/packages/ai/core/generate-image/generate-image-result.ts
@@ -9,7 +9,17 @@ The first image that was generated.
   readonly image: string;
 
   /**
+The first image that was generated, as a Uint8Array.
+   */
+  readonly imageAsUint8Array: Uint8Array;
+
+  /**
 The images that were generated (base64 encoded).
      */
   readonly images: Array<string>;
+
+  /**
+The images that were generated as Uint8Array objects.
+   */
+  readonly imagesAsUint8Arrays: Array<Uint8Array>;
 }

--- a/packages/ai/core/generate-image/generate-image-result.ts
+++ b/packages/ai/core/generate-image/generate-image-result.ts
@@ -1,0 +1,10 @@
+/**
+The result of a `generateImage` call.
+It contains the images and additional information.
+ */
+export interface GenerateImageResult {
+  /**
+The images that were generated (base64 encoded).
+     */
+  readonly images: Array<string>;
+}

--- a/packages/ai/core/generate-image/generate-image-result.ts
+++ b/packages/ai/core/generate-image/generate-image-result.ts
@@ -4,7 +4,7 @@ It contains the images and additional information.
  */
 export interface GenerateImageResult {
   /**
-The first image that was generated.
+The first image that was generated (base64 encoded).
    */
   readonly image: string;
 

--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -1,0 +1,33 @@
+import { ImageModelV1 } from '@ai-sdk/provider';
+import { MockImageModelV1 } from '../test/mock-image-model-v1';
+import { generateImage } from './generate-image';
+
+const prompt = 'sunny day at the beach';
+
+describe('generateImage', () => {
+  it('should send args to doGenerate', async () => {
+    const abortController = new AbortController();
+    const abortSignal = abortController.signal;
+
+    let capturedArgs!: Parameters<ImageModelV1['doGenerate']>[0];
+
+    await generateImage({
+      model: new MockImageModelV1({
+        doGenerate: async args => {
+          capturedArgs = args;
+          return { images: [] };
+        },
+      }),
+      prompt,
+      headers: { 'custom-request-header': 'request-header-value' },
+      abortSignal,
+    });
+
+    expect(capturedArgs).toStrictEqual({
+      prompt,
+      n: 1,
+      headers: { 'custom-request-header': 'request-header-value' },
+      abortSignal,
+    });
+  });
+});

--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -30,4 +30,20 @@ describe('generateImage', () => {
       abortSignal,
     });
   });
+
+  it('should return generated images', async () => {
+    const result = await generateImage({
+      model: new MockImageModelV1({
+        doGenerate: async () => {
+          return { images: ['base64-image-data', 'base64-image-data'] };
+        },
+      }),
+      prompt,
+    });
+
+    expect(result.images).toStrictEqual([
+      'base64-image-data',
+      'base64-image-data',
+    ]);
+  });
 });

--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -19,13 +19,15 @@ describe('generateImage', () => {
         },
       }),
       prompt,
+      size: '1024x1024',
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
     });
 
     expect(capturedArgs).toStrictEqual({
-      prompt,
       n: 1,
+      prompt,
+      size: '1024x1024',
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
     });

--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -1,6 +1,7 @@
 import { ImageModelV1 } from '@ai-sdk/provider';
 import { MockImageModelV1 } from '../test/mock-image-model-v1';
 import { generateImage } from './generate-image';
+import { convertBase64ToUint8Array } from '@ai-sdk/provider-utils';
 
 const prompt = 'sunny day at the beach';
 
@@ -36,47 +37,6 @@ describe('generateImage', () => {
   });
 
   it('should return generated images', async () => {
-    const result = await generateImage({
-      model: new MockImageModelV1({
-        doGenerate: async () => ({
-          images: ['base64-image-1', 'base64-image-2'],
-        }),
-      }),
-      prompt,
-    });
-
-    expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
-  });
-
-  it('should return the first image as a Uint8Array', async () => {
-    const base64Image = 'SGVsbG8gV29ybGQ='; // "Hello World" in base64
-
-    const result = await generateImage({
-      model: new MockImageModelV1({
-        doGenerate: async () => ({ images: [base64Image, 'base64-image-2'] }),
-      }),
-      prompt,
-    });
-
-    expect(result.imageAsUint8Array).toStrictEqual(
-      new Uint8Array(Buffer.from(base64Image, 'base64')),
-    );
-  });
-
-  it('should return the first image', async () => {
-    const result = await generateImage({
-      model: new MockImageModelV1({
-        doGenerate: async () => ({
-          images: ['base64-image-1', 'base64-image-2'],
-        }),
-      }),
-      prompt,
-    });
-
-    expect(result.image).toStrictEqual('base64-image-1');
-  });
-
-  it('should return the images as Uint8Arrays', async () => {
     const base64Images = [
       'SGVsbG8gV29ybGQ=', // "Hello World" in base64
       'VGVzdGluZw==', // "Testing" in base64
@@ -89,9 +49,31 @@ describe('generateImage', () => {
       prompt,
     });
 
-    expect(result.imagesAsUint8Arrays).toStrictEqual([
-      new Uint8Array(Buffer.from(base64Images[0], 'base64')),
-      new Uint8Array(Buffer.from(base64Images[1], 'base64')),
+    expect(result.images).toStrictEqual([
+      {
+        base64: base64Images[0],
+        uint8Array: convertBase64ToUint8Array(base64Images[0]),
+      },
+      {
+        base64: base64Images[1],
+        uint8Array: convertBase64ToUint8Array(base64Images[1]),
+      },
     ]);
+  });
+
+  it('should return the first image', async () => {
+    const base64Image = 'SGVsbG8gV29ybGQ='; // "Hello World" in base64
+
+    const result = await generateImage({
+      model: new MockImageModelV1({
+        doGenerate: async () => ({ images: [base64Image, 'base64-image-2'] }),
+      }),
+      prompt,
+    });
+
+    expect(result.image).toStrictEqual({
+      base64: base64Image,
+      uint8Array: convertBase64ToUint8Array(base64Image),
+    });
   });
 });

--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -37,15 +37,25 @@ describe('generateImage', () => {
     const result = await generateImage({
       model: new MockImageModelV1({
         doGenerate: async () => {
-          return { images: ['base64-image-data', 'base64-image-data'] };
+          return { images: ['base64-image-1', 'base64-image-2'] };
         },
       }),
       prompt,
     });
 
-    expect(result.images).toStrictEqual([
-      'base64-image-data',
-      'base64-image-data',
-    ]);
+    expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
+  });
+
+  it('should return the first image', async () => {
+    const result = await generateImage({
+      model: new MockImageModelV1({
+        doGenerate: async () => {
+          return { images: ['base64-image-1', 'base64-image-2'] };
+        },
+      }),
+      prompt,
+    });
+
+    expect(result.image).toStrictEqual('base64-image-1');
   });
 });

--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -36,9 +36,9 @@ describe('generateImage', () => {
   it('should return generated images', async () => {
     const result = await generateImage({
       model: new MockImageModelV1({
-        doGenerate: async () => {
-          return { images: ['base64-image-1', 'base64-image-2'] };
-        },
+        doGenerate: async () => ({
+          images: ['base64-image-1', 'base64-image-2'],
+        }),
       }),
       prompt,
     });
@@ -46,16 +46,50 @@ describe('generateImage', () => {
     expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
   });
 
+  it('should return the first image as a Uint8Array', async () => {
+    const base64Image = 'SGVsbG8gV29ybGQ='; // "Hello World" in base64
+
+    const result = await generateImage({
+      model: new MockImageModelV1({
+        doGenerate: async () => ({ images: [base64Image, 'base64-image-2'] }),
+      }),
+      prompt,
+    });
+
+    expect(result.imageAsUint8Array).toStrictEqual(
+      new Uint8Array(Buffer.from(base64Image, 'base64')),
+    );
+  });
+
   it('should return the first image', async () => {
     const result = await generateImage({
       model: new MockImageModelV1({
-        doGenerate: async () => {
-          return { images: ['base64-image-1', 'base64-image-2'] };
-        },
+        doGenerate: async () => ({
+          images: ['base64-image-1', 'base64-image-2'],
+        }),
       }),
       prompt,
     });
 
     expect(result.image).toStrictEqual('base64-image-1');
+  });
+
+  it('should return the images as Uint8Arrays', async () => {
+    const base64Images = [
+      'SGVsbG8gV29ybGQ=', // "Hello World" in base64
+      'VGVzdGluZw==', // "Testing" in base64
+    ];
+
+    const result = await generateImage({
+      model: new MockImageModelV1({
+        doGenerate: async () => ({ images: base64Images }),
+      }),
+      prompt,
+    });
+
+    expect(result.imagesAsUint8Arrays).toStrictEqual([
+      new Uint8Array(Buffer.from(base64Images[0], 'base64')),
+      new Uint8Array(Buffer.from(base64Images[1], 'base64')),
+    ]);
   });
 });

--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -20,6 +20,7 @@ describe('generateImage', () => {
       }),
       prompt,
       size: '1024x1024',
+      providerOptions: { openai: { style: 'vivid' } },
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
     });
@@ -28,6 +29,7 @@ describe('generateImage', () => {
       n: 1,
       prompt,
       size: '1024x1024',
+      providerOptions: { openai: { style: 'vivid' } },
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
     });

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -1,7 +1,7 @@
 import { ImageModelV1, JSONValue } from '@ai-sdk/provider';
 import { convertBase64ToUint8Array } from '@ai-sdk/provider-utils';
 import { prepareRetries } from '../prompt/prepare-retries';
-import { GenerateImageResult } from './generate-image-result';
+import { GeneratedImage, GenerateImageResult } from './generate-image-result';
 
 /**
 Embed a value using an embedding model. The type of the value is defined by the embedding model.
@@ -92,25 +92,22 @@ Only applicable for HTTP-based providers.
     }),
   );
 
-  return new DefaultGenerateImageResult({ images });
+  return new DefaultGenerateImageResult({ base64Images: images });
 }
 
 class DefaultGenerateImageResult implements GenerateImageResult {
-  readonly images: GenerateImageResult['images'];
+  readonly images: Array<GeneratedImage>;
 
-  constructor(options: { images: GenerateImageResult['images'] }) {
-    this.images = options.images;
+  constructor(options: { base64Images: Array<string> }) {
+    this.images = options.base64Images.map(base64 => ({
+      base64,
+      get uint8Array() {
+        return convertBase64ToUint8Array(this.base64);
+      },
+    }));
   }
 
   get image() {
     return this.images[0];
-  }
-
-  get imageAsUint8Array() {
-    return convertBase64ToUint8Array(this.image);
-  }
-
-  get imagesAsUint8Arrays() {
-    return this.images.map(convertBase64ToUint8Array);
   }
 }

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -82,4 +82,8 @@ class DefaultGenerateImageResult implements GenerateImageResult {
   constructor(options: { images: GenerateImageResult['images'] }) {
     this.images = options.images;
   }
+
+  get image() {
+    return this.images[0];
+  }
 }

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -1,6 +1,7 @@
 import { ImageModelV1 } from '@ai-sdk/provider';
 import { prepareRetries } from '../prompt/prepare-retries';
 import { GenerateImageResult } from './generate-image-result';
+import { convertBase64ToUint8Array } from '@ai-sdk/provider-utils';
 
 /**
 Embed a value using an embedding model. The type of the value is defined by the embedding model.
@@ -85,5 +86,13 @@ class DefaultGenerateImageResult implements GenerateImageResult {
 
   get image() {
     return this.images[0];
+  }
+
+  get imageAsUint8Array() {
+    return convertBase64ToUint8Array(this.image);
+  }
+
+  get imagesAsUint8Arrays() {
+    return this.images.map(convertBase64ToUint8Array);
   }
 }

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -1,7 +1,7 @@
-import { ImageModelV1 } from '@ai-sdk/provider';
+import { ImageModelV1, JSONValue } from '@ai-sdk/provider';
+import { convertBase64ToUint8Array } from '@ai-sdk/provider-utils';
 import { prepareRetries } from '../prompt/prepare-retries';
 import { GenerateImageResult } from './generate-image-result';
-import { convertBase64ToUint8Array } from '@ai-sdk/provider-utils';
 
 /**
 Embed a value using an embedding model. The type of the value is defined by the embedding model.
@@ -20,6 +20,7 @@ export async function generateImage({
   prompt,
   n,
   size,
+  providerOptions,
   maxRetries: maxRetriesArg,
   abortSignal,
   headers,
@@ -43,6 +44,22 @@ Number of images to generate.
 Size of the images to generate. Must have the format `{width}x{height}`.
    */
   size?: `${number}x${number}`;
+
+  /**
+Additional provider-specific options that are passed through to the provider
+as body parameters.
+
+The outer record is keyed by the provider name, and the inner
+record is keyed by the provider-specific metadata key.
+```ts
+{
+  "openai": {
+    "style": "vivid"
+  }
+}
+```
+     */
+  providerOptions?: Record<string, Record<string, JSONValue>>;
 
   /**
 Maximum number of retries per embedding model call. Set to 0 to disable retries.
@@ -71,6 +88,7 @@ Only applicable for HTTP-based providers.
       abortSignal,
       headers,
       size,
+      providerOptions: providerOptions ?? {},
     }),
   );
 

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -1,0 +1,73 @@
+import { ImageModelV1 } from '@ai-sdk/provider';
+import { prepareRetries } from '../prompt/prepare-retries';
+import { GenerateImageResult } from './generate-image-result';
+
+/**
+Embed a value using an embedding model. The type of the value is defined by the embedding model.
+
+@param model - The embedding model to use.
+@param value - The value that should be embedded.
+
+@param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
+@param abortSignal - An optional abort signal that can be used to cancel the call.
+@param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
+
+@returns A result object that contains the embedding, the value, and additional information.
+ */
+export async function generateImage({
+  model,
+  prompt,
+  n,
+  maxRetries: maxRetriesArg,
+  abortSignal,
+  headers,
+}: {
+  /**
+The image model to use.
+     */
+  model: ImageModelV1;
+
+  /**
+The prompt that should be used to generate the image.
+   */
+  prompt: string;
+
+  /**
+Number of images to generate.
+   */
+  n: number;
+
+  /**
+Maximum number of retries per embedding model call. Set to 0 to disable retries.
+
+@default 2
+   */
+  maxRetries?: number;
+
+  /**
+Abort signal.
+ */
+  abortSignal?: AbortSignal;
+
+  /**
+Additional headers to include in the request.
+Only applicable for HTTP-based providers.
+ */
+  headers?: Record<string, string>;
+}): Promise<GenerateImageResult> {
+  const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
+
+  const { images } = await retry(() =>
+    model.doGenerate({ prompt, n, abortSignal, headers }),
+  );
+
+  return new DefaultGenerateImageResult({ images });
+}
+
+class DefaultGenerateImageResult implements GenerateImageResult {
+  readonly images: GenerateImageResult['images'];
+
+  constructor(options: { images: GenerateImageResult['images'] }) {
+    this.images = options.images;
+  }
+}

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -18,6 +18,7 @@ export async function generateImage({
   model,
   prompt,
   n,
+  size,
   maxRetries: maxRetriesArg,
   abortSignal,
   headers,
@@ -36,6 +37,11 @@ The prompt that should be used to generate the image.
 Number of images to generate.
    */
   n?: number;
+
+  /**
+Size of the images to generate. Must have the format `{width}x{height}`.
+   */
+  size?: `${number}x${number}`;
 
   /**
 Maximum number of retries per embedding model call. Set to 0 to disable retries.
@@ -63,6 +69,7 @@ Only applicable for HTTP-based providers.
       n: n ?? 1,
       abortSignal,
       headers,
+      size,
     }),
   );
 

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -4,16 +4,19 @@ import { prepareRetries } from '../prompt/prepare-retries';
 import { GeneratedImage, GenerateImageResult } from './generate-image-result';
 
 /**
-Embed a value using an embedding model. The type of the value is defined by the embedding model.
+Generates images using an image model.
 
-@param model - The embedding model to use.
-@param value - The value that should be embedded.
-
+@param model - The image model to use.
+@param prompt - The prompt that should be used to generate the image.
+@param n - Number of images to generate. Default: 1.
+@param size - Size of the images to generate. Must have the format `{width}x{height}`.
+@param providerOptions - Additional provider-specific options that are passed through to the provider
+as body parameters.
 @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
 @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
-@returns A result object that contains the embedding, the value, and additional information.
+@returns A result object that contains the generated images.
  */
 export async function generateImage({
   model,

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -35,7 +35,7 @@ The prompt that should be used to generate the image.
   /**
 Number of images to generate.
    */
-  n: number;
+  n?: number;
 
   /**
 Maximum number of retries per embedding model call. Set to 0 to disable retries.
@@ -58,7 +58,12 @@ Only applicable for HTTP-based providers.
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
   const { images } = await retry(() =>
-    model.doGenerate({ prompt, n, abortSignal, headers }),
+    model.doGenerate({
+      prompt,
+      n: n ?? 1,
+      abortSignal,
+      headers,
+    }),
   );
 
   return new DefaultGenerateImageResult({ images });

--- a/packages/ai/core/generate-image/index.ts
+++ b/packages/ai/core/generate-image/index.ts
@@ -1,2 +1,5 @@
 export { generateImage as experimental_generateImage } from './generate-image';
-export type { GenerateImageResult as Experimental_GenerateImageResult } from './generate-image-result';
+export type {
+  GenerateImageResult as Experimental_GenerateImageResult,
+  GeneratedImage as Experimental_GeneratedImage,
+} from './generate-image-result';

--- a/packages/ai/core/generate-image/index.ts
+++ b/packages/ai/core/generate-image/index.ts
@@ -1,0 +1,2 @@
+export { generateImage } from './generate-image';
+export type { GenerateImageResult } from './generate-image-result';

--- a/packages/ai/core/generate-image/index.ts
+++ b/packages/ai/core/generate-image/index.ts
@@ -1,2 +1,2 @@
-export { generateImage } from './generate-image';
-export type { GenerateImageResult } from './generate-image-result';
+export { generateImage as experimental_generateImage } from './generate-image';
+export type { GenerateImageResult as Experimental_GenerateImageResult } from './generate-image-result';

--- a/packages/ai/core/index.ts
+++ b/packages/ai/core/index.ts
@@ -2,6 +2,7 @@ export { jsonSchema } from '@ai-sdk/ui-utils';
 export type { DeepPartial, Schema } from '@ai-sdk/ui-utils';
 export * from './data-stream';
 export * from './embed';
+export * from './generate-image';
 export * from './generate-object';
 export * from './generate-text';
 export * from './middleware';

--- a/packages/ai/core/test/mock-embedding-model-v1.ts
+++ b/packages/ai/core/test/mock-embedding-model-v1.ts
@@ -1,6 +1,7 @@
 import { EmbeddingModelV1 } from '@ai-sdk/provider';
 import { Embedding } from '../types';
 import { EmbeddingModelUsage } from '../types/usage';
+import { notImplemented } from './not-implemented';
 
 export class MockEmbeddingModelV1<VALUE> implements EmbeddingModelV1<VALUE> {
   readonly specificationVersion = 'v1';
@@ -44,8 +45,4 @@ export function mockEmbed<VALUE>(
     assert.deepStrictEqual(expectedValues, values);
     return { embeddings, usage };
   };
-}
-
-function notImplemented(): never {
-  throw new Error('Not implemented');
 }

--- a/packages/ai/core/test/mock-image-model-v1.ts
+++ b/packages/ai/core/test/mock-image-model-v1.ts
@@ -1,0 +1,25 @@
+import { ImageModelV1 } from '@ai-sdk/provider';
+import { notImplemented } from './not-implemented';
+
+export class MockImageModelV1 implements ImageModelV1 {
+  readonly specificationVersion = 'v1';
+
+  readonly provider: ImageModelV1['provider'];
+  readonly modelId: ImageModelV1['modelId'];
+
+  doGenerate: ImageModelV1['doGenerate'];
+
+  constructor({
+    provider = 'mock-provider',
+    modelId = 'mock-model-id',
+    doGenerate = notImplemented,
+  }: {
+    provider?: ImageModelV1['provider'];
+    modelId?: ImageModelV1['modelId'];
+    doGenerate?: ImageModelV1['doGenerate'];
+  } = {}) {
+    this.provider = provider;
+    this.modelId = modelId;
+    this.doGenerate = doGenerate;
+  }
+}

--- a/packages/ai/core/test/mock-language-model-v1.ts
+++ b/packages/ai/core/test/mock-language-model-v1.ts
@@ -1,4 +1,5 @@
 import { LanguageModelV1 } from '@ai-sdk/provider';
+import { notImplemented } from './not-implemented';
 
 export class MockLanguageModelV1 implements LanguageModelV1 {
   readonly specificationVersion = 'v1';
@@ -38,8 +39,4 @@ export class MockLanguageModelV1 implements LanguageModelV1 {
     this.defaultObjectGenerationMode = defaultObjectGenerationMode;
     this.supportsStructuredOutputs = supportsStructuredOutputs;
   }
-}
-
-function notImplemented(): never {
-  throw new Error('Not implemented');
 }

--- a/packages/ai/core/test/not-implemented.ts
+++ b/packages/ai/core/test/not-implemented.ts
@@ -1,0 +1,3 @@
+export function notImplemented(): never {
+  throw new Error('Not implemented');
+}

--- a/packages/openai/src/openai-config.ts
+++ b/packages/openai/src/openai-config.ts
@@ -1,0 +1,8 @@
+import { FetchFunction } from '@ai-sdk/provider-utils';
+
+export type OpenAIConfig = {
+  provider: string;
+  url: (options: { modelId: string; path: string }) => string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+};

--- a/packages/openai/src/openai-embedding-model.ts
+++ b/packages/openai/src/openai-embedding-model.ts
@@ -5,28 +5,21 @@ import {
 import {
   combineHeaders,
   createJsonResponseHandler,
-  FetchFunction,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
+import { OpenAIConfig } from './openai-config';
 import {
   OpenAIEmbeddingModelId,
   OpenAIEmbeddingSettings,
 } from './openai-embedding-settings';
 import { openaiFailedResponseHandler } from './openai-error';
 
-type OpenAIEmbeddingConfig = {
-  provider: string;
-  url: (options: { modelId: string; path: string }) => string;
-  headers: () => Record<string, string | undefined>;
-  fetch?: FetchFunction;
-};
-
 export class OpenAIEmbeddingModel implements EmbeddingModelV1<string> {
   readonly specificationVersion = 'v1';
   readonly modelId: OpenAIEmbeddingModelId;
 
-  private readonly config: OpenAIEmbeddingConfig;
+  private readonly config: OpenAIConfig;
   private readonly settings: OpenAIEmbeddingSettings;
 
   get provider(): string {
@@ -44,7 +37,7 @@ export class OpenAIEmbeddingModel implements EmbeddingModelV1<string> {
   constructor(
     modelId: OpenAIEmbeddingModelId,
     settings: OpenAIEmbeddingSettings,
-    config: OpenAIEmbeddingConfig,
+    config: OpenAIConfig,
   ) {
     this.modelId = modelId;
     this.settings = settings;

--- a/packages/openai/src/openai-image-model.test.ts
+++ b/packages/openai/src/openai-image-model.test.ts
@@ -1,0 +1,98 @@
+import { JsonTestServer } from '@ai-sdk/provider-utils/test';
+import { createOpenAI } from './openai-provider';
+
+const prompt = 'A cute baby sea otter';
+
+const provider = createOpenAI({ apiKey: 'test-api-key' });
+const model = provider.image('dall-e-3');
+
+describe('doGenerate', () => {
+  const server = new JsonTestServer(
+    'https://api.openai.com/v1/images/generations',
+  );
+
+  server.setupTestEnvironment();
+
+  function prepareJsonResponse() {
+    server.responseBodyJson = {
+      created: 1733837122,
+      data: [
+        {
+          revised_prompt:
+            'A charming visual illustration of a baby sea otter swimming joyously.',
+          b64_json: 'base64-image-1',
+        },
+        {
+          b64_json: 'base64-image-2',
+        },
+      ],
+    };
+  }
+
+  it('should pass the model and the settings', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      prompt,
+      n: 2,
+      size: '1024x1024',
+      providerOptions: { openai: { style: 'vivid' } },
+    });
+
+    expect(await server.getRequestBodyJson()).toStrictEqual({
+      model: 'dall-e-3',
+      prompt,
+      n: 2,
+      size: '1024x1024',
+      style: 'vivid',
+      response_format: 'b64_json',
+    });
+  });
+
+  it('should pass headers', async () => {
+    prepareJsonResponse();
+
+    const provider = createOpenAI({
+      apiKey: 'test-api-key',
+      organization: 'test-organization',
+      project: 'test-project',
+      headers: {
+        'Custom-Provider-Header': 'provider-header-value',
+      },
+    });
+
+    await provider.image('dall-e-3').doGenerate({
+      prompt,
+      n: 2,
+      size: '1024x1024',
+      providerOptions: { openai: { style: 'vivid' } },
+      headers: {
+        'Custom-Request-Header': 'request-header-value',
+      },
+    });
+
+    const requestHeaders = await server.getRequestHeaders();
+
+    expect(requestHeaders).toStrictEqual({
+      authorization: 'Bearer test-api-key',
+      'content-type': 'application/json',
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+      'openai-organization': 'test-organization',
+      'openai-project': 'test-project',
+    });
+  });
+
+  it('should extract the generated images', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      prompt,
+      n: 2,
+      size: undefined,
+      providerOptions: {},
+    });
+
+    expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
+  });
+});

--- a/packages/openai/src/openai-image-model.ts
+++ b/packages/openai/src/openai-image-model.ts
@@ -28,6 +28,7 @@ export class OpenAIImageModel implements ImageModelV1 {
   async doGenerate({
     prompt,
     n,
+    size,
     headers,
     abortSignal,
   }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
@@ -43,7 +44,7 @@ export class OpenAIImageModel implements ImageModelV1 {
         model: this.modelId,
         prompt,
         n,
-        // TODO size
+        size,
         // TODO passthrough provider options
         response_format: 'b64_json',
       },

--- a/packages/openai/src/openai-image-model.ts
+++ b/packages/openai/src/openai-image-model.ts
@@ -1,0 +1,66 @@
+import { ImageModelV1 } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  postJsonToApi,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+import { OpenAIConfig } from './openai-config';
+import { openaiFailedResponseHandler } from './openai-error';
+
+export type OpenAIImageModelId = 'dall-e-3' | 'dall-e-2' | (string & {});
+
+export class OpenAIImageModel implements ImageModelV1 {
+  readonly specificationVersion = 'v1';
+  readonly modelId: OpenAIImageModelId;
+
+  private readonly config: OpenAIConfig;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(modelId: OpenAIImageModelId, config: OpenAIConfig) {
+    this.modelId = modelId;
+    this.config = config;
+  }
+
+  async doGenerate({
+    prompt,
+    n,
+    headers,
+    abortSignal,
+  }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV1['doGenerate']>>
+  > {
+    const { value: response } = await postJsonToApi({
+      url: this.config.url({
+        path: '/images/generations',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers(), headers),
+      body: {
+        model: this.modelId,
+        prompt,
+        n,
+        // TODO size
+        // TODO passthrough settings
+        response_format: 'b64_json',
+      },
+      failedResponseHandler: openaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        openaiImageResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      images: response.map(item => item.b64_json),
+    };
+  }
+}
+
+// minimal version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+const openaiImageResponseSchema = z.array(z.object({ b64_json: z.string() }));

--- a/packages/openai/src/openai-image-model.ts
+++ b/packages/openai/src/openai-image-model.ts
@@ -56,11 +56,13 @@ export class OpenAIImageModel implements ImageModelV1 {
     });
 
     return {
-      images: response.map(item => item.b64_json),
+      images: response.data.map(item => item.b64_json),
     };
   }
 }
 
 // minimal version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const openaiImageResponseSchema = z.array(z.object({ b64_json: z.string() }));
+const openaiImageResponseSchema = z.object({
+  data: z.array(z.object({ b64_json: z.string() })),
+});

--- a/packages/openai/src/openai-image-model.ts
+++ b/packages/openai/src/openai-image-model.ts
@@ -44,7 +44,7 @@ export class OpenAIImageModel implements ImageModelV1 {
         prompt,
         n,
         // TODO size
-        // TODO passthrough settings
+        // TODO passthrough provider options
         response_format: 'b64_json',
       },
       failedResponseHandler: openaiFailedResponseHandler,

--- a/packages/openai/src/openai-image-model.ts
+++ b/packages/openai/src/openai-image-model.ts
@@ -29,6 +29,7 @@ export class OpenAIImageModel implements ImageModelV1 {
     prompt,
     n,
     size,
+    providerOptions,
     headers,
     abortSignal,
   }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
@@ -45,7 +46,7 @@ export class OpenAIImageModel implements ImageModelV1 {
         prompt,
         n,
         size,
-        // TODO passthrough provider options
+        ...(providerOptions.openai ?? {}),
         response_format: 'b64_json',
       },
       failedResponseHandler: openaiFailedResponseHandler,

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -1,5 +1,6 @@
 import {
   EmbeddingModelV1,
+  ImageModelV1,
   LanguageModelV1,
   ProviderV1,
 } from '@ai-sdk/provider';
@@ -20,6 +21,7 @@ import {
   OpenAIEmbeddingModelId,
   OpenAIEmbeddingSettings,
 } from './openai-embedding-settings';
+import { OpenAIImageModel, OpenAIImageModelId } from './openai-image-model';
 
 export interface OpenAIProvider extends ProviderV1 {
   (
@@ -81,6 +83,11 @@ Creates a model for text embeddings.
     modelId: OpenAIEmbeddingModelId,
     settings?: OpenAIEmbeddingSettings,
   ): EmbeddingModelV1<string>;
+
+  /**
+Creates a model for image generation.
+   */
+  image(modelId: OpenAIImageModelId): ImageModelV1;
 }
 
 export interface OpenAIProviderSettings {
@@ -188,6 +195,14 @@ export function createOpenAI(
       fetch: options.fetch,
     });
 
+  const createImageModel = (modelId: OpenAIImageModelId) =>
+    new OpenAIImageModel(modelId, {
+      provider: `${providerName}.image`,
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const createLanguageModel = (
     modelId: OpenAIChatModelId | OpenAICompletionModelId,
     settings?: OpenAIChatSettings | OpenAICompletionSettings,
@@ -221,7 +236,7 @@ export function createOpenAI(
   provider.embedding = createEmbeddingModel;
   provider.textEmbedding = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
-
+  provider.image = createImageModel;
   return provider as OpenAIProvider;
 }
 

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -237,6 +237,7 @@ export function createOpenAI(
   provider.textEmbedding = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
+
   return provider as OpenAIProvider;
 }
 

--- a/packages/provider/src/embedding-model/v1/embedding-model-v1.ts
+++ b/packages/provider/src/embedding-model/v1/embedding-model-v1.ts
@@ -1,7 +1,7 @@
 import { EmbeddingModelV1Embedding } from './embedding-model-v1-embedding';
 
 /**
-Experimental: Specification for an embedding model that implements the embedding model 
+Experimental: Specification for an embedding model that implements the embedding model
 interface version 1.
 
 VALUE is the type of the values that the model can embed.

--- a/packages/provider/src/image-model/index.ts
+++ b/packages/provider/src/image-model/index.ts
@@ -1,0 +1,1 @@
+export * from './v1/index';

--- a/packages/provider/src/image-model/v1/image-model-v1.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1.ts
@@ -1,9 +1,7 @@
+import { JSONValue } from '../../json-value/json-value';
+
 /**
 Image generation model specification version 1.
-
-VALUE is the type of the values that the model can embed.
-This will allow us to go beyond text embeddings in the future,
-e.g. to support image embeddings
  */
 export type ImageModelV1 = {
   /**
@@ -43,6 +41,22 @@ Number of images to generate.
 Size of the images to generate. Must have the format `{width}x{height}`.
      */
     size: `${number}x${number}` | undefined;
+
+    /**
+Additional provider-specific options that are passed through to the provider
+as body parameters.
+
+The outer record is keyed by the provider name, and the inner
+record is keyed by the provider-specific metadata key.
+```ts
+{
+  "openai": {
+    "style": "vivid"
+  }
+}
+```
+     */
+    providerOptions: Record<string, Record<string, JSONValue>>;
 
     /**
 Abort signal for cancelling the operation.

--- a/packages/provider/src/image-model/v1/image-model-v1.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1.ts
@@ -1,0 +1,53 @@
+/**
+Image generation model specification version 1.
+
+VALUE is the type of the values that the model can embed.
+This will allow us to go beyond text embeddings in the future,
+e.g. to support image embeddings
+ */
+export type ImageModelV1 = {
+  /**
+The image model must specify which image model interface
+version it implements. This will allow us to evolve the image
+model interface and retain backwards compatibility. The different
+implementation versions can be handled as a discriminated union
+on our side.
+   */
+  readonly specificationVersion: 'v1';
+
+  /**
+Name of the provider for logging purposes.
+   */
+  readonly provider: string;
+
+  /**
+Provider-specific model ID for logging purposes.
+   */
+  readonly modelId: string;
+
+  /**
+Generates an array of images.
+   */
+  doGenerate(options: {
+    /**
+Prompt for the image generation.
+     */
+    prompt: string;
+
+    /**
+Abort signal for cancelling the operation.
+     */
+    abortSignal?: AbortSignal;
+
+    /**
+  Additional HTTP headers to be sent with the request.
+  Only applicable for HTTP-based providers.
+     */
+    headers?: Record<string, string | undefined>;
+  }): PromiseLike<{
+    /**
+Generated images as base64 encoded strings.
+     */
+    images: Array<string>;
+  }>;
+};

--- a/packages/provider/src/image-model/v1/image-model-v1.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1.ts
@@ -35,6 +35,11 @@ Prompt for the image generation.
     prompt: string;
 
     /**
+Number of images to generate.
+     */
+    n: number;
+
+    /**
 Abort signal for cancelling the operation.
      */
     abortSignal?: AbortSignal;

--- a/packages/provider/src/image-model/v1/image-model-v1.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1.ts
@@ -40,6 +40,11 @@ Number of images to generate.
     n: number;
 
     /**
+Size of the images to generate. Must have the format `{width}x{height}`.
+     */
+    size: `${number}x${number}` | undefined;
+
+    /**
 Abort signal for cancelling the operation.
      */
     abortSignal?: AbortSignal;

--- a/packages/provider/src/image-model/v1/index.ts
+++ b/packages/provider/src/image-model/v1/index.ts
@@ -1,0 +1,1 @@
+export * from './image-model-v1';

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,5 +1,6 @@
 export * from './embedding-model/index';
 export * from './errors/index';
+export * from './image-model/index';
 export * from './json-value/index';
 export * from './language-model/index';
 export * from './provider/index';


### PR DESCRIPTION
Fixes #2524 

## Tasks

- [x] implementation
   - [x] spec
   - [x] openai image generation model
   - [x] openai image generation model test
   - [x] generateImage
   - [x] generateImage test
   - [x] size
   - [x] providerOptions
   - [x] experimental
   - [x] uint8array conversion
   - [x] image
   - [x] redesign result
- [x] examples
   - [x] basic example
   - [x] next.js example
- [x] documentation
   - [x] generateImage reference
   - [x] core guide
   - [x] openai model
- [x] changeset