### PR TITLE
docs (examples): add instructions to `examples/node-http-server/.env.example`

### DIFF
--- a/examples/node-http-server/.env.example
+++ b/examples/node-http-server/.env.example
@@ -1,1 +1,3 @@
+# You must first activate a Billing Account here: https://platform.openai.com/account/billing/overview
+# Then get your OpenAI API Key here: https://platform.openai.com/api-keys
 OPENAI_API_KEY=""


### PR DESCRIPTION
Given that the node server seems to be the simplest of the examples, I figured it might be helpful to add links on where to obtain the required token from OpenAI