### PR TITLE
feat (provider/openai-compatible) Additional exports for detailed customization

### DIFF
--- a/packages/openai-compatible/src/index.ts
+++ b/packages/openai-compatible/src/index.ts
@@ -2,6 +2,10 @@ export { createOpenAICompatible } from './openai-compatible-provider';
 export { OpenAICompatibleChatLanguageModel } from './openai-compatible-chat-language-model';
 export { OpenAICompatibleCompletionLanguageModel } from './openai-compatible-completion-language-model';
 export { OpenAICompatibleEmbeddingModel } from './openai-compatible-embedding-model';
+export { convertToOpenAICompatibleChatMessages } from './convert-to-openai-compatible-chat-messages';
+export { mapOpenAICompatibleFinishReason } from './map-openai-compatible-finish-reason';
+export { getResponseMetadata } from './get-response-metadata';
+
 export type {
   OpenAICompatibleProvider,
   OpenAICompatibleProviderSettings,
@@ -10,3 +14,4 @@ export type { ProviderErrorStructure } from './openai-compatible-error';
 export type { OpenAICompatibleChatSettings } from './openai-compatible-chat-settings';
 export type { OpenAICompatibleCompletionSettings } from './openai-compatible-completion-settings';
 export type { OpenAICompatibleEmbeddingSettings } from './openai-compatible-embedding-settings';
+export type { OpenAICompatibleChatConfig } from './openai-compatible-chat-language-model';


### PR DESCRIPTION
When creating an external provider using provider/openai-compatible, additional exports are required for detailed customization.