### PR TITLE
fix (docs): changed links to troubleshooting schema limitations in Google AI/Vertex

### DIFF
--- a/content/providers/01-ai-sdk-providers/10-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/10-google-generative-ai.mdx
@@ -107,7 +107,7 @@ The following optional settings are available for Google Generative AI models:
   Google Generative AI uses. You can use this to disable
   structured outputs if you need to.
 
-  See [Troubleshooting: Schema Limitations](#troubleshooting-schema-limitations) for more details.
+  See [Troubleshooting: Schema Limitations](#schema-limitations) for more details.
 
 - **safetySettings** _Array\<\{ category: string; threshold: string \}\>_
 

--- a/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
@@ -263,7 +263,7 @@ The following optional settings are available for Google Vertex models:
   Google Vertex uses. You can use this to disable
   structured outputs if you need to.
 
-  See [Troubleshooting: Schema Limitations](#troubleshooting-schema-limitations) for more details.
+  See [Troubleshooting: Schema Limitations](#schema-limitations) for more details.
 
 - **safetySettings** _Array\<\{ category: string; threshold: string \}\>_
 


### PR DESCRIPTION
The link "Troubleshooting schema limitations" under structuredOutputs in Google AI / Vertex documentation is linking to an incorrect anchor.

![image](https://github.com/user-attachments/assets/8540c2ec-f3ca-411e-ab3f-a444f5cd3d31)
