### PR TITLE
fix (provider/anthropic): add model setting to allow omitting reasoning content from model requests

### DIFF
--- a/.changeset/fluffy-geckos-occur.md
+++ b/.changeset/fluffy-geckos-occur.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix (provider/anthropic): omit reasoning messages with no signature

--- a/.changeset/fluffy-geckos-occur.md
+++ b/.changeset/fluffy-geckos-occur.md
@@ -2,4 +2,4 @@
 '@ai-sdk/anthropic': patch
 ---
 
-fix (provider/anthropic): omit reasoning messages with no signature
+fix (provider/anthropic): add model setting to allow omitting reasoning content from model requests

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -95,6 +95,15 @@ Anthropic language models can also be used in the `streamText`, `generateObject`
   instead of streaming it incrementally.
 </Note>
 
+The following optional settings are available for Anthropic models:
+
+- `sendReasoning` _boolean_
+
+  Optional. Include reasoning content in requests sent to the model. Defaults to `true`.
+
+  If you are experiencing issues with the model handling requests involving
+  reasoning content, you can set this to `false` to omit them from the request.
+
 ### Reasoning
 
 Anthropic has reasoning support for the `claude-3-7-sonnet-20250219` model.

--- a/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/11-google-vertex.mdx
@@ -816,6 +816,15 @@ Anthropic language models can also be used in the `streamText`, `generateObject`
   instead of streaming it incrementally.
 </Note>
 
