### PR TITLE
feat (ai/core): add wrapEmbeddingModel function for embedding model v2 middleware

### DIFF
--- a/.changeset/unlucky-houses-dance.md
+++ b/.changeset/unlucky-houses-dance.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+feat (ai-core): add wrapEmbeddingModel function for embedding model v2 middleware

--- a/content/docs/03-ai-sdk-core/41-embed-middleware.mdx
+++ b/content/docs/03-ai-sdk-core/41-embed-middleware.mdx
@@ -1,0 +1,122 @@
+---
+title: Embedding Model Middleware
+description: Learn how to use middleware to enhance the behavior of embedding models
+---
+
+# Embedding Model Middleware
+
+Embedding model middleware is a way to enhance the behavior of embedding models
+by intercepting and modifying the calls to the embedding model.
+
+It can be used to add features like caching and logging
+in an embedding model agnostic way. Such middleware can be developed and
+distributed independently from the embedding models that they are applied to.
+
+## Using Embedding Model Middleware
+
+You can use embedding model middleware with the `wrapEmbeddingModel` function.
+It takes an embedding model and an embedding model middleware and returns a new
+embedding model that incorporates the middleware.
+
+```ts
+import { wrapEmbeddingModel } from 'ai';
+
+const wrappedEmbeddingModel = wrapEmbeddingModel({
+  model: yourModel,
+  middleware: yourEmbeddingModelMiddleware,
+});
+```
+
+The wrapped embedding model can be used just like any other embedding model, e.g. in `embed`:
+
+```ts highlight="2"
+const result = embed({
+  model: wrappedEmbeddingModel,
+  value: 'sunny day at the beach',
+});
+```
+
+## Multiple middlewares
+
+You can provide multiple middlewares to the `wrapEmbeddingModel` function.
+The middlewares will be applied in the order they are provided.
+
+```ts
+const wrappedEmbeddingModel = wrapEmbeddingModel({
+  model: yourModel,
+  middleware: [firstMiddleware, secondMiddleware],
+});
+
+// applied as: firstMiddleware(secondMiddleware(yourModel))
+```
+
+## Implementing Embedding Model Middleware
+
+<Note>
+  Implementing embedding model middleware is advanced functionality and requires
+  a solid understanding of the [embedding model
+  specification](https://github.com/vercel/ai/blob/v5/packages/provider/src/embedding-model/v2/embedding-model-v2.ts).
+</Note>
+
+You can implement any of the following two functions to modify the behavior of the embedding model:
+
+1. `transformParams`: Transforms the parameters before they are passed to the embedding model.
+2. `wrapEmbed`: Wraps the `doEmbed` method of the [embedding model](https://github.com/vercel/ai/blob/v5/packages/provider/src/embedding-model/v2/embedding-model-v2.ts).
+   You can modify the parameters, call the embedding model, and modify the result.
+
+Here are some examples of how to implement embedding model middleware:
+
+## Examples
+
+<Note>
+  These examples are not meant to be used in production. They are just to show
+  how you can use middleware to enhance the behavior of embedding models.
+</Note>
+
+### Logging
+
+This example shows how to log the parameters and generated text of an embedding model call.
+
+```ts
+import type { EmbeddingModelV2Middleware } from '@ai-sdk/provider';
+
+export const yourEmbedLogMiddleware: EmbeddingModelV2Middleware<string> = {
+  wrapEmbed: async ({ doEmbed, params }) => {
+    console.log('doEmbed called');
+    console.log(`params: ${JSON.stringify(params, null, 2)}`);
+
+    const result = await doEmbed();
+
+    console.log('doEmbed finished');
+    console.log(`embedding: ${result.embeddings}`);
+
+    return result;
+  },
+};
+```
+
+### Caching
+
+This example shows how to build a simple cache for the generated embeddings of an embedding model call.
+
+```ts
+import type { EmbeddingModelV2Middleware } from '@ai-sdk/provider';
+
+const cache = new Map<string, any>();
+
+export const yourEmbedCacheMiddleware: EmbeddingModelV2Middleware<string> = {
+  wrapEmbed: async ({ doEmbed, params }) => {
+    const cacheKey = JSON.stringify(params);
+
+    if (cache.has(cacheKey)) {
+      return cache.get(cacheKey);
+    }
+
+    const result = await doEmbed();
+
+    cache.set(cacheKey, result);
+
+    return result;
+  },
+};
+```

--- a/content/docs/03-ai-sdk-core/index.mdx
+++ b/content/docs/03-ai-sdk-core/index.mdx
@@ -65,6 +65,12 @@ description: Learn about AI SDK Core.
       href: '/docs/ai-sdk-core/middleware',
     },
     {
+      title: 'Embedding Model Middleware',
+      description:
+        'Learn how to use embedding model middleware with AI SDK Core.',
+      href: '/docs/ai-sdk-core/embedding-middleware',
+    },
+    {
       title: 'Error Handling',
       description: 'Learn how to handle errors with AI SDK Core.',
       href: '/docs/ai-sdk-core/error-handling',

--- a/content/docs/07-reference/01-ai-sdk-core/70-wrap-embedding-model.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/70-wrap-embedding-model.mdx
@@ -1,0 +1,59 @@
+---
+title: wrapEmbeddingModel
+description: Function for wrapping an embedding model with middleware (API Reference)
+---
+
+# `wrapEmbeddingModel()`
+
+The `wrapEmbeddingModel` function provides a way to enhance the behavior of embedding models
+by wrapping them with middleware.
+See [Embedding Model Middleware](/docs/ai-sdk-core/middleware) for more information on middleware.
+
+```ts
+import { wrapEmbeddingModel } from 'ai';
+
+const wrappedEmbeddingModel = wrapEmbeddingModel({
+  model: yourModel,
+  middleware: yourEmbeddingModelMiddleware,
+});
+```
+
+## Import
+
+<Snippet text={`import { wrapEmbeddingModel } from "ai"`} prompt={false} />
+
+## API Signature
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'model',
+      type: 'EmbeddingModelV2',
+      description: 'The original EmbeddingModelV2 instance to be wrapped.',
+    },
+    {
+      name: 'middleware',
+      type: 'EmbeddingModelV2Middleware | EmbeddingModelV2Middleware[]',
+      description:
+        'The middleware to be applied to the embedding model. When multiple middlewares are provided, the first middleware will transform the input first, and the last middleware will be wrapped directly around the model.',
+    },
+    {
+      name: 'modelId',
+      type: 'string',
+      description:
+        "Optional custom model ID to override the original model's ID.",
+    },
+    {
+      name: 'providerId',
+      type: 'string',
+      description:
+        "Optional custom provider ID to override the original model's provider.",
+    },
+  ]}
+/>
+
+### Returns
+
+A new `EmbeddingModelV2` instance with middleware applied.

