### PR TITLE
Fix: Add ‘await’ to resolve ‘toDataStreamResponse’ property on Promise

### DIFF
--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -98,7 +98,7 @@ const openai = createOpenAI({
 export const POST = (async ({ request }) => {
   const { messages } = await request.json();
 
-  const result = streamText({
+  const result = await streamText({
     model: openai('gpt-4o'),
     messages,
   });


### PR DESCRIPTION
Fixed the error shown in the screenshot by adding await to handle the Promise correctly.

![Screenshot 2025-01-24 at 2 01 47 in the morning](https://github.com/user-attachments/assets/8d59e138-9d91-4c26-9074-eb08e846c479)
