### PR TITLE
feat (ai/core): return reasoning in generateObject

### DIFF
--- a/packages/ai/core/generate-object/generate-object-result.ts
+++ b/packages/ai/core/generate-object/generate-object-result.ts
@@ -43,6 +43,11 @@ Additional response information.
   readonly response: LanguageModelResponseMetadata;
 
   /**
+  The reasoning of the model.
+   */
+  readonly reasoning: string | undefined;
+
+  /**
  Logprobs for the completion.
 `undefined` if the mode does not support logprobs or if was not enabled.
 

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -428,7 +428,7 @@ export async function generateObject<SCHEMA, RESULT>({
       let request: LanguageModelRequestMetadata;
       let logprobs: LogProbs | undefined;
       let resultProviderMetadata: ProviderMetadata | undefined;
-
+      let reasoning: string | undefined;
       switch (mode) {
         case 'json': {
           const standardizedPrompt = standardizePrompt({
@@ -557,7 +557,7 @@ export async function generateObject<SCHEMA, RESULT>({
           resultProviderMetadata = generateResult.providerMetadata;
           request = generateResult.request ?? {};
           response = generateResult.responseData;
-
+          reasoning = generateResult.reasoning;
           break;
         }
 
@@ -682,7 +682,7 @@ export async function generateObject<SCHEMA, RESULT>({
           resultProviderMetadata = generateResult.providerMetadata;
           request = generateResult.request ?? {};
           response = generateResult.responseData;
-
+          reasoning = generateResult.reasoning;
           break;
         }
 
@@ -751,6 +751,7 @@ export async function generateObject<SCHEMA, RESULT>({
         usage: calculateLanguageModelUsage(usage),
         warnings,
         request,
+        reasoning,
         response: {
           ...response,
           headers: rawResponse?.headers,
@@ -772,7 +773,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
   readonly providerMetadata: GenerateObjectResult<T>['providerMetadata'];
   readonly response: GenerateObjectResult<T>['response'];
   readonly request: GenerateObjectResult<T>['request'];
-
+  readonly reasoning: GenerateObjectResult<T>['reasoning'];
   constructor(options: {
     object: GenerateObjectResult<T>['object'];
     finishReason: GenerateObjectResult<T>['finishReason'];
@@ -782,6 +783,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
     providerMetadata: GenerateObjectResult<T>['providerMetadata'];
     response: GenerateObjectResult<T>['response'];
     request: GenerateObjectResult<T>['request'];
+    reasoning: GenerateObjectResult<T>['reasoning'];
   }) {
     this.object = options.object;
     this.finishReason = options.finishReason;
@@ -792,6 +794,7 @@ class DefaultGenerateObjectResult<T> implements GenerateObjectResult<T> {
     this.response = options.response;
     this.request = options.request;
     this.logprobs = options.logprobs;
+    this.reasoning = options.reasoning;
   }
 
   toJsonResponse(init?: ResponseInit): Response {


### PR DESCRIPTION
This allows non-streaming object generation, when used with a reasoning model, to provide the reasoning output the same as generateText does