### PR TITLE
feat: change image generation errors to warnings

### DIFF
--- a/.changeset/sour-months-give.md
+++ b/.changeset/sour-months-give.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/openai': patch
+'ai': patch
+---
+
+feat: change image generation errors to warnings

--- a/content/docs/03-ai-sdk-core/35-image-generation.mdx
+++ b/content/docs/03-ai-sdk-core/35-image-generation.mdx
@@ -148,6 +148,17 @@ const { image } = await generateImage({
 });
 ```
 
+### Warnings
+
+If the model returns warnings, e.g. for unsupported parameters, they will be available in the `warnings` property of the response.
+
+```tsx
+const { image, warnings } = await generateImage({
+  model: openai.image('dall-e-3'),
+  prompt: 'Santa Claus driving a Cadillac',
+});
+```
+
 ## Image Models
 
 | Provider                                                                | Model                                          | Sizes                           | Aspect Ratios                                   |

--- a/content/docs/07-reference/01-ai-sdk-core/10-generate-image.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/10-generate-image.mdx
@@ -149,5 +149,11 @@ console.log(images);
         },
       ],
     },
+    {
+      name: 'warnings',
+      type: 'ImageGenerationWarning[]',
+      description:
+        'Warnings from the model provider (e.g. unsupported settings).',
+    },
   ]}
 />

--- a/packages/ai/core/generate-image/generate-image-result.ts
+++ b/packages/ai/core/generate-image/generate-image-result.ts
@@ -1,3 +1,5 @@
+import { ImageModelCallWarning } from '../types/image-model';
+
 /**
 The result of a `generateImage` call.
 It contains the images and additional information.
@@ -12,6 +14,11 @@ The first image that was generated.
 The images that were generated.
      */
   readonly images: Array<GeneratedImage>;
+
+  /**
+Warnings for the call, e.g. unsupported settings.
+     */
+  readonly warnings: Array<ImageModelCallWarning>;
 }
 
 export interface GeneratedImage {

--- a/packages/ai/core/generate-image/generate-image-result.ts
+++ b/packages/ai/core/generate-image/generate-image-result.ts
@@ -1,4 +1,4 @@
-import { ImageModelCallWarning } from '../types/image-model';
+import { ImageGenerationWarning } from '../types/image-model';
 
 /**
 The result of a `generateImage` call.
@@ -18,7 +18,7 @@ The images that were generated.
   /**
 Warnings for the call, e.g. unsupported settings.
      */
-  readonly warnings: Array<ImageModelCallWarning>;
+  readonly warnings: Array<ImageGenerationWarning>;
 }
 
 export interface GeneratedImage {

--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -19,7 +19,7 @@ describe('generateImage', () => {
       model: new MockImageModelV1({
         doGenerate: async args => {
           capturedArgs = args;
-          return { images: [] };
+          return { images: [], warnings: [] };
         },
       }),
       prompt,
@@ -43,6 +43,30 @@ describe('generateImage', () => {
     });
   });
 
+  it('should return warnings', async () => {
+    const result = await generateImage({
+      model: new MockImageModelV1({
+        doGenerate: async () => ({
+          images: [],
+          warnings: [
+            {
+              type: 'other',
+              message: 'Setting is not supported',
+            },
+          ],
+        }),
+      }),
+      prompt,
+    });
+
+    expect(result.warnings).toStrictEqual([
+      {
+        type: 'other',
+        message: 'Setting is not supported',
+      },
+    ]);
+  });
+
   describe('base64 image data', () => {
     it('should return generated images', async () => {
       const base64Images = [
@@ -52,7 +76,7 @@ describe('generateImage', () => {
 
       const result = await generateImage({
         model: new MockImageModelV1({
-          doGenerate: async () => ({ images: base64Images }),
+          doGenerate: async () => ({ images: base64Images, warnings: [] }),
         }),
         prompt,
       });
@@ -79,7 +103,10 @@ describe('generateImage', () => {
 
       const result = await generateImage({
         model: new MockImageModelV1({
-          doGenerate: async () => ({ images: [base64Image, 'base64-image-2'] }),
+          doGenerate: async () => ({
+            images: [base64Image, 'base64-image-2'],
+            warnings: [],
+          }),
         }),
         prompt,
       });
@@ -103,7 +130,7 @@ describe('generateImage', () => {
 
       const result = await generateImage({
         model: new MockImageModelV1({
-          doGenerate: async () => ({ images: uint8ArrayImages }),
+          doGenerate: async () => ({ images: uint8ArrayImages, warnings: [] }),
         }),
         prompt,
       });

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -4,6 +4,7 @@ import {
   convertUint8ArrayToBase64,
 } from '@ai-sdk/provider-utils';
 import { prepareRetries } from '../prompt/prepare-retries';
+import { ImageModelCallWarning } from '../types/image-model';
 import { GeneratedImage, GenerateImageResult } from './generate-image-result';
 
 /**
@@ -101,29 +102,34 @@ Only applicable for HTTP-based providers.
 }): Promise<GenerateImageResult> {
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
-  const { images } = await retry(() =>
-    model.doGenerate({
-      prompt,
-      n: n ?? 1,
-      abortSignal,
-      headers,
-      size,
-      aspectRatio,
-      seed,
-      providerOptions: providerOptions ?? {},
-    }),
+  return new DefaultGenerateImageResult(
+    await retry(() =>
+      model.doGenerate({
+        prompt,
+        n: n ?? 1,
+        abortSignal,
+        headers,
+        size,
+        aspectRatio,
+        seed,
+        providerOptions: providerOptions ?? {},
+      }),
+    ),
   );
-
-  return new DefaultGenerateImageResult({ images });
 }
 
 class DefaultGenerateImageResult implements GenerateImageResult {
   readonly images: Array<GeneratedImage>;
+  readonly warnings: Array<ImageModelCallWarning>;
 
-  constructor(options: { images: Array<string> | Array<Uint8Array> }) {
+  constructor(options: {
+    images: Array<string> | Array<Uint8Array>;
+    warnings: Array<ImageModelCallWarning>;
+  }) {
     this.images = options.images.map(
       image => new DefaultGeneratedImage({ imageData: image }),
     );
+    this.warnings = options.warnings;
   }
 
   get image() {

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -4,7 +4,7 @@ import {
   convertUint8ArrayToBase64,
 } from '@ai-sdk/provider-utils';
 import { prepareRetries } from '../prompt/prepare-retries';
-import { ImageModelCallWarning } from '../types/image-model';
+import { ImageGenerationWarning } from '../types/image-model';
 import { GeneratedImage, GenerateImageResult } from './generate-image-result';
 
 /**
@@ -120,11 +120,11 @@ Only applicable for HTTP-based providers.
 
 class DefaultGenerateImageResult implements GenerateImageResult {
   readonly images: Array<GeneratedImage>;
-  readonly warnings: Array<ImageModelCallWarning>;
+  readonly warnings: Array<ImageGenerationWarning>;
 
   constructor(options: {
     images: Array<string> | Array<Uint8Array>;
-    warnings: Array<ImageModelCallWarning>;
+    warnings: Array<ImageGenerationWarning>;
   }) {
     this.images = options.images.map(
       image => new DefaultGeneratedImage({ imageData: image }),

--- a/packages/ai/core/types/image-model.ts
+++ b/packages/ai/core/types/image-model.ts
@@ -1,12 +1,12 @@
 import { ImageModelV1, ImageModelV1CallWarning } from '@ai-sdk/provider';
 
 /**
-  Image model that is used by the AI SDK Core functions.
+Image model that is used by the AI SDK Core functions.
   */
 export type ImageModel = ImageModelV1;
 
 /**
-  Warning from the model provider for this call. The call will proceed, but e.g.
-  some settings might not be supported, which can lead to suboptimal results.
+Warning from the model provider for this call. The call will proceed, but e.g.
+some settings might not be supported, which can lead to suboptimal results.
   */
-export type ImageModelCallWarning = ImageModelV1CallWarning;
+export type ImageGenerationWarning = ImageModelV1CallWarning;

--- a/packages/ai/core/types/image-model.ts
+++ b/packages/ai/core/types/image-model.ts
@@ -1,0 +1,12 @@
+import { ImageModelV1, ImageModelV1CallWarning } from '@ai-sdk/provider';
+
+/**
+  Image model that is used by the AI SDK Core functions.
+  */
+export type ImageModel = ImageModelV1;
+
+/**
+  Warning from the model provider for this call. The call will proceed, but e.g.
+  some settings might not be supported, which can lead to suboptimal results.
+  */
+export type ImageModelCallWarning = ImageModelV1CallWarning;

--- a/packages/ai/core/types/index.ts
+++ b/packages/ai/core/types/index.ts
@@ -1,4 +1,5 @@
 export type { Embedding, EmbeddingModel } from './embedding-model';
+export type { ImageModel, ImageModelCallWarning } from './image-model';
 export type {
   CallWarning,
   CoreToolChoice,

--- a/packages/ai/core/types/index.ts
+++ b/packages/ai/core/types/index.ts
@@ -1,5 +1,8 @@
 export type { Embedding, EmbeddingModel } from './embedding-model';
-export type { ImageModel, ImageModelCallWarning } from './image-model';
+export type {
+  ImageModel,
+  ImageGenerationWarning as ImageModelCallWarning,
+} from './image-model';
 export type {
   CallWarning,
   CoreToolChoice,

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -169,41 +169,27 @@ describe('FireworksImageModel', () => {
       });
     });
 
-    it('should throw error when requesting more than one image', async () => {
-      await expect(
-        model.doGenerate({
-          prompt,
-          n: 2,
-          size: undefined,
-          aspectRatio: undefined,
-          seed: undefined,
-          providerOptions: {},
-        }),
-      ).rejects.toThrowError(
-        new UnsupportedFunctionalityError({
-          functionality: 'generate multiple images',
-          message: `This model does not support generating more than 1 images at a time.`,
-        }),
-      );
-    });
+    it('should return warnings for unsupported settings', async () => {
+      const mockImageBuffer = Buffer.from('mock-image-data');
+      server.responseBody = mockImageBuffer;
 
-    it('should throw error when specifying image size', async () => {
-      await expect(
-        model.doGenerate({
-          prompt,
-          n: 1,
-          size: '512x512',
-          aspectRatio: undefined,
-          seed: undefined,
-          providerOptions: {},
-        }),
-      ).rejects.toThrowError(
-        new UnsupportedFunctionalityError({
-          functionality: 'image size',
-          message:
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        size: '1024x1024',
+        aspectRatio: '1:1',
+        seed: 123,
+        providerOptions: {},
+      });
+
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported-setting',
+          setting: 'size',
+          details:
             'This model does not support the `size` option. Use `aspectRatio` instead.',
-        }),
-      );
+        },
+      ]);
     });
   });
 });

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -1,8 +1,7 @@
 import { APICallError } from '@ai-sdk/provider';
 import { BinaryTestServer } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it } from 'vitest';
 import { FireworksImageModel } from './fireworks-image-model';
-import { describe, it, expect } from 'vitest';
-import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
 
 const prompt = 'A cute baby sea otter';
 

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -1,8 +1,7 @@
 import {
   APICallError,
   ImageModelV1,
-  ImageModelV1Warning,
-  UnsupportedFunctionalityError,
+  ImageModelV1CallWarning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -107,7 +106,7 @@ export class FireworksImageModel implements ImageModelV1 {
   }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
     Awaited<ReturnType<ImageModelV1['doGenerate']>>
   > {
-    const warnings: Array<ImageModelV1Warning> = [];
+    const warnings: Array<ImageModelV1CallWarning> = [];
 
     if (size != null) {
       warnings.push({

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -1,6 +1,7 @@
 import {
   APICallError,
   ImageModelV1,
+  ImageModelV1Warning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import {
@@ -106,18 +107,14 @@ export class FireworksImageModel implements ImageModelV1 {
   }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
     Awaited<ReturnType<ImageModelV1['doGenerate']>>
   > {
-    if (size != null) {
-      throw new UnsupportedFunctionalityError({
-        functionality: 'image size',
-        message:
-          'This model does not support the `size` option. Use `aspectRatio` instead.',
-      });
-    }
+    const warnings: Array<ImageModelV1Warning> = [];
 
-    if (n > this.maxImagesPerCall) {
-      throw new UnsupportedFunctionalityError({
-        functionality: `generate more than ${this.maxImagesPerCall} images`,
-        message: `This model does not support generating more than ${this.maxImagesPerCall} images at a time.`,
+    if (size != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'size',
+        details:
+          'This model does not support the `size` option. Use `aspectRatio` instead.',
       });
     }
 
@@ -139,6 +136,6 @@ export class FireworksImageModel implements ImageModelV1 {
       fetch: this.config.fetch,
     });
 
-    return { images: [new Uint8Array(response)] };
+    return { images: [new Uint8Array(response)], warnings };
   }
 }

--- a/packages/google-vertex/src/google-vertex-image-model.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.ts
@@ -1,4 +1,4 @@
-import { ImageModelV1, ImageModelV1Warning } from '@ai-sdk/provider';
+import { ImageModelV1, ImageModelV1CallWarning } from '@ai-sdk/provider';
 import {
   Resolvable,
   combineHeaders,
@@ -49,7 +49,7 @@ export class GoogleVertexImageModel implements ImageModelV1 {
   }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
     Awaited<ReturnType<ImageModelV1['doGenerate']>>
   > {
-    const warnings: Array<ImageModelV1Warning> = [];
+    const warnings: Array<ImageModelV1CallWarning> = [];
 
     if (size != null) {
       warnings.push({

--- a/packages/google-vertex/src/google-vertex-image-model.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.ts
@@ -1,4 +1,4 @@
-import { ImageModelV1, UnsupportedFunctionalityError } from '@ai-sdk/provider';
+import { ImageModelV1, ImageModelV1Warning } from '@ai-sdk/provider';
 import {
   Resolvable,
   combineHeaders,
@@ -49,18 +49,14 @@ export class GoogleVertexImageModel implements ImageModelV1 {
   }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
     Awaited<ReturnType<ImageModelV1['doGenerate']>>
   > {
-    if (size != null) {
-      throw new UnsupportedFunctionalityError({
-        functionality: 'image size',
-        message:
-          'This model does not support the `size` option. Use `aspectRatio` instead.',
-      });
-    }
+    const warnings: Array<ImageModelV1Warning> = [];
 
-    if (n > this.maxImagesPerCall) {
-      throw new UnsupportedFunctionalityError({
-        functionality: `generate more than ${this.maxImagesPerCall} images`,
-        message: `This model does not support generating more than ${this.maxImagesPerCall} images at a time.`,
+    if (size != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'size',
+        details:
+          'This model does not support the `size` option. Use `aspectRatio` instead.',
       });
     }
 
@@ -90,6 +86,7 @@ export class GoogleVertexImageModel implements ImageModelV1 {
       images: response.predictions.map(
         (p: { bytesBase64Encoded: string }) => p.bytesBase64Encoded,
       ),
+      warnings,
     };
   }
 }

--- a/packages/openai/src/openai-image-model.test.ts
+++ b/packages/openai/src/openai-image-model.test.ts
@@ -110,7 +110,7 @@ describe('doGenerate', () => {
       n: 1,
       size: '1024x1024',
       aspectRatio: '1:1',
-      seed: undefined,
+      seed: 123,
       providerOptions: {},
     });
 
@@ -120,6 +120,10 @@ describe('doGenerate', () => {
         setting: 'aspectRatio',
         details:
           'This model does not support aspect ratio. Use `size` instead.',
+      },
+      {
+        type: 'unsupported-setting',
+        setting: 'seed',
       },
     ]);
   });

--- a/packages/openai/src/openai-image-model.test.ts
+++ b/packages/openai/src/openai-image-model.test.ts
@@ -101,4 +101,26 @@ describe('doGenerate', () => {
 
     expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
   });
+
+  it('should return warnings for unsupported settings', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: '1:1',
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    expect(result.warnings).toStrictEqual([
+      {
+        type: 'unsupported-setting',
+        setting: 'aspectRatio',
+        details:
+          'This model does not support aspect ratio. Use `size` instead.',
+      },
+    ]);
+  });
 });

--- a/packages/openai/src/openai-image-model.ts
+++ b/packages/openai/src/openai-image-model.ts
@@ -1,4 +1,4 @@
-import { ImageModelV1, ImageModelV1CallOptions } from '@ai-sdk/provider';
+import { ImageModelV1, ImageModelV1CallWarning } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createJsonResponseHandler,
@@ -47,7 +47,7 @@ export class OpenAIImageModel implements ImageModelV1 {
   }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
     Awaited<ReturnType<ImageModelV1['doGenerate']>>
   > {
-    const warnings: Array<ImageModelV1CallOptions> = [];
+    const warnings: Array<ImageModelV1CallWarning> = [];
 
     if (aspectRatio != null) {
       warnings.push({

--- a/packages/openai/src/openai-image-model.ts
+++ b/packages/openai/src/openai-image-model.ts
@@ -1,4 +1,4 @@
-import { ImageModelV1, ImageModelV1Warning } from '@ai-sdk/provider';
+import { ImageModelV1, ImageModelV1CallOptions } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createJsonResponseHandler,
@@ -47,7 +47,7 @@ export class OpenAIImageModel implements ImageModelV1 {
   }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
     Awaited<ReturnType<ImageModelV1['doGenerate']>>
   > {
-    const warnings: Array<ImageModelV1Warning> = [];
+    const warnings: Array<ImageModelV1CallOptions> = [];
 
     if (aspectRatio != null) {
       warnings.push({

--- a/packages/provider-utils/src/test/binary-test-server.ts
+++ b/packages/provider-utils/src/test/binary-test-server.ts
@@ -60,6 +60,8 @@ export class BinaryTestServer {
     beforeEach(() => {
       this.responseBody = null;
       this.request = undefined;
+      this.responseHeaders = {};
+      this.responseStatus = 200;
     });
     afterEach(() => this.server.resetHandlers());
     afterAll(() => this.server.close());

--- a/packages/provider/src/image-model/v1/image-model-v1-call-options.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1-call-options.ts
@@ -1,0 +1,60 @@
+import { JSONValue } from '../../json-value/json-value';
+
+export type ImageModelV1CallOptions = {
+  /**
+Prompt for the image generation.
+     */
+  prompt: string;
+
+  /**
+Number of images to generate.
+ */
+  n: number;
+
+  /**
+Size of the images to generate.
+Must have the format `{width}x{height}`.
+`undefined` will use the provider's default size.
+ */
+  size: `${number}x${number}` | undefined;
+
+  /**
+Aspect ratio of the images to generate.
+Must have the format `{width}:{height}`.
+`undefined` will use the provider's default aspect ratio.
+ */
+  aspectRatio: `${number}:${number}` | undefined;
+
+  /**
+Seed for the image generation.
+`undefined` will use the provider's default seed.
+ */
+  seed: number | undefined;
+
+  /**
+Additional provider-specific options that are passed through to the provider
+as body parameters.
+
+The outer record is keyed by the provider name, and the inner
+record is keyed by the provider-specific metadata key.
+```ts
+{
+"openai": {
+"style": "vivid"
+}
+}
+```
+ */
+  providerOptions: Record<string, Record<string, JSONValue>>;
+
+  /**
+Abort signal for cancelling the operation.
+ */
+  abortSignal?: AbortSignal;
+
+  /**
+Additional HTTP headers to be sent with the request.
+Only applicable for HTTP-based providers.
+ */
+  headers?: Record<string, string | undefined>;
+};

--- a/packages/provider/src/image-model/v1/image-model-v1-call-warning.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1-call-warning.ts
@@ -4,7 +4,7 @@ import { ImageModelV1CallOptions } from './image-model-v1-call-options';
 Warning from the model provider for this call. The call will proceed, but e.g.
 some settings might not be supported, which can lead to suboptimal results.
  */
-export type ImageModelV1Warning =
+export type ImageModelV1CallWarning =
   | {
       type: 'unsupported-setting';
       setting: keyof ImageModelV1CallOptions;

--- a/packages/provider/src/image-model/v1/image-model-v1-call-warning.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1-call-warning.ts
@@ -1,0 +1,16 @@
+import { ImageModelV1CallOptions } from './image-model-v1-call-options';
+
+/**
+Warning from the model provider for this call. The call will proceed, but e.g.
+some settings might not be supported, which can lead to suboptimal results.
+ */
+export type ImageModelV1Warning =
+  | {
+      type: 'unsupported-setting';
+      setting: keyof ImageModelV1CallOptions;
+      details?: string;
+    }
+  | {
+      type: 'other';
+      message: string;
+    };

--- a/packages/provider/src/image-model/v1/image-model-v1.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1.ts
@@ -1,4 +1,5 @@
-import { JSONValue } from '../../json-value/json-value';
+import { ImageModelV1CallOptions } from './image-model-v1-call-options';
+import { ImageModelV1Warning } from './image-model-v1-call-warning';
 
 /**
 Image generation model specification version 1.
@@ -32,64 +33,7 @@ If undefined, we will max generate one image per call.
   /**
 Generates an array of images.
    */
-  doGenerate(options: {
-    /**
-Prompt for the image generation.
-     */
-    prompt: string;
-
-    /**
-Number of images to generate.
-     */
-    n: number;
-
-    /**
-Size of the images to generate.
-Must have the format `{width}x{height}`.
-`undefined` will use the provider's default size.
-     */
-    size: `${number}x${number}` | undefined;
-
-    /**
-Aspect ratio of the images to generate.
-Must have the format `{width}:{height}`.
-`undefined` will use the provider's default aspect ratio.
-     */
-    aspectRatio: `${number}:${number}` | undefined;
-
-    /**
-Seed for the image generation.
-`undefined` will use the provider's default seed.
-     */
-    seed: number | undefined;
-
-    /**
-Additional provider-specific options that are passed through to the provider
-as body parameters.
-
-The outer record is keyed by the provider name, and the inner
-record is keyed by the provider-specific metadata key.
-```ts
-{
-  "openai": {
-    "style": "vivid"
-  }
-}
-```
-     */
-    providerOptions: Record<string, Record<string, JSONValue>>;
-
-    /**
-Abort signal for cancelling the operation.
-     */
-    abortSignal?: AbortSignal;
-
-    /**
-  Additional HTTP headers to be sent with the request.
-  Only applicable for HTTP-based providers.
-     */
-    headers?: Record<string, string | undefined>;
-  }): PromiseLike<{
+  doGenerate(options: ImageModelV1CallOptions): PromiseLike<{
     /**
 Generated images as base64 encoded strings or binary data.
 The images should be returned without any unnecessary conversion.
@@ -98,5 +42,10 @@ as base64 encoded strings. If the API returns binary data, the images should
 be returned as binary data.
      */
     images: Array<string> | Array<Uint8Array>;
+
+    /**
+Warnings for the call, e.g. unsupported settings.
+     */
+    warnings?: Array<ImageModelV1Warning>;
   }>;
 };

--- a/packages/provider/src/image-model/v1/image-model-v1.ts
+++ b/packages/provider/src/image-model/v1/image-model-v1.ts
@@ -1,5 +1,5 @@
 import { ImageModelV1CallOptions } from './image-model-v1-call-options';
-import { ImageModelV1Warning } from './image-model-v1-call-warning';
+import { ImageModelV1CallWarning } from './image-model-v1-call-warning';
 
 /**
 Image generation model specification version 1.
@@ -46,6 +46,6 @@ be returned as binary data.
     /**
 Warnings for the call, e.g. unsupported settings.
      */
-    warnings?: Array<ImageModelV1Warning>;
+    warnings: Array<ImageModelV1CallWarning>;
   }>;
 };

--- a/packages/provider/src/image-model/v1/index.ts
+++ b/packages/provider/src/image-model/v1/index.ts
@@ -1,2 +1,3 @@
 export type { ImageModelV1 } from './image-model-v1';
 export type { ImageModelV1CallOptions } from './image-model-v1-call-options';
+export type { ImageModelV1Warning } from './image-model-v1-call-warning';

--- a/packages/provider/src/image-model/v1/index.ts
+++ b/packages/provider/src/image-model/v1/index.ts
@@ -1,3 +1,3 @@
 export type { ImageModelV1 } from './image-model-v1';
 export type { ImageModelV1CallOptions } from './image-model-v1-call-options';
-export type { ImageModelV1Warning } from './image-model-v1-call-warning';
+export type { ImageModelV1CallWarning } from './image-model-v1-call-warning';

--- a/packages/provider/src/image-model/v1/index.ts
+++ b/packages/provider/src/image-model/v1/index.ts
@@ -1,1 +1,2 @@
-export * from './image-model-v1';
+export type { ImageModelV1 } from './image-model-v1';
+export type { ImageModelV1CallOptions } from './image-model-v1-call-options';

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -236,7 +236,10 @@ Non-HTTP(s) providers should not set this.
       body?: string;
     };
 
-    warnings?: LanguageModelV1CallWarning[];
+    /**
+Warnings for the call, e.g. unsupported settings.
+     */
+    warnings?: Array<LanguageModelV1CallWarning>;
   }>;
 };
 


### PR DESCRIPTION
## Background

Image models throw errors at the moment. However, this hinders easily changing out models. To align with language models, we switch to warnings.

## Tasks

- [x] specification changes
- [x] generateImage
- [x] provider changes
   - [x] vertex
   - [x] openai
   - [x] fireworks
- [x] documentation
   - [x] reference
   - [x] guide
- [x] changeset