### PR TITLE
feat (provider/groq): reasoning format support

### DIFF
--- a/.changeset/perfect-frogs-notice.md
+++ b/.changeset/perfect-frogs-notice.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/google': patch
+'@ai-sdk/groq': patch
+---
+
+feat (provider-utils): parseProviderOptions function

--- a/.changeset/selfish-berries-think.md
+++ b/.changeset/selfish-berries-think.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+fix (provider/groq): skip empty text deltas

--- a/.changeset/silent-bees-smell.md
+++ b/.changeset/silent-bees-smell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+feat (provider/groq): reasoning format support

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -77,20 +77,24 @@ const model = groq('gemma2-9b-it');
 
 ### Reasoning Models
 
-Groq exposes the thinking of `deepseek-r1-distill-llama-70b` in the generated text using the `<think>` tag.
-You can use the `extractReasoningMiddleware` to extract this reasoning and expose it as a `reasoning` property on the result:
+Groq offers several reasoning models such as `qwen-qwq-32b` and `deepseek-r1-distill-llama-70b`.
+You can configure how the reasoning is exposed in the generated text by using the `reasoningFormat` option.
+It supports the options `parsed`, `hidden`, and `raw`.
 
 ```ts
 import { groq } from '@ai-sdk/groq';
-import { wrapLanguageModel, extractReasoningMiddleware } from 'ai';
+import { generateText } from 'ai';
 
-const enhancedModel = wrapLanguageModel({
-  model: groq('deepseek-r1-distill-llama-70b'),
-  middleware: extractReasoningMiddleware({ tagName: 'think' }),
+const result = await generateText({
+  model: groq('qwen-qwq-32b'),
+  providerOptions: {
+    groq: { reasoningFormat: 'parsed' },
+  },
+  prompt: 'How many "r"s are in the word "strawberry"?',
 });
 ```
 
-You can then use that enhanced model in functions like `generateText` and `streamText`.
+<Note>Only Groq reasoning models support the `reasoningFormat` option.</Note>
 
 ### Example
 

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -110,13 +110,18 @@ const { text } = await generateText({
 
 | Model                           | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | ------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `deepseek-r1-distill-llama-70b` | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemma2-9b-it`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `llama-3.3-70b-versatile`       | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `llama-3.1-8b-instant`          | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `mistral-saba-24b`              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `qwen-qwq-32b`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `llama-guard-3-8b`              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `llama3-70b-8192`               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `llama3-8b-8192`                | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `mixtral-8x7b-32768`            | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemma2-9b-it`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `qwen-qwq-32b`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `mistral-saba-24b`              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `qwen-2.5-32b`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `deepseek-r1-distill-qwen-32b`  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `deepseek-r1-distill-llama-70b` | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   The table above lists popular models. Please see the [Groq

--- a/examples/ai-core/src/generate-text/groq-reasoning.ts
+++ b/examples/ai-core/src/generate-text/groq-reasoning.ts
@@ -1,0 +1,26 @@
+import { groq } from '@ai-sdk/groq';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: groq('qwen-qwq-32b'),
+    providerOptions: {
+      groq: { reasoningFormat: 'parsed' },
+    },
+    prompt: 'How many "r"s are in the word "strawberry"?',
+  });
+
+  console.log('Reasoning:');
+  console.log(result.reasoning);
+  console.log();
+
+  console.log('Text:');
+  console.log(result.text);
+  console.log();
+
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/groq-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/groq-reasoning-fullstream.ts
@@ -1,13 +1,13 @@
 import { groq } from '@ai-sdk/groq';
-import { extractReasoningMiddleware, streamText, wrapLanguageModel } from 'ai';
+import { streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
   const result = streamText({
-    model: wrapLanguageModel({
-      model: groq('deepseek-r1-distill-llama-70b'),
-      middleware: extractReasoningMiddleware({ tagName: 'think' }),
-    }),
+    model: groq('deepseek-r1-distill-llama-70b'),
+    providerOptions: {
+      groq: { reasoningFormat: 'parsed' },
+    },
     prompt: 'How many "r"s are in the word "strawberry"?',
   });
 

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -46,6 +46,7 @@ describe('doGenerate', () => {
 
   function prepareJsonResponse({
     content = '',
+    reasoning,
     tool_calls,
     function_call,
     usage = {
@@ -59,6 +60,7 @@ describe('doGenerate', () => {
     model = 'gemma2-9b-it',
   }: {
     content?: string;
+    reasoning?: string;
     tool_calls?: Array<{
       id: string;
       type: 'function';
@@ -92,6 +94,7 @@ describe('doGenerate', () => {
           message: {
             role: 'assistant',
             content,
+            reasoning,
             tool_calls,
             function_call,
           },
@@ -113,6 +116,20 @@ describe('doGenerate', () => {
     });
 
     expect(text).toStrictEqual('Hello, World!');
+  });
+
+  it('should extract reasoning', async () => {
+    prepareJsonResponse({
+      reasoning: 'This is a test reasoning',
+    });
+
+    const { reasoning } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(reasoning).toStrictEqual('This is a test reasoning');
   });
 
   it('should extract usage', async () => {

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -510,10 +510,53 @@ describe('doStream', () => {
         modelId: 'gemma2-9b-it',
         timestamp: new Date('2023-12-15T16:17:00.000Z'),
       },
-      { type: 'text-delta', textDelta: '' },
       { type: 'text-delta', textDelta: 'Hello' },
       { type: 'text-delta', textDelta: ', ' },
       { type: 'text-delta', textDelta: 'World!' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { promptTokens: 18, completionTokens: 439 },
+      },
+    ]);
+  });
+
+  it('should stream reasoning deltas', async () => {
+    server.responseChunks = [
+      `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"gemma2-9b-it",` +
+        `"system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n`,
+      `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"gemma2-9b-it",` +
+        `"system_fingerprint":null,"choices":[{"index":1,"delta":{"reasoning":"I think,"},"finish_reason":null}]}\n\n`,
+      `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"gemma2-9b-it",` +
+        `"system_fingerprint":null,"choices":[{"index":1,"delta":{"reasoning":"therefore I am."},"finish_reason":null}]}\n\n`,
+      `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"gemma2-9b-it",` +
+        `"system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"Hello"},"finish_reason":null}]}\n\n`,
+      `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1702657020,"model":"gemma2-9b-it",` +
+        `"system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n`,
+      `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"gemma2-9b-it",` +
+        `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],` +
+        `"x_groq":{"id":"req_01jadadp0femyae9kav1gpkhe8","usage":{"queue_time":0.061348671,"prompt_tokens":18,"prompt_time":0.000211569,` +
+        `"completion_tokens":439,"completion_time":0.798181818,"total_tokens":457,"total_time":0.798393387}}}\n\n`,
+      'data: [DONE]\n\n',
+    ];
+
+    const { stream } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    // note: space moved to last chunk bc of trimming
+    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
+      {
+        type: 'response-metadata',
+        id: 'chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798',
+        modelId: 'gemma2-9b-it',
+        timestamp: new Date('2023-12-15T16:17:00.000Z'),
+      },
+      { type: 'reasoning', textDelta: 'I think,' },
+      { type: 'reasoning', textDelta: 'therefore I am.' },
+      { type: 'text-delta', textDelta: 'Hello' },
       {
         type: 'finish',
         finishReason: 'stop',
@@ -848,10 +891,6 @@ describe('doStream', () => {
         id: 'chat-2267f7e2910a4254bac0650ba74cfc1c',
         modelId: 'meta/llama-3.1-8b-instruct:fp8',
         timestamp: new Date('2024-12-02T17:57:21.000Z'),
-      },
-      {
-        type: 'text-delta',
-        textDelta: '',
       },
       {
         type: 'tool-call-delta',

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -249,6 +249,9 @@ describe('doGenerate', () => {
       inputFormat: 'prompt',
       mode: { type: 'regular' },
       prompt: TEST_PROMPT,
+      providerMetadata: {
+        groq: { reasoningFormat: 'hidden' },
+      },
     });
 
     expect(await server.getRequestBodyJson()).toStrictEqual({
@@ -256,6 +259,7 @@ describe('doGenerate', () => {
       messages: [{ role: 'user', content: 'Hello' }],
       parallel_tool_calls: false,
       user: 'test-user-id',
+      reasoning_format: 'hidden',
     });
   });
 

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -346,6 +346,13 @@ export class GroqChatLanguageModel implements LanguageModelV1 {
 
             const delta = choice.delta;
 
+            if (delta.reasoning != null) {
+              controller.enqueue({
+                type: 'reasoning',
+                textDelta: delta.reasoning,
+              });
+            }
+
             if (delta.content != null) {
               controller.enqueue({
                 type: 'text-delta',
@@ -493,7 +500,6 @@ const groqChatResponseSchema = z.object({
   choices: z.array(
     z.object({
       message: z.object({
-        role: z.literal('assistant').nullish(),
         content: z.string().nullish(),
         reasoning: z.string().nullish(),
         tool_calls: z
@@ -532,7 +538,6 @@ const groqChatChunkSchema = z.union([
       z.object({
         delta: z
           .object({
-            role: z.enum(['assistant']).nullish(),
             content: z.string().nullish(),
             reasoning: z.string().nullish(),
             tool_calls: z

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -346,14 +346,14 @@ export class GroqChatLanguageModel implements LanguageModelV1 {
 
             const delta = choice.delta;
 
-            if (delta.reasoning != null) {
+            if (delta.reasoning != null && delta.reasoning.length > 0) {
               controller.enqueue({
                 type: 'reasoning',
                 textDelta: delta.reasoning,
               });
             }
 
-            if (delta.content != null) {
+            if (delta.content != null && delta.content.length > 0) {
               controller.enqueue({
                 type: 'text-delta',
                 textDelta: delta.content,

--- a/packages/groq/src/groq-chat-settings.ts
+++ b/packages/groq/src/groq-chat-settings.ts
@@ -1,15 +1,19 @@
 // https://console.groq.com/docs/models
-// production models
 export type GroqChatModelId =
-  | 'deepseek-r1-distill-llama-70b'
+  // production models
   | 'gemma2-9b-it'
-  | 'gemma-7b-it'
   | 'llama-3.3-70b-versatile'
   | 'llama-3.1-8b-instant'
   | 'llama-guard-3-8b'
   | 'llama3-70b-8192'
   | 'llama3-8b-8192'
   | 'mixtral-8x7b-32768'
+  // preview models (selection)
+  | 'qwen-qwq-32b'
+  | 'mistral-saba-24b'
+  | 'qwen-2.5-32b'
+  | 'deepseek-r1-distill-qwen-32b'
+  | 'deepseek-r1-distill-llama-70b'
   | (string & {});
 
 export interface GroqChatSettings {

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -12,8 +12,8 @@ export { loadOptionalSetting } from './load-optional-setting';
 export { loadSetting } from './load-setting';
 export * from './parse-json';
 export * from './post-to-api';
-export * from './resolve';
 export * from './remove-undefined-entries';
+export * from './resolve';
 export * from './response-handler';
 export * from './uint8-utils';
 export * from './validate-types';
@@ -21,5 +21,6 @@ export * from './validator';
 export * from './without-trailing-slash';
 
 export type { IDGenerator } from './generate-id';
+export { parseProviderOptions } from './parse-provider-options';
 export type { CoreToolCall, ToolCall } from './types/tool-call';
 export type { CoreToolResult, ToolResult } from './types/tool-result';

--- a/packages/provider-utils/src/parse-provider-options.ts
+++ b/packages/provider-utils/src/parse-provider-options.ts
@@ -1,0 +1,32 @@
+import { InvalidArgumentError } from '@ai-sdk/provider';
+import { safeValidateTypes } from './validate-types';
+import { z } from 'zod';
+
+export function parseProviderOptions<T>({
+  provider,
+  providerOptions,
+  schema,
+}: {
+  provider: string;
+  providerOptions: Record<string, unknown> | undefined;
+  schema: z.ZodSchema<T>;
+}): T | undefined {
+  if (providerOptions?.[provider] == null) {
+    return undefined;
+  }
+
+  const parsedProviderOptions = safeValidateTypes({
+    value: providerOptions[provider],
+    schema,
+  });
+
+  if (!parsedProviderOptions.success) {
+    throw new InvalidArgumentError({
+      argument: 'providerOptions',
+      message: `invalid ${provider} provider options`,
+      cause: parsedProviderOptions.error,
+    });
+  }
+
+  return parsedProviderOptions.value;
+}


### PR DESCRIPTION
Fixes #5233 

## Summary
- update groq models
- support groq reasoning format option
- omit empty groq text deltas

## Tasks

- [x] update groq models (settings)
- [x] update groq models (docs)
- [x] groq reasoning section (docs)
- [x] implement groq reasoning
   - [x] option
   - [x] option test
   - [x] generate
   - [x] generate test
   - [x] stream
   - [x] stream test
   - [x] test out defaults - would need to be model specific, not adding
   - [x] extract provider option parsing
- [x] groq reasoning example
   - [x] generate
   - [x] stream
- [x] changeset