### PR TITLE
fix (ai/react): fire tool results after `experimental_throttle`

### DIFF
--- a/packages/react/src/util/delayed-check.ts
+++ b/packages/react/src/util/delayed-check.ts
@@ -1,0 +1,9 @@
+export const createDelayedCheck = (
+  fn: () => Promise<void> | void,
+  delay: number | undefined,
+) => {
+  if (delay) {
+    return () => setTimeout(fn, delay + 50);
+  }
+  return fn;
+};


### PR DESCRIPTION
## Background

Race condition between (1) triggering client-side tool results + (2) messages array mutations, that occurs when `experimental_throttle` is used

Addresses https://github.com/vercel/ai/issues/5023

## Summary

When `experimental_throttle` is present, we add a deliberate delay to:

- `addToolResult`
- The re-triggering of a request after `callChatApi` 

This allows for throttled mutations to "catch up" and tool results are appended after their invocations are present in the array.

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If required, a _patch_ changeset for relevant packages has been added
- [ ] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
