### PR TITLE
feat (provider/bedrock): add image generation support

### DIFF
--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -320,11 +320,11 @@ import { experimental_generateImage as generateImage } from 'ai';
 const { image } = await generateImage({
   model: bedrock.imageModel('amazon.nova-canvas-v1:0'),
   prompt: 'A beautiful sunset over a calm ocean',
+  size: '512x512',
   seed: 42,
   providerOptions: {
     bedrock: {
-      width: 512,
-      height: 512,
+      quality: 'premium',
     },
   },
 });
@@ -342,7 +342,7 @@ Documentation for additional settings can be found within the [Amazon Bedrock Us
 
 | Model                      | Sizes                           |
 | -------------------------- | ------------------------------- |
-| `amazon.nova-canvas-v1:03` | 1024x1024, 1792x1024, 1024x1792 |
+| `amazon.nova-canvas-v1:0`  | 1024x1024, 1792x1024, 1024x1792 |
 
 ## Response Headers
 

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -293,6 +293,57 @@ The following optional settings are available for Bedrock Titan embedding models
 | `amazon.titan-embed-text-v1`   | 1536               | <Cross size={18} /> |
 | `amazon.titan-embed-text-v2:0` | 1024               | <Check size={18} /> |
 
+## Image Models
+
+You can create models that call the Bedrock API [Bedrock API](https://docs.aws.amazon.com/nova/latest/userguide/image-generation.html)
+using the `.image()` factory method.
+
+```ts
+const model = bedrock.image('amazon.nova-canvas-v1:0');
+```
+
+Amazon Nova Canvas supports specifying the max number of images generated.
+You can pass it as an options argument:
+
+```ts
+const model = bedrock.imageModel('amazon.nova-canvas-v1:0', {
+  maxImagesPerCall: 5,
+});
+```
+
+You can use Amazon Nova Canvas to generate images with the `experimental_generateImage` function:
+
+```ts
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { experimental_generateImage as generateImage } from 'ai';
+
+const { image } = await generateImage({
+  model: bedrock.imageModel('amazon.nova-canvas-v1:0'),
+  prompt: 'A beautiful sunset over a calm ocean',
+  seed: 42,
+  providerOptions: {
+    bedrock: {
+      width: 512,
+      height: 512,
+    },
+  },
+});
+```
+
+<Note>
+  The Amazon Nova Canvas model doesn't support the `aspectRatio` and `size`
+  parameters. Use the `providerOptions.bedrock.width` and
+  `providerOptions.bedrock.height` parameters instead.
+</Note>
+
+Documentation for additional settings can be found within the [Amazon Bedrock User Guide for Amazon Nova Documentation](https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html).
+
+### Model Capabilities
+
+| Model                      | Sizes                           |
+| -------------------------- | ------------------------------- |
+| `amazon.nova-canvas-v1:03` | 1024x1024, 1792x1024, 1024x1792 |
+
 ## Response Headers
 
 The Amazon Bedrock provider will return the response headers associated with

--- a/packages/amazon-bedrock/src/bedrock-image-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.test.ts
@@ -1,0 +1,229 @@
+import { createTestServer } from '@ai-sdk/provider-utils/test';
+import { createAmazonBedrock } from './bedrock-provider';
+import { BedrockImageModel } from './bedrock-image-model';
+import { injectFetchHeaders } from './inject-fetch-headers';
+
+const prompt = 'A cute baby sea otter';
+
+const provider = createAmazonBedrock();
+const model = provider.image('amazon.nova-canvas-v1:0', { maxImagesPerCall: 2});
+const fakeFetchWithAuth = injectFetchHeaders({ 'x-amz-auth': 'test-auth' });
+
+const invokeUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(
+  'amazon.nova-canvas-v1:0',
+)}/invoke`;
+
+describe('doGenerate', () => {
+  const mockConfigHeaders = {
+    'config-header': 'config-value',
+    'shared-header': 'config-shared',
+  };
+
+  const server = createTestServer({
+    [invokeUrl]: {
+      response: {
+        type: 'binary',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: Buffer.from(
+          JSON.stringify({
+            images: ['base64-image-1', 'base64-image-2'],
+          }),
+        ),
+      },
+    },
+  });
+
+  const model = new BedrockImageModel(
+    'amazon.nova-canvas-v1:0',
+    {},
+    {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: mockConfigHeaders,
+      fetch: fakeFetchWithAuth,
+    }
+  )
+
+  it('should pass the model and the settings', async () => {
+    await model.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: 1234,
+      providerOptions: {
+        bedrock: {
+          negativeText: 'bad',
+          quality: 'premium',
+          cfgScale: 1.2,
+          width: 1024,
+          height: 1024,
+        }
+      },
+    });
+
+    const body = await server.calls[0].requestBody;
+    expect(body).toStrictEqual({
+      taskType: 'TEXT_IMAGE',
+      textToImageParams: {
+        text: prompt,
+        negativeText: 'bad',
+      },
+      imageGenerationConfig: {
+        numberOfImages: 1,
+        seed: 1234,
+        quality: 'premium',
+        cfgScale: 1.2,
+        width: 1024,
+        height: 1024,
+      }
+    });
+  });
+
+  it('should properly combine headers from all sources', async () => {
+    const optionsHeaders = {
+      'options-header': 'options-value',
+      'shared-header': 'options-shared',
+    };
+    
+    const modelWithHeaders = new BedrockImageModel(
+      'amazon.nova-canvas-v1:0',
+      {},
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: {
+          'model-header': 'model-value',
+          'shared-header': 'model-shared',
+        },
+        fetch: injectFetchHeaders({
+          'signed-header': 'signed-value',
+          authorization: 'AWS4-HMAC-SHA256...',
+        }),
+      },
+    );
+
+    await modelWithHeaders.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: undefined,
+      headers: optionsHeaders,
+    });
+
+    const requestHeaders = server.calls[0].requestHeaders;
+    expect(requestHeaders['options-header']).toBe('options-value');
+    expect(requestHeaders['model-header']).toBe('model-value');
+    expect(requestHeaders['signed-header']).toBe('signed-value');
+    expect(requestHeaders['authorization']).toBe('AWS4-HMAC-SHA256...');
+    expect(requestHeaders['shared-header']).toBe('options-shared');
+  });
+
+  it('should respect maxImagesPerCall setting', async () => {
+    const customModel = provider.image('amazon.nova-canvas-v1:0', { maxImagesPerCall: 2 });
+    expect(customModel.maxImagesPerCall).toBe(2);
+
+    const defaultModel = provider.image('amazon.nova-canvas-v1:0',);
+    expect(defaultModel.maxImagesPerCall).toBe(5); // 'amazon.nova-canvas-v1:0','s default from settings
+
+    const unknownModel = provider.image('unknown-model' as any);
+    expect(unknownModel.maxImagesPerCall).toBe(1); // fallback for unknown models
+  });
+
+  it('should return warnings for unsupported settings', async () => {
+    const result = await model.doGenerate({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: '1:1',
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    expect(result.warnings).toStrictEqual([
+      {
+        type: 'unsupported-setting',
+        setting: 'aspectRatio',
+        details:
+          'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
+      },
+      {
+        type: 'unsupported-setting',
+        setting: 'size',
+        details: 'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
+      },
+    ]);
+  });
+
+  it('should extract the generated images', async () => {
+    const result = await model.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
+  });
+
+  it('should include response data with timestamp, modelId and headers', async () => {
+    const testDate = new Date('2024-03-15T12:00:00Z');
+
+    const customModel = new BedrockImageModel(
+      'amazon.nova-canvas-v1:0',
+      {},
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: () => ({}),
+        _internal: {
+          currentDate: () => testDate,
+        },
+      },
+    );
+
+    const result = await customModel.doGenerate({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    expect(result.response).toStrictEqual({
+      timestamp: testDate,
+      modelId: 'amazon.nova-canvas-v1:0',
+      headers: {
+        'content-length': '46',
+        'content-type': 'application/json',
+      },
+    });
+  });
+
+  it('should use real date when no custom date provider is specified', async () => {
+    const beforeDate = new Date();
+
+    const result = await model.doGenerate({
+      prompt,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: 1234,
+      providerOptions: {},
+    });
+
+    const afterDate = new Date();
+
+    expect(result.response.timestamp.getTime()).toBeGreaterThanOrEqual(
+      beforeDate.getTime(),
+    );
+    expect(result.response.timestamp.getTime()).toBeLessThanOrEqual(
+      afterDate.getTime(),
+    );
+    expect(result.response.modelId).toBe('amazon.nova-canvas-v1:0');
+  });
+});

--- a/packages/amazon-bedrock/src/bedrock-image-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.test.ts
@@ -6,7 +6,9 @@ import { injectFetchHeaders } from './inject-fetch-headers';
 const prompt = 'A cute baby sea otter';
 
 const provider = createAmazonBedrock();
-const model = provider.image('amazon.nova-canvas-v1:0', { maxImagesPerCall: 2});
+const model = provider.image('amazon.nova-canvas-v1:0', {
+  maxImagesPerCall: 2,
+});
 const fakeFetchWithAuth = injectFetchHeaders({ 'x-amz-auth': 'test-auth' });
 
 const invokeUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(
@@ -42,8 +44,8 @@ describe('doGenerate', () => {
       baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
       headers: mockConfigHeaders,
       fetch: fakeFetchWithAuth,
-    }
-  )
+    },
+  );
 
   it('should pass the model and the settings', async () => {
     await model.doGenerate({
@@ -59,7 +61,7 @@ describe('doGenerate', () => {
           cfgScale: 1.2,
           width: 1024,
           height: 1024,
-        }
+        },
       },
     });
 
@@ -77,7 +79,7 @@ describe('doGenerate', () => {
         cfgScale: 1.2,
         width: 1024,
         height: 1024,
-      }
+      },
     });
   });
 
@@ -86,7 +88,7 @@ describe('doGenerate', () => {
       'options-header': 'options-value',
       'shared-header': 'options-shared',
     };
-    
+
     const modelWithHeaders = new BedrockImageModel(
       'amazon.nova-canvas-v1:0',
       {},
@@ -122,10 +124,12 @@ describe('doGenerate', () => {
   });
 
   it('should respect maxImagesPerCall setting', async () => {
-    const customModel = provider.image('amazon.nova-canvas-v1:0', { maxImagesPerCall: 2 });
+    const customModel = provider.image('amazon.nova-canvas-v1:0', {
+      maxImagesPerCall: 2,
+    });
     expect(customModel.maxImagesPerCall).toBe(2);
 
-    const defaultModel = provider.image('amazon.nova-canvas-v1:0',);
+    const defaultModel = provider.image('amazon.nova-canvas-v1:0');
     expect(defaultModel.maxImagesPerCall).toBe(5); // 'amazon.nova-canvas-v1:0','s default from settings
 
     const unknownModel = provider.image('unknown-model' as any);
@@ -152,7 +156,8 @@ describe('doGenerate', () => {
       {
         type: 'unsupported-setting',
         setting: 'size',
-        details: 'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
+        details:
+          'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
       },
     ]);
   });

--- a/packages/amazon-bedrock/src/bedrock-image-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.test.ts
@@ -6,9 +6,6 @@ import { injectFetchHeaders } from './inject-fetch-headers';
 const prompt = 'A cute baby sea otter';
 
 const provider = createAmazonBedrock();
-const model = provider.image('amazon.nova-canvas-v1:0', {
-  maxImagesPerCall: 2,
-});
 const fakeFetchWithAuth = injectFetchHeaders({ 'x-amz-auth': 'test-auth' });
 
 const invokeUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(
@@ -51,7 +48,7 @@ describe('doGenerate', () => {
     await model.doGenerate({
       prompt,
       n: 1,
-      size: undefined,
+      size: '1024x1024',
       aspectRatio: undefined,
       seed: 1234,
       providerOptions: {
@@ -59,8 +56,6 @@ describe('doGenerate', () => {
           negativeText: 'bad',
           quality: 'premium',
           cfgScale: 1.2,
-          width: 1024,
-          height: 1024,
         },
       },
     });
@@ -111,7 +106,7 @@ describe('doGenerate', () => {
       size: undefined,
       aspectRatio: undefined,
       seed: undefined,
-      providerOptions: undefined,
+      providerOptions: {},
       headers: optionsHeaders,
     });
 
@@ -151,13 +146,7 @@ describe('doGenerate', () => {
         type: 'unsupported-setting',
         setting: 'aspectRatio',
         details:
-          'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
-      },
-      {
-        type: 'unsupported-setting',
-        setting: 'size',
-        details:
-          'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
+          'This model does not support aspect ratio. Use `size` instead.',
       },
     ]);
   });

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -63,19 +63,29 @@ export class BedrockImageModel implements ImageModelV1 {
       taskType: 'TEXT_IMAGE',
       textToImageParams: {
         text: prompt,
-        ...(providerOptions?.bedrock?.negativeText ? {
-          negativeText: providerOptions.bedrock.negativeText,
-        } : {}),
+        ...(providerOptions?.bedrock?.negativeText
+          ? {
+              negativeText: providerOptions.bedrock.negativeText,
+            }
+          : {}),
       },
       imageGenerationConfig: {
-        ...(providerOptions?.bedrock?.width ? { width: providerOptions.bedrock.width} : {}),
-        ...(providerOptions?.bedrock?.height ? { height: providerOptions.bedrock.height} : {}),
+        ...(providerOptions?.bedrock?.width
+          ? { width: providerOptions.bedrock.width }
+          : {}),
+        ...(providerOptions?.bedrock?.height
+          ? { height: providerOptions.bedrock.height }
+          : {}),
         ...(seed ? { seed } : {}),
         ...(n ? { numberOfImages: n } : {}),
-        ...(providerOptions?.bedrock?.quality ? { quality: providerOptions.bedrock.quality } : {}),
-        ...(providerOptions?.bedrock?.cfgScale ? { cfgScale: providerOptions.bedrock.cfgScale } : {}),
-      }
-    }
+        ...(providerOptions?.bedrock?.quality
+          ? { quality: providerOptions.bedrock.quality }
+          : {}),
+        ...(providerOptions?.bedrock?.cfgScale
+          ? { cfgScale: providerOptions.bedrock.cfgScale }
+          : {}),
+      },
+    };
 
     if (aspectRatio != null) {
       warnings.push({

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -14,7 +14,7 @@ import {
   modelMaxImagesPerCall,
 } from './bedrock-image-settings';
 import { BedrockErrorSchema } from './bedrock-error';
-import { number, z } from 'zod';
+import { z } from 'zod';
 
 type BedrockImageModelConfig = {
   baseUrl: () => string;

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -1,0 +1,129 @@
+import { ImageModelV1, ImageModelV1CallWarning } from '@ai-sdk/provider';
+import {
+  FetchFunction,
+  Resolvable,
+  combineHeaders,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  postJsonToApi,
+  resolve,
+} from '@ai-sdk/provider-utils';
+import {
+  BedrockImageModelId,
+  BedrockImageSettings,
+  modelMaxImagesPerCall,
+} from './bedrock-image-settings';
+import { BedrockErrorSchema } from './bedrock-error';
+import { number, z } from 'zod';
+
+type BedrockImageModelConfig = {
+  baseUrl: () => string;
+  headers: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+};
+
+export class BedrockImageModel implements ImageModelV1 {
+  readonly specificationVersion = 'v1';
+  readonly provider = 'amazon-bedrock';
+
+  get maxImagesPerCall(): number {
+    return (
+      this.settings.maxImagesPerCall ?? modelMaxImagesPerCall[this.modelId] ?? 1
+    );
+  }
+
+  private getUrl(modelId: string): string {
+    const encodedModelId = encodeURIComponent(modelId);
+    return `${this.config.baseUrl()}/model/${encodedModelId}/invoke`;
+  }
+
+  constructor(
+    readonly modelId: BedrockImageModelId,
+    private readonly settings: BedrockImageSettings,
+    private readonly config: BedrockImageModelConfig,
+  ) {}
+
+  async doGenerate({
+    prompt,
+    n,
+    size,
+    aspectRatio,
+    seed,
+    providerOptions,
+    headers,
+    abortSignal,
+  }: Parameters<ImageModelV1['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV1['doGenerate']>>
+  > {
+    const warnings: Array<ImageModelV1CallWarning> = [];
+    const args = {
+      taskType: 'TEXT_IMAGE',
+      textToImageParams: {
+        text: prompt,
+      },
+      imageGenerationConfig: {
+        ...(providerOptions.bedrock.width ? { width: providerOptions.bedrock.width} : {}),
+        ...(providerOptions.bedrock.height ? { height: providerOptions.bedrock.height} : {}),
+        ...(seed ? { seed } : {}),
+        ...(n ? { numberOfOutputs: n } : {}),
+        ...(providerOptions.bedrock.quality ? { quality: providerOptions.bedrock.quality } : {}),
+        ...(providerOptions.bedrock.cfgScale ? { cfgScale: providerOptions.bedrock.cfgScale } : {}),
+      }
+    }
+
+    if (aspectRatio != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'aspectRatio',
+        details:
+          'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
+      });
+    }
+
+    if (size != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'size',
+        details:
+          'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { value: response, responseHeaders } = await postJsonToApi({
+      url: this.getUrl(this.modelId),
+      headers: await resolve(
+        combineHeaders(await resolve(this.config.headers), headers),
+      ),
+      body: args,
+      failedResponseHandler: createJsonErrorResponseHandler({
+        errorSchema: BedrockErrorSchema,
+        errorToMessage: error => `${error.type}: ${error.message}`,
+      }),
+      successfulResponseHandler: createJsonResponseHandler(
+        bedrockImageResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return {
+      images: response.images,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+      },
+    };
+  }
+}
+
+// minimal version of the schema, focussed on what is needed for the implementation
+// this approach limits breakages when the API changes and increases efficiency
+const bedrockImageResponseSchema = z.object({
+  images: z.array(z.string()),
+});

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -59,6 +59,7 @@ export class BedrockImageModel implements ImageModelV1 {
     Awaited<ReturnType<ImageModelV1['doGenerate']>>
   > {
     const warnings: Array<ImageModelV1CallWarning> = [];
+    const [width, height] = size ? size.split('x').map(Number) : [];
     const args = {
       taskType: 'TEXT_IMAGE',
       textToImageParams: {
@@ -70,12 +71,8 @@ export class BedrockImageModel implements ImageModelV1 {
           : {}),
       },
       imageGenerationConfig: {
-        ...(providerOptions?.bedrock?.width
-          ? { width: providerOptions.bedrock.width }
-          : {}),
-        ...(providerOptions?.bedrock?.height
-          ? { height: providerOptions.bedrock.height }
-          : {}),
+        ...(width ? { width } : {}),
+        ...(height ? { height } : {}),
         ...(seed ? { seed } : {}),
         ...(n ? { numberOfImages: n } : {}),
         ...(providerOptions?.bedrock?.quality
@@ -87,21 +84,12 @@ export class BedrockImageModel implements ImageModelV1 {
       },
     };
 
-    if (aspectRatio != null) {
+    if (aspectRatio != undefined) {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'aspectRatio',
         details:
-          'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
-      });
-    }
-
-    if (size != null) {
-      warnings.push({
-        type: 'unsupported-setting',
-        setting: 'size',
-        details:
-          'This model does not support aspect ratio. Use `providerOptions.bedrock.width` & `providerOptions.bedrock.height` instead.',
+          'This model does not support aspect ratio. Use `size` instead.',
       });
     }
 

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -63,14 +63,17 @@ export class BedrockImageModel implements ImageModelV1 {
       taskType: 'TEXT_IMAGE',
       textToImageParams: {
         text: prompt,
+        ...(providerOptions?.bedrock?.negativeText ? {
+          negativeText: providerOptions.bedrock.negativeText,
+        } : {}),
       },
       imageGenerationConfig: {
-        ...(providerOptions.bedrock.width ? { width: providerOptions.bedrock.width} : {}),
-        ...(providerOptions.bedrock.height ? { height: providerOptions.bedrock.height} : {}),
+        ...(providerOptions?.bedrock?.width ? { width: providerOptions.bedrock.width} : {}),
+        ...(providerOptions?.bedrock?.height ? { height: providerOptions.bedrock.height} : {}),
         ...(seed ? { seed } : {}),
-        ...(n ? { numberOfOutputs: n } : {}),
-        ...(providerOptions.bedrock.quality ? { quality: providerOptions.bedrock.quality } : {}),
-        ...(providerOptions.bedrock.cfgScale ? { cfgScale: providerOptions.bedrock.cfgScale } : {}),
+        ...(n ? { numberOfImages: n } : {}),
+        ...(providerOptions?.bedrock?.quality ? { quality: providerOptions.bedrock.quality } : {}),
+        ...(providerOptions?.bedrock?.cfgScale ? { cfgScale: providerOptions.bedrock.cfgScale } : {}),
       }
     }
 

--- a/packages/amazon-bedrock/src/bedrock-image-settings.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-settings.ts
@@ -1,0 +1,14 @@
+export type BedrockImageModelId = 'amazon.nova-canvas-v1:0' | (string & {});
+
+// https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html
+export const modelMaxImagesPerCall: Record<BedrockImageModelId, number> = {
+  'amazon.nova-canvas-v1:0': 5,
+};
+
+export interface BedrockImageSettings {
+  /**
+   * Override the maximum number of images per call (default is dependent on the
+   * model, or 1 for an unknown model).
+   */
+  maxImagesPerCall?: number;
+}

--- a/packages/amazon-bedrock/src/bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.test.ts
@@ -2,12 +2,13 @@ import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { createAmazonBedrock } from './bedrock-provider';
 import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
 import { BedrockEmbeddingModel } from './bedrock-embedding-model';
-import { loadSetting } from '@ai-sdk/provider-utils';
+import { BedrockImageModel } from './bedrock-image-model';
 
 // Add type assertions for the mocked classes
 const BedrockChatLanguageModelMock =
   BedrockChatLanguageModel as unknown as Mock;
 const BedrockEmbeddingModelMock = BedrockEmbeddingModel as unknown as Mock;
+const BedrockImageModelMock = BedrockImageModel as unknown as Mock;
 
 vi.mock('./bedrock-chat-language-model', () => ({
   BedrockChatLanguageModel: vi.fn(),
@@ -15,6 +16,10 @@ vi.mock('./bedrock-chat-language-model', () => ({
 
 vi.mock('./bedrock-embedding-model', () => ({
   BedrockEmbeddingModel: vi.fn(),
+}));
+
+vi.mock('./bedrock-image-model', () => ({
+  BedrockImageModel: vi.fn(),
 }));
 
 vi.mock('@ai-sdk/provider-utils', () => ({
@@ -120,6 +125,34 @@ describe('AmazonBedrockProvider', () => {
       expect(constructorCall[0]).toBe(modelId);
       expect(constructorCall[1]).toEqual({ dimensions: 1024, normalize: true });
       expect(model).toBeInstanceOf(BedrockEmbeddingModel);
+    });
+
+    it('should create an image model', () => {
+      const provider = createAmazonBedrock();
+      const modelId = 'amazon.titan-image-generator';
+
+      const model = provider.image(modelId, {
+        maxImagesPerCall: 5,
+      });
+
+      const constructorCall = BedrockImageModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe(modelId);
+      expect(constructorCall[1]).toEqual({ maxImagesPerCall: 5 });
+      expect(model).toBeInstanceOf(BedrockImageModel);
+    });
+
+    it('should create an image model via imageModel method', () => {
+      const provider = createAmazonBedrock();
+      const modelId = 'amazon.titan-image-generator';
+
+      const model = provider.imageModel(modelId, {
+        maxImagesPerCall: 5,
+      });
+
+      const constructorCall = BedrockImageModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe(modelId);
+      expect(constructorCall[1]).toEqual({ maxImagesPerCall: 5 });
+      expect(model).toBeInstanceOf(BedrockImageModel);
     });
   });
 });

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -1,5 +1,6 @@
 import {
   EmbeddingModelV1,
+  ImageModelV1,
   LanguageModelV1,
   ProviderV1,
 } from '@ai-sdk/provider';
@@ -20,6 +21,11 @@ import {
   BedrockEmbeddingModelId,
   BedrockEmbeddingSettings,
 } from './bedrock-embedding-settings';
+import { BedrockImageModel } from './bedrock-image-model';
+import {
+  BedrockImageModelId,
+  BedrockImageSettings,
+} from './bedrock-image-settings';
 import { createSigV4FetchFunction } from './bedrock-sigv4-fetch';
 
 export interface AmazonBedrockProviderSettings {
@@ -81,6 +87,16 @@ export interface AmazonBedrockProvider extends ProviderV1 {
     modelId: BedrockEmbeddingModelId,
     settings?: BedrockEmbeddingSettings,
   ): EmbeddingModelV1<string>;
+  
+  image(
+    modelId: BedrockImageModelId,
+    settings?: BedrockImageSettings,
+  ): ImageModelV1;
+
+  imageModel(
+    modelId: BedrockImageModelId,
+    settings?: BedrockImageSettings,
+  ): ImageModelV1;
 }
 
 /**
@@ -162,10 +178,22 @@ export function createAmazonBedrock(
       fetch: sigv4Fetch,
     });
 
+  const createImageModel = (
+    modelId: BedrockImageModelId,
+    settings: BedrockImageSettings = {},
+  ) =>
+    new BedrockImageModel(modelId, settings, {
+      baseUrl: getBaseUrl,
+      headers: options.headers ?? {},
+      fetch: sigv4Fetch,
+    });
+
   provider.languageModel = createChatModel;
   provider.embedding = createEmbeddingModel;
   provider.textEmbedding = createEmbeddingModel;
   provider.textEmbeddingModel = createEmbeddingModel;
+  provider.image = createImageModel;
+  provider.imageModel = createImageModel;
 
   return provider;
 }

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -87,7 +87,7 @@ export interface AmazonBedrockProvider extends ProviderV1 {
     modelId: BedrockEmbeddingModelId,
     settings?: BedrockEmbeddingSettings,
   ): EmbeddingModelV1<string>;
-  
+
   image(
     modelId: BedrockImageModelId,
     settings?: BedrockImageSettings,


### PR DESCRIPTION
This PR adds support for image generation via the Amazon Nova Canvas.

Support is added via the experimental `generateImage` feature and at this time it focus exclusively on the Amazon Nova Canvas model available in `us-east-1`.

For the implementation I created a `BedrockImageModel` that implements the `ImageModelV1` interface. I modeled the implementation using the OpenAI image model class and other Bedrock ones for the request/signature part. I also updated the `AmazonBedrockProvider` class to add an `image` and `imageModel` similar to what found in the OpenAI provider.

As part of the PR I also added a new section to the documentation following the style and format of other sections as close as possible. 

Finally, I added tests for the new code.

I'm open to address any feedback or suggestions from maintainers as needed.

Closes #4942