### PR TITLE
feat (ai): expose raw response body in generateText and generateObject

### DIFF
--- a/.changeset/hip-shoes-appear.md
+++ b/.changeset/hip-shoes-appear.md
@@ -1,0 +1,14 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/perplexity': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/groq': patch
+'ai': patch
+---
+
+feat (ai): expose raw response body in generateText and generateObject

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -50,6 +50,24 @@ The result object of `generateText` contains several promises that resolve when 
 - `result.finishReason`: The reason the model finished generating text.
 - `result.usage`: The usage of the model during text generation.
 
+### Accessing response headers & body
+
+Sometimes you need access to the full response from the model provider,
+e.g. to access some provider-specific headers or body content.
+
+You can access the raw response headers and body using the `response` property:
+
+```ts
+import { generateText } from 'ai';
+
+const result = await generateText({
+  // ...
+});
+
+console.log(JSON.stringify(result.response.headers, null, 2));
+console.log(JSON.stringify(result.response.body, null, 2));
+```
+
 ## `streamText`
 
 Depending on your model and prompt, it can take a large language model (LLM) up to a minute to finish generating its response. This delay can be unacceptable for interactive use cases such as chatbots or real-time applications, where users expect immediate responses.

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -50,6 +50,24 @@ const { object } = await generateObject({
   See `generateObject` in action with [these examples](#more-examples)
 </Note>
 
+### Accessing response headers & body
+
+Sometimes you need access to the full response from the model provider,
+e.g. to access some provider-specific headers or body content.
+
+You can access the raw response headers and body using the `response` property:
+
+```ts
+import { generateText } from 'ai';
+
+const result = await generateText({
+  // ...
+});
+
+console.log(JSON.stringify(result.response.headers, null, 2));
+console.log(JSON.stringify(result.response.body, null, 2));
+```
+
 ## Stream Object
 
 Given the added complexity of returning structured data, model response time can be unacceptable for your interactive use case.

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -699,6 +699,12 @@ To see `generateText` in action, check out [these examples](#examples).
                       type: 'Record<string, string>',
                       description: 'Optional response headers.',
                     },
+                    {
+                      name: 'body',
+                      isOptional: true,
+                      type: 'unknown',
+                      description: 'Optional response body.',
+                    },
                   ],
                 },
               ],

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -648,6 +648,12 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
               type: 'Record<string, string>',
               description: 'Optional response headers.',
             },
+            {
+              name: 'body',
+              isOptional: true,
+              type: 'unknown',
+              description: 'Optional response body.',
+            },
           ],
         },
       ],

