### PR TITLE
Clarify useObject framework support in 01-overview.mdx

### DIFF
--- a/content/docs/04-ai-sdk-ui/01-overview.mdx
+++ b/content/docs/04-ai-sdk-ui/01-overview.mdx
@@ -25,7 +25,7 @@ Here is a comparison of the supported functions across these frameworks:
 | --------------------------------------------------------- | ------------------- | ------------------------------------ | ------------------- | -------------------- |
 | [useChat](/docs/reference/ai-sdk-ui/use-chat)             | <Check size={18} /> | <Check size={18} /> Chat             | <Check size={18} /> | <Check size={18} />  |
 | [useCompletion](/docs/reference/ai-sdk-ui/use-completion) | <Check size={18} /> | <Check size={18} /> Completion       | <Check size={18} /> | <Check size={18} />  |
-| [useObject](/docs/reference/ai-sdk-ui/use-object)         | <Check size={18} /> | <Check size={18} /> StructuredObject | <Cross size={18} /> | <Check size={18} />  |
+| [useObject](/docs/reference/ai-sdk-ui/use-object)         | <Check size={18} /> | <Cross size={18} />                  | <Cross size={18} /> | <Check size={18} />  |
 | [useAssistant](/docs/reference/ai-sdk-ui/use-assistant)   | <Check size={18} /> | <Cross size={18} />                  | <Check size={18} /> | <Check size={18} />  |
 
 <Note>


### PR DESCRIPTION
According to the documentation for useObject (https://sdk.vercel.ai/docs/reference/ai-sdk-ui/use-object),   "useObject is an experimental feature and only available in React and SolidJS."  

However, the overview page did not reflect this limitation.   To maintain consistency, I have updated the framework support table by adding a ❌ (cross) for useObject in Svelte.