### PR TITLE
fix (provider/google-vertex): pass through auth options for vertex provider

### DIFF
--- a/.changeset/silver-snails-greet.md
+++ b/.changeset/silver-snails-greet.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix (provider/google-vertex): pass through auth options for vertex provider

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -22,7 +22,8 @@
     "prettier-check": "prettier --check \"./**/*.ts*\"",
     "test": "pnpm test:node && pnpm test:edge",
     "test:edge": "vitest --config vitest.edge.config.js --run",
-    "test:node": "vitest --config vitest.node.config.js --run"
+    "test:node": "vitest --config vitest.node.config.js --run",
+    "test:node:watch": "vitest --config vitest.node.config.js"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.ts
+++ b/packages/google-vertex/src/anthropic/edge/google-vertex-anthropic-provider-edge.ts
@@ -1,3 +1,4 @@
+import { resolve } from '@ai-sdk/provider-utils';
 import {
   generateAuthToken,
   GoogleCredentials,
@@ -25,13 +26,12 @@ export function createVertexAnthropic(
 ): GoogleVertexAnthropicProvider {
   return createVertexAnthropicOriginal({
     ...options,
-    headers:
-      options.headers ??
-      (async () => ({
-        Authorization: `Bearer ${await generateAuthToken(
-          options.googleCredentials,
-        )}`,
-      })),
+    headers: async () => ({
+      Authorization: `Bearer ${await generateAuthToken(
+        options.googleCredentials,
+      )}`,
+      ...(await resolve(options.headers)),
+    }),
   });
 }
 

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider-node.ts
@@ -1,10 +1,11 @@
+import { resolve } from '@ai-sdk/provider-utils';
+import { GoogleAuthOptions } from 'google-auth-library';
 import { generateAuthToken } from '../google-vertex-auth-google-auth-library';
 import {
   createVertexAnthropic as createVertexAnthropicOriginal,
   GoogleVertexAnthropicProvider,
   GoogleVertexAnthropicProviderSettings as GoogleVertexAnthropicProviderSettingsOriginal,
 } from './google-vertex-anthropic-provider';
-import { GoogleAuthOptions } from 'google-auth-library';
 
 export type { GoogleVertexAnthropicProvider };
 
@@ -24,13 +25,12 @@ export function createVertexAnthropic(
 ): GoogleVertexAnthropicProvider {
   return createVertexAnthropicOriginal({
     ...options,
-    headers:
-      options.headers ??
-      (async () => ({
-        Authorization: `Bearer ${await generateAuthToken(
-          options.googleAuthOptions,
-        )}`,
-      })),
+    headers: async () => ({
+      Authorization: `Bearer ${await generateAuthToken(
+        options.googleAuthOptions,
+      )}`,
+      ...(await resolve(options.headers)),
+    }),
   });
 }
 

--- a/packages/google-vertex/src/edge/google-vertex-auth-edge.test.ts
+++ b/packages/google-vertex/src/edge/google-vertex-auth-edge.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi } from 'vitest';
 import {
   generateAuthToken,
   GoogleCredentials,

--- a/packages/google-vertex/src/edge/google-vertex-provider-edge.test.ts
+++ b/packages/google-vertex/src/edge/google-vertex-provider-edge.test.ts
@@ -1,6 +1,7 @@
+import { resolve } from '@ai-sdk/provider-utils';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createVertex } from './google-vertex-provider-edge';
-import * as baseProvider from '../google-vertex-provider';
+import { createVertex as createVertexEdge } from './google-vertex-provider-edge';
+import { createVertex as createVertexOriginal } from '../google-vertex-provider';
 import * as edgeAuth from './google-vertex-auth-edge';
 
 // Mock the imported modules
@@ -19,79 +20,68 @@ describe('google-vertex-provider-edge', () => {
     vi.clearAllMocks();
   });
 
-  it('should set up default auth token header when no headers provided', () => {
-    createVertex({ project: 'test-project' });
+  it('default headers function should return auth token', async () => {
+    createVertexEdge({ project: 'test-project' });
 
-    const mockCreateVertex = vi.mocked(baseProvider.createVertex);
+    const mockCreateVertex = vi.mocked(createVertexOriginal);
     const passedOptions = mockCreateVertex.mock.calls[0][0];
 
     expect(mockCreateVertex).toHaveBeenCalledTimes(1);
     expect(typeof passedOptions?.headers).toBe('function');
-  });
 
-  it('default headers function should return auth token', async () => {
-    createVertex({ project: 'test-project' });
-
-    const mockCreateVertex = vi.mocked(baseProvider.createVertex);
-    const passedOptions = mockCreateVertex.mock.calls[0][0];
-    const headersFunction = passedOptions?.headers as () => Promise<
-      Record<string, string>
-    >;
-    const headers = await headersFunction();
-
-    expect(headers).toEqual({
+    expect(await resolve(passedOptions?.headers)).toStrictEqual({
       Authorization: 'Bearer mock-auth-token',
     });
   });
 
-  it('should pass through custom headers when provided', () => {
-    const customHeaders = async () => ({
-      'Custom-Header': 'custom-value',
-    });
-
-    createVertex({
+  it('should use custom headers in addition to auth token when provided', async () => {
+    createVertexEdge({
       project: 'test-project',
-      headers: customHeaders,
+      headers: async () => ({
+        'Custom-Header': 'custom-value',
+      }),
     });
 
-    const mockCreateVertex = vi.mocked(baseProvider.createVertex);
+    const mockCreateVertex = vi.mocked(createVertexOriginal);
     const passedOptions = mockCreateVertex.mock.calls[0][0];
 
     expect(mockCreateVertex).toHaveBeenCalledTimes(1);
-    expect(passedOptions?.headers).toBe(customHeaders);
+    expect(typeof passedOptions?.headers).toBe('function');
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer mock-auth-token',
+      'Custom-Header': 'custom-value',
+    });
   });
 
-  it('should use edge auth token generator', () => {
-    createVertex({ project: 'test-project' });
+  it('should use edge auth token generator', async () => {
+    createVertexEdge({ project: 'test-project' });
 
-    const mockCreateVertex = vi.mocked(baseProvider.createVertex);
+    const mockCreateVertex = vi.mocked(createVertexOriginal);
     const passedOptions = mockCreateVertex.mock.calls[0][0];
 
-    // Verify the headers function is using the edge auth generator
+    // Verify the headers function actually calls generateAuthToken by checking its result
     expect(passedOptions?.headers).toBeDefined();
-    expect(passedOptions?.headers?.toString()).toContain('generateAuthToken');
+    await resolve(passedOptions?.headers);
+    expect(edgeAuth.generateAuthToken).toHaveBeenCalled();
   });
 
-  it('should call generateAuthToken with provided googleCredentials', async () => {
-    const mockCredentials = {
-      clientEmail: 'test@example.com',
-      privateKey: 'test-key',
-    };
-
-    createVertex({
+  it('passes googleCredentials to generateAuthToken', async () => {
+    createVertexEdge({
       project: 'test-project',
-      googleCredentials: mockCredentials,
+      googleCredentials: {
+        clientEmail: 'test@example.com',
+        privateKey: 'test-key',
+      },
     });
 
-    const mockCreateVertex = vi.mocked(baseProvider.createVertex);
+    const mockCreateVertex = vi.mocked(createVertexOriginal);
     const passedOptions = mockCreateVertex.mock.calls[0][0];
-    const headersFunction = passedOptions?.headers as () => Promise<
-      Record<string, string>
-    >;
 
-    // Call the headers function to trigger generateAuthToken
-    await headersFunction();
+    await resolve(passedOptions?.headers); // call the headers function
 
-    expect(edgeAuth.generateAuthToken).toHaveBeenCalledWith(mockCredentials);
+    expect(edgeAuth.generateAuthToken).toHaveBeenCalledWith({
+      clientEmail: 'test@example.com',
+      privateKey: 'test-key',
+    });
   });
 });

--- a/packages/google-vertex/src/edge/google-vertex-provider-edge.test.ts
+++ b/packages/google-vertex/src/edge/google-vertex-provider-edge.test.ts
@@ -1,5 +1,4 @@
 import { resolve } from '@ai-sdk/provider-utils';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createVertex as createVertexEdge } from './google-vertex-provider-edge';
 import { createVertex as createVertexOriginal } from '../google-vertex-provider';
 import * as edgeAuth from './google-vertex-auth-edge';

--- a/packages/google-vertex/src/edge/google-vertex-provider-edge.ts
+++ b/packages/google-vertex/src/edge/google-vertex-provider-edge.ts
@@ -1,12 +1,13 @@
-import {
-  generateAuthToken,
-  GoogleCredentials,
-} from './google-vertex-auth-edge';
+import { resolve } from '@ai-sdk/provider-utils';
 import {
   createVertex as createVertexOriginal,
   GoogleVertexProvider,
   GoogleVertexProviderSettings as GoogleVertexProviderSettingsOriginal,
 } from '../google-vertex-provider';
+import {
+  generateAuthToken,
+  GoogleCredentials,
+} from './google-vertex-auth-edge';
 
 export type { GoogleVertexProvider };
 
@@ -25,13 +26,13 @@ export function createVertex(
 ): GoogleVertexProvider {
   return createVertexOriginal({
     ...options,
-    headers:
-      options.headers ??
-      (async () => ({
-        Authorization: `Bearer ${await generateAuthToken(
-          options.googleCredentials,
-        )}`,
-      })),
+    headers: async () => ({
+      // generate auth token
+      Authorization: `Bearer ${await generateAuthToken(
+        options.googleCredentials,
+      )}`,
+      ...(await resolve(options.headers)),
+    }),
   });
 }
 

--- a/packages/google-vertex/src/edge/google-vertex-provider-edge.ts
+++ b/packages/google-vertex/src/edge/google-vertex-provider-edge.ts
@@ -27,7 +27,6 @@ export function createVertex(
   return createVertexOriginal({
     ...options,
     headers: async () => ({
-      // generate auth token
       Authorization: `Bearer ${await generateAuthToken(
         options.googleCredentials,
       )}`,

--- a/packages/google-vertex/src/google-vertex-provider-node.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-node.test.ts
@@ -1,5 +1,4 @@
 import { resolve } from '@ai-sdk/provider-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createVertex as createVertexOriginal } from './google-vertex-provider';
 import { createVertex as createVertexNode } from './google-vertex-provider-node';
 import { generateAuthToken } from './google-vertex-auth-google-auth-library';

--- a/packages/google-vertex/src/google-vertex-provider-node.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-node.test.ts
@@ -43,7 +43,6 @@ describe('google-vertex-provider-node', () => {
     expect(createVertexOriginal).toHaveBeenCalledTimes(1);
     const passedOptions = vi.mocked(createVertexOriginal).mock.calls[0][0];
 
-    expect(typeof passedOptions?.headers).toBe('function');
     expect(await resolve(passedOptions?.headers)).toEqual({
       Authorization: 'Bearer mock-auth-token',
       'Custom-Header': 'custom-value',
@@ -60,13 +59,10 @@ describe('google-vertex-provider-node', () => {
 
     expect(createVertexOriginal).toHaveBeenCalledTimes(1);
     const passedOptions = vi.mocked(createVertexOriginal).mock.calls[0][0];
-    expect(typeof passedOptions?.headers).toBe('function');
 
     await resolve(passedOptions?.headers); // call the headers function
 
-    const authLibraryArg = vi.mocked(generateAuthToken).mock.calls[0][0];
-
-    expect(authLibraryArg).toStrictEqual({
+    expect(generateAuthToken).toHaveBeenCalledWith({
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       keyFile: 'path/to/key.json',
     });

--- a/packages/google-vertex/src/google-vertex-provider-node.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-node.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createVertex } from './google-vertex-provider-node';
-import * as baseProvider from './google-vertex-provider';
+import { resolve } from '@ai-sdk/provider-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createVertex as createVertexOriginal } from './google-vertex-provider';
+import { createVertex as createVertexNode } from './google-vertex-provider-node';
+import { generateAuthToken } from './google-vertex-auth-google-auth-library';
 
 // Mock the imported modules
 vi.mock('./google-vertex-auth-google-auth-library', () => ({
@@ -19,63 +20,55 @@ describe('google-vertex-provider-node', () => {
     vi.clearAllMocks();
   });
 
-  it('should set up default auth token header when no headers provided', () => {
-    createVertex({ project: 'test-project' });
-
-    const mockCreateVertex = vi.mocked(baseProvider.createVertex);
-    const passedOptions = mockCreateVertex.mock.calls[0][0];
-
-    expect(mockCreateVertex).toHaveBeenCalledTimes(1);
-    expect(typeof passedOptions?.headers).toBe('function');
-  });
-
   it('default headers function should return auth token', async () => {
-    createVertex({ project: 'test-project' });
+    createVertexNode({ project: 'test-project' });
 
-    const mockCreateVertex = vi.mocked(baseProvider.createVertex);
-    const passedOptions = mockCreateVertex.mock.calls[0][0];
-    const headersFunction = passedOptions?.headers as () => Promise<
-      Record<string, string>
-    >;
-    const headers = await headersFunction();
+    expect(createVertexOriginal).toHaveBeenCalledTimes(1);
+    const passedOptions = vi.mocked(createVertexOriginal).mock.calls[0][0];
 
-    expect(headers).toEqual({
+    expect(typeof passedOptions?.headers).toBe('function');
+    expect(await resolve(passedOptions?.headers)).toStrictEqual({
       Authorization: 'Bearer mock-auth-token',
     });
   });
 
-  it('should pass through custom headers when provided', () => {
-    const customHeaders = async () => ({
+  it('should use custom headers in addition to auth token when provided', async () => {
+    createVertexNode({
+      project: 'test-project',
+      headers: async () => ({
+        'Custom-Header': 'custom-value',
+      }),
+    });
+
+    expect(createVertexOriginal).toHaveBeenCalledTimes(1);
+    const passedOptions = vi.mocked(createVertexOriginal).mock.calls[0][0];
+
+    expect(typeof passedOptions?.headers).toBe('function');
+    expect(await resolve(passedOptions?.headers)).toEqual({
+      Authorization: 'Bearer mock-auth-token',
       'Custom-Header': 'custom-value',
     });
-
-    createVertex({
-      project: 'test-project',
-      headers: customHeaders,
-    });
-
-    const mockCreateVertex = vi.mocked(baseProvider.createVertex);
-    const passedOptions = mockCreateVertex.mock.calls[0][0];
-
-    expect(mockCreateVertex).toHaveBeenCalledTimes(1);
-    expect(passedOptions?.headers).toBe(customHeaders);
   });
 
-  it('passes googleAuthOptions through to createVertexOriginal', () => {
-    const mockAuthOptions = {
-      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-      keyFile: 'path/to/key.json',
-    };
-
-    createVertex({
-      googleAuthOptions: mockAuthOptions,
+  it('passes googleAuthOptions to generateAuthToken', async () => {
+    createVertexNode({
+      googleAuthOptions: {
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+        keyFile: 'path/to/key.json',
+      },
     });
 
-    expect(createVertexOriginal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        googleAuthOptions: mockAuthOptions,
-        headers: expect.any(Function),
-      }),
-    );
+    expect(createVertexOriginal).toHaveBeenCalledTimes(1);
+    const passedOptions = vi.mocked(createVertexOriginal).mock.calls[0][0];
+    expect(typeof passedOptions?.headers).toBe('function');
+
+    await resolve(passedOptions?.headers); // call the headers function
+
+    const authLibraryArg = vi.mocked(generateAuthToken).mock.calls[0][0];
+
+    expect(authLibraryArg).toStrictEqual({
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      keyFile: 'path/to/key.json',
+    });
   });
 });

--- a/packages/google-vertex/src/google-vertex-provider-node.ts
+++ b/packages/google-vertex/src/google-vertex-provider-node.ts
@@ -1,10 +1,11 @@
+import { resolve } from '@ai-sdk/provider-utils';
+import { GoogleAuthOptions } from 'google-auth-library';
 import { generateAuthToken } from './google-vertex-auth-google-auth-library';
 import {
   createVertex as createVertexOriginal,
   GoogleVertexProvider,
   GoogleVertexProviderSettings as GoogleVertexProviderSettingsOriginal,
 } from './google-vertex-provider';
-import { GoogleAuthOptions } from 'google-auth-library';
 
 export interface GoogleVertexProviderSettings
   extends GoogleVertexProviderSettingsOriginal {
@@ -24,13 +25,13 @@ export function createVertex(
 ): GoogleVertexProvider {
   return createVertexOriginal({
     ...options,
-    headers:
-      options.headers ??
-      (async () => ({
-        Authorization: `Bearer ${await generateAuthToken(
-          options.googleAuthOptions,
-        )}`,
-      })),
+    headers: async () => ({
+      // generate auth token
+      Authorization: `Bearer ${await generateAuthToken(
+        options.googleAuthOptions,
+      )}`,
+      ...(await resolve(options.headers)),
+    }),
   });
 }
 

--- a/packages/google-vertex/src/google-vertex-provider-node.ts
+++ b/packages/google-vertex/src/google-vertex-provider-node.ts
@@ -26,7 +26,6 @@ export function createVertex(
   return createVertexOriginal({
     ...options,
     headers: async () => ({
-      // generate auth token
       Authorization: `Bearer ${await generateAuthToken(
         options.googleAuthOptions,
       )}`,


### PR DESCRIPTION
Fixes #4963
Fixes #5386