### PR TITLE
fix (provider/google-vertex): Use optional fetch in embed.

### DIFF
--- a/.changeset/witty-rockets-compete.md
+++ b/.changeset/witty-rockets-compete.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix (provider/google-vertex): Use optional fetch in embed and streamline config.

--- a/packages/google-vertex/src/google-vertex-config.ts
+++ b/packages/google-vertex/src/google-vertex-config.ts
@@ -1,0 +1,8 @@
+import { FetchFunction, Resolvable } from '@ai-sdk/provider-utils';
+
+export interface GoogleVertexConfig {
+  provider: string;
+  baseURL: string;
+  headers: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+}

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -182,7 +182,7 @@ describe('GoogleVertexEmbeddingModel', () => {
     );
   });
 
-  it('should use custom fetch when provided', async () => {
+  it('should use custom fetch when provided and include proper request content', async () => {
     const customFetch = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -212,9 +212,20 @@ describe('GoogleVertexEmbeddingModel', () => {
     });
 
     expect(response.embeddings).toStrictEqual(dummyEmbeddings);
+
     expect(customFetch).toHaveBeenCalledWith(
       `${customBaseURL}/models/textembedding-gecko@001:predict`,
       expect.any(Object),
     );
+
+    const [_, secondArgument] = customFetch.mock.calls[0];
+    const requestBody = JSON.parse(secondArgument.body);
+
+    expect(requestBody).toStrictEqual({
+      instances: testValues.map(value => ({ content: value })),
+      parameters: {
+        outputDimensionality: 768,
+      },
+    });
   });
 });

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -15,20 +15,13 @@ import {
   GoogleVertexEmbeddingModelId,
   GoogleVertexEmbeddingSettings,
 } from './google-vertex-embedding-settings';
-
-type GoogleVertexEmbeddingConfig = {
-  provider: string;
-  region: string;
-  project: string;
-  headers: Resolvable<Record<string, string | undefined>>;
-  baseURL: string;
-};
+import { GoogleVertexConfig } from './google-vertex-config';
 
 export class GoogleVertexEmbeddingModel implements EmbeddingModelV1<string> {
   readonly specificationVersion = 'v1';
   readonly modelId: GoogleVertexEmbeddingModelId;
 
-  private readonly config: GoogleVertexEmbeddingConfig;
+  private readonly config: GoogleVertexConfig;
   private readonly settings: GoogleVertexEmbeddingSettings;
 
   get provider(): string {
@@ -46,7 +39,7 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV1<string> {
   constructor(
     modelId: GoogleVertexEmbeddingModelId,
     settings: GoogleVertexEmbeddingSettings,
-    config: GoogleVertexEmbeddingConfig,
+    config: GoogleVertexConfig,
   ) {
     this.modelId = modelId;
     this.settings = settings;
@@ -89,6 +82,7 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV1<string> {
         googleVertexTextEmbeddingResponseSchema,
       ),
       abortSignal,
+      fetch: this.config.fetch,
     });
 
     return {

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -67,8 +67,6 @@ describe('google-vertex-provider', () => {
       {},
       expect.objectContaining({
         provider: 'google.vertex.embedding',
-        project: 'test-project',
-        region: 'test-location',
         headers: expect.any(Object),
         baseURL:
           'https://test-location-aiplatform.googleapis.com/v1/projects/test-project/locations/test-location/publishers/google',

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -20,6 +20,7 @@ import {
   GoogleVertexImageModel,
   GoogleVertexImageModelId,
 } from './google-vertex-image-model';
+import { GoogleVertexConfig } from './google-vertex-config';
 
 export interface GoogleVertexProvider extends ProviderV1 {
   /**
@@ -107,16 +108,22 @@ export function createVertex(
     );
   };
 
+  const createConfig = (name: string): GoogleVertexConfig => {
+    return {
+      provider: `google.vertex.${name}`,
+      headers: options.headers ?? {},
+      fetch: options.fetch,
+      baseURL: loadBaseURL(),
+    };
+  };
+
   const createChatModel = (
     modelId: GoogleVertexModelId,
     settings: GoogleVertexSettings = {},
   ) => {
     return new GoogleGenerativeAILanguageModel(modelId, settings, {
-      provider: `google.vertex.chat`,
-      headers: options.headers ?? {},
+      ...createConfig('chat'),
       generateId: options.generateId ?? generateId,
-      fetch: options.fetch,
-      baseURL: loadBaseURL(),
     });
   };
 
@@ -124,21 +131,14 @@ export function createVertex(
     modelId: GoogleVertexEmbeddingModelId,
     settings: GoogleVertexEmbeddingSettings = {},
   ) =>
-    new GoogleVertexEmbeddingModel(modelId, settings, {
-      provider: `google.vertex.embedding`,
-      region: loadVertexLocation(),
-      project: loadVertexProject(),
-      headers: options.headers ?? {},
-      baseURL: loadBaseURL(),
-    });
+    new GoogleVertexEmbeddingModel(
+      modelId,
+      settings,
+      createConfig('embedding'),
+    );
 
   const createImageModel = (modelId: GoogleVertexImageModelId) =>
-    new GoogleVertexImageModel(modelId, {
-      provider: `google.vertex.image`,
-      baseURL: loadBaseURL(),
-      headers: options.headers ?? {},
-      fetch: options.fetch,
-    });
+    new GoogleVertexImageModel(modelId, createConfig('image'));
 
   const provider = function (
     modelId: GoogleVertexModelId,


### PR DESCRIPTION
Also streamline config data across model-create functions.