### PR TITLE
fix(docs): remove unnecessary apostrophes

### DIFF
--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -52,7 +52,7 @@ The result object of `generateText` contains several promises that resolve when 
 
 ## `streamText`
 
-Depending on your model and prompt, it can take a large language model (LLM) up to a minute to finish generating it's response. This delay can be unacceptable for interactive use cases such as chatbots or real-time applications, where users expect immediate responses.
+Depending on your model and prompt, it can take a large language model (LLM) up to a minute to finish generating its response. This delay can be unacceptable for interactive use cases such as chatbots or real-time applications, where users expect immediate responses.
 
 AI SDK Core provides the [`streamText`](/docs/reference/ai-sdk-core/stream-text) function which simplifies streaming text from LLMs:
 
@@ -79,7 +79,7 @@ for await (const textPart of result.textStream) {
   server crashes. Use the `onError` callback to log errors.
 </Note>
 
-You can use `streamText` on it's own or in combination with [AI SDK
+You can use `streamText` on its own or in combination with [AI SDK
 UI](/examples/next-pages/basics/streaming-text-generation) and [AI SDK
 RSC](/examples/next-app/basics/streaming-text-generation).
 The result object contains several helper functions to make the integration into [AI SDK UI](/docs/ai-sdk-ui) easier:


### PR DESCRIPTION
Changed `it's` to `its` in a couple of places because `it's` is incorrect in these contexts.