### PR TITLE
fix (ai/mcp): prevent mutation of customEnv

### DIFF
--- a/.changeset/fix-env-mutation.md
+++ b/.changeset/fix-env-mutation.md
@@ -1,5 +1,0 @@
----
-"@ai/core": patch
----
-
-Fix Environment Object Mutation in `get-environment.ts`

--- a/.changeset/fix-env-mutation.md
+++ b/.changeset/fix-env-mutation.md
@@ -1,0 +1,5 @@
+---
+"@ai/core": patch
+---
+
+Fix Environment Object Mutation in `get-environment.ts`

--- a/.changeset/fix-env-mutation.md
+++ b/.changeset/fix-env-mutation.md
@@ -1,0 +1,5 @@
+---
+'@ai/core': patch
+---
+
+fix (ai/mcp): prevent mutation of customEnv

--- a/packages/ai/mcp-stdio/create-child-process.test.ts
+++ b/packages/ai/mcp-stdio/create-child-process.test.ts
@@ -52,6 +52,22 @@ describe('createChildProcess', () => {
     childProcessWithCustomEnv.kill();
   });
 
+  it('should not mutate the original environment object', async () => {
+    const originalConfig = {
+      command: process.execPath,
+      env: { CUSTOM_VAR: 'custom_value' },
+    };
+    const originalConfigCopy = JSON.parse(JSON.stringify(originalConfig));
+
+    const childProcessWithCustomEnv = await createChildProcess(
+      originalConfig,
+      new AbortController().signal,
+    );
+
+    expect(originalConfig.env).toEqual(originalConfigCopy.env);
+    childProcessWithCustomEnv.kill();
+  });
+
   it('should spawn a child process with args', async () => {
     const childProcessWithArgs = await createChildProcess(
       { command: process.execPath, args: ['-c', 'echo', 'test'] },

--- a/packages/ai/mcp-stdio/create-child-process.test.ts
+++ b/packages/ai/mcp-stdio/create-child-process.test.ts
@@ -52,22 +52,6 @@ describe('createChildProcess', () => {
     childProcessWithCustomEnv.kill();
   });
 
-  it('should not mutate the original environment object', async () => {
-    const originalConfig = {
-      command: process.execPath,
-      env: { CUSTOM_VAR: 'custom_value' },
-    };
-    const originalConfigCopy = JSON.parse(JSON.stringify(originalConfig));
-
-    const childProcessWithCustomEnv = await createChildProcess(
-      originalConfig,
-      new AbortController().signal,
-    );
-
-    expect(originalConfig.env).toEqual(originalConfigCopy.env);
-    childProcessWithCustomEnv.kill();
-  });
-
   it('should spawn a child process with args', async () => {
     const childProcessWithArgs = await createChildProcess(
       { command: process.execPath, args: ['-c', 'echo', 'test'] },

--- a/packages/ai/mcp-stdio/get-environment.test.ts
+++ b/packages/ai/mcp-stdio/get-environment.test.ts
@@ -7,7 +7,7 @@ describe('getEnvironment', () => {
 
     const result = getEnvironment(customEnv);
 
-    expect(customEnv).toEqual({ CUSTOM_VAR: 'custom_value' });
+    expect(customEnv).toStrictEqual({ CUSTOM_VAR: 'custom_value' });
     expect(result).not.toBe(customEnv);
   });
 });

--- a/packages/ai/mcp-stdio/get-environment.test.ts
+++ b/packages/ai/mcp-stdio/get-environment.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { getEnvironment } from './get-environment';
+
+describe('getEnvironment', () => {
+  it('should not mutate the original custom environment object', () => {
+    const customEnv = { CUSTOM_VAR: 'custom_value' };
+
+    const result = getEnvironment(customEnv);
+
+    expect(customEnv).toEqual({ CUSTOM_VAR: 'custom_value' });
+    expect(result).not.toBe(customEnv);
+  });
+});

--- a/packages/ai/mcp-stdio/get-environment.ts
+++ b/packages/ai/mcp-stdio/get-environment.ts
@@ -24,7 +24,7 @@ export function getEnvironment(
         ]
       : ['HOME', 'LOGNAME', 'PATH', 'SHELL', 'TERM', 'USER'];
 
-  const env: Record<string, string> = customEnv ?? {};
+  const env: Record<string, string> = customEnv ? { ...customEnv } : {};
 
   for (const key of DEFAULT_INHERITED_ENV_VARS) {
     const value = globalThis.process.env[key];


### PR DESCRIPTION
## Description
This PR fixes an issue where the original `customEnv` object passed to functions in `get-environment.ts` was being mutated due to JavaScript's pass-by-reference behavior for objects.

## Problem
When a configuration object with an `env` property was passed to `createChildProcess`, any modifications to the environment inside the function would also affect the original object, potentially causing unexpected behavior in subsequent code.

In our project, we encountered this issue specifically when using `serverConfig` with the MCP client:

```typescript
const serverConfig = await findMcpServerConfig(id);
// {
//   command: 'node server.js',
//   env: { PORT: '3000' }
// };

const client = await createMCPClient({
      name,
      onUncaughtError,
      transport: new StdioMCPTransport(serverConfig),
});

return Response.json(...)
```

After the `createMCPClient` call, we discovered that the original `serverConfig.env` was being modified. This could cause problems when:
1. The same config object is reused for multiple operations
2. The config needs to be stored back to the database in its original form
3. The config is used for comparison or validation later in the code

This change preserves the immutability of configuration objects throughout the application, making the code more predictable and preventing hard-to-trace bugs that might occur when objects are unexpectedly modified.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/57ee3a83-aefb-4e82-a25a-4b9026556066" />
