### PR TITLE
refactor (provider-utils): move `customAlphabet()` method from `nanoid` into codebase

### DIFF
--- a/.changeset/eleven-lobsters-rescue.md
+++ b/.changeset/eleven-lobsters-rescue.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+refactor (provider-utils): move `customAlphabet()` method from `nanoid` into codebase

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@ai-sdk/provider": "2.0.0-canary.0",
-    "nanoid": "^3.3.8",
     "secure-json-parse": "^2.7.0"
   },
   "devDependencies": {

--- a/packages/provider-utils/src/generate-id-custom-alphabet.ts
+++ b/packages/provider-utils/src/generate-id-custom-alphabet.ts
@@ -3,7 +3,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2020–2024 AI
+// Copyright (c) 2017 Andrey Sitnik <andrey@sitnik.ru>
 // Copyright (c) Vercel, Inc. (https://vercel.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/packages/provider-utils/src/generate-id-custom-alphabet.ts
+++ b/packages/provider-utils/src/generate-id-custom-alphabet.ts
@@ -1,0 +1,34 @@
+// License for this File only.
+// Based on https://github.com/ai/nanoid/blob/c49cc113499f2b44ab52b80314e18043ad0f3f79/non-secure/index.js
+//
+// MIT License
+//
+// Copyright (c) 2020–2024 AI
+// Copyright (c) Vercel, Inc. (https://vercel.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+export function customAlphabet(alphabet: string, defaultSize: number) {
+  return (size = defaultSize) => {
+    let id = '';
+    // A compact alternative for `for (var i = 0; i < step; i++)`.
+    let i = size | 0;
+    while (i--) {
+      // `| 0` is more compact and faster than `Math.floor()`.
+      id += alphabet[(Math.random() * alphabet.length) | 0];
+    }
+    return id;
+  };
+}

--- a/packages/provider-utils/src/generate-id.ts
+++ b/packages/provider-utils/src/generate-id.ts
@@ -1,5 +1,5 @@
 import { InvalidArgumentError } from '@ai-sdk/provider';
-import { customAlphabet } from 'nanoid/non-secure';
+import { customAlphabet } from './generate-id-custom-alphabet';
 
 /**
 Creates an ID generator.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1701,9 +1701,6 @@ importers:
       '@ai-sdk/provider':
         specifier: 2.0.0-canary.0
         version: link:../provider
-      nanoid:
-        specifier: ^3.3.8
-        version: 3.3.8
       secure-json-parse:
         specifier: ^2.7.0
         version: 2.7.0


### PR DESCRIPTION
@lgrammel and I discussed that [`nanoid`](https://github.com/ai/nanoid/) could be removed as dependency, to further reduce the number of external dependencies.

`@ai-sdk/provider-utils` is the only package that had a dependency on `nanoid`, and it only used the [`customAlphabet()` method](https://github.com/ai/nanoid/blob/c49cc113499f2b44ab52b80314e18043ad0f3f79/non-secure/index.js#L12C12-L23) from the non-secure module export.

### Todos

- [x] merge target should be `v5` branch
- [x] no vercel ai copyright header needed; however we should keep original copyright if copied from nanoid - see example here: https://github.com/vercel/ai/blob/main/packages/ui-utils/src/deep-partial.ts
- [x] add a patch changeset for the `provider-utils` pkg (with PR title as description)