### PR TITLE
fix (docs): type imports in caching examples

### DIFF
--- a/content/cookbook/01-next/122-caching-middleware.mdx
+++ b/content/cookbook/01-next/122-caching-middleware.mdx
@@ -64,10 +64,10 @@ You can control the initial delay and delay between chunks by adjusting the `ini
 
 ```tsx filename='ai/middleware.ts'
 import { Redis } from '@upstash/redis';
-import type {
-  LanguageModelV1,
-  LanguageModelV1Middleware,
-  LanguageModelV1StreamPart,
+import {
+  type LanguageModelV1,
+  type LanguageModelV1Middleware,
+  type LanguageModelV1StreamPart,
   simulateReadableStream,
 } from 'ai';
 

--- a/content/docs/06-advanced/04-caching.mdx
+++ b/content/docs/06-advanced/04-caching.mdx
@@ -17,10 +17,10 @@ Let's see how you can use language model middleware to cache responses.
 
 ```ts filename="ai/middleware.ts"
 import { Redis } from '@upstash/redis';
-import type {
-  LanguageModelV1,
-  LanguageModelV1Middleware,
-  LanguageModelV1StreamPart,
+import {
+  type LanguageModelV1,
+  type LanguageModelV1Middleware,
+  type LanguageModelV1StreamPart,
   simulateReadableStream,
 } from 'ai';
 


### PR DESCRIPTION
Copying and pasting the existing examples lead to the following error

> 'simulateReadableStream' cannot be used as a value because it was imported using 'import type'.