### PR TITLE
Feat: Allow onStepFinish to optionally mutate AI Execution Context

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -100,12 +100,12 @@ There are several providers that offer pre-built tools as **toolkits** that you 
 - **[Composio](https://docs.composio.dev/javascript/vercel)** - Composio provides 250+ tools like GitHub, Gmail, Salesforce and [more](https://composio.dev/tools).
 - **[Interlify](https://www.interlify.com/docs/integrate-with-vercel-ai)** - Convert APIs into tools so that AI can connect to your backend in minutes.
 - **[Freestyle](https://docs.freestyle.sh/integrations/vercel)** — Tool for your AI to execute JavaScript or TypeScript with arbitrary node modules.
-s
-<Note>
-  Do you have open source tools or tool libraries that are compatible with the
-  AI SDK? Please [file a pull request](https://github.com/vercel/ai/pulls) to
-  add them to this list.
-</Note>
+  s
+  <Note>
+    Do you have open source tools or tool libraries that are compatible with the
+    AI SDK? Please [file a pull request](https://github.com/vercel/ai/pulls) to
+    add them to this list.
+  </Note>
 
 ## Learn more
 

--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -99,7 +99,8 @@ There are several providers that offer pre-built tools as **toolkits** that you 
 - **[AI Tool Maker](https://github.com/nihaocami/ai-tool-maker)** - A CLI utility to generate AI SDK tools from OpenAPI specs.
 - **[Composio](https://docs.composio.dev/javascript/vercel)** - Composio provides 250+ tools like GitHub, Gmail, Salesforce and [more](https://composio.dev/tools).
 - **[Interlify](https://www.interlify.com/docs/integrate-with-vercel-ai)** - Convert APIs into tools so that AI can connect to your backend in minutes.
-
+- **[Freestyle](https://docs.freestyle.sh/integrations/vercel)** — Tool for your AI to execute JavaScript or TypeScript with arbitrary node modules.
+s
 <Note>
   Do you have open source tools or tool libraries that are compatible with the
   AI SDK? Please [file a pull request](https://github.com/vercel/ai/pulls) to

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -100,7 +100,16 @@ Callback that is set using the `onStepFinish` option.
  */
 export type StreamTextOnStepFinishCallback<TOOLS extends ToolSet> = (
   stepResult: StepResult<TOOLS>,
-) => Promise<void> | void;
+) =>
+  | Promise<void | Partial<{
+      tools: TOOLS;
+      system: Prompt['system'];
+    }>>
+  | void
+  | Partial<{
+      tools: TOOLS;
+      system: Prompt['system'];
+    }>;
 
 /**
 Callback that is set using the `onChunk` option.
@@ -751,7 +760,17 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
             isContinued: part.isContinued,
           };
 
-          await onStepFinish?.(currentStepResult);
+          const stepFinish = await onStepFinish?.(currentStepResult);
+
+          if (stepFinish) {
+            if (stepFinish.tools) {
+              tools = stepFinish.tools;
+            }
+
+            if (stepFinish.system) {
+              system = stepFinish.system;
+            }
+          }
 
           recordedSteps.push(currentStepResult);
 


### PR DESCRIPTION
This is a prototype for a feature I really want in the ai sdk. I want to be able to dynamically change the environment of the execution during execution runs, including everything around the message history.

use case for us is changing environment variables in code execution, but i think it could also be useful for changing the model dynamically based on arbitrary params, or changing the job based in the system prompt. 

Using this I can make the AI get progressively ruder in the system prompt after someone runs out of credits.

Don't think its mergable yet, just putting it here for thoughts