### PR TITLE
fix regex in smoothStream()

### DIFF
--- a/packages/ai/core/generate-text/smooth-stream.ts
+++ b/packages/ai/core/generate-text/smooth-stream.ts
@@ -43,12 +43,12 @@ export function smoothStream<TOOLS extends ToolSet>({
   }
 
   return () => {
-    let buffer = ''
+    let buffer = '';
 
     const flushBuffer = (controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>) => {
       if (buffer.length > 0) {
-        controller.enqueue({ type: 'text-delta', textDelta: buffer })
-        buffer = ''
+        controller.enqueue({ type: 'text-delta', textDelta: buffer });
+        buffer = '';
       }
     }
 
@@ -56,34 +56,34 @@ export function smoothStream<TOOLS extends ToolSet>({
       async transform(chunk, controller) {
         if (chunk.type === 'step-finish') {
           if (buffer.length > 0) {
-            controller.enqueue({ type: 'text-delta', textDelta: buffer })
-            buffer = ''
+            controller.enqueue({ type: 'text-delta', textDelta: buffer });
+            buffer = '';
           }
 
-          controller.enqueue(chunk)
-          return
+          controller.enqueue(chunk);
+          return;
         }
 
         if (chunk.type !== 'text-delta') {
-          flushBuffer(controller)
-          controller.enqueue(chunk)
-          return
+          flushBuffer(controller);
+          controller.enqueue(chunk);
+          return;
         }
 
-        buffer += chunk.textDelta
+        buffer += chunk.textDelta;
 
-        let match = chunkingRegexp.exec(buffer)
+        let match = chunkingRegexp.exec(buffer);
         while (match != null) {
-          const chunk = match[0]
-          controller.enqueue({ type: 'text-delta', textDelta: chunk })
-          buffer = buffer.slice(chunk.length)
+          const chunk = match[0];
+          controller.enqueue({ type: 'text-delta', textDelta: chunk });
+          buffer = buffer.slice(chunk.length);
 
-          await delay(delayInMs)
-          match = chunkingRegexp.exec(buffer)
+          await delay(delayInMs);
+          match = chunkingRegexp.exec(buffer);
         }
       },
       flush(controller) {
-        flushBuffer(controller)
+        flushBuffer(controller);
       },
     })
   }

--- a/packages/ai/core/generate-text/smooth-stream.ts
+++ b/packages/ai/core/generate-text/smooth-stream.ts
@@ -72,19 +72,18 @@ export function smoothStream<TOOLS extends ToolSet>({
 
         buffer += chunk.textDelta;
 
-        let match = chunkingRegexp.exec(buffer);
-        while (match != null) {
+        let match;
+        while ((match = chunkingRegexp.exec(buffer)) != null) {
           const chunk = match[0];
           controller.enqueue({ type: 'text-delta', textDelta: chunk });
           buffer = buffer.slice(chunk.length);
 
           await delay(delayInMs);
-          match = chunkingRegexp.exec(buffer);
         }
       },
       flush(controller) {
         flushBuffer(controller);
       },
-    })
-  }
+    });
+  };
 }

--- a/packages/ai/core/generate-text/smooth-stream.ts
+++ b/packages/ai/core/generate-text/smooth-stream.ts
@@ -4,7 +4,7 @@ import { TextStreamPart } from './stream-text-result';
 import { ToolSet } from './tool-set';
 
 const CHUNKING_REGEXPS = {
-  word: /\s*\S+\s+/m,
+  word: /\s*\S+\s*/m,
   line: /[^\n]*\n/m,
 };
 


### PR DESCRIPTION
The word-based regex pattern `/\s*\S+\s+/m` requires trailing whitespace after each word. The last `text-delta` won't have a trailing space causing the last word in the last `text-delta` to not be returned until after any tool calls the model may make. The proposed solution is to match words even if they don't have trailing whitespace.

Resolves https://github.com/vercel/ai/issues/5493