### PR TITLE
Langchain adapter fix deprecated

### DIFF
--- a/content/docs/07-reference/04-stream-helpers/16-langchain-adapter.mdx
+++ b/content/docs/07-reference/04-stream-helpers/16-langchain-adapter.mdx
@@ -31,7 +31,7 @@ It supports:
     },
     {
       name: 'toDataStreamResponse',
-      type: '(stream: ReadableStream<LangChainAIMessageChunk> | ReadableStream<string>, options?: {init?: ResponseInit, data?: StreamData, callbacks?: AIStreamCallbacksAndOptions}) => Response',
+      type: '(stream: ReadableStream<LangChainAIMessageChunk> | ReadableStream<string>, options?: {init?: ResponseInit, data?: ReadableStream<DataStreamString>, callbacks?: AIStreamCallbacksAndOptions}) => Response',
       description: 'Converts LangChain output streams to data stream response.',
     },
     {
@@ -62,6 +62,32 @@ export async function POST(req: Request) {
   const stream = await model.stream(prompt);
 
   return LangChainAdapter.toDataStreamResponse(stream);
+}
+```
+
+### Merge LangChain Expression Language Stream With Data Stream
+
+```tsx filename="app/api/completion/route.ts" highlight={"14"}
+import { ChatOpenAI } from '@langchain/openai';
+import { LangChainAdapter } from 'ai';
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json();
+
+  const model = new ChatOpenAI({
+    model: 'gpt-3.5-turbo-0125',
+    temperature: 0,
+  });
+
+  const stream = await model.stream(prompt);
+
+  const dataStream = createDataStream({
+    execute(writer) {
+      writer.writeData({ metadata: 'Custom metadata' });
+    },
+  });
+
+  return LangChainAdapter.toDataStreamResponse(stream, { data: dataStream });
 }
 ```
 

--- a/packages/ai/streams/langchain-adapter.test.ts
+++ b/packages/ai/streams/langchain-adapter.test.ts
@@ -77,6 +77,26 @@ describe('toDataStreamResponse', () => {
       '0:"World"\n',
     ]);
   });
+
+  it('should merge options.data into the response stream', async () => {
+    const inputStream = convertArrayToReadableStream([
+      { event: 'on_chat_model_stream', data: { chunk: { content: 'Hello' } } },
+      { event: 'on_chat_model_stream', data: { chunk: { content: 'World' } } },
+    ]);
+
+    const dataStream = createDataStream({
+      execute(writer) {
+        writer.writeData({ metadata: 'Custom metadata' });
+      },
+    });
+
+    const response = toDataStreamResponse(inputStream, { data: dataStream });
+    assert.deepStrictEqual(await convertResponseStreamToArray(response), [
+      '2:[{"metadata":"Custom metadata"}]\n',
+      '0:"Hello"\n',
+      '0:"World"\n',
+    ]);
+  });
 });
 
 describe('mergeIntoDataStream', () => {


### PR DESCRIPTION
I updated the langchain method to no longer use the deprecated StreamData() method. I also updated the documentation to reflect this change. I added a test case to ensure that the data stream is correctly being merged into the response stream!

Resolves this issue: #5552 