### PR TITLE
Add Replicate image provider

### DIFF
--- a/examples/ai-core/src/generate-image/replicate.ts
+++ b/examples/ai-core/src/generate-image/replicate.ts
@@ -1,0 +1,18 @@
+import { replicate } from '@ai-sdk/replicate';
+import { experimental_generateImage as generateImage } from 'ai';
+import 'dotenv/config';
+import fs from 'node:fs';
+
+async function main() {
+  console.log('Generating image...');
+  const { image } = await generateImage({
+    model: replicate.image('black-forest-labs/flux-schnell'),
+    prompt: 'The Loch Ness Monster getting a manicure',
+  });
+
+  const filename = `image-${Date.now()}.png`;
+  fs.writeFileSync(filename, image.uint8Array);
+  console.log(`Image saved to ${filename}`);
+}
+
+main().catch(console.error);

--- a/packages/replicate/README.md
+++ b/packages/replicate/README.md
@@ -10,6 +10,13 @@ The Replicate provider is available in the `@ai-sdk/replicate` module, which is 
 npm i @ai-sdk/replicate
 ```
 
+## Supported Models
+
+The Replicate provider currently supports the following models:
+
+- [black-forest-labs/flux-schnell](https://replicate.com/black-forest-labs/flux-schnell)
+- [black-forest-labs/flux-dev](https://replicate.com/black-forest-labs/flux-dev)
+
 ## Usage
 
 ```ts

