### PR TITLE
feat(provider/openai): add support for developer role in chat message conversion

### DIFF
--- a/packages/openai/src/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.test.ts
@@ -308,3 +308,52 @@ describe('tool calls', () => {
     ]);
   });
 });
+
+describe('system messages', () => {
+  it('should convert system messages to developer role when useDeveloperRole is true', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant.',
+        },
+      ],
+      useDeveloperRole: true,
+    });
+
+    expect(result).toEqual([
+      { role: 'developer', content: 'You are a helpful assistant.' },
+    ]);
+  });
+
+  it('should keep system messages as system role when useDeveloperRole is false', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant.',
+        },
+      ],
+      useDeveloperRole: false,
+    });
+
+    expect(result).toEqual([
+      { role: 'system', content: 'You are a helpful assistant.' },
+    ]);
+  });
+
+  it('should default to system role when useDeveloperRole is not specified', () => {
+    const result = convertToOpenAIChatMessages({
+      prompt: [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant.',
+        },
+      ],
+    });
+
+    expect(result).toEqual([
+      { role: 'system', content: 'You are a helpful assistant.' },
+    ]);
+  });
+});

--- a/packages/openai/src/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.ts
@@ -8,16 +8,21 @@ import { OpenAIChatPrompt } from './openai-chat-prompt';
 export function convertToOpenAIChatMessages({
   prompt,
   useLegacyFunctionCalling = false,
+  useDeveloperRole = false,
 }: {
   prompt: LanguageModelV1Prompt;
   useLegacyFunctionCalling?: boolean;
+  useDeveloperRole?: boolean;
 }): OpenAIChatPrompt {
   const messages: OpenAIChatPrompt = [];
 
   for (const { role, content } of prompt) {
     switch (role) {
       case 'system': {
-        messages.push({ role: 'system', content });
+        messages.push({
+          role: useDeveloperRole ? 'developer' : 'system',
+          content,
+        });
         break;
       }
 

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -188,6 +188,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
       messages: convertToOpenAIChatMessages({
         prompt,
         useLegacyFunctionCalling,
+        useDeveloperRole: isReasoningModel(this.modelId),
       }),
     };
 

--- a/packages/openai/src/openai-chat-prompt.ts
+++ b/packages/openai/src/openai-chat-prompt.ts
@@ -1,12 +1,21 @@
 export type OpenAIChatPrompt = Array<ChatCompletionMessage>;
 
 export type ChatCompletionMessage =
+  | ChatCompletionDeveloperMessage
   | ChatCompletionSystemMessage
   | ChatCompletionUserMessage
   | ChatCompletionAssistantMessage
   | ChatCompletionToolMessage
   | ChatCompletionFunctionMessage;
 
+export interface ChatCompletionDeveloperMessage {
+  role: 'developer';
+  content: string;
+}
+
+/**
+ * @deprecated With o1 models and newer, use `ChatCompletionDeveloperMessage` messages for this purpose instead.
+ */
 export interface ChatCompletionSystemMessage {
   role: 'system';
   content: string;


### PR DESCRIPTION
- Introduced `useDeveloperRole` option in `convertToOpenAIChatMessages` to allow conversion of system messages to developer role based on user preference.
- Updated tests to verify behavior for system messages with `useDeveloperRole` set to true, false, and undefined.
- Enhanced type definitions to include `ChatCompletionDeveloperMessage` for better clarity and usage in the OpenAI chat prompt structure.

reference: https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages