### PR TITLE
Expose mcp-stdio in `ai` package.

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "mcp-stdio/**/*",
     "react/dist/**/*",
     "rsc/dist/**/*",
     "test/dist/**/*",


### PR DESCRIPTION
Fixes  #5286

This PR exposes `mcp-stdio` as a public artifact in the `ai` package, cc @iteratetograceness 