### PR TITLE
Add support for `taskType` and `autoTruncate` parameters for VertexAI Embeddings Model

### DIFF
--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -563,6 +563,8 @@ Google Vertex AI embedding models support additional settings. You can pass them
 ```ts
 const model = vertex.textEmbeddingModel('text-embedding-004', {
   outputDimensionality: 512, // optional, number of dimensions for the embedding
+  taskType: 'RETRIEVAL_DOCUMENT', // optional, task type for which embeddings will be used
+  autoTruncate: true, // optional, whether to auto-truncate text exceeding token limit
 });
 ```
 
@@ -571,6 +573,30 @@ The following optional settings are available for Google Vertex AI embedding mod
 - **outputDimensionality**: _number_
 
   Optional reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end.
+
+- **taskType**: _string_
+
+  Optional. Specifies the task type for which the embeddings will be used.
+  Used to convey intended downstream application to help the model produce better embeddings.
+  If left blank, the default used is RETRIEVAL_QUERY.
+
+  Values:
+
+  - `RETRIEVAL_QUERY`: Specifies the given text is a query in a search or retrieval setting.
+  - `RETRIEVAL_DOCUMENT`: Specifies the given text is a document in a search or retrieval setting.
+  - `SEMANTIC_SIMILARITY`: Specifies the given text is used for Semantic Textual Similarity (STS).
+  - `CLASSIFICATION`: Specifies that the embedding is used for classification.
+  - `CLUSTERING`: Specifies that the embedding is used for clustering.
+  - `QUESTION_ANSWERING`: Specifies that the query embedding is used for answering questions.
+  - `FACT_VERIFICATION`: Specifies that the query embedding is used for fact verification.
+  - `CODE_RETRIEVAL_QUERY`: Specifies that the query embedding is used for code retrieval for Java and Python.
+
+  For more information, see the [Google Vertex AI documentation on task types](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#tasktype).
+
+- **autoTruncate**: _boolean_
+
+  Optional. If set to false, text that exceeds the token limit causes the request to fail.
+  The default value is true.
 
 #### Model Capabilities
 

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -13,7 +13,11 @@ const testValues = ['test text one', 'test text two'];
 
 describe('GoogleVertexEmbeddingModel', () => {
   const mockModelId = 'textembedding-gecko@001';
-  const mockSettings = { outputDimensionality: 768 };
+  const mockSettings = {
+    outputDimensionality: 768,
+    taskType: 'RETRIEVAL_QUERY',
+    autoTruncate: true,
+  };
   const mockConfig = {
     provider: 'google-vertex',
     region: 'us-central1',
@@ -93,9 +97,13 @@ describe('GoogleVertexEmbeddingModel', () => {
     await model.doEmbed({ values: testValues });
 
     expect(await server.getRequestBodyJson()).toStrictEqual({
-      instances: testValues.map(value => ({ content: value })),
+      instances: testValues.map(value => ({
+        content: value,
+        task_type: mockSettings.taskType,
+      })),
       parameters: {
         outputDimensionality: mockSettings.outputDimensionality,
+        autoTruncate: mockSettings.autoTruncate,
       },
     });
   });
@@ -198,7 +206,11 @@ describe('GoogleVertexEmbeddingModel', () => {
 
     const modelWithCustomFetch = new GoogleVertexEmbeddingModel(
       'textembedding-gecko@001',
-      { outputDimensionality: 768 },
+      {
+        outputDimensionality: 768,
+        taskType: 'RETRIEVAL_QUERY',
+        autoTruncate: true,
+      },
       {
         headers: () => ({}),
         baseURL: customBaseURL,
@@ -222,9 +234,13 @@ describe('GoogleVertexEmbeddingModel', () => {
     const requestBody = JSON.parse(secondArgument.body);
 
     expect(requestBody).toStrictEqual({
-      instances: testValues.map(value => ({ content: value })),
+      instances: testValues.map(value => ({
+        content: value,
+        task_type: 'RETRIEVAL_QUERY',
+      })),
       parameters: {
         outputDimensionality: 768,
+        autoTruncate: true,
       },
     });
   });

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -72,9 +72,13 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV1<string> {
       url,
       headers: mergedHeaders,
       body: {
-        instances: values.map(value => ({ content: value })),
+        instances: values.map(value => ({
+          content: value,
+          task_type: this.settings.taskType,
+        })),
         parameters: {
           outputDimensionality: this.settings.outputDimensionality,
+          autoTruncate: this.settings.autoTruncate,
         },
       },
       failedResponseHandler: googleVertexFailedResponseHandler,

--- a/packages/google-vertex/src/google-vertex-embedding-settings.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-settings.ts
@@ -19,6 +19,8 @@ export interface GoogleVertexEmbeddingSettings {
 
   /**
    * Optional. Specifies the task type for which the embeddings will be used.
+   * Used to convey intended downstream application to help the model produce better embeddings.
+   * If left blank, the default used is RETRIEVAL_QUERY.
    *
    * Values:
    * - RETRIEVAL_QUERY: Specifies the given text is a query in a search or retrieval setting.
@@ -38,7 +40,8 @@ export interface GoogleVertexEmbeddingSettings {
     | 'CLUSTERING'
     | 'QUESTION_ANSWERING'
     | 'FACT_VERIFICATION'
-    | 'CODE_RETRIEVAL_QUERY';
+    | 'CODE_RETRIEVAL_QUERY'
+    | (string & {});
 
   /**
    * Optional. If set to false, text that exceeds the token limit causes the request to fail.

--- a/packages/google-vertex/src/google-vertex-embedding-settings.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-settings.ts
@@ -16,4 +16,33 @@ export interface GoogleVertexEmbeddingSettings {
    * If set, excessive values in the output embedding are truncated from the end.
    */
   outputDimensionality?: number;
+
+  /**
+   * Optional. Specifies the task type for which the embeddings will be used.
+   *
+   * Values:
+   * - RETRIEVAL_QUERY: Specifies the given text is a query in a search or retrieval setting.
+   * - RETRIEVAL_DOCUMENT: Specifies the given text is a document in a search or retrieval setting.
+   * - SEMANTIC_SIMILARITY: Specifies the given text is used for Semantic Textual Similarity (STS).
+   * - CLASSIFICATION: Specifies that the embedding is used for classification.
+   * - CLUSTERING: Specifies that the embedding is used for clustering.
+   * - QUESTION_ANSWERING: Specifies that the query embedding is used for answering questions.
+   * - FACT_VERIFICATION: Specifies that the query embedding is used for fact verification.
+   * - CODE_RETRIEVAL_QUERY: Specifies that the query embedding is used for code retrieval for Java and Python.
+   */
+  taskType?:
+    | 'RETRIEVAL_QUERY'
+    | 'RETRIEVAL_DOCUMENT'
+    | 'SEMANTIC_SIMILARITY'
+    | 'CLASSIFICATION'
+    | 'CLUSTERING'
+    | 'QUESTION_ANSWERING'
+    | 'FACT_VERIFICATION'
+    | 'CODE_RETRIEVAL_QUERY';
+
+  /**
+   * Optional. If set to false, text that exceeds the token limit causes the request to fail.
+   * The default value is true.
+   */
+  autoTruncate?: boolean;
 }


### PR DESCRIPTION
Please review official Vertex AI Docs Here: 

https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api

More specifically it lists a `taskType` parameter: 

> Used to convey intended downstream application to help the model produce better embeddings. If left blank, the default used is RETRIEVAL_QUERY.

As well as an `autoTruncate` parameter:

> When set to true, input text will be truncated. When set to false, an error is returned if the input text is longer than the maximum length supported by the model. Defaults to true.


Currently these are inaccessible via the Vercel AI SDK so I've added them to the settings and updated the implementation of the embedding model for Vertex-AI to be able to pass in these parameters.


Before:

```typescript
const model = vertex.textEmbeddingModel('text-embedding-004', {
  outputDimensionality: 512, // optional, number of dimensions for the embedding
});
```

After:

```typescript
const model = vertex.textEmbeddingModel('text-embedding-004', {
  outputDimensionality: 512, // optional, number of dimensions for the embedding
  taskType: 'RETRIEVAL_DOCUMENT', // optional, task type for which embeddings will be used
  autoTruncate: true, // optional, whether to auto-truncate text exceeding token limit
});

```
