### PR TITLE
fix: handle empty object for content in responseSchema

### DIFF
--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -8,6 +8,7 @@ import { createGoogleGenerativeAI } from './google-provider';
 import {
   GoogleGenerativeAILanguageModel,
   groundingMetadataSchema,
+  responseSchema,
 } from './google-generative-ai-language-model';
 import { GoogleGenerativeAIGroundingMetadata } from './google-generative-ai-prompt';
 
@@ -166,6 +167,43 @@ describe('groundingMetadataSchema', () => {
 
     const result = groundingMetadataSchema.safeParse(metadata);
     expect(result.success).toBe(false);
+  });
+});
+
+describe('responseSchema', () => {
+  it('validates response with empty content object and MALFORMED_FUNCTION_CALL finish reason', () => {
+    // Test data with empty content object
+    const responseWithEmptyContent = {
+      "candidates": [
+        {
+          "content": {},
+          "finishReason": "MALFORMED_FUNCTION_CALL"
+        }
+      ],
+      "usageMetadata": {
+        "promptTokenCount": 9056,
+        "totalTokenCount": 9056,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 9056
+          }
+        ]
+      },
+      "modelVersion": "gemini-2.0-flash-lite"
+    };
+
+    // Parse the test data with the schema
+    const result = responseSchema.safeParse(responseWithEmptyContent);
+    
+    // The schema validation should succeed
+    expect(result.success).toBe(true);
+    
+    if (result.success) {
+      // Verify the parsed data has the expected structure
+      expect(result.data.candidates?.[0]?.content).toEqual({});
+      expect(result.data.candidates?.[0]?.finishReason).toBe("MALFORMED_FUNCTION_CALL");
+    }
   });
 });
 

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -512,10 +512,10 @@ export const safetyRatingSchema = z.object({
   blocked: z.boolean().nullish(),
 });
 
-const responseSchema = z.object({
+export const responseSchema = z.object({
   candidates: z.array(
     z.object({
-      content: contentSchema.nullish(),
+      content: contentSchema.nullish().or(z.object({}).strict()),
       finishReason: z.string().nullish(),
       safetyRatings: z.array(safetyRatingSchema).nullish(),
       groundingMetadata: groundingMetadataSchema.nullish(),


### PR DESCRIPTION
Not sure if it's a gemini-2.0-flash-lite API thing, but their endpoint started returning an empty object for content for `MALFORMED_FUNCTION_CALL`. This PR updates the responseSchema to handle it.

```
{
  "candidates": [
    {
      "content": {},
      "finishReason": "MALFORMED_FUNCTION_CALL"
    }
  ],
  "usageMetadata": {
    "promptTokenCount": 9056,
    "totalTokenCount": 9056,
    "promptTokensDetails": [
      {
        "modality": "TEXT",
        "tokenCount": 9056
      }
    ]
  },
  "modelVersion": "gemini-2.0-flash-lite"
}
```