### PR TITLE
fix (docs): Getting Started: NextJS App Router: Add @ai-sdk/react

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -50,13 +50,13 @@ Install `ai`, `@ai-sdk/react`, and `@ai-sdk/openai`, the AI package, AI SDK's Re
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet text="pnpm add ai @ai-sdk/openai zod" dark />
+      <Snippet text="pnpm add ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
     <Tab>
-      <Snippet text="npm install ai @ai-sdk/openai zod" dark />
+      <Snippet text="npm install ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
     <Tab>
-      <Snippet text="yarn add ai @ai-sdk/openai zod" dark />
+      <Snippet text="yarn add ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
   </Tabs>
 </div>


### PR DESCRIPTION
Recently, the react hooks were moved into a separate package `@ai-sdk/react`. That package is currently missing from the code snippet for installing the dependencies:

![image](https://github.com/user-attachments/assets/eb983500-5f08-44f4-90d3-c5cafbe559d8)


URL: https://sdk.vercel.ai/docs/getting-started/nextjs-app-router#install-dependencies