### PR TITLE
chore (docs): edit streamObject error callback highlight

### DIFF
--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -73,7 +73,7 @@ Errors become part of the stream and are not thrown to prevent e.g. servers from
 
 To log errors, you can provide an `onError` callback that is triggered when an error occurs.
 
-```tsx highlight="6-8"
+```tsx highlight="5-7"
 import { streamObject } from 'ai';
 
 const result = streamObject({


### PR DESCRIPTION
Looks like off-by-one: https://sdk.vercel.ai/docs/ai-sdk-core/generating-structured-data#onerror-callback