### PR TITLE
chore (examples/svelte): clarify docs

### DIFF
--- a/examples/sveltekit-openai/README.md
+++ b/examples/sveltekit-openai/README.md
@@ -1,6 +1,13 @@
 # `sveltekit-openai`
 
-To run this example, clone the repository, install dependencies, and create a `.env.local` file in `examples/sveltekit-openai` with:
+To run this example, clone the repository, and at the root install dependencies and build:
+
+```
+pnpm install
+pnpm build
+```
+
+Then create a `.env.local` file in `examples/sveltekit-openai` with:
 
 ```
 OPENAI_API_KEY=<your key>


### PR DESCRIPTION
Svelte Kit docs do not mention you need to build the monorepo before attempting to run the svelte kit example.

If you do not, you get the following error

```bash
Failed to resolve entry for package "@ai-sdk/svelte". The package may have incorrect main/module/exports specified in its package.json.
```

Solution is `pnpm build`