### PR TITLE
feat (provider/anthropic): default cache-control on and mark model setting deprecated

### DIFF
--- a/.changeset/lemon-spoons-mix.md
+++ b/.changeset/lemon-spoons-mix.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat (provider/anthropic): default cache-control on and mark model setting deprecated

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -74,14 +74,6 @@ Some models have multi-modal capabilities.
 const model = anthropic('claude-3-haiku-20240307');
 ```
 
-The following optional settings are available for Anthropic models:
-
-- **cacheControl** _boolean_
-
-  Enable the Anthropic cache control feature.
-
-  You can then use provider metadata to set cache control breakpoints ([example](#cache-control))
-
 You can use Anthropic language models to generate text with the `generateText` function:
 
 ```ts
@@ -105,9 +97,14 @@ Anthropic language models can also be used in the `streamText`, `generateObject`
 
 ### Cache Control
 
-You can enable the cache control feature by setting the `cacheControl` option to `true` when creating the model instance.
+<Note>
+  Anthropic cache control was originally a beta feature and required passing an
+  opt-in `cacheControl` setting when creating the model instance. It is now
+  Generally Available and enabled by default. The `cacheControl` setting is no
+  longer needed and will be removed in a future release.
+</Note>
 
-In the messages and message parts, you can then use the `experimental_providerMetadata` property to set cache control breakpoints.
+In the messages and message parts, you can use the `experimental_providerMetadata` property to set cache control breakpoints.
 You need to set the `anthropic` property in the `experimental_providerMetadata` object to `{ cacheControl: { type: 'ephemeral' } }` to set a cache control breakpoint.
 
 The cache creation input tokens are then returned in the `experimental_providerMetadata` object
