### PR TITLE
Add `useBranchingChat` hook for tree-structured conversations

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,5 @@
 export * from './use-assistant';
+export * from './use-branching-chat';
 export * from './use-chat';
 export * from './use-completion';
 export * from './use-object';

--- a/packages/react/src/use-branching-chat.ts
+++ b/packages/react/src/use-branching-chat.ts
@@ -1,0 +1,424 @@
+import type {
+  ChatRequestOptions,
+  UIMessage,
+  UUID,
+  BranchMessage,
+  BranchMessageCreate,
+} from '@ai-sdk/ui-utils';
+
+import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
+import useSWR from 'swr';
+
+import {
+  buildAdjacency,
+  getConversationPath,
+  getSiblingIdsSorted,
+  findLatestLeafDescendant,
+  generateId as generateIdFunc,
+} from '@ai-sdk/ui-utils';
+import { useChat } from './use-chat';
+
+type UseBranchingChatOptions = Parameters<typeof useChat>[0] & {
+  id?: UUID;
+  initialMessages?: BranchMessage[];
+  initialCurrentLeafId?: UUID;
+  generateId?: () => UUID;
+  onFinish?: (message: UIMessage) => void;
+  /**
+   * Called after an early `stop` call (to invoke the abort signal), but before
+   * we finalize the partial response message in state, letting the caller
+   * transform or replace the partial completion or perform side effects if needed.
+   */
+  onStop?: (partialMessage?: UIMessage) => Promise<void> | void;
+};
+
+/**
+ * useBranchingChat manages a conversation tree with branching support.
+ *
+ * State maintained:
+ *  - `fullTreeMessages`: the entire conversation (source-of-truth).
+ *  - `currentLeafId`: the ID of the tip of the active branch.
+ *
+ * It derives the current branch (to display) by computing the unique path
+ * from the root to currentLeafId.
+ *
+ * The hook wraps `useChat` so that streaming updates occur on the current branch.
+ * When streaming is finished (`onFinish`), the new assistant message is merged into
+ * `fullTreeMessages`, and `currentLeafId` is updated.
+ *
+ * The hook exposes the following API:
+ *  - `messages`, `append`, `reload`, `stop`, `input`, `setInput`, etc. from `useChat`.
+ *  - Some methods are overridden such as `handleSubmit`, which updates the full tree.
+ *  - Some methods are extended like `onFinish`, which merges new assistant messages.
+ *  - `fullTreeMessages` and helpers (`messagesById`, `childrenMap`).
+ *  - `messagesById` is a mapping of UIMessage ID → message
+ *  - `childrenMap` is a mapping of Parent ID → array of child IDs
+ *  - `selectBranch`: call this to switch to a different branch/fork.
+ *  - `getSiblingIdsSortedByDate`: returns the IDs of sibling messages sorted by createdAt ascending.
+ *  - `retryMessage`: remove all messages after `messageId` and re-submit the last user message.
+ *  - `editMessage`: remove all messages after `messageId`, push a new user message, and re-submit.
+ */
+export function useBranchingChat(options: UseBranchingChatOptions) {
+  const chatId = options.id;
+  const chatKey = ['fullTreeMessages', chatId];
+  const generateId = options.generateId ?? generateIdFunc;
+  const { onStop, onFinish } = options;
+
+  // -------------------------------
+  // 1. Full-tree messages in SWR
+  // -------------------------------
+
+  // Store an empty array as the initial full tree messages
+  // (instead of using a default parameter value that gets re-created each time)
+  // to avoid re-renders:
+  const [noMessagesFallback] = useState([]);
+  const { data: fullTreeMessages = [], mutate: mutateAll } = useSWR<
+    BranchMessage[]
+  >(chatKey, null, {
+    fallbackData: options.initialMessages ?? noMessagesFallback,
+  });
+
+  // Keep a ref of the latest full conversation, so we never rely on stale state.
+  const fullTreeMessagesRef = useRef<BranchMessage[]>(fullTreeMessages);
+  useEffect(() => {
+    fullTreeMessagesRef.current = fullTreeMessages || [];
+  }, [fullTreeMessages]);
+
+  // A setter that parallels setMessages from `useChat`.
+  // If called with a function, we pass the ref instead of the previous state.
+  const setFullTreeMessages = useCallback(
+    (
+      updater: BranchMessage[] | ((cur: BranchMessage[]) => BranchMessage[]),
+    ) => {
+      void mutateAll(() => {
+        let next: BranchMessage[];
+
+        if (typeof updater === 'function') {
+          next = (updater as (x: BranchMessage[]) => BranchMessage[])(
+            fullTreeMessagesRef.current,
+          );
+        } else {
+          next = updater;
+        }
+        fullTreeMessagesRef.current = next;
+        return next;
+      }, false);
+    },
+    [mutateAll],
+  );
+
+  // ------------------------------------------------
+  // 2. Current leaf ID (tip of the active branch)
+  // ------------------------------------------------
+  const [currentLeafId, setCurrentLeafId] = useState<UUID | undefined>(
+    options.initialCurrentLeafId || fullTreeMessages.at(-1)?.id,
+  );
+
+  // Update the current leaf when the full tree messages change
+  useEffect(() => {
+    if (fullTreeMessages.length) {
+      if (
+        !currentLeafId ||
+        !fullTreeMessages.some(msg => msg.id === currentLeafId)
+      ) {
+        setCurrentLeafId(fullTreeMessages.at(-1)!.id);
+      }
+    }
+  }, [fullTreeMessages, currentLeafId]);
+
+  // -------------------------------------
+  // 3. Build adjacency + current branch
+  // -------------------------------------
+  // Build the adjacency mapping for the conversation tree.
+  const { messagesById, childrenMap } = useMemo(() => {
+    return buildAdjacency(fullTreeMessages);
+  }, [fullTreeMessages]);
+
+  // Compute the current branch (a linear array) using the tree helpers.
+  const currentBranch = useMemo(() => {
+    if (!currentLeafId) return [];
+    return getConversationPath(messagesById, currentLeafId, fullTreeMessages);
+  }, [messagesById, currentLeafId, fullTreeMessages]);
+
+  // ----------------------------
+  // 4. Track streaming status
+  // ----------------------------
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  // ------------------------------------------------------------------------------------
+  // 5. The custom onFinish merges new assistant messages and updates the current leaf
+  // ------------------------------------------------------------------------------------
+  const customOnFinish = useCallback(
+    (respMessage: UIMessage) => {
+      setIsStreaming(false);
+      setFullTreeMessages(messages => [
+        ...messages,
+        respMessage as BranchMessage,
+      ]);
+      setCurrentLeafId(respMessage.id as UUID);
+      onFinish?.(respMessage);
+    },
+    [onFinish, setFullTreeMessages, setCurrentLeafId, setIsStreaming],
+  );
+
+  // -------------------------------------------
+  // 6. The streaming chat (the active branch)
+  // -------------------------------------------
+  const {
+    messages,
+    setMessages,
+    append,
+    stop: stopStream,
+    reload,
+    setInput,
+    input,
+    isLoading,
+    ...chat
+  } = useChat({
+    ...options,
+    sendExtraMessageFields: true,
+    streamProtocol: 'data',
+    initialMessages: currentBranch,
+    generateId,
+    onFinish: customOnFinish,
+  });
+
+  // --------------------------------
+  // 7. Branch navigation
+  // --------------------------------
+  // When a branch is selected, we find the "latest" leaf if there are multiple
+  // branches below the chosen node, then build the path from the root to that final leaf.
+  const selectBranch = useCallback(
+    (leafId: UUID) => {
+      const latestTree = fullTreeMessagesRef.current;
+      const adj = buildAdjacency(latestTree);
+
+      // Find the newest leaf that is a descendant of `leafId`.
+      const finalLeaf = findLatestLeafDescendant(
+        adj.messagesById,
+        adj.childrenMap,
+        leafId,
+      );
+      const finalLeafId = finalLeaf.id;
+
+      // Update currentLeafId to that final descendant
+      setCurrentLeafId(finalLeafId);
+
+      // Build the path from the root to finalLeafId
+      const newBranch = getConversationPath(
+        adj.messagesById,
+        finalLeafId,
+        latestTree,
+      );
+
+      // Update useChat's messages to the new branch
+      setMessages(newBranch);
+    },
+    [setMessages],
+  );
+
+  // ----------------------------------------------
+  // 8.  Override the append method
+  // ----------------------------------------------
+  // Add the user message to the full tree before calling the original append.
+  const originalAppend = append;
+
+  const branchingAppend = useCallback(
+    async (
+      msg: BranchMessage | BranchMessageCreate,
+      requestOptions?: ChatRequestOptions,
+    ) => {
+      const newMsg: BranchMessage = {
+        id: (msg.id as UUID) ?? (generateId() as UUID),
+        role: msg.role,
+        content: msg.content ?? '',
+        createdAt: msg.createdAt ?? new Date(),
+        ...(msg.annotations && { annotations: msg.annotations }),
+      };
+
+      // If no parent is set, use the current leaf
+      if (!newMsg.annotations?.length && currentLeafId) {
+        newMsg.annotations = [{ parentId: currentLeafId }];
+      }
+
+      // Let useChat handle the streaming & attachment preparation:
+      setIsStreaming(true);
+      const result = await originalAppend(newMsg, requestOptions);
+
+      // Insert new message into full tree
+      const attachments = requestOptions?.experimental_attachments;
+      // TODO: Support `FileList` attachments
+      if (attachments) {
+        if (!Array.isArray(attachments))
+          throw new Error('Attachments must be an array of Attachment');
+        newMsg.experimental_attachments = attachments;
+      }
+      setFullTreeMessages(prev => [...prev, newMsg]);
+      return result;
+    },
+    [originalAppend, setFullTreeMessages, currentLeafId, generateId],
+  );
+
+  // ----------------------------------------------
+  // 9. handleSubmit override
+  // ----------------------------------------------
+  // This replaces the standard handleSubmit from useChat
+  // so we can do both local insertion and streaming together.
+  const handleSubmit = useCallback(
+    async (
+      event?: { preventDefault?: () => void },
+      requestOptions?: ChatRequestOptions,
+    ) => {
+      event?.preventDefault?.();
+      if (!input.trim()) return;
+
+      // Rely on branchingAppend to handle ID, date, attachments
+      const newMsg = { role: 'user', content: input } as BranchMessage;
+      setInput('');
+      setIsStreaming(true);
+
+      // Insert into the full tree and begin streaming
+      await branchingAppend(newMsg, requestOptions);
+    },
+    [input, setInput, branchingAppend],
+  );
+
+  // ------------------------------------------------------------------------------------
+  // Additional exposed methods:
+  // ------------------------------------------------------------------------------------
+  /**
+   *  Helper to get sibling IDs sorted by createdAt (ascending).
+   */
+  const getSiblingIdsSortedByDate = (messageId: UUID) => {
+    return getSiblingIdsSorted(messagesById, childrenMap, messageId);
+  };
+
+  /**
+   *  Remove all messages after `messageId` (but keep that message),
+   *  then call `reload`, which re-submits the last user message.
+   */
+  const retryMessage = useCallback(
+    async (messageId: UUID, opts?: ChatRequestOptions) => {
+      setMessages(messages => {
+        const idx = messages.findIndex(m => m.id === messageId);
+        if (idx === -1) {
+          throw new Error(`retryMessage: messageId ${messageId} not found`);
+        }
+        return messages.slice(0, idx + 1);
+      });
+      setIsStreaming(true);
+      await reload(opts);
+    },
+    [setMessages, reload, setIsStreaming],
+  );
+
+  /**
+   *  Remove all messages after `messageId`, including that message,
+   *  push a new user message to the tip (fresh content/id but same parent),
+   *  then call `reload` which submits that user message in place of the old one.
+   */
+  const editMessage = useCallback(
+    async (messageId: UUID, newContent: string, opts?: ChatRequestOptions) => {
+      const fullTree = fullTreeMessagesRef.current;
+      const oldMsg = fullTree.find(m => m.id === messageId);
+      if (!oldMsg) {
+        throw new Error(
+          `editMessage: messageId ${messageId} not found in tree`,
+        );
+      }
+
+      // Prepare a new user message with the same parent as the old one.
+      const newMsg: BranchMessage = {
+        id: generateId() as UUID,
+        role: 'user',
+        content: newContent,
+        createdAt: new Date(),
+        annotations: oldMsg.annotations,
+        experimental_attachments: oldMsg.experimental_attachments,
+      };
+
+      // On the active branch, remove old message & everything after it, then add the new one:
+      setMessages(messages => {
+        const idx = messages.findIndex(m => m.id === messageId);
+        if (idx === -1) {
+          console.error(
+            `editMessage: messageId ${messageId} not found in active branch`,
+          );
+          return messages;
+        }
+        return [...messages.slice(0, idx), newMsg] as BranchMessage[];
+      });
+
+      // Insert into the full conversation
+      setFullTreeMessages(fullTree => [...fullTree, newMsg]);
+
+      // let useChat handle the reload
+      setIsStreaming(true);
+      await reload(opts);
+    },
+    [setFullTreeMessages, reload, setMessages, generateId, setIsStreaming],
+  );
+
+  /**
+   * Stop override to handle partial assistant message similarly to onFinish,
+   *  If streaming is active, we finalize the partial message.
+   *  If an `onBeforeStop` callback is provided, we allow it to transform or
+   *  mutate the partial message before storing in the full tree.
+   */
+  const stop = useCallback(async () => {
+    if (!isLoading) {
+      // Not streaming, no partial to merge.
+      stopStream();
+      setIsStreaming(false);
+      return;
+    }
+    const partialMessage = messages[messages.length - 1];
+    stopStream();
+    setIsStreaming(false);
+
+    // Give the caller a chance to transform or do side effects
+    const maybeTransformedMsg = onStop
+      ? (await onStop?.(partialMessage)) ?? partialMessage
+      : partialMessage;
+
+    if (maybeTransformedMsg) {
+      setFullTreeMessages(msgs => [
+        ...msgs,
+        maybeTransformedMsg as BranchMessage,
+      ]);
+      setCurrentLeafId(maybeTransformedMsg.id as UUID);
+    }
+  }, [
+    isLoading,
+    messages,
+    stopStream,
+    onStop,
+    setFullTreeMessages,
+    setIsStreaming,
+    setCurrentLeafId,
+  ]);
+
+  // Return everything from `useChat`, plus tree-based helpers + overrides.
+  return {
+    messages,
+    setMessages,
+    reload,
+    setInput,
+    input,
+    isLoading,
+    ...chat,
+    append: branchingAppend,
+    stop,
+    handleSubmit,
+    fullTreeMessages,
+    setFullTreeMessages,
+    currentLeafId,
+    selectBranch,
+    messagesById,
+    childrenMap,
+    getSiblingIdsSortedByDate,
+    retryMessage,
+    editMessage,
+    isStreaming,
+  };
+}

