### PR TITLE
feat (provider/inflection-ai): Add Inflection AI as a new provider 

### DIFF
--- a/packages/inflection-ai/CHANGELOG.md
+++ b/packages/inflection-ai/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ai-sdk/inflection-ai
+
+## 1.0.0
+
+### Patch Changes
+
+- Initial release of Inflection AI provider

--- a/packages/inflection-ai/README.md
+++ b/packages/inflection-ai/README.md
@@ -1,0 +1,35 @@
+# AI SDK - Inflection AI Provider
+
+The **[Inflection AI provider](https://sdk.vercel.ai/providers/ai-sdk-providers/inflection-ai)** for the [AI SDK](https://sdk.vercel.ai/docs) contains language model support for the [Inflection AI API](https://developers.inflection.ai/).
+
+## Setup
+
+The Inflection AI provider is available in the `@ai-sdk/inflection-ai` module. You can install it with
+
+```bash
+npm i @ai-sdk/inflection-ai
+```
+
+## Provider Instance
+
+You can import the default provider instance `inflection` from `@ai-sdk/inflection-ai`:
+
+```ts
+import { inflection } from '@ai-sdk/inflection-ai';
+```
+
+## Example
+
+```ts
+import { inflection } from '@ai-sdk/inflection-ai';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: inflection('inflection_3_with_tools'),
+  prompt: 'how can I make quick chicken pho?',
+});
+```
+
+## Documentation
+
+Please check out the **[Inflection AI provider](https://sdk.vercel.ai/providers/ai-sdk-providers/inflection-ai)** for more information.

--- a/packages/inflection-ai/package.json
+++ b/packages/inflection-ai/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@ai-sdk/inflection-ai",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "rm -rf dist",
+    "lint": "eslint \"./**/*.ts*\"",
+    "type-check": "tsc --noEmit",
+    "prettier-check": "prettier --check \"./**/*.ts*\"",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "1.0.7",
+    "@ai-sdk/provider-utils": "2.1.6"
+  },
+  "devDependencies": {
+    "@types/node": "^18",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8",
+    "typescript": "5.6.3",
+    "zod": "3.23.8"
+  },
+  "peerDependencies": {
+    "zod": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://sdk.vercel.ai/docs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/ai.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/inflection-ai/src/__snapshots__/convert-to-inflection-chat-messages.test.ts.snap
+++ b/packages/inflection-ai/src/__snapshots__/convert-to-inflection-chat-messages.test.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`assistant messages > should add prefix true to trailing assistant messages 1`] = `
+[
+  {
+    "text": "Hello",
+    "type": "Human",
+  },
+  {
+    "text": "Hello!",
+    "type": "AI",
+  },
+]
+`;
+
+exports[`tool calls > should stringify arguments to tool calls 1`] = `[]`;

--- a/packages/inflection-ai/src/__snapshots__/inflection-chat-language-model.test.ts.snap
+++ b/packages/inflection-ai/src/__snapshots__/inflection-chat-language-model.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`doStream > should stream text deltas 1`] = `
+[
+  {
+    "finishReason": "stop",
+    "type": "finish",
+    "usage": {
+      "completionTokens": 0,
+      "promptTokens": 2,
+    },
+  },
+]
+`;

