### PR TITLE
Modified append-response-messages to prevent exceptions when messages are passed as an empty array

### DIFF
--- a/packages/ai/core/prompt/append-response-messages.ts
+++ b/packages/ai/core/prompt/append-response-messages.ts
@@ -35,7 +35,7 @@ Internal. For test use only. May change without notice.
 
     // check if the last message is an assistant message:
     const lastMessage = clonedMessages[clonedMessages.length - 1];
-    const isLastMessageAssistant = lastMessage.role === 'assistant';
+    const isLastMessageAssistant = lastMessage?.role === 'assistant';
 
     switch (role) {
       case 'assistant': // only include text in the content:


### PR DESCRIPTION
I am using this function to convert from Core Message to UI Message, and I have modified the code so that no exception occurs even when an empty array is passed to the messages parameter.