### PR TITLE
fix (docs): typo in replicate example

### DIFF
--- a/content/providers/01-ai-sdk-providers/60-replicate.mdx
+++ b/content/providers/01-ai-sdk-providers/60-replicate.mdx
@@ -39,7 +39,7 @@ and create a provider instance with your settings:
 import { createReplicate } from '@ai-sdk/replicate';
 
 const replicate = createReplicate({
-  apiKey: process.env.REPLICATE_API_TOKEN ?? '',
+  apiToken: process.env.REPLICATE_API_TOKEN ?? '',
 });
 ```
 


### PR DESCRIPTION
fix naming: apiKey to apiToken