### PR TITLE
feat(provider/anthropic): add bash_20250124 and text_editor_20250124

### DIFF
--- a/.changeset/orange-rocks-wash.md
+++ b/.changeset/orange-rocks-wash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(provider/anthropic): add bash_20250124 and text_editor_20250124 tools

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ server/dist
 public/dist
 .turbo
 test-results
+.tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ server/dist
 public/dist
 .turbo
 test-results
-.tool-versions

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -99,11 +99,11 @@ export type AnthropicTool =
     }
   | {
       name: string;
-      type: 'text_editor_20241022';
+      type: 'text_editor_20250124' | 'text_editor_20241022';
     }
   | {
       name: string;
-      type: 'bash_20241022';
+      type: 'bash_20250124' | 'bash_20241022';
     };
 
 export type AnthropicToolChoice =

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -86,7 +86,6 @@ export function prepareTools(
               type: 'bash_20241022',
             });
             break;
-
           default:
             toolWarnings.push({ type: 'unsupported-tool', tool });
             break;

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -58,11 +58,25 @@ export function prepareTools(
               display_number: tool.args.displayNumber as number,
             });
             break;
+          case 'anthropic.text_editor_20250124':
+            betas.add('computer-use-2025-01-24');
+            anthropicTools.push({
+              name: tool.name,
+              type: 'text_editor_20250124',
+            });
+            break;
           case 'anthropic.text_editor_20241022':
             betas.add('computer-use-2024-10-22');
             anthropicTools.push({
               name: tool.name,
               type: 'text_editor_20241022',
+            });
+            break;
+          case 'anthropic.bash_20250124':
+            betas.add('computer-use-2025-01-24');
+            anthropicTools.push({
+              name: tool.name,
+              type: 'bash_20250124',
             });
             break;
           case 'anthropic.bash_20241022':
@@ -72,6 +86,7 @@ export function prepareTools(
               type: 'bash_20241022',
             });
             break;
+
           default:
             toolWarnings.push({ type: 'unsupported-tool', tool });
             break;

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -69,6 +69,54 @@ function bashTool_20241022<RESULT>(
   };
 }
 
+const Bash20250124Parameters = z.object({
+  command: z.string(),
+  restart: z.boolean().optional(),
+});
+
+/**
+ * Creates a tool for running a bash command. Must have name "bash".
+ *
+ * Image results are supported.
+ *
+ * @param execute - The function to execute the tool. Optional.
+ */
+function bashTool_20250124<RESULT>(
+  options: {
+    execute?: ExecuteFunction<
+      {
+        /**
+         * The bash command to run. Required unless the tool is being restarted.
+         */
+        command: string;
+
+        /**
+         * Specifying true will restart this tool. Otherwise, leave this unspecified.
+         */
+        restart?: boolean;
+      },
+      RESULT
+    >;
+    experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
+  } = {},
+): {
+  type: 'provider-defined';
+  id: 'anthropic.bash_20250124';
+  args: {};
+  parameters: typeof Bash20250124Parameters;
+  execute: ExecuteFunction<z.infer<typeof Bash20250124Parameters>, RESULT>;
+  experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
+} {
+  return {
+    type: 'provider-defined',
+    id: 'anthropic.bash_20250124',
+    args: {},
+    parameters: Bash20250124Parameters,
+    execute: options.execute,
+    experimental_toToolResultContent: options.experimental_toToolResultContent,
+  };
+}
+
 const TextEditor20241022Parameters = z.object({
   command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
   path: z.string(),
@@ -145,6 +193,87 @@ function textEditorTool_20241022<RESULT>(
     id: 'anthropic.text_editor_20241022',
     args: {},
     parameters: TextEditor20241022Parameters,
+    execute: options.execute,
+    experimental_toToolResultContent: options.experimental_toToolResultContent,
+  };
+}
+
+const TextEditor20250124Parameters = z.object({
+  command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
+  path: z.string(),
+  file_text: z.string().optional(),
+  insert_line: z.number().int().optional(),
+  new_str: z.string().optional(),
+  old_str: z.string().optional(),
+  view_range: z.array(z.number().int()).optional(),
+});
+
+/**
+ * Creates a tool for editing text. Must have name "str_replace_editor".
+ *
+ * Image results are supported.
+ *
+ * @param execute - The function to execute the tool. Optional.
+ */
+function textEditorTool_20250124<RESULT>(
+  options: {
+    execute?: ExecuteFunction<
+      {
+        /**
+         * The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.
+         */
+        command: 'view' | 'create' | 'str_replace' | 'insert' | 'undo_edit';
+
+        /**
+         * Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.
+         */
+        path: string;
+
+        /**
+         * Required parameter of `create` command, with the content of the file to be created.
+         */
+        file_text?: string;
+
+        /**
+         * Required parameter of `insert` command. The `new_str` will be inserted AFTER the line `insert_line` of `path`.
+         */
+        insert_line?: number;
+
+        /**
+         * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
+         */
+        new_str?: string;
+
+        /**
+         * Required parameter of `str_replace` command containing the string in `path` to replace.
+         */
+        old_str?: string;
+
+        /**
+         * Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.
+         */
+        view_range?: number[];
+      },
+      RESULT
+    >;
+    experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
+  } = {},
+): {
+  type: 'provider-defined';
+  id: 'anthropic.text_editor_20250124';
+  args: {};
+  parameters: typeof TextEditor20250124Parameters;
+  execute: ExecuteFunction<
+    z.infer<typeof TextEditor20250124Parameters>,
+    RESULT
+  >;
+  experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
+} {
+  return {
+    type: 'provider-defined',
+    id: 'anthropic.text_editor_20250124',
+    args: {},
+    parameters: TextEditor20250124Parameters,
     execute: options.execute,
     experimental_toToolResultContent: options.experimental_toToolResultContent,
   };
@@ -383,7 +512,9 @@ function computerTool_20250124<RESULT>(options: {
 
 export const anthropicTools = {
   bash_20241022: bashTool_20241022,
+  bash_20250124: bashTool_20250124,
   textEditor_20241022: textEditorTool_20241022,
+  textEditor_20250124: textEditorTool_20250124,
   computer_20241022: computerTool_20241022,
   computer_20250124: computerTool_20250124,
 };


### PR DESCRIPTION
#4971 introduced [`claude-3-7-sonnet-20250219`](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use#claude-3-7-sonnet-beta-flag) and one of the 3 tools available, `computer_20250124`.
This PR adds the other 2 tools available, `bash_20250124` and `text_editor_20250124`.

Ref: https://docs.anthropic.com/en/docs/agents-and-tools/computer-use#claude-3-7-sonnet-tools

> [!NOTE]
> The example on the [Anthropic site](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use) can be confusing.
> It uses `claude-3-7-sonnet-20250219` with `computer_20250124` and the older versions of `text_editor_20241022` and `bash_20241022`.
> The API would return an error with that sample code, as `*_20241022` versions are not supported with the 3.7 model
> 

<details>
<summary>Example</summary>

![CleanShot 2025-02-28 at 16 21 40@2x](https://github.com/user-attachments/assets/2620df3b-2f31-4a08-b19e-9b32fdd8c10c)

</details>

<details>
<summary>Sample error</summary>

```
  error: {
    type: 'error',
    error: {
      type: 'invalid_request_error',
      message: "tools.1: Input tag 'text_editor_20241022' found using 'type' does not match any of the expected tags: 'bash_20250124', 'computer_20250124', 'custom', 'text_editor_20250124'"
    }
  }
```

</details>



