### PR TITLE
fix: add tool call id to ToolExecutionError

### DIFF
--- a/content/docs/07-reference/05-ai-sdk-errors/ai-tool-execution-error.mdx
+++ b/content/docs/07-reference/05-ai-sdk-errors/ai-tool-execution-error.mdx
@@ -11,6 +11,7 @@ This error occurs when there is a failure during the execution of a tool.
 
 - `toolName`: The name of the tool that failed
 - `toolArgs`: The arguments passed to the tool
+- `toolCallId`: The ID of the tool call that failed
 - `message`: The error message
 - `cause`: The underlying error that caused the tool execution to fail
 

--- a/examples/ai-core/src/generate-text/openai-tool-execution-error.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-execution-error.ts
@@ -26,6 +26,7 @@ async function main() {
     if (ToolExecutionError.isInstance(error)) {
       console.error('Tool execution error: ' + error.message);
       console.error('Tool name: ' + error.toolName);
+      console.error('Tool call ID: ' + error.toolCallId);
       console.error('Tool args: ' + JSON.stringify(error.toolArgs));
       console.error('Cause: ' + error.cause);
     } else {

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -1402,6 +1402,7 @@ describe('tool execution errors', () => {
     }).rejects.toThrow(
       new ToolExecutionError({
         toolName: 'tool1',
+        toolCallId: 'call-1',
         toolArgs: { value: 'value' },
         cause: new Error('test error'),
       }),

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -611,6 +611,7 @@ async function executeTools<TOOLS extends Record<string, CoreTool>>({
             return result;
           } catch (error) {
             throw new ToolExecutionError({
+              toolCallId,
               toolName,
               toolArgs: args,
               cause: error,

--- a/packages/ai/core/generate-text/run-tools-transformation.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.ts
@@ -244,6 +244,7 @@ export function runToolsTransformation<TOOLS extends Record<string, CoreTool>>({
                       toolResultsStreamController!.enqueue({
                         type: 'error',
                         error: new ToolExecutionError({
+                          toolCallId: toolCall.toolCallId,
                           toolName: toolCall.toolName,
                           toolArgs: toolCall.args,
                           cause: error,

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -2812,6 +2812,7 @@ describe('streamText', () => {
           type: 'error',
           error: new ToolExecutionError({
             toolName: 'tool1',
+            toolCallId: 'call-1',
             toolArgs: { value: 'value' },
             cause: new Error('test error'),
           }),

--- a/packages/ai/errors/tool-execution-error.ts
+++ b/packages/ai/errors/tool-execution-error.ts
@@ -9,22 +9,26 @@ export class ToolExecutionError extends AISDKError {
 
   readonly toolName: string;
   readonly toolArgs: JSONValue;
+  readonly toolCallId: string;
 
   constructor({
     toolArgs,
     toolName,
+    toolCallId,
     cause,
     message = `Error executing tool ${toolName}: ${getErrorMessage(cause)}`,
   }: {
     message?: string;
     toolArgs: JSONValue;
     toolName: string;
+    toolCallId: string;
     cause: unknown;
   }) {
     super({ name, message, cause });
 
     this.toolArgs = toolArgs;
     this.toolName = toolName;
+    this.toolCallId = toolCallId;
   }
 
   static isInstance(error: unknown): error is ToolExecutionError {


### PR DESCRIPTION
The `ToolExecutionError` is missing `toolCallId` making tool error events hard to correlate back to which tool call failed exactly. This PR simply adds that to the error object.