--- a/packages/inflection-ai/src/convert-to-inflection-chat-messages.test.ts
+++ b/packages/inflection-ai/src/convert-to-inflection-chat-messages.test.ts
@@ -1,0 +1,133 @@
+import { expect, describe, it } from 'vitest';
+import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
+import { convertToInflectionChatMessages } from './convert-to-inflection-chat-messages';
+
+describe('convertToInflectionChatMessages', () => {
+  it('should convert basic user and assistant messages', () => {
+    const result = convertToInflectionChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text' as const, text: 'Hello' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text' as const, text: 'Hi there!' }],
+      },
+    ]);
+
+    expect(result).toEqual([
+      { type: 'Human', text: 'Hello' },
+      { type: 'AI', text: 'Hi there!' },
+    ]);
+  });
+
+  it('should convert system messages to instruction type', () => {
+    const result = convertToInflectionChatMessages([
+      {
+        role: 'system',
+        content: 'Be helpful and concise.',
+      },
+    ]);
+
+    expect(result).toEqual([
+      { type: 'Instruction', text: 'Be helpful and concise.' },
+    ]);
+  });
+
+  it('should combine multiple text parts', () => {
+    const result = convertToInflectionChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text' as const, text: 'Hello ' },
+          { type: 'text' as const, text: 'world!' },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([{ type: 'Human', text: 'Hello world!' }]);
+  });
+
+  it('should throw error for image content', () => {
+    expect(() =>
+      convertToInflectionChatMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              image: new Uint8Array([1, 2, 3]),
+              mimeType: 'image/jpeg',
+            },
+          ],
+        },
+      ]),
+    ).toThrow(UnsupportedFunctionalityError);
+  });
+
+  it('should throw error for tool results', () => {
+    expect(() =>
+      convertToInflectionChatMessages([
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'tool-call-id-1',
+              toolName: 'tool-1',
+              result: { key: 'result-value' },
+            },
+          ],
+        },
+      ]),
+    ).toThrow(UnsupportedFunctionalityError);
+  });
+
+  it('should skip empty messages', () => {
+    const result = convertToInflectionChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text' as const, text: '' }],
+      },
+    ]);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('tool calls', () => {
+  it('should throw error for tool calls', () => {
+    expect(() =>
+      convertToInflectionChatMessages([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              args: { key: 'arg-value' },
+              toolCallId: 'tool-call-id-1',
+              toolName: 'tool-1',
+            },
+          ],
+        },
+      ]),
+    ).toThrow(UnsupportedFunctionalityError);
+  });
+});
+
+describe('assistant messages', () => {
+  it('should add prefix true to trailing assistant messages', () => {
+    const result = convertToInflectionChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text' as const, text: 'Hello' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text' as const, text: 'Hello!' }],
+      },
+    ]);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/inflection-ai/src/convert-to-inflection-chat-messages.ts
+++ b/packages/inflection-ai/src/convert-to-inflection-chat-messages.ts
@@ -1,0 +1,109 @@
+import {
+  LanguageModelV1Prompt,
+  LanguageModelV1TextPart,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
+
+/**
+ * Represents a message in the Inflection AI format
+ */
+export interface InflectionMessage {
+  /** The type of the message sender */
+  type: 'Human' | 'AI' | 'Instruction';
+  /** The text content of the message */
+  text: string;
+  /** Optional timestamp in seconds since epoch */
+  ts?: number;
+}
+
+export type InflectionContext = InflectionMessage[];
+
+/**
+ * Converts a Language Model prompt to Inflection AI's context format
+ * @param prompt The input prompt in the Language Model format
+ * @returns An array of messages in Inflection AI's format
+ * @throws {UnsupportedFunctionalityError} If the prompt contains unsupported content types
+ */
+export function convertToInflectionChatMessages(
+  prompt: LanguageModelV1Prompt,
+): InflectionContext {
+  const context: InflectionContext = [];
+
+  for (const { role, content } of prompt) {
+    let text = '';
+
+    if (typeof content === 'string') {
+      text = content;
+    } else {
+      // Combine all text parts into a single string
+      for (const part of content) {
+        switch (part.type) {
+          case 'text': {
+            text += part.text;
+            break;
+          }
+          case 'image': {
+            throw new UnsupportedFunctionalityError({
+              functionality:
+                'Image content parts are not supported by Inflection AI at this time',
+            });
+          }
+          case 'file': {
+            throw new UnsupportedFunctionalityError({
+              functionality:
+                'File content parts are not supported by Inflection AI at this time',
+            });
+          }
+          case 'tool-call': {
+            throw new UnsupportedFunctionalityError({
+              functionality:
+                'Tool calls are not supported by Inflection AI at this time',
+            });
+          }
+          case 'tool-result': {
+            throw new UnsupportedFunctionalityError({
+              functionality:
+                'Tool results are not supported by Inflection AI at this time',
+            });
+          }
+          default: {
+            const _exhaustiveCheck: never = part;
+            throw new Error(
+              `Unsupported content part type: ${_exhaustiveCheck}`,
+            );
+          }
+        }
+      }
+    }
+
+    if (!text) {
+      continue; // Skip empty messages
+    }
+
+    // Map the role to Inflection's expected type
+    switch (role) {
+      case 'user': {
+        context.push({ type: 'Human', text });
+        break;
+      }
+      case 'assistant': {
+        context.push({ type: 'AI', text });
+        break;
+      }
+      case 'system': {
+        context.push({ type: 'Instruction', text });
+        break;
+      }
+      case 'tool': {
+        // Tool responses are handled as part of the content processing above
+        break;
+      }
+      default: {
+        const _exhaustiveCheck: never = role;
+        throw new Error(`Unsupported role: ${_exhaustiveCheck}`);
+      }
+    }
+  }
+
+  return context;
+}

--- a/packages/inflection-ai/src/get-response-metadata.ts
+++ b/packages/inflection-ai/src/get-response-metadata.ts
@@ -1,0 +1,15 @@
+export function getResponseMetadata({
+  id,
+  model,
+  created,
+}: {
+  id?: string | undefined | null;
+  created?: number | undefined | null;
+  model?: string | undefined | null;
+}) {
+  return {
+    id: id ?? undefined,
+    modelId: model ?? undefined,
+    timestamp: created != null ? new Date(created * 1000) : undefined,
+  };
+}

--- a/packages/inflection-ai/src/index.ts
+++ b/packages/inflection-ai/src/index.ts
@@ -1,0 +1,9 @@
+export { createInflection, inflection } from './inflection-provider';
+export type {
+  InflectionProvider,
+  InflectionProviderSettings,
+} from './inflection-provider';
+export type {
+  InflectionChatModelId,
+  InflectionChatSettings,
+} from './inflection-chat-settings';

--- a/packages/inflection-ai/src/inflection-chat-language-model.test.ts
+++ b/packages/inflection-ai/src/inflection-chat-language-model.test.ts
@@ -1,0 +1,146 @@
+import { expect, describe, it, beforeEach } from 'vitest';
+import { LanguageModelV1Prompt } from '@ai-sdk/provider';
+import {
+  createTestServer,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
+import { createInflection } from './inflection-provider';
+
+const TEST_PROMPT: LanguageModelV1Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+const INFERENCE_URL =
+  'https://layercake.pubwestus3.inf7ks8.com/external/api/inference';
+const STREAMING_URL = `${INFERENCE_URL}/streaming`;
+
+/**
+ * Test server for mocking API responses
+ */
+const server = createTestServer({
+  [INFERENCE_URL]: {
+    response: {
+      type: 'json-value',
+      body: {
+        created: 1714688002.0557644,
+        text: 'Hello there!',
+      },
+    },
+  },
+  [STREAMING_URL]: {
+    response: {
+      type: 'stream-chunks',
+      chunks: [
+        '{"created": 1728094708.2514212, "idx": 0, "text": "Hello"}',
+        '{"created": 1728094708.5789802, "idx": 1, "text": " there"}',
+        '{"created": 1728094708.7364252, "idx": 2, "text": "!"}',
+      ],
+    },
+  },
+});
+
+beforeEach(() => {
+  // Reset the test server before each test
+  server.urls[INFERENCE_URL].response = {
+    type: 'json-value',
+    body: {
+      created: 1714688002.0557644,
+      text: 'Hello there!',
+    },
+  };
+  server.urls[STREAMING_URL].response = {
+    type: 'stream-chunks',
+    chunks: [
+      '{"created": 1728094708.2514212, "idx": 0, "text": "Hello"}',
+      '{"created": 1728094708.5789802, "idx": 1, "text": " there"}',
+      '{"created": 1728094708.7364252, "idx": 2, "text": "!"}',
+    ],
+  };
+});
+
+const provider = createInflection({
+  apiKey: 'test-api-key',
+  baseURL: INFERENCE_URL,
+});
+
+const model = provider.chat('inflection_3_pi');
+
+describe('doGenerate', () => {
+  it('should extract text response', async () => {
+    server.urls[INFERENCE_URL].response = {
+      type: 'json-value',
+      body: {
+        created: 1714688002.0557644,
+        text: 'Hello there!',
+      },
+    };
+
+    const result = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.text).toBe('Hello there!');
+  });
+
+  it('should throw error when trying to use tools', async () => {
+    await expect(
+      model.doGenerate({
+        inputFormat: 'prompt',
+        mode: {
+          type: 'regular',
+          tools: [
+            {
+              type: 'function',
+              name: 'weatherTool',
+              description: 'Get weather information',
+              parameters: { type: 'object', properties: {} },
+            },
+          ],
+        },
+        prompt: TEST_PROMPT,
+      }),
+    ).rejects.toThrow('Tool calls are not supported by Inflection AI');
+  });
+
+  it('should extract usage', async () => {
+    server.urls[INFERENCE_URL].response = {
+      type: 'json-value',
+      body: {
+        created: 1714688002.0557644,
+        text: 'Hello there!',
+      },
+    };
+
+    const { usage } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    // Since Inflection API doesn't return usage info, we should expect undefined or estimated values
+    expect(usage).toStrictEqual({
+      promptTokens: expect.any(Number),
+      completionTokens: expect.any(Number),
+    });
+  });
+});
+
+describe('doStream', () => {
+  it('should stream text deltas', async () => {
+    server.urls[STREAMING_URL].response = {
+      type: 'stream-chunks',
+      chunks: ['Hello', ' there', '!'],
+    };
+
+    const result = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    const parts = await convertReadableStreamToArray(result.stream);
+    expect(parts).toMatchSnapshot();
+  });
+});

--- a/packages/inflection-ai/src/inflection-chat-language-model.ts
+++ b/packages/inflection-ai/src/inflection-chat-language-model.ts
@@ -1,0 +1,220 @@
+import {
+  LanguageModelV1,
+  LanguageModelV1CallWarning,
+  LanguageModelV1FinishReason,
+  LanguageModelV1StreamPart,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
+import {
+  FetchFunction,
+  ParseResult,
+  combineHeaders,
+  createEventSourceResponseHandler,
+  createJsonResponseHandler,
+  postJsonToApi,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+import { convertToInflectionChatMessages } from './convert-to-inflection-chat-messages';
+import {
+  InflectionChatModelId,
+  InflectionChatSettings,
+} from './inflection-chat-settings';
+import { inflectionFailedResponseHandler } from './inflection-error';
+import { getResponseMetadata } from './get-response-metadata';
+
+type InflectionChatConfig = {
+  provider: string;
+  baseURL: string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+};
+
+export class InflectionChatLanguageModel implements LanguageModelV1 {
+  readonly specificationVersion = 'v1';
+  readonly defaultObjectGenerationMode = 'json';
+  readonly supportsImageUrls = false;
+
+  readonly modelId: InflectionChatModelId;
+  readonly settings: InflectionChatSettings;
+
+  private readonly config: InflectionChatConfig;
+
+  constructor(
+    modelId: InflectionChatModelId,
+    settings: InflectionChatSettings,
+    config: InflectionChatConfig,
+  ) {
+    this.modelId = modelId;
+    this.settings = settings;
+    this.config = config;
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  private getArgs({
+    mode,
+    prompt,
+    maxTokens,
+    temperature,
+    topP,
+    stopSequences,
+    seed,
+  }: Parameters<LanguageModelV1['doGenerate']>[0]) {
+    const type = mode.type;
+    const warnings: LanguageModelV1CallWarning[] = [];
+
+    // Throw error if trying to use tool-related modes
+    if (type === 'object-tool' || (type === 'regular' && mode.tools?.length)) {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'Tool calls are not supported by Inflection AI',
+      });
+    }
+
+    const baseArgs = {
+      // config instead of model:
+      config: this.modelId,
+
+      // standardized settings:
+      max_tokens: maxTokens,
+      temperature,
+      top_p: topP,
+      stop_tokens: stopSequences,
+      web_search: this.settings.web_search,
+
+      // metadata if provided:
+      metadata: this.settings.metadata,
+
+      // context (messages):
+      context: convertToInflectionChatMessages(prompt),
+    };
+
+    return { args: baseArgs, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<LanguageModelV1['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
+    const { args, warnings } = this.getArgs(options);
+
+    const { responseHeaders, value: response } = await postJsonToApi({
+      url: this.config.baseURL,
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body: args,
+      failedResponseHandler: inflectionFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        inflectionChatResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const { context: rawPrompt, ...rawSettings } = args;
+
+    // Estimate token counts since API doesn't provide them
+    const promptText = rawPrompt.map(m => m.text).join('');
+    const promptTokens = Math.ceil(promptText.length / 4);
+    const completionTokens = Math.ceil(response.text.length / 4);
+
+    return {
+      text: response.text,
+      finishReason: 'stop',
+      usage: {
+        promptTokens,
+        completionTokens,
+      },
+      rawCall: { rawPrompt, rawSettings },
+      rawResponse: { headers: responseHeaders },
+      request: { body: JSON.stringify(args) },
+      response: getResponseMetadata(response),
+      warnings,
+    };
+  }
+
+  async doStream(
+    options: Parameters<LanguageModelV1['doStream']>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV1['doStream']>>> {
+    const { args, warnings } = this.getArgs(options);
+
+    const body = { ...args, stream: true };
+
+    const { responseHeaders, value: response } = await postJsonToApi({
+      url: `${this.config.baseURL}/streaming`,
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body,
+      failedResponseHandler: inflectionFailedResponseHandler,
+      successfulResponseHandler: createEventSourceResponseHandler(
+        inflectionChatChunkSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const { context: rawPrompt, ...rawSettings } = args;
+
+    let finishReason: LanguageModelV1FinishReason = 'stop';
+    const promptText = rawPrompt.map(m => m.text).join('');
+    const promptTokens = Math.ceil(promptText.length / 4);
+    let completionTokens = 0;
+
+    return {
+      stream: response.pipeThrough(
+        new TransformStream<
+          ParseResult<z.infer<typeof inflectionChatChunkSchema>>,
+          LanguageModelV1StreamPart
+        >({
+          transform(chunk, controller) {
+            if (!chunk.success) {
+              controller.enqueue({ type: 'error', error: chunk.error });
+              return;
+            }
+
+            const value = chunk.value;
+            completionTokens += Math.ceil(value.text.length / 4);
+
+            if (chunk.value.idx === 0) {
+              controller.enqueue({
+                type: 'response-metadata',
+                timestamp: new Date(value.created * 1000),
+              });
+            }
+
+            controller.enqueue({
+              type: 'text-delta',
+              textDelta: value.text,
+            });
+          },
+
+          flush(controller) {
+            controller.enqueue({
+              type: 'finish',
+              finishReason,
+              usage: {
+                promptTokens,
+                completionTokens,
+              },
+            });
+          },
+        }),
+      ),
+      rawCall: { rawPrompt, rawSettings },
+      rawResponse: { headers: responseHeaders },
+      request: { body: JSON.stringify(body) },
+      warnings,
+    };
+  }
+}
+
+// limited version of the schema, focussed on what is needed for the implementation
+const inflectionChatResponseSchema = z.object({
+  created: z.number(),
+  text: z.string(),
+});
+
+// limited version of the schema, focussed on what is needed for the implementation
+const inflectionChatChunkSchema = z.object({
+  created: z.number(),
+  idx: z.number(),
+  text: z.string(),
+});

--- a/packages/inflection-ai/src/inflection-chat-settings.ts
+++ b/packages/inflection-ai/src/inflection-chat-settings.ts
@@ -1,0 +1,51 @@
+// https://developers.inflection.ai/docs
+export type InflectionChatModelId =
+  | 'inflection_3_with_tools'
+  | 'inflection_3_pi'
+  | 'inflection_3_productivity'
+  | (string & {});
+
+export interface InflectionChatSettings {
+  /**
+   * Optional metadata about the user that the AI can utilize
+   */
+  metadata?: {
+    /** The user's first name */
+    user_firstname?: string;
+    /** The user's timezone, e.g. "America/Los_Angeles" */
+    user_timezone?: string;
+    /** The user's country, e.g. England */
+    user_country?: string;
+    /** The user's region within their country, e.g. "CA" for California */
+    user_region?: string;
+    /** The user's city, e.g. "San Francisco" */
+    user_city?: string;
+  };
+
+  /**
+   * Whether to allow web search. Defaults to true.
+   */
+  web_search?: boolean;
+
+  /**
+   * Controls randomness in the model's output. Higher values (e.g., 0.8) make the
+   * output more random, while lower values (e.g., 0.2) make it more deterministic.
+   * Defaults to 1.0.
+   */
+  temperature?: number;
+
+  /**
+   * Sequences that will cause the model to stop generating further tokens.
+   */
+  stop_tokens?: string[];
+
+  /**
+   * The maximum number of tokens to generate. Defaults to 1024.
+   */
+  max_tokens?: number;
+
+  /**
+   * Controls diversity via nucleus sampling. Defaults to 0.95.
+   */
+  top_p?: number;
+}

--- a/packages/inflection-ai/src/inflection-error.ts
+++ b/packages/inflection-ai/src/inflection-error.ts
@@ -1,0 +1,17 @@
+import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+
+const inflectionErrorDataSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    type: z.string(),
+    code: z.string().nullable(),
+  }),
+});
+
+export type InflectionErrorData = z.infer<typeof inflectionErrorDataSchema>;
+
+export const inflectionFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: inflectionErrorDataSchema,
+  errorToMessage: data => data.error.message,
+});

--- a/packages/inflection-ai/src/inflection-prepare-tools.ts
+++ b/packages/inflection-ai/src/inflection-prepare-tools.ts
@@ -1,0 +1,93 @@
+import {
+  LanguageModelV1,
+  LanguageModelV1CallWarning,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
+
+export function prepareTools(
+  mode: Parameters<LanguageModelV1['doGenerate']>[0]['mode'] & {
+    type: 'regular';
+  },
+): {
+  tools:
+    | Array<{
+        type: 'function';
+        function: {
+          name: string;
+          description: string | undefined;
+          parameters: unknown;
+        };
+      }>
+    | undefined;
+  tool_choice:
+    | { type: 'function'; function: { name: string } }
+    | 'auto'
+    | 'none'
+    | 'any'
+    | undefined;
+  toolWarnings: LanguageModelV1CallWarning[];
+} {
+  // when the tools array is empty, change it to undefined to prevent errors:
+  const tools = mode.tools?.length ? mode.tools : undefined;
+  const toolWarnings: LanguageModelV1CallWarning[] = [];
+
+  if (tools == null) {
+    return { tools: undefined, tool_choice: undefined, toolWarnings };
+  }
+
+  const inflectionTools: Array<{
+    type: 'function';
+    function: {
+      name: string;
+      description: string | undefined;
+      parameters: unknown;
+    };
+  }> = [];
+
+  for (const tool of tools) {
+    if (tool.type === 'provider-defined') {
+      toolWarnings.push({ type: 'unsupported-tool', tool });
+    } else {
+      inflectionTools.push({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+        },
+      });
+    }
+  }
+
+  const toolChoice = mode.toolChoice;
+
+  if (toolChoice == null) {
+    return { tools: inflectionTools, tool_choice: undefined, toolWarnings };
+  }
+
+  const type = toolChoice.type;
+
+  switch (type) {
+    case 'auto':
+    case 'none':
+      return { tools: inflectionTools, tool_choice: type, toolWarnings };
+    case 'required':
+      // Inflection supports 'any' for required tool usage
+      return { tools: inflectionTools, tool_choice: 'any', toolWarnings };
+    case 'tool':
+      // For specific tool selection, filter to just that tool and use 'any'
+      return {
+        tools: inflectionTools.filter(
+          tool => tool.function.name === toolChoice.toolName,
+        ),
+        tool_choice: 'any',
+        toolWarnings,
+      };
+    default: {
+      const _exhaustiveCheck: never = type;
+      throw new UnsupportedFunctionalityError({
+        functionality: `Unsupported tool choice type: ${_exhaustiveCheck}`,
+      });
+    }
+  }
+}

--- a/packages/inflection-ai/src/inflection-provider.ts
+++ b/packages/inflection-ai/src/inflection-provider.ts
@@ -1,0 +1,128 @@
+import {
+  LanguageModelV1,
+  ProviderV1,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
+import {
+  FetchFunction,
+  loadApiKey,
+  withoutTrailingSlash,
+} from '@ai-sdk/provider-utils';
+import { InflectionChatLanguageModel } from './inflection-chat-language-model';
+import {
+  InflectionChatModelId,
+  InflectionChatSettings,
+} from './inflection-chat-settings';
+
+export interface InflectionProvider extends ProviderV1 {
+  (
+    modelId: InflectionChatModelId,
+    settings?: InflectionChatSettings,
+  ): LanguageModelV1;
+
+  /**
+   * Creates a model for text generation.
+   */
+  languageModel(
+    modelId: InflectionChatModelId,
+    settings?: InflectionChatSettings,
+  ): LanguageModelV1;
+
+  /**
+   * Creates a model for text generation.
+   */
+  chat(
+    modelId: InflectionChatModelId,
+    settings?: InflectionChatSettings,
+  ): LanguageModelV1;
+
+  /**
+   * Not supported by Inflection AI
+   * @throws {UnsupportedFunctionalityError}
+   */
+  textEmbeddingModel(modelId: string): never;
+}
+
+export interface InflectionProviderSettings {
+  /**
+   * Use a different URL prefix for API calls, e.g. to use proxy servers.
+   * The default prefix is `https://layercake.pubwestus3.inf7ks8.com/external/api/inference`
+   */
+  baseURL?: string;
+
+  /**
+   * API key that is being sent using the `Authorization` header.
+   * It defaults to the `INFLECTION_API_KEY` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+/**
+ * Create an Inflection AI provider instance.
+ */
+export function createInflection(
+  options: InflectionProviderSettings = {},
+): InflectionProvider {
+  const baseURL =
+    withoutTrailingSlash(options.baseURL) ??
+    'https://layercake.pubwestus3.inf7ks8.com/external/api/inference';
+
+  const getHeaders = () => ({
+    Authorization: `Bearer ${loadApiKey({
+      apiKey: options.apiKey,
+      environmentVariableName: 'INFLECTION_API_KEY',
+      description: 'Inflection',
+    })}`,
+    ...options.headers,
+  });
+
+  const createChatModel = (
+    modelId: InflectionChatModelId,
+    settings: InflectionChatSettings = {},
+  ) =>
+    new InflectionChatLanguageModel(modelId, settings, {
+      provider: 'inflection.chat',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
+  const provider = function (
+    modelId: InflectionChatModelId,
+    settings?: InflectionChatSettings,
+  ) {
+    if (new.target) {
+      throw new Error(
+        'The Inflection model function cannot be called with the new keyword.',
+      );
+    }
+
+    return createChatModel(modelId, settings);
+  };
+
+  provider.languageModel = createChatModel;
+  provider.chat = createChatModel;
+  provider.textEmbeddingModel = () => {
+    throw new UnsupportedFunctionalityError({
+      functionality: 'Text embeddings are not supported by Inflection AI',
+    });
+  };
+
+  return provider;
+}
+
+/**
+ * Default Inflection provider instance.
+ */
+export const inflection = createInflection();

--- a/packages/inflection-ai/src/map-inflection-finish-reason.ts
+++ b/packages/inflection-ai/src/map-inflection-finish-reason.ts
@@ -1,0 +1,22 @@
+import { LanguageModelV1FinishReason } from '@ai-sdk/provider';
+
+export function mapInflectionFinishReason(
+  reason: string | null | undefined,
+): LanguageModelV1FinishReason {
+  if (!reason) {
+    return 'unknown';
+  }
+
+  switch (reason) {
+    case 'stop':
+      return 'stop';
+    case 'length':
+      return 'length';
+    case 'tool_calls':
+      return 'tool-calls';
+    case 'content_filter':
+      return 'content-filter';
+    default:
+      return 'unknown';
+  }
+}

--- a/packages/inflection-ai/tsconfig.json
+++ b/packages/inflection-ai/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "include": ["."],
+  "exclude": ["*/dist", "dist", "build", "node_modules"]
+}

--- a/packages/inflection-ai/tsup.config.ts
+++ b/packages/inflection-ai/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+  },
+]);

--- a/packages/inflection-ai/turbo.json
+++ b/packages/inflection-ai/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "**/dist/**"
+      ]
+    }
+  }
+}

