### PR TITLE
feat (ui): add `credentials` support to experimental `useObject`

### DIFF
--- a/.changeset/eleven-parents-brake.md
+++ b/.changeset/eleven-parents-brake.md
@@ -2,6 +2,7 @@
 '@ai-sdk/provider-utils': patch
 '@ai-sdk/react': patch
 '@ai-sdk/solid': patch
+'@ai-sdk/svelte': patch
 ---
 
 feat: add credentials support to experimental useObject

--- a/.changeset/eleven-parents-brake.md
+++ b/.changeset/eleven-parents-brake.md
@@ -1,8 +1,7 @@
 ---
-'@ai-sdk/provider-utils': patch
 '@ai-sdk/react': patch
 '@ai-sdk/solid': patch
 '@ai-sdk/svelte': patch
 ---
 
-feat: add credentials support to experimental useObject
+feat: add credentials support to experimental useObject and StructuredObject

--- a/.changeset/eleven-parents-brake.md
+++ b/.changeset/eleven-parents-brake.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/react': patch
+'@ai-sdk/solid': patch
+---
+
+feat: add credentials support to experimental useObject

--- a/content/docs/04-ai-sdk-ui/08-object-generation.mdx
+++ b/content/docs/04-ai-sdk-ui/08-object-generation.mdx
@@ -270,7 +270,7 @@ export default function Page() {
 
 ## Configure Request Options
 
-You can configure the API endpoint and optional headers using the `api` and `headers` settings.
+You can configure the API endpoint, optional headers and credentials using the `api`, `headers` and `credentials` settings.
 
 ```tsx highlight="2-5"
 const { submit, object } = useObject({
@@ -278,6 +278,7 @@ const { submit, object } = useObject({
   headers: {
     'X-Custom-Header': 'CustomValue',
   },
+  credentials: 'include',
   schema: yourSchema,
 });
 ```

--- a/content/docs/07-reference/02-ai-sdk-ui/03-use-object.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/03-use-object.mdx
@@ -86,6 +86,13 @@ export default function Page() {
         'A headers object to be passed to the API endpoint. Optional.',
     },
     {
+      name: 'credentials',
+      type: 'RequestCredentials',
+      isOptional: true,
+      description:
+        'The credentials mode to be used for the fetch request. Possible values are: "omit", "same-origin", "include". Optional.',
+    },
+    {
       name: 'onError',
       type: '(error: Error) => void',
       isOptional: true,

--- a/packages/provider-utils/src/test/test-server.ts
+++ b/packages/provider-utils/src/test/test-server.ts
@@ -35,6 +35,11 @@ class TestServerCall {
     return JSON.parse(await this.request!.text());
   }
 
+  getRequestCredentials() {
+    expect(this.request).toBeDefined();
+    return this.request!.credentials;
+  }
+
   getRequestHeaders() {
     expect(this.request).toBeDefined();
     const requestHeaders = this.request!.headers;

--- a/packages/react/src/use-object.ts
+++ b/packages/react/src/use-object.ts
@@ -71,6 +71,13 @@ Optional error object. This is e.g. a TypeValidationError when the final object 
    * Additional HTTP headers to be included in the request.
    */
   headers?: Record<string, string> | Headers;
+
+  /**
+   * The credentials mode to be used for the fetch request.
+   * Possible values are: 'omit', 'same-origin', 'include'.
+   * Defaults to 'same-origin'.
+   */
+  credentials?: RequestCredentials;
 };
 
 export type Experimental_UseObjectHelpers<RESULT, INPUT> = {
@@ -109,6 +116,7 @@ function useObject<RESULT, INPUT = any>({
   onError,
   onFinish,
   headers,
+  credentials,
 }: Experimental_UseObjectOptions<RESULT>): Experimental_UseObjectHelpers<
   RESULT,
   INPUT
@@ -156,6 +164,7 @@ function useObject<RESULT, INPUT = any>({
           'Content-Type': 'application/json',
           ...headers,
         },
+        credentials,
         signal: abortController.signal,
         body: JSON.stringify(input),
       });

--- a/packages/react/src/use-object.ui.test.tsx
+++ b/packages/react/src/use-object.ui.test.tsx
@@ -17,8 +17,10 @@ describe('text stream', () => {
 
   const TestComponent = ({
     headers,
+    credentials,
   }: {
     headers?: Record<string, string> | Headers;
+    credentials?: RequestCredentials;
   }) => {
     const { object, error, submit, isLoading, stop } = experimental_useObject({
       api: '/api/use-object',
@@ -30,6 +32,7 @@ describe('text stream', () => {
         onFinishCalls.push(event);
       },
       headers,
+      credentials,
     });
 
     return (
@@ -251,6 +254,22 @@ describe('text stream', () => {
           authorization: 'Bearer TEST_TOKEN',
           'x-custom-header': 'CustomValue',
         });
+      },
+    ),
+  );
+
+  it(
+    'should send custom credentials',
+    withTestServer(
+      {
+        url: '/api/use-object',
+        type: 'stream-values',
+        content: ['{ ', '"content": "Authenticated ', 'content', '!"', '}'],
+      },
+      async ({ call }) => {
+        render(<TestComponent credentials="include" />);
+        await userEvent.click(screen.getByTestId('submit-button'));
+        expect(call(0).getRequestCredentials()).toBe('include');
       },
     ),
   );

--- a/packages/solid/src/use-object.ts
+++ b/packages/solid/src/use-object.ts
@@ -72,6 +72,13 @@ export type Experimental_UseObjectOptions<RESULT> = {
    * Additional HTTP headers to be included in the request.
    */
   headers?: Record<string, string> | Headers;
+
+  /**
+   * The credentials mode to be used for the fetch request.
+   * Possible values are: 'omit', 'same-origin', 'include'.
+   * Defaults to 'same-origin'.
+   */
+  credentials?: RequestCredentials;
 };
 
 export type Experimental_UseObjectHelpers<RESULT, INPUT> = {
@@ -112,7 +119,6 @@ function useObject<RESULT, INPUT = any>(
     convertToAccessorOptions(rawUseObjectOptions),
   );
 
-  const api = createMemo(() => useObjectOptions().api?.() ?? '/api/object');
   // Generate an unique id for the completion if not provided.
   const idKey = createMemo(
     () => useObjectOptions().id?.() ?? `object-${createUniqueId()}`,
@@ -161,6 +167,7 @@ function useObject<RESULT, INPUT = any>(
           'Content-Type': 'application/json',
           ...useObjectOptions().headers?.(),
         },
+        credentials: useObjectOptions().credentials?.(),
         signal: abortController.signal,
         body: JSON.stringify(input),
       });

--- a/packages/svelte/src/structured-object.svelte.test.ts
+++ b/packages/svelte/src/structured-object.svelte.test.ts
@@ -1,10 +1,10 @@
 import {
-  withTestServer,
   describeWithTestServer,
+  withTestServer,
 } from '@ai-sdk/provider-utils/test';
-import { StructuredObject } from './structured-object.svelte.js';
 import { render } from '@testing-library/svelte';
 import { z } from 'zod';
+import { StructuredObject } from './structured-object.svelte.js';
 import StructuredObjectSynchronization from './tests/structured-object-synchronization.svelte';
 
 describe('text stream', () => {
@@ -200,6 +200,28 @@ describe('text stream', () => {
           authorization: 'Bearer TEST_TOKEN',
           'x-custom-header': 'CustomValue',
         });
+      },
+    ),
+  );
+
+  it(
+    'should send custom credentials',
+    withTestServer(
+      {
+        url: '/api/object',
+        type: 'stream-values',
+        content: ['{ ', '"content": "Hello, ', 'world', '!"', '}'],
+      },
+      async ({ call }) => {
+        const structuredObjectWithCustomCredentials = new StructuredObject({
+          api: '/api/object',
+          schema: z.object({ content: z.string() }),
+          credentials: 'include',
+        });
+
+        await structuredObjectWithCustomCredentials.submit('test-input');
+
+        expect(call(0).getRequestCredentials()).toBe('include');
       },
     ),
   );

--- a/packages/svelte/src/structured-object.svelte.ts
+++ b/packages/svelte/src/structured-object.svelte.ts
@@ -73,6 +73,13 @@ export type Experimental_StructuredObjectOptions<RESULT> = {
    * Additional HTTP headers to be included in the request.
    */
   headers?: Record<string, string> | Headers;
+
+  /**
+   * The credentials mode to be used for the fetch request.
+   * Possible values are: 'omit', 'same-origin', 'include'.
+   * Defaults to 'same-origin'.
+   */
+  credentials?: RequestCredentials;
 };
 
 export class StructuredObject<RESULT, INPUT = unknown> {
@@ -150,6 +157,7 @@ export class StructuredObject<RESULT, INPUT = unknown> {
           'Content-Type': 'application/json',
           ...this.#options.headers,
         },
+        credentials: this.#options.credentials,
         signal: abortController.signal,
         body: JSON.stringify(input),
       });


### PR DESCRIPTION
Fixes https://github.com/vercel/ai/issues/4982