### PR TITLE
feat (provider/openai): support file search tool

### DIFF
--- a/examples/next-openai/app/use-chat-custom-sources/page.tsx
+++ b/examples/next-openai/app/use-chat-custom-sources/page.tsx
@@ -33,13 +33,19 @@ export default function Chat() {
             .map(part => (
               <span key={`source-${part.source.id}`}>
                 [
-                <a
-                  href={part.source.url}
-                  target="_blank"
-                  className="text-sm font-bold text-blue-500 hover:underline"
-                >
-                  {part.source.title ?? new URL(part.source.url).hostname}
-                </a>
+                {part.source.sourceType === 'url' ? (
+                  <a
+                    href={part.source.url}
+                    target="_blank"
+                    className="text-sm font-bold text-blue-500 hover:underline"
+                  >
+                    {part.source.title ?? new URL(part.source.url).hostname}
+                  </a>
+                ) : part.source.sourceType === 'file' ? (
+                  <span className="text-sm font-bold text-green-500">
+                    {part.source.filename}
+                  </span>
+                ) : null}
                 ]
               </span>
             ))}

--- a/examples/next-openai/app/use-chat-sources/page.tsx
+++ b/examples/next-openai/app/use-chat-sources/page.tsx
@@ -33,13 +33,19 @@ export default function Chat() {
             .map(part => (
               <span key={`source-${part.source.id}`}>
                 [
-                <a
-                  href={part.source.url}
-                  target="_blank"
-                  className="text-sm font-bold text-blue-500 hover:underline"
-                >
-                  {part.source.title ?? new URL(part.source.url).hostname}
-                </a>
+                {part.source.sourceType === 'url' ? (
+                  <a
+                    href={part.source.url}
+                    target="_blank"
+                    className="text-sm font-bold text-blue-500 hover:underline"
+                  >
+                    {part.source.title ?? new URL(part.source.url).hostname}
+                  </a>
+                ) : part.source.sourceType === 'file' ? (
+                  <span className="text-sm font-bold text-green-500">
+                    {part.source.filename}
+                  </span>
+                ) : null}
                 ]
               </span>
             ))}

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -31,6 +31,29 @@ function webSearchPreviewTool({
   };
 }
 
+const FileSearchPreviewParameters = z.object({});
+
+function fileSearchTool({
+  vectorStoreIds,
+}: {
+  vectorStoreIds?: string[];
+} = {}): {
+  type: 'provider-defined';
+  id: 'openai.file_search';
+  args: {};
+  parameters: typeof FileSearchPreviewParameters;
+} {
+  return {
+    type: 'provider-defined',
+    id: 'openai.file_search',
+    args: {
+      vectorStoreIds,
+    },
+    parameters: FileSearchPreviewParameters,
+  };
+}
+
 export const openaiTools = {
   webSearchPreview: webSearchPreviewTool,
+  fileSearch: fileSearchTool,
 };

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -24,21 +24,24 @@ export type OpenAIResponsesUserMessage = {
 
 export type OpenAIResponsesAssistantMessage = {
   role: 'assistant';
-  content: Array<{ 
-    type: 'output_text'; 
-    text: string; 
-    annotations?: Array<{
-      type: 'file_citation';
-      index: number;
-      file_id: string;
-      filename: string;
-    } | {
-      type: 'url_citation';
-      start_index: number;
-      end_index: number;
-      url: string;
-      title: string;
-    }>;
+  content: Array<{
+    type: 'output_text';
+    text: string;
+    annotations?: Array<
+      | {
+          type: 'file_citation';
+          index: number;
+          file_id: string;
+          filename: string;
+        }
+      | {
+          type: 'url_citation';
+          start_index: number;
+          end_index: number;
+          url: string;
+          title: string;
+        }
+    >;
   }>;
 };
 

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -56,4 +56,9 @@ export type OpenAIResponsesTool =
         city: string;
         region: string;
       };
+    }
+  | {
+      type: 'file_search';
+      vector_store_ids: string[];
     };
