### PR TITLE
fix (react): infinite re-render caused by `fillMessageParts` 

### DIFF
--- a/.changeset/tricky-walls-poke.md
+++ b/.changeset/tricky-walls-poke.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix (react): infinite re-render caused by fillMessageParts

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -18,8 +18,8 @@ import {
   shouldResubmitMessages,
   updateToolCallResult,
 } from '@ai-sdk/ui-utils';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import useSWR from 'swr';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useSWR, { unstable_serialize } from 'swr';
 import { throttle } from './throttle';
 
 export type { CreateMessage, Message, UseChatOptions };
@@ -179,19 +179,19 @@ By default, it's set to 1, which means that only a single LLM call is made.
   const chatKey = typeof api === 'string' ? [api, chatId] : chatId;
 
   // Store a empty array as the initial messages
-  // (instead of using a default parameter value that gets re-created each time)
+  // (processed with messaged parts if applicable)
+  // instead of using a default parameter value that gets re-created each time
   // to avoid re-renders:
-  const [initialMessagesFallback] = useState([]);
+  const [initialMessagesFallback] = useState(
+    initialMessages != null ? fillMessageParts(initialMessages) : [],
+  );
 
   // Store the chat state in SWR, using the chatId as the key to share states.
   const { data: messages, mutate } = useSWR<UIMessage[]>(
     [chatKey, 'messages'],
     null,
     {
-      fallbackData:
-        initialMessages != null
-          ? fillMessageParts(initialMessages)
-          : initialMessagesFallback,
+      fallbackData: initialMessagesFallback,
     },
   );
 

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -19,7 +19,7 @@ import {
   updateToolCallResult,
 } from '@ai-sdk/ui-utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import useSWR, { unstable_serialize } from 'swr';
+import useSWR from 'swr';
 import { throttle } from './throttle';
 
 export type { CreateMessage, Message, UseChatOptions };
@@ -178,7 +178,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
   const chatId = id ?? hookId;
   const chatKey = typeof api === 'string' ? [api, chatId] : chatId;
 
-  // Store a empty array as the initial messages
+  // Store array of the initial messages
   // (processed with messaged parts if applicable)
   // instead of using a default parameter value that gets re-created each time
   // to avoid re-renders:

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1944,27 +1944,24 @@ describe('initialMessages stability', () => {
   });
 
   it('should not cause infinite rerenders when initialMessages is defined and messages is a dependency of useEffect', async () => {
+    // wait for initial render to complete
     await waitFor(() => {
       expect(screen.getByTestId('message-user')).toHaveTextContent(
         'Test message',
       );
     });
 
-    const initialRenderCount = parseInt(
-      screen.getByTestId('render-count').textContent || '0',
+    // confirm useEffect ran
+    await waitFor(() => {
+      expect(screen.getByTestId('derived-state')).toHaveTextContent(
+        'Test message, Test response',
+      );
+    });
+
+    const renderCount = parseInt(
+      screen.getByTestId('render-count').textContent!,
     );
 
-    await new Promise(resolve => setTimeout(resolve, 100));
-
-    const finalRenderCount = parseInt(
-      screen.getByTestId('render-count').textContent || '0',
-    );
-
-    expect(finalRenderCount).toBeLessThan(3);
-    expect(finalRenderCount).toBe(initialRenderCount);
-
-    expect(screen.getByTestId('derived-state')).toHaveTextContent(
-      'Test message, Test response',
-    );
+    expect(renderCount).toBe(2);
   });
 });


### PR DESCRIPTION
Addresses https://github.com/vercel/ai/issues/4741, caused by referential instability of `initialMessages`

When initial messages are present in `useChat`, we would call `fillMessageParts` when setting SWR `fallbackData`; this would create a new array every render

Resolved by implementing the same logic used for `initialMessagesFallback`, where we store the array of initial messages (with parts, if applicable) instead of relying on the default parameter value