### PR TITLE
fix (docs): fix minor typo in Groq note

### DIFF
--- a/content/providers/01-ai-sdk-providers/50-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/50-groq.mdx
@@ -117,7 +117,7 @@ const { text } = await generateText({
 | `mixtral-8x7b-32768`            | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
-  The table above lists popular models. Please see the [Grop
+  The table above lists popular models. Please see the [Groq
   docs](https://console.groq.com/docs/models) for a full list of available
   models. The table above lists popular models. You can also pass any available
   provider model ID as a string if needed.


### PR DESCRIPTION
Changes "Grop docs" to "Groq docs".