--- a/examples/ai-core/src/generate-text/anthropic.ts
+++ b/examples/ai-core/src/generate-text/anthropic.ts
@@ -10,8 +10,6 @@ async function main() {
 
   console.log(result.text);
   console.log();
-  console.log('Token usage:', result.usage);
-  console.log('Finish reason:', result.finishReason);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-text/anthropic.ts
+++ b/examples/ai-core/src/generate-text/anthropic.ts
@@ -10,6 +10,8 @@ async function main() {
 
   console.log(result.text);
   console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-text/fireworks-deepseek.ts
+++ b/examples/ai-core/src/generate-text/fireworks-deepseek.ts
@@ -3,14 +3,14 @@ import { generateText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { text, usage } = await generateText({
+  const result = await generateText({
     model: fireworks('accounts/fireworks/models/deepseek-v3'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
-  console.log(text);
+  console.log(result.text);
   console.log();
-  console.log('Usage:', usage);
+  console.log('Usage:', result.usage);
 }
 
 main().catch(console.error);

--- a/packages/ai/core/generate-object/generate-object-result.ts
+++ b/packages/ai/core/generate-object/generate-object-result.ts
@@ -40,7 +40,12 @@ Additional request information.
   /**
 Additional response information.
    */
-  readonly response: LanguageModelResponseMetadata;
+  readonly response: LanguageModelResponseMetadata & {
+    /**
+Response body (available only for providers that use HTTP requests).
+    */
+    body?: unknown;
+  };
 
   /**
  Logprobs for the completion.

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -312,6 +312,7 @@ describe('output = "object"', () => {
               headers: {
                 'custom-response-header': 'response-header-value',
               },
+              body: 'test body',
             },
           }),
         }),
@@ -327,6 +328,7 @@ describe('output = "object"', () => {
         headers: {
           'custom-response-header': 'response-header-value',
         },
+        body: 'test body',
       });
     });
 
@@ -352,6 +354,7 @@ describe('output = "object"', () => {
               headers: {
                 'custom-response-header': 'response-header-value',
               },
+              body: 'test body',
             },
           }),
         }),
@@ -367,6 +370,7 @@ describe('output = "object"', () => {
         headers: {
           'custom-response-header': 'response-header-value',
         },
+        body: 'test body',
       });
     });
   });

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -464,7 +464,9 @@ export async function generateObject<SCHEMA, RESULT>({
       let finishReason: FinishReason;
       let usage: Parameters<typeof calculateLanguageModelUsage>[0];
       let warnings: CallWarning[] | undefined;
-      let rawResponse: { headers?: Record<string, string> } | undefined;
+      let rawResponse:
+        | { headers?: Record<string, string>; body?: unknown }
+        | undefined;
       let response: LanguageModelResponseMetadata;
       let request: LanguageModelRequestMetadata;
       let logprobs: LogProbs | undefined;
@@ -824,6 +826,7 @@ export async function generateObject<SCHEMA, RESULT>({
         response: {
           ...response,
           headers: rawResponse?.headers,
+          body: rawResponse?.body,
         },
         logprobs,
         providerMetadata: resultProviderMetadata,

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -851,6 +851,7 @@ exports[`options.maxSteps > 4 steps: initial, continue, continue, continue > res
 
 exports[`result.response > should contain response information 1`] = `
 {
+  "body": "test body",
   "headers": {
     "custom-response-header": "response-header-value",
   },

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -99,6 +99,11 @@ If there are tools that do not have execute functions, they are not included in 
 need to be added separately.
        */
     messages: Array<CoreAssistantMessage | CoreToolMessage>;
+
+    /**
+Response body (available only for providers that use HTTP requests).
+     */
+    body?: unknown;
   };
 
   /**

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -439,6 +439,7 @@ describe('result.response', () => {
             headers: {
               'custom-response-header': 'response-header-value',
             },
+            body: 'test body',
           },
         }),
       }),

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -583,6 +583,7 @@ A function that attempts to repair a tool call that failed to parse.
         response: {
           ...currentModelResponse.response,
           headers: currentModelResponse.rawResponse?.headers,
+          body: currentModelResponse.rawResponse?.body,
           messages: responseMessages,
         },
         logprobs: currentModelResponse.logprobs,

--- a/packages/ai/core/types/language-model-response-metadata.ts
+++ b/packages/ai/core/types/language-model-response-metadata.ts
@@ -15,7 +15,7 @@ export type LanguageModelResponseMetadata = {
   modelId: string;
 
   /**
-Response headers.
+Response headers (available only for providers that use HTTP requests).
      */
   headers?: Record<string, string>;
 };

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -262,7 +262,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args, warnings, betas } = await this.getArgs(options);
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: this.buildRequestUrl(false),
       headers: await this.getHeaders({ betas, headers: options.headers }),
       body: this.transformRequestBody(args),
@@ -328,7 +332,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
         completionTokens: response.usage.output_tokens,
       },
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: {
+        headers: responseHeaders,
+        body: rawResponse,
+      },
       response: {
         id: response.id ?? undefined,
         modelId: response.model ?? undefined,

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -191,7 +191,11 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
     const { warnings, ...args } = this.getArgs(options);
     args.tools = args.tools && this.removeJsonSchemaExtras(args.tools);
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: `${this.config.baseURL}/chat`,
       headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
@@ -204,7 +208,8 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
     });
 
     const { messages, ...rawSettings } = args;
-    let text = response.message.content?.[0]?.text ?? '';
+
+    const text = response.message.content?.[0]?.text ?? '';
 
     return {
       text,
@@ -232,7 +237,10 @@ export class CohereChatLanguageModel implements LanguageModelV1 {
       response: {
         id: response.generation_id ?? undefined,
       },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: {
+        headers: responseHeaders,
+        body: rawResponse,
+      },
       warnings,
       request: { body: JSON.stringify(args) },
     };

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -204,7 +204,11 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       options.headers,
     );
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: `${this.config.baseURL}/${getModelPath(
         this.modelId,
       )}:generateContent`,
@@ -245,7 +249,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
         completionTokens: usageMetadata?.candidatesTokenCount ?? NaN,
       },
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: { headers: responseHeaders, body: rawResponse },
       warnings,
       providerMetadata: {
         google: {

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -190,7 +190,11 @@ export class GroqChatLanguageModel implements LanguageModelV1 {
 
     const body = JSON.stringify(args);
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: this.config.url({
         path: '/chat/completions',
         modelId: this.modelId,
@@ -222,7 +226,7 @@ export class GroqChatLanguageModel implements LanguageModelV1 {
         completionTokens: response.usage?.completion_tokens ?? NaN,
       },
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: { headers: responseHeaders, body: rawResponse },
       response: getResponseMetadata(response),
       warnings,
       request: { body },

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -175,7 +175,11 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args, warnings } = this.getArgs(options);
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: `${this.config.baseURL}/chat/completions`,
       headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
@@ -219,7 +223,10 @@ export class MistralChatLanguageModel implements LanguageModelV1 {
         completionTokens: response.usage.completion_tokens,
       },
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: {
+        headers: responseHeaders,
+        body: rawResponse,
+      },
       request: { body: JSON.stringify(args) },
       response: getResponseMetadata(response),
       warnings,

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -246,7 +246,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV1 {
     const {
       responseHeaders,
       value: responseBody,
-      rawValue: parsedBody,
+      rawValue: rawResponse,
     } = await postJsonToApi({
       url: this.config.url({
         path: '/chat/completions',
@@ -265,7 +265,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV1 {
     const { messages: rawPrompt, ...rawSettings } = args;
     const choice = responseBody.choices[0];
     const providerMetadata = this.config.metadataExtractor?.extractMetadata?.({
-      parsedBody,
+      parsedBody: rawResponse,
     });
 
     return {
@@ -284,7 +284,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV1 {
       },
       ...(providerMetadata && { providerMetadata }),
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: { headers: responseHeaders, body: rawResponse },
       response: getResponseMetadata(responseBody),
       warnings,
       request: { body },

--- a/packages/openai-compatible/src/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-completion-language-model.ts
@@ -182,7 +182,11 @@ export class OpenAICompatibleCompletionLanguageModel
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args, warnings } = this.getArgs(options);
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: this.config.url({
         path: '/completions',
         modelId: this.modelId,
@@ -208,7 +212,7 @@ export class OpenAICompatibleCompletionLanguageModel
       },
       finishReason: mapOpenAICompatibleFinishReason(choice.finish_reason),
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: { headers: responseHeaders, body: rawResponse },
       response: getResponseMetadata(response),
       warnings,
       request: { body: JSON.stringify(args) },

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -364,7 +364,11 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args: body, warnings } = this.getArgs(options);
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: this.config.url({
         path: '/chat/completions',
         modelId: this.modelId,
@@ -427,7 +431,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV1 {
         completionTokens: response.usage?.completion_tokens ?? NaN,
       },
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: { headers: responseHeaders, body: rawResponse },
       request: { body: JSON.stringify(body) },
       response: getResponseMetadata(response),
       warnings,

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -171,7 +171,11 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args, warnings } = this.getArgs(options);
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: this.config.url({
         path: '/completions',
         modelId: this.modelId,
@@ -198,7 +202,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV1 {
       finishReason: mapOpenAIFinishReason(choice.finish_reason),
       logprobs: mapOpenAICompletionLogProbs(choice.logprobs),
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: { headers: responseHeaders, body: rawResponse },
       response: getResponseMetadata(response),
       warnings,
       request: { body: JSON.stringify(args) },

--- a/packages/perplexity/src/perplexity-language-model.ts
+++ b/packages/perplexity/src/perplexity-language-model.ts
@@ -148,7 +148,11 @@ export class PerplexityLanguageModel implements LanguageModelV1 {
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args, warnings } = this.getArgs(options);
 
-    const { responseHeaders, value: response } = await postJsonToApi({
+    const {
+      responseHeaders,
+      value: response,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
       url: `${this.config.baseURL}/chat/completions`,
       headers: combineHeaders(this.config.headers(), options.headers),
       body: args,
@@ -176,7 +180,7 @@ export class PerplexityLanguageModel implements LanguageModelV1 {
         completionTokens: response.usage.completion_tokens,
       },
       rawCall: { rawPrompt, rawSettings },
-      rawResponse: { headers: responseHeaders },
+      rawResponse: { headers: responseHeaders, body: rawResponse },
       request: { body: JSON.stringify(args) },
       response: getResponseMetadata(response),
       warnings,

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -1,3 +1,4 @@
+import { JSONValue } from '../../json-value';
 import { LanguageModelV1CallOptions } from './language-model-v1-call-options';
 import { LanguageModelV1CallWarning } from './language-model-v1-call-warning';
 import { LanguageModelV1FinishReason } from './language-model-v1-finish-reason';
@@ -159,6 +160,11 @@ Optional response information for telemetry and debugging purposes.
 Response headers.
       */
       headers?: Record<string, string>;
+
+      /**
+Response body.
+      */
+      body?: unknown;
     };
 
     /**


### PR DESCRIPTION
## Background

Providers often expose additional information in the response body that is not accessible through standard AI SDK properties nor through provider metadata. Exposing the full response when available provides a way to get that information when needed.