### PR TITLE
docs: rag chatbot guide fix

### DIFF
--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -186,7 +186,7 @@ Currently, your application has one table (`resources`) which has a column (`con
 Create a new file (`lib/db/schema/embeddings.ts`) and add the following code:
 
 ```tsx filename="lib/db/schema/embeddings.ts"
-import { generateId } from 'ai';
+import { nanoid } from '@/lib/utils';
 import { index, pgTable, text, varchar, vector } from 'drizzle-orm/pg-core';
 import { resources } from './resources';
 
@@ -195,7 +195,7 @@ export const embeddings = pgTable(
   {
     id: varchar('id', { length: 191 })
       .primaryKey()
-      .$defaultFn(() => generateId()),
+      .$defaultFn(() => nanoid()),
     resourceId: varchar('resource_id', { length: 191 }).references(
       () => resources.id,
       { onDelete: 'cascade' },


### PR DESCRIPTION
This reverts an unintentional change in https://github.com/vercel/ai/pull/3481 that replaced the `nanoid()` function with `generateId()` before the AI package is installed in the guide.

Fixes: https://github.com/vercel/ai-sdk-rag-starter/issues/9