--- a/packages/ui-utils/src/index.ts
+++ b/packages/ui-utils/src/index.ts
@@ -29,6 +29,12 @@ export { processAssistantStream } from './process-assistant-stream';
 export { processDataStream } from './process-data-stream';
 export { processTextStream } from './process-text-stream';
 export { asSchema, jsonSchema } from './schema';
+export {
+  buildAdjacency,
+  getConversationPath,
+  getSiblingIdsSorted,
+  findLatestLeafDescendant,
+} from './tree';
 export type { Schema } from './schema';
 export {
   isAssistantMessageWithCompletedToolCalls,

--- a/packages/ui-utils/src/tree.ts
+++ b/packages/ui-utils/src/tree.ts
@@ -1,0 +1,124 @@
+import { BranchMessage, UUID } from './types';
+
+interface AdjacencyData {
+  messagesById: Record<UUID, BranchMessage>;
+  childrenMap: Record<string, UUID[]>; // parentId (or '__root__') -> array of child message IDs
+}
+
+/**
+ * Build adjacency structures for the conversation tree.
+ * If a message has no parentId, we treat it as a child of "__root__".
+ */
+export function buildAdjacency(messages: BranchMessage[]): AdjacencyData {
+  const messagesById: Record<UUID, BranchMessage> = {};
+  const childrenMap: Record<string, UUID[]> = {};
+
+  for (const msg of messages) {
+    messagesById[msg.id] = msg;
+
+    const parentId = msg.annotations?.[0]?.parentId ?? '__root__';
+
+    if (!childrenMap[parentId]) {
+      childrenMap[parentId] = [];
+    }
+    childrenMap[parentId].push(msg.id);
+  }
+
+  return { messagesById, childrenMap };
+}
+
+// Reconstruct a linear conversation path from the root to the current leaf.
+// We also accept allMessages (in insertion order) so that if the very last
+// message is a user message that has not yet been “attached” by the leaf id,
+// we can do further logic if needed (Currently not used but splitting out
+// stable messages from the currently streaming message could improve performance).
+export function getConversationPath(
+  messagesById: Record<UUID, BranchMessage>,
+  leafId: UUID | undefined,
+  allMessages?: BranchMessage[]
+): BranchMessage[] {
+  const path: BranchMessage[] = [];
+  if (leafId && messagesById[leafId]) {
+    let current = messagesById[leafId];
+    while (current) {
+      path.unshift(current);
+      const parentId = current.annotations?.[0]?.parentId;
+      if (!parentId || !messagesById[parentId]) break;
+      current = messagesById[parentId];
+    }
+  }
+  return path;
+}
+
+/**
+ * Recursively collect all “leaf” nodes that are descendants of `fromId`.
+ * A leaf is a node with zero children.
+ */
+function findDescendantLeaves(
+  messagesById: Record<UUID, BranchMessage>,
+  childrenMap: Record<string, UUID[]>,
+  fromId: UUID,
+  leaves: BranchMessage[]
+) {
+  const children = childrenMap[fromId] || [];
+  if (!children.length) {
+    // If no children, `fromId` itself is a leaf
+    leaves.push(messagesById[fromId]);
+    return;
+  }
+  for (const childId of children) {
+    findDescendantLeaves(messagesById, childrenMap, childId, leaves);
+  }
+}
+
+/**
+ * Finds all terminal descendants of `fromId` (i.e. leaves) and returns
+ * the single leaf with the greatest `createdAt`. If `fromId` itself has
+ * no children, `fromId` is returned.
+ */
+export function findLatestLeafDescendant(
+  messagesById: Record<UUID, BranchMessage>,
+  childrenMap: Record<string, UUID[]>,
+  fromId: UUID
+): BranchMessage {
+  const node = messagesById[fromId];
+  const allLeaves: BranchMessage[] = [];
+  findDescendantLeaves(messagesById, childrenMap, fromId, allLeaves);
+  if (!allLeaves.length) {
+    // `fromId` might be a leaf if we have no children
+    return node;
+  }
+  // Return the most recently created leaf
+  let latest = allLeaves[0];
+  for (let i = 1; i < allLeaves.length; i++) {
+    const leaf = allLeaves[i];
+    if (leaf.createdAt.getTime() > latest.createdAt.getTime()) {
+      latest = leaf;
+    }
+  }
+  return latest;
+}
+
+/**
+ * Return the IDs of all sibling messages, sorted by createdAt ascending,
+ * where siblings share the same parentId (or both are root).
+ */
+export function getSiblingIdsSorted(
+  messagesById: Record<UUID, BranchMessage>,
+  childrenMap: Record<string, UUID[]>,
+  messageId: UUID
+): UUID[] {
+  const msg = messagesById[messageId];
+  if (!msg) return [];
+
+  const parentId = msg.annotations?.[0]?.parentId ?? '__root__';
+
+  // slice so we can safely sort in place
+  const childIds = (childrenMap[parentId] || []).slice();
+  childIds.sort(
+    (a, b) =>
+      new Date(messagesById[a].createdAt).getTime() -
+      new Date(messagesById[b].createdAt).getTime()
+  );
+  return childIds;
+}

--- a/packages/ui-utils/src/types.ts
+++ b/packages/ui-utils/src/types.ts
@@ -182,6 +182,23 @@ export type CreateMessage = Omit<Message, 'id'> & {
   id?: Message['id'];
 };
 
+export type UUID = string & { readonly brand: unique symbol };
+
+export type BranchMessageAnnotations = {
+  parentId?: UUID;
+  name?: string;
+  modelId?: string;
+};
+
+export type BranchMessage = UIMessage & {
+  id: UUID;
+  createdAt: Date;
+  annotations?: Array<BranchMessageAnnotations>;
+};
+
+export type BranchMessageCreate = Omit<BranchMessage, 'id' | 'createdAt'> &
+  Partial<Pick<BranchMessage, 'id' | 'createdAt'>>;
+
 export type ChatRequest = {
   /**
 An optional object of headers to be passed to the API endpoint.


### PR DESCRIPTION
## Description
This PR introduces a `useBranchingChat` hook, wrapping the `useChat` hook to facilitate conversation branching support. It enables tree-structured conversations, supporting features such as branching, editing, and retrying previous messages within a conversation tree (a similar UX to ChatGPT or Claude).

## Key Features

- **Branching Conversations**: Manage conversations as trees, allowing users to branch conversations, navigate different paths, and revisit previous nodes.
- **Message Editing and Retry**: Edit previous user messages or retry assistant responses without discarding subsequent conversation history.
- **Branch Navigation**: Switch between conversation branches (versions of a message), automatically updating the active conversation view.

## Changes

- **`useBranchingChat` hook**: Extends `useChat` with additional state management for branching conversations.
- **Adjacency utilities**: Utility functions (`buildAdjacency`, `getConversationPath`, `findLatestLeafDescendant`, and `getSiblingIdsSorted`) to manage and traverse the conversation tree.

## Additional Details

- I presume you guys don't want to merge this in as v0 has a branching feature, so I presume you have a better pattern for this in mind already. And I figure the feature isn't relevant for most use cases and would add unnecessary complexity. This is only added here to `ai/react`, without any tests, mostly just as an example in case it's useful for anyone.
- To use this hook, messages need to have `parentId` annotations added before saving them to the database. The first message in a conversation should have a `null` `parentId`. A `BranchMessage` type that extends `UIMessage` is added to type this required annotation.

## Example Usage
- Here is a minimal example, based on the `Chat` component used in the example repo https://github.com/vercel/ai-chatbot
```tsx
'use client';

import type { Attachment, BranchMessage, UUID } from 'ai';
import type { AIState, ModelId } from '@/types/chat';

import { useState, memo, useCallback } from 'react';
import { useSWRConfig } from 'swr';

import { useBranchingChat } from '@/hooks/use-branching-chat';
import { sanitizeUIMessages } from '@/lib/chat/utils/message';

import { Messages } from '@/components/chat/chat-messages';
import { MultimodalInput } from '@/components/chat/multimodal-input';
interface ChatProps extends React.ComponentProps<'div'> {
  aiState: AIState;
}

export const Chat = memo(function Chat({ aiState }: ChatProps) {
  const {
    id,
    modelId,
    createdAt,
    messages: initialMessages,
    isReadonly,
    currentLeafMessageId: initialCurrentLeafId,
  } = aiState;
  const { mutate } = useSWRConfig();

  const {
    selectBranch,
    append,
    handleSubmit,
    editMessage,
    retryMessage,
    isLoading,
    isStreaming,
    input,
    setInput,
    stop,
    messages,
    setMessages,
    getSiblingIdsSortedByDate,
  } = useBranchingChat({
    id,
    body: { id, model: modelId },
    initialMessages,
    initialCurrentLeafId,
    onError: error => {
      console.error('onError:', String(error));
    },
    onStop: async () => {
      setMessages(messages => sanitizeUIMessages(messages as BranchMessage[]));
      if (!createdAt) {
        void mutate('/api/chat/history');
      }
      return;
    },
    onFinish: () => {
      if (!createdAt) {
        void mutate('/api/chat/history');
      }
    },
  });

  const [attachments, setAttachments] = useState<Array<Attachment>>([]);

  // Handle retrying an assistant message.
  const handleRetry = useCallback(
    async (messageId: UUID, newModelId?: ModelId) => {
      await retryMessage(messageId, {
        body: newModelId ? { model: newModelId } : undefined,
      });
    },
    [retryMessage]
  );

  return (
    <>
      <Messages
        chatId={id}
        modelId={modelId}
        messages={messages as BranchMessage[]}
        isReadonly={isReadonly}
        isLoading={isLoading}
        isStreaming={isStreaming}
        onEdit={editMessage}
        onRetry={handleRetry}
        getSiblingIdsSortedByDate={getSiblingIdsSortedByDate}
        onSelectChild={selectBranch}
      />
      <MultimodalInput
        chatId={id}
        input={input}
        setInput={setInput}
        handleSubmit={handleSubmit}
        isLoading={isLoading}
        onStop={stop}
        attachments={attachments}
        setAttachments={setAttachments}
        messages={messages as BranchMessage[]}
        setMessages={setMessages}
        append={append}
      />
    </>
  );
});

```
```tsx
'use client';

import type { UUID } from 'ai';

import React, { memo, useState } from 'react';
import equal from 'fast-deep-equal';
import { ChevronLeft, ChevronRight } from 'lucide-react';

import { ButtonThin } from '@/components/ui/button';
import {
  Tooltip,
  TooltipContent,
  TooltipTrigger,
} from '@/components/ui/tooltip';

interface MessageVersionsProps {
  messageId: UUID;
  siblingIds: UUID[];
  onSelectChild: (childId: UUID) => void;
  isStreaming: boolean;
}

function PureMessageBranches({
  messageId,
  siblingIds,
  onSelectChild,
  isStreaming,
}: MessageVersionsProps) {
  if (siblingIds.length <= 1) return null;

  const currentIndex = siblingIds.indexOf(messageId);
  const defaultIndex = currentIndex >= 0 ? currentIndex : siblingIds.length - 1;

  const [selectedIndex, setSelectedIndex] = useState(defaultIndex);

  function handlePrevious() {
    setSelectedIndex(old => {
      const newIndex = Math.max(0, old - 1);
      onSelectChild(siblingIds[newIndex]);
      return newIndex;
    });
  }

  function handleNext() {
    setSelectedIndex(old => {
      const newIndex = Math.min(siblingIds.length - 1, old + 1);
      onSelectChild(siblingIds[newIndex]);
      return newIndex;
    });
  }

  return (
    <div className="flex items-center justify-center rounded-lg">
      <Tooltip>
        <TooltipTrigger asChild>
          <ButtonThin
            variant="ghost"
            size="icon"
            onClick={handlePrevious}
            disabled={isStreaming || selectedIndex === 0}
            className="size-4"
          >
            <ChevronLeft className="size-4" />
          </ButtonThin>
        </TooltipTrigger>
        <TooltipContent>Previous version</TooltipContent>
      </Tooltip>
      <span className="text-sm font-semibold">
        {selectedIndex + 1} / {siblingIds.length}
      </span>
      <Tooltip>
        <TooltipTrigger asChild>
          <ButtonThin
            variant="ghost"
            size="icon"
            onClick={handleNext}
            disabled={isStreaming || selectedIndex === siblingIds.length - 1}
            className="size-4"
          >
            <ChevronRight className="size-4" />
          </ButtonThin>
        </TooltipTrigger>
        <TooltipContent>Next version</TooltipContent>
      </Tooltip>
    </div>
  );
}

export const MessageBranches = memo(
  PureMessageBranches,
  (prevProps, nextProps) => {
    if (prevProps.isStreaming !== nextProps.isStreaming) return false;
    if (prevProps.siblingIds.length !== nextProps.siblingIds.length)
      return false;
    if (!equal(prevProps.siblingIds, nextProps.siblingIds)) return false;
    if (prevProps.messageId !== nextProps.messageId) return false;
    return true;
  }
);

```
- Note that in this example, we are ordering sibling messages based on their `created_at` property. Therefore, we need to ensure that sibling messages have a unique `created_at` property. This would typically be the case, but for example, in integration tests etc if populating a db with mock data, we would need to use something like the Postgres `clock_timestamp()` as the default to ensure this remains the case if bulk inserting mock data. 