### PR TITLE
feat(mcp) - export SseMCPTransport class

### DIFF
--- a/packages/ai/core/tool/index.ts
+++ b/packages/ai/core/tool/index.ts
@@ -1,4 +1,7 @@
 export { createMCPClient as experimental_createMCPClient } from './mcp/mcp-client';
 export type { MCPTransport } from './mcp/mcp-transport';
+export { SseMCPTransport } from './mcp/mcp-sse-transport';
+export { JSONRPCMessageSchema } from './mcp/json-rpc-message';
+export type { JSONRPCMessage } from './mcp/json-rpc-message';
 export { tool } from './tool';
 export type { CoreTool, Tool, ToolExecutionOptions } from './tool';

--- a/packages/ai/core/tool/mcp/mcp-sse-transport.ts
+++ b/packages/ai/core/tool/mcp/mcp-sse-transport.ts
@@ -4,11 +4,11 @@ import { JSONRPCMessage, JSONRPCMessageSchema } from './json-rpc-message';
 import { MCPTransport } from './mcp-transport';
 
 export class SseMCPTransport implements MCPTransport {
-  private endpoint?: URL;
-  private abortController?: AbortController;
-  private url: URL;
-  private connected = false;
-  private sseConnection?: {
+  protected endpoint?: URL;
+  protected abortController?: AbortController;
+  protected url: URL;
+  protected connected = false;
+  protected sseConnection?: {
     close: () => void;
   };
 


### PR DESCRIPTION
## MR: Enhance MCP Module with SseMCPTransport Class Extensibility

### Summary
This merge request improves the flexibility and extensibility of the MCP module by exposing the `SseMCPTransport` class and related types through the public API, while also modifying the class's internal properties from `private` to `protected` to enable inheritance and customization.

### Changes
1. **Exposed New Classes and Types in Public API**:
   - Added `SseMCPTransport` export in `packages/ai/core/tool/index.ts`
   - Exposed `JSONRPCMessageSchema` and `JSONRPCMessage` type for public use

2. **Enhanced Extensibility**:
   - Changed internal properties of `SseMCPTransport` from `private` to `protected`:
     - `endpoint`
     - `abortController`
     - `url`
     - `connected`
     - `sseConnection`

### Benefits
- **Developer Experience**: Makes it easier to create custom transport implementations by extending the `SseMCPTransport` class
- **Customization**: Allows developers to override or extend specific behaviors while reusing core functionality
- **Maintainability**: Promotes code reuse through inheritance rather than duplication

### Technical Details
This change is backward compatible as it only exposes additional functionality and doesn't modify existing behavior. The change from `private` to `protected` properties enables subclassing while maintaining encapsulation from external code.

### Testing Considerations
- Existing functionality should remain unchanged