### PR TITLE
feat(provider/openai-compatible): add support for optional custom URL parameters in requests

### DIFF
--- a/content/providers/02-openai-compatible-providers/01-custom-providers.mdx
+++ b/content/providers/02-openai-compatible-providers/01-custom-providers.mdx
@@ -73,6 +73,10 @@ Custom headers to include in the requests.
 */
   headers?: Record<string, string>;
   /**
+Optional custom url params to include in requests url.
+*/
+  params?: Record<string, string>;
+  /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
 */

--- a/packages/openai-compatible/src/openai-compatible-provider.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.test.ts
@@ -51,6 +51,7 @@ describe('OpenAICompatibleProvider', () => {
         name: 'test-provider',
         apiKey: 'test-api-key',
         headers: { 'Custom-Header': 'value' },
+        params: { 'Custom-Param': 'value' },
       };
 
       const provider = createOpenAICompatible(options);
@@ -67,7 +68,7 @@ describe('OpenAICompatibleProvider', () => {
       });
       expect(config.provider).toBe('test-provider.chat');
       expect(config.url({ modelId: 'model-id', path: '/v1/chat' })).toBe(
-        'https://api.example.com/v1/chat',
+        'https://api.example.com/v1/chat?Custom-Param=value',
       );
     });
 
@@ -98,6 +99,7 @@ describe('OpenAICompatibleProvider', () => {
       name: 'test-provider',
       apiKey: 'test-api-key',
       headers: { 'Custom-Header': 'value' },
+      params: { 'Custom-Param': 'value' },
     };
 
     it('should create chat model with correct configuration', () => {
@@ -117,7 +119,7 @@ describe('OpenAICompatibleProvider', () => {
       });
       expect(config.provider).toBe('test-provider.chat');
       expect(config.url({ modelId: 'model-id', path: '/v1/chat' })).toBe(
-        'https://api.example.com/v1/chat',
+        'https://api.example.com/v1/chat?Custom-Param=value',
       );
     });
 
@@ -139,7 +141,7 @@ describe('OpenAICompatibleProvider', () => {
       expect(config.provider).toBe('test-provider.completion');
       expect(
         config.url({ modelId: 'completion-model', path: '/v1/completions' }),
-      ).toBe('https://api.example.com/v1/completions');
+      ).toBe('https://api.example.com/v1/completions?Custom-Param=value');
     });
 
     it('should create embedding model with correct configuration', () => {
@@ -159,7 +161,7 @@ describe('OpenAICompatibleProvider', () => {
       expect(config.provider).toBe('test-provider.embedding');
       expect(
         config.url({ modelId: 'embedding-model', path: '/v1/embeddings' }),
-      ).toBe('https://api.example.com/v1/embeddings');
+      ).toBe('https://api.example.com/v1/embeddings?Custom-Param=value');
     });
 
     it('should use languageModel as default when called as function', () => {

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -66,6 +66,11 @@ after any headers potentially added by use of the `apiKey` option.
   headers?: Record<string, string>;
 
   /**
+Optional custom url params to include in requests url.
+   */
+  params?: Record<string, string>;
+
+  /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
    */
@@ -115,7 +120,15 @@ export function createOpenAICompatible<
 
   const getCommonModelConfig = (modelType: string): CommonModelConfig => ({
     provider: `${providerName}.${modelType}`,
-    url: ({ path }) => `${baseURL}${path}`,
+    url: ({ path }) => {
+      const url = new URL(`${baseURL}${path}`);
+      if (options.params) {
+        for (const [key, value] of Object.entries(options.params)) {
+          url.searchParams.set(key, value);
+        }
+      }
+      return url.toString();
+    },
     headers: getHeaders,
     fetch: options.fetch,
   });


### PR DESCRIPTION
Closes: #4339 

Azure AI Model Inference API , requires custom url params to be set for the openai compatibility API. This PR will add custom parameter called `params` to the openai compatible API provider to support this.