### PR TITLE
add support for versioned replicate models

### DIFF
--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -267,4 +267,36 @@ describe('doGenerate', () => {
       },
     });
   });
+
+  it('should set version in request body for versioned models', async () => {
+    prepareResponse();
+    
+    const versionedModel = provider.image(
+      'bytedance/sdxl-lightning-4step:5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637'
+    );
+
+    await versionedModel.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    expect(server.calls[0].requestMethod).toStrictEqual('POST');
+    expect(server.calls[0].requestUrl).toStrictEqual(
+      'https://api.replicate.com/v1/predictions'
+    );
+    expect(await server.calls[0].requestBody).toStrictEqual({
+      input: {
+        prompt,
+        num_outputs: 1,
+        aspect_ratio: undefined,
+        size: undefined,
+        seed: undefined,
+      },
+      version: '5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637'
+    });
+  });
 });


### PR DESCRIPTION
This PR adds support for versioned Replicate models.

### Unversioned models

✅  The AI SDK already supports "unversioned" Replicate models. [Here's the list](https://github.com/vercel/ai/blob/8fa9cc16648e4a1d1309324ce3fcebe6eb55b66e/content/providers/01-ai-sdk-providers/60-replicate.mdx#L78-L95).

Some models on Replicate like [black-forest-labs/flux-schnell](https://replicate.com/black-forest-labs/flux-schnell) are _unversioned_. You can run them with a short model identifier like `owner/model`. Replicate staff maintains these as evergreen models, improving their performance and fixing bugs while maintaining API compatibility, so users know they're always running the latest and greatest.

Unversioned models have their own [`models.predictions.create`](https://replicate.com/docs/reference/http#models.predictions.create) HTTP API operation:

```
POST /v1/models/{owner}/{model}/predictions
```

### Versioned models

🛑 The AI SDK does not yet support "versioned" models. That's where this PR comes in!

The vast majority of models on Replicate are [versioned](https://replicate.com/docs/topics/models/versions). Each time a model author publishes changes to the model, a new version is created with a new 64-character SHA identifier. You have to specify a model's version by ID when running them with the API. 

Versioned models use the older [`predictions.create`](https://replicate.com/docs/reference/http#predictions.create)  HTTP API operation:

```
POST /v1/predictions
```

☝🏼 This endpoint expects a `version` in the body of the request.


---

## Changes

- [x] Add support for versioned models, e.g. `{owner}/{name}:{sha}`
- [x] Add a mock test for running versioned models
- [ ] Make sure the tests pass 🤞🏼 
- [ ] Document versioned models in the provider docs.

cc @lgrammel @nicoalbanese @MaxLeiter 