@@ -123,9 +120,7 @@ import { generateText } from 'ai';
 const errorMessage = '... long error message ...';
 
 const result = await generateText({
-  model: anthropic('claude-3-5-sonnet-20240620', {
-    cacheControl: true,
-  }),
+  model: anthropic('claude-3-5-sonnet-20240620'),
   messages: [
     {
       role: 'user',
@@ -153,9 +148,7 @@ You can also use cache control on system messages by providing multiple system m
 
 ```ts highlight="3,9-11"
 const result = await generateText({
-  model: anthropic('claude-3-5-sonnet-20240620', {
-    cacheControl: true,
-  }),
+  model: anthropic('claude-3-5-sonnet-20240620'),
   messages: [
     {
       role: 'system',

--- a/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
@@ -776,14 +776,6 @@ Some models have multi-modal capabilities.
 const model = anthropic('claude-3-haiku-20240307');
 ```
 
-The following optional settings are available for Google Vertex Anthropic models:
-
-- **cacheControl** _boolean_
-
-  Enable the Anthropic cache control feature.
-
-  You can then use provider metadata to set cache control breakpoints ([example](#cache-control))
-
 You can use Anthropic language models to generate text with the `generateText` function:
 
 ```ts
@@ -807,9 +799,13 @@ Anthropic language models can also be used in the `streamText`, `generateObject`
 
 #### Cache Control
 
-You can enable the cache control feature by setting the `cacheControl` option to `true` when creating the model instance.
+<Note>
+  Anthropic cache control is in a Pre-Generally Available (GA) state on Google
+  Vertex. For more see [Google Vertex Anthropic cache control
+  documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude-prompt-caching).
+</Note>
 
-In the messages and message parts, you can then use the `experimental_providerMetadata` property to set cache control breakpoints.
+In the messages and message parts, you can use the `experimental_providerMetadata` property to set cache control breakpoints.
 You need to set the `anthropic` property in the `experimental_providerMetadata` object to `{ cacheControl: { type: 'ephemeral' } }` to set a cache control breakpoint.
 
 The cache creation input tokens are then returned in the `experimental_providerMetadata` object
@@ -825,9 +821,7 @@ import { generateText } from 'ai';
 const errorMessage = '... long error message ...';
 
 const result = await generateText({
-  model: vertexAnthropic('claude-3-5-sonnet-20240620', {
-    cacheControl: true,
-  }),
+  model: vertexAnthropic('claude-3-5-sonnet-20240620'),
   messages: [
     {
       role: 'user',
@@ -855,9 +849,7 @@ You can also use cache control on system messages by providing multiple system m
 
 ```ts highlight="3,9-11"
 const result = await generateText({
-  model: vertexAnthropic('claude-3-5-sonnet-20240620', {
-    cacheControl: true,
-  }),
+  model: vertexAnthropic('claude-3-5-sonnet-20240620'),
   messages: [
     {
       role: 'system',

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -379,9 +379,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         },
       });
 
-      const model = provider('claude-3-haiku-20240307', {
-        cacheControl: true,
-      });
+      const model = provider('claude-3-haiku-20240307');
 
       const result = await model.doGenerate({
         mode: { type: 'regular' },
@@ -473,21 +471,37 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      // note: space moved to last chunk bc of trimming
       expect(await convertReadableStreamToArray(stream)).toStrictEqual([
         {
-          type: 'response-metadata',
           id: 'msg_01KfpJoAEabmH2iHRRFjQMAG',
           modelId: 'claude-3-haiku-20240307',
+          type: 'response-metadata',
         },
-        { type: 'text-delta', textDelta: 'Hello' },
-        { type: 'text-delta', textDelta: ', ' },
-        { type: 'text-delta', textDelta: 'World!' },
         {
-          type: 'finish',
+          textDelta: 'Hello',
+          type: 'text-delta',
+        },
+        {
+          textDelta: ', ',
+          type: 'text-delta',
+        },
+        {
+          textDelta: 'World!',
+          type: 'text-delta',
+        },
+        {
           finishReason: 'stop',
-          usage: { promptTokens: 17, completionTokens: 227 },
-          providerMetadata: undefined,
+          providerMetadata: {
+            anthropic: {
+              cacheCreationInputTokens: null,
+              cacheReadInputTokens: null,
+            },
+          },
+          type: 'finish',
+          usage: {
+            completionTokens: 227,
+            promptTokens: 17,
+          },
         },
       ]);
     });
@@ -600,10 +614,18 @@ describe('AnthropicMessagesLanguageModel', () => {
           args: '{"value":"Sparkle Day"}',
         },
         {
-          type: 'finish',
           finishReason: 'tool-calls',
-          usage: { promptTokens: 441, completionTokens: 65 },
-          providerMetadata: undefined,
+          providerMetadata: {
+            anthropic: {
+              cacheCreationInputTokens: null,
+              cacheReadInputTokens: null,
+            },
+          },
+          type: 'finish',
+          usage: {
+            completionTokens: 65,
+            promptTokens: 441,
+          },
         },
       ]);
     });
@@ -722,9 +744,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         ],
       };
 
-      const model = provider('claude-3-haiku-20240307', {
-        cacheControl: true,
-      });
+      const model = provider('claude-3-haiku-20240307');
 
       const { stream } = await model.doStream({
         inputFormat: 'prompt',

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -109,7 +109,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
     const { prompt: messagesPrompt, betas: messagesBetas } =
       convertToAnthropicMessagesPrompt({
         prompt,
-        cacheControl: this.settings.cacheControl ?? false,
       });
 
     const baseArgs = {
@@ -254,17 +253,13 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
         modelId: response.model ?? undefined,
       },
       warnings,
-      providerMetadata:
-        this.settings.cacheControl === true
-          ? {
-              anthropic: {
-                cacheCreationInputTokens:
-                  response.usage.cache_creation_input_tokens ?? null,
-                cacheReadInputTokens:
-                  response.usage.cache_read_input_tokens ?? null,
-              },
-            }
-          : undefined,
+      providerMetadata: {
+        anthropic: {
+          cacheCreationInputTokens:
+            response.usage.cache_creation_input_tokens ?? null,
+          cacheReadInputTokens: response.usage.cache_read_input_tokens ?? null,
+        },
+      },
       request: { body: JSON.stringify(args) },
     };
   }
@@ -413,16 +408,14 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
                 usage.promptTokens = value.message.usage.input_tokens;
                 usage.completionTokens = value.message.usage.output_tokens;
 
-                if (self.settings.cacheControl === true) {
-                  providerMetadata = {
-                    anthropic: {
-                      cacheCreationInputTokens:
-                        value.message.usage.cache_creation_input_tokens ?? null,
-                      cacheReadInputTokens:
-                        value.message.usage.cache_read_input_tokens ?? null,
-                    },
-                  };
-                }
+                providerMetadata = {
+                  anthropic: {
+                    cacheCreationInputTokens:
+                      value.message.usage.cache_creation_input_tokens ?? null,
+                    cacheReadInputTokens:
+                      value.message.usage.cache_read_input_tokens ?? null,
+                  },
+                };
 
                 controller.enqueue({
                   type: 'response-metadata',

--- a/packages/anthropic/src/anthropic-messages-settings.ts
+++ b/packages/anthropic/src/anthropic-messages-settings.ts
@@ -13,7 +13,11 @@ export type AnthropicMessagesModelId =
 
 export interface AnthropicMessagesSettings {
   /**
-Enable Anthropic cache control. This will allow you to use provider-specific `cacheControl` metadata.
-   */
+Enable Anthropic cache control. This will allow you to use provider-specific
+`cacheControl` metadata.
+
+@deprecated cache control is now enabled by default (meaning you are able to
+optionally mark content for caching) and this setting is no longer needed.
+*/
   cacheControl?: boolean;
 }

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -4,7 +4,6 @@ describe('system messages', () => {
   it('should convert a single system message into an anthropic system message', async () => {
     const result = convertToAnthropicMessagesPrompt({
       prompt: [{ role: 'system', content: 'This is a system message' }],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -22,7 +21,6 @@ describe('system messages', () => {
         { role: 'system', content: 'This is a system message' },
         { role: 'system', content: 'This is another system message' },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -53,7 +51,6 @@ describe('user messages', () => {
           ],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -93,7 +90,6 @@ describe('user messages', () => {
           ],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -134,7 +130,6 @@ describe('user messages', () => {
             ],
           },
         ],
-        cacheControl: false,
       }),
     ).toThrow('Non-PDF files in user messages');
   });
@@ -154,7 +149,6 @@ describe('user messages', () => {
             ],
           },
         ],
-        cacheControl: false,
       }),
     ).toThrow('Non-PDF files in user messages');
   });
@@ -176,7 +170,6 @@ describe('tool messages', () => {
           ],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -221,7 +214,6 @@ describe('tool messages', () => {
           ],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -270,7 +262,6 @@ describe('tool messages', () => {
           content: [{ type: 'text', text: 'This is a user message' }],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -321,7 +312,6 @@ describe('tool messages', () => {
           ],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -368,7 +358,6 @@ describe('assistant messages', () => {
           content: [{ type: 'text', text: 'assistant content  ' }],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -403,7 +392,6 @@ describe('assistant messages', () => {
           ],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -442,7 +430,6 @@ describe('assistant messages', () => {
           content: [{ type: 'text', text: 'user content 2' }],
         },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -474,7 +461,6 @@ describe('assistant messages', () => {
         { role: 'assistant', content: [{ type: 'text', text: 'World' }] },
         { role: 'assistant', content: [{ type: 'text', text: '!' }] },
       ],
-      cacheControl: false,
     });
 
     expect(result).toEqual({
@@ -509,7 +495,6 @@ describe('cache control', () => {
             },
           },
         ],
-        cacheControl: true,
       });
 
       expect(result).toEqual({
@@ -547,7 +532,6 @@ describe('cache control', () => {
             ],
           },
         ],
-        cacheControl: true,
       });
 
       expect(result).toEqual({
@@ -585,7 +569,6 @@ describe('cache control', () => {
             },
           },
         ],
-        cacheControl: true,
       });
 
       expect(result).toEqual({
@@ -633,7 +616,6 @@ describe('cache control', () => {
             ],
           },
         ],
-        cacheControl: true,
       });
 
       expect(result).toEqual({
@@ -677,7 +659,6 @@ describe('cache control', () => {
             ],
           },
         ],
-        cacheControl: true,
       });
 
       expect(result).toEqual({
@@ -719,7 +700,6 @@ describe('cache control', () => {
             },
           },
         ],
-        cacheControl: true,
       });
 
       expect(result).toEqual({
@@ -769,7 +749,6 @@ describe('cache control', () => {
             ],
           },
         ],
-        cacheControl: true,
       });
 
       expect(result).toEqual({
@@ -819,7 +798,6 @@ describe('cache control', () => {
             },
           },
         ],
-        cacheControl: true,
       });
 
       expect(result).toEqual({
@@ -841,48 +819,6 @@ describe('cache control', () => {
                   content: '{"test":"part2"}',
                   is_error: undefined,
                   cache_control: { type: 'ephemeral' },
-                },
-              ],
-            },
-          ],
-        },
-        betas: new Set(),
-      });
-    });
-  });
-
-  describe('disabled cache control', () => {
-    it('should not set cache_control on messages', async () => {
-      const result = convertToAnthropicMessagesPrompt({
-        prompt: [
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'text',
-                text: 'test',
-                providerMetadata: {
-                  anthropic: {
-                    cacheControl: { type: 'ephemeral' },
-                  },
-                },
-              },
-            ],
-          },
-        ],
-        cacheControl: false,
-      });
-
-      expect(result).toEqual({
-        prompt: {
-          messages: [
-            {
-              role: 'user',
-              content: [
-                {
-                  type: 'text',
-                  text: 'test',
-                  cache_control: undefined,
                 },
               ],
             },

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -14,10 +14,8 @@ import {
 
 export function convertToAnthropicMessagesPrompt({
   prompt,
-  cacheControl: isCacheControlEnabled,
 }: {
   prompt: LanguageModelV1Prompt;
-  cacheControl: boolean;
 }): {
   prompt: AnthropicMessagesPrompt;
   betas: Set<string>;
@@ -31,10 +29,6 @@ export function convertToAnthropicMessagesPrompt({
   function getCacheControl(
     providerMetadata: LanguageModelV1ProviderMetadata | undefined,
   ): AnthropicCacheControl | undefined {
-    if (isCacheControlEnabled === false) {
-      return undefined;
-    }
-
     const anthropic = providerMetadata?.anthropic;
 
     // allow both cacheControl and cache_control:


### PR DESCRIPTION
Follow-up to #4431 