### PR TITLE
feat (docs): Add SambaNova community provider

### DIFF
--- a/content/providers/03-community-providers/96-sambanova.md
+++ b/content/providers/03-community-providers/96-sambanova.md
@@ -4,8 +4,7 @@ description: Learn how to use the SambaNova provider for the AI SDK.
 ---
 # SambaNova Provider
 
-<!-- TODO: add github repo url -->
-[sambanova-ai-provider]() provider contains language model support for the [SambaNova API](https://cloud.sambanova.ai/).
+[sambanova-ai-provider](https://github.com/sambanova/sambanova-ai-provider) contains language model support for the SambaNova API.
 
 API keys can be obtained from the [SambaNova Cloud Platform](https://cloud.sambanova.ai/apis).
 

--- a/content/providers/03-community-providers/96-sambanova.md
+++ b/content/providers/03-community-providers/96-sambanova.md
@@ -1,0 +1,178 @@
+---
+title: SambaNova
+description: Learn how to use SambaNova provider for the AI SDK.
+---
+# SambaNova Provider
+
+<!-- TODO: add github repo url -->
+[sambanova-ai-provider]() provider contains language model support for the [SambaNova API](https://cloud.sambanova.ai/).
+
+API keys can be obtained from the [SambaNova Cloud Platform](https://cloud.sambanova.ai/apis).
+
+## Setup
+
+The SambaNova provider is available via the `sambanova-ai-provider` module. You can install it with:
+
+```bash
+# With npm
+npm install sambanova-ai-provider
+```
+
+```bash
+# With yarn
+yarn add sambanova-ai-provider
+```
+
+```bash
+# With pnpm
+pnpm add sambanova-ai-provider
+```
+
+### Environment variables
+
+Create a `.env` file with a `SAMBANOVA_API_KEY` variable.
+
+## Provider Instance
+
+You can import the default provider instance `sambanova` from `sambanova-ai-provider`:
+
+```ts
+import { sambanova } from 'sambanova-ai-provider';
+```
+
+If you need a customized setup, you can import `createSambaNova` from `sambanova-ai-provider` and create a provider instance with your settings:
+
+```ts
+import { createSambaNova } from 'sambanova-ai-provider';
+
+const sambanova = createSambaNova({
+  // Optional settings
+});
+```
+
+You can use the following optional settings to customize the SambaNova provider instance:
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls, e.g. to use proxy servers.
+  The default prefix is `https://api.sambanova.ai/v1`.
+
+- **apiKey** _string_
+
+  API key that is being sent using the `Authorization` header.
+  It defaults to the `SAMBANOVA_API_KEY` environment variable.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+  Defaults to the global `fetch` function.
+  You can use it as a middleware to intercept requests,
+  or to provide a custom fetch implementation for e.g. testing.
+
+## Models
+
+You can use [SambaNova models](https://docs.sambanova.ai/cloud/docs/get-started/supported-models) on a provider instance.
+The first argument is the model id, e.g. `Meta-Llama-3.1-70B-Instruct`.
+
+```ts
+const model = sambanova('Meta-Llama-3.1-70B-Instruct');
+```
+
+## Tested models and capabilities
+
+This provider is capable of generating and streaming text, and interpreting image inputs.
+
+At least it has been tested with the following features (which use the `/chat/completion` endpoint):
+
+| Chat completion    | Image input        |
+| ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: |
+
+### Image input
+
+You need to use any of the following models for visual understanding:
+
+- Llama3.2-11B-Vision-Instruct
+- Llama3.2-90B-Vision-Instruct
+
+SambaNova does not support URLs, but the ai-sdk is able to download the file and send it to the model.
+
+## Example Usage
+
+Basic demonstration of text generation using the SambaNova provider.
+
+```js
+import { createSambaNova } from 'sambanova-ai-provider';
+import { generateText } from 'ai';
+
+const sambanova = createSambaNova({
+  apiKey: 'YOUR_API_KEY',
+});
+
+const model = sambanova('Meta-Llama-3.1-70B-Instruct');
+
+const { text } = await generateText({
+  model,
+  prompt: 'Hello, nice to meet you.',
+});
+
+console.log(text);
+```
+
+You will get an output text similar to this one:
+
+```
+Hello. Nice to meet you too. Is there something I can help you with or would you like to chat?
+```
+
+## Intercepting Fetch Requests
+
+This provider supports [Intercepting Fetch Requests](https://sdk.vercel.ai/examples/providers/intercepting-fetch-requests).
+
+### Example
+
+```js
+import { createSambaNova } from 'sambanova-ai-provider';
+import { generateText } from 'ai';
+
+const sambanovaProvider = createSambaNova({
+  apiKey: 'YOUR_API_KEY',
+  fetch: async (url, options) => {
+    console.log('URL', url);
+    console.log('Headers', JSON.stringify(options.headers, null, 2));
+    console.log(`Body ${JSON.stringify(JSON.parse(options.body), null, 2)}`);
+    return await fetch(url, options);
+  },
+});
+
+const model = sambanovaProvider('Meta-Llama-3.1-70B-Instruct');
+
+await generateText({
+  model,
+  prompt: 'Hello, nice to meet you.',
+});
+```
+
+And you will get an output like this:
+
+```bash
+URL https://api.sambanova.ai/v1/chat/completions
+Headers {
+  "Content-Type": "application/json",
+  "Authorization": "Bearer YOUR_API_KEY"
+}
+Body {
+  "model": "Meta-Llama-3.1-70B-Instruct",
+  "temperature": 0,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, nice to meet you."
+    }
+  ]
+}
+```

--- a/content/providers/03-community-providers/96-sambanova.md
+++ b/content/providers/03-community-providers/96-sambanova.md
@@ -1,6 +1,6 @@
 ---
 title: SambaNova
-description: Learn how to use SambaNova provider for the AI SDK.
+description: Learn how to use the SambaNova provider for the AI SDK.
 ---
 # SambaNova Provider
 
@@ -13,20 +13,17 @@ API keys can be obtained from the [SambaNova Cloud Platform](https://cloud.samba
 
 The SambaNova provider is available via the `sambanova-ai-provider` module. You can install it with:
 
-```bash
-# With npm
-npm install sambanova-ai-provider
-```
-
-```bash
-# With yarn
-yarn add sambanova-ai-provider
-```
-
-```bash
-# With pnpm
-pnpm add sambanova-ai-provider
-```
+<Tabs items={['pnpm', 'npm', 'yarn']}>
+  <Tab>
+    <Snippet text="pnpm add sambanova-ai-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install sambanova-ai-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add sambanova-ai-provider" dark />
+  </Tab>
+</Tabs>
 
 ### Environment variables
 
@@ -88,9 +85,9 @@ This provider is capable of generating and streaming text, and interpreting imag
 
 At least it has been tested with the following features (which use the `/chat/completion` endpoint):
 
-| Chat completion    | Image input        |
-| ------------------ | ------------------ |
-| :white_check_mark: | :white_check_mark: |
+| Chat completion     | Image input         |
+| ------------------- | ------------------- |
+| <Check size={18} /> | <Check size={18} /> |
 
 ### Image input
 
@@ -105,7 +102,7 @@ SambaNova does not support URLs, but the ai-sdk is able to download the file and
 
 Basic demonstration of text generation using the SambaNova provider.
 
-```js
+```ts
 import { createSambaNova } from 'sambanova-ai-provider';
 import { generateText } from 'ai';
 
@@ -135,7 +132,7 @@ This provider supports [Intercepting Fetch Requests](https://sdk.vercel.ai/examp
 
 ### Example
 
-```js
+```ts
 import { createSambaNova } from 'sambanova-ai-provider';
 import { generateText } from 'ai';
 
@@ -151,7 +148,7 @@ const sambanovaProvider = createSambaNova({
 
 const model = sambanovaProvider('Meta-Llama-3.1-70B-Instruct');
 
-await generateText({
+const { text } = await generateText({
   model,
   prompt: 'Hello, nice to meet you.',
 });

--- a/content/providers/03-community-providers/96-sambanova.mdx
+++ b/content/providers/03-community-providers/96-sambanova.mdx
@@ -2,6 +2,7 @@
 title: SambaNova
 description: Learn how to use the SambaNova provider for the AI SDK.
 ---
+
 # SambaNova Provider
 
 [sambanova-ai-provider](https://github.com/sambanova/sambanova-ai-provider) contains language model support for the SambaNova API.


### PR DESCRIPTION
As it was suggested at #5122, I want to add SambaNova as a custom third party provider.

We're currently missing the NPM package and official repository link as we're currently working to publish it, but if we can get reviewed to know that everything's working fine would be great.

I was wondering if this is the correct approach, and not the approach of an individual that wants to create an unofficial provider, because I noticed that there are two types of providers: "official" ones being handled at `content/providers/01-ai-sdk-providers` and community ones being handled at `content/providers/03-community-providers`.

And we want our company to have an official integration/provider with this repo, so that's why I'm asking this.

Thanks.

cc. @lgrammel 