--- a/packages/inflection-ai/vitest.edge.config.js
+++ b/packages/inflection-ai/vitest.edge.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    globals: true,
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+});

--- a/packages/inflection-ai/vitest.node.config.js
+++ b/packages/inflection-ai/vitest.node.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+});


### PR DESCRIPTION
This adds Inflection AI as a custom provider with `inflection_3_pi`, `inflection_3_productivity`, and `inflection_3_with_tools` models.

No npm package has been created or exists yet with `@ai-sdk/inflection-ia`.

Created using the documentation at [Inflection AI for Developers](https://developers.inflection.ai/). You can obtain an INFLECTION_API_KEY from there by registering.

Their API currently supports streaming.

Their API does not yet support: image, file, tool-calling, JSON mode, or OpenAI API compatibility, but when does features arrive support could be added.

I am not affiliated with Inflection AI, I'm just adding support so others can take advantage of the work I put into making their API compatible with the AI SDK.

![image](https://github.com/user-attachments/assets/9f91819c-522d-49d3-84a7-e29ca415a9a1)
![image](https://github.com/user-attachments/assets/3dc0026d-da38-43ee-87ab-1ce3091e949e)
![image](https://github.com/user-attachments/assets/a262cf74-1777-42b6-94d0-38fb3fa1d2f8)

