### PR TITLE
feat (provider/google-vertex): support prompt caching for Anthropic Claude models

### DIFF
--- a/.changeset/serious-waves-care.md
+++ b/.changeset/serious-waves-care.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/anthropic': patch
+---
+
+feat (provider/google-vertex): support prompt caching for Anthropic Claude models

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -78,9 +78,9 @@ The following optional settings are available for Anthropic models:
 
 - **cacheControl** _boolean_
 
-  Enable the Anthropic cache control beta.
+  Enable the Anthropic cache control feature.
 
-  You can then use provider metadata to set cache control breakpoints ([example](#example-cache-control))
+  You can then use provider metadata to set cache control breakpoints ([example](#cache-control))
 
 You can use Anthropic language models to generate text with the `generateText` function:
 
@@ -105,7 +105,7 @@ Anthropic language models can also be used in the `streamText`, `generateObject`
 
 ### Cache Control
 
-You can enable the cache control beta by setting the `cacheControl` option to `true` when creating the model instance.
+You can enable the cache control feature by setting the `cacheControl` option to `true` when creating the model instance.
 
 In the messages and message parts, you can then use the `experimental_providerMetadata` property to set cache control breakpoints.
 You need to set the `anthropic` property in the `experimental_providerMetadata` object to `{ cacheControl: { type: 'ephemeral' } }` to set a cache control breakpoint.
@@ -175,6 +175,8 @@ const result = await generateText({
   ],
 });
 ```
+
+For more on prompt caching with Anthropic, see [Anthropic's Cache Control documentation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
 
 ### Computer Use
 

--- a/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
@@ -766,6 +766,120 @@ You can use the following optional settings to customize the provider instance:
   You can use it as a middleware to intercept requests,
   or to provide a custom fetch implementation for e.g. testing.
 
+### Language Models
+
+You can create models that call the [Anthropic Messages API](https://docs.anthropic.com/claude/reference/messages_post) using the provider instance.
+The first argument is the model id, e.g. `claude-3-haiku-20240307`.
+Some models have multi-modal capabilities.
+
+```ts
+const model = anthropic('claude-3-haiku-20240307');
+```
+
+The following optional settings are available for Google Vertex Anthropic models:
+
+- **cacheControl** _boolean_
+
+  Enable the Anthropic cache control feature.
+
+  You can then use provider metadata to set cache control breakpoints ([example](#cache-control))
+
+You can use Anthropic language models to generate text with the `generateText` function:
+
+```ts
+import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: vertexAnthropic('claude-3-haiku-20240307'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+```
+
+Anthropic language models can also be used in the `streamText`, `generateObject`, and `streamObject` functions
+(see [AI SDK Core](/docs/ai-sdk-core) and [AI SDK RSC](/docs/ai-sdk-rsc)).
+
+<Note>
+  The Anthropic API returns streaming tool calls all at once after a delay. This
+  causes the `streamObject` function to generate the object fully after a delay
+  instead of streaming it incrementally.
+</Note>
+
+#### Cache Control
+
+You can enable the cache control feature by setting the `cacheControl` option to `true` when creating the model instance.
+
+In the messages and message parts, you can then use the `experimental_providerMetadata` property to set cache control breakpoints.
+You need to set the `anthropic` property in the `experimental_providerMetadata` object to `{ cacheControl: { type: 'ephemeral' } }` to set a cache control breakpoint.
+
+The cache creation input tokens are then returned in the `experimental_providerMetadata` object
+for `generateText` and `generateObject`, again under the `anthropic` property.
+When you use `streamText` or `streamObject`, the response contains a promise
+that resolves to the metadata. Alternatively you can receive it in the
+`onFinish` callback.
+
+```ts highlight="8,18-20,29-30"
+import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { generateText } from 'ai';
+
+const errorMessage = '... long error message ...';
+
+const result = await generateText({
+  model: vertexAnthropic('claude-3-5-sonnet-20240620', {
+    cacheControl: true,
+  }),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'You are a JavaScript expert.' },
+        {
+          type: 'text',
+          text: `Error message: ${errorMessage}`,
+          experimental_providerMetadata: {
+            anthropic: { cacheControl: { type: 'ephemeral' } },
+          },
+        },
+        { type: 'text', text: 'Explain the error message.' },
+      ],
+    },
+  ],
+});
+
+console.log(result.text);
+console.log(result.experimental_providerMetadata?.anthropic);
+// e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
+```
+
+You can also use cache control on system messages by providing multiple system messages at the head of your messages array:
+
+```ts highlight="3,9-11"
+const result = await generateText({
+  model: vertexAnthropic('claude-3-5-sonnet-20240620', {
+    cacheControl: true,
+  }),
+  messages: [
+    {
+      role: 'system',
+      content: 'Cached system message part',
+      experimental_providerMetadata: {
+        anthropic: { cacheControl: { type: 'ephemeral' } },
+      },
+    },
+    {
+      role: 'system',
+      content: 'Uncached system message part',
+    },
+    {
+      role: 'user',
+      content: 'User prompt',
+    },
+  ],
+});
+```
+
+For more on prompt caching with Anthropic, see [Google Vertex AI's Claude prompt caching documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude-prompt-caching) and [Anthropic's Cache Control documentation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
+
 ### Computer Use
 
 Anthropic provides three built-in tools that can be used to interact with external systems:

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -178,10 +178,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
     betas: Set<string>;
     headers: Record<string, string | undefined> | undefined;
   }) {
-    if (this.settings.cacheControl) {
-      betas.add('prompt-caching-2024-07-31');
-    }
-
     return combineHeaders(
       await resolve(this.config.headers),
       betas.size > 0 ? { 'anthropic-beta': Array.from(betas).join(',') } : {},

--- a/packages/anthropic/src/anthropic-messages-settings.ts
+++ b/packages/anthropic/src/anthropic-messages-settings.ts
@@ -13,8 +13,7 @@ export type AnthropicMessagesModelId =
 
 export interface AnthropicMessagesSettings {
   /**
-Enable Anthropic cache control (beta feature). This will add the beta header and
-allow you to use provider-specific cacheControl metadata.
+Enable Anthropic cache control. This will allow you to use provider-specific `cacheControl` metadata.
    */
   cacheControl?: boolean;
 }

--- a/packages/google-vertex/README.md
+++ b/packages/google-vertex/README.md
@@ -78,6 +78,60 @@ const { text } = await generateText({
 });
 ```
 
