### PR TITLE
doc: fix explainQuery code doc

### DIFF
--- a/content/docs/02-guides/06-natural-language-postgres.mdx
+++ b/content/docs/02-guides/06-natural-language-postgres.mdx
@@ -410,6 +410,7 @@ export const explainQuery = async (input: string, sqlQuery: string) => {
   try {
     const result = await generateObject({
       model: openai('gpt-4o'),
+      schema: explanationSchema,
       system: `You are a SQL (postgres) expert. ...`, // SYSTEM PROMPT AS ABOVE - OMITTED FOR BREVITY
       prompt: `Explain the SQL query you generated to retrieve the data the user wanted. Assume the user is not an expert in SQL. Break down the query into steps. Be concise.
 
@@ -418,8 +419,6 @@ export const explainQuery = async (input: string, sqlQuery: string) => {
 
       Generated SQL Query:
       ${sqlQuery}`,
-      schema: explanationSchema,
-      output: 'array',
     });
     return result.object;
   } catch (e) {


### PR DESCRIPTION
This pull request includes changes to the `explainQuery` function in the `content/docs/02-guides/06-natural-language-postgres.mdx` file. The main change involves adjusting the position of the `schema` parameter within the `generateObject` function call.

![image](https://github.com/user-attachments/assets/34632dc2-4930-4dac-afd2-ed9f5a97778a)

Changes to `explainQuery` function:
* Moved the `schema` parameter immediately after the `model` parameter in the `generateObject` function call.
* Removed `output: "array"` 
