### PR TITLE
fix (docs): correct annotations json structure

### DIFF
--- a/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
+++ b/content/docs/04-ai-sdk-ui/50-stream-protocol.mdx
@@ -128,11 +128,11 @@ Example: `2:[{"key":"object1"},{"anotherKey":"object2"}]\n`
 
 ### Message Annotation Part
 
-The message annotation parts are appended to the message as they are received.
+The message annotation parts are appended to the message as they are received. The annotation part is available through `annotations`.
 
-Format: `8:JSONValue\n`
+Format: `8:Array<JSONValue>\n`
 
-Example: `8:{"id":"message-123","other":"annotation"}\n`
+Example: `8:[{"id":"message-123","other":"annotation"}]\n`
 
 ### Error Part
 


### PR DESCRIPTION
The annotations only work when you wrap the JSON in an array, in the docs this is not shown