### PR TITLE
feat(solid): add support for prepareRequestBody in solidjs

### DIFF
--- a/content/cookbook/01-next/80-send-custom-body-from-use-chat.mdx
+++ b/content/cookbook/01-next/80-send-custom-body-from-use-chat.mdx
@@ -8,7 +8,7 @@ tags: ['next', 'chat']
 
 <Note type="warning">
   `experimental_prepareRequestBody` is an experimental feature and only
-  available in React.
+  available in React and Solid.
 </Note>
 
 By default, `useChat` sends all messages as well as information from the request to the server.

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -192,7 +192,7 @@ Allows you to easily create a conversational user interface for your chatbot app
       type: '(options: { messages: Message[]; requestData?: JSONValue; requestBody?: object, id: string }) => unknown',
       isOptional: true,
       description:
-        'Experimental (React only). When a function is provided, it will be used to prepare the request body for the chat API. This can be useful for customizing the request body based on the messages and data in the chat.',
+        'Experimental (React & Solid only). When a function is provided, it will be used to prepare the request body for the chat API. This can be useful for customizing the request body based on the messages and data in the chat.',
     },
     {
       name: 'experimental_throttle',

--- a/examples/solidstart-openai/src/routes/api/use-chat-request/index.ts
+++ b/examples/solidstart-openai/src/routes/api/use-chat-request/index.ts
@@ -1,0 +1,24 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText, Message } from 'ai';
+import { APIEvent } from '@solidjs/start/server';
+
+export const POST = async (event: APIEvent) => {
+  // Extract the `messages` from the body of the request
+  const { message } = await event.request.json();
+
+  // Implement your own logic here to add message history
+  const previousMessages: Message[] = [];
+  const messages = [...previousMessages, message];
+
+  // Call the language model
+  const result = streamText({
+    model: openai('gpt-4o-mini'),
+    messages,
+    async onFinish({ text, toolCalls, toolResults, usage, finishReason }) {
+      // Implement your own logic here, e.g. for storing messages
+    },
+  });
+
+  // Respond with the stream
+  return result.toDataStreamResponse();
+};