+## Prompt Caching Support for Anthropic Claude Models
+
+The Google Vertex Anthropic provider now supports prompt caching for Anthropic Claude models. Prompt caching can help reduce latency and costs by reusing cached results for identical requests. Caches are unique to Google Cloud projects and have a five-minute lifetime. Prompt caching can be enabled via the Anthropic Claude SDK or the Vertex AI REST API.
+
+### Enabling Prompt Caching
+
+To enable prompt caching, you can use the `cacheControl` property in the settings. Here is an example demonstrating how to enable prompt caching:
+
+```ts
+import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+
+const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
+
+async function main() {
+  const result = await generateText({
+    model: vertexAnthropic('claude-3-5-sonnet-v2@20241022', {
+      cacheControl: true,
+    }),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a JavaScript expert.',
+          },
+          {
+            type: 'text',
+            text: `Error message: ${errorMessage}`,
+            experimental_providerMetadata: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+          {
+            type: 'text',
+            text: 'Explain the error message.',
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(result.text);
+  console.log(result.experimental_providerMetadata?.anthropic);
+  // e.g. { cacheCreationInputTokens: 2118, cacheReadInputTokens: 0 }
+}
+
+main().catch(console.error);
+```
+
 ## Custom Provider Configuration
 
 You can create a custom provider instance using the `createVertex` function. This allows you to specify additional configuration options. Below is an example with the default Node.js provider which includes a `googleAuthOptions` object.

--- a/packages/google-vertex/README.md
+++ b/packages/google-vertex/README.md
@@ -80,7 +80,7 @@ const { text } = await generateText({
 
 ## Prompt Caching Support for Anthropic Claude Models
 
-The Google Vertex Anthropic provider now supports prompt caching for Anthropic Claude models. Prompt caching can help reduce latency and costs by reusing cached results for identical requests. Caches are unique to Google Cloud projects and have a five-minute lifetime. Prompt caching can be enabled via the Anthropic Claude SDK or the Vertex AI REST API.
+The Google Vertex Anthropic provider supports prompt caching for Anthropic Claude models. Prompt caching can help reduce latency and costs by reusing cached results for identical requests. Caches are unique to Google Cloud projects and have a five-minute lifetime.
 
 ### Enabling Prompt Caching
 

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts
@@ -11,4 +11,6 @@ export type GoogleVertexAnthropicMessagesModelId =
   | (string & {});
 
 export interface GoogleVertexAnthropicMessagesSettings
-  extends Omit<AnthropicMessagesSettings, 'cacheControl'> {}
+  extends AnthropicMessagesSettings {
+  cacheControl?: AnthropicMessagesSettings['cacheControl'];
+}

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-messages-settings.ts
@@ -11,6 +11,4 @@ export type GoogleVertexAnthropicMessagesModelId =
   | (string & {});
 
 export interface GoogleVertexAnthropicMessagesSettings
-  extends AnthropicMessagesSettings {
-  cacheControl?: AnthropicMessagesSettings['cacheControl'];
-}
+  extends AnthropicMessagesSettings {}

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -106,10 +106,11 @@ export function createVertexAnthropic(
           }`,
         transformRequestBody: args => {
           // Remove model from args and add anthropic version
-          const { model, ...rest } = args;
+          const { model, cacheControl, ...rest } = args;
           return {
             ...rest,
             anthropic_version: 'vertex-2023-10-16',
+            cache_control: cacheControl,
           };
         },
       },

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -106,11 +106,10 @@ export function createVertexAnthropic(
           }`,
         transformRequestBody: args => {
           // Remove model from args and add anthropic version
-          const { model, cacheControl, ...rest } = args;
+          const { model, ...rest } = args;
           return {
             ...rest,
             anthropic_version: 'vertex-2023-10-16',
-            cache_control: cacheControl,
           };
         },
       },


### PR DESCRIPTION
Updated version of #4269 

- caching is [out of beta](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching), from the FAQ, "Prompt caching is now generally available...". Observed behavior:
  - Anthropic supports prompt caching without the header presence
  - Vertex requires *not* passing the beta header to use caching, else it fails the request with:
```
Unexpected value(s) `prompt-caching-2024-07-31` for the `anthropic-beta` header. Please consult our documentation at docs.anthropic.com or try again without the header.`
```