### PR TITLE
fix (provider/mistral): Ignore Mistral reference chunks

### DIFF
--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -370,7 +370,7 @@ const mistralChatResponseSchema = z.object({
     z.object({
       message: z.object({
         role: z.literal('assistant'),
-        content: z.union([z.string(), z.array().transform(() => '')).nullable(),
+        content: z.union([z.string(), z.array(z.any()).transform(() => '')]).nullable(),
         tool_calls: z
           .array(
             z.object({
@@ -401,7 +401,7 @@ const mistralChatChunkSchema = z.object({
     z.object({
       delta: z.object({
         role: z.enum(['assistant']).optional(),
-        content: z.union([z.string(), z.array().transform(() => '')).nullish(),
+        content: z.union([z.string(), z.array(z.any()).transform(() => '')]).nullish(),
         tool_calls: z
           .array(
             z.object({

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -370,7 +370,7 @@ const mistralChatResponseSchema = z.object({
     z.object({
       message: z.object({
         role: z.literal('assistant'),
-        content: z.string().nullable(),
+        content: z.union([z.string(), z.array().transform(() => '')).nullable(),
         tool_calls: z
           .array(
             z.object({
@@ -401,7 +401,7 @@ const mistralChatChunkSchema = z.object({
     z.object({
       delta: z.object({
         role: z.enum(['assistant']).optional(),
-        content: z.string().nullish(),
+        content: z.union([z.string(), z.array().transform(() => '')).nullish(),
         tool_calls: z
           .array(
             z.object({


### PR DESCRIPTION
The new Mistral model `mistral-large-latest` integrates web search capabilities, allowing it to reference sources accurately in its responses: [References/Web Search Cookbook](https://github.com/mistralai/cookbook/blob/main/mistral/rag/mistral-reference-rag.ipynb)

While text chunks are returned as usual from the API, references use special chunk format that is not supported by the Vercel AI SDK. Parsing the response fails, and the model is practically unusable for most queries at the moment that involve looking up recent data or events.

**Normal response**
```json
{"id":"d31407ffe0de4806a8468872b1d04f61","object":"chat.completion.chunk","created":1738858716,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"content":"Vercel"},"finish_reason":null}]}
```

**Reference type response**
```json
{"id":"d31407ffe0de4806a8468872b1d04f61","object":"chat.completion.chunk","created":1738858716,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"content":[{"type":"reference","reference_ids":[1,2]}]},"finish_reason":null}]}
```

Note that the `content` is not a string anymore, but an array. This causes the Mistral Language Model to throw a validation error:
```[Error [AI_TypeValidationError]: Type validation failed: Expected string, received array; failed to parse]]```
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/ca101b81-cc06-48ae-bc9f-46337f390e00" />


**Proposed solution**
The changes in the PR allow the Vercel AI SDK to ignore these reference chunks. This makes the `mistral-large` model at least usable until it is further decided how to deal with these non-standard chunks.

Zod Playground to test the changes: [Zod Playground](https://zod-playground.vercel.app?appdata=N4IgzgxgFgpgtgQxALhALwHQHsBGArGCAFwApgAdAOwAJbqItKiYnlrMBXSgS0ZIG1MYIgCdulAOYkAlABp2GBCJEIAniUwJK66dIyitYAGZYRcEjOoBeAHzUA5Pd0ZKHADZvuYKDKoBfaRBZEAA3BDcOGDAUfhAKGjoGJhYiNnIQADUYEQgYN3T-ILiqOnpGZlZqfgoQIlUABxh05HSRGCNsllz02Vb2zspcgH1uABMwZv4ARlkAJgBdP3nC%2BeCQ7LBeShQQAGYMWf2ADhA-IA)