### PR TITLE
fix (ai/core): Revert "chore (core): strip internal properties from auto-complete. (#4561)"

### DIFF
--- a/.changeset/olive-mayflies-deliver.md
+++ b/.changeset/olive-mayflies-deliver.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai/core): revert '@internal' tag on function definitions due to build impacts

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -106,7 +106,7 @@ Only applicable for HTTP-based providers.
   headers?: Record<string, string>;
 
   /**
-   * @internal For test use only. May change without notice.
+   * Internal. For test use only. May change without notice.
    */
   _internal?: {
     currentDate?: () => Date;

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -183,7 +183,7 @@ functionality that can be fully encapsulated in the provider.
       experimental_providerMetadata?: ProviderMetadata;
 
       /**
-       * @internal For test use only. May change without notice.
+       * Internal. For test use only. May change without notice.
        */
       _internal?: {
         generateId?: () => string;

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -170,7 +170,7 @@ Callback that is called when the LLM response and the final object validation ar
       onFinish?: OnFinishCallback<OBJECT>;
 
       /**
-       * @internal For test use only. May change without notice.
+       * Internal. For test use only. May change without notice.
        */
       _internal?: {
         generateId?: () => string;

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -198,7 +198,7 @@ A function that attempts to repair a tool call that failed to parse.
     onStepFinish?: (event: StepResult<TOOLS>) => Promise<void> | void;
 
     /**
-     * @internal For test use only. May change without notice.
+     * Internal. For test use only. May change without notice.
      */
     _internal?: {
       generateId?: IDGenerator;

--- a/packages/ai/core/generate-text/smooth-stream.ts
+++ b/packages/ai/core/generate-text/smooth-stream.ts
@@ -24,7 +24,7 @@ export function smoothStream<TOOLS extends ToolSet>({
   delayInMs?: number | null;
   chunking?: 'word' | 'line' | RegExp;
   /**
-   * @internal For test use only. May change without notice.
+   * Internal. For test use only. May change without notice.
    */
   _internal?: {
     delay?: (delayInMs: number | null) => Promise<void>;

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -288,7 +288,7 @@ Callback that is called when each step (LLM call) is finished, including interme
     onStepFinish?: (event: StepResult<TOOLS>) => Promise<void> | void;
 
     /**
-@internal For test use only. May change without notice.
+Internal. For test use only. May change without notice.
      */
     _internal?: {
       now?: () => number;

--- a/packages/ai/core/util/simulate-readable-stream.ts
+++ b/packages/ai/core/util/simulate-readable-stream.ts
@@ -18,9 +18,6 @@ export function simulateReadableStream<T>({
   chunks: T[];
   initialDelayInMs?: number | null;
   chunkDelayInMs?: number | null;
-  /**
-   * @internal For test use only. May change without notice.
-   */
   _internal?: {
     delay?: (ms: number | null) => Promise<void>;
   };


### PR DESCRIPTION
This reverts commit dbefbfcf9d6e5a291b7f685ea354441cf07a1017.

Part of #4686 