### PR TITLE
feat (docs): document supported Replicate image models

### DIFF
--- a/content/providers/01-ai-sdk-providers/60-replicate.mdx
+++ b/content/providers/01-ai-sdk-providers/60-replicate.mdx
@@ -75,6 +75,25 @@ For more on image generation with the AI SDK see [generateImage()](/docs/referen
   `providerOptions.replicate`.
 </Note>
 
+## Supported Image Models
+
+The following image models are currently supported by the Replicate provider:
+
+- [black-forest-labs/flux-1.1-pro-ultra](https://replicate.com/black-forest-labs/flux-1.1-pro-ultra)
+- [black-forest-labs/flux-1.1-pro](https://replicate.com/black-forest-labs/flux-1.1-pro)
+- [black-forest-labs/flux-dev](https://replicate.com/black-forest-labs/flux-dev)
+- [black-forest-labs/flux-pro](https://replicate.com/black-forest-labs/flux-pro)
+- [black-forest-labs/flux-schnell](https://replicate.com/black-forest-labs/flux-schnell)
+- [ideogram-ai/ideogram-v2-turbo](https://replicate.com/ideogram-ai/ideogram-v2-turbo)
+- [ideogram-ai/ideogram-v2](https://replicate.com/ideogram-ai/ideogram-v2)
+- [luma/photon-flash](https://replicate.com/luma/photon-flash)
+- [luma/photon](https://replicate.com/luma/photon)
+- [recraft-ai/recraft-v3-svg](https://replicate.com/recraft-ai/recraft-v3-svg)
+- [recraft-ai/recraft-v3](https://replicate.com/recraft-ai/recraft-v3)
+- [stability-ai/stable-diffusion-3.5-large-turbo](https://replicate.com/stability-ai/stable-diffusion-3.5-large-turbo)
+- [stability-ai/stable-diffusion-3.5-large](https://replicate.com/stability-ai/stable-diffusion-3.5-large)
+- [stability-ai/stable-diffusion-3.5-medium](https://replicate.com/stability-ai/stable-diffusion-3.5-medium)
+
 ### Basic Usage
 
 ```ts


### PR DESCRIPTION
This pull request updates the [Replicate Provider](https://sdk.vercel.ai/providers/ai-sdk-providers/replicate) docs page with a list of supported models.

I tested that all of these models actually work with the 4.1 SDK. ⚡ 

Test code: https://github.com/zeke/vercel-ai-sdk-replicate-test

cc @lgrammel @nicoalbanese 

---

![ideogram-ai_ideogram-v2](https://github.com/user-attachments/assets/71977933-e81c-416f-896b-65950495a1c7)
