### PR TITLE
fix (provider/google): allow "OFF" for Google HarmBlockThreshold

### DIFF
--- a/.changeset/huge-cloths-burn.md
+++ b/.changeset/huge-cloths-burn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix (provider/google): allow "OFF" for Google HarmBlockThreshold

--- a/packages/google/src/google-generative-ai-settings.ts
+++ b/packages/google/src/google-generative-ai-settings.ts
@@ -72,7 +72,8 @@ Optional. A list of unique safety settings for blocking unsafe content.
       | 'BLOCK_LOW_AND_ABOVE'
       | 'BLOCK_MEDIUM_AND_ABOVE'
       | 'BLOCK_ONLY_HIGH'
-      | 'BLOCK_NONE';
+      | 'BLOCK_NONE'
+      | 'OFF';
   }>;
   /**
    * Optional. Enables timestamp understanding for audio-only files.


### PR DESCRIPTION
"OFF" can be included and it does not fail when used on API requests. Using other unsupported strings will return an error.

See also:
https://ai.google.dev/api/generate-content#HarmBlockThreshold