### PR TITLE
feat (docs): improve replicate code snippets

### DIFF
--- a/content/providers/01-ai-sdk-providers/60-replicate.mdx
+++ b/content/providers/01-ai-sdk-providers/60-replicate.mdx
@@ -14,13 +14,13 @@ The Replicate provider is available via the `@ai-sdk/replicate` module. You can 
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm add @ai-sdk/replicate" dark />
+    <Snippet text="pnpm add ai @ai-sdk/replicate" dark />
   </Tab>
   <Tab>
-    <Snippet text="npm install @ai-sdk/replicate" dark />
+    <Snippet text="npm install ai @ai-sdk/replicate" dark />
   </Tab>
   <Tab>
-    <Snippet text="yarn add @ai-sdk/replicate" dark />
+    <Snippet text="yarn add ai @ai-sdk/replicate" dark />
   </Tab>
 </Tabs>
 
@@ -80,12 +80,17 @@ For more on image generation with the AI SDK see [generateImage()](/docs/referen
 ```ts
 import { replicate } from '@ai-sdk/replicate';
 import { experimental_generateImage as generateImage } from 'ai';
+import { writeFile } from 'node:fs/promises';
 
 const { image } = await generateImage({
   model: replicate.image('black-forest-labs/flux-schnell'),
   prompt: 'The Loch Ness Monster getting a manicure',
   aspectRatio: '16:9',
 });
+
+await writeFile('image.webp', image.uint8Array);
+
+console.log('Image saved as image.webp');
 ```
 
 ### Model-specific options


### PR DESCRIPTION
This PR makes some minor updates to the [Replicate provider docs](https://sdk.vercel.ai/providers/ai-sdk-providers/replicate): 

1. Add `ai` package to the list of npm packages to install
2. Update code example to save the generated image file.


cc @lgrammel 

---

Here's the test repo I'm using to kick the tires: https://github.com/zeke/test-vercel-ai-sdk-replicate