### PR TITLE
feat (docs): Update langsmith custom run ids to clarify custom run ids must be uuid

### DIFF
--- a/content/providers/05-observability/langsmith.mdx
+++ b/content/providers/05-observability/langsmith.mdx
@@ -205,13 +205,14 @@ await generateText({
 ### Customize run ID
 
 You can customize the run ID by passing the `runId` argument to the `AISDKExporter.getSettings()` method. This is especially useful if you want to know the run ID before the run has been completed.
-Note that the run ID has to be a valid UUID.
+
+<Note>The run ID has to be a valid UUID.</Note>
 
 ```ts
 import { AISDKExporter } from 'langsmith/vercel';
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from 'uuid';
 
 await generateText({
   model: openai('gpt-4o-mini'),

--- a/content/providers/05-observability/langsmith.mdx
+++ b/content/providers/05-observability/langsmith.mdx
@@ -205,17 +205,19 @@ await generateText({
 ### Customize run ID
 
 You can customize the run ID by passing the `runId` argument to the `AISDKExporter.getSettings()` method. This is especially useful if you want to know the run ID before the run has been completed.
+Note that the run ID has to be a valid UUID.
 
 ```ts
 import { AISDKExporter } from 'langsmith/vercel';
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
+import { v4 as uuidv4 } from "uuid";
 
 await generateText({
   model: openai('gpt-4o-mini'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
   experimental_telemetry: AISDKExporter.getSettings({
-    runId: 'my-custom-run-id',
+    runId: uuidv4(),
   }),
 });
 ```


### PR DESCRIPTION
Resolves #4843 

Improve clarity around what format a `runId` can be defined as when using the vercel ai sdk. Currently only UUID is supported with langsmith. 
Also update to mirror changes in [langsmith docs](https://docs.smith.langchain.com/observability/how_to_guides/trace_with_vercel_ai_sdk)
