### PR TITLE
fix(rsc): use project references

### DIFF
--- a/packages/rsc/tsconfig.json
+++ b/packages/rsc/tsconfig.json
@@ -2,8 +2,20 @@
   "extends": "./node_modules/@vercel/ai-tsconfig/react-library.json",
   "compilerOptions": {
     "target": "ES2018",
-    "stripInternal": true
+    "stripInternal": true,
+    "rootDir": "src",
+    "outDir": "dist"
   },
-  "include": ["."],
-  "exclude": ["*/dist", "dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "node_modules", "*.config.ts", "tests"],
+  "references": [
+    {
+      "path": "../ai"
+    },
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
       "path": "packages/ai"
     },
     {
+      "path": "packages/rsc"
+    },
+    {
       "path": "packages/amazon-bedrock"
     },
     {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

I noticed we weren't using project references in the rsc package as i forgot to do it with the separation of packages

## Summary

<!-- What did you change? -->

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
