### PR TITLE
fix(core): response.messages is empty in onFinish and onStepFinish callbacks

### DIFF
--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -1010,7 +1010,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
       "response": {
         "headers": undefined,
         "id": "id-0",
-        "messages": [],
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "part 1 
+ ",
+                "type": "text",
+              },
+            ],
+            "id": "msg-0",
+            "role": "assistant",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
@@ -1040,7 +1052,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
       "response": {
         "headers": undefined,
         "id": "id-1",
-        "messages": [],
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "part 1 
+ no-whitespace",
+                "type": "text",
+              },
+            ],
+            "id": "msg-0",
+            "role": "assistant",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
@@ -1083,7 +1107,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
           "call": "3",
         },
         "id": "id-2",
-        "messages": [],
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "part 1 
+ no-whitespaceimmediatefollow  ",
+                "type": "text",
+              },
+            ],
+            "id": "msg-0",
+            "role": "assistant",
+          },
+        ],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
@@ -1197,7 +1233,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "response": {
       "headers": undefined,
       "id": "id-0",
-      "messages": [],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -1227,7 +1275,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "response": {
       "headers": undefined,
       "id": "id-1",
-      "messages": [],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ no-whitespace",
+              "type": "text",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -1270,7 +1330,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
         "call": "3",
       },
       "id": "id-2",
-      "messages": [],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ no-whitespaceimmediatefollow  ",
+              "type": "text",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -1870,7 +1942,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "response": {
       "headers": undefined,
       "id": "id-0",
-      "messages": [],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ ",
+              "type": "text",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -1900,7 +1984,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "response": {
       "headers": undefined,
       "id": "id-1",
-      "messages": [],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ no-whitespace",
+              "type": "text",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -1943,7 +2039,19 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
         "call": "3",
       },
       "id": "id-2",
-      "messages": [],
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "part 1 
+ no-whitespaceimmediatefollow  ",
+              "type": "text",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+      ],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -1010,19 +1010,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
       "response": {
         "headers": undefined,
         "id": "id-0",
-        "messages": [
-          {
-            "content": [
-              {
-                "text": "part 1 
- ",
-                "type": "text",
-              },
-            ],
-            "id": "msg-0",
-            "role": "assistant",
-          },
-        ],
+        "messages": [],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
@@ -1052,19 +1040,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
       "response": {
         "headers": undefined,
         "id": "id-1",
-        "messages": [
-          {
-            "content": [
-              {
-                "text": "part 1 
- no-whitespace",
-                "type": "text",
-              },
-            ],
-            "id": "msg-0",
-            "role": "assistant",
-          },
-        ],
+        "messages": [],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
@@ -1107,19 +1083,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
           "call": "3",
         },
         "id": "id-2",
-        "messages": [
-          {
-            "content": [
-              {
-                "text": "part 1 
- no-whitespaceimmediatefollow  ",
-                "type": "text",
-              },
-            ],
-            "id": "msg-0",
-            "role": "assistant",
-          },
-        ],
+        "messages": [],
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
@@ -1233,19 +1197,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "response": {
       "headers": undefined,
       "id": "id-0",
-      "messages": [
-        {
-          "content": [
-            {
-              "text": "part 1 
- ",
-              "type": "text",
-            },
-          ],
-          "id": "msg-0",
-          "role": "assistant",
-        },
-      ],
+      "messages": [],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -1275,19 +1227,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "response": {
       "headers": undefined,
       "id": "id-1",
-      "messages": [
-        {
-          "content": [
-            {
-              "text": "part 1 
- no-whitespace",
-              "type": "text",
-            },
-          ],
-          "id": "msg-0",
-          "role": "assistant",
-        },
-      ],
+      "messages": [],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -1330,19 +1270,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
         "call": "3",
       },
       "id": "id-2",
-      "messages": [
-        {
-          "content": [
-            {
-              "text": "part 1 
- no-whitespaceimmediatefollow  ",
-              "type": "text",
-            },
-          ],
-          "id": "msg-0",
-          "role": "assistant",
-        },
-      ],
+      "messages": [],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -1942,19 +1870,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "response": {
       "headers": undefined,
       "id": "id-0",
-      "messages": [
-        {
-          "content": [
-            {
-              "text": "part 1 
- ",
-              "type": "text",
-            },
-          ],
-          "id": "msg-0",
-          "role": "assistant",
-        },
-      ],
+      "messages": [],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
@@ -1984,19 +1900,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "response": {
       "headers": undefined,
       "id": "id-1",
-      "messages": [
-        {
-          "content": [
-            {
-              "text": "part 1 
- no-whitespace",
-              "type": "text",
-            },
-          ],
-          "id": "msg-0",
-          "role": "assistant",
-        },
-      ],
+      "messages": [],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
@@ -2039,19 +1943,7 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
         "call": "3",
       },
       "id": "id-2",
-      "messages": [
-        {
-          "content": [
-            {
-              "text": "part 1 
- no-whitespaceimmediatefollow  ",
-              "type": "text",
-            },
-          ],
-          "id": "msg-0",
-          "role": "assistant",
-        },
-      ],
+      "messages": [],
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -744,9 +744,10 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
             request: part.request,
             response: {
               ...part.response,
-              messages: nextStepType === 'continue' 
-                ? [...recordedResponse.messages] 
-                : [...recordedResponse.messages, ...stepMessages],
+              messages:
+                nextStepType === 'continue'
+                  ? [...recordedResponse.messages]
+                  : [...recordedResponse.messages, ...stepMessages],
             },
             providerMetadata: part.experimental_providerMetadata,
             experimental_providerMetadata: part.experimental_providerMetadata,

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -744,7 +744,9 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
             request: part.request,
             response: {
               ...part.response,
-              messages: [...recordedResponse.messages, ...stepMessages],
+              messages: nextStepType === 'continue' 
+                ? [...recordedResponse.messages] 
+                : [...recordedResponse.messages, ...stepMessages],
             },
             providerMetadata: part.experimental_providerMetadata,
             experimental_providerMetadata: part.experimental_providerMetadata,


### PR DESCRIPTION
The issue occurred because in step-finish events, response.messages wasn't  properly populated for continuation steps. Now message data is correctly  included in both onFinish and onStepFinish callbacks.

Added tests to verify both callbacks receive the expected message data.