### PR TITLE
feat (ui): expose useChat id and send it to the server

### DIFF
--- a/.changeset/warm-waves-call.md
+++ b/.changeset/warm-waves-call.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/ui-utils': patch
+'@ai-sdk/svelte': patch
+'@ai-sdk/react': patch
+'@ai-sdk/solid': patch
+'@ai-sdk/vue': patch
+---
+
+feat (ui): expose useChat id and send it to the server

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -136,7 +136,7 @@ Allows you to easily create a conversational user interface for your chatbot app
       name: 'generateId',
       type: '() => string',
       isOptional: true,
-      description: 'A custom id generator for messages. Optional.',
+      description: 'A custom id generator for message ids and the chat id. Optional.',
     },
     {
       name: 'headers',
@@ -189,7 +189,7 @@ Allows you to easily create a conversational user interface for your chatbot app
     },
     {
       name: 'experimental_prepareRequestBody',
-      type: '(options: { messages: Message[]; requestData?: JSONValue; requestBody?: object }) => JSONValue',
+      type: '(options: { messages: Message[]; requestData?: JSONValue; requestBody?: object, id: string }) => JSONValue',
       isOptional: true,
       description:
         'Experimental (React only). When a function is provided, it will be used to prepare the request body for the chat API. This can be useful for customizing the request body based on the messages and data in the chat.',
@@ -552,6 +552,11 @@ Allows you to easily create a conversational user interface for your chatbot app
       type: 'boolean',
       description:
         'Boolean flag indicating whether a request is currently in progress.',
+    },
+    {
+      name: 'id',
+      type: 'string',
+      description: 'The unique identifier of the chat.',
     },
     {
       name: 'data',

--- a/examples/next-openai/app/api/chat/route.ts
+++ b/examples/next-openai/app/api/chat/route.ts
@@ -6,7 +6,9 @@ export const maxDuration = 30;
 
 export async function POST(req: Request) {
   // Extract the `messages` from the body of the request
-  const { messages } = await req.json();
+  const { messages, id } = await req.json();
+
+  console.log('chat id', id); // can be used for persisting the chat
 
   // Call the language model
   const result = streamText({

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -244,7 +244,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
   }) => void;
 } {
   // Generate ID once, store in state for stability across re-renders
-  const [hookId] = useState(() => generateId());
+  const [hookId] = useState(generateId);
 
   // Use the caller-supplied ID if available; otherwise, fall back to our stable ID
   const idKey = id ?? hookId;

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -247,8 +247,8 @@ By default, it's set to 1, which means that only a single LLM call is made.
   const [hookId] = useState(generateId);
 
   // Use the caller-supplied ID if available; otherwise, fall back to our stable ID
-  const idKey = id ?? hookId;
-  const chatKey = typeof api === 'string' ? [api, idKey] : idKey;
+  const chatId = id ?? hookId;
+  const chatKey = typeof api === 'string' ? [api, chatId] : chatId;
 
   // Store a empty array as the initial messages
   // (instead of using a default parameter value that gets re-created each time)
@@ -336,7 +336,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
           experimental_prepareRequestBody,
           fetch,
           keepLastMessageOnError,
-          idKey,
+          chatId,
         );
 
         abortControllerRef.current = null;
@@ -396,7 +396,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
       fetch,
       keepLastMessageOnError,
       throttleWaitMs,
-      idKey,
+      chatId,
     ],
   );
 
