### PR TITLE
chore: refactor file towards source pattern (spec)

### DIFF
--- a/.changeset/itchy-cars-relax.md
+++ b/.changeset/itchy-cars-relax.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider': major
+'ai': major
+---
+
+chore: refactor file towards source pattern (spec)

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1856,19 +1856,31 @@ To see `streamText` in action, check out [these examples](#examples).
               description: 'The type to identify the object as file.',
             },
             {
-              name: 'base64',
-              type: 'string',
-              description: 'File as a base64 encoded string.',
-            },
-            {
-              name: 'uint8Array',
-              type: 'Uint8Array',
-              description: 'File as a Uint8Array.',
-            },
-            {
-              name: 'mediaType',
-              type: 'string',
-              description: 'The IANA media type of the file.',
+              name: 'file',
+              type: 'GeneratedFile',
+              description: 'The file.',
+              properties: [
+                {
+                  type: 'GeneratedFile',
+                  parameters: [
+                    {
+                      name: 'base64',
+                      type: 'string',
+                      description: 'File as a base64 encoded string.',
+                    },
+                    {
+                      name: 'uint8Array',
+                      type: 'Uint8Array',
+                      description: 'File as a Uint8Array.',
+                    },
+                    {
+                      name: 'mediaType',
+                      type: 'string',
+                      description: 'The IANA media type of the file.',
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },

--- a/examples/ai-core/src/stream-text/google-chatbot-image-output.ts
+++ b/examples/ai-core/src/stream-text/google-chatbot-image-output.ts
@@ -32,9 +32,9 @@ async function main() {
         }
 
         case 'file': {
-          if (delta.mediaType.startsWith('image/')) {
-            console.log();
-            await presentImages([delta]);
+          if (delta.file.mediaType.startsWith('image/')) {
+            console.log(delta.file);
+            await presentImages([delta.file]);
           }
         }
       }

--- a/examples/ai-core/src/stream-text/google-image-output.ts
+++ b/examples/ai-core/src/stream-text/google-image-output.ts
@@ -20,8 +20,8 @@ async function main() {
       }
 
       case 'file': {
-        if (part.mediaType.startsWith('image/')) {
-          await presentImages([part]);
+        if (part.file.mediaType.startsWith('image/')) {
+          await presentImages([part.file]);
         }
 
         break;

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -3359,21 +3359,27 @@ exports[`streamText > result.fullStream > should send files 1`] = `
     "type": "step-start",
     "warnings": [],
   },
-  DefaultGeneratedFileWithType {
-    "base64Data": "Hello World",
-    "mediaType": "text/plain",
+  {
+    "file": DefaultGeneratedFileWithType {
+      "base64Data": "Hello World",
+      "mediaType": "text/plain",
+      "type": "file",
+      "uint8ArrayData": undefined,
+    },
     "type": "file",
-    "uint8ArrayData": undefined,
   },
   {
     "textDelta": "Hello!",
     "type": "text-delta",
   },
-  DefaultGeneratedFileWithType {
-    "base64Data": "QkFVRw==",
-    "mediaType": "image/jpeg",
+  {
+    "file": DefaultGeneratedFileWithType {
+      "base64Data": "QkFVRw==",
+      "mediaType": "image/jpeg",
+      "type": "file",
+      "uint8ArrayData": undefined,
+    },
     "type": "file",
-    "uint8ArrayData": undefined,
   },
   {
     "finishReason": "stop",

--- a/packages/ai/core/generate-text/run-tools-transformation.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.ts
@@ -39,13 +39,8 @@ export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
       type: 'redacted-reasoning';
       data: string;
     }
-  | ({
-      type: 'file';
-    } & GeneratedFile)
-  | {
-      type: 'source';
-      source: Source;
-    }
+  | { type: 'file'; file: GeneratedFile }
+  | { type: 'source'; source: Source }
   | ({
       type: 'tool-call';
     } & ToolCallUnion<TOOLS>)
@@ -166,12 +161,13 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
         }
 
         case 'file': {
-          controller.enqueue(
-            new DefaultGeneratedFileWithType({
-              data: chunk.data,
-              mediaType: chunk.mediaType,
+          controller.enqueue({
+            type: 'file',
+            file: new DefaultGeneratedFileWithType({
+              data: chunk.file.data,
+              mediaType: chunk.file.mediaType,
             }),
-          );
+          });
           break;
         }
 

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -317,9 +317,10 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       type: 'source';
       source: Source;
     }
-  | ({
+  | {
       type: 'file';
-    } & GeneratedFile)
+      file: GeneratedFile;
+    }
   | ({
       type: 'tool-call';
     } & ToolCallUnion<TOOLS>)

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -110,14 +110,18 @@ const modelWithFiles = new MockLanguageModelV2({
     stream: convertArrayToReadableStream([
       {
         type: 'file',
-        data: 'Hello World',
-        mediaType: 'text/plain',
+        file: {
+          data: 'Hello World',
+          mediaType: 'text/plain',
+        },
       },
       { type: 'text-delta', textDelta: 'Hello!' },
       {
         type: 'file',
-        data: 'QkFVRw==',
-        mediaType: 'image/jpeg',
+        file: {
+          data: 'QkFVRw==',
+          mediaType: 'image/jpeg',
+        },
       },
       {
         type: 'finish',

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -672,7 +672,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
         }
 
         if (part.type === 'file') {
-          stepFiles.push(part);
+          stepFiles.push(part.file);
         }
 
         if (part.type === 'source') {
@@ -1253,7 +1253,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                     }
 
                     case 'file': {
-                      stepFiles.push(chunk);
+                      stepFiles.push(chunk.file);
                       controller.enqueue(chunk);
                       break;
                     }
@@ -1663,9 +1663,10 @@ However, the LLM results are expected to be small enough to not cause issues.
 
             case 'file': {
               controller.enqueue(
+                // TODO update protocol to v2 or replace with event stream
                 formatDataStreamPart('file', {
-                  mimeType: chunk.mediaType,
-                  data: chunk.base64,
+                  mimeType: chunk.file.mediaType,
+                  data: chunk.file.base64,
                 }),
               );
               break;

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1778,10 +1778,48 @@ describe('doStream', () => {
 
     const events = await convertReadableStreamToArray(stream);
 
-    expect(events.filter(event => event.type === 'error')).toEqual([]); // no errors
-    expect(events.filter(event => event.type === 'file')).toEqual([
-      { type: 'file', mediaType: 'text/plain', data: 'test' },
-    ]);
+    expect(events).toMatchInlineSnapshot(`
+      [
+        {
+          "file": {
+            "data": "test",
+            "mediaType": "text/plain",
+          },
+          "type": "file",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "google": {
+              "groundingMetadata": null,
+              "safetyRatings": [
+                {
+                  "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_HATE_SPEECH",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_HARASSMENT",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                  "probability": "NEGLIGIBLE",
+                },
+              ],
+            },
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 294,
+            "outputTokens": 233,
+          },
+        },
+      ]
+    `);
   });
 
   it('should set finishReason to tool-calls when chunk contains functionCall', async () => {

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -310,8 +310,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
                 for (const part of inlineDataParts) {
                   controller.enqueue({
                     type: 'file',
-                    mediaType: part.inlineData.mimeType,
-                    data: part.inlineData.data,
+                    file: {
+                      mediaType: part.inlineData.mimeType,
+                      data: part.inlineData.data,
+                    },
                   });
                 }
               }

--- a/packages/provider/src/language-model/v2/language-model-v2.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2.ts
@@ -253,11 +253,10 @@ export type LanguageModelV2StreamPart =
   | { type: 'redacted-reasoning'; data: string }
 
   // Sources:
-  // TODO lift up source
   | { type: 'source'; source: LanguageModelV2Source }
 
   // Files:
-  | ({ type: 'file' } & LanguageModelV2File)
+  | { type: 'file'; file: LanguageModelV2File }
 
   // Complete tool calls:
   | ({ type: 'tool-call' } & LanguageModelV2FunctionToolCall)


### PR DESCRIPTION
## Background
Aligning all language model stream outputs towards a pattern similar to what we use for `source`.