+The following optional settings are available for Anthropic models:
+
+- `sendReasoning` _boolean_
+
+  Optional. Include reasoning content in requests sent to the model. Defaults to `true`.
+
+  If you are experiencing issues with the model handling requests involving
+  reasoning content, you can set this to `false` to omit them from the request.
+
 ### Reasoning
 
 Anthropic has reasoning support for the `claude-3-7-sonnet@20250219` model.

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
@@ -12,7 +12,13 @@ import { weatherTool } from '../tools/weather-tool';
 async function main() {
   const result = streamText({
     model: wrapLanguageModel({
-      model: anthropic('claude-3-opus-20240229'),
+      model: anthropic('claude-3-opus-20240229', {
+        // Anthropic produces 'thinking' tags for this model and example
+        // configuration.  These will never include signature content and so
+        // will fail the provider-side signature check if included in subsequent
+        // request messages, so we disable sending reasoning content.
+        sendReasoning: false,
+      }),
       middleware: [extractReasoningMiddleware({ tagName: 'thinking' })],
     }),
     tools: {

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
@@ -1,0 +1,71 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import {
+  extractReasoningMiddleware,
+  streamText,
+  ToolCallPart,
+  ToolResultPart,
+  wrapLanguageModel,
+} from 'ai';
+import 'dotenv/config';
+import { weatherTool } from '../tools/weather-tool';
+
+async function main() {
+  const result = streamText({
+    model: wrapLanguageModel({
+      model: anthropic('claude-3-opus-20240229'),
+      middleware: [extractReasoningMiddleware({ tagName: 'thinking' })],
+    }),
+    tools: {
+      weather: weatherTool,
+    },
+    prompt: 'What is the weather in San Francisco?',
+    maxSteps: 5,
+  });
+
+  let enteredReasoning = false;
+  let enteredText = false;
+  const toolCalls: ToolCallPart[] = [];
+  const toolResponses: ToolResultPart[] = [];
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'reasoning': {
+        if (!enteredReasoning) {
+          enteredReasoning = true;
+          console.log('\nREASONING:\n');
+        }
+        process.stdout.write(part.textDelta);
+        break;
+      }
+
+      case 'text-delta': {
+        if (!enteredText) {
+          enteredText = true;
+          console.log('\nTEXT:\n');
+        }
+        process.stdout.write(part.textDelta);
+        break;
+      }
+
+      case 'tool-call': {
+        toolCalls.push(part);
+
+        process.stdout.write(
+          `\nTool call: '${part.toolName}' ${JSON.stringify(part.args)}`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        toolResponses.push(part);
+
+        process.stdout.write(
+          `\nTool response: '${part.toolName}' ${JSON.stringify(part.result)}`,
+        );
+        break;
+      }
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -111,6 +111,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
     const { prompt: messagesPrompt, betas: messagesBetas } =
       convertToAnthropicMessagesPrompt({
         prompt,
+        sendReasoning: this.settings.sendReasoning ?? true,
       });
 
     const thinkingOptions = thinkingOptionsSchema.safeParse(

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -112,6 +112,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
       convertToAnthropicMessagesPrompt({
         prompt,
         sendReasoning: this.settings.sendReasoning ?? true,
+        warnings,
       });
 
     const thinkingOptions = thinkingOptionsSchema.safeParse(

--- a/packages/anthropic/src/anthropic-messages-settings.ts
+++ b/packages/anthropic/src/anthropic-messages-settings.ts
@@ -21,4 +21,12 @@ Enable Anthropic cache control. This will allow you to use provider-specific
 optionally mark content for caching) and this setting is no longer needed.
 */
   cacheControl?: boolean;
+
+  /**
+Include reasoning content in requests sent to the model. Defaults to `true`.
+
+If you are experiencing issues with the model handling requests involving
+reasoning content, you can set this to `false` to omit them from the request.
+  */
+  sendReasoning?: boolean;
 }

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1,3 +1,4 @@
+import { LanguageModelV1CallWarning } from '@ai-sdk/provider';
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 
 describe('system messages', () => {
@@ -5,6 +6,7 @@ describe('system messages', () => {
     const result = convertToAnthropicMessagesPrompt({
       prompt: [{ role: 'system', content: 'This is a system message' }],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -23,6 +25,7 @@ describe('system messages', () => {
         { role: 'system', content: 'This is another system message' },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -54,6 +57,7 @@ describe('user messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -94,6 +98,7 @@ describe('user messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -135,6 +140,7 @@ describe('user messages', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       }),
     ).toThrow('Non-PDF files in user messages');
   });
@@ -155,6 +161,7 @@ describe('user messages', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       }),
     ).toThrow('Non-PDF files in user messages');
   });
@@ -177,6 +184,7 @@ describe('tool messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -222,6 +230,7 @@ describe('tool messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -271,6 +280,7 @@ describe('tool messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -322,6 +332,7 @@ describe('tool messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -369,6 +380,7 @@ describe('assistant messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -404,6 +416,7 @@ describe('assistant messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -443,6 +456,7 @@ describe('assistant messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -475,6 +489,7 @@ describe('assistant messages', () => {
         { role: 'assistant', content: [{ type: 'text', text: '!' }] },
       ],
       sendReasoning: true,
+      warnings: [],
     });
 
     expect(result).toEqual({
@@ -496,6 +511,7 @@ describe('assistant messages', () => {
   });
 
   it('should convert assistant message reasoning parts with signature into thinking parts when sendReasoning is true', async () => {
+    const warnings: LanguageModelV1CallWarning[] = [];
     const result = convertToAnthropicMessagesPrompt({
       prompt: [
         {
@@ -514,6 +530,7 @@ describe('assistant messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings,
     });
 
     expect(result).toEqual({
@@ -538,9 +555,11 @@ describe('assistant messages', () => {
       },
       betas: new Set(),
     });
+    expect(warnings).toEqual([]);
   });
 
   it('should convert reasoning parts without signature into thinking parts when sendReasoning is true', async () => {
+    const warnings: LanguageModelV1CallWarning[] = [];
     const result = convertToAnthropicMessagesPrompt({
       prompt: [
         {
@@ -558,6 +577,7 @@ describe('assistant messages', () => {
         },
       ],
       sendReasoning: true,
+      warnings,
     });
 
     expect(result).toEqual({
@@ -581,9 +601,11 @@ describe('assistant messages', () => {
       },
       betas: new Set(),
     });
+    expect(warnings).toEqual([]);
   });
 
   it('should omit assistant message reasoning parts with signature when sendReasoning is false', async () => {
+    const warnings: LanguageModelV1CallWarning[] = [];
     const result = convertToAnthropicMessagesPrompt({
       prompt: [
         {
@@ -602,6 +624,7 @@ describe('assistant messages', () => {
         },
       ],
       sendReasoning: false,
+      warnings,
     });
 
     expect(result).toEqual({
@@ -620,14 +643,25 @@ describe('assistant messages', () => {
       },
       betas: new Set(),
     });
+    expect(warnings).toEqual([
+      {
+        type: 'other',
+        message: 'reasoning content is removed for this model',
+      },
+    ]);
   });
 
   it('should omit reasoning parts without signature when sendReasoning is false', async () => {
+    const warnings: LanguageModelV1CallWarning[] = [];
     const result = convertToAnthropicMessagesPrompt({
       prompt: [
         {
           role: 'assistant',
           content: [
+            {
+              type: 'reasoning',
+              text: 'I need to count the number of "r"s in the word "strawberry".',
+            },
             {
               type: 'text',
               text: 'The word "strawberry" has 2 "r"s.',
@@ -636,6 +670,7 @@ describe('assistant messages', () => {
         },
       ],
       sendReasoning: false,
+      warnings,
     });
 
     expect(result).toEqual({
@@ -654,6 +689,12 @@ describe('assistant messages', () => {
       },
       betas: new Set(),
     });
+    expect(warnings).toEqual([
+      {
+        type: 'other',
+        message: 'reasoning content is removed for this model',
+      },
+    ]);
   });
 });
 
@@ -671,6 +712,7 @@ describe('cache control', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       });
 
       expect(result).toEqual({
@@ -709,6 +751,7 @@ describe('cache control', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       });
 
       expect(result).toEqual({
@@ -747,6 +790,7 @@ describe('cache control', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       });
 
       expect(result).toEqual({
@@ -795,6 +839,7 @@ describe('cache control', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       });
 
       expect(result).toEqual({
@@ -839,6 +884,7 @@ describe('cache control', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       });
 
       expect(result).toEqual({
@@ -881,6 +927,7 @@ describe('cache control', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       });
 
       expect(result).toEqual({
@@ -931,6 +978,7 @@ describe('cache control', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       });
 
       expect(result).toEqual({
@@ -981,6 +1029,7 @@ describe('cache control', () => {
           },
         ],
         sendReasoning: true,
+        warnings: [],
       });
 
       expect(result).toEqual({

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -4,6 +4,7 @@ describe('system messages', () => {
   it('should convert a single system message into an anthropic system message', async () => {
     const result = convertToAnthropicMessagesPrompt({
       prompt: [{ role: 'system', content: 'This is a system message' }],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -21,6 +22,7 @@ describe('system messages', () => {
         { role: 'system', content: 'This is a system message' },
         { role: 'system', content: 'This is another system message' },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -51,6 +53,7 @@ describe('user messages', () => {
           ],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -90,6 +93,7 @@ describe('user messages', () => {
           ],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -130,6 +134,7 @@ describe('user messages', () => {
             ],
           },
         ],
+        sendReasoning: true,
       }),
     ).toThrow('Non-PDF files in user messages');
   });
@@ -149,6 +154,7 @@ describe('user messages', () => {
             ],
           },
         ],
+        sendReasoning: true,
       }),
     ).toThrow('Non-PDF files in user messages');
   });
@@ -170,6 +176,7 @@ describe('tool messages', () => {
           ],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -214,6 +221,7 @@ describe('tool messages', () => {
           ],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -262,6 +270,7 @@ describe('tool messages', () => {
           content: [{ type: 'text', text: 'This is a user message' }],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -312,6 +321,7 @@ describe('tool messages', () => {
           ],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -358,6 +368,7 @@ describe('assistant messages', () => {
           content: [{ type: 'text', text: 'assistant content  ' }],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -392,6 +403,7 @@ describe('assistant messages', () => {
           ],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -430,6 +442,7 @@ describe('assistant messages', () => {
           content: [{ type: 'text', text: 'user content 2' }],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -461,6 +474,7 @@ describe('assistant messages', () => {
         { role: 'assistant', content: [{ type: 'text', text: 'World' }] },
         { role: 'assistant', content: [{ type: 'text', text: '!' }] },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -481,7 +495,7 @@ describe('assistant messages', () => {
     });
   });
 
-  it('should convert assistant message reasoning parts with signature into thinking parts', async () => {
+  it('should convert assistant message reasoning parts with signature into thinking parts when sendReasoning is true', async () => {
     const result = convertToAnthropicMessagesPrompt({
       prompt: [
         {
@@ -499,6 +513,7 @@ describe('assistant messages', () => {
           ],
         },
       ],
+      sendReasoning: true,
     });
 
     expect(result).toEqual({
@@ -525,7 +540,7 @@ describe('assistant messages', () => {
     });
   });
 
-  it('should omit reasoning parts without signature', async () => {
+  it('should convert reasoning parts without signature into thinking parts when sendReasoning is true', async () => {
     const result = convertToAnthropicMessagesPrompt({
       prompt: [
         {
@@ -542,6 +557,85 @@ describe('assistant messages', () => {
           ],
         },
       ],
+      sendReasoning: true,
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'thinking',
+                thinking:
+                  'I need to count the number of "r"s in the word "strawberry".',
+              },
+              {
+                type: 'text',
+                text: 'The word "strawberry" has 2 "r"s.',
+              },
+            ],
+          },
+        ],
+      },
+      betas: new Set(),
+    });
+  });
+
+  it('should omit assistant message reasoning parts with signature when sendReasoning is false', async () => {
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: 'I need to count the number of "r"s in the word "strawberry".',
+              signature: 'test-signature',
+            },
+            {
+              type: 'text',
+              text: 'The word "strawberry" has 2 "r"s.',
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'The word "strawberry" has 2 "r"s.',
+              },
+            ],
+          },
+        ],
+      },
+      betas: new Set(),
+    });
+  });
+
+  it('should omit reasoning parts without signature when sendReasoning is false', async () => {
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'The word "strawberry" has 2 "r"s.',
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
     });
 
     expect(result).toEqual({
@@ -576,6 +670,7 @@ describe('cache control', () => {
             },
           },
         ],
+        sendReasoning: true,
       });
 
       expect(result).toEqual({
@@ -613,6 +708,7 @@ describe('cache control', () => {
             ],
           },
         ],
+        sendReasoning: true,
       });
 
       expect(result).toEqual({
@@ -650,6 +746,7 @@ describe('cache control', () => {
             },
           },
         ],
+        sendReasoning: true,
       });
 
       expect(result).toEqual({
@@ -697,6 +794,7 @@ describe('cache control', () => {
             ],
           },
         ],
+        sendReasoning: true,
       });
 
       expect(result).toEqual({
@@ -740,6 +838,7 @@ describe('cache control', () => {
             ],
           },
         ],
+        sendReasoning: true,
       });
 
       expect(result).toEqual({
@@ -781,6 +880,7 @@ describe('cache control', () => {
             },
           },
         ],
+        sendReasoning: true,
       });
 
       expect(result).toEqual({
@@ -830,6 +930,7 @@ describe('cache control', () => {
             ],
           },
         ],
+        sendReasoning: true,
       });
 
       expect(result).toEqual({
@@ -879,6 +980,7 @@ describe('cache control', () => {
             },
           },
         ],
+        sendReasoning: true,
       });
 
       expect(result).toEqual({

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -646,7 +646,7 @@ describe('assistant messages', () => {
     expect(warnings).toEqual([
       {
         type: 'other',
-        message: 'reasoning content is removed for this model',
+        message: 'sending reasoning content is disabled for this model',
       },
     ]);
   });
@@ -692,7 +692,7 @@ describe('assistant messages', () => {
     expect(warnings).toEqual([
       {
         type: 'other',
-        message: 'reasoning content is removed for this model',
+        message: 'sending reasoning content is disabled for this model',
       },
     ]);
   });

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -481,7 +481,51 @@ describe('assistant messages', () => {
     });
   });
 
-  it('should convert assistant message reasoning parts into thinking parts', async () => {
+  it('should convert assistant message reasoning parts with signature into thinking parts', async () => {
+    const result = convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: 'I need to count the number of "r"s in the word "strawberry".',
+              signature: 'test-signature',
+            },
+            {
+              type: 'text',
+              text: 'The word "strawberry" has 2 "r"s.',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'thinking',
+                thinking:
+                  'I need to count the number of "r"s in the word "strawberry".',
+                signature: 'test-signature',
+              },
+              {
+                type: 'text',
+                text: 'The word "strawberry" has 2 "r"s.',
+              },
+            ],
+          },
+        ],
+      },
+      betas: new Set(),
+    });
+  });
+
+  it('should omit reasoning parts without signature', async () => {
     const result = convertToAnthropicMessagesPrompt({
       prompt: [
         {
@@ -506,11 +550,6 @@ describe('assistant messages', () => {
           {
             role: 'assistant',
             content: [
-              {
-                type: 'thinking',
-                thinking:
-                  'I need to count the number of "r"s in the word "strawberry".',
-              },
               {
                 type: 'text',
                 text: 'The word "strawberry" has 2 "r"s.',

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -251,12 +251,18 @@ export function convertToAnthropicMessagesPrompt({
               }
 
               case 'reasoning': {
-                anthropicContent.push({
-                  type: 'thinking',
-                  thinking: part.text,
-                  signature: part.signature!,
-                  cache_control: cacheControl,
-                });
+                // omit reasoning content if no signature is present. middleware
+                // could have extracted it from an older model's text content
+                // with no associated signature, and anthropic API
+                // requires signature presence even for older models.
+                if (part.signature) {
+                  anthropicContent.push({
+                    type: 'thinking',
+                    thinking: part.text,
+                    signature: part.signature,
+                    cache_control: cacheControl,
+                  });
+                }
                 break;
               }
 

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -266,7 +266,8 @@ export function convertToAnthropicMessagesPrompt({
                 } else {
                   warnings.push({
                     type: 'other',
-                    message: 'reasoning content is removed for this model',
+                    message:
+                      'sending reasoning content is disabled for this model',
                   });
                 }
                 break;

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -1,4 +1,5 @@
 import {
+  LanguageModelV1CallWarning,
   LanguageModelV1Message,
   LanguageModelV1Prompt,
   LanguageModelV1ProviderMetadata,
@@ -15,9 +16,11 @@ import {
 export function convertToAnthropicMessagesPrompt({
   prompt,
   sendReasoning,
+  warnings,
 }: {
   prompt: LanguageModelV1Prompt;
   sendReasoning: boolean;
+  warnings: LanguageModelV1CallWarning[];
 }): {
   prompt: AnthropicMessagesPrompt;
   betas: Set<string>;
@@ -260,6 +263,11 @@ export function convertToAnthropicMessagesPrompt({
                     signature: part.signature!,
                     cache_control: cacheControl,
                   });
+                } else {
+                  warnings.push({
+                    type: 'other',
+                    message: 'reasoning content is removed for this model',
+                  });
                 }
                 break;
               }
@@ -272,6 +280,7 @@ export function convertToAnthropicMessagesPrompt({
                 });
                 break;
               }
+
               case 'tool-call': {
                 anthropicContent.push({
                   type: 'tool_use',

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -14,8 +14,10 @@ import {
 
 export function convertToAnthropicMessagesPrompt({
   prompt,
+  sendReasoning,
 }: {
   prompt: LanguageModelV1Prompt;
+  sendReasoning: boolean;
 }): {
   prompt: AnthropicMessagesPrompt;
   betas: Set<string>;
@@ -251,15 +253,11 @@ export function convertToAnthropicMessagesPrompt({
               }
 
               case 'reasoning': {
-                // omit reasoning content if no signature is present. middleware
-                // could have extracted it from an older model's text content
-                // with no associated signature, and anthropic API
-                // requires signature presence even for older models.
-                if (part.signature) {
+                if (sendReasoning) {
                   anthropicContent.push({
                     type: 'thinking',
                     thinking: part.text,
-                    signature: part.signature,
+                    signature: part.signature!,
                     cache_control: cacheControl,
                   });
                 }


### PR DESCRIPTION
For the included example script with a tool call, claude 3 opus produces thinking-tagged content below which, when extracted with middleware into a `reasoning` part, produces `thinking` content. Anthropic API then throws an error on the request as it enforces a signature requirement on `thinking` content.

This change adds a `sendReasoning` model setting, defaulting to `true`. When set to `false`, we omit reasoning content from inclusion in model requests.

```
<thinking>
The user is asking for the weather in a specific location, San Francisco. The weather tool is directly relevant for answering this query.

Looking at the required parameters for the weather tool:
- location (required): The user directly provided the location of "San Francisco"

Since the required location parameter is present, we can proceed with calling the weather tool to get the forecast for San Francisco. No other tools are needed.
</thinking>
```