### PR TITLE
chore (provider): remove image parts

### DIFF
--- a/.changeset/selfish-rice-own.md
+++ b/.changeset/selfish-rice-own.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': major
+---
+
+chore (provider): remove image parts

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -39,9 +39,9 @@ describe('convertToLanguageModelPrompt', () => {
             role: 'user',
             content: [
               {
-                type: 'image',
+                type: 'file',
                 mimeType: 'image/png',
-                image: new Uint8Array([0, 1, 2, 3]),
+                data: 'AAECAw==',
               },
             ],
           },
@@ -80,9 +80,9 @@ describe('convertToLanguageModelPrompt', () => {
             role: 'user',
             content: [
               {
-                type: 'image',
+                type: 'file',
                 mimeType: 'image/png',
-                image: new Uint8Array([0, 1, 2, 3]),
+                data: 'AAECAw==',
               },
             ],
           },
@@ -627,8 +627,9 @@ describe('convertToLanguageModelMessage', () => {
           role: 'user',
           content: [
             {
-              type: 'image',
-              image: new URL('https://example.com/image.jpg'),
+              type: 'file',
+              data: new URL('https://example.com/image.jpg'),
+              mimeType: 'image/png',
             },
           ],
         });
@@ -652,8 +653,8 @@ describe('convertToLanguageModelMessage', () => {
           role: 'user',
           content: [
             {
-              type: 'image',
-              image: new Uint8Array([255, 216, 255, 221]),
+              type: 'file',
+              data: '/9j/3Q==',
               mimeType: 'image/jpeg',
             },
           ],
@@ -679,8 +680,8 @@ describe('convertToLanguageModelMessage', () => {
           role: 'user',
           content: [
             {
-              type: 'image',
-              image: new Uint8Array([255, 216, 255, 221]),
+              type: 'file',
+              data: '/9j/3Q==',
               mimeType: 'image/jpeg',
             },
           ],

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -629,7 +629,7 @@ describe('convertToLanguageModelMessage', () => {
             {
               type: 'file',
               data: new URL('https://example.com/image.jpg'),
-              mimeType: 'image/png',
+              mimeType: 'image/*', // wildcard since we don't know the exact type
             },
           ],
         });

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -4,6 +4,7 @@ import {
   LanguageModelV2Prompt,
   LanguageModelV2TextPart,
 } from '@ai-sdk/provider';
+import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 import { download } from '../../util/download';
 import { CoreMessage } from '../prompt/message';
 import {
@@ -19,7 +20,6 @@ import {
 import { InvalidMessageRoleError } from './invalid-message-role-error';
 import { splitDataUrl } from './split-data-url';
 import { StandardizedPrompt } from './standardize-prompt';
-import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 
 export async function convertToLanguageModelPrompt({
   prompt,

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -354,7 +354,7 @@ function convertPartToLanguageModelPart(
           normalizedData instanceof Uint8Array
             ? convertUint8ArrayToBase64(normalizedData) // TODO prevent double conversion
             : normalizedData,
-        mimeType: mimeType ?? 'image/png', // TODO buggy what if it is a URL?
+        mimeType: mimeType ?? 'image/*', // any image
         filename: undefined,
         providerOptions:
           part.providerOptions ?? part.experimental_providerMetadata,

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -350,12 +350,12 @@ function convertPartToLanguageModelPart(
 
       return {
         type: 'file',
+        mimeType: mimeType ?? 'image/*', // any image
+        filename: undefined,
         data:
           normalizedData instanceof Uint8Array
             ? convertUint8ArrayToBase64(normalizedData) // TODO prevent double conversion
             : normalizedData,
-        mimeType: mimeType ?? 'image/*', // any image
-        filename: undefined,
         providerOptions:
           part.providerOptions ?? part.experimental_providerMetadata,
       };
@@ -369,12 +369,12 @@ function convertPartToLanguageModelPart(
 
       return {
         type: 'file',
+        mimeType,
+        filename: part.filename,
         data:
           normalizedData instanceof Uint8Array
             ? convertDataContentToBase64String(normalizedData)
             : normalizedData,
-        filename: part.filename,
-        mimeType,
         providerOptions:
           part.providerOptions ?? part.experimental_providerMetadata,
       };

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -7,6 +7,7 @@ import {
 } from '@ai-sdk/provider';
 
 // Re-export LanguageModelV2 types for the middleware:
+// TODO remove in v5
 export type {
   LanguageModelV2,
   LanguageModelV2CallOptions,
@@ -14,7 +15,6 @@ export type {
   LanguageModelV2FilePart,
   LanguageModelV2FinishReason,
   LanguageModelV2FunctionToolCall,
-  LanguageModelV2ImagePart,
   LanguageModelV2Message,
   LanguageModelV2ObjectGenerationMode,
   LanguageModelV2Prompt,

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -36,8 +36,8 @@ describe('system messages', () => {
 });
 
 describe('user messages', () => {
-  it('should convert messages with file, image, and text parts to multiple parts', async () => {
-    const fileData = new Uint8Array([0, 1, 2, 3]);
+  it('should convert messages with image parts', async () => {
+    const imageData = new Uint8Array([0, 1, 2, 3]);
 
     const { messages } = convertToBedrockChatMessages([
       {
@@ -45,14 +45,9 @@ describe('user messages', () => {
         content: [
           { type: 'text', text: 'Hello' },
           {
-            type: 'image',
-            image: new Uint8Array([0, 1, 2, 3]),
-            mimeType: 'image/png',
-          },
-          {
             type: 'file',
-            data: Buffer.from(fileData).toString('base64'),
-            mimeType: 'application/pdf',
+            data: Buffer.from(imageData).toString('base64'),
+            mimeType: 'image/png',
           },
         ],
       },
@@ -69,6 +64,33 @@ describe('user messages', () => {
               source: { bytes: 'AAECAw==' },
             },
           },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert messages with document parts', async () => {
+    const fileData = new Uint8Array([0, 1, 2, 3]);
+
+    const { messages } = convertToBedrockChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'file',
+            data: Buffer.from(fileData).toString('base64'),
+            mimeType: 'application/pdf',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { text: 'Hello' },
           {
             document: {
               format: 'pdf',

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -78,48 +78,40 @@ export function convertToBedrockChatMessages(prompt: LanguageModelV2Prompt): {
                     });
                     break;
                   }
-                  case 'image': {
-                    if (part.image instanceof URL) {
-                      // The AI SDK automatically downloads images for user image parts with URLs
-                      throw new UnsupportedFunctionalityError({
-                        functionality: 'Image URLs in user messages',
-                      });
-                    }
 
-                    bedrockContent.push({
-                      image: {
-                        format: part.mimeType?.split(
-                          '/',
-                        )?.[1] as BedrockImageFormat,
-                        source: {
-                          bytes: convertUint8ArrayToBase64(
-                            part.image ?? (part.image as Uint8Array),
-                          ),
-                        },
-                      },
-                    });
-
-                    break;
-                  }
                   case 'file': {
                     if (part.data instanceof URL) {
                       // The AI SDK automatically downloads files for user file parts with URLs
                       throw new UnsupportedFunctionalityError({
-                        functionality: 'File URLs in user messages',
+                        functionality: 'File URL data',
                       });
                     }
 
-                    bedrockContent.push({
-                      document: {
-                        format: part.mimeType?.split(
-                          '/',
-                        )?.[1] as BedrockDocumentFormat,
-                        name: generateFileId(),
-                        source: {
-                          bytes: part.data,
+                    if (part.mimeType.startsWith('image/')) {
+                      const bedrockImageFormat =
+                        part.mimeType === 'image/*'
+                          ? undefined
+                          : part.mimeType?.split('/')?.[1];
+
+                      bedrockContent.push({
+                        image: {
+                          format: bedrockImageFormat as BedrockImageFormat,
+                          source: { bytes: part.data },
                         },
-                      },
-                    });
+                      });
+                    } else {
+                      bedrockContent.push({
+                        document: {
+                          format: part.mimeType?.split(
+                            '/',
+                          )?.[1] as BedrockDocumentFormat,
+                          name: generateFileId(),
+                          source: {
+                            bytes: part.data,
+                          },
+                        },
+                      });
+                    }
 
                     break;
                   }

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -1,4 +1,12 @@
 import {
+  JSONObject,
+  LanguageModelV2Message,
+  LanguageModelV2Prompt,
+  LanguageModelV2ProviderMetadata,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
+import { createIdGenerator } from '@ai-sdk/provider-utils';
+import {
   BEDROCK_CACHE_POINT,
   BedrockAssistantMessage,
   BedrockCachePoint,
@@ -8,17 +16,6 @@ import {
   BedrockSystemMessages,
   BedrockUserMessage,
 } from './bedrock-api-types';
-import {
-  JSONObject,
-  LanguageModelV2Message,
-  LanguageModelV2Prompt,
-  LanguageModelV2ProviderMetadata,
-  UnsupportedFunctionalityError,
-} from '@ai-sdk/provider';
-import {
-  convertUint8ArrayToBase64,
-  createIdGenerator,
-} from '@ai-sdk/provider-utils';
 
 const generateFileId = createIdGenerator({ prefix: 'file', size: 16 });
 

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -49,8 +49,8 @@ describe('user messages', () => {
           role: 'user',
           content: [
             {
-              type: 'image',
-              image: new Uint8Array([0, 1, 2, 3]),
+              type: 'file',
+              data: 'AAECAw==',
               mimeType: 'image/png',
             },
           ],
@@ -90,9 +90,9 @@ describe('user messages', () => {
           role: 'user',
           content: [
             {
-              type: 'image',
-              image: new URL('https://example.com/image.png'),
-              mimeType: 'image/png',
+              type: 'file',
+              data: new URL('https://example.com/image.png'),
+              mimeType: 'image/*',
             },
           ],
         },
@@ -182,28 +182,9 @@ describe('user messages', () => {
         sendReasoning: true,
         warnings: [],
       }),
-    ).toThrow('Non-PDF files in user messages');
-  });
-
-  it('should throw error for URL-based file parts', async () => {
-    expect(() =>
-      convertToAnthropicMessagesPrompt({
-        prompt: [
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'file',
-                data: 'base64data',
-                mimeType: 'text/plain',
-              },
-            ],
-          },
-        ],
-        sendReasoning: true,
-        warnings: [],
-      }),
-    ).toThrow('Non-PDF files in user messages');
+    ).toThrow(
+      "'unsupported file content type: text/plain' functionality not supported.",
+    );
   });
 });
 

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -5,7 +5,6 @@ import {
   LanguageModelV2ProviderMetadata,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
-import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 import {
   AnthropicAssistantMessage,
   AnthropicCacheControl,

--- a/packages/cohere/src/convert-to-cohere-chat-prompt.ts
+++ b/packages/cohere/src/convert-to-cohere-chat-prompt.ts
@@ -25,9 +25,9 @@ export function convertToCohereChatPrompt(
                 case 'text': {
                   return part.text;
                 }
-                case 'image': {
+                case 'file': {
                   throw new UnsupportedFunctionalityError({
-                    functionality: 'image-part',
+                    functionality: 'File URL data',
                   });
                 }
               }

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -25,14 +25,14 @@ describe('system messages', () => {
 });
 
 describe('user messages', () => {
-  it('should add image parts for UInt8Array images', async () => {
+  it('should add image parts', async () => {
     const result = convertToGoogleGenerativeAIMessages([
       {
         role: 'user',
         content: [
           {
-            type: 'image',
-            image: new Uint8Array([0, 1, 2, 3]),
+            type: 'file',
+            data: 'AAECAw==',
             mimeType: 'image/png',
           },
         ],

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -42,41 +42,15 @@ export function convertToGoogleGenerativeAIMessages(
               break;
             }
 
-            case 'image': {
-              parts.push(
-                part.image instanceof URL
-                  ? {
-                      fileData: {
-                        mimeType: part.mimeType ?? 'image/jpeg',
-                        fileUri: part.image.toString(),
-                      },
-                    }
-                  : {
-                      inlineData: {
-                        mimeType: part.mimeType ?? 'image/jpeg',
-                        data: convertUint8ArrayToBase64(part.image),
-                      },
-                    },
-              );
-
-              break;
-            }
-
             case 'file': {
+              // default to image/jpeg for unknown image/* types
+              const mimeType =
+                part.mimeType === 'image/*' ? 'image/jpeg' : part.mimeType;
+
               parts.push(
                 part.data instanceof URL
-                  ? {
-                      fileData: {
-                        mimeType: part.mimeType,
-                        fileUri: part.data.toString(),
-                      },
-                    }
-                  : {
-                      inlineData: {
-                        mimeType: part.mimeType,
-                        data: part.data,
-                      },
-                    },
+                  ? { fileData: { mimeType, fileUri: part.data.toString() } }
+                  : { inlineData: { mimeType, data: part.data } },
               );
 
               break;

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -2,7 +2,6 @@ import {
   LanguageModelV2Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
-import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 import {
   GoogleGenerativeAIContent,
   GoogleGenerativeAIContentPart,

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -8,8 +8,8 @@ describe('user messages', () => {
         content: [
           { type: 'text', text: 'Hello' },
           {
-            type: 'image',
-            image: new Uint8Array([0, 1, 2, 3]),
+            type: 'file',
+            data: 'AAECAw==',
             mimeType: 'image/png',
           },
         ],

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -2,7 +2,6 @@ import {
   LanguageModelV2Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
-import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 import { GroqChatPrompt } from './groq-api-types';
 
 export function convertToGroqChatMessages(
@@ -30,23 +29,24 @@ export function convertToGroqChatMessages(
               case 'text': {
                 return { type: 'text', text: part.text };
               }
-              case 'image': {
+              case 'file': {
+                if (!part.mimeType.startsWith('image/')) {
+                  throw new UnsupportedFunctionalityError({
+                    functionality: 'Non-image file content parts',
+                  });
+                }
+
                 return {
                   type: 'image_url',
                   image_url: {
                     url:
-                      part.image instanceof URL
-                        ? part.image.toString()
+                      part.data instanceof URL
+                        ? part.data.toString()
                         : `data:${
                             part.mimeType ?? 'image/jpeg'
-                          };base64,${convertUint8ArrayToBase64(part.image)}`,
+                          };base64,${part.data}`,
                   },
                 };
-              }
-              case 'file': {
-                throw new UnsupportedFunctionalityError({
-                  functionality: 'File content parts in user messages',
-                });
               }
             }
           }),

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -36,15 +36,16 @@ export function convertToGroqChatMessages(
                   });
                 }
 
+                const mimeType =
+                  part.mimeType === 'image/*' ? 'image/jpeg' : part.mimeType;
+
                 return {
                   type: 'image_url',
                   image_url: {
                     url:
                       part.data instanceof URL
                         ? part.data.toString()
-                        : `data:${
-                            part.mimeType ?? 'image/jpeg'
-                          };base64,${part.data}`,
+                        : `data:${mimeType};base64,${part.data}`,
                   },
                 };
               }

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -8,8 +8,8 @@ describe('user messages', () => {
         content: [
           { type: 'text', text: 'Hello' },
           {
-            type: 'image',
-            image: new Uint8Array([0, 1, 2, 3]),
+            type: 'file',
+            data: 'AAECAw==',
             mimeType: 'image/png',
           },
         ],

--- a/packages/openai-compatible/src/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/convert-to-openai-compatible-chat-messages.test.ts
@@ -19,8 +19,8 @@ describe('user messages', () => {
         content: [
           { type: 'text', text: 'Hello' },
           {
-            type: 'image',
-            image: new Uint8Array([0, 1, 2, 3]),
+            type: 'file',
+            data: Buffer.from([0, 1, 2, 3]).toString('base64'),
             mimeType: 'image/png',
           },
         ],
@@ -47,9 +47,9 @@ describe('user messages', () => {
         role: 'user',
         content: [
           {
-            type: 'image',
-            image: new URL('https://example.com/image.jpg'),
-            mimeType: 'image/jpeg',
+            type: 'file',
+            data: new URL('https://example.com/image.jpg'),
+            mimeType: 'image/*',
           },
         ],
       },
@@ -248,9 +248,9 @@ describe('provider-specific metadata merging', () => {
         role: 'user',
         content: [
           {
-            type: 'image',
-            image: imageUrl,
-            mimeType: 'image/jpeg',
+            type: 'file',
+            data: imageUrl,
+            mimeType: 'image/*',
             providerOptions: {
               openaiCompatible: {
                 cacheControl: { type: 'ephemeral' },
@@ -310,8 +310,8 @@ describe('provider-specific metadata merging', () => {
             },
           },
           {
-            type: 'image',
-            image: new Uint8Array([0, 1, 2, 3]),
+            type: 'file',
+            data: Buffer.from([0, 1, 2, 3]).toString('base64'),
             mimeType: 'image/png',
             providerOptions: {
               openaiCompatible: { alt_text: 'A sample image' },
@@ -483,8 +483,8 @@ describe('provider-specific metadata merging', () => {
             },
           },
           {
-            type: 'image',
-            image: new Uint8Array([9, 8, 7, 6]),
+            type: 'file',
+            data: Buffer.from([9, 8, 7, 6]).toString('base64'),
             mimeType: 'image/png',
             providerOptions: {
               openaiCompatible: { imagePartLevel: 'image-data' },

--- a/packages/openai-compatible/src/convert-to-openai-compatible-completion-prompt.ts
+++ b/packages/openai-compatible/src/convert-to-openai-compatible-completion-prompt.ts
@@ -54,13 +54,9 @@ export function convertToOpenAICompatibleCompletionPrompt({
               case 'text': {
                 return part.text;
               }
-              case 'image': {
-                throw new UnsupportedFunctionalityError({
-                  functionality: 'images',
-                });
-              }
             }
           })
+          .filter(Boolean)
           .join('');
 
         text += `${user}:\n${userMessage}\n\n`;

--- a/packages/openai/src/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.test.ts
@@ -54,9 +54,9 @@ describe('user messages', () => {
           content: [
             { type: 'text', text: 'Hello' },
             {
-              type: 'image',
-              image: new Uint8Array([0, 1, 2, 3]),
+              type: 'file',
               mimeType: 'image/png',
+              data: Buffer.from([0, 1, 2, 3]).toString('base64'),
             },
           ],
         },
@@ -84,9 +84,9 @@ describe('user messages', () => {
           role: 'user',
           content: [
             {
-              type: 'image',
-              image: new Uint8Array([0, 1, 2, 3]),
+              type: 'file',
               mimeType: 'image/png',
+              data: Buffer.from([0, 1, 2, 3]).toString('base64'),
               providerOptions: {
                 openai: {
                   imageDetail: 'low',
@@ -122,14 +122,16 @@ describe('user messages', () => {
             {
               role: 'user',
               content: [
-                { type: 'file', data: 'AAECAw==', mimeType: 'image/png' },
+                {
+                  type: 'file',
+                  data: 'AAECAw==',
+                  mimeType: 'application/something',
+                },
               ],
             },
           ],
         }),
-      ).toThrow(
-        "'File content part type image/png in user messages' functionality not supported.",
-      );
+      ).toThrow('file part media type application/something');
     });
 
     it('should throw for URL data', () => {
@@ -148,9 +150,7 @@ describe('user messages', () => {
             },
           ],
         }),
-      ).toThrow(
-        "'File content parts with URL data' functionality not supported.",
-      );
+      ).toThrow('audio file parts with URLs');
     });
 
     it('should add audio content for audio/wav file parts', () => {
@@ -330,9 +330,7 @@ describe('user messages', () => {
           ],
           systemMessageMode: 'system',
         });
-      }).toThrow(
-        "'File content part type text/plain in user messages' functionality not supported.",
-      );
+      }).toThrow('file part media type text/plain');
     });
 
     it('should throw error for file URLs', async () => {
@@ -352,9 +350,7 @@ describe('user messages', () => {
           ],
           systemMessageMode: 'system',
         });
-      }).toThrow(
-        "'File content parts with URL data' functionality not supported.",
-      );
+      }).toThrow('PDF file parts with URLs');
     });
   });
 });

--- a/packages/openai/src/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.ts
@@ -3,7 +3,6 @@ import {
   LanguageModelV2Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
-import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 import { OpenAIChatPrompt } from './openai-chat-prompt';
 
 export function convertToOpenAIChatMessages({
@@ -63,58 +62,69 @@ export function convertToOpenAIChatMessages({
               case 'text': {
                 return { type: 'text', text: part.text };
               }
-              case 'image': {
-                return {
-                  type: 'image_url',
-                  image_url: {
-                    url:
-                      part.image instanceof URL
-                        ? part.image.toString()
-                        : `data:${
-                            part.mimeType ?? 'image/jpeg'
-                          };base64,${convertUint8ArrayToBase64(part.image)}`,
-
-                    // OpenAI specific extension: image detail
-                    detail: part.providerOptions?.openai?.imageDetail,
-                  },
-                };
-              }
               case 'file': {
-                if (part.data instanceof URL) {
-                  throw new UnsupportedFunctionalityError({
-                    functionality:
-                      "'File content parts with URL data' functionality not supported.",
-                  });
-                }
+                if (part.mimeType.startsWith('image/')) {
+                  const mimeType =
+                    part.mimeType === 'image/*' ? 'image/jpeg' : part.mimeType;
 
-                switch (part.mimeType) {
-                  case 'audio/wav': {
-                    return {
-                      type: 'input_audio',
-                      input_audio: { data: part.data, format: 'wav' },
-                    };
-                  }
-                  case 'audio/mp3':
-                  case 'audio/mpeg': {
-                    return {
-                      type: 'input_audio',
-                      input_audio: { data: part.data, format: 'mp3' },
-                    };
-                  }
-                  case 'application/pdf': {
-                    return {
-                      type: 'file',
-                      file: {
-                        filename: part.filename ?? `part-${index}.pdf`,
-                        file_data: `data:application/pdf;base64,${part.data}`,
-                      },
-                    };
-                  }
-                  default: {
+                  return {
+                    type: 'image_url',
+                    image_url: {
+                      url:
+                        part.data instanceof URL
+                          ? part.data.toString()
+                          : `data:${mimeType};base64,${part.data}`,
+
+                      // OpenAI specific extension: image detail
+                      detail: part.providerOptions?.openai?.imageDetail,
+                    },
+                  };
+                } else if (part.mimeType.startsWith('audio/')) {
+                  if (part.data instanceof URL) {
                     throw new UnsupportedFunctionalityError({
-                      functionality: `File content part type ${part.mimeType} in user messages`,
+                      functionality: 'audio file parts with URLs',
                     });
                   }
+
+                  switch (part.mimeType) {
+                    case 'audio/wav': {
+                      return {
+                        type: 'input_audio',
+                        input_audio: { data: part.data, format: 'wav' },
+                      };
+                    }
+                    case 'audio/mp3':
+                    case 'audio/mpeg': {
+                      return {
+                        type: 'input_audio',
+                        input_audio: { data: part.data, format: 'mp3' },
+                      };
+                    }
+
+                    default: {
+                      throw new UnsupportedFunctionalityError({
+                        functionality: `audio content parts with media type ${part.mimeType}`,
+                      });
+                    }
+                  }
+                } else if (part.mimeType === 'application/pdf') {
+                  if (part.data instanceof URL) {
+                    throw new UnsupportedFunctionalityError({
+                      functionality: 'PDF file parts with URLs',
+                    });
+                  }
+
+                  return {
+                    type: 'file',
+                    file: {
+                      filename: part.filename ?? `part-${index}.pdf`,
+                      file_data: `data:application/pdf;base64,${part.data}`,
+                    },
+                  };
+                } else {
+                  throw new UnsupportedFunctionalityError({
+                    functionality: `file part media type ${part.mimeType}`,
+                  });
                 }
               }
             }

--- a/packages/openai/src/convert-to-openai-completion-prompt.ts
+++ b/packages/openai/src/convert-to-openai-completion-prompt.ts
@@ -54,13 +54,9 @@ export function convertToOpenAICompletionPrompt({
               case 'text': {
                 return part.text;
               }
-              case 'image': {
-                throw new UnsupportedFunctionalityError({
-                  functionality: 'images',
-                });
-              }
             }
           })
+          .filter(Boolean)
           .join('');
 
         text += `${user}:\n${userMessage}\n\n`;

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
@@ -57,8 +57,9 @@ describe('convertToOpenAIResponsesMessages', () => {
             content: [
               { type: 'text', text: 'Hello' },
               {
-                type: 'image',
-                image: new URL('https://example.com/image.jpg'),
+                type: 'file',
+                mimeType: 'image/*',
+                data: new URL('https://example.com/image.jpg'),
               },
             ],
           },
@@ -87,9 +88,9 @@ describe('convertToOpenAIResponsesMessages', () => {
             role: 'user',
             content: [
               {
-                type: 'image',
-                image: new Uint8Array([0, 1, 2, 3]),
+                type: 'file',
                 mimeType: 'image/png',
+                data: Buffer.from([0, 1, 2, 3]).toString('base64'),
               },
             ],
           },
@@ -117,8 +118,9 @@ describe('convertToOpenAIResponsesMessages', () => {
             role: 'user',
             content: [
               {
-                type: 'image',
-                image: new Uint8Array([0, 1, 2, 3]),
+                type: 'file',
+                mimeType: 'image/*',
+                data: Buffer.from([0, 1, 2, 3]).toString('base64'),
               },
             ],
           },
@@ -146,9 +148,9 @@ describe('convertToOpenAIResponsesMessages', () => {
             role: 'user',
             content: [
               {
-                type: 'image',
-                image: new Uint8Array([0, 1, 2, 3]),
+                type: 'file',
                 mimeType: 'image/png',
+                data: Buffer.from([0, 1, 2, 3]).toString('base64'),
                 providerOptions: {
                   openai: {
                     imageDetail: 'low',
@@ -261,7 +263,7 @@ describe('convertToOpenAIResponsesMessages', () => {
           ],
           systemMessageMode: 'system',
         });
-      }).toThrow('Only PDF files are supported in user messages');
+      }).toThrow('file part media type text/plain');
     });
 
     it('should throw error for file URLs', async () => {
@@ -281,7 +283,7 @@ describe('convertToOpenAIResponsesMessages', () => {
           ],
           systemMessageMode: 'system',
         });
-      }).toThrow('File URLs in user messages');
+      }).toThrow('PDF file parts with URLs');
     });
   });
 

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.ts
@@ -3,7 +3,6 @@ import {
   LanguageModelV2Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
-import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 import { OpenAIResponsesPrompt } from './openai-responses-api-types';
 
 export function convertToOpenAIResponsesMessages({
@@ -56,42 +55,38 @@ export function convertToOpenAIResponsesMessages({
               case 'text': {
                 return { type: 'input_text', text: part.text };
               }
-              case 'image': {
-                return {
-                  type: 'input_image',
-                  image_url:
-                    part.image instanceof URL
-                      ? part.image.toString()
-                      : `data:${
-                          part.mimeType ?? 'image/jpeg'
-                        };base64,${convertUint8ArrayToBase64(part.image)}`,
-
-                  // OpenAI specific extension: image detail
-                  detail: part.providerOptions?.openai?.imageDetail,
-                };
-              }
               case 'file': {
-                if (part.data instanceof URL) {
-                  // The AI SDK automatically downloads files for user file parts with URLs
-                  throw new UnsupportedFunctionalityError({
-                    functionality: 'File URLs in user messages',
-                  });
-                }
+                if (part.mimeType.startsWith('image/')) {
+                  const mimeType =
+                    part.mimeType === 'image/*' ? 'image/jpeg' : part.mimeType;
 
-                switch (part.mimeType) {
-                  case 'application/pdf': {
-                    return {
-                      type: 'input_file',
-                      filename: part.filename ?? `part-${index}.pdf`,
-                      file_data: `data:application/pdf;base64,${part.data}`,
-                    };
-                  }
-                  default: {
+                  return {
+                    type: 'input_image',
+                    image_url:
+                      part.data instanceof URL
+                        ? part.data.toString()
+                        : `data:${mimeType};base64,${part.data}`,
+
+                    // OpenAI specific extension: image detail
+                    detail: part.providerOptions?.openai?.imageDetail,
+                  };
+                } else if (part.mimeType === 'application/pdf') {
+                  if (part.data instanceof URL) {
+                    // The AI SDK automatically downloads files for user file parts with URLs
                     throw new UnsupportedFunctionalityError({
-                      functionality:
-                        'Only PDF files are supported in user messages',
+                      functionality: 'PDF file parts with URLs',
                     });
                   }
+
+                  return {
+                    type: 'input_file',
+                    filename: part.filename ?? `part-${index}.pdf`,
+                    file_data: `data:application/pdf;base64,${part.data}`,
+                  };
+                } else {
+                  throw new UnsupportedFunctionalityError({
+                    functionality: `file part media type ${part.mimeType}`,
+                  });
                 }
               }
             }

--- a/packages/perplexity/src/convert-to-perplexity-messages.test.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.test.ts
@@ -29,38 +29,6 @@ describe('convertToPerplexityMessages', () => {
         ]),
       ).toMatchSnapshot();
     });
-
-    it('should throw an error for user messages with image parts', () => {
-      expect(() => {
-        convertToPerplexityMessages([
-          {
-            role: 'user',
-            content: [
-              { type: 'text', text: 'Hello ' },
-              {
-                type: 'image',
-                image: new Uint8Array([0, 1, 2, 3]),
-                mimeType: 'image/png',
-              },
-            ],
-          },
-        ]);
-      }).toThrow(UnsupportedFunctionalityError);
-    });
-
-    it('should throw an error for user messages with file parts', () => {
-      expect(() => {
-        convertToPerplexityMessages([
-          {
-            role: 'user',
-            content: [
-              { type: 'text', text: 'Document: ' },
-              { type: 'file', data: 'dummy-data', mimeType: 'text/plain' },
-            ],
-          },
-        ]);
-      }).toThrow(UnsupportedFunctionalityError);
-    });
   });
 
   describe('assistant messages', () => {
@@ -73,24 +41,6 @@ describe('convertToPerplexityMessages', () => {
           },
         ]),
       ).toMatchSnapshot();
-    });
-
-    it('should throw an error for assistant messages with tool-call parts', () => {
-      expect(() => {
-        convertToPerplexityMessages([
-          {
-            role: 'assistant',
-            content: [
-              {
-                type: 'tool-call',
-                args: { key: 'value' },
-                toolCallId: 'call-1',
-                toolName: 'example-tool',
-              },
-            ],
-          },
-        ]);
-      }).toThrow(UnsupportedFunctionalityError);
     });
   });
 

--- a/packages/perplexity/src/convert-to-perplexity-messages.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.ts
@@ -1,5 +1,6 @@
 import {
   LanguageModelV2Prompt,
+  LanguageModelV2TextPart,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { PerplexityPrompt } from './perplexity-language-model-prompt';
@@ -22,35 +23,9 @@ export function convertToPerplexityMessages(
           role,
           content: content
             .filter(
-              part =>
-                part.type !== 'reasoning' && part.type !== 'redacted-reasoning',
+              (part): part is LanguageModelV2TextPart => part.type === 'text',
             )
-            .map(part => {
-              switch (part.type) {
-                case 'text': {
-                  return part.text;
-                }
-                case 'image': {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: 'Image content parts in user messages',
-                  });
-                }
-                case 'file': {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: 'File content parts in user messages',
-                  });
-                }
-                case 'tool-call': {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: 'Tool calls in assistant messages',
-                  });
-                }
-                default: {
-                  const _exhaustiveCheck: never = part;
-                  throw new Error(`Unsupported part: ${_exhaustiveCheck}`);
-                }
-              }
-            })
+            .map(part => part.text)
             .join(''),
         });
         break;

--- a/packages/perplexity/src/convert-to-perplexity-messages.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.ts
@@ -1,6 +1,5 @@
 import {
   LanguageModelV2Prompt,
-  LanguageModelV2TextPart,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { PerplexityPrompt } from './perplexity-language-model-prompt';
@@ -22,10 +21,14 @@ export function convertToPerplexityMessages(
         messages.push({
           role,
           content: content
-            .filter(
-              (part): part is LanguageModelV2TextPart => part.type === 'text',
-            )
-            .map(part => part.text)
+            .map(part => {
+              switch (part.type) {
+                case 'text': {
+                  return part.text;
+                }
+              }
+            })
+            .filter(Boolean)
             .join(''),
         });
         break;

--- a/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
@@ -22,11 +22,7 @@ export type LanguageModelV2Message =
       }
     | {
         role: 'user';
-        content: Array<
-          | LanguageModelV2TextPart
-          | LanguageModelV2ImagePart
-          | LanguageModelV2FilePart
-        >;
+        content: Array<LanguageModelV2TextPart | LanguageModelV2FilePart>;
       }
     | {
         role: 'assistant';
@@ -114,31 +110,6 @@ Redacted reasoning data.
 }
 
 /**
-Image content part of a prompt. It contains an image.
- */
-// TODO merge into file part in language model v2
-export interface LanguageModelV2ImagePart {
-  type: 'image';
-
-  /**
-Image data as a Uint8Array (e.g. from a Blob or Buffer) or a URL.
-   */
-  image: Uint8Array | URL;
-
-  /**
-Optional mime type of the image.
-   */
-  mimeType?: string;
-
-  /**
-   * Additional provider-specific options. They are passed through
-   * to the provider from the AI SDK and enable provider-specific
-   * functionality that can be fully encapsulated in the provider.
-   */
-  providerOptions?: LanguageModelV2ProviderOptions;
-}
-
-/**
 File content part of a prompt. It contains a file.
  */
 export interface LanguageModelV2FilePart {
@@ -154,6 +125,7 @@ File data as base64 encoded string or as a URL.
    */
   // Note: base64-encoded strings are used to prevent
   // unnecessary conversions from string to buffer to string
+  // TODO support Uint8Array | string | URL
   data: string | URL;
 
   /**

--- a/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
@@ -130,7 +130,11 @@ File data as base64 encoded string or as a URL.
 
   /**
 Mime type of the file.
+
+Can support wildcards, e.g. `image/*` (in which case the provider needs to take appropriate action).
    */
+  // TODO rename to mediaType or contentType
+  // https://www.iana.org/assignments/media-types/media-types.xhtml
   mimeType: string;
 
   /**

--- a/packages/provider/src/language-model/v2/language-model-v2.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2.ts
@@ -64,7 +64,7 @@ use further optimizations if this flag is set to `true`.
 
 Defaults to `false`.
 */
-  // TODO v2: rename to supportsGrammarGuidedGeneration?
+  // TODO v2: rename to supportsGrammarGuidedGeneration? supports output schemas?
   readonly supportsStructuredOutputs?: boolean;
 
   /**


### PR DESCRIPTION
## Background
Unifying file and image parts on the spec level will enable passing images as file parts in the user-facing level. User-facing image parts remain.

## Tasks

- [x] changeset
- [x] spec update
- [x] core update
- [x] bedrock
- [x] anthropic
- [x] cohere
- [x] google
- [x] groq
- [x] mistral
- [x] openai
- [x] openai compat
- [x] perplexity