### PR TITLE
fix (ui/svelte): error resulting from hard cast from readable to writable

### DIFF
--- a/.changeset/empty-moose-march.md
+++ b/.changeset/empty-moose-march.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/svelte': patch
+---
+
+fix: Remove hard-cast causing `Readable` to be treated as `Writable`

--- a/packages/svelte/src/use-chat.ts
+++ b/packages/svelte/src/use-chat.ts
@@ -1,9 +1,7 @@
-import { FetchFunction } from '@ai-sdk/provider-utils';
 import type {
   ChatRequest,
   ChatRequestOptions,
   CreateMessage,
-  IdGenerator,
   JSONValue,
   Message,
   UseChatOptions as SharedUseChatOptions,
@@ -143,7 +141,10 @@ export function useChat({
   const chatId = id ?? generateId();
 
   const key = `${api}|${chatId}`;
-  const data = derived([store], ([$store]) => $store[key] ?? initialMessages);
+  const messages = derived(
+    [store],
+    ([$store]) => $store[key] ?? fillMessageParts(initialMessages),
+  );
 
   const streamData = writable<JSONValue[] | undefined>(undefined);
 
@@ -157,9 +158,6 @@ export function useChat({
       return value;
     });
   };
-
-  // Because of the `fallbackData` option, the `data` will never be `undefined`.
-  const messages = data as Writable<UIMessage[]>;
 
   // Abort controller to cancel the current API call.
   let abortController: AbortController | null = null;
@@ -419,7 +417,7 @@ export function useChat({
       toolResult: result,
     });
 
-    messages.set(messagesSnapshot);
+    mutate(messagesSnapshot);
 
     // auto-submit when all tool calls in the last assistant message have results:
     const lastMessage = messagesSnapshot[messagesSnapshot.length - 1];

--- a/packages/svelte/src/use-chat.ts
+++ b/packages/svelte/src/use-chat.ts
@@ -309,7 +309,7 @@ export function useChat({
         experimental_attachments:
           attachmentsForRequest.length > 0 ? attachmentsForRequest : undefined,
         parts: getMessageParts(message),
-      } as UIMessage),
+      }),
       headers,
       body,
       data,


### PR DESCRIPTION
This is just another example of why `as X` is evil and shouldn't ever be used. A `Readable` was being cast to a `Writable`.

I stuck a button in my test app with 
```
	<button
		onclick={() => {
			console.log('adding tool result');
			addToolResult({
				toolCallId: 'call_wLJFuAcFfygtlxd3nAtYRpt8',
				result: { location: 'Denver, CO', temperature: 68 }
			});
		}}>Add Tool Result</button
	>
```

on `main` this causes the failure reported in the #5056 comments. With this branch, the error is gone and everything seems to be working correctly.
