### PR TITLE
feat: pass seed to google generate

### DIFF
--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -83,13 +83,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
 
     const warnings: LanguageModelV1CallWarning[] = [];
 
-    if (seed != null) {
-      warnings.push({
-        type: 'unsupported-setting',
-        setting: 'seed',
-      });
-    }
-
     const generationConfig = {
       // standardized settings:
       maxOutputTokens: maxTokens,
@@ -99,6 +92,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       frequencyPenalty,
       presencePenalty,
       stopSequences,
+      seed,
 
       // response format:
       responseMimeType:


### PR DESCRIPTION
Google supports a `seed` parameter in its `GenerationConfig` in both the [Gemini API](https://ai.google.dev/api/generate-content) and the [Vertex API](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/GenerationConfig)

This PR updates the library to pass along the seed value when it is provided