### PR TITLE
chore (ui/solid): deprecate ai-sdk/solid

### DIFF
--- a/.changeset/tame-deers-thank.md
+++ b/.changeset/tame-deers-thank.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/solid': patch
+---
+
+chore (ui/solid): deprecate ai-sdk/solid

--- a/content/docs/04-ai-sdk-ui/01-overview.mdx
+++ b/content/docs/04-ai-sdk-ui/01-overview.mdx
@@ -18,15 +18,15 @@ These hooks are designed to reduce the complexity and time required to implement
 
 ## UI Framework Support
 
-AI SDK UI supports the following frameworks: [React](https://react.dev/), [Svelte](https://svelte.dev/), [Vue.js](https://vuejs.org/), and [SolidJS](https://www.solidjs.com/).
+AI SDK UI supports the following frameworks: [React](https://react.dev/), [Svelte](https://svelte.dev/), [Vue.js](https://vuejs.org/), and [SolidJS](https://www.solidjs.com/) (deprecated).
 Here is a comparison of the supported functions across these frameworks:
 
-| Function                                                  | React               | Svelte              | Vue.js              | SolidJS             |
-| --------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| [useChat](/docs/reference/ai-sdk-ui/use-chat)             | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [useCompletion](/docs/reference/ai-sdk-ui/use-completion) | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [useObject](/docs/reference/ai-sdk-ui/use-object)         | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> |
-| [useAssistant](/docs/reference/ai-sdk-ui/use-assistant)   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| Function                                                  | React               | Svelte                               | Vue.js              | SolidJS (deprecated) |
+| --------------------------------------------------------- | ------------------- | ------------------------------------ | ------------------- | -------------------- |
+| [useChat](/docs/reference/ai-sdk-ui/use-chat)             | <Check size={18} /> | <Check size={18} /> Chat             | <Check size={18} /> | <Check size={18} />  |
+| [useCompletion](/docs/reference/ai-sdk-ui/use-completion) | <Check size={18} /> | <Check size={18} /> Completion       | <Check size={18} /> | <Check size={18} />  |
+| [useObject](/docs/reference/ai-sdk-ui/use-object)         | <Check size={18} /> | <Check size={18} /> StructuredObject | <Cross size={18} /> | <Check size={18} />  |
+| [useAssistant](/docs/reference/ai-sdk-ui/use-assistant)   | <Check size={18} /> | <Cross size={18} />                  | <Check size={18} /> | <Check size={18} />  |
 
 <Note>
   [Contributions](https://github.com/vercel/ai/blob/main/CONTRIBUTING.md) are

--- a/content/docs/07-reference/02-ai-sdk-ui/index.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/index.mdx
@@ -93,15 +93,15 @@ It also contains the following helper functions:
 
 ## UI Framework Support
 
-AI SDK UI supports the following frameworks: [React](https://react.dev/), [Svelte](https://svelte.dev/), [Vue.js](https://vuejs.org/), and [SolidJS](https://www.solidjs.com/).
+AI SDK UI supports the following frameworks: [React](https://react.dev/), [Svelte](https://svelte.dev/), [Vue.js](https://vuejs.org/), and [SolidJS](https://www.solidjs.com/) (deprecated).
 Here is a comparison of the supported functions across these frameworks:
 
-| Function                                                  | React               | Svelte              | Vue.js              | SolidJS             |
-| --------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| [useChat](/docs/reference/ai-sdk-ui/use-chat)             | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [useCompletion](/docs/reference/ai-sdk-ui/use-completion) | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| [useObject](/docs/reference/ai-sdk-ui/use-object)         | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Check size={18} /> |
-| [useAssistant](/docs/reference/ai-sdk-ui/use-assistant)   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| Function                                                  | React               | Svelte                               | Vue.js              | SolidJS (deprecated) |
+| --------------------------------------------------------- | ------------------- | ------------------------------------ | ------------------- | -------------------- |
+| [useChat](/docs/reference/ai-sdk-ui/use-chat)             | <Check size={18} /> | <Check size={18} /> Chat             | <Check size={18} /> | <Check size={18} />  |
+| [useCompletion](/docs/reference/ai-sdk-ui/use-completion) | <Check size={18} /> | <Check size={18} /> Completion       | <Check size={18} /> | <Check size={18} />  |
+| [useObject](/docs/reference/ai-sdk-ui/use-object)         | <Check size={18} /> | <Check size={18} /> StructuredObject | <Cross size={18} /> | <Check size={18} />  |
+| [useAssistant](/docs/reference/ai-sdk-ui/use-assistant)   | <Check size={18} /> | <Cross size={18} />                  | <Check size={18} /> | <Check size={18} />  |
 
 <Note>
   [Contributions](https://github.com/vercel/ai/blob/main/CONTRIBUTING.md) are

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,6 +1,9 @@
 # AI SDK: Solid.js provider
 
+> **Warning** `@ai-sdk/solid` has been deprecated and will be removed in AI SDK 5
+
 [Solid.js](https://www.solidjs.com/) UI components for the [AI SDK](https://sdk.vercel.ai/docs):
 
 - [`useChat`](https://sdk.vercel.ai/docs/reference/ai-sdk-ui/use-chat) hook
 - [`useCompletion`](https://sdk.vercel.ai/docs/reference/ai-sdk-ui/use-completion) hook
+- [`useObject`](https://sdk.vercel.ai/docs/reference/ai-sdk-ui/use-object) hook

--- a/packages/solid/src/use-assistant.ts
+++ b/packages/solid/src/use-assistant.ts
@@ -92,6 +92,9 @@ Abort the current request immediately, keep the generated tokens if any.
   error: Accessor<undefined | Error>;
 };
 
+/**
+ * @deprecated `@ai-sdk/solid` has been deprecated and will be removed in AI SDK 5.
+ */
 export function useAssistant(
   rawUseAssistantOptions: UseAssistantOptions | Accessor<UseAssistantOptions>,
 ): UseAssistantHelpers {

--- a/packages/solid/src/use-chat.ts
+++ b/packages/solid/src/use-chat.ts
@@ -161,6 +161,9 @@ By default, it's set to 1, which means that only a single LLM call is made.
   }) => unknown;
 };
 
+/**
+ * @deprecated `@ai-sdk/solid` has been deprecated and will be removed in AI SDK 5.
+ */
 export function useChat(
   rawUseChatOptions: UseChatOptions | Accessor<UseChatOptions> = {},
 ): UseChatHelpers {

--- a/packages/solid/src/use-completion.ts
+++ b/packages/solid/src/use-completion.ts
@@ -74,6 +74,9 @@ or to provide a custom fetch implementation for e.g. testing.
 
 const completionCache = new ReactiveLRU<string, string>();
 
+/**
+ * @deprecated `@ai-sdk/solid` has been deprecated and will be removed in AI SDK 5.
+ */
 export function useCompletion(
   rawUseCompletionOptions:
     | UseCompletionOptions

--- a/packages/solid/src/use-object.ts
+++ b/packages/solid/src/use-object.ts
@@ -103,6 +103,9 @@ export type Experimental_UseObjectHelpers<RESULT, INPUT> = {
 
 const objectCache = new ReactiveLRU<string, DeepPartial<any>>();
 
+/**
+ * @deprecated `@ai-sdk/solid` has been deprecated and will be removed in AI SDK 5.
+ */
 function useObject<RESULT, INPUT = any>(
   rawUseObjectOptions:
     | Experimental_UseObjectOptions<RESULT>
@@ -112,7 +115,6 @@ function useObject<RESULT, INPUT = any>(
     convertToAccessorOptions(rawUseObjectOptions),
   );
 
-  const api = createMemo(() => useObjectOptions().api?.() ?? '/api/object');
   // Generate an unique id for the completion if not provided.
   const idKey = createMemo(
     () => useObjectOptions().id?.() ?? `object-${createUniqueId()}`,


### PR DESCRIPTION
## Background
`@ai-sdk/solid` is not used much (less than 500 weekly NPM downloads for 1.x.x) and takes away time from maintaining and improving the rest of the AI SDK.

Ideally someone outside of the AI SDK team would maintain it post AI SDK 5.0 in a separate repository.