### PR TITLE
Add brace balancing to `safeParseJSON` for malformed JSON strings

### DIFF
--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -675,7 +675,10 @@ export async function generateObject<SCHEMA, RESULT>({
         }
       }
 
-      const parseResult = safeParseJSON({ text: result });
+      const parseResult = safeParseJSON({
+        text: result,
+        tryMutipleBraceVariations: true,
+      });
 
       if (!parseResult.success) {
         throw new NoObjectGeneratedError({

--- a/packages/provider-utils/src/parse-json.ts
+++ b/packages/provider-utils/src/parse-json.ts
@@ -65,6 +65,7 @@ export type ParseResult<T> =
  * Safely parses a JSON string and returns the result as an object of type `unknown`.
  *
  * @param text - The JSON string to parse.
+ * @param {boolean} tryMutipleBraceVariations - Whether to try multiple variations of the JSON string to fix potential issues with missing or extra braces.
  * @returns {object} Either an object with `success: true` and the parsed data, or an object with `success: false` and the error that occurred.
  */
 export function safeParseJSON(options: {
@@ -78,6 +79,7 @@ export function safeParseJSON(options: {
  * @template T - The type of the object to parse the JSON into.
  * @param {string} text - The JSON string to parse.
  * @param {Validator<T>} schema - The schema to use for parsing the JSON.
+ * @param {boolean} tryMutipleBraceVariations - Whether to try multiple variations of the JSON string to fix potential issues with missing or extra braces.
  * @returns An object with either a `success` flag and the parsed and typed data, or a `success` flag and an error object.
  */
 export function safeParseJSON<T>(options: {


### PR DESCRIPTION
When inferring large objects with `generateObject`, parsing sometimes fails due to AI outputs having incorrect numbers of closing braces `}`. This PR enhances `safeParseJSON` to attempt parsing with different brace configurations, adding or removing closing braces to handle malformed JSON more gracefully.

Key changes:
 - Added `generateJSONBraceVariations` to create variations of JSON strings with different brace counts
 - Modified `safeParseJSON` to attempt parsing each variation if the initial parse fails (only if the option `tryMutipleBraceVariations` is true)
 - Set `tryMutipleBraceVariations` to true in `generateObject`