### PR TITLE
added bedrock middleware adapter method

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -38,6 +38,11 @@ export interface AmazonBedrockProviderSettings {
 
   // for testing
   generateId?: () => string;
+
+  /**
+   * Middleware to modify the BedrockRuntimeClient instance.
+   */
+  bedrockMiddleware?: (client: BedrockRuntimeClient) => BedrockRuntimeClient;
 }
 
 export interface AmazonBedrockProvider extends ProviderV1 {
@@ -63,8 +68,8 @@ Create an Amazon Bedrock provider instance.
 export function createAmazonBedrock(
   options: AmazonBedrockProviderSettings = {},
 ): AmazonBedrockProvider {
-  const createBedrockRuntimeClient = () =>
-    new BedrockRuntimeClient(
+  const createBedrockRuntimeClient = () => {
+    const client = new BedrockRuntimeClient(
       options.bedrockOptions ?? {
         region: loadSetting({
           settingValue: options.region,
@@ -92,6 +97,13 @@ export function createAmazonBedrock(
         },
       },
     );
+
+    if (options.bedrockMiddleware) {
+      return options.bedrockMiddleware(client);
+    }
+
+    return client;
+  };
 
   const createChatModel = (
     modelId: BedrockChatModelId,


### PR DESCRIPTION
Allow the user to modify the Bedrock client to add a middleware. 

ex:
```ts

const provider = createAmazonBedrock({
  region: 'us-east-1',
  accessKeyId: 'test-access-key',
  secretAccessKey: 'test-secret-key',
  sessionToken: 'test-token-key',
  bedrockMiddleware: client => {
    client.middlewareStack.add(
      (next, context) => async (args: any) => {
        if (!args.request.headers) {
          args.request.headers = {};
        }

        // Add your custom headers here
        args.request.headers['Test'] = `Example`;

        return next(args);
      },
      {
        step: 'build',
        name: 'addCustomHeaders',
      },
    );

    return client;
  },
});


```

Fixes

- [4517](https://github.com/vercel/ai/discussions/4517)
- [4475](https://github.com/vercel/ai/discussions/4575)