### PR TITLE
Update beta flag for sonnet-3-7 when using new computer-use tool

### DIFF
--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -37,9 +37,9 @@ export function prepareTools(
         });
         break;
       case 'provider-defined':
-        betas.add('computer-use-2024-10-22');
         switch (tool.id) {
           case 'anthropic.computer_20250124':
+            betas.add('computer-use-2025-01-24');
             anthropicTools.push({
               name: tool.name,
               type: 'computer_20250124',
@@ -49,6 +49,7 @@ export function prepareTools(
             });
             break;
           case 'anthropic.computer_20241022':
+            betas.add('computer-use-2024-10-22');
             anthropicTools.push({
               name: tool.name,
               type: 'computer_20241022',
@@ -58,12 +59,14 @@ export function prepareTools(
             });
             break;
           case 'anthropic.text_editor_20241022':
+            betas.add('computer-use-2024-10-22');
             anthropicTools.push({
               name: tool.name,
               type: 'text_editor_20241022',
             });
             break;
           case 'anthropic.bash_20241022':
+            betas.add('computer-use-2024-10-22');
             anthropicTools.push({
               name: tool.name,
               type: 'bash_20241022',


### PR DESCRIPTION
New model and tool require new beta flag:
https://docs.anthropic.com/en/docs/agents-and-tools/computer-use#claude-3-7-sonnet-beta-flag

The proposed changes may seem like it leads to two different flags being set at the same time, however it's not possible logically. 

In the worst case API seems to be accepting and handling well when both beta flags are set.