### PR TITLE
fix (docs): update link to BrowserBase

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -92,7 +92,7 @@ When you work with tools, you typically need a mix of application specific tools
 There are several providers that offer pre-built tools as **toolkits** that you can use out of the box:
 
 - **[agentic](https://github.com/transitive-bullshit/agentic)** - A collection of 20+ tools. Most tools connect to access external APIs such as [Exa](https://exa.ai/) or [E2B](https://e2b.dev/).
-- **[browserbase](https://github.com/browserbase/js-sdk?tab=readme-ov-file#vercel-ai-sdk-integration)** - Browser tool that runs a headless browser
+- **[browserbase](https://docs.browserbase.com/integrations/vercel-ai/introduction)** - Browser tool that runs a headless browser
 - **[Stripe agent tools](https://docs.stripe.com/agents)** - Tools for interacting with Stripe.
 - **[Toolhouse](https://docs.toolhouse.ai/toolhouse/using-vercel-ai)** - AI function-calling in 3 lines of code for over 25 different actions.
 - **[Agent Tools](https://ai-sdk-agents.vercel.app/?item=introduction)** - A collection of tools for agents.


### PR DESCRIPTION
The previous BrowserBase link was to the GitHub repository that was archived Oct 30, 2024. The development has moved to [broswerbase/sdk-node](https://github.com/browserbase/sdk-node?tab=readme-ov-file) but has move the AI SDK documentation to the website.