### PR TITLE
fix(amazon-bedrock): image conversion in tool use

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/bedrock-api-types.ts
@@ -115,7 +115,7 @@ export interface BedrockImageBlock {
 export interface BedrockToolResultBlock {
   toolResult: {
     toolUseId: string;
-    content: Array<{ text: string }>;
+    content: Array<BedrockTextBlock | BedrockImageBlock>;
   };
 }
 

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -3,9 +3,11 @@ import {
   BedrockAssistantMessage,
   BedrockCachePoint,
   BedrockDocumentFormat,
+  BedrockImageBlock,
   BedrockImageFormat,
   BedrockMessages,
   BedrockSystemMessages,
+  BedrockTextBlock,
   BedrockUserMessage,
 } from './bedrock-api-types';
 import {
@@ -132,22 +134,22 @@ export function convertToBedrockChatMessages(prompt: LanguageModelV1Prompt): {
               for (let i = 0; i < content.length; i++) {
                 const part = content[i];
                 const toolResultContent =
-                  part.content !== undefined
+                  part.content != undefined
                     ? part.content.map(part => {
                         switch (part.type) {
                           case 'text':
                             return {
                               text: part.text,
-                            };
+                            } as BedrockTextBlock;
                           case 'image':
                             return {
                               image: {
-                                format: part.mimeType?.split(
-                                  '/',
-                                )?.[1] as BedrockDocumentFormat,
-                                source: part.data
-                              }
-                            };
+                                format: part.mimeType?.split('/')?.[1],
+                                source: {
+                                  bytes: part.data,
+                                },
+                              },
+                            } as BedrockImageBlock;
                         }
                       })
                     : [{ text: JSON.stringify(part.result) }];

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -131,11 +131,31 @@ export function convertToBedrockChatMessages(prompt: LanguageModelV1Prompt): {
             case 'tool': {
               for (let i = 0; i < content.length; i++) {
                 const part = content[i];
+                const toolResultContent =
+                  part.content !== undefined
+                    ? part.content.map(part => {
+                        switch (part.type) {
+                          case 'text':
+                            return {
+                              text: part.text,
+                            };
+                          case 'image':
+                            return {
+                              image: {
+                                format: part.mimeType?.split(
+                                  '/',
+                                )?.[1] as BedrockDocumentFormat,
+                                source: part.data
+                              }
+                            };
+                        }
+                      })
+                    : [{ text: JSON.stringify(part.result) }];
 
                 bedrockContent.push({
                   toolResult: {
                     toolUseId: part.toolCallId,
-                    content: [{ text: JSON.stringify(part.result) }],
+                    content: toolResultContent,
                   },
                 });
               }


### PR DESCRIPTION
This PR fixes #5133.

This PR improves the handling of different content types in the `amazon-bedrock` package when working with tool usage and the experimental `toToolResultContent` function.

Specifically, the PR updates the logic that converts results to Bedrock messages by adding support for handling both text and image content.

Before this PR, as reported in the linked issue, this logic always assumed the result content was a text string and converted it to a JSON string, causing hallucinations.