### PR TITLE
fix (docs): highlight

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -244,7 +244,7 @@ Notice the blank response in the UI? This is because instead of generating a tex
 
 To display the tool invocations in your UI, update your `app/page.tsx` file:
 
-```tsx filename="app/page.tsx" highlight="18-24"
+```tsx filename="app/page.tsx" highlight="16-21"
 'use client';
 
 import { useChat } from '@ai-sdk/react';


### PR DESCRIPTION
Hi, there.

I have modified the code highlighting added in the documentation steps.

https://sdk.vercel.ai/docs/getting-started/nextjs-app-router#update-the-ui

| actual | expected |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/3ff5a501-66ba-40bd-a5b6-0a54b7bffa5a) | ![image](https://github.com/user-attachments/assets/27f95f11-a79c-4d12-af1e-2a8dbfaa7b37) |
