### PR TITLE
fix (provider/google): Add support for executableCode in Gemini response

### DIFF
--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -458,6 +458,12 @@ const contentSchema = z.object({
           args: z.unknown(),
         }),
       }),
+      z.object({
+        executableCode: z.object({
+          language: z.string(),
+          code: z.string(),
+        }),
+      }),
     ]),
   ),
 });


### PR DESCRIPTION
Something seems to have changed with the search tool, as it's consistently returning executableCode in the response. SearchGrounding is pretty much unusable for us because of this. More than 90% of the responses return `print(google_search.search(queries=["<original search query>"]))`.

![bweng-Cursor-2025-02-17-at-00 28 33@2x](https://github.com/user-attachments/assets/f011642c-bf2c-4e9f-b5c5-2bf03c4a5358)


Gemini's doc on Search Grounding, it sounds like search grounding implicitly enables other tools as well now.. 
![bweng-Google Chrome-2025-02-17-at-00 59 15@2x](https://github.com/user-attachments/assets/45e1d733-fe15-45c6-9391-3aa89beb5462)

Related to this: https://github.com/vercel/ai/issues/3205 