### PR TITLE
docs: Update Conflicting OpenAI Providers documentation

### DIFF
--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -566,7 +566,7 @@ The following optional settings are available for OpenAI completion models:
 | `gpt-4`                | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-3.5-turbo`        | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `o1`                   | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `o1-mini`              | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `o1-mini`              | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `o1-preview`           | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `o3-mini`              | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 


### PR DESCRIPTION
There is conflicting docs between: 
https://sdk.vercel.ai/docs/guides/o1 and https://sdk.vercel.ai/providers/ai-sdk-providers/openai under the `o1-mini` models with the latter suggesting `o1-mini` supports object generation and tool usage. The former suggests these are not available. 

This is an update to the docs to ensure consistency and avoid confusion from the capabilities of `o1-mini` when using the sdk