### PR TITLE
fix: expose deepseek cache usage #4333

### DIFF
--- a/packages/deepseek/src/deepseek-provider.ts
+++ b/packages/deepseek/src/deepseek-provider.ts
@@ -95,14 +95,15 @@ export function createDeepSeek(
           prompt_cache_miss_tokens: z.number().nullish(),
         })
         .nullish(),
-      getProviderMetadata(value: any, _cur: LanguageModelV1ProviderMetadata | undefined) {
+      getProviderMetadata(
+        value: any,
+        _cur: LanguageModelV1ProviderMetadata | undefined,
+      ) {
         if (value?.usage?.prompt_cache_hit_tokens != null) {
           return {
             deepseek: {
-              promptCacheHitTokens: value.usage
-                .prompt_cache_hit_tokens,
-              promptCacheMissTokens: value.usage
-                .prompt_cache_miss_tokens,
+              promptCacheHitTokens: value.usage.prompt_cache_hit_tokens,
+              promptCacheMissTokens: value.usage.prompt_cache_miss_tokens,
             },
           };
         } else {


### PR DESCRIPTION
Currently, the openai compatible provider doesn't support customizing chunkSchema and adding providerMetadata extracting logic, so it's hard to use some provider-specific data, as #4333 points out.

This PR enhances `OpenAICompatibleChatConfig`, which makes it easier to add provider-specific logic.