### PR TITLE
fix (ai/core): add `startWithReasoning` option to `extractReasoningMiddleware`

### DIFF
--- a/.changeset/few-cherries-attack.md
+++ b/.changeset/few-cherries-attack.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-fix (ai/core): resolve </think> edge cases in reasoning extractor middleware
+fix (ai/core): add `startWithReasoning` option to `extractReasoningMiddleware`

--- a/.changeset/few-cherries-attack.md
+++ b/.changeset/few-cherries-attack.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai/core): resolve </think> edge cases in reasoning extractor middleware

--- a/content/docs/02-guides/04-r1.mdx
+++ b/content/docs/02-guides/04-r1.mdx
@@ -99,10 +99,14 @@ const { reasoning, text } = await generateText({
 });
 ```
 
-<Note>
-  The AI SDK provides a [middleware](/docs/ai-sdk-core/middleware)
-  (`extractReasoningMiddleware`) that can be used to extract the reasoning
-  tokens from the model's output.
+<Note id="deepseek-r1-middleware">
+The AI SDK provides a [middleware](/docs/ai-sdk-core/middleware)
+(`extractReasoningMiddleware`) that can be used to extract the reasoning
+tokens from the model's output.
+
+When using DeepSeek-R1 series models, we recommend using the `startWithReasoning`
+option in the `extractReasoningMiddleware` function, as they tend to bypass thinking patterns.
+
 </Note>
 
 ### Model Provider Comparison

--- a/content/docs/02-guides/04-r1.mdx
+++ b/content/docs/02-guides/04-r1.mdx
@@ -104,7 +104,7 @@ The AI SDK provides a [middleware](/docs/ai-sdk-core/middleware)
 (`extractReasoningMiddleware`) that can be used to extract the reasoning
 tokens from the model's output.
 
-When using DeepSeek-R1 series models, we recommend using the `startWithReasoning`
+When using DeepSeek-R1 series models with third-party providers like Together AI, we recommend using the `startWithReasoning`
 option in the `extractReasoningMiddleware` function, as they tend to bypass thinking patterns.
 
 </Note>

--- a/content/docs/03-ai-sdk-core/45-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/45-middleware.mdx
@@ -70,7 +70,10 @@ const model = wrapLanguageModel({
 
 You can then use that enhanced model in functions like `generateText` and `streamText`.
 
-The `extractReasoningMiddleware` function also includes a `startWithReasoning` option. When set to `true`, the reasoning tag will be prepended to the generated text. This is useful for models that do not include the reasoning tag at the beginning of the response. For more details, see [here](https://sdk.vercel.ai/docs/guides/r1#deepseek-r1-middleware).
+The `extractReasoningMiddleware` function also includes a `startWithReasoning` option.
+When set to `true`, the reasoning tag will be prepended to the generated text.
+This is useful for models that do not include the reasoning tag at the beginning of the response.
+For more details, see the [DeepSeek R1 guide](https://sdk.vercel.ai/docs/guides/r1#deepseek-r1-middleware).
 
 ## Implementing Language Model Middleware
 

--- a/content/docs/03-ai-sdk-core/45-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/45-middleware.mdx
@@ -70,6 +70,8 @@ const model = wrapLanguageModel({
 
 You can then use that enhanced model in functions like `generateText` and `streamText`.
 
+The `extractReasoningMiddleware` function also includes a `startWithReasoning` option. When set to `true`, the reasoning tag will be prepended to the generated text. This is useful for models that do not include the reasoning tag at the beginning of the response. For more details, see [here](https://sdk.vercel.ai/docs/guides/r1#deepseek-r1-middleware).
+
 ## Implementing Language Model Middleware
 
 <Note>

--- a/content/docs/07-reference/01-ai-sdk-core/66-extract-reasoning-middleware.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/66-extract-reasoning-middleware.mdx
@@ -43,6 +43,13 @@ const middleware = extractReasoningMiddleware({
       description:
         'The separator to use between reasoning and text sections. Defaults to "\\n"',
     },
+    {
+      name: 'startWithReasoning',
+      type: 'boolean',
+      isOptional: true,
+      description:
+        'Prepends the response with the reasoning tag. Primarily used for patching edge cases in reasoning extraction in certain models, see [here](https://sdk.vercel.ai/docs/guides/r1#deepseek-r1-middleware) for more details. Defaults to false',
+    },
   ]}
 />
 

--- a/content/docs/07-reference/01-ai-sdk-core/66-extract-reasoning-middleware.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/66-extract-reasoning-middleware.mdx
@@ -48,7 +48,7 @@ const middleware = extractReasoningMiddleware({
       type: 'boolean',
       isOptional: true,
       description:
-        'Prepends the response with the reasoning tag. Primarily used for patching edge cases in reasoning extraction in certain models, see [here](https://sdk.vercel.ai/docs/guides/r1#deepseek-r1-middleware) for more details. Defaults to false',
+        'Starts with reasoning tokens. Set to true when the response always starts with reasoning and the initial tag is omitted. Defaults to false.',
     },
   ]}
 />

--- a/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
@@ -83,6 +83,47 @@ describe('extractReasoningMiddleware', () => {
       );
       expect(result.text).toStrictEqual('Here is the response\nmore');
     });
+
+    it('should preprend <think> tag IFF startWithReasoning is true', async () => {
+      const mockModel = new MockLanguageModelV1({
+        async doGenerate() {
+          return {
+            text: 'analyzing the request</think>Here is the response',
+            finishReason: 'stop',
+            usage: { promptTokens: 10, completionTokens: 10 },
+            rawCall: { rawPrompt: '', rawSettings: {} },
+          };
+        },
+      });
+
+      const resultTrue = await generateText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractReasoningMiddleware({
+            tagName: 'think',
+            startWithReasoning: true,
+          }),
+        }),
+        prompt: 'Hello, how can I help?',
+      });
+
+      const resultFalse = await generateText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractReasoningMiddleware({
+            tagName: 'think',
+          }),
+        }),
+        prompt: 'Hello, how can I help?',
+      });
+
+      expect(resultTrue.reasoning).toStrictEqual('analyzing the request');
+      expect(resultTrue.text).toStrictEqual('Here is the response');
+      expect(resultFalse.reasoning).toBeUndefined();
+      expect(resultFalse.text).toStrictEqual(
+        'analyzing the request</think>Here is the response',
+      );
+    });
   });
 
   describe('wrapStream', () => {
@@ -328,6 +369,104 @@ describe('extractReasoningMiddleware', () => {
         model: wrapLanguageModel({
           model: mockModel,
           middleware: extractReasoningMiddleware({ tagName: 'think' }),
+        }),
+        prompt: 'Hello, how can I help?',
+        experimental_generateMessageId: mockId({ prefix: 'msg' }),
+      });
+
+      expect(
+        await convertAsyncIterableToArray(result.fullStream),
+      ).toStrictEqual([
+        {
+          messageId: 'msg-0',
+          request: {},
+          type: 'step-start',
+          warnings: [],
+        },
+        {
+          type: 'reasoning',
+          textDelta: 'ana',
+        },
+        {
+          type: 'reasoning',
+          textDelta: 'lyzing the request\n',
+        },
+        {
+          experimental_providerMetadata: undefined,
+          providerMetadata: undefined,
+          finishReason: 'stop',
+          isContinued: false,
+          logprobs: undefined,
+          messageId: 'msg-0',
+          request: {},
+          response: {
+            headers: undefined,
+            id: 'id-0',
+            modelId: 'mock-model-id',
+            timestamp: new Date(0),
+          },
+          type: 'step-finish',
+          usage: {
+            completionTokens: 10,
+            promptTokens: 3,
+            totalTokens: 13,
+          },
+          warnings: undefined,
+        },
+        {
+          experimental_providerMetadata: undefined,
+          providerMetadata: undefined,
+          finishReason: 'stop',
+          logprobs: undefined,
+          response: {
+            headers: undefined,
+            id: 'id-0',
+            modelId: 'mock-model-id',
+            timestamp: new Date(0),
+          },
+          type: 'finish',
+          usage: {
+            completionTokens: 10,
+            promptTokens: 3,
+            totalTokens: 13,
+          },
+        },
+      ]);
+    });
+
+    it('should preprend <think> tag IFF startWithReasoning is true', async () => {
+      const mockModel = new MockLanguageModelV1({
+        async doStream() {
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-delta', textDelta: 'ana' },
+              { type: 'text-delta', textDelta: 'lyzing the request\n' },
+              { type: 'text-delta', textDelta: '</think>' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                logprobs: undefined,
+                usage: { completionTokens: 10, promptTokens: 3 },
+              },
+            ]),
+            rawCall: { rawPrompt: '', rawSettings: {} },
+          };
+        },
+      });
+
+      const result = streamText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractReasoningMiddleware({
+            tagName: 'think',
+            startWithReasoning: true,
+          }),
         }),
         prompt: 'Hello, how can I help?',
         experimental_generateMessageId: mockId({ prefix: 'msg' }),

--- a/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
@@ -448,6 +448,7 @@ describe('extractReasoningMiddleware', () => {
               { type: 'text-delta', textDelta: 'ana' },
               { type: 'text-delta', textDelta: 'lyzing the request\n' },
               { type: 'text-delta', textDelta: '</think>' },
+              { type: 'text-delta', textDelta: 'this is the response' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -497,6 +498,10 @@ describe('extractReasoningMiddleware', () => {
         {
           type: 'reasoning',
           textDelta: 'lyzing the request\n',
+        },
+        {
+          type: 'text-delta',
+          textDelta: 'this is the response',
         },
         {
           experimental_providerMetadata: undefined,
@@ -560,6 +565,10 @@ describe('extractReasoningMiddleware', () => {
         {
           type: 'text-delta',
           textDelta: '</think>',
+        },
+        {
+          type: 'text-delta',
+          textDelta: 'this is the response',
         },
         {
           experimental_providerMetadata: undefined,

--- a/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
@@ -460,7 +460,7 @@ describe('extractReasoningMiddleware', () => {
         },
       });
 
-      const result = streamText({
+      const resultTrue = streamText({
         model: wrapLanguageModel({
           model: mockModel,
           middleware: extractReasoningMiddleware({
@@ -472,8 +472,17 @@ describe('extractReasoningMiddleware', () => {
         experimental_generateMessageId: mockId({ prefix: 'msg' }),
       });
 
+      const resultFalse = streamText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractReasoningMiddleware({ tagName: 'think' }),
+        }),
+        prompt: 'Hello, how can I help?',
+        experimental_generateMessageId: mockId({ prefix: 'msg' }),
+      });
+
       expect(
-        await convertAsyncIterableToArray(result.fullStream),
+        await convertAsyncIterableToArray(resultTrue.fullStream),
       ).toStrictEqual([
         {
           messageId: 'msg-0',
@@ -488,6 +497,69 @@ describe('extractReasoningMiddleware', () => {
         {
           type: 'reasoning',
           textDelta: 'lyzing the request\n',
+        },
+        {
+          experimental_providerMetadata: undefined,
+          providerMetadata: undefined,
+          finishReason: 'stop',
+          isContinued: false,
+          logprobs: undefined,
+          messageId: 'msg-0',
+          request: {},
+          response: {
+            headers: undefined,
+            id: 'id-0',
+            modelId: 'mock-model-id',
+            timestamp: new Date(0),
+          },
+          type: 'step-finish',
+          usage: {
+            completionTokens: 10,
+            promptTokens: 3,
+            totalTokens: 13,
+          },
+          warnings: undefined,
+        },
+        {
+          experimental_providerMetadata: undefined,
+          providerMetadata: undefined,
+          finishReason: 'stop',
+          logprobs: undefined,
+          response: {
+            headers: undefined,
+            id: 'id-0',
+            modelId: 'mock-model-id',
+            timestamp: new Date(0),
+          },
+          type: 'finish',
+          usage: {
+            completionTokens: 10,
+            promptTokens: 3,
+            totalTokens: 13,
+          },
+        },
+      ]);
+
+      expect(
+        await convertAsyncIterableToArray(resultFalse.fullStream),
+      ).toStrictEqual([
+        {
+          messageId: 'msg-0',
+          request: {},
+          type: 'step-start',
+          warnings: [],
+        },
+        {
+          type: 'text-delta',
+          textDelta: 'ana',
+        },
+        {
+          type: 'text-delta',
+          textDelta: 'lyzing the request\n',
+        },
+        {
+          type: 'text-delta',
+          textDelta: '</think>',
         },
         {
           experimental_providerMetadata: undefined,

--- a/packages/ai/core/middleware/extract-reasoning-middleware.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.ts
@@ -8,6 +8,7 @@ import type { LanguageModelV1Middleware } from './language-model-v1-middleware';
  *
  * @param tagName - The name of the XML tag to extract reasoning from.
  * @param separator - The separator to use between reasoning and text sections.
+ * @param startWithReasoning - Whether to start with reasoning tokens.
  */
 export function extractReasoningMiddleware({
   tagName,

--- a/packages/ai/core/middleware/extract-reasoning-middleware.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.ts
@@ -24,17 +24,13 @@ export function extractReasoningMiddleware({
   return {
     middlewareVersion: 'v1',
     wrapGenerate: async ({ doGenerate }) => {
-      const { text: textFromDoGenerate, ...rest } = await doGenerate();
+      const { text: rawText, ...rest } = await doGenerate();
 
-      if (textFromDoGenerate == null) {
-        return { text: textFromDoGenerate, ...rest };
+      if (rawText == null) {
+        return { text: rawText, ...rest };
       }
 
-      let text = textFromDoGenerate;
-
-      if (startWithReasoning) {
-        text = openingTag + text;
-      }
+      const text = startWithReasoning ? openingTag + rawText : rawText;
 
       const regexp = new RegExp(`${openingTag}(.*?)${closingTag}`, 'gs');
       const matches = Array.from(text.matchAll(regexp));
@@ -69,8 +65,8 @@ export function extractReasoningMiddleware({
       let isFirstReasoning = true;
       let isFirstText = true;
       let afterSwitch = false;
-      let isReasoning = false;
-      let buffer = startWithReasoning ? openingTag : '';
+      let isReasoning = startWithReasoning;
+      let buffer = '';
 
       return {
         stream: stream.pipeThrough(


### PR DESCRIPTION
Resolves https://github.com/vercel/ai/issues/4920.

Adds new `startWithReasoning` option to `extractReasoningMiddleware`: resolves issues with DeepSeek R1 bypassing thinking patterns by prepending output with `<think>`