--- a/packages/replicate/README.md
+++ b/packages/replicate/README.md
@@ -1,0 +1,70 @@
+# AI SDK - Replicate Provider
+
+Run models on [Replicate](https://replicate.com) using the [Vercel AI SDK](https://sdk.vercel.ai/docs).
+
+## Installation
+
+The Replicate provider is available in the `@ai-sdk/replicate` module, which is published on npm. You can install it with:
+
+```bash
+npm i @ai-sdk/replicate
+```
+
+## Usage
+
+```ts
+import { replicate } from '@ai-sdk/replicate';
+import { experimental_generateImage as generateImage } from 'ai';
+
+const { image } = await generateImage({
+  model: replicate.image('black-forest-labs/flux-schnell'),
+  prompt: 'The Loch Ness Monster getting a manicure',
+});
+
+console.log(image);
+```
+
+If you want to pass additional inputs to the model besides the prompt, use the `providerOptions` property:
+
+```ts
+const { image } = await generateImage({
+  model: replicate.image('black-forest-labs/flux-schnell'),
+  prompt: 'The Loch Ness Monster getting a manicure, wide shot',
+  providerOptions: {
+    replicate: {
+      input: { 
+        aspect_ratio: '16:9',
+        seed: 123456,
+      },
+    },
+  },
+});
+```
+
+## Development
+
+To contribute to the Replicate provider, do the following:
+
+Clone the repo:
+
+```
+git clone https://github.com/vercel/ai
+```
+
+Go into the `replicate` package:
+
+```
+cd packages/replicate
+```
+
+Install the dependencies (using [pnpm](https://pnpm.io/)):
+
+```bash
+pnpm install
+```
+
+Run the tests (again using pnpm):
+
+```bash
+pnpm test
+```

--- a/packages/replicate/package.json
+++ b/packages/replicate/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@ai-sdk/replicate",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "rm -rf dist && rm -rf edge/dist",
+    "lint": "eslint \"./**/*.ts*\"",
+    "type-check": "tsc --noEmit",
+    "prettier-check": "prettier --check \"./**/*.ts*\"",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./edge": {
+      "types": "./edge/dist/index.d.ts",
+      "import": "./edge/dist/index.mjs",
+      "require": "./edge/dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "1.0.3",
+    "@ai-sdk/provider-utils": "2.0.5",
+    "replicate": "^1.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^18",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8",
+    "typescript": "5.6.3",
+    "zod": "3.23.8"
+  },
+  "peerDependencies": {
+    "zod": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/replicate/src/index.ts
+++ b/packages/replicate/src/index.ts
@@ -1,15 +1,6 @@
-export * from './replicate-image-model';
-export * from './replicate-config';
-export * from './replicate-error';
+export { createReplicate, replicate } from './replicate-provider';
 
-import { ReplicateImageModel, ReplicateImageModelId } from './replicate-image-model';
-import { ReplicateConfig, createReplicateConfig } from './replicate-config';
-
-export function createReplicate(config: Omit<ReplicateConfig, 'provider'>) {
-  const fullConfig = createReplicateConfig(config);
-  
-  return {
-    image: (modelId: ReplicateImageModelId) => 
-      new ReplicateImageModel(modelId, fullConfig),
-  };
-} 
+export type {
+  ReplicateProvider,
+  ReplicateProviderSettings,
+} from './replicate-provider';

--- a/packages/replicate/src/index.ts
+++ b/packages/replicate/src/index.ts
@@ -1,0 +1,15 @@
+export * from './replicate-image-model';
+export * from './replicate-config';
+export * from './replicate-error';
+
+import { ReplicateImageModel, ReplicateImageModelId } from './replicate-image-model';
+import { ReplicateConfig, createReplicateConfig } from './replicate-config';
+
+export function createReplicate(config: Omit<ReplicateConfig, 'provider'>) {
+  const fullConfig = createReplicateConfig(config);
+  
+  return {
+    image: (modelId: ReplicateImageModelId) => 
+      new ReplicateImageModel(modelId, fullConfig),
+  };
+} 

--- a/packages/replicate/src/replicate-config.ts
+++ b/packages/replicate/src/replicate-config.ts
@@ -1,0 +1,21 @@
+import type { Resolvable } from '@ai-sdk/provider-utils';
+
+export interface ReplicateConfig {
+  provider: string;
+  apiToken: string;
+  baseURL?: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: typeof fetch;
+}
+
+export function createReplicateConfig(config: Omit<ReplicateConfig, 'provider'>) {
+  return {
+    ...config,
+    provider: 'replicate',
+    baseURL: config.baseURL ?? 'https://api.replicate.com/v1',
+    headers: {
+      ...config.headers,
+      'Authorization': `Bearer ${config.apiToken}`,
+    },
+  };
+} 

--- a/packages/replicate/src/replicate-error.ts
+++ b/packages/replicate/src/replicate-error.ts
@@ -1,0 +1,14 @@
+import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+
+const replicateErrorSchema = z.object({
+  detail: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export const replicateFailedResponseHandler = createJsonErrorResponseHandler(
+  {
+    errorSchema: replicateErrorSchema,
+    errorToMessage: error => error.detail || error.error || 'Unknown Replicate error',
+  },
+); 

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -120,6 +120,8 @@ describe('ReplicateImageModel', () => {
         baseURL: 'https://api.replicate.com/v1',
         headers: { 
           Authorization: `Bearer ${process.env.REPLICATE_API_TOKEN}`, 
+
+          // https://replicate.fyi/prefer-header
           Prefer: 'wait'
         },
       });

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -111,4 +111,34 @@ describe('ReplicateImageModel', () => {
       ).rejects.toThrow(/Replicate does not support the `size` option./);
     });
   });
+
+  describe('e2e integration with the real Replicate API', () => {
+    // Skip if no API token is provided
+    it.runIf(process.env.REPLICATE_API_TOKEN)('should generate an image', async () => {
+      const modelWithAuth = new ReplicateImageModel('black-forest-labs/flux-schnell', {
+        provider: 'replicate',
+        baseURL: 'https://api.replicate.com/v1',
+        headers: { 
+          Authorization: `Bearer ${process.env.REPLICATE_API_TOKEN}`, 
+          Prefer: 'wait'
+        },
+      });
+
+      const { images } = await modelWithAuth.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        providerOptions: {
+          replicate: {
+            input: {
+              num_inference_steps: 2
+            }
+          }
+        }
+      });
+      
+      expect(images).toHaveLength(1);
+      expect(images[0]).toMatch(/^https:\/\/replicate\.delivery\/.+/);
+    }, 30000);
+  });
 }); 

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -81,6 +81,7 @@ describe('ReplicateImageModel', () => {
         'content-type': 'application/json',
         'custom-provider-header': 'provider-header-value',
         'custom-request-header': 'request-header-value',
+        'prefer': 'wait',
       });
     });
 