--- a/content/docs/07-reference/01-ai-sdk-core/71-embedding-model-v2-middleware.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/71-embedding-model-v2-middleware.mdx
@@ -1,0 +1,37 @@
+---
+title: EmbeddingModelV2Middleware
+description: Middleware for enhancing embedding model behavior (API Reference)
+---
+
+# `EmbeddingModelV2Middleware`
+
+Embedding model middleware provides a way to enhance the behavior of embedding models
+by intercepting and modifying the calls to the embedding model. It can be used to add
+features like caching and logging in a embedding model agnostic way.
+
+See [Embedding Model Middleware](/docs/ai-sdk-core/embedding-middleware) for more information.
+
+## Import
+
+<Snippet
+  text={`import type { EmbeddingModelV2Middleware } from "@ai-sdk/provider"`}
+  prompt={false}
+/>
+
+## API Signature
+
+<PropertiesTable
+  content={[
+    {
+      name: 'transformParams',
+      type: '({ params: EmbeddingModelV2CallOptions }) => Promise<EmbeddingModelV2CallOptions>',
+      description:
+        'Transforms the parameters before they are passed to the embedding model.',
+    },
+    {
+      name: 'wrapEmbed',
+      type: '({ doEmbed: DoEmbedFunction, params: EmbeddingModelV2CallOptions, model: EmbeddingModelV2 }) => Promise<DoEmbedResult>',
+      description: 'Wraps the embed operation of the embedding model.',
+    },
+  ]}
+/>

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -108,6 +108,11 @@ It also contains the following helper functions:
       href: '/docs/reference/ai-sdk-core/wrap-language-model',
     },
     {
+      title: 'wrapEmbeddingModel()',
+      description: 'Wraps an embedding model with middleware.',
+      href: '/docs/reference/ai-sdk-core/wrap-embedding-model',
+    },
+    {
       title: 'extractReasoningMiddleware()',
       description:
         'Extracts reasoning from the generated text and exposes it as a `reasoning` property on the result.',

--- a/examples/ai-core/src/middleware/embed-cache-middleware-example.ts
+++ b/examples/ai-core/src/middleware/embed-cache-middleware-example.ts
@@ -1,0 +1,32 @@
+import { openai } from '@ai-sdk/openai';
+import { embed, wrapEmbeddingModel } from 'ai';
+import 'dotenv/config';
+import { yourEmbedCacheMiddleware } from './your-embed-cache-middleware';
+
+async function main() {
+  const modelWithCaching = wrapEmbeddingModel({
+    model: openai.embedding('text-embedding-3-small'),
+    middleware: yourEmbedCacheMiddleware,
+  });
+
+  const start1 = Date.now();
+  const result1 = await embed({
+    model: modelWithCaching,
+    value: 'sunny day at the beach',
+  });
+  const end1 = Date.now();
+
+  const start2 = Date.now();
+  const result2 = await embed({
+    model: modelWithCaching,
+    value: 'sunny day at the beach',
+  });
+  const end2 = Date.now();
+
+  console.log(`Time taken for result1: ${end1 - start1}ms`);
+  console.log(`Time taken for result2: ${end2 - start2}ms`);
+
+  console.log(result1.embedding === result2.embedding);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/middleware/embed-log-middleware-example.ts
+++ b/examples/ai-core/src/middleware/embed-log-middleware-example.ts
@@ -1,0 +1,16 @@
+import { openai } from '@ai-sdk/openai';
+import { embed, wrapEmbeddingModel } from 'ai';
+import 'dotenv/config';
+import { yourEmbedLogMiddleware } from './your-embed-log-middleware';
+
+async function main() {
+  const result = await embed({
+    model: wrapEmbeddingModel({
+      model: openai.embedding('text-embedding-3-small'),
+      middleware: yourEmbedLogMiddleware,
+    }),
+    value: 'sunny day at the beach',
+  });
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/middleware/your-embed-cache-middleware.ts
+++ b/examples/ai-core/src/middleware/your-embed-cache-middleware.ts
@@ -1,0 +1,19 @@
+import type { EmbeddingModelV2Middleware } from '@ai-sdk/provider';
+
+const cache = new Map<string, any>();
+
+export const yourEmbedCacheMiddleware: EmbeddingModelV2Middleware<string> = {
+  wrapEmbed: async ({ doEmbed, params }) => {
+    const cacheKey = JSON.stringify(params);
+
+    if (cache.has(cacheKey)) {
+      return cache.get(cacheKey);
+    }
+
+    const result = await doEmbed();
+
+    cache.set(cacheKey, result);
+
+    return result;
+  },
+};

--- a/examples/ai-core/src/middleware/your-embed-log-middleware.ts
+++ b/examples/ai-core/src/middleware/your-embed-log-middleware.ts
@@ -1,0 +1,15 @@
+import type { EmbeddingModelV2Middleware } from '@ai-sdk/provider';
+
+export const yourEmbedLogMiddleware: EmbeddingModelV2Middleware<string> = {
+  wrapEmbed: async ({ doEmbed, params }) => {
+    console.log('doEmbed called');
+    console.log(`params: ${JSON.stringify(params, null, 2)}`);
+
+    const result = await doEmbed();
+
+    console.log('doEmbed finished');
+    console.log(`embedding: ${result.embeddings}`);
+
+    return result;
+  },
+};

--- a/packages/ai/core/middleware/index.ts
+++ b/packages/ai/core/middleware/index.ts
@@ -5,3 +5,4 @@ export {
   experimental_wrapLanguageModel,
   wrapLanguageModel,
 } from './wrap-language-model';
+export { wrapEmbeddingModel } from './wrap-embedding-model';

--- a/packages/ai/core/middleware/wrap-embedding-model.test.ts
+++ b/packages/ai/core/middleware/wrap-embedding-model.test.ts
@@ -1,0 +1,194 @@
+import { EmbeddingModelV2CallOptions } from '@ai-sdk/provider';
+import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
+import { wrapEmbeddingModel } from './wrap-embedding-model';
+
+describe('wrapEmbeddingModel', () => {
+  it('should pass through model properties', () => {
+    const wrappedModel = wrapEmbeddingModel({
+      model: new MockEmbeddingModelV2({
+        provider: 'test-provider',
+        modelId: 'test-model',
+        maxEmbeddingsPerCall: 10,
+        supportsParallelCalls: true,
+      }),
+      middleware: {
+        middlewareVersion: 'v2',
+      },
+    });
+
+    expect(wrappedModel.provider).toBe('test-provider');
+    expect(wrappedModel.modelId).toBe('test-model');
+    expect(wrappedModel.maxEmbeddingsPerCall).toBe(10);
+    expect(wrappedModel.supportsParallelCalls).toBe(true);
+  });
+
+  it('should override provider and modelId if provided', () => {
+    const wrappedModel = wrapEmbeddingModel({
+      model: new MockEmbeddingModelV2(),
+      middleware: {
+        middlewareVersion: 'v2',
+      },
+      providerId: 'override-provider',
+      modelId: 'override-model',
+    });
+
+    expect(wrappedModel.provider).toBe('override-provider');
+    expect(wrappedModel.modelId).toBe('override-model');
+  });
+
+  it('should call transformParams middleware for doEmbed', async () => {
+    const mockModel = new MockEmbeddingModelV2({
+      doEmbed: vi.fn().mockResolvedValue('mock result'),
+    });
+    const transformParams = vi.fn().mockImplementation(({ params }) => ({
+      ...params,
+      transformed: true,
+    }));
+
+    const wrappedModel = wrapEmbeddingModel({
+      model: mockModel,
+      middleware: {
+        middlewareVersion: 'v2',
+        transformParams,
+      },
+    });
+
+    const params: EmbeddingModelV2CallOptions<string> = {
+      values: ['Hello'],
+    };
+
+    await wrappedModel.doEmbed(params);
+
+    expect(transformParams).toHaveBeenCalledWith({
+      params,
+    });
+
+    expect(mockModel.doEmbed).toHaveBeenCalledWith({
+      ...params,
+      transformed: true,
+    });
+  });
+
+  it('should call wrapEmbed middleware', async () => {
+    const mockModel = new MockEmbeddingModelV2({
+      doEmbed: vi.fn().mockResolvedValue('mock result'),
+    });
+    const wrapEmbed = vi.fn().mockImplementation(({ doEmbed }) => doEmbed());
+
+    const wrappedModel = wrapEmbeddingModel({
+      model: mockModel,
+      middleware: {
+        middlewareVersion: 'v2',
+        wrapEmbed,
+      },
+    });
+
+    const params: EmbeddingModelV2CallOptions<string> = {
+      values: ['Hello'],
+    };
+
+    await wrappedModel.doEmbed(params);
+
+    expect(wrapEmbed).toHaveBeenCalledWith({
+      doEmbed: expect.any(Function),
+      params,
+      model: mockModel,
+    });
+  });
+
+  describe('wrapEmbeddingModel with multiple middlewares', () => {
+    it('should call multiple transformParams middlewares in sequence for doEmbed', async () => {
+      const mockModel = new MockEmbeddingModelV2({
+        doEmbed: vi.fn().mockResolvedValue('final result'),
+      });
+
+      const transformParams1 = vi.fn().mockImplementation(({ params }) => ({
+        ...params,
+        transformationStep1: true,
+      }));
+      const transformParams2 = vi.fn().mockImplementation(({ params }) => ({
+        ...params,
+        transformationStep2: true,
+      }));
+
+      const wrappedModel = wrapEmbeddingModel({
+        model: mockModel,
+        middleware: [
+          {
+            middlewareVersion: 'v2',
+            transformParams: transformParams1,
+          },
+          {
+            middlewareVersion: 'v2',
+            transformParams: transformParams2,
+          },
+        ],
+      });
+
+      const params: EmbeddingModelV2CallOptions<string> = {
+        values: ['Hello'],
+      };
+
+      await wrappedModel.doEmbed(params);
+
+      expect(transformParams1).toHaveBeenCalledWith({
+        params,
+      });
+
+      expect(transformParams2).toHaveBeenCalledWith({
+        params: { ...params, transformationStep1: true },
+      });
+
+      expect(mockModel.doEmbed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transformationStep1: true,
+          transformationStep2: true,
+        }),
+      );
+    });
+
+    it('should chain multiple wrapEmbed middlewares in the correct order', async () => {
+      const mockModel = new MockEmbeddingModelV2({
+        doEmbed: vi.fn().mockResolvedValue('final embed result'),
+      });
+
+      const wrapEmbed1 = vi
+        .fn()
+        .mockImplementation(async ({ doEmbed, params, model }) => {
+          const result = await doEmbed();
+          return `wrapEmbed1(${result})`;
+        });
+      const wrapEmbed2 = vi
+        .fn()
+        .mockImplementation(async ({ doEmbed, params, model }) => {
+          const result = await doEmbed();
+          return `wrapEmbed2(${result})`;
+        });
+
+      const wrappedModel = wrapEmbeddingModel({
+        model: mockModel,
+        middleware: [
+          {
+            middlewareVersion: 'v2',
+            wrapEmbed: wrapEmbed1,
+          },
+          {
+            middlewareVersion: 'v2',
+            wrapEmbed: wrapEmbed2,
+          },
+        ],
+      });
+
+      const params: EmbeddingModelV2CallOptions<string> = {
+        values: ['Hello'],
+      };
+
+      const result = await wrappedModel.doEmbed(params);
+
+      // The middlewares should wrap in order, applying wrapEmbed2 last
+      expect(result).toBe('wrapEmbed1(wrapEmbed2(final embed result))');
+      expect(wrapEmbed1).toHaveBeenCalled();
+      expect(wrapEmbed2).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ai/core/middleware/wrap-embedding-model.ts
+++ b/packages/ai/core/middleware/wrap-embedding-model.ts
@@ -1,0 +1,82 @@
+import {
+  EmbeddingModelV2,
+  EmbeddingModelV2CallOptions,
+  EmbeddingModelV2Middleware,
+} from '@ai-sdk/provider';
+import { asArray } from '../../util/as-array';
+
+/**
+ * Wraps a EmbeddingModelV2 instance with middleware functionality.
+ * This function allows you to apply middleware to transform parameters,
+ * wrap embed operations of an embedding model.
+ *
+ * @param options - Configuration options for wrapping the embedding model.
+ * @param options.model - The original EmbeddingModelV2 instance to be wrapped.
+ * @param options.middleware - The middleware to be applied to the embedding model. When multiple middlewares are provided, the first middleware will transform the input first, and the last middleware will be wrapped directly around the model.
+ * @param options.modelId - Optional custom model ID to override the original model's ID.
+ * @param options.providerId - Optional custom provider ID to override the original model's provider.
+ * @returns A new EmbeddingModelV2 instance with middleware applied.
+ */
+export const wrapEmbeddingModel = <VALUE>({
+  model,
+  middleware: middlewareArg,
+  modelId,
+  providerId,
+}: {
+  model: EmbeddingModelV2<VALUE>;
+  middleware:
+    | EmbeddingModelV2Middleware<VALUE>
+    | EmbeddingModelV2Middleware<VALUE>[];
+  modelId?: string;
+  providerId?: string;
+}): EmbeddingModelV2<VALUE> => {
+  return asArray(middlewareArg)
+    .reverse()
+    .reduce((wrappedModel, middleware) => {
+      return doWrap({ model: wrappedModel, middleware, modelId, providerId });
+    }, model);
+};
+
+const doWrap = <VALUE>({
+  model,
+  middleware: { transformParams, wrapEmbed },
+  modelId,
+  providerId,
+}: {
+  model: EmbeddingModelV2<VALUE>;
+  middleware: EmbeddingModelV2Middleware<VALUE>;
+  modelId?: string;
+  providerId?: string;
+}): EmbeddingModelV2<VALUE> => {
+  async function doTransform({
+    params,
+  }: {
+    params: EmbeddingModelV2CallOptions<VALUE>;
+  }) {
+    return transformParams ? await transformParams({ params }) : params;
+  }
+
+  return {
+    specificationVersion: 'v2',
+
+    provider: providerId ?? model.provider,
+    modelId: modelId ?? model.modelId,
+
+    maxEmbeddingsPerCall: model.maxEmbeddingsPerCall,
+    supportsParallelCalls: model.supportsParallelCalls,
+
+    async doEmbed(
+      params: EmbeddingModelV2CallOptions<VALUE>,
+    ): Promise<Awaited<ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>>> {
+      const transformedParams = await doTransform({ params });
+      const doEmbed = async () => model.doEmbed(transformedParams);
+      return wrapEmbed
+        ? wrapEmbed({
+            doEmbed,
+            params: transformedParams,
+            model,
+          })
+        : doEmbed();
+    },
+  };
+};

--- a/packages/provider/src/embedding-model-middleware/index.ts
+++ b/packages/provider/src/embedding-model-middleware/index.ts
@@ -1,0 +1,1 @@
+export * from './v2/index';

--- a/packages/provider/src/embedding-model-middleware/v2/embedding-model-v2-middleware.ts
+++ b/packages/provider/src/embedding-model-middleware/v2/embedding-model-v2-middleware.ts
@@ -1,0 +1,39 @@
+import { EmbeddingModelV2 } from '../../embedding-model/v2/embedding-model-v2';
+import { EmbeddingModelV2CallOptions } from '../../embedding-model/v2/embedding-model-v2-call-options';
+
+/**
+ * Middleware for EmbeddingModelV2.
+ * This type defines the structure for middleware that can be used to modify
+ * the behavior of EmbeddingModelV2 operations.
+ */
+export type EmbeddingModelV2Middleware<VALUE> = {
+  /**
+   * Middleware specification version. Use `v2` for the current version.
+   */
+  middlewareVersion?: 'v2' | undefined; // backwards compatibility
+
+  /**
+   * Transforms the parameters before they are passed to the embedding model.
+   * @param options - Object containing the parameters.
+   * @param options.params - The original parameters for the embedding model call.
+   * @returns A promise that resolves to the transformed parameters.
+   */
+  transformParams?: (options: {
+    params: EmbeddingModelV2CallOptions<VALUE>;
+  }) => PromiseLike<EmbeddingModelV2CallOptions<VALUE>>;
+
+  /**
+   * Wraps the embed operation of the embedding model.
+   * @param options - Object containing the embed function, parameters, and model.
+   * @param options.doEmbed - The original embed function.
+   * @param options.params - The parameters for the embed call. If the
+   * `transformParams` middleware is used, this will be the transformed parameters.
+   * @param options.model - The embedding model instance.
+   * @returns A promise that resolves to the result of the embed operation.
+   */
+  wrapEmbed?: (options: {
+    doEmbed: () => ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>;
+    params: EmbeddingModelV2CallOptions<VALUE>;
+    model: EmbeddingModelV2<VALUE>;
+  }) => Promise<Awaited<ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>>>;
+};

--- a/packages/provider/src/embedding-model-middleware/v2/index.ts
+++ b/packages/provider/src/embedding-model-middleware/v2/index.ts
@@ -1,0 +1,1 @@
+export * from './embedding-model-v2-middleware';

--- a/packages/provider/src/embedding-model/v2/embedding-model-v2-call-options.ts
+++ b/packages/provider/src/embedding-model/v2/embedding-model-v2-call-options.ts
@@ -1,0 +1,17 @@
+export type EmbeddingModelV2CallOptions<VALUE> = {
+  /**
+List of values to embed.
+   */
+  values: Array<VALUE>;
+
+  /**
+Abort signal for cancelling the operation.
+   */
+  abortSignal?: AbortSignal;
+
+  /**
+Additional HTTP headers to be sent with the request.
+Only applicable for HTTP-based providers.
+   */
+  headers?: Record<string, string | undefined>;
+};

--- a/packages/provider/src/embedding-model/v2/embedding-model-v2.ts
+++ b/packages/provider/src/embedding-model/v2/embedding-model-v2.ts
@@ -1,3 +1,4 @@
+import { EmbeddingModelV2CallOptions } from './embedding-model-v2-call-options';
 import { EmbeddingModelV2Embedding } from './embedding-model-v2-embedding';
 
 /**
@@ -44,23 +45,7 @@ Generates a list of embeddings for the given input text.
 Naming: "do" prefix to prevent accidental direct usage of the method
 by the user.
    */
-  doEmbed(options: {
-    /**
-List of values to embed.
-     */
-    values: Array<VALUE>;
-
-    /**
-Abort signal for cancelling the operation.
-     */
-    abortSignal?: AbortSignal;
-
-    /**
-  Additional HTTP headers to be sent with the request.
-  Only applicable for HTTP-based providers.
-     */
-    headers?: Record<string, string | undefined>;
-  }): PromiseLike<{
+  doEmbed(options: EmbeddingModelV2CallOptions<VALUE>): PromiseLike<{
     /**
 Generated embeddings. They are in the same order as the input values.
      */

--- a/packages/provider/src/embedding-model/v2/index.ts
+++ b/packages/provider/src/embedding-model/v2/index.ts
@@ -1,2 +1,3 @@
 export * from './embedding-model-v2';
 export * from './embedding-model-v2-embedding';
+export * from './embedding-model-v2-call-options';

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,4 +1,5 @@
 export * from './embedding-model/index';
+export * from './embedding-model-middleware/index';
 export * from './errors/index';
 export * from './image-model/index';
 export * from './json-value/index';


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this necessary? -->
Currently the AI SDK allows creating middleware for language models but not for embedding models.

## Summary

<!-- What did you change? -->
I created the `wrapEmbeddingModel` function, which enables the addition of middleware to embedding model v2 calls. This provides benefits similar to those gained from adding middleware to language models, such as caching and logging.

See the example below that demonstrates caching embedding model calls:

```tsx
import type { EmbeddingModelV2Middleware } from '@ai-sdk/provider';

const cache = new Map<string, any>();

export const yourEmbedCacheMiddleware: EmbeddingModelV2Middleware<string> = {
  wrapEmbed: async ({ doEmbed, params }) => {
    const cacheKey = JSON.stringify(params);

    if (cache.has(cacheKey)) {
      return cache.get(cacheKey);
    }

    const result = await doEmbed();

    cache.set(cacheKey, result);

    return result;
  },
};


async function main() {
  const modelWithCaching = wrapEmbeddingModel({
    model: openai.embedding('text-embedding-3-small'),
    middleware: yourEmbedCacheMiddleware,
  });

  const start1 = Date.now();
  const result1 = await embed({
    model: modelWithCaching,
    value: 'sunny day at the beach',
  });
  const end1 = Date.now();

  const start2 = Date.now();
  const result2 = await embed({
    model: modelWithCaching,
    value: 'sunny day at the beach',
  });
  const end2 = Date.now();

  console.log(`Time taken for result1: ${end1 - start1}ms`);
  console.log(`Time taken for result2: ${end2 - start2}ms`);

  console.log(result1.embedding === result2.embedding);
}

main().catch(console.error);
```

```
Time taken for result1: 767ms
Time taken for result2: 0ms
true
```

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
