### PR TITLE
fix (docs): fix heading level in replicate doc

### DIFF
--- a/content/providers/01-ai-sdk-providers/60-replicate.mdx
+++ b/content/providers/01-ai-sdk-providers/60-replicate.mdx
@@ -75,7 +75,7 @@ For more on image generation with the AI SDK see [generateImage()](/docs/referen
   `providerOptions.replicate`.
 </Note>
 
-## Supported Image Models
+### Supported Image Models
 
 The following image models are currently supported by the Replicate provider:
 


### PR DESCRIPTION
(Tiniest diff ever)

Just noticed this puppy should be indented:

![image](https://github.com/user-attachments/assets/7f70d4b8-11f0-4a7c-b819-2a72d15c137a)

cc @lgrammel @nicoalbanese 