### PR TITLE
fix (ai/core): limit node imports to types where possible

### DIFF
--- a/.changeset/slimy-points-fly.md
+++ b/.changeset/slimy-points-fly.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai/core): limit node imports to types where possible

--- a/packages/ai/core/tool/mcp/mcp-stdio-transport.test.ts
+++ b/packages/ai/core/tool/mcp/mcp-stdio-transport.test.ts
@@ -1,4 +1,4 @@
-import { ChildProcess } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCPClientError } from '../../../errors';

--- a/packages/ai/core/tool/mcp/mcp-stdio-transport.ts
+++ b/packages/ai/core/tool/mcp/mcp-stdio-transport.ts
@@ -1,4 +1,4 @@
-import { ChildProcess } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { MCPClientError } from '../../../errors';
 import {
   JSONRPCMessage,

--- a/packages/ai/core/tool/mcp/types.ts
+++ b/packages/ai/core/tool/mcp/types.ts
@@ -1,5 +1,5 @@
-import { IOType } from 'node:child_process';
-import { Stream } from 'node:stream';
+import type { IOType } from 'node:child_process';
+import type { Stream } from 'node:stream';
 import { z } from 'zod';
 import {
   inferParameters,


### PR DESCRIPTION
Fixes https://github.com/vercel/ai/issues/5148