### PR TITLE
docs: fix highlights in node.js guide

### DIFF
--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -149,7 +149,7 @@ Let's enhance your chatbot by adding a simple weather tool.
 
 Modify your `index.ts` file to include the new weather tool:
 
-```ts filename="index.ts" highlight="2,4,25-36"
+```ts filename="index.ts" highlight="2,4,25-38"
 import { openai } from '@ai-sdk/openai';
 import { CoreMessage, streamText, tool } from 'ai';
 import dotenv from 'dotenv';
@@ -289,7 +289,7 @@ To solve this, you can enable multi-step tool calls using `maxSteps`. This featu
 
 Modify your `index.ts` file to include the `maxSteps` option:
 
-```ts filename="index.ts" highlight="37-40"
+```ts filename="index.ts" highlight="37-42"
 import { openai } from '@ai-sdk/openai';
 import { CoreMessage, streamText, tool } from 'ai';
 import dotenv from 'dotenv';
@@ -362,7 +362,7 @@ By setting `maxSteps` to 5, you're allowing the model to use up to 5 "steps" for
 
 Update your `index.ts` file to add a new tool to convert the temperature from Celsius to Fahrenheit:
 
-```ts filename="index.ts" highlight="36-45"
+```ts filename="index.ts" highlight="38-49"
 import { openai } from '@ai-sdk/openai';
 import { CoreMessage, streamText, tool } from 'ai';
 import dotenv from 'dotenv';

--- a/content/docs/02-getting-started/06-nodejs.mdx
+++ b/content/docs/02-getting-started/06-nodejs.mdx
@@ -289,7 +289,7 @@ To solve this, you can enable multi-step tool calls using `maxSteps`. This featu
 
 Modify your `index.ts` file to include the `maxSteps` option:
 
-```ts filename="index.ts" highlight="37-42"
+```ts filename="index.ts" highlight="39-42"
 import { openai } from '@ai-sdk/openai';
 import { CoreMessage, streamText, tool } from 'ai';
 import dotenv from 'dotenv';


### PR DESCRIPTION
this should fix the wrong highlightings

1. should be 25-38

![CleanShot 2025-04-03 at 10 28 44](https://github.com/user-attachments/assets/e995c501-134a-4b63-88a2-5be77478ee29)

2. should be 39-42

![CleanShot 2025-04-03 at 10 28 33](https://github.com/user-attachments/assets/71e16215-6ed0-4f91-b177-94e7d77d1837)


3. should be 38-49

![CleanShot 2025-04-03 at 10 28 51](https://github.com/user-attachments/assets/6d746c6c-53d6-4243-bf03-e81dbb95a26c)