@@ -113,6 +114,14 @@ describe('ReplicateImageModel', () => {
   });
 
   describe('e2e integration with the real Replicate API', () => {
+    it('errors if an invalid model is provided', () => {
+      expect(() => new ReplicateImageModel('some/invalid-model', {
+        provider: 'replicate',
+        baseURL: 'https://api.replicate.com/v1',
+        headers: { Authorization: 'Bearer test-token' },
+      })).toThrow('Unsupported model: some/invalid-model. Supported models are: black-forest-labs/flux-schnell, black-forest-labs/flux-dev');
+    });
+
     // Skip if no API token is provided
     it.runIf(process.env.REPLICATE_API_TOKEN)('should generate an image', async () => {
       const modelWithAuth = new ReplicateImageModel('black-forest-labs/flux-schnell', {
@@ -140,4 +149,24 @@ describe('ReplicateImageModel', () => {
       expect(images[0]).toMatch(/^https:\/\/replicate\.delivery\/.+/);
     }, 30000);
   });
+
+  it.runIf(process.env.REPLICATE_API_TOKEN)('should generate an image with a different model', async () => {
+    const modelWithAuth = new ReplicateImageModel('black-forest-labs/flux-dev', {
+      provider: 'replicate',
+      baseURL: 'https://api.replicate.com/v1',
+      headers: { Authorization: `Bearer ${process.env.REPLICATE_API_TOKEN}` },
+    });
+
+    const { images } = await modelWithAuth.doGenerate({
+      prompt: 'A cat in a hat',
+      n: 1,
+      size: undefined,
+      providerOptions: {},
+    });
+
+    expect(images).toHaveLength(1);
+    expect(images[0]).toMatch(/^https:\/\/replicate\.delivery\/.+/);
+  }, 30000);
+
+
 }); 

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -119,10 +119,7 @@ describe('ReplicateImageModel', () => {
         provider: 'replicate',
         baseURL: 'https://api.replicate.com/v1',
         headers: { 
-          Authorization: `Bearer ${process.env.REPLICATE_API_TOKEN}`, 
-
-          // https://replicate.fyi/prefer-header
-          Prefer: 'wait'
+          Authorization: `Bearer ${process.env.REPLICATE_API_TOKEN}`,
         },
       });
 

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -13,7 +13,7 @@ const model = new ReplicateImageModel('black-forest-labs/flux-schnell', {
 describe('ReplicateImageModel', () => {
   describe('doGenerate', () => {
     const server = new JsonTestServer(
-      'https://api.replicate.com/v1/models/stability-ai/sdxl/predictions',
+      'https://api.replicate.com/v1/models/black-forest-labs/flux-schnell/predictions',
     );
 
     server.setupTestEnvironment();
@@ -36,24 +36,18 @@ describe('ReplicateImageModel', () => {
         size: undefined,
         providerOptions: { 
           replicate: { 
-            version: 'v1.0',
             input: { 
-              width: 1024,
-              height: 1024,
-              num_inference_steps: 50 
+              num_inference_steps: 10 
             } 
           } 
         },
       });
 
       expect(await server.getRequestBodyJson()).toStrictEqual({
-        version: 'v1.0',
         input: {
           prompt,
           num_outputs: 2,
-          width: 1024,
-          height: 1024,
-          num_inference_steps: 50,
+          num_inference_steps: 10,
         },
       });
     });
@@ -61,7 +55,7 @@ describe('ReplicateImageModel', () => {
     it('should pass headers', async () => {
       prepareJsonResponse();
 
-      const modelWithHeaders = new ReplicateImageModel('stability-ai/sdxl', {
+      const modelWithHeaders = new ReplicateImageModel('black-forest-labs/flux-schnell', {
         provider: 'replicate',
         baseURL: 'https://api.replicate.com/v1',
         headers: {

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -1,0 +1,85 @@
+import type { ImageModelV1 } from '@ai-sdk/provider';
+import type { Resolvable } from '@ai-sdk/provider-utils';
+import {
+  postJsonToApi,
+  combineHeaders,
+  createJsonResponseHandler,
+  resolve,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+import { replicateFailedResponseHandler } from './replicate-error';
+
+export type ReplicateImageModelId = 
+  | 'black-forest-labs/flux-schnell'
+  | 'black-forest-labs/flux-dev'
+  | (string & {});
+
+interface ReplicateImageModelConfig {
+  provider: string;
+  baseURL: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: typeof fetch;
+}
+
+export class ReplicateImageModel implements ImageModelV1 {
+  readonly specificationVersion = 'v1';
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: ReplicateImageModelId,
+    private config: ReplicateImageModelConfig,
+  ) {}
+
+  async doGenerate({
+    prompt,
+    n = 1,
+    size,
+    providerOptions,
+    headers,
+    abortSignal,
+  }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV1['doGenerate']>>
+  > {
+    if (size) {
+      throw new Error(
+        'Replicate does not support the `size` option. Use ' +
+          '`providerOptions.replicate.input.width` and ' +
+          '`providerOptions.replicate.input.height` instead.',
+      );
+    }
+
+    const [owner, model] = this.modelId.split('/');
+    
+    const body = {
+      version: providerOptions.replicate?.version,
+      input: {
+        prompt,
+        num_outputs: n,
+        ...(providerOptions.replicate?.input ?? {}),
+      },
+    };
+
+    const { value: response } = await postJsonToApi({
+      url: `${this.config.baseURL}/models/${owner}/${model}/predictions`,
+      headers: combineHeaders(await resolve(this.config.headers), headers),
+      body,
+      failedResponseHandler: replicateFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        replicateImageResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      images: response.output,
+    };
+  }
+}
+
+const replicateImageResponseSchema = z.object({
+  output: z.array(z.string()),
+}); 

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -51,17 +51,23 @@ export class ReplicateImageModel implements ImageModelV1 {
 
     const [owner, model] = this.modelId.split('/');
     
+    const url = `${this.config.baseURL}/models/${owner}/${model}/predictions`;
+    
     const body = {
       input: {
         prompt,
         num_outputs: n,
-        ...(providerOptions.replicate?.input ?? {}),
+        ...(providerOptions.replicate?.input as Record<string, unknown> ?? {}),
       },
     };
 
+    const combinedHeaders = combineHeaders(await resolve(this.config.headers), headers);
+
+    // console.log({url, body, combinedHeaders});
+
     const { value: response } = await postJsonToApi({
-      url: `${this.config.baseURL}/models/${owner}/${model}/predictions`,
-      headers: combineHeaders(await resolve(this.config.headers), headers),
+      url,
+      headers: combinedHeaders,
       body,
       failedResponseHandler: replicateFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -31,7 +31,18 @@ export class ReplicateImageModel implements ImageModelV1 {
   constructor(
     readonly modelId: ReplicateImageModelId,
     private config: ReplicateImageModelConfig,
-  ) {}
+  ) {
+    if (!SUPPORTED_MODEL_IDS.includes(modelId as SupportedModelId)) {
+      throw new Error(
+        `Unsupported model: ${modelId}. ` + 
+        `Supported models are: ${SUPPORTED_MODEL_IDS.join(', ')}`
+      );
+    }
+    this.config.headers = {
+      ...this.config.headers,
+      'Prefer': 'wait',
+    };
+  }
 
   async doGenerate({
     prompt,

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -45,16 +45,13 @@ export class ReplicateImageModel implements ImageModelV1 {
   > {
     if (size) {
       throw new Error(
-        'Replicate does not support the `size` option. Use ' +
-          '`providerOptions.replicate.input.width` and ' +
-          '`providerOptions.replicate.input.height` instead.',
+        'Replicate does not support the `size` option. Some models support width and height, some support aspect ratio, etc. Use model-specific input parameters instead, setting them in `providerOptions.replicate.input`.',
       );
     }
 
     const [owner, model] = this.modelId.split('/');
     
     const body = {
-      version: providerOptions.replicate?.version,
       input: {
         prompt,
         num_outputs: n,

--- a/packages/replicate/src/replicate-provider.test.ts
+++ b/packages/replicate/src/replicate-provider.test.ts
@@ -18,7 +18,7 @@ describe('createReplicate', () => {
 
   it('creates an image model instance', () => {
     const provider = createReplicate({ apiToken: 'test-token' });
-    const model = provider.image('stability-ai/sdxl:abc123');
+    const model = provider.image('black-forest-labs/flux-schnell');
     expect(model).toBeInstanceOf(ReplicateImageModel);
   });
 
@@ -28,7 +28,7 @@ describe('createReplicate', () => {
       baseURL: 'https://custom.replicate.com',
     };
     const provider = createReplicate(customConfig);
-    const model = provider.image('stability-ai/sdxl:abc123');
+    const model = provider.image('black-forest-labs/flux-schnell');
     
     // Access internal config to verify it was passed correctly
     const modelConfig = (model as { config: typeof customConfig & { provider: string } }).config;

--- a/packages/replicate/src/replicate-provider.test.ts
+++ b/packages/replicate/src/replicate-provider.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { createReplicate } from './replicate-provider';
+import { ReplicateImageModel } from './replicate-image-model';
+
+describe('createReplicate', () => {
+  it('creates a provider with required settings', () => {
+    const provider = createReplicate({ apiToken: 'test-token' });
+    expect(provider.image).toBeDefined();
+  });
+
+  it('creates a provider with custom settings', () => {
+    const provider = createReplicate({
+      apiToken: 'test-token',
+      baseURL: 'https://custom.replicate.com',
+    });
+    expect(provider.image).toBeDefined();
+  });
+
+  it('creates an image model instance', () => {
+    const provider = createReplicate({ apiToken: 'test-token' });
+    const model = provider.image('stability-ai/sdxl:abc123');
+    expect(model).toBeInstanceOf(ReplicateImageModel);
+  });
+
+  it('passes configuration to image model', () => {
+    const customConfig = {
+      apiToken: 'test-token',
+      baseURL: 'https://custom.replicate.com',
+    };
+    const provider = createReplicate(customConfig);
+    const model = provider.image('stability-ai/sdxl:abc123');
+    
+    // Access internal config to verify it was passed correctly
+    const modelConfig = (model as { config: typeof customConfig & { provider: string } }).config;
+    expect(modelConfig).toMatchObject({
+      ...customConfig,
+      provider: 'replicate',
+    });
+  });
+}); 

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -6,24 +6,37 @@ import { createReplicateConfig } from './replicate-config';
 export interface ReplicateProviderSettings extends Omit<ReplicateConfig, 'provider'> {}
 
 export interface ReplicateProvider {
+  (modelId: ReplicateImageModelId): ReplicateImageModelType;
+
   /**
    * Creates an image generation model
    */
   image(modelId: ReplicateImageModelId): ReplicateImageModelType;
 }
 
+/**
+ * Create a Replicate provider instance.
+ */
 export function createReplicate(
   options: ReplicateProviderSettings,
 ): ReplicateProvider {
   const config = createReplicateConfig(options);
-  
-  return {
-    image: (modelId: ReplicateImageModelId) => 
-      new ReplicateImageModel(modelId, config),
+
+  const createImageModel = (modelId: ReplicateImageModelId) =>
+    new ReplicateImageModel(modelId, config);
+
+  const provider = (modelId: ReplicateImageModelId) => {
+    return createImageModel(modelId);
   };
+
+  provider.image = createImageModel;
+
+  return provider as ReplicateProvider;
 }
 
 /**
  * Default Replicate provider instance
  */
-export const replicate = createReplicate({ apiToken: process.env.REPLICATE_API_TOKEN ?? '' }); 
+export const replicate = createReplicate({ 
+  apiToken: process.env.REPLICATE_API_TOKEN ?? '' 
+}); 

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -1,0 +1,29 @@
+import { ReplicateImageModel } from './replicate-image-model';
+import type { ReplicateImageModelId, ReplicateImageModel as ReplicateImageModelType } from './replicate-image-model';
+import type { ReplicateConfig } from './replicate-config';
+import { createReplicateConfig } from './replicate-config';
+
+export interface ReplicateProviderSettings extends Omit<ReplicateConfig, 'provider'> {}
+
+export interface ReplicateProvider {
+  /**
+   * Creates an image generation model
+   */
+  image(modelId: ReplicateImageModelId): ReplicateImageModelType;
+}
+
+export function createReplicate(
+  options: ReplicateProviderSettings,
+): ReplicateProvider {
+  const config = createReplicateConfig(options);
+  
+  return {
+    image: (modelId: ReplicateImageModelId) => 
+      new ReplicateImageModel(modelId, config),
+  };
+}
+
+/**
+ * Default Replicate provider instance
+ */
+export const replicate = createReplicate({ apiToken: process.env.REPLICATE_API_TOKEN ?? '' }); 

--- a/packages/replicate/vitest.edge.config.js
+++ b/packages/replicate/vitest.edge.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    globals: true,
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+});

--- a/packages/replicate/vitest.node.config.js
+++ b/packages/replicate/vitest.node.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+});


### PR DESCRIPTION
This PR adds support for generating images using Replicate models using the new `generateImage()` function in the Vercel AI SDK.

## To Do

- [x] Scaffold the Replicate package
- [x] Add a test harness with mocked requests
- [x] Add example code in examples/ai-core/src/generate-image
- [x] Figure out how to smoke test it!
- [x] Choose initial set of image models to support
- [x] Add support for the image models
- [x] Add documentation in a package README
- [ ] Publish!