### PR TITLE
feat (provider): add image model support to provider registry

### DIFF
--- a/.changeset/hip-bikes-shop.md
+++ b/.changeset/hip-bikes-shop.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/replicate': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/luma': patch
+'@ai-sdk/fal': patch
+'ai': patch
+---
+
+feat (provider): add image model support to provider specification

--- a/.changeset/nine-balloons-matter.md
+++ b/.changeset/nine-balloons-matter.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (core): type ahead for model ids with custom provider

--- a/content/docs/03-ai-sdk-core/40-provider-management.mdx
+++ b/content/docs/03-ai-sdk-core/40-provider-management.mdx
@@ -136,3 +136,18 @@ const { embedding } = await embed({
   value: 'sunny day at the beach',
 });
 ```
+
+### Example: Use image models
+
+You can access image models by using the `imageModel` method on the registry.
+The provider id will become the prefix of the model id: `providerId:modelId`.
+
+```ts highlight={"5"}
+import { generateImage } from 'ai';
+import { registry } from './registry';
+
+const { image } = await generateImage({
+  model: registry.imageModel('openai:dall-e-3'),
+  prompt: 'A beautiful sunset over a calm ocean',
+});
+```

--- a/content/docs/07-reference/01-ai-sdk-core/40-provider-registry.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/40-provider-registry.mdx
@@ -63,6 +63,21 @@ const { embedding } = await embed({
 });
 ```
 
+### Image models
+
+You can access image models by using the `imageModel` method on the registry.
+The provider id will become the prefix of the model id: `providerId:modelId`.
+
+```ts highlight={"5"}
+import { generateImage } from 'ai';
+import { registry } from './registry';
+
+const { image } = await generateImage({
+  model: registry.imageModel('openai:dall-e-3'),
+  prompt: 'A beautiful sunset over a calm ocean',
+});
+```
+
 ## Import
 
 <Snippet
@@ -97,6 +112,11 @@ const { embedding } = await embed({
               description:
                 'A function that returns a text embedding model by its id.',
             },
+            {
+              name: 'imageModel',
+              type: '(id: string) => ImageModel',
+              description: 'A function that returns an image model by its id.',
+            },
           ],
         },
       ],
@@ -121,6 +141,12 @@ The `createProviderRegistry` function returns a `Provider` instance. It has the 
       type: '(id: string) => EmbeddingModel<string>',
       description:
         'A function that returns a text embedding model by its id (format: providerId:modelId)',
+    },
+    {
+      name: 'imageModel',
+      type: '(id: string) => ImageModel',
+      description:
+        'A function that returns an image model by its id (format: providerId:modelId)',
     },
   ]}
 />

--- a/content/docs/07-reference/01-ai-sdk-core/42-custom-provider.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/42-custom-provider.mdx
@@ -60,6 +60,13 @@ export const myOpenAI = customProvider({
         'A record of text embedding models, where keys are model IDs and values are EmbeddingModel<string> instances.',
     },
     {
+      name: 'imageModels',
+      type: 'Record<string, ImageModelV1>',
+      isOptional: true,
+      description:
+        'A record of image models, where keys are model IDs and values are ImageModelV1 instances.',
+    },
+    {
       name: 'fallbackProvider',
       type: 'Provider',
       isOptional: true,
@@ -86,6 +93,12 @@ The `createCustomProvider` function returns a `Provider` instance. It has the fo
       type: '(id: string) => EmbeddingModel<string>',
       description:
         'A function that returns a text embedding model by its id (format: providerId:modelId)',
+    },
+    {
+      name: 'imageModel',
+      type: '(id: string) => ImageModel',
+      description:
+        'A function that returns an image model by its id (format: providerId:modelId)',
     },
   ]}
 />

