### PR TITLE
allow user to override ChatConfig when creating LanguageModel for LMStudio (openAiCompatible) Provider

### DIFF
--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -55,6 +55,11 @@ model. `undefined` can be specified if object generation is not supported.
   supportsStructuredOutputs?: boolean;
 };
 
+export type OpenAICompatibleChatConfigOverride = Pick<
+  OpenAICompatibleChatConfig,
+  'defaultObjectGenerationMode' | 'supportsStructuredOutputs'
+>;
+
 export class OpenAICompatibleChatLanguageModel implements LanguageModelV1 {
   readonly specificationVersion = 'v1';
 

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -4,7 +4,10 @@ import {
   ProviderV1,
 } from '@ai-sdk/provider';
 import { FetchFunction, withoutTrailingSlash } from '@ai-sdk/provider-utils';
-import { OpenAICompatibleChatLanguageModel } from './openai-compatible-chat-language-model';
+import {
+  OpenAICompatibleChatConfigOverride,
+  OpenAICompatibleChatLanguageModel,
+} from './openai-compatible-chat-language-model';
 import { OpenAICompatibleChatSettings } from './openai-compatible-chat-settings';
 import { OpenAICompatibleCompletionLanguageModel } from './openai-compatible-completion-language-model';
 import { OpenAICompatibleCompletionSettings } from './openai-compatible-completion-settings';
@@ -19,16 +22,19 @@ export interface OpenAICompatibleProvider<
   (
     modelId: CHAT_MODEL_IDS,
     settings?: OpenAICompatibleChatSettings,
+    config?: OpenAICompatibleChatConfigOverride,
   ): LanguageModelV1;
 
   languageModel(
     modelId: CHAT_MODEL_IDS,
     settings?: OpenAICompatibleChatSettings,
+    config?: OpenAICompatibleChatConfigOverride,
   ): LanguageModelV1;
 
   chatModel(
     modelId: CHAT_MODEL_IDS,
     settings?: OpenAICompatibleChatSettings,
+    config?: OpenAICompatibleChatConfigOverride,
   ): LanguageModelV1;
 
   completionModel(
@@ -123,15 +129,18 @@ export function createOpenAICompatible<
   const createLanguageModel = (
     modelId: CHAT_MODEL_IDS,
     settings: OpenAICompatibleChatSettings = {},
-  ) => createChatModel(modelId, settings);
+    config: OpenAICompatibleChatConfigOverride = {},
+  ) => createChatModel(modelId, settings, config);
 
   const createChatModel = (
     modelId: CHAT_MODEL_IDS,
     settings: OpenAICompatibleChatSettings = {},
+    config: OpenAICompatibleChatConfigOverride = {},
   ) =>
     new OpenAICompatibleChatLanguageModel(modelId, settings, {
       ...getCommonModelConfig('chat'),
       defaultObjectGenerationMode: 'tool',
+      ...config,
     });
 
   const createCompletionModel = (
@@ -157,7 +166,8 @@ export function createOpenAICompatible<
   const provider = (
     modelId: CHAT_MODEL_IDS,
     settings?: OpenAICompatibleChatSettings,
-  ) => createLanguageModel(modelId, settings);
+    config?: OpenAICompatibleChatConfigOverride,
+  ) => createLanguageModel(modelId, settings, config);
 
   provider.languageModel = createLanguageModel;
   provider.chatModel = createChatModel;


### PR DESCRIPTION
See discussion in https://github.com/vercel/ai/issues/5197#issuecomment-2722322811

This PR now allows to optionally override languageModel configuration properties `defaultObjectGenerationMode` and `supportStructuredOutputs`.

When setting `supportStructuredOutputs` to `true`, this will now make  the openAiCompatible provider add the schema to the request when generating objects (and when a schema was provided).

This is how this change can be used:

```
const lmstudio = createOpenAICompatible({
    name: 'lmstudio',
    baseURL: 'http://localhost:1234/v1',
});
model = lmstudio('mistral-nemo-instruct-2407', undefined, {
    supportsStructuredOutputs: true,
});
```

It is not ideal to have to add an `undefined` settings, since the extra config that was added to the function's signature is added as last optional parameter, to allow for backwards compatibility.

Better would be to add overloaded function signatures to allow for all possible construction methods:
```
model = lmstudio('mistral-nemo-instruct-2407');
model2 = lmstudio({
  modelId: 'mistral-nemo-instruct-2407', 
  config: {
    supportsStructuredOutputs: true,
  }
});
```