@@ -578,7 +578,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
 
   return {
     messages: messages || [],
-    id: idKey,
+    id: chatId,
     setMessages,
     data: streamData,
     setData,

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -675,6 +675,7 @@ describe('prepareRequestBody', () => {
         expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
 
         expect(bodyOptions).toStrictEqual({
+          id: expect.any(String),
           messages: [
             {
               role: 'user',
@@ -1257,6 +1258,7 @@ describe('file attachments with data url', () => {
         );
 
         expect(await call(0).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [
             {
               role: 'user',
@@ -1314,6 +1316,7 @@ describe('file attachments with data url', () => {
         );
 
         expect(await call(0).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [
             {
               role: 'user',
@@ -1437,6 +1440,7 @@ describe('file attachments with url', () => {
         );
 
         expect(await call(0).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [
             {
               role: 'user',
@@ -1534,6 +1538,7 @@ describe('attachments with empty submit', () => {
         expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
 
         expect(await call(0).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [
             {
               role: 'user',
@@ -1640,6 +1645,7 @@ describe('should append message with attachments', () => {
         expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
 
         expect(await call(0).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [
             {
               role: 'user',
@@ -1729,6 +1735,7 @@ describe('reload', () => {
         await userEvent.click(screen.getByTestId('do-reload'));
 
         expect(await call(1).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [{ content: 'hi', role: 'user' }],
           data: { 'test-data-key': 'test-data-value' },
           'request-body-key': 'request-body-value',
@@ -1801,6 +1808,7 @@ describe('test sending additional fields during message submission', () => {
         expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
 
         expect(await call(0).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [
             {
               role: 'user',

--- a/packages/solid/src/use-chat.ui.test.tsx
+++ b/packages/solid/src/use-chat.ui.test.tsx
@@ -1061,6 +1061,7 @@ describe('reload', () => {
         await userEvent.click(screen.getByTestId('do-reload'));
 
         expect(await call(1).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [{ content: 'hi', role: 'user' }],
           data: { 'test-data-key': 'test-data-value' },
           'request-body-key': 'request-body-value',

--- a/packages/svelte/src/use-chat.ts
+++ b/packages/svelte/src/use-chat.ts
@@ -80,6 +80,9 @@ export type UseChatHelpers = {
       | undefined
       | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
   ) => void;
+
+  /** The id of the chat */
+  id: string;
 };
 
 const getStreamedResponse = async (
@@ -103,6 +106,7 @@ const getStreamedResponse = async (
   sendExtraMessageFields: boolean | undefined,
   fetch: FetchFunction | undefined,
   keepLastMessageOnError: boolean | undefined,
+  chatId: string,
 ) => {
   // Do an optimistic update to the chat state to show the updated messages
   // immediately.
@@ -123,6 +127,7 @@ const getStreamedResponse = async (
   return await callChatApi({
     api,
     body: {
+      id: chatId,
       messages: constructedMessagesPayload,
       data: chatRequest.data,
       ...extraMetadata.body,
@@ -216,7 +221,7 @@ export function useChat({
   }) => void;
 } {
   // Generate a unique id for the chat if not provided.
-  const chatId = id || `chat-${uniqueId++}`;
+  const chatId = id ?? generateId();
 
   const key = `${api}|${chatId}`;
   const {
@@ -284,6 +289,7 @@ export function useChat({
         sendExtraMessageFields,
         fetch,
         keepLastMessageOnError,
+        chatId,
       );
     } catch (err) {
       // Ignore abort errors as they are expected.
@@ -468,6 +474,7 @@ export function useChat({
   };
 
   return {
+    id: chatId,
     messages,
     error,
     append,

--- a/packages/ui-utils/src/types.ts
+++ b/packages/ui-utils/src/types.ts
@@ -217,7 +217,7 @@ either synchronously or asynchronously.
   onError?: (error: Error) => void;
 
   /**
-   * A way to provide a function that is going to be used for ids for messages.
+   * A way to provide a function that is going to be used for ids for messages and the chat.
    * If not provided the default AI SDK `generateId` is used.
    */
   generateId?: IdGenerator;

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -77,9 +77,10 @@ export type UseChatHelpers = {
     toolCallId: string;
     result: any;
   }) => void;
-};
 
-let uniqueId = 0;
+  /** The id of the chat */
+  id: string;
+};
 
 // @ts-expect-error - some issues with the default export of useSWRV
 const useSWRV = (swrv.default as typeof import('swrv')['default']) || swrv;
@@ -116,7 +117,7 @@ export function useChat(
   },
 ): UseChatHelpers {
   // Generate a unique ID for the chat if not provided.
-  const chatId = id || `chat-${uniqueId++}`;
+  const chatId = id ?? generateId();
 
   const key = `${api}|${chatId}`;
   const { data: messagesData, mutate: originalMutate } = useSWRV<Message[]>(
@@ -199,6 +200,7 @@ export function useChat(
       await callChatApi({
         api,
         body: {
+          id: chatId,
           messages: constructedMessagesPayload,
           data: chatRequest.data,
           ...unref(metadataBody), // Use unref to unwrap the ref value
@@ -397,6 +399,7 @@ export function useChat(
   };
 
   return {
+    id: chatId,
     messages,
     append,
     error,

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -318,6 +318,7 @@ describe('custom metadata', () => {
         await screen.findByTestId('message-1');
 
         expect(await call(0).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [{ content: 'custom metadata component', role: 'user' }],
           body1: 'value1',
           body2: 'value2',
@@ -476,6 +477,7 @@ describe('reload', () => {
         await userEvent.click(screen.getByTestId('do-reload'));
 
         expect(await call(1).getRequestBodyJson()).toStrictEqual({
+          id: expect.any(String),
           messages: [{ content: 'hi', role: 'user' }],
           data: { 'test-data-key': 'test-data-value' },
           'request-body-key': 'request-body-value',


### PR DESCRIPTION
## Background
For persistence it is necessary that the chat has a unique ID. This makes the automated id generation accessible for that purpose.

## Tasks

- [x] implementation
   - [x] react
   - [x] solid
   - [x] svelte
   - [x] vue
- [x] documentation
   - [x] reference
      - [x] id returned
      - [x] helper
- [x] changeset