--- a/examples/ai-core/src/registry/generate-image.ts
+++ b/examples/ai-core/src/registry/generate-image.ts
@@ -1,0 +1,17 @@
+import { experimental_generateImage as generateImage } from 'ai';
+import 'dotenv/config';
+import fs from 'node:fs';
+import { myImageModels } from './setup-registry';
+
+async function main() {
+  const { image } = await generateImage({
+    model: myImageModels.imageModel('flux'),
+    prompt: 'The Loch Ness Monster getting a manicure',
+  });
+
+  const filename = `image-${Date.now()}.png`;
+  fs.writeFileSync(filename, image.uint8Array);
+  console.log(`Image saved to ${filename}`);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/registry/setup-registry.ts
+++ b/examples/ai-core/src/registry/setup-registry.ts
@@ -1,8 +1,11 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { xai } from '@ai-sdk/xai';
+import { fal } from '@ai-sdk/fal';
 import { groq } from '@ai-sdk/groq';
+import { luma } from '@ai-sdk/luma';
 import { mistral } from '@ai-sdk/mistral';
 import { openai } from '@ai-sdk/openai';
+import { replicate } from '@ai-sdk/replicate';
+import { xai } from '@ai-sdk/xai';
 import {
   experimental_createProviderRegistry as createProviderRegistry,
   experimental_customProvider as customProvider,
@@ -36,4 +39,12 @@ export const registry = createProviderRegistry({
   openai: myOpenAI,
   xai,
   groq,
+});
+
+export const myImageModels = customProvider({
+  imageModels: {
+    recraft: fal.imageModel('recraft-v3'),
+    photon: luma.imageModel('photon-flash-1'),
+    flux: replicate.imageModel('black-forest-labs/flux-schnell'),
+  },
 });

--- a/packages/ai/core/registry/custom-provider.ts
+++ b/packages/ai/core/registry/custom-provider.ts
@@ -1,4 +1,9 @@
-import { EmbeddingModelV1, LanguageModelV1 } from '@ai-sdk/provider';
+import {
+  EmbeddingModelV1,
+  LanguageModelV1,
+  ImageModelV1,
+  ProviderV1,
+} from '@ai-sdk/provider';
 import { Provider } from '../types';
 import { NoSuchModelError } from '@ai-sdk/provider';
 
@@ -13,17 +18,29 @@ import { NoSuchModelError } from '@ai-sdk/provider';
  *
  * @throws {NoSuchModelError} Throws when a requested model is not found and no fallback provider is available.
  */
-export function experimental_customProvider({
+export function experimental_customProvider<
+  LANGUAGE_MODELS extends Record<string, LanguageModelV1>,
+  EMBEDDING_MODELS extends Record<string, EmbeddingModelV1<string>>,
+  IMAGE_MODELS extends Record<string, ImageModelV1>,
+>({
   languageModels,
   textEmbeddingModels,
+  imageModels,
   fallbackProvider,
 }: {
-  languageModels?: Record<string, LanguageModelV1>;
-  textEmbeddingModels?: Record<string, EmbeddingModelV1<string>>;
-  fallbackProvider?: Provider;
-}): Provider {
+  languageModels?: LANGUAGE_MODELS;
+  textEmbeddingModels?: EMBEDDING_MODELS;
+  imageModels?: IMAGE_MODELS;
+  fallbackProvider?: ProviderV1;
+}): Provider & {
+  languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModelV1;
+  textEmbeddingModel(
+    modelId: ExtractModelId<EMBEDDING_MODELS>,
+  ): EmbeddingModelV1<string>;
+  imageModel(modelId: ExtractModelId<IMAGE_MODELS>): ImageModelV1;
+} {
   return {
-    languageModel(modelId: string): LanguageModelV1 {
+    languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModelV1 {
       if (languageModels != null && modelId in languageModels) {
         return languageModels[modelId];
       }
@@ -35,7 +52,9 @@ export function experimental_customProvider({
       throw new NoSuchModelError({ modelId, modelType: 'languageModel' });
     },
 
-    textEmbeddingModel(modelId: string): EmbeddingModelV1<string> {
+    textEmbeddingModel(
+      modelId: ExtractModelId<EMBEDDING_MODELS>,
+    ): EmbeddingModelV1<string> {
       if (textEmbeddingModels != null && modelId in textEmbeddingModels) {
         return textEmbeddingModels[modelId];
       }
@@ -46,5 +65,22 @@ export function experimental_customProvider({
 
       throw new NoSuchModelError({ modelId, modelType: 'textEmbeddingModel' });
     },
+
+    imageModel(modelId: ExtractModelId<IMAGE_MODELS>): ImageModelV1 {
+      if (imageModels != null && modelId in imageModels) {
+        return imageModels[modelId];
+      }
+
+      if (fallbackProvider?.imageModel) {
+        return fallbackProvider.imageModel(modelId);
+      }
+
+      throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+    },
   };
 }
+
+type ExtractModelId<MODELS extends Record<string, unknown>> = Extract<
+  keyof MODELS,
+  string
+>;

--- a/packages/ai/core/registry/provider-registry.test.ts
+++ b/packages/ai/core/registry/provider-registry.test.ts
@@ -3,6 +3,7 @@ import { MockEmbeddingModelV1 } from '../test/mock-embedding-model-v1';
 import { MockLanguageModelV1 } from '../test/mock-language-model-v1';
 import { NoSuchProviderError } from './no-such-provider-error';
 import { experimental_createProviderRegistry } from './provider-registry';
+import { MockImageModelV1 } from '../test/mock-image-model-v1';
 
 describe('languageModel', () => {
   it('should return language model from provider', () => {
@@ -125,5 +126,52 @@ describe('textEmbeddingModel', () => {
     expect(() => registry.textEmbeddingModel('model')).toThrowError(
       NoSuchModelError,
     );
+  });
+});
+
+describe('imageModel', () => {
+  it('should return image model from provider', () => {
+    const model = new MockImageModelV1();
+
+    const modelRegistry = experimental_createProviderRegistry({
+      provider: {
+        imageModel: id => {
+          expect(id).toEqual('model');
+          return model;
+        },
+        languageModel: () => null as any,
+        textEmbeddingModel: () => null as any,
+      },
+    });
+
+    expect(modelRegistry.imageModel('provider:model')).toEqual(model);
+  });
+
+  it('should throw NoSuchProviderError if provider does not exist', () => {
+    const registry = experimental_createProviderRegistry({});
+
+    expect(() => registry.imageModel('provider:model')).toThrowError(
+      NoSuchProviderError,
+    );
+  });
+
+  it('should throw NoSuchModelError if provider does not return a model', () => {
+    const registry = experimental_createProviderRegistry({
+      provider: {
+        imageModel: () => null as any,
+        languageModel: () => null as any,
+        textEmbeddingModel: () => null as any,
+      },
+    });
+
+    expect(() => registry.imageModel('provider:model')).toThrowError(
+      NoSuchModelError,
+    );
+  });
+
+  it("should throw NoSuchModelError if model id doesn't contain a colon", () => {
+    const registry = experimental_createProviderRegistry({});
+
+    expect(() => registry.imageModel('model')).toThrowError(NoSuchModelError);
   });
 });

--- a/packages/ai/core/types/provider.ts
+++ b/packages/ai/core/types/provider.ts
@@ -1,12 +1,10 @@
 import { EmbeddingModel } from './embedding-model';
 import { LanguageModel } from './language-model';
+import { ImageModel } from './image-model';
 
 /**
- * Provider for language and text embedding models.
+ * Provider for language, text embedding, and image models.
  */
-// NOTE: this matches the ProviderV1 interface in @ai-sdk/provider
-// It is re-implemented to prevent the following error:
-// "This is likely not portable. A type annotation is necessary.ts(2742)"
 export type Provider = {
   /**
   Returns the language model with the given id.
@@ -31,4 +29,14 @@ export type Provider = {
   @throws {NoSuchModelError} If no such model exists.
      */
   textEmbeddingModel(modelId: string): EmbeddingModel<string>;
+
+  /**
+  Returns the image model with the given id.
+  The model id is then passed to the provider function to get the model.
+
+  @param {string} id - The id of the model to return.
+
+  @returns {ImageModel} The image model associated with the id
+  */
+  imageModel(modelId: string): ImageModel;
 };

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -114,6 +114,14 @@ Creates a model for image generation.
     modelId: FireworksImageModelId,
     settings?: FireworksImageSettings,
   ): ImageModelV1;
+
+  /**
+Creates a model for image generation.
+*/
+  imageModel(
+    modelId: FireworksImageModelId,
+    settings?: FireworksImageSettings,
+  ): ImageModelV1;
 }
 
 const defaultBaseURL = 'https://api.fireworks.ai/inference/v1';
@@ -193,7 +201,7 @@ export function createFireworks(
   provider.languageModel = createChatModel;
   provider.textEmbeddingModel = createTextEmbeddingModel;
   provider.image = createImageModel;
-
+  provider.imageModel = createImageModel;
   return provider as FireworksProvider;
 }
 

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -45,6 +45,14 @@ Creates a model for text generation.
     modelId: GoogleVertexImageModelId,
     settings?: GoogleVertexImageSettings,
   ): ImageModelV1;
+
+  /**
+Creates a model for image generation.
+   */
+  imageModel(
+    modelId: GoogleVertexImageModelId,
+    settings?: GoogleVertexImageSettings,
+  ): ImageModelV1;
 }
 
 export interface GoogleVertexProviderSettings {
@@ -164,6 +172,7 @@ export function createVertex(
   provider.languageModel = createChatModel;
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
+  provider.imageModel = createImageModel;
 
   return provider as GoogleVertexProvider;
 }

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -95,6 +95,14 @@ Creates a model for image generation.
     modelId: OpenAIImageModelId,
     settings?: OpenAIImageSettings,
   ): ImageModelV1;
+
+  /**
+Creates a model for image generation.
+   */
+  imageModel(
+    modelId: OpenAIImageModelId,
+    settings?: OpenAIImageSettings,
+  ): ImageModelV1;
 }
 
 export interface OpenAIProviderSettings {
@@ -246,7 +254,9 @@ export function createOpenAI(
   provider.embedding = createEmbeddingModel;
   provider.textEmbedding = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
+
   provider.image = createImageModel;
+  provider.imageModel = createImageModel;
 
   return provider as OpenAIProvider;
 }

--- a/packages/provider/src/errors/no-such-model-error.ts
+++ b/packages/provider/src/errors/no-such-model-error.ts
@@ -8,7 +8,7 @@ export class NoSuchModelError extends AISDKError {
   private readonly [symbol] = true; // used in isInstance
 
   readonly modelId: string;
-  readonly modelType: 'languageModel' | 'textEmbeddingModel';
+  readonly modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel';
 
   constructor({
     errorName = name,
@@ -18,7 +18,7 @@ export class NoSuchModelError extends AISDKError {
   }: {
     errorName?: string;
     modelId: string;
-    modelType: 'languageModel' | 'textEmbeddingModel';
+    modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel';
     message?: string;
   }) {
     super({ name: errorName, message });

--- a/packages/provider/src/provider/v1/provider-v1.ts
+++ b/packages/provider/src/provider/v1/provider-v1.ts
@@ -1,4 +1,5 @@
 import { EmbeddingModelV1 } from '../../embedding-model/v1/embedding-model-v1';
+import { ImageModelV1 } from '../../image-model/v1/image-model-v1';
 import { LanguageModelV1 } from '../../language-model/v1/language-model-v1';
 
 /**
@@ -28,4 +29,14 @@ The model id is then passed to the provider function to get the model.
 @throws {NoSuchModelError} If no such model exists.
    */
   textEmbeddingModel(modelId: string): EmbeddingModelV1<string>;
+
+  /**
+Returns the image model with the given id.
+The model id is then passed to the provider function to get the model.
+
+@param {string} modelId - The id of the model to return.
+
+@returns {ImageModel} The image model associated with the id
+*/
+  readonly imageModel?: (modelId: string) => ImageModelV1;
 }

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -1,3 +1,4 @@
+import { NoSuchModelError, ProviderV1 } from '@ai-sdk/provider';
 import type { FetchFunction } from '@ai-sdk/provider-utils';
 import { loadApiKey } from '@ai-sdk/provider-utils';
 import { ReplicateImageModel } from './replicate-image-model';
@@ -31,11 +32,19 @@ or to provide a custom fetch implementation for e.g. testing.
   fetch?: FetchFunction;
 }
 
-export interface ReplicateProvider {
+export interface ReplicateProvider extends ProviderV1 {
   /**
    * Creates a Replicate image generation model.
    */
   image(
+    modelId: ReplicateImageModelId,
+    settings?: ReplicateImageSettings,
+  ): ReplicateImageModel;
+
+  /**
+   * Creates a Replicate image generation model.
+   */
+  imageModel(
     modelId: ReplicateImageModelId,
     settings?: ReplicateImageSettings,
   ): ReplicateImageModel;
@@ -47,24 +56,39 @@ export interface ReplicateProvider {
 export function createReplicate(
   options: ReplicateProviderSettings = {},
 ): ReplicateProvider {
+  const createImageModel = (
+    modelId: ReplicateImageModelId,
+    settings?: ReplicateImageSettings,
+  ) =>
+    new ReplicateImageModel(modelId, settings ?? {}, {
+      provider: 'replicate',
+      baseURL: options.baseURL ?? 'https://api.replicate.com/v1',
+      headers: {
+        Authorization: `Bearer ${loadApiKey({
+          apiKey: options.apiToken,
+          environmentVariableName: 'REPLICATE_API_TOKEN',
+          description: 'Replicate',
+        })}`,
+        ...options.headers,
+      },
+      fetch: options.fetch,
+    });
+
   return {
-    image: (
-      modelId: ReplicateImageModelId,
-      settings?: ReplicateImageSettings,
-    ) =>
-      new ReplicateImageModel(modelId, settings ?? {}, {
-        provider: 'replicate',
-        baseURL: options.baseURL ?? 'https://api.replicate.com/v1',
-        headers: {
-          Authorization: `Bearer ${loadApiKey({
-            apiKey: options.apiToken,
-            environmentVariableName: 'REPLICATE_API_TOKEN',
-            description: 'Replicate',
-          })}`,
-          ...options.headers,
-        },
-        fetch: options.fetch,
-      }),
+    image: createImageModel,
+    imageModel: createImageModel,
+    languageModel: () => {
+      throw new NoSuchModelError({
+        modelId: 'languageModel',
+        modelType: 'languageModel',
+      });
+    },
+    textEmbeddingModel: () => {
+      throw new NoSuchModelError({
+        modelId: 'textEmbeddingModel',
+        modelType: 'textEmbeddingModel',
+      });
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- type-ahead for model ids in custom provider
- image model support in custom provider and registry
- image model support on provider spec level