### PR TITLE
chore (provider-utils): update unified test server

### DIFF
--- a/.changeset/tasty-cobras-reply.md
+++ b/.changeset/tasty-cobras-reply.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+chore (provider-utils): update unified test server

--- a/packages/ai/core/tool/mcp/mcp-sse-transport.test.ts
+++ b/packages/ai/core/tool/mcp/mcp-sse-transport.test.ts
@@ -22,10 +22,6 @@ describe('SseMCPTransport', () => {
     },
   });
 
-  beforeEach(() => {
-    server.urls['http://localhost:3000/sse'].response = undefined;
-  });
-
   it('should establish connection and receive endpoint', async () => {
     const controller = new TestResponseController();
 

--- a/packages/ai/core/tool/mcp/mcp-sse-transport.test.ts
+++ b/packages/ai/core/tool/mcp/mcp-sse-transport.test.ts
@@ -7,9 +7,7 @@ import { SseMCPTransport } from './mcp-sse-transport';
 
 describe('SseMCPTransport', () => {
   const server = createTestServer({
-    'http://localhost:3000/sse': {
-      response: undefined,
-    },
+    'http://localhost:3000/sse': {},
     'http://localhost:3000/messages': {
       response: {
         type: 'json-value',

--- a/packages/provider-utils/src/test/unified-test-server.ts
+++ b/packages/provider-utils/src/test/unified-test-server.ts
@@ -39,39 +39,7 @@ export type UrlHandler = {
 };
 
 export type FullUrlHandler = {
-  response:
-    | {
-        type: 'json-value';
-        headers?: Record<string, string>;
-        body: JsonBodyType;
-      }
-    | {
-        type: 'stream-chunks';
-        headers?: Record<string, string>;
-        chunks: Array<string>;
-      }
-    | {
-        type: 'binary';
-        headers?: Record<string, string>;
-        body: Buffer;
-      }
-    | {
-        type: 'error';
-        headers?: Record<string, string>;
-        status: number;
-        body?: string;
-      }
-    | {
-        type: 'empty';
-        headers?: Record<string, string>;
-        status?: number;
-      }
-    | {
-        type: 'controlled-stream';
-        headers?: Record<string, string>;
-        controller: TestResponseController;
-      }
-    | undefined;
+  response: UrlHandler['response']; // mandatory
 };
 
 export type FullHandlers<URLS extends { [url: string]: UrlHandler }> = {

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { withTestServer } from '@ai-sdk/provider-utils/test';
+import { createTestServer, withTestServer } from '@ai-sdk/provider-utils/test';
 import {
   formatDataStreamPart,
   generateId,
@@ -94,27 +94,28 @@ describe('data protocol stream', () => {
     onFinishCalls = [];
   });
 
-  it(
-    'should show streamed response',
-    withTestServer(
-      {
-        type: 'stream-values',
-        url: '/api/chat',
-        content: ['0:"Hello"\n', '0:","\n', '0:" world"\n', '0:"."\n'],
+  describe('streamed response', () => {
+    createTestServer({
+      '/api/chat': {
+        response: {
+          type: 'stream-chunks',
+          chunks: ['0:"Hello"\n', '0:","\n', '0:" world"\n', '0:"."\n'],
+        },
       },
-      async () => {
-        await userEvent.click(screen.getByTestId('do-append'));
+    });
 
-        await screen.findByTestId('message-0');
-        expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+    it('should show streamed response', async () => {
+      await userEvent.click(screen.getByTestId('do-append'));
 
-        await screen.findByTestId('message-1');
-        expect(screen.getByTestId('message-1')).toHaveTextContent(
-          'AI: Hello, world.',
-        );
-      },
-    ),
-  );
+      await screen.findByTestId('message-0');
+      expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+      await screen.findByTestId('message-1');
+      expect(screen.getByTestId('message-1')).toHaveTextContent(
+        'AI: Hello, world.',
+      );
+    });
+  });
 
   it(
     'should set stream data',

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2,7 +2,6 @@
 import {
   createTestServer,
   TestResponseController,
-  withTestServer,
 } from '@ai-sdk/provider-utils/test';
 import {
   formatDataStreamPart,
@@ -488,41 +487,35 @@ describe('form actions', () => {
     );
   });
 
-  it(
-    'should show streamed response using handleSubmit',
-    withTestServer(
-      [
-        {
-          url: '/api/chat',
-          type: 'stream-values',
-          content: ['Hello', ',', ' world', '.'],
-        },
-        {
-          url: '/api/chat',
-          type: 'stream-values',
-          content: ['How', ' can', ' I', ' help', ' you', '?'],
-        },
-      ],
-      async () => {
-        const firstInput = screen.getByTestId('do-input');
-        await userEvent.type(firstInput, 'hi');
-        await userEvent.keyboard('{Enter}');
-
-        await screen.findByTestId('message-0');
-        expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
-
-        await screen.findByTestId('message-1');
-        expect(screen.getByTestId('message-1')).toHaveTextContent(
-          'AI: Hello, world.',
-        );
-
-        const secondInput = screen.getByTestId('do-input');
-        await userEvent.type(secondInput, '{Enter}');
-
-        expect(screen.queryByTestId('message-2')).not.toBeInTheDocument();
+  it('should show streamed response using handleSubmit', async () => {
+    server.urls['/api/chat'].response = [
+      {
+        type: 'stream-chunks',
+        chunks: ['Hello', ',', ' world', '.'],
       },
-    ),
-  );
+      {
+        type: 'stream-chunks',
+        chunks: ['How', ' can', ' I', ' help', ' you', '?'],
+      },
+    ];
+
+    const firstInput = screen.getByTestId('do-input');
+    await userEvent.type(firstInput, 'hi');
+    await userEvent.keyboard('{Enter}');
+
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent(
+      'AI: Hello, world.',
+    );
+
+    const secondInput = screen.getByTestId('do-input');
+    await userEvent.type(secondInput, '{Enter}');
+
+    expect(screen.queryByTestId('message-2')).not.toBeInTheDocument();
+  });
 });
 
 describe('form actions (with options)', () => {
@@ -558,64 +551,57 @@ describe('form actions (with options)', () => {
     );
   });
 
-  it(
-    'allowEmptySubmit',
-    withTestServer(
-      [
-        {
-          url: '/api/chat',
-          type: 'stream-values',
-          content: ['Hello', ',', ' world', '.'],
-        },
-        {
-          url: '/api/chat',
-          type: 'stream-values',
-          content: ['How', ' can', ' I', ' help', ' you', '?'],
-        },
-        {
-          url: '/api/chat',
-          type: 'stream-values',
-          content: ['The', ' sky', ' is', ' blue', '.'],
-        },
-      ],
-      async () => {
-        const firstInput = screen.getByTestId('do-input');
-        await userEvent.type(firstInput, 'hi');
-        await userEvent.keyboard('{Enter}');
-
-        await screen.findByTestId('message-0');
-        expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
-
-        await screen.findByTestId('message-1');
-        expect(screen.getByTestId('message-1')).toHaveTextContent(
-          'AI: Hello, world.',
-        );
-
-        const secondInput = screen.getByTestId('do-input');
-        await userEvent.type(secondInput, '{Enter}');
-
-        await screen.findByTestId('message-2');
-        expect(screen.getByTestId('message-2')).toHaveTextContent('User:');
-
-        expect(screen.getByTestId('message-3')).toHaveTextContent(
-          'AI: How can I help you?',
-        );
-
-        const thirdInput = screen.getByTestId('do-input');
-        await userEvent.type(thirdInput, 'what color is the sky?');
-        await userEvent.type(thirdInput, '{Enter}');
-
-        expect(screen.getByTestId('message-4')).toHaveTextContent(
-          'User: what color is the sky?',
-        );
-
-        await screen.findByTestId('message-5');
-        expect(screen.getByTestId('message-5')).toHaveTextContent(
-          'AI: The sky is blue.',
-        );
+  it('allowEmptySubmit', async () => {
+    server.urls['/api/chat'].response = [
+      {
+        type: 'stream-chunks',
+        chunks: ['Hello', ',', ' world', '.'],
       },
-    ),
-  );
+      {
+        type: 'stream-chunks',
+        chunks: ['How', ' can', ' I', ' help', ' you', '?'],
+      },
+      {
+        type: 'stream-chunks',
+        chunks: ['The', ' sky', ' is', ' blue', '.'],
+      },
+    ];
+
+    const firstInput = screen.getByTestId('do-input');
+    await userEvent.type(firstInput, 'hi');
+    await userEvent.keyboard('{Enter}');
+
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent(
+      'AI: Hello, world.',
+    );
+
+    const secondInput = screen.getByTestId('do-input');
+    await userEvent.type(secondInput, '{Enter}');
+
+    await screen.findByTestId('message-2');
+    expect(screen.getByTestId('message-2')).toHaveTextContent('User:');
+
+    expect(screen.getByTestId('message-3')).toHaveTextContent(
+      'AI: How can I help you?',
+    );
+
+    const thirdInput = screen.getByTestId('do-input');
+    await userEvent.type(thirdInput, 'what color is the sky?');
+    await userEvent.type(thirdInput, '{Enter}');
+
+    expect(screen.getByTestId('message-4')).toHaveTextContent(
+      'User: what color is the sky?',
+    );
+
+    await screen.findByTestId('message-5');
+    expect(screen.getByTestId('message-5')).toHaveTextContent(
+      'AI: The sky is blue.',
+    );
+  });
 });
 
 describe('prepareRequestBody', () => {
@@ -995,39 +981,31 @@ describe('maxSteps', () => {
       onToolCallInvoked = false;
     });
 
-    it(
-      'should automatically call api when tool call gets executed via onToolCall',
-      withTestServer(
-        [
-          {
-            url: '/api/chat',
-            type: 'stream-values',
-            content: [
-              formatDataStreamPart('tool_call', {
-                toolCallId: 'tool-call-0',
-                toolName: 'test-tool',
-                args: { testArg: 'test-value' },
-              }),
-            ],
-          },
-          {
-            url: '/api/chat',
-            type: 'stream-values',
-            content: [formatDataStreamPart('text', 'final result')],
-          },
-        ],
-        async () => {
-          await userEvent.click(screen.getByTestId('do-append'));
-
-          expect(onToolCallInvoked).toBe(true);
-
-          await screen.findByTestId('message-1');
-          expect(screen.getByTestId('message-1')).toHaveTextContent(
-            'final result',
-          );
+    it('should automatically call api when tool call gets executed via onToolCall', async () => {
+      server.urls['/api/chat'].response = [
+        {
+          type: 'stream-chunks',
+          chunks: [
+            formatDataStreamPart('tool_call', {
+              toolCallId: 'tool-call-0',
+              toolName: 'test-tool',
+              args: { testArg: 'test-value' },
+            }),
+          ],
         },
-      ),
-    );
+        {
+          type: 'stream-chunks',
+          chunks: [formatDataStreamPart('text', 'final result')],
+        },
+      ];
+
+      await userEvent.click(screen.getByTestId('do-append'));
+
+      expect(onToolCallInvoked).toBe(true);
+
+      await screen.findByTestId('message-1');
+      expect(screen.getByTestId('message-1')).toHaveTextContent('final result');
+    });
   });
 
   describe('two steps with error response', () => {
@@ -1074,40 +1052,34 @@ describe('maxSteps', () => {
       onToolCallCounter = 0;
     });
 
-    it(
-      'should automatically call api when tool call gets executed via onToolCall',
-      withTestServer(
-        [
-          {
-            url: '/api/chat',
-            type: 'stream-values',
-            content: [
-              formatDataStreamPart('tool_call', {
-                toolCallId: 'tool-call-0',
-                toolName: 'test-tool',
-                args: { testArg: 'test-value' },
-              }),
-            ],
-          },
-          {
-            url: '/api/chat',
-            type: 'error',
-            status: 400,
-            content: 'call failure',
-          },
-        ],
-        async () => {
-          await userEvent.click(screen.getByTestId('do-append'));
-
-          await screen.findByTestId('error');
-          expect(screen.getByTestId('error')).toHaveTextContent(
-            'Error: call failure',
-          );
-
-          expect(onToolCallCounter).toBe(1);
+    it('should automatically call api when tool call gets executed via onToolCall', async () => {
+      server.urls['/api/chat'].response = [
+        {
+          type: 'stream-chunks',
+          chunks: [
+            formatDataStreamPart('tool_call', {
+              toolCallId: 'tool-call-0',
+              toolName: 'test-tool',
+              args: { testArg: 'test-value' },
+            }),
+          ],
         },
-      ),
-    );
+        {
+          type: 'error',
+          status: 400,
+          body: 'call failure',
+        },
+      ];
+
+      await userEvent.click(screen.getByTestId('do-append'));
+
+      await screen.findByTestId('error');
+      expect(screen.getByTestId('error')).toHaveTextContent(
+        'Error: call failure',
+      );
+
+      expect(onToolCallCounter).toBe(1);
+    });
   });
 });
 
@@ -1617,57 +1589,51 @@ describe('reload', () => {
     );
   });
 
-  it(
-    'should show streamed response',
-    withTestServer(
-      [
+  it('should show streamed response', async () => {
+    server.urls['/api/chat'].response = [
+      {
+        type: 'stream-chunks',
+        chunks: ['0:"first response"\n'],
+      },
+      {
+        type: 'stream-chunks',
+        chunks: ['0:"second response"\n'],
+      },
+    ];
+
+    await userEvent.click(screen.getByTestId('do-append'));
+
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+    await screen.findByTestId('message-1');
+
+    // setup done, click reload:
+    await userEvent.click(screen.getByTestId('do-reload'));
+
+    expect(await server.calls[1].requestBody).toStrictEqual({
+      id: expect.any(String),
+      messages: [
         {
-          url: '/api/chat',
-          type: 'stream-values',
-          content: ['0:"first response"\n'],
-        },
-        {
-          url: '/api/chat',
-          type: 'stream-values',
-          content: ['0:"second response"\n'],
+          content: 'hi',
+          role: 'user',
+          parts: [{ text: 'hi', type: 'text' }],
         },
       ],
-      async ({ call }) => {
-        await userEvent.click(screen.getByTestId('do-append'));
+      data: { 'test-data-key': 'test-data-value' },
+      'request-body-key': 'request-body-value',
+    });
 
-        await screen.findByTestId('message-0');
-        expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+    expect(server.calls[1].requestHeaders).toStrictEqual({
+      'content-type': 'application/json',
+      'header-key': 'header-value',
+    });
 
-        await screen.findByTestId('message-1');
-
-        // setup done, click reload:
-        await userEvent.click(screen.getByTestId('do-reload'));
-
-        expect(await call(1).getRequestBodyJson()).toStrictEqual({
-          id: expect.any(String),
-          messages: [
-            {
-              content: 'hi',
-              role: 'user',
-              parts: [{ text: 'hi', type: 'text' }],
-            },
-          ],
-          data: { 'test-data-key': 'test-data-value' },
-          'request-body-key': 'request-body-value',
-        });
-
-        expect(call(1).getRequestHeaders()).toStrictEqual({
-          'content-type': 'application/json',
-          'header-key': 'header-value',
-        });
-
-        await screen.findByTestId('message-1');
-        expect(screen.getByTestId('message-1')).toHaveTextContent(
-          'AI: second response',
-        );
-      },
-    ),
-  );
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent(
+      'AI: second response',
+    );
+  });
 });
 
 describe('test sending additional fields during message submission', () => {

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1425,57 +1425,52 @@ describe('file attachments with url', () => {
     cleanup();
   });
 
-  it(
-    'should handle image file attachment and submission',
-    withTestServer(
-      {
-        url: '/api/chat',
-        type: 'stream-values',
-        content: ['0:"Response to message with image attachment"\n'],
-      },
-      async ({ call }) => {
-        const messageInput = screen.getByTestId('message-input');
-        await userEvent.type(messageInput, 'Message with image attachment');
+  it('should handle image file attachment and submission', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: ['0:"Response to message with image attachment"\n'],
+    };
 
-        const submitButton = screen.getByTestId('submit-button');
-        await userEvent.click(submitButton);
+    const messageInput = screen.getByTestId('message-input');
+    await userEvent.type(messageInput, 'Message with image attachment');
 
-        await screen.findByTestId('message-0');
-        expect(screen.getByTestId('message-0')).toHaveTextContent(
-          'User: Message with image attachment',
-        );
+    const submitButton = screen.getByTestId('submit-button');
+    await userEvent.click(submitButton);
 
-        await screen.findByTestId('attachment-0');
-        expect(screen.getByTestId('attachment-0')).toHaveAttribute(
-          'src',
-          expect.stringContaining('https://example.com/image.png'),
-        );
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent(
+      'User: Message with image attachment',
+    );
 
-        await screen.findByTestId('message-1');
-        expect(screen.getByTestId('message-1')).toHaveTextContent(
-          'AI: Response to message with image attachment',
-        );
+    await screen.findByTestId('attachment-0');
+    expect(screen.getByTestId('attachment-0')).toHaveAttribute(
+      'src',
+      expect.stringContaining('https://example.com/image.png'),
+    );
 
-        expect(await call(0).getRequestBodyJson()).toStrictEqual({
-          id: expect.any(String),
-          messages: [
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent(
+      'AI: Response to message with image attachment',
+    );
+
+    expect(await server.calls[0].requestBody).toStrictEqual({
+      id: expect.any(String),
+      messages: [
+        {
+          role: 'user',
+          content: 'Message with image attachment',
+          experimental_attachments: [
             {
-              role: 'user',
-              content: 'Message with image attachment',
-              experimental_attachments: [
-                {
-                  name: 'test.png',
-                  contentType: 'image/png',
-                  url: 'https://example.com/image.png',
-                },
-              ],
-              parts: [{ text: 'Message with image attachment', type: 'text' }],
+              name: 'test.png',
+              contentType: 'image/png',
+              url: 'https://example.com/image.png',
             },
           ],
-        });
-      },
-    ),
-  );
+          parts: [{ text: 'Message with image attachment', type: 'text' }],
+        },
+      ],
+    });
+  });
 });
 
 describe('attachments with empty submit', () => {
@@ -1531,50 +1526,45 @@ describe('attachments with empty submit', () => {
     cleanup();
   });
 
-  it(
-    'should handle image file attachment and submission',
-    withTestServer(
-      {
-        url: '/api/chat',
-        type: 'stream-values',
-        content: ['0:"Response to message with image attachment"\n'],
-      },
-      async ({ call }) => {
-        const submitButton = screen.getByTestId('submit-button');
-        await userEvent.click(submitButton);
+  it('should handle image file attachment and submission', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: ['0:"Response to message with image attachment"\n'],
+    };
 
-        await screen.findByTestId('message-0');
-        expect(screen.getByTestId('message-0')).toHaveTextContent('User:');
+    const submitButton = screen.getByTestId('submit-button');
+    await userEvent.click(submitButton);
 
-        await screen.findByTestId('attachment-0');
-        expect(screen.getByTestId('attachment-0')).toHaveAttribute(
-          'src',
-          expect.stringContaining('https://example.com/image.png'),
-        );
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent('User:');
 
-        await screen.findByTestId('message-1');
-        expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
+    await screen.findByTestId('attachment-0');
+    expect(screen.getByTestId('attachment-0')).toHaveAttribute(
+      'src',
+      expect.stringContaining('https://example.com/image.png'),
+    );
 
-        expect(await call(0).getRequestBodyJson()).toStrictEqual({
-          id: expect.any(String),
-          messages: [
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
+
+    expect(await server.calls[0].requestBody).toStrictEqual({
+      id: expect.any(String),
+      messages: [
+        {
+          role: 'user',
+          content: '',
+          experimental_attachments: [
             {
-              role: 'user',
-              content: '',
-              experimental_attachments: [
-                {
-                  name: 'test.png',
-                  contentType: 'image/png',
-                  url: 'https://example.com/image.png',
-                },
-              ],
-              parts: [{ text: '', type: 'text' }],
+              name: 'test.png',
+              contentType: 'image/png',
+              url: 'https://example.com/image.png',
             },
           ],
-        });
-      },
-    ),
-  );
+          parts: [{ text: '', type: 'text' }],
+        },
+      ],
+    });
+  });
 });
 
 describe('should append message with attachments', () => {
@@ -1637,52 +1627,47 @@ describe('should append message with attachments', () => {
     cleanup();
   });
 
-  it(
-    'should handle image file attachment and submission',
-    withTestServer(
-      {
-        url: '/api/chat',
-        type: 'stream-values',
-        content: ['0:"Response to message with image attachment"\n'],
-      },
-      async ({ call }) => {
-        const submitButton = screen.getByTestId('submit-button');
-        await userEvent.click(submitButton);
+  it('should handle image file attachment and submission', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: ['0:"Response to message with image attachment"\n'],
+    };
 
-        await screen.findByTestId('message-0');
-        expect(screen.getByTestId('message-0')).toHaveTextContent(
-          'User: Message with image attachment',
-        );
+    const submitButton = screen.getByTestId('submit-button');
+    await userEvent.click(submitButton);
 
-        await screen.findByTestId('attachment-0');
-        expect(screen.getByTestId('attachment-0')).toHaveAttribute(
-          'src',
-          expect.stringContaining('https://example.com/image.png'),
-        );
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent(
+      'User: Message with image attachment',
+    );
 
-        await screen.findByTestId('message-1');
-        expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
+    await screen.findByTestId('attachment-0');
+    expect(screen.getByTestId('attachment-0')).toHaveAttribute(
+      'src',
+      expect.stringContaining('https://example.com/image.png'),
+    );
 
-        expect(await call(0).getRequestBodyJson()).toStrictEqual({
-          id: expect.any(String),
-          messages: [
+    await screen.findByTestId('message-1');
+    expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
+
+    expect(await server.calls[0].requestBody).toStrictEqual({
+      id: expect.any(String),
+      messages: [
+        {
+          role: 'user',
+          content: 'Message with image attachment',
+          experimental_attachments: [
             {
-              role: 'user',
-              content: 'Message with image attachment',
-              experimental_attachments: [
-                {
-                  name: 'test.png',
-                  contentType: 'image/png',
-                  url: 'https://example.com/image.png',
-                },
-              ],
-              parts: [{ text: 'Message with image attachment', type: 'text' }],
+              name: 'test.png',
+              contentType: 'image/png',
+              url: 'https://example.com/image.png',
             },
           ],
-        });
-      },
-    ),
-  );
+          parts: [{ text: 'Message with image attachment', type: 'text' }],
+        },
+      ],
+    });
+  });
 });
 
 describe('reload', () => {
@@ -1817,36 +1802,29 @@ describe('test sending additional fields during message submission', () => {
     cleanup();
   });
 
-  it(
-    'annotations',
-    withTestServer(
-      [
+  it('annotations', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: ['0:"first response"\n'],
+    };
+
+    await userEvent.click(screen.getByTestId('do-append'));
+
+    await screen.findByTestId('message-0');
+    expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+    expect(await server.calls[0].requestBody).toStrictEqual({
+      id: expect.any(String),
+      messages: [
         {
-          url: '/api/chat',
-          type: 'stream-values',
-          content: ['0:"first response"\n'],
+          role: 'user',
+          content: 'hi',
+          annotations: ['this is an annotation'],
+          parts: [{ text: 'hi', type: 'text' }],
         },
       ],
-      async ({ call }) => {
-        await userEvent.click(screen.getByTestId('do-append'));
-
-        await screen.findByTestId('message-0');
-        expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
-
-        expect(await call(0).getRequestBodyJson()).toStrictEqual({
-          id: expect.any(String),
-          messages: [
-            {
-              role: 'user',
-              content: 'hi',
-              annotations: ['this is an annotation'],
-              parts: [{ text: 'hi', type: 'text' }],
-            },
-          ],
-        });
-      },
-    ),
-  );
+    });
+  });
 });
 
 describe('initialMessages', () => {


### PR DESCRIPTION
## Summary
- move `TestResponseController` into provider utils and refactor unified test server to make stream control easier
- update react useChat test to unified test server
- introduce createTestComponent helper
- add support for function and array responses to unified test server
- remove FullUrlHandler types