### PR TITLE
feat (provider/openai-compatible): add support for optional custom URL parameters in requests.

### DIFF
--- a/.changeset/serious-points-collect.md
+++ b/.changeset/serious-points-collect.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+feat (provider/openai-compatible): add support for optional custom URL parameters in requests.

--- a/content/providers/02-openai-compatible-providers/01-custom-providers.mdx
+++ b/content/providers/02-openai-compatible-providers/01-custom-providers.mdx
@@ -73,6 +73,10 @@ Custom headers to include in the requests.
 */
   headers?: Record<string, string>;
   /**
+Optional custom url params to include in requests url.
+*/
+  params?: Record<string, string>;
+  /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
 */

--- a/content/providers/02-openai-compatible-providers/01-custom-providers.mdx
+++ b/content/providers/02-openai-compatible-providers/01-custom-providers.mdx
@@ -73,9 +73,9 @@ Custom headers to include in the requests.
 */
   headers?: Record<string, string>;
   /**
-Optional custom url params to include in requests url.
+Optional custom url query parameters to include in request urls.
 */
-  params?: Record<string, string>;
+  queryParams?: Record<string, string>;
   /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
@@ -141,7 +141,13 @@ export function createExample(
 
   const getCommonModelConfig = (modelType: string): CommonModelConfig => ({
     provider: `example.${modelType}`,
-    url: ({ path }) => `${baseURL}${path}`,
+    url: ({ path }) => {
+      const url = new URL(`${baseURL}${path}`);
+      if (options.queryParams) {
+        url.search = new URLSearchParams(options.queryParams).toString();
+      }
+      return url.toString();
+    },
     headers: getHeaders,
     fetch: options.fetch,
   });

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -47,6 +47,34 @@ const provider = createOpenAICompatible({
 });
 ```
 
+You can use the following optional settings to customize the provider instance:
+
+- **baseURL** _string_
+
+  Set the URL prefix for API calls.
+
+- **apiKey** _string_
+
+  API key for authenticating requests. If specified, adds an `Authorization`
+  header to request headers with the value `Bearer <apiKey>`. This will be added
+  before any headers potentially specified in the `headers` option.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Optional custom headers to include in requests. These will be added to request headers
+  after any headers potentially added by use of the `apiKey` option.
+
+- **queryParams** _Record&lt;string,string&gt;_
+
+  Optional custom url query parameters to include in request urls.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
 ## Language Models
 
 You can create provider models using a provider instance.
@@ -116,3 +144,29 @@ const { text } = await generateText({
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
+
+### Custom query parameters
+
+Some providers may require custom query parameters. An example is the [Azure AI
+Model Inference
+API](https://learn.microsoft.com/en-us/azure/machine-learning/reference-model-inference-chat-completions?view=azureml-api-2)
+which requires an `api-version` query parameter.
+
+You can set these via the optional `queryParams` provider setting. These will be
+added to all requests made by the provider.
+
+```ts highlight="7-9"
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const provider = createOpenAICompatible({
+  name: 'provider-name',
+  apiKey: process.env.PROVIDER_API_KEY,
+  baseURL: 'https://api.provider.com/v1',
+  queryParams: {
+    'api-version': '1.0.0',
+  },
+});
+```
+
+For example, with the above configuration, API requests would include the query parameter in the URL like:
+`https://api.provider.com/v1/chat/completions?api-version=1.0.0`.

--- a/packages/openai-compatible/src/openai-compatible-provider.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.test.ts
@@ -51,6 +51,7 @@ describe('OpenAICompatibleProvider', () => {
         name: 'test-provider',
         apiKey: 'test-api-key',
         headers: { 'Custom-Header': 'value' },
+        params: { 'Custom-Param': 'value' },
       };
 
       const provider = createOpenAICompatible(options);
@@ -67,7 +68,7 @@ describe('OpenAICompatibleProvider', () => {
       });
       expect(config.provider).toBe('test-provider.chat');
       expect(config.url({ modelId: 'model-id', path: '/v1/chat' })).toBe(
-        'https://api.example.com/v1/chat',
+        'https://api.example.com/v1/chat?Custom-Param=value',
       );
     });
 
