### PR TITLE
feat (vertex/anthropic): add prompt caching support for Anthropic Claude models in Google Vertex AI SDK

### DIFF
--- a/packages/google-vertex/README.md
+++ b/packages/google-vertex/README.md
@@ -78,6 +78,60 @@ const { text } = await generateText({
 });
 ```
 
+## Prompt Caching Support for Anthropic Claude Models
+
+The Google Vertex Anthropic provider now supports prompt caching for Anthropic Claude models. Prompt caching can help reduce latency and costs by reusing cached results for identical requests. Caches are unique to Google Cloud projects and have a five-minute lifetime. Prompt caching can be enabled via the Anthropic Claude SDK or the Vertex AI REST API.
+
+### Enabling Prompt Caching
+
+To enable prompt caching, you can use the `cacheControl` property in the settings. Here is an example demonstrating how to enable prompt caching:
+
+```ts
+import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+
+const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
+
+async function main() {
+  const result = await generateText({
+    model: vertexAnthropic('claude-3-5-sonnet-v2@20241022', {
+      cacheControl: true,
+    }),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a JavaScript expert.',
+          },
+          {
+            type: 'text',
+            text: `Error message: ${errorMessage}`,
+            experimental_providerMetadata: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Explain the error message.',
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(result.text);
+  console.log(result.experimental_providerMetadata?.anthropic);
+  // e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
+}
+
+main().catch(console.error);
+```
+
 ## Custom Provider Configuration
 
 You can create a custom provider instance using the `createVertex` function. This allows you to specify additional configuration options. Below is an example with the default Node.js provider which includes a `googleAuthOptions` object.

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts
@@ -11,4 +11,6 @@ export type GoogleVertexAnthropicMessagesModelId =
   | (string & {});
 
 export interface GoogleVertexAnthropicMessagesSettings
-  extends Omit<AnthropicMessagesSettings, 'cacheControl'> {}
+  extends AnthropicMessagesSettings {
+  cacheControl?: AnthropicMessagesSettings['cacheControl'];
+}

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -106,10 +106,11 @@ export function createVertexAnthropic(
           }`,
         transformRequestBody: args => {
           // Remove model from args and add anthropic version
-          const { model, ...rest } = args;
+          const { model, cacheControl, ...rest } = args;
           return {
             ...rest,
             anthropic_version: 'vertex-2023-10-16',
+            cache_control: cacheControl,
           };
         },
       },


### PR DESCRIPTION
Add support for prompt caching for Anthropic Claude models in the Google Vertex AI SDK.

* **`packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts`**
  - Add `cacheControl` property to `GoogleVertexAnthropicMessagesSettings` interface.

* **`packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts`**
  - Update `transformRequestBody` function to include `cacheControl` in the request body.

* **`packages/google-vertex/README.md`**
  - Add a section about prompt caching support for Anthropic Claude models.
  - Include an example demonstrating how to enable prompt caching.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vercel/ai/pull/4269?shareId=c1001488-396c-4944-9fbf-d92a17197168).