### PR TITLE
fix (ai/core): Add null check for OTEL attributes

### DIFF
--- a/packages/ai/core/telemetry/select-telemetry-attributes.test.ts
+++ b/packages/ai/core/telemetry/select-telemetry-attributes.test.ts
@@ -99,6 +99,7 @@ it('should handle mixed attribute types correctly', () => {
       input: { input: () => 'input value' },
       output: { output: () => 'output value' },
       undefined: undefined,
+      someNull: null,
     },
   });
   expect(result).toEqual({

--- a/packages/ai/core/telemetry/select-telemetry-attributes.ts
+++ b/packages/ai/core/telemetry/select-telemetry-attributes.ts
@@ -11,7 +11,8 @@ export function selectTelemetryAttributes({
       | AttributeValue
       | { input: () => AttributeValue | undefined }
       | { output: () => AttributeValue | undefined }
-      | undefined;
+      | undefined
+      | null;
   };
 }): Attributes {
   // when telemetry is disabled, return an empty object to avoid serialization overhead:
@@ -20,7 +21,7 @@ export function selectTelemetryAttributes({
   }
 
   return Object.entries(attributes).reduce((attributes, [key, value]) => {
-    if (value === undefined) {
+    if (value === undefined || value === null) {
       return attributes;
     }
 


### PR DESCRIPTION
My mind was boggle today when i learned that in JS `(typeof null === 'object') === true` So this helps protect from trying to access `'input' in null` which throws below