@@ -98,6 +99,7 @@ describe('OpenAICompatibleProvider', () => {
       name: 'test-provider',
       apiKey: 'test-api-key',
       headers: { 'Custom-Header': 'value' },
+      params: { 'Custom-Param': 'value' },
     };
 
     it('should create chat model with correct configuration', () => {
@@ -117,7 +119,7 @@ describe('OpenAICompatibleProvider', () => {
       });
       expect(config.provider).toBe('test-provider.chat');
       expect(config.url({ modelId: 'model-id', path: '/v1/chat' })).toBe(
-        'https://api.example.com/v1/chat',
+        'https://api.example.com/v1/chat?Custom-Param=value',
       );
     });
 
@@ -139,7 +141,7 @@ describe('OpenAICompatibleProvider', () => {
       expect(config.provider).toBe('test-provider.completion');
       expect(
         config.url({ modelId: 'completion-model', path: '/v1/completions' }),
-      ).toBe('https://api.example.com/v1/completions');
+      ).toBe('https://api.example.com/v1/completions?Custom-Param=value');
     });
 
     it('should create embedding model with correct configuration', () => {
@@ -159,7 +161,7 @@ describe('OpenAICompatibleProvider', () => {
       expect(config.provider).toBe('test-provider.embedding');
       expect(
         config.url({ modelId: 'embedding-model', path: '/v1/embeddings' }),
-      ).toBe('https://api.example.com/v1/embeddings');
+      ).toBe('https://api.example.com/v1/embeddings?Custom-Param=value');
     });
 
     it('should use languageModel as default when called as function', () => {

--- a/packages/openai-compatible/src/openai-compatible-provider.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.test.ts
@@ -51,11 +51,11 @@ describe('OpenAICompatibleProvider', () => {
         name: 'test-provider',
         apiKey: 'test-api-key',
         headers: { 'Custom-Header': 'value' },
-        params: { 'Custom-Param': 'value' },
+        queryParams: { 'Custom-Param': 'value' },
       };
 
       const provider = createOpenAICompatible(options);
-      const model = provider('model-id');
+      provider('model-id');
 
       const constructorCall =
         OpenAICompatibleChatLanguageModelMock.mock.calls[0];
@@ -99,7 +99,7 @@ describe('OpenAICompatibleProvider', () => {
       name: 'test-provider',
       apiKey: 'test-api-key',
       headers: { 'Custom-Header': 'value' },
-      params: { 'Custom-Param': 'value' },
+      queryParams: { 'Custom-Param': 'value' },
     };
 
     it('should create chat model with correct configuration', () => {
@@ -177,6 +177,25 @@ describe('OpenAICompatibleProvider', () => {
           provider: 'test-provider.chat',
           defaultObjectGenerationMode: 'tool',
         }),
+      );
+    });
+
+    it('should create URL without query parameters when queryParams is not specified', () => {
+      const options = {
+        baseURL: 'https://api.example.com',
+        name: 'test-provider',
+        apiKey: 'test-api-key',
+      };
+
+      const provider = createOpenAICompatible(options);
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[2];
+
+      expect(config.url({ modelId: 'model-id', path: '/v1/chat' })).toBe(
+        'https://api.example.com/v1/chat',
       );
     });
   });

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -66,6 +66,11 @@ after any headers potentially added by use of the `apiKey` option.
   headers?: Record<string, string>;
 
   /**
+Optional custom url params to include in requests url.
+   */
+  params?: Record<string, string>;
+
+  /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
    */
@@ -115,7 +120,15 @@ export function createOpenAICompatible<
 
   const getCommonModelConfig = (modelType: string): CommonModelConfig => ({
     provider: `${providerName}.${modelType}`,
-    url: ({ path }) => `${baseURL}${path}`,
+    url: ({ path }) => {
+      const url = new URL(`${baseURL}${path}`);
+      if (options.params) {
+        for (const [key, value] of Object.entries(options.params)) {
+          url.searchParams.set(key, value);
+        }
+      }
+      return url.toString();
+    },
     headers: getHeaders,
     fetch: options.fetch,
   });

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -66,9 +66,9 @@ after any headers potentially added by use of the `apiKey` option.
   headers?: Record<string, string>;
 
   /**
-Optional custom url params to include in requests url.
+Optional custom url query parameters to include in request urls.
    */
-  params?: Record<string, string>;
+  queryParams?: Record<string, string>;
 
   /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
@@ -122,10 +122,8 @@ export function createOpenAICompatible<
     provider: `${providerName}.${modelType}`,
     url: ({ path }) => {
       const url = new URL(`${baseURL}${path}`);
-      if (options.params) {
-        for (const [key, value] of Object.entries(options.params)) {
-          url.searchParams.set(key, value);
-        }
+      if (options.queryParams) {
+        url.search = new URLSearchParams(options.queryParams).toString();
       }
       return url.toString();
     },


### PR DESCRIPTION
Updated version of #4340. Closes #4339.

Azure AI Model Inference API requires custom url params to be set for the OpenAI compatibility API. This PR adds a provider setting `queryParams` to support this.
