### PR TITLE
fix (docs): change typo 'use chat' to 'use client'

### DIFF
--- a/content/cookbook/01-next/120-stream-assistant-response.mdx
+++ b/content/cookbook/01-next/120-stream-assistant-response.mdx
@@ -11,7 +11,7 @@ tags: ['next', 'streaming', 'assistant']
 Let's create a simple chat interface that allows users to send messages to the assistant and receive responses. You will integrate the `useAssistant` hook from `ai/react` to stream the messages and status.
 
 ```tsx filename='app/page.tsx'
-'use chat';
+'use client';
 
 import { Message, useAssistant } from 'ai/react';
 


### PR DESCRIPTION

<img width="704" alt="Screen Shot 2025-01-10 at 12 29 58 PM" src="https://github.com/user-attachments/assets/98ccee75-422d-401b-9780-6dc219156d50" />

'use chat' 

should be 

'use client'