### PR TITLE
fix(docs): correct Completions API example by using openai() instead of openai.responses() 

### DIFF
--- a/content/docs/02-guides/19-openai-responses.mdx
+++ b/content/docs/02-guides/19-openai-responses.mdx
@@ -180,7 +180,7 @@ import { openai } from '@ai-sdk/openai';
 
 // Completions API
 const { text } = await generateText({
-  model: openai.responses('gpt-4o', { parallelToolCalls: false }),
+  model: openai('gpt-4o', { parallelToolCalls: false }),
   prompt: 'Explain the concept of quantum entanglement.',
 });
 


### PR DESCRIPTION
The original example incorrectly used openai.responses() for the Completions API section. Changed it to use openai() directly to match the correct API usage pattern.