### PR TITLE
docs: update deprecated toolInvocations to parts

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -227,11 +227,11 @@ In this updated code:
    - Defines parameters using a Zod schema, specifying that it requires a `location` string to execute this tool. The model will attempt to extract this parameter from the context of the conversation. If it can't, it will ask the user for the missing information.
    - Defines an `execute` function that simulates getting weather data (in this case, it returns a random temperature). This is an asynchronous function running on the server so you can fetch real data from an external API.
 
-   Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `toolInvocations` that is available on the message object.
+   Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `parts` that is available on the message object.
 
 Try asking something like "What's the weather in New York?" and see how the model uses the new tool.
 
-Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `toolInvocations` key of the message object.
+Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `parts` key of the message object.
 
 ### Update the UI
 
@@ -249,8 +249,8 @@ export default function Chat() {
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {m.toolInvocations ? (
-            <pre>{JSON.stringify(m.toolInvocations, null, 2)}</pre>
+          {m.parts ? (
+            <pre>{JSON.stringify(m.parts, null, 2)}</pre>
           ) : (
             <p>{m.content}</p>
           )}
@@ -270,7 +270,7 @@ export default function Chat() {
 }
 ```
 
-With this change, you check each message for any tool calls (`toolInvocations`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
+With this change, you check each message for any tool calls (`parts`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
 
 Now, when you ask about the weather, you'll see the tool invocation and its result displayed in your chat interface.
 

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -227,11 +227,11 @@ In this updated code:
    - Defines parameters using a Zod schema, specifying that it requires a `location` string to execute this tool. The model will attempt to extract this parameter from the context of the conversation. If it can't, it will ask the user for the missing information.
    - Defines an `execute` function that simulates getting weather data (in this case, it returns a random temperature). This is an asynchronous function running on the server so you can fetch real data from an external API.
 
-   Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `toolInvocations` that is available on the message object.
+   Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `parts` that is available on the message object.
 
 Try asking something like "What's the weather in New York?" and see how the model uses the new tool.
 
-Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `toolInvocations` key of the message object.
+Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `parts` key of the message object.
 
 ### Update the UI
 
@@ -247,8 +247,8 @@ export default function Chat() {
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {m.toolInvocations ? (
-            <pre>{JSON.stringify(m.toolInvocations, null, 2)}</pre>
+          {m.parts ? (
+            <pre>{JSON.stringify(m.parts, null, 2)}</pre>
           ) : (
             <p>{m.content}</p>
           )}
@@ -268,7 +268,7 @@ export default function Chat() {
 }
 ```
 
-With this change, you check each message for any tool calls (`toolInvocations`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
+With this change, you check each message for any tool calls (`parts`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
 
 Now, when you ask about the weather, you'll see the tool invocation and its result displayed in your chat interface.
 

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -222,11 +222,11 @@ In this updated code:
    - Defines parameters using a Zod schema, specifying that it requires a `location` string to execute this tool. The model will attempt to extract this parameter from the context of the conversation. If it can't, it will ask the user for the missing information.
    - Defines an `execute` function that simulates getting weather data (in this case, it returns a random temperature). This is an asynchronous function running on the server so you can fetch real data from an external API.
 
-Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `toolInvocations` that is available on the message object.
+Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `parts` that is available on the message object.
 
 Try asking something like "What's the weather in New York?" and see how the model uses the new tool.
 
-Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `toolInvocations` key of the message object.
+Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `parts` key of the message object.
 
 ### Update the UI
 
@@ -244,8 +244,8 @@ To display the tool invocations in your UI, update your `src/routes/+page.svelte
     {#each $messages as message}
       <li>
         {message.role}:
-        {#if message.toolInvocations}
-          <pre>{JSON.stringify(message.toolInvocations, null, 2)}</pre>
+        {#if message.parts}
+          <pre>{JSON.stringify(message.parts, null, 2)}</pre>
         {:else}
           {message.content}
         {/if}
@@ -259,7 +259,7 @@ To display the tool invocations in your UI, update your `src/routes/+page.svelte
 </main>
 ```
 
-With this change, you check each message for any tool calls (`toolInvocations`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
+With this change, you check each message for any tool calls (`parts`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
 
 Now, when you ask about the weather, you'll see the tool invocation and its result displayed in your chat interface.
 

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -238,11 +238,11 @@ In this updated code:
    - Defines parameters using a Zod schema, specifying that it requires a `location` string to execute this tool. The model will attempt to extract this parameter from the context of the conversation. If it can't, it will ask the user for the missing information.
    - Defines an `execute` function that simulates getting weather data (in this case, it returns a random temperature). This is an asynchronous function running on the server so you can fetch real data from an external API.
 
-Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `toolInvocations` that is available on the message object.
+Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `parts` that is available on the message object.
 
 Try asking something like "What's the weather in New York?" and see how the model uses the new tool.
 
-Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `toolInvocations` key of the message object.
+Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `parts` key of the message object.
 
 ### Update the UI
 
@@ -259,8 +259,8 @@ const { messages, input, handleSubmit } = useChat();
   <div class="flex flex-col w-full max-w-md py-24 mx-auto stretch">
     <div v-for="m in messages" :key="m.id" class="whitespace-pre-wrap">
       {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
-      <template v-if="m.toolInvocations">
-        <pre>{{ JSON.stringify(m.toolInvocations, null, 2) }}</pre>
+      <template v-if="m.parts">
+        <pre>{{ JSON.stringify(m.parts, null, 2) }}</pre>
       </template>
       <template v-else>
         <p>{{ m.content }}</p>
@@ -278,7 +278,7 @@ const { messages, input, handleSubmit } = useChat();
 </template>
 ```
 
-With this change, you check each message for any tool calls (`toolInvocations`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
+With this change, you check each message for any tool calls (`parts`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
 
 Now, when you ask about the weather, you'll see the tool invocation and its result displayed in your chat interface.
 

--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -296,7 +296,7 @@ In this updated code:
    - Defines parameters using a Zod schema, specifying that it requires a `location` string to execute this tool. The model will attempt to extract this parameter from the context of the conversation. If it can't, it will ask the user for the missing information.
    - Defines an `execute` function that simulates getting weather data (in this case, it returns a random temperature). This is an asynchronous function running on the server so you can fetch real data from an external API.
 
-   Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `toolInvocations` that is available on the message object.
+   Now your chatbot can "fetch" weather information for any location the user asks about. When the model determines it needs to use the weather tool, it will generate a tool call with the necessary parameters. The `execute` function will then be automatically run, and you can access the results via `parts` that is available on the message object.
 
 <Note>
   You may need to restart your development server for the changes to take
@@ -305,7 +305,7 @@ In this updated code:
 
 Try asking something like "What's the weather in New York?" and see how the model uses the new tool.
 
-Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `toolInvocations` key of the message object.
+Notice the blank response in the UI? This is because instead of generating a text response, the model generated a tool call. You can access the tool call and subsequent tool result in the `parts` key of the message object.
 
 ### Update the UI
 
@@ -341,8 +341,8 @@ export default function App() {
             <View key={m.id} style={{ marginVertical: 8 }}>
               <View>
                 <Text style={{ fontWeight: 700 }}>{m.role}</Text>
-                {m.toolInvocations ? (
-                  <Text>{JSON.stringify(m.toolInvocations, null, 2)}</Text>
+                {m.parts ? (
+                  <Text>{JSON.stringify(m.parts, null, 2)}</Text>
                 ) : (
                   <Text>{m.content}</Text>
                 )}
@@ -383,7 +383,7 @@ export default function App() {
   effect.
 </Note>
 
-With this change, you check each message for any tool calls (`toolInvocations`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
+With this change, you check each message for any tool calls (`parts`). These tool calls will be displayed as stringified JSON. Otherwise, you show the message content as before.
 
 Now, when you ask about the weather, you'll see the tool invocation and its result displayed in your chat interface.
 

--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -567,7 +567,7 @@ export default function Chat() {
                   m.content
                 ) : (
                   <span className="italic font-light">
-                    {'calling tool: ' + m?.toolInvocations?.[0].toolName}
+                    {'calling tool: ' + m?.parts?.[0].toolName}
                   </span>
                 )}
               </p>

--- a/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
@@ -106,7 +106,7 @@ There are three things worth mentioning:
 1. The [`onToolCall`](/docs/reference/ai-sdk-ui/use-chat#on-tool-call) callback is used to handle client-side tools that should be automatically executed.
    In this example, the `getLocation` tool is a client-side tool that returns a random city.
 
-2. The `toolInvocations` property of the last assistant message contains all tool calls and results.
+2. The `parts` property of the last assistant message contains all tool calls and results.
    The client-side tool `askForConfirmation` is displayed in the UI.
    It asks the user for confirmation and displays the result once the user confirms or denies the execution.
    The result is added to the chat using `addToolResult`.

--- a/content/docs/04-ai-sdk-ui/04-generative-user-interfaces.mdx
+++ b/content/docs/04-ai-sdk-ui/04-generative-user-interfaces.mdx
@@ -162,7 +162,7 @@ This component will display the weather information for a given location. It tak
 
 Now that you have your tool and corresponding React component, let's integrate them into your chat interface. You'll render the Weather component when the model calls the weather tool.
 
-To check if the model has called a tool, you can use the `toolInvocations` property of the message object. This property contains information about any tools that were invoked in that generation including `toolCallId`, `toolName`, `args`, `toolState`, and `result`.
+To check if the model has called a tool, you can use the `parts` property of the message object. This property contains information about any tools that were invoked in that generation including `toolCallId`, `toolName`, `args`, `toolState`, and `result`.
 
 Update your `page.tsx` file:
 
@@ -183,7 +183,7 @@ export default function Page() {
           <div>{message.content}</div>
 
           <div>
-            {message.toolInvocations?.map(toolInvocation => {
+            {message.parts?.map(toolInvocation => {
               const { toolName, toolCallId, state } = toolInvocation;
 
               if (state === 'result') {
@@ -224,7 +224,7 @@ export default function Page() {
 
 In this updated code snippet, you:
 
-1. Check if the message has `toolInvocations`.
+1. Check if the message has `parts`.
 2. Check if the tool invocation state is 'result'.
 3. If it's a result and the tool name is 'displayWeather', render the Weather component.
 4. If the tool invocation state is not 'result', show a loading message.
@@ -299,7 +299,7 @@ export default function Page() {
           <div>{message.content}</div>
 
           <div>
-            {message.toolInvocations?.map(toolInvocation => {
+            {message.parts?.map(toolInvocation => {
               const { toolName, toolCallId, state } = toolInvocation;
 
               if (state === 'result') {

--- a/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
+++ b/content/docs/05-ai-sdk-rsc/10-migrating-to-ui.mdx
@@ -210,7 +210,7 @@ As mentioned earlier, `streamUI` generates text and renders the React component 
 
 #### After: Replace with route handler and stream props data to client
 
-The `streamText` function streams the props data as response to the client, while `useChat` decode the stream as `toolInvocations` and renders the chat interface.
+The `streamText` function streams the props data as response to the client, while `useChat` decode the stream as `parts` and renders the chat interface.
 
 ```ts filename="@/app/api/chat/route.ts"
 import { z } from 'zod';
@@ -263,7 +263,7 @@ export default function Page() {
           <div>{message.content}</div>
 
           <div>
-            {message.toolInvocations.map(toolInvocation => {
+            {message.parts.map(toolInvocation => {
               const { toolName, toolCallId, state } = toolInvocation;
 
               if (state === 'result') {
@@ -410,15 +410,15 @@ With AI SDK UI, you can use the tool invocation state to show a loading indicato
 ```tsx filename="@/app/components/message.tsx"
 'use client';
 
-export function Message({ role, content, toolInvocations }) {
+export function Message({ role, content, parts }) {
   return (
     <div>
       <div>{role}</div>
       <div>{content}</div>
 
-      {toolInvocations && (
+      {parts && (
         <div>
-          {toolInvocations.map(toolInvocation => {
+          {parts.map(toolInvocation => {
             const { toolName, toolCallId, state } = toolInvocation;
 
             if (state === 'result') {


### PR DESCRIPTION
Here’s an enhanced commit description with **before and after** sections in Markdown:  


## Refactor: Replace `toolInvocations` with `parts` in message rendering

### Changes:
- Replaced deprecated `toolInvocations` with `parts` in message rendering logic.
- Ensured compatibility with the latest API from `useChat`.

### Before:
```jsx
<ScrollView style={{ flex: 1 }}>
  {messages.map(m => (
    <View key={m.id} style={{ marginVertical: 8 }}>
      <View>
        <Text style={{ fontWeight: 700 }}>{m.role}</Text>
        {m.toolInvocations ? (
          <Text>{JSON.stringify(m.toolInvocations, null, 2)}</Text>
        ) : (
          <Text>{m.content}</Text>
        )}
      </View>
    </View>
  ))}
</ScrollView>
```

### After:
```jsx
<ScrollView style={{ flex: 1 }}>
  {messages.map(m => (
    <View key={m.id} style={{ marginVertical: 8 }}>
      <View>
        <Text style={{ fontWeight: 700 }}>{m.role}</Text>
        {m.parts ? (
          <Text>{JSON.stringify(m.parts, null, 2)}</Text>
        ) : (
          <Text>{m.content}</Text>
        )}
      </View>
    </View>
  ))}
</ScrollView>
```

### Why:
- `toolInvocations` has been deprecated in favor of `parts`.
- Aligns message rendering with the latest `useChat` API changes.

### Impact:
- Ensures compatibility with future updates.
- Prevents breaking changes due to deprecated properties.
```  

This keeps the commit message clear, structured, and easy to understand. 🚀