### PR TITLE
fix (ai/core): throw error when accessing output when no output is defined in generateText

### DIFF
--- a/.changeset/orange-plums-know.md
+++ b/.changeset/orange-plums-know.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai/core): throw error when accessing output when no output is defined in generateText (breaking/experimental)

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -1177,7 +1177,7 @@ describe('options.messages', () => {
 
 describe('options.output', () => {
   describe('no output', () => {
-    it('should have undefined output', async () => {
+    it('should throw error when accessing output', async () => {
       const result = await generateText({
         model: new MockLanguageModelV1({
           doGenerate: async () => ({
@@ -1188,7 +1188,9 @@ describe('options.output', () => {
         prompt: 'prompt',
       });
 
-      expect(result.experimental_output).toBeUndefined();
+      expect(() => {
+        result.experimental_output;
+      }).toThrow('No output specified');
     });
   });
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -1,10 +1,8 @@
 import { createIdGenerator } from '@ai-sdk/provider-utils';
 import { Tracer } from '@opentelemetry/api';
-import {
-  InvalidArgumentError,
-  NoOutputSpecifiedError,
-  ToolExecutionError,
-} from '../../errors';
+import { InvalidArgumentError } from '../../errors/invalid-argument-error';
+import { NoOutputSpecifiedError } from '../../errors/no-output-specified-error';
+import { ToolExecutionError } from '../../errors/tool-execution-error';
 import { CoreAssistantMessage, CoreMessage, CoreToolMessage } from '../prompt';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
@@ -654,7 +652,7 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>, OUTPUT>
   readonly response: GenerateTextResult<TOOLS, OUTPUT>['response'];
   readonly request: GenerateTextResult<TOOLS, OUTPUT>['request'];
 
-  readonly outputResolver: () => GenerateTextResult<
+  private readonly outputResolver: () => GenerateTextResult<
     TOOLS,
     OUTPUT
   >['experimental_output'];

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -1,6 +1,10 @@
 import { createIdGenerator } from '@ai-sdk/provider-utils';
 import { Tracer } from '@opentelemetry/api';
-import { InvalidArgumentError, ToolExecutionError } from '../../errors';
+import {
+  InvalidArgumentError,
+  NoOutputSpecifiedError,
+  ToolExecutionError,
+} from '../../errors';
 import { CoreAssistantMessage, CoreMessage, CoreToolMessage } from '../prompt';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
@@ -511,16 +515,16 @@ A function that attempts to repair a tool call that failed to parse.
 
       return new DefaultGenerateTextResult({
         text,
-        output:
-          output == null
-            ? (undefined as never)
-            : output.parseOutput(
-                { text },
-                {
-                  response: currentModelResponse.response,
-                  usage,
-                },
-              ),
+        outputResolver: () => {
+          if (output == null) {
+            throw new NoOutputSpecifiedError();
+          }
+
+          return output.parseOutput(
+            { text },
+            { response: currentModelResponse.response, usage },
+          );
+        },
         toolCalls: currentToolCalls,
         toolResults: currentToolResults,
         finishReason: currentModelResponse.finishReason,
@@ -649,7 +653,8 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>, OUTPUT>
   >['experimental_providerMetadata'];
   readonly response: GenerateTextResult<TOOLS, OUTPUT>['response'];
   readonly request: GenerateTextResult<TOOLS, OUTPUT>['request'];
-  readonly experimental_output: GenerateTextResult<
+
+  readonly outputResolver: () => GenerateTextResult<
     TOOLS,
     OUTPUT
   >['experimental_output'];
@@ -669,7 +674,10 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>, OUTPUT>
     >['experimental_providerMetadata'];
     response: GenerateTextResult<TOOLS, OUTPUT>['response'];
     request: GenerateTextResult<TOOLS, OUTPUT>['request'];
-    output: GenerateTextResult<TOOLS, OUTPUT>['experimental_output'];
+    outputResolver: () => GenerateTextResult<
+      TOOLS,
+      OUTPUT
+    >['experimental_output'];
   }) {
     this.text = options.text;
     this.toolCalls = options.toolCalls;
@@ -682,6 +690,10 @@ class DefaultGenerateTextResult<TOOLS extends Record<string, CoreTool>, OUTPUT>
     this.steps = options.steps;
     this.experimental_providerMetadata = options.providerMetadata;
     this.logprobs = options.logprobs;
-    this.experimental_output = options.output;
+    this.outputResolver = options.outputResolver;
+  }
+
+  get experimental_output() {
+    return this.outputResolver();
   }
 }


### PR DESCRIPTION
## Background
Aligns behavior with `streamText` for when `output` is not provided in the settings.