### PR TITLE
docs: Update o1-mini capabilities in openai provider to match getting started with o1 page

### DIFF
--- a/content/providers/01-ai-sdk-providers/01-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-openai.mdx
@@ -561,7 +561,7 @@ The following optional settings are available for OpenAI completion models:
 | `gpt-4`                | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-3.5-turbo`        | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `o1`                   | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `o1-mini`              | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `o1-mini`              | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `o1-preview`           | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `o3-mini`              | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 


### PR DESCRIPTION
There are currently conflicting docs between the tables in [OpenAI Providers](https://sdk.vercel.ai/providers/ai-sdk-providers/openai) and [Get Started with o1](https://sdk.vercel.ai/docs/guides/o1) with the former suggesting that using `o1-mini` is capable of object generation and tool usage whereas the latter suggesting it isn't. 

Updates the discrepancy to ensure consistency between these two pages