--- a/examples/solidstart-openai/src/routes/use-chat-request/index.tsx
+++ b/examples/solidstart-openai/src/routes/use-chat-request/index.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable @next/next/no-img-element */
+import { For } from 'solid-js';
+import { useChat } from '@ai-sdk/solid';
+import { createIdGenerator } from 'ai';
+
+export default function Chat() {
+  const {
+    input,
+    messages,
+    handleInputChange,
+    handleSubmit,
+    isLoading,
+    error,
+    stop,
+    reload,
+  } = useChat({
+    api: '/api/use-chat-request',
+    sendExtraMessageFields: true,
+    generateId: createIdGenerator({ prefix: 'msgc', size: 16 }),
+
+    experimental_prepareRequestBody({ messages }) {
+      return {
+        message: messages[messages.length - 1],
+      };
+    },
+  });
+
+  return (
+    <div class="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      <div class="flex flex-col gap-2 p-2">
+        <For each={messages()}>
+          {message => (
+            <div class="whitespace-pre-wrap">
+              {message.role === 'user' ? 'User: ' : 'AI: '}
+              {message.content}
+            </div>
+          )}
+        </For>
+      </div>
+
+      {isLoading() && (
+        <div class="mt-4 text-gray-500">
+          <div>Loading...</div>
+          <button
+            type="button"
+            class="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+            onClick={stop}
+          >
+            Stop
+          </button>
+        </div>
+      )}
+
+      {error() && (
+        <div class="mt-4">
+          <div class="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            class="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+            onClick={() => reload()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} class="fixed bottom-0 w-full max-w-md p-2">
+        <input
+          class="w-full p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          value={input()}
+          placeholder="Say something..."
+          onInput={handleInputChange}
+          disabled={isLoading()}
+        />
+      </form>
+    </div>
+  );
+}

--- a/packages/solid/src/use-chat.ts
+++ b/packages/solid/src/use-chat.ts
@@ -241,14 +241,16 @@ By default, it's set to 1, which means that only a single LLM call is made.
 export function useChat(
   rawUseChatOptions: UseChatOptions | Accessor<UseChatOptions> = {},
 ): UseChatHelpers {
+  const resolvedOptions = createMemo(() => convertToAccessorOptions(rawUseChatOptions));
+  const prepareFn = createMemo(() => {
+    const opts = resolvedOptions();
+    return opts.experimental_prepareRequestBody?.();
+  });
   const useChatOptions = createMemo(() => ({
-    ...convertToAccessorOptions(rawUseChatOptions),
-    // avoid awkward double invocation syntax so add it here.
-    experimental_prepareRequestBody: () => {
-      const options = convertToAccessorOptions(rawUseChatOptions);
-      return options.experimental_prepareRequestBody?.();
-    },
+    ...resolvedOptions(),
+    experimental_prepareRequestBody: prepareFn,
   }));
+
   const api = createMemo(() => useChatOptions().api?.() ?? '/api/chat');
   const generateId = createMemo(
     () => useChatOptions().generateId?.() ?? generateIdFunc,

--- a/packages/solid/src/use-chat.ts
+++ b/packages/solid/src/use-chat.ts
@@ -241,7 +241,9 @@ By default, it's set to 1, which means that only a single LLM call is made.
 export function useChat(
   rawUseChatOptions: UseChatOptions | Accessor<UseChatOptions> = {},
 ): UseChatHelpers {
-  const resolvedOptions = createMemo(() => convertToAccessorOptions(rawUseChatOptions));
+  const resolvedOptions = createMemo(() =>
+    convertToAccessorOptions(rawUseChatOptions),
+  );
   const prepareFn = createMemo(() => {
     const opts = resolvedOptions();
     return opts.experimental_prepareRequestBody?.();

--- a/packages/solid/src/use-chat.ui.test.tsx
+++ b/packages/solid/src/use-chat.ui.test.tsx
@@ -7,12 +7,99 @@ import {
   findByText,
   render,
   screen,
+  fireEvent,
   waitFor,
 } from '@solidjs/testing-library';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { createSignal, For } from 'solid-js';
 import { useChat } from './use-chat';
+
+describe('prepareRequestBody', () => {
+  let bodyOptions: any;
+
+  const TestComponent = () => {
+    const { messages, append, isLoading } = useChat({
+      experimental_prepareRequestBody: options => {
+        bodyOptions = options;
+        return 'test-request-body';
+      },
+    });
+
+    return (
+      <div>
+        <div data-testid="loading">{isLoading().toString()}</div>
+        <For each={messages()}>
+          {(m, idx) => (
+            <div data-testid={`message-${idx()}`}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.content}
+            </div>
+          )}
+        </For>
+
+        <button
+          data-testid="do-append"
+          onClick={() => {
+            append(
+              { role: 'user', content: 'hi' },
+              {
+                data: { 'test-data-key': 'test-data-value' },
+                body: { 'request-body-key': 'request-body-value' },
+              },
+            );
+          }}
+        />
+      </div>
+    );
+  };
+
+  beforeEach(async () => {
+    await render(() => <TestComponent />);
+  });
+
+  afterEach(() => {
+    bodyOptions = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('should use prepared request body', () =>
+    withTestServer(
+      {
+        url: '/api/chat',
+        type: 'stream-values',
+        content: ['0:"Hello"\n', '0:","\n', '0:" world"\n', '0:"."\n'],
+      },
+      async ({ call }) => {
+        fireEvent.click(screen.getByTestId('do-append'));
+
+        await screen.findByTestId('message-0');
+        expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+        expect(bodyOptions).toStrictEqual({
+          id: expect.any(String),
+          messages: [
+            {
+              role: 'user',
+              content: 'hi',
+              id: expect.any(String),
+              experimental_attachments: undefined,
+              createdAt: expect.any(Date),
+            },
+          ],
+          requestData: { 'test-data-key': 'test-data-value' },
+          requestBody: { 'request-body-key': 'request-body-value' },
+        });
+
+        expect(await call(0).getRequestBodyJson()).toBe('test-request-body');
+
+        await screen.findByTestId('message-1');
+        expect(screen.getByTestId('message-1')).toHaveTextContent(
+          'AI: Hello, world.',
+        );
+      },
+    ));
+});
 
 describe('file attachments with data url', () => {
   const TestComponent = () => {


### PR DESCRIPTION
This PR adds support for the experimental_prepareRequestBody option in SolidJS's useChat implementation, aligning it with the existing React functionality. Includes tests & documentation updates