+

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -24,7 +24,22 @@ export type OpenAIResponsesUserMessage = {
 
 export type OpenAIResponsesAssistantMessage = {
   role: 'assistant';
-  content: Array<{ type: 'output_text'; text: string }>;
+  content: Array<{ 
+    type: 'output_text'; 
+    text: string; 
+    annotations?: Array<{
+      type: 'file_citation';
+      index: number;
+      file_id: string;
+      filename: string;
+    } | {
+      type: 'url_citation';
+      start_index: number;
+      end_index: number;
+      url: string;
+      title: string;
+    }>;
+  }>;
 };
 
 export type OpenAIResponsesFunctionCall = {

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -61,4 +61,3 @@ export type OpenAIResponsesTool =
       type: 'file_search';
       vector_store_ids: string[];
     };
-

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -2,6 +2,7 @@ import {
   LanguageModelV1,
   LanguageModelV1CallWarning,
   LanguageModelV1FinishReason,
+  LanguageModelV1Source,
   LanguageModelV1StreamPart,
 } from '@ai-sdk/provider';
 import {
@@ -257,15 +258,25 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
                   z.object({
                     type: z.literal('output_text'),
                     text: z.string(),
-                    annotations: z.array(
-                      z.object({
-                        type: z.literal('url_citation'),
-                        start_index: z.number(),
-                        end_index: z.number(),
-                        url: z.string(),
-                        title: z.string(),
-                      }),
-                    ),
+                    annotations: z
+                      .array(
+                        z.discriminatedUnion('type', [
+                          z.object({
+                            type: z.literal('url_citation'),
+                            start_index: z.number(),
+                            end_index: z.number(),
+                            url: z.string(),
+                            title: z.string(),
+                          }),
+                          z.object({
+                            type: z.literal('file_citation'),
+                            index: z.number(),
+                            file_id: z.string(),
+                            filename: z.string(),
+                          }),
+                        ]),
+                      )
+                      .optional(),
                   }),
                 ),
               }),
@@ -280,6 +291,13 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
               }),
               z.object({
                 type: z.literal('computer_call'),
+              }),
+              z.object({
+                type: z.literal('file_search_call'),
+                id: z.string(),
+                status: z.string(),
+                queries: z.array(z.string()),
+                results: z.any().nullable(),
               }),
               z.object({
                 type: z.literal('reasoning'),
@@ -310,14 +328,33 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
 
     return {
       text: outputTextElements.map(content => content.text).join('\n'),
-      sources: outputTextElements.flatMap(content =>
-        content.annotations.map(annotation => ({
-          sourceType: 'url',
-          id: this.config.generateId?.() ?? generateId(),
-          url: annotation.url,
-          title: annotation.title,
-        })),
-      ),
+      sources: outputTextElements.flatMap(content => {
+        if (!content.annotations) return [];
+
+        return content.annotations
+          .filter(
+            annotation =>
+              annotation.type === 'url_citation' ||
+              annotation.type === 'file_citation',
+          )
+          .map(annotation => {
+            if (annotation.type === 'url_citation') {
+              return {
+                sourceType: 'url',
+                id: this.config.generateId?.() ?? generateId(),
+                url: annotation.url,
+                title: annotation.title,
+              };
+            } else {
+              return {
+                sourceType: 'file',
+                id: this.config.generateId?.() ?? generateId(),
+                fileId: annotation.file_id,
+                filename: annotation.filename,
+              };
+            }
+          });
+      }),
       finishReason: mapOpenAIResponseFinishReason({
         finishReason: response.incomplete_details?.reason,
         hasToolCalls: toolCalls.length > 0,
@@ -403,7 +440,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
             // handle failed chunk parsing / validation:
             if (!chunk.success) {
               finishReason = 'error';
-              controller.enqueue({ type: 'error', error: chunk.error });
+              controller.enqueue({
+                type: 'error',
+                error: new Error('Failed to parse response chunk'),
+              });
               return;
             }
 
@@ -476,15 +516,31 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
                 value.response.usage.output_tokens_details?.reasoning_tokens ??
                 reasoningTokens;
             } else if (isResponseAnnotationAddedChunk(value)) {
-              controller.enqueue({
-                type: 'source',
-                source: {
+              // Handle annotation sources (citations) in the response
+              let source: LanguageModelV1Source | undefined;
+
+              if (value.annotation.type === 'url_citation') {
+                source = {
                   sourceType: 'url',
                   id: self.config.generateId?.() ?? generateId(),
                   url: value.annotation.url,
                   title: value.annotation.title,
-                },
-              });
+                };
+              } else if (value.annotation.type === 'file_citation') {
+                source = {
+                  sourceType: 'file',
+                  id: self.config.generateId?.() ?? generateId(),
+                  fileId: value.annotation.file_id,
+                  filename: value.annotation.filename,
+                };
+              }
+
+              if (source) {
+                controller.enqueue({
+                  type: 'source',
+                  source,
+                });
+              }
             }
           },
 
@@ -594,11 +650,19 @@ const responseOutputItemAddedSchema = z.object({
 
 const responseAnnotationAddedSchema = z.object({
   type: z.literal('response.output_text.annotation.added'),
-  annotation: z.object({
-    type: z.literal('url_citation'),
-    url: z.string(),
-    title: z.string(),
-  }),
+  annotation: z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('url_citation'),
+      url: z.string(),
+      title: z.string(),
+    }),
+    z.object({
+      type: z.literal('file_citation'),
+      file_id: z.string(),
+      filename: z.string(),
+      index: z.number(),
+    }),
+  ]),
 });
 
 const openaiResponsesChunkSchema = z.union([

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -62,6 +62,12 @@ export function prepareResponsesTools({
               },
             });
             break;
+          case 'openai.file_search':
+            openaiTools.push({
+              type: 'file_search',
+              vector_store_ids: tool.args.vectorStoreIds as string[],
+            });
+            break;
           default:
             toolWarnings.push({ type: 'unsupported-tool', tool });
             break;

--- a/packages/provider/src/language-model/v1/language-model-v1-source.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-source.ts
@@ -3,56 +3,56 @@ import { LanguageModelV1ProviderMetadata } from './language-model-v1-provider-me
 /**
  * A source that has been used as input to generate the response.
  */
-export type LanguageModelV1Source = 
+export type LanguageModelV1Source =
   | {
-    /**
-     * A URL source. This is return by web search RAG models.
-     */
-    sourceType: 'url';
+      /**
+       * A URL source. This is return by web search RAG models.
+       */
+      sourceType: 'url';
 
-    /**
-     * The ID of the source.
-     */
-    id: string;
+      /**
+       * The ID of the source.
+       */
+      id: string;
 
-    /**
-     * The URL of the source.
-     */
-    url: string;
+      /**
+       * The URL of the source.
+       */
+      url: string;
 
-    /**
-     * The title of the source.
-     */
-    title?: string;
+      /**
+       * The title of the source.
+       */
+      title?: string;
 
-    /**
-     * Additional provider metadata for the source.
-     */
-    providerMetadata?: LanguageModelV1ProviderMetadata;
-  }
+      /**
+       * Additional provider metadata for the source.
+       */
+      providerMetadata?: LanguageModelV1ProviderMetadata;
+    }
   | {
-    /**
-     * A file source. This is returned by file search RAG models.
-     */
-    sourceType: 'file';
+      /**
+       * A file source. This is returned by file search RAG models.
+       */
+      sourceType: 'file';
 
-    /**
-     * The ID of the source.
-     */
-    id: string;
+      /**
+       * The ID of the source.
+       */
+      id: string;
 
-    /**
-     * The ID of the file.
-     */
-    fileId: string;
+      /**
+       * The ID of the file.
+       */
+      fileId: string;
 
-    /**
-     * The name of the file.
-     */
-    filename: string;
+      /**
+       * The name of the file.
+       */
+      filename: string;
 
-    /**
-     * Additional provider metadata for the source.
-     */
-    providerMetadata?: LanguageModelV1ProviderMetadata;
-  };
+      /**
+       * Additional provider metadata for the source.
+       */
+      providerMetadata?: LanguageModelV1ProviderMetadata;
+    };

--- a/packages/provider/src/language-model/v1/language-model-v1-source.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1-source.ts
@@ -3,29 +3,56 @@ import { LanguageModelV1ProviderMetadata } from './language-model-v1-provider-me
 /**
  * A source that has been used as input to generate the response.
  */
-export type LanguageModelV1Source = {
-  /**
-   * A URL source. This is return by web search RAG models.
-   */
-  sourceType: 'url';
+export type LanguageModelV1Source = 
+  | {
+    /**
+     * A URL source. This is return by web search RAG models.
+     */
+    sourceType: 'url';
 
-  /**
-   * The ID of the source.
-   */
-  id: string;
+    /**
+     * The ID of the source.
+     */
+    id: string;
 
-  /**
-   * The URL of the source.
-   */
-  url: string;
+    /**
+     * The URL of the source.
+     */
+    url: string;
 
-  /**
-   * The title of the source.
-   */
-  title?: string;
+    /**
+     * The title of the source.
+     */
+    title?: string;
 
-  /**
-   * Additional provider metadata for the source.
-   */
-  providerMetadata?: LanguageModelV1ProviderMetadata;
-};
+    /**
+     * Additional provider metadata for the source.
+     */
+    providerMetadata?: LanguageModelV1ProviderMetadata;
+  }
+  | {
+    /**
+     * A file source. This is returned by file search RAG models.
+     */
+    sourceType: 'file';
+
+    /**
+     * The ID of the source.
+     */
+    id: string;
+
+    /**
+     * The ID of the file.
+     */
+    fileId: string;
+
+    /**
+     * The name of the file.
+     */
+    filename: string;
+
+    /**
+     * Additional provider metadata for the source.
+     */
+    providerMetadata?: LanguageModelV1ProviderMetadata;
+  };


### PR DESCRIPTION
Extending the openai-tools to support the "file_search" tool call documented by OpenAI here: https://platform.openai.com/docs/guides/tools-file-search?lang=javascript

Note: originally set this up as "file_search_preview", but opted for "file_search" because OpenAI does not have this tool tagged as a preview feature and the tool name in the OpenAI docs is "file_search".