### PR TITLE
feat (provider/google): add promptFeedback outputs

### DIFF
--- a/.changeset/poor-clouds-eat.md
+++ b/.changeset/poor-clouds-eat.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat (provider/google): add promptFeedback outputs

--- a/examples/ai-core/src/generate-text/google.ts
+++ b/examples/ai-core/src/generate-text/google.ts
@@ -8,9 +8,15 @@ async function main() {
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
+  const googleMetadata = result.experimental_providerMetadata?.google;
+
   console.log(result.text);
   console.log();
   console.log('Token usage:', result.usage);
+  console.log('Safety info:', {
+    promptFeedback: googleMetadata?.promptFeedback,
+    safetyRatings: googleMetadata?.safetyRatings,
+  });
   console.log('Finish reason:', result.finishReason);
 }
 

--- a/examples/ai-core/src/stream-text/google.ts
+++ b/examples/ai-core/src/stream-text/google.ts
@@ -13,8 +13,14 @@ async function main() {
     process.stdout.write(textPart);
   }
 
+  const googleMetadata = (await result.experimental_providerMetadata)?.google;
+
   console.log();
   console.log('Token usage:', await result.usage);
+  console.log('Safety info:', {
+    promptFeedback: googleMetadata?.promptFeedback,
+    safetyRatings: googleMetadata?.safetyRatings,
+  });
   console.log('Finish reason:', await result.finishReason);
 }
 

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -799,6 +799,42 @@ describe('doGenerate', () => {
   );
 
   it(
+    'should expose PromptFeedback in provider metadata',
+    withTestServer(
+      {
+        url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent',
+        type: 'json-value',
+        content: {
+          candidates: [
+            {
+              content: { parts: [{ text: 'No' }], role: 'model' },
+              finishReason: 'SAFETY',
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+          promptFeedback: {
+            blockReason: 'SAFETY',
+            safetyRatings: SAFETY_RATINGS,
+          },
+        },
+      },
+      async () => {
+        const { providerMetadata } = await model.doGenerate({
+          inputFormat: 'prompt',
+          mode: { type: 'regular' },
+          prompt: TEST_PROMPT,
+        });
+
+        expect(providerMetadata?.google.promptFeedback).toStrictEqual({
+          blockReason: 'SAFETY',
+          safetyRatings: SAFETY_RATINGS,
+        });
+      },
+    ),
+  );
+
+  it(
     'should expose grounding metadata in provider metadata',
     withTestServer(
       prepareJsonResponse({
@@ -1086,6 +1122,7 @@ describe('doStream', () => {
             providerMetadata: {
               google: {
                 groundingMetadata: null,
+                promptFeedback: null,
                 safetyRatings: [
                   {
                     category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
@@ -1260,6 +1297,7 @@ describe('doStream', () => {
             providerMetadata: {
               google: {
                 groundingMetadata: null,
+                promptFeedback: null,
                 safetyRatings: [
                   {
                     category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
@@ -1323,6 +1361,43 @@ describe('doStream', () => {
             blocked: false,
           },
         ]);
+      },
+    ),
+  );
+
+  it(
+    'should expose PromptFeedback in provider metadata on finish',
+    withTestServer(
+      {
+        url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent',
+        type: 'stream-values',
+        content: [
+          `data: {"candidates": [{"content": {"parts": [{"text": "No"}],"role": "model"},` +
+            `"finishReason": "PROHIBITED_CONTENT","index": 0}],` +
+            `"promptFeedback": {"blockReason": "PROHIBITED_CONTENT","safetyRatings": [` +
+            `{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},` +
+            `{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},` +
+            `{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},` +
+            `{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}}\n\n`,
+        ],
+      },
+      async () => {
+        const { stream } = await model.doStream({
+          inputFormat: 'prompt',
+          mode: { type: 'regular' },
+          prompt: TEST_PROMPT,
+        });
+
+        const events = await convertReadableStreamToArray(stream);
+        const finishEvent = events.find(event => event.type === 'finish');
+
+        expect(
+          finishEvent?.type === 'finish' &&
+            finishEvent.providerMetadata?.google.promptFeedback,
+        ).toStrictEqual({
+          blockReason: 'PROHIBITED_CONTENT',
+          safetyRatings: SAFETY_RATINGS,
+        });
       },
     ),
   );

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -248,6 +248,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       warnings,
       providerMetadata: {
         google: {
+          promptFeedback: response.promptFeedback ?? null,
           groundingMetadata: candidate.groundingMetadata ?? null,
           safetyRatings: candidate.safetyRatings ?? null,
         },
@@ -330,6 +331,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
 
               providerMetadata = {
                 google: {
+                  promptFeedback: value.promptFeedback ?? null,
                   groundingMetadata: candidate.groundingMetadata ?? null,
                   safetyRatings: candidate.safetyRatings ?? null,
                 },
@@ -521,6 +523,12 @@ const responseSchema = z.object({
       groundingMetadata: groundingMetadataSchema.nullish(),
     }),
   ),
+  promptFeedback: z
+    .object({
+      blockReason: z.string().nullish(),
+      safetyRatings: z.array(safetyRatingSchema).nullish(),
+    })
+    .nullish(),
   usageMetadata: z
     .object({
       promptTokenCount: z.number().nullish(),
@@ -542,6 +550,12 @@ const chunkSchema = z.object({
         groundingMetadata: groundingMetadataSchema.nullish(),
       }),
     )
+    .nullish(),
+  promptFeedback: z
+    .object({
+      blockReason: z.string().nullish(),
+      safetyRatings: z.array(safetyRatingSchema).nullish(),
+    })
     .nullish(),
   usageMetadata: z
     .object({


### PR DESCRIPTION
Hi,

I've added promptFeedback support from the response, fix: https://github.com/vercel/ai/issues/4236

A new `promptFeedback` object has been added to the providerMetadata, with `blockReason` and  `safetyRatings`.

Where is the best place to add this in the documentation?