### PR TITLE
fix (docs): update Hono examples to use the text/event-stream content type

### DIFF
--- a/content/cookbook/15-api-servers/30-hono.mdx
+++ b/content/cookbook/15-api-servers/30-hono.mdx
@@ -44,7 +44,7 @@ app.post('/', async c => {
 
   // Mark the response as a v1 data stream:
   c.header('X-Vercel-AI-Data-Stream', 'v1');
-  c.header('Content-Type', 'text/plain; charset=utf-8');
+  c.header('Content-Type', 'text/event-stream');
 
   return stream(c, stream => stream.pipe(result.toDataStream()));
 });
@@ -87,7 +87,7 @@ app.post('/stream-data', async c => {
 
   // Mark the response as a v1 data stream:
   c.header('X-Vercel-AI-Data-Stream', 'v1');
-  c.header('Content-Type', 'text/plain; charset=utf-8');
+  c.header('Content-Type', 'text/event-stream');
 
   return stream(c, stream =>
     stream.pipe(dataStream.pipeThrough(new TextEncoderStream())),
@@ -116,7 +116,7 @@ app.post('/', async c => {
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
-  c.header('Content-Type', 'text/plain; charset=utf-8');
+  c.header('Content-Type', 'text/event-stream');
 
   return stream(c, stream => stream.pipe(result.textStream));
 });

--- a/examples/hono/src/server.ts
+++ b/examples/hono/src/server.ts
@@ -42,7 +42,7 @@ app.post('/stream-data', async c => {
 
   // Mark the response as a v1 data stream:
   c.header('X-Vercel-AI-Data-Stream', 'v1');
-  c.header('Content-Type', 'text/plain; charset=utf-8');
+  c.header('Content-Type', 'text/event-stream');
 
   return stream(c, stream =>
     stream.pipe(dataStream.pipeThrough(new TextEncoderStream())),


### PR DESCRIPTION
The current documentation explicitly sets the `Content-Type` header to `text/plain`, which disables streaming functionality in browsers, defeating the purpose of streaming data. When set to `text/plain`, browsers wait for the HTTP request to complete before passing data to client-side logic.

This issue can be resolved by changing the HTTP header `Content-Type` to `text/event-stream`.