### PR TITLE
feat (provider/openai): support for prediction tokens usage in the response

### DIFF
--- a/.changeset/nasty-beers-rule.md
+++ b/.changeset/nasty-beers-rule.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat (provider/openai): add predicted outputs usages

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -269,7 +269,7 @@ Predicted outputs help you reduce latency by allowing you to specify a base text
 You can enable predicted outputs by adding the `prediction` option to the `experimental_providerMetadata.openai` object:
 
 ```ts highlight="15-18"
-const result = streamText({
+const { text, usage, experimental_providerMetadata } = streamText({
   model: openai('gpt-4o'),
   messages: [
     {
@@ -290,7 +290,23 @@ const result = streamText({
     },
   },
 });
+
+console.log('usage:', {
+  ...usage,
+  accepted_prediction_tokens:
+    experimental_providerMetadata?.openai?.acceptedPredictionTokens,
+  rejected_prediction_tokens:
+    experimental_providerMetadata?.openai?.rejectedPredictionTokens,
+});
 ```
+
+<Note type="warning">
+  OpenAI Predicted Outputs have several
+  [limitations](https://platform.openai.com/docs/guides/predicted-outputs#limitations),
+  as some [API
+  parameters](https://platform.openai.com/docs/api-reference/chat/create) are
+  not supported.
+</Note>
 
 #### Image Detail
 

--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -292,11 +292,11 @@ const { text, usage, experimental_providerMetadata } = streamText({
 });
 
 console.log('usage:', {
-  ...usage,
-  accepted_prediction_tokens:
-    experimental_providerMetadata?.openai?.acceptedPredictionTokens,
-  rejected_prediction_tokens:
-    experimental_providerMetadata?.openai?.rejectedPredictionTokens,
+  ...(await usage),
+  acceptedPredictionTokens: (await experimental_providerMetadata)?.openai
+    ?.acceptedPredictionTokens,
+  rejectedPredictionTokens: (await experimental_providerMetadata)?.openai
+    ?.rejectedPredictionTokens,
 });
 ```
 

--- a/examples/ai-core/src/stream-text/openai-predicted-output.ts
+++ b/examples/ai-core/src/stream-text/openai-predicted-output.ts
@@ -54,7 +54,13 @@ async function main() {
   }
 
   console.log();
-  console.log('Token usage:', await result.usage);
+  console.log('Token usage:', {
+    ...(await result.usage),
+    acceptedPredictionTokens: (await result.experimental_providerMetadata)
+      ?.openai?.acceptedPredictionTokens,
+    rejectedPredictionTokens: (await result.experimental_providerMetadata)
+      ?.openai?.rejectedPredictionTokens,
+  });
   console.log('Finish reason:', await result.finishReason);
 }
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -175,6 +175,8 @@ describe('doGenerate', () => {
       completion_tokens?: number;
       completion_tokens_details?: {
         reasoning_tokens?: number;
+        accepted_prediction_tokens?: number;
+        rejected_prediction_tokens?: number;
       };
       prompt_tokens_details?: {
         cached_tokens?: number;

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -312,12 +312,30 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
     let providerMetadata: LanguageModelV1ProviderMetadata | undefined;
     if (
       response.usage?.completion_tokens_details?.reasoning_tokens != null ||
+      response.usage?.completion_tokens_details?.accepted_prediction_tokens !=
+        null ||
+      response.usage?.completion_tokens_details?.rejected_prediction_tokens !=
+        null ||
       response.usage?.prompt_tokens_details?.cached_tokens != null
     ) {
       providerMetadata = { openai: {} };
       if (response.usage?.completion_tokens_details?.reasoning_tokens != null) {
         providerMetadata.openai.reasoningTokens =
           response.usage?.completion_tokens_details?.reasoning_tokens;
+      }
+      if (
+        response.usage?.completion_tokens_details?.accepted_prediction_tokens !=
+        null
+      ) {
+        providerMetadata.openai.acceptedPredictionTokens =
+          response.usage.completion_tokens_details?.accepted_prediction_tokens;
+      }
+      if (
+        response.usage?.completion_tokens_details?.rejected_prediction_tokens !=
+        null
+      ) {
+        providerMetadata.openai.rejectedPredictionTokens =
+          response.usage.completion_tokens_details?.rejected_prediction_tokens;
       }
       if (response.usage?.prompt_tokens_details?.cached_tokens != null) {
         providerMetadata.openai.cachedPromptTokens =
@@ -497,12 +515,26 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
 
               if (
                 completionTokenDetails?.reasoning_tokens != null ||
+                completionTokenDetails?.accepted_prediction_tokens != null ||
+                completionTokenDetails?.rejected_prediction_tokens != null ||
                 promptTokenDetails?.cached_tokens != null
               ) {
                 providerMetadata = { openai: {} };
                 if (completionTokenDetails?.reasoning_tokens != null) {
                   providerMetadata.openai.reasoningTokens =
                     completionTokenDetails?.reasoning_tokens;
+                }
+                if (
+                  completionTokenDetails?.accepted_prediction_tokens != null
+                ) {
+                  providerMetadata.openai.acceptedPredictionTokens =
+                    completionTokenDetails?.accepted_prediction_tokens;
+                }
+                if (
+                  completionTokenDetails?.rejected_prediction_tokens != null
+                ) {
+                  providerMetadata.openai.rejectedPredictionTokens =
+                    completionTokenDetails?.rejected_prediction_tokens;
                 }
                 if (promptTokenDetails?.cached_tokens != null) {
                   providerMetadata.openai.cachedPromptTokens =
@@ -695,6 +727,8 @@ const openaiTokenUsageSchema = z
     completion_tokens_details: z
       .object({
         reasoning_tokens: z.number().nullish(),
+        accepted_prediction_tokens: z.number().nullish(),
+        rejected_prediction_tokens: z.number().nullish(),
       })
       .nullish(),
   })


### PR DESCRIPTION
Hi,

I've added support for prediction tokens in the response, continuing from #3475.

-  the `accepted_prediction_tokens` and `rejected_prediction_tokens` from the usage object to the providerMetadata.

And updated examples in the docs.