### PR TITLE
feat (provider/cohere): support tool calls finish reason

### DIFF
--- a/.changeset/khaki-weeks-love.md
+++ b/.changeset/khaki-weeks-love.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cohere': patch
+---
+
+feat (provider/cohere): support tool calls finish reason

--- a/packages/cohere/CHANGELOG.md
+++ b/packages/cohere/CHANGELOG.md
@@ -1,10 +1,5 @@
 # @ai-sdk/cohere
 
-## 1.2.1
-
-### Patch Changes
-- 591d42d: feat (provider/cohere): support tool calls finish reason
-
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/cohere/CHANGELOG.md
+++ b/packages/cohere/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @ai-sdk/cohere
 
+## 1.2.1
+
+### Patch Changes
+- 591d42d: feat (provider/cohere): support tool calls finish reason
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/cohere/CHANGELOG.md
+++ b/packages/cohere/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 1.2.1
 
 ### Patch Changes
-
 - 591d42d: feat (provider/cohere): support tool calls finish reason
 
 ## 1.2.0

--- a/packages/cohere/CHANGELOG.md
+++ b/packages/cohere/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1
 
 ### Patch Changes
+
 - 591d42d: feat (provider/cohere): support tool calls finish reason
 
 ## 1.2.0

--- a/packages/cohere/src/map-cohere-finish-reason.ts
+++ b/packages/cohere/src/map-cohere-finish-reason.ts
@@ -21,6 +21,9 @@ export function mapCohereFinishReason(
     case 'USER_CANCEL':
       return 'other';
 
+    case 'TOOL_CALL':
+      return 'tool-calls';
+
     default:
       return 'unknown';
   }


### PR DESCRIPTION
Responses from command-a with tool calls had a finish reason of 'unknown'. This fixes that.