### PR TITLE
feat (provider/open-ai): add instructions to providerOptions

### DIFF
--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -467,6 +467,29 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send instructions provider option', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          inputFormat: 'prompt',
+          mode: { type: 'regular' },
+          prompt: TEST_PROMPT,
+          providerMetadata: {
+            openai: {
+              instructions: 'You are a friendly assistant.',
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBody).toStrictEqual({
+          model: 'gpt-4o',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          instructions: 'You are a friendly assistant.',
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send object-tool format', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           inputFormat: 'prompt',

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -147,6 +147,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
       previous_response_id: openaiOptions?.previousResponseId,
       store: openaiOptions?.store,
       user: openaiOptions?.user,
+      instructions: openaiOptions?.instructions,
 
       // model-specific settings:
       ...(modelConfig.isReasoningModel &&
@@ -684,6 +685,7 @@ const providerOptionsSchema = z.object({
       user: z.string().nullish(),
       reasoningEffort: z.string().nullish(),
       strictSchemas: z.boolean().nullish(),
+      instructions: z.string().nullish(),
     })
     .nullish(),
 });


### PR DESCRIPTION
### **Expose OpenAI's `instructions` Property in `providerOptions`**  

#### **Problem**  
The OpenAI **Responses API** introduces an `instructions` property ([api docs link](https://platform.openai.com/docs/api-reference/responses/create#responses-create-instructions)) that allows setting a persistent system message. However, **this property is not currently exposed** in our API, meaning developers must pass system messages inside `messages`, which only apply per request.  

#### **Current Workaround**  
Right now, the only way to set a system message is by manually including it in `messages`:  
```js
const { text } = await generateText({
  model: openai.responses('gpt-4o'),
  messages: [
    { role: "system", "context": "You are a helpful assistant." },
    { role: "user", "context": "Hello!" }
  ]
});
```
👉 This approach works but means system messages **aren't persistent** and must be included with every request.  

#### **Proposed Solution**  
This PR adds support for passing `instructions` inside `providerOptions`, so the system message is applied **persistently**:  
```js
const { text } = await generateText({
  model: openai.responses('gpt-4o'),
  prompt: "Hello!",
  providerMetadata: {
    openai: {
      instructions: "You are a friendly assistant.",
    },
  },
});
```
👉 This ensures system messages are **consistently applied** across requests, aligning with OpenAI’s intended usage of `instructions`.  

#### **Alternative Approach: Using the `system` Property**  
There may be a better approach where we use the `system` property instead. This would require refactoring how system messages and user messages are merged (e.g., in `convertToOpenAIResponsesMessages`). We'd also likely need a **flag in `providerOptions`** to determine when to merge the system message into `input` vs. when to pass it directly to `instructions`.  

Example of what this could look like:  
```js
const { text } = await generateText({
  model: openai.responses('gpt-4o'),
  prompt: "Hello!",
  system: "You are a friendly assistant."
});
```

#### **Request for Feedback**  
Would love feedback and I'm open to thoughts on the cleanest way to handle this! 🚀