### PR TITLE
fix (docs): bedrock import

### DIFF
--- a/content/docs/02-guides/04-sonnet-3-7.mdx
+++ b/content/docs/02-guides/04-sonnet-3-7.mdx
@@ -35,7 +35,7 @@ console.log(text); // text response
 The unified interface also means that you can easily switch between providers by changing just two lines of code. For example, to use Claude 3.7 Sonnet via Amazon Bedrock:
 
 ```ts
-import { bedrock } from '@ai-sdk/bedrock';
+import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { generateText } from 'ai';
 
 const { reasoning, text } = await generateText({


### PR DESCRIPTION
Small detail: The example for Amazon bedrock import is wrong and should use [`@ai-sdk/amazon-bedrock`](https://www.npmjs.com/package/@ai-sdk/amazon-bedrock)