### PR TITLE
fix (examples): remove obsolete `build` script from Node server example

### DIFF
--- a/examples/node-http-server/README.md
+++ b/examples/node-http-server/README.md
@@ -14,13 +14,12 @@ OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
 
 ```sh
 pnpm install
-pnpm build
 ```
 
 3. Run the following command:
 
 ```sh
-pnpm tsx src/server.ts
+pnpm dev
 ```
 
 4. Test the endpoint with Curl:


### PR DESCRIPTION
I assume there used to be a `build` step but that is not the case today for the Node server example.

I also assume it would be better to utilize the `dev` script instead of running `tsx src/server.ts` directly.