### PR TITLE
fix (provider/bedrock): support budgetTokens

### DIFF
--- a/.changeset/green-camels-play.md
+++ b/.changeset/green-camels-play.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/amazon-bedrock': none
----
-
-docs(@ai-sdk/bedrock): Typo fix in documentation

--- a/.changeset/green-camels-play.md
+++ b/.changeset/green-camels-play.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': none
+---
+
+docs(@ai-sdk/bedrock): Typo fix in documentation

--- a/.changeset/strange-foxes-remember.md
+++ b/.changeset/strange-foxes-remember.md
@@ -1,8 +1,5 @@
 ---
 '@ai-sdk/amazon-bedrock': patch
-'ai-core-examples': patch
 ---
 
-fix(providers/amazon-bedrock) Standardize on budgetTokens in bedrock provider for reasoning config. Add backwards compatability for reasoning_tokens
-
-tweak(ai-core-examples/amazon-bedrock): Make bedrock examples all use budgetTokens
+fix (provider/bedrock): support budgetTokens

--- a/.changeset/strange-foxes-remember.md
+++ b/.changeset/strange-foxes-remember.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'ai-core-examples': patch
+---
+
+fix(providers/amazon-bedrock) Standardize on budgetTokens in bedrock provider for reasoning config. Add backwards compatability for reasoning_tokens
+
+tweak(ai-core-examples/amazon-bedrock): Make bedrock examples all use budgetTokens

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -331,7 +331,7 @@ const { text, reasoning, reasoningDetails } = await generateText({
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
     bedrock: {
-      reasoningConfig: { type: 'enabled', budget_tokens: 1024 },
+      reasoningConfig: { type: 'enabled', budgetTokens: 1024 },
     },
   },
 });

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -331,7 +331,7 @@ const { text, reasoning, reasoningDetails } = await generateText({
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
     bedrock: {
-      reasoningConfig: { type: 'enabled', budgetTokens: 12000 },
+      reasoningConfig: { type: 'enabled', budget_tokens: 1024 },
     },
   },
 });

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
@@ -43,7 +43,7 @@ async function main() {
         for (const toolCall of step.toolCalls) {
           console.log(
             `\x1b[33m${toolCall.toolName}\x1b[0m` +
-            JSON.stringify(toolCall.args),
+              JSON.stringify(toolCall.args),
           );
         }
       }

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
@@ -24,7 +24,7 @@ async function main() {
       maxSteps: 5,
       providerOptions: {
         bedrock: {
-          reasoning_config: { type: 'enabled', budget_tokens: 2048 },
+          reasoning_config: { type: 'enabled', budgetTokens: 2048 },
         },
       },
     });
@@ -43,7 +43,7 @@ async function main() {
         for (const toolCall of step.toolCalls) {
           console.log(
             `\x1b[33m${toolCall.toolName}\x1b[0m` +
-              JSON.stringify(toolCall.args),
+            JSON.stringify(toolCall.args),
           );
         }
       }

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning.ts
@@ -9,7 +9,7 @@ async function main() {
     temperature: 0.5, // should get ignored (warning)
     providerOptions: {
       bedrock: {
-        reasoning_config: { type: 'enabled', budget_tokens: 2048 },
+        reasoning_config: { type: 'enabled', budgetTokens: 2048 },
       },
     },
     maxRetries: 0,

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
@@ -50,7 +50,7 @@ async function main() {
       maxRetries: 0,
       providerOptions: {
         bedrock: {
-          reasoning_config: { type: 'enabled', budget_tokens: 2048 },
+          reasoning_config: { type: 'enabled', budgetTokens: 2048 },
         },
       },
       onError: error => {

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
@@ -12,10 +12,11 @@ async function main() {
     prompt: 'What is the weather in San Francisco?',
     providerOptions: {
       bedrock: {
-        reasoning_config: { type: 'enabled', budget_tokens: 12000 },
+        reasoning_config: { type: 'enabled', budgetTokens: 1024 },
       },
     },
     maxSteps: 5,
+    maxRetries: 5,
   });
 
   let enteredReasoning = false;

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
@@ -12,7 +12,7 @@ async function main() {
     },
     providerOptions: {
       bedrock: {
-        reasoning_config: { type: 'enabled', budget_tokens: 1024 },
+        reasoning_config: { type: 'enabled', budgetTokens: 1024 },
       },
     },
     maxRetries: 0,

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -51,7 +51,7 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
     readonly modelId: BedrockChatModelId,
     private readonly settings: BedrockChatSettings,
     private readonly config: BedrockChatConfig,
-  ) { }
+  ) {}
 
   private getArgs({
     mode,
@@ -150,7 +150,7 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
         ...this.settings.additionalModelRequestFields,
         reasoning_config: {
           type: reasoningConfigOptions.data?.type,
-          budget_tokens: thinkingBudget
+          budget_tokens: thinkingBudget,
         },
       };
     }
@@ -262,20 +262,20 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
     const providerMetadata =
       response.trace || response.usage
         ? {
-          bedrock: {
-            ...(response.trace && typeof response.trace === 'object'
-              ? { trace: response.trace as JSONObject }
-              : {}),
-            ...(response.usage && {
-              usage: {
-                cacheReadInputTokens:
-                  response.usage?.cacheReadInputTokens ?? Number.NaN,
-                cacheWriteInputTokens:
-                  response.usage?.cacheWriteInputTokens ?? Number.NaN,
-              },
-            }),
-          },
-        }
+            bedrock: {
+              ...(response.trace && typeof response.trace === 'object'
+                ? { trace: response.trace as JSONObject }
+                : {}),
+              ...(response.usage && {
+                usage: {
+                  cacheReadInputTokens:
+                    response.usage?.cacheReadInputTokens ?? Number.NaN,
+                  cacheWriteInputTokens:
+                    response.usage?.cacheWriteInputTokens ?? Number.NaN,
+                },
+              }),
+            },
+          }
         : undefined;
 
     const reasoning = response.output.message.content
@@ -431,23 +431,23 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
 
               const cacheUsage =
                 value.metadata.usage?.cacheReadInputTokens != null ||
-                  value.metadata.usage?.cacheWriteInputTokens != null
+                value.metadata.usage?.cacheWriteInputTokens != null
                   ? {
-                    usage: {
-                      cacheReadInputTokens:
-                        value.metadata.usage?.cacheReadInputTokens ??
-                        Number.NaN,
-                      cacheWriteInputTokens:
-                        value.metadata.usage?.cacheWriteInputTokens ??
-                        Number.NaN,
-                    },
-                  }
+                      usage: {
+                        cacheReadInputTokens:
+                          value.metadata.usage?.cacheReadInputTokens ??
+                          Number.NaN,
+                        cacheWriteInputTokens:
+                          value.metadata.usage?.cacheWriteInputTokens ??
+                          Number.NaN,
+                      },
+                    }
                   : undefined;
 
               const trace = value.metadata.trace
                 ? {
-                  trace: value.metadata.trace as JSONObject,
-                }
+                    trace: value.metadata.trace as JSONObject,
+                  }
                 : undefined;
 
               if (cacheUsage || trace) {


### PR DESCRIPTION
Adds backwards compatibility to support specifying `budgetTokens` in reasoning config for amazon-bedrock provider. This will be transformed to `budget_tokens` before being sent to the model.