### PR TITLE
chore (provider): extract shared provider options and metadata (spec)

### DIFF
--- a/.changeset/neat-pillows-occur.md
+++ b/.changeset/neat-pillows-occur.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+chore (provider): extract shared provider options and metadata (spec)

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -3,7 +3,7 @@ import {
   LanguageModelV2CallOptions,
   LanguageModelV2FinishReason,
   LanguageModelV2LogProbs,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
 } from '@ai-sdk/provider';
@@ -1113,5 +1113,5 @@ export type ObjectStreamInputPart =
       finishReason: LanguageModelV2FinishReason;
       logprobs?: LanguageModelV2LogProbs;
       usage: LanguageModelV2Usage;
-      providerMetadata?: LanguageModelV2ProviderMetadata;
+      providerMetadata?: SharedV2ProviderMetadata;
     };

--- a/packages/ai/core/middleware/default-settings-middleware.ts
+++ b/packages/ai/core/middleware/default-settings-middleware.ts
@@ -1,7 +1,7 @@
 import {
   LanguageModelV2CallOptions,
   LanguageModelV2Middleware,
-  LanguageModelV2ProviderOptions,
+  SharedV2ProviderOptions,
 } from '@ai-sdk/provider';
 import { mergeObjects } from '../util/merge-objects';
 
@@ -13,7 +13,7 @@ export function defaultSettingsMiddleware({
 }: {
   settings: Partial<
     LanguageModelV2CallOptions & {
-      providerOptions?: LanguageModelV2ProviderOptions;
+      providerOptions?: SharedV2ProviderOptions;
     }
   >;
 }): LanguageModelV2Middleware {

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -19,7 +19,7 @@ export type {
   LanguageModelV2ObjectGenerationMode,
   LanguageModelV2Prompt,
   LanguageModelV2ProviderDefinedTool,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   LanguageModelV2StreamPart,
   LanguageModelV2TextPart,
   LanguageModelV2ToolCallPart,

--- a/packages/ai/core/types/provider-metadata.ts
+++ b/packages/ai/core/types/provider-metadata.ts
@@ -1,4 +1,7 @@
-import { SharedV2ProviderMetadata } from '@ai-sdk/provider';
+import {
+  SharedV2ProviderMetadata,
+  SharedV2ProviderOptions,
+} from '@ai-sdk/provider';
 import { z } from 'zod';
 import { jsonValueSchema } from './json-value';
 
@@ -16,8 +19,7 @@ Additional provider-specific options.
 They are passed through to the provider from the AI SDK and enable
 provider-specific functionality that can be fully encapsulated in the provider.
  */
-// TODO change to LanguageModelV2ProviderOptions in language model v2
-export type ProviderOptions = SharedV2ProviderMetadata;
+export type ProviderOptions = SharedV2ProviderOptions;
 
 export const providerMetadataSchema: z.ZodType<ProviderMetadata> = z.record(
   z.string(),

--- a/packages/ai/core/types/provider-metadata.ts
+++ b/packages/ai/core/types/provider-metadata.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV2ProviderMetadata } from '@ai-sdk/provider';
+import { SharedV2ProviderMetadata } from '@ai-sdk/provider';
 import { z } from 'zod';
 import { jsonValueSchema } from './json-value';
 
@@ -8,7 +8,7 @@ Additional provider-specific metadata that is returned from the provider.
 This is needed to enable provider-specific functionality that can be
 fully encapsulated in the provider.
  */
-export type ProviderMetadata = LanguageModelV2ProviderMetadata;
+export type ProviderMetadata = SharedV2ProviderMetadata;
 
 /**
 Additional provider-specific options.
@@ -17,7 +17,7 @@ They are passed through to the provider from the AI SDK and enable
 provider-specific functionality that can be fully encapsulated in the provider.
  */
 // TODO change to LanguageModelV2ProviderOptions in language model v2
-export type ProviderOptions = LanguageModelV2ProviderMetadata;
+export type ProviderOptions = SharedV2ProviderMetadata;
 
 export const providerMetadataSchema: z.ZodType<ProviderMetadata> = z.record(
   z.string(),

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -4,7 +4,7 @@ import {
   LanguageModelV2,
   LanguageModelV2CallWarning,
   LanguageModelV2FinishReason,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
 } from '@ai-sdk/provider';
@@ -315,8 +315,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
       inputTokens: undefined,
       outputTokens: undefined,
     };
-    let providerMetadata: LanguageModelV2ProviderMetadata | undefined =
-      undefined;
+    let providerMetadata: SharedV2ProviderMetadata | undefined = undefined;
 
     const toolCallContentBlocks: Record<
       number,

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -2,7 +2,7 @@ import {
   JSONObject,
   LanguageModelV2Message,
   LanguageModelV2Prompt,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { convertToBase64, createIdGenerator } from '@ai-sdk/provider-utils';
@@ -20,7 +20,7 @@ import {
 const generateFileId = createIdGenerator({ prefix: 'file', size: 16 });
 
 function getCachePoint(
-  providerMetadata: LanguageModelV2ProviderMetadata | undefined,
+  providerMetadata: SharedV2ProviderMetadata | undefined,
 ): BedrockCachePoint | undefined {
   return providerMetadata?.bedrock?.cachePoint as BedrockCachePoint | undefined;
 }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -3,7 +3,7 @@ import {
   LanguageModelV2CallWarning,
   LanguageModelV2FinishReason,
   LanguageModelV2FunctionToolCall,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
   UnsupportedFunctionalityError,
@@ -359,8 +359,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
       }
     > = {};
 
-    let providerMetadata: LanguageModelV2ProviderMetadata | undefined =
-      undefined;
+    let providerMetadata: SharedV2ProviderMetadata | undefined = undefined;
 
     let blockType:
       | 'text'

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -2,7 +2,7 @@ import {
   LanguageModelV2CallWarning,
   LanguageModelV2Message,
   LanguageModelV2Prompt,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import {
@@ -32,7 +32,7 @@ export function convertToAnthropicMessagesPrompt({
   const messages: AnthropicMessagesPrompt['messages'] = [];
 
   function getCacheControl(
-    providerMetadata: LanguageModelV2ProviderMetadata | undefined,
+    providerMetadata: SharedV2ProviderMetadata | undefined,
   ): AnthropicCacheControl | undefined {
     const anthropic = providerMetadata?.anthropic;
 

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -2,7 +2,7 @@ import {
   LanguageModelV2,
   LanguageModelV2CallWarning,
   LanguageModelV2FinishReason,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   LanguageModelV2Source,
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
@@ -258,8 +258,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
       inputTokens: undefined,
       outputTokens: undefined,
     };
-    let providerMetadata: LanguageModelV2ProviderMetadata | undefined =
-      undefined;
+    let providerMetadata: SharedV2ProviderMetadata | undefined = undefined;
 
     const generateId = this.config.generateId;
     let hasToolCalls = false;

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -3,7 +3,7 @@ import {
   LanguageModelV2,
   LanguageModelV2CallWarning,
   LanguageModelV2FinishReason,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
 } from '@ai-sdk/provider';
@@ -250,7 +250,7 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
     };
     let isFirstChunk = true;
 
-    let providerMetadata: LanguageModelV2ProviderMetadata | undefined;
+    let providerMetadata: SharedV2ProviderMetadata | undefined;
     return {
       stream: response.pipeThrough(
         new TransformStream<

--- a/packages/openai-compatible/src/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/convert-to-openai-compatible-chat-messages.ts
@@ -1,12 +1,12 @@
 import {
   LanguageModelV2Prompt,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { OpenAICompatibleChatPrompt } from './openai-compatible-api-types';
 
 function getOpenAIMetadata(message: {
-  providerOptions?: LanguageModelV2ProviderMetadata;
+  providerOptions?: SharedV2ProviderMetadata;
 }) {
   return message?.providerOptions?.openaiCompatible ?? {};
 }

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -5,7 +5,7 @@ import {
   LanguageModelV2CallWarning,
   LanguageModelV2FinishReason,
   LanguageModelV2ObjectGenerationMode,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider';
 import {
@@ -217,7 +217,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
     const choice = responseBody.choices[0];
 
     // provider metadata:
-    const providerMetadata: LanguageModelV2ProviderMetadata = {
+    const providerMetadata: SharedV2ProviderMetadata = {
       [this.providerOptionsName]: {},
       ...this.config.metadataExtractor?.extractMetadata?.({
         parsedBody: rawResponse,
@@ -539,7 +539,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
           },
 
           flush(controller) {
-            const providerMetadata: LanguageModelV2ProviderMetadata = {
+            const providerMetadata: SharedV2ProviderMetadata = {
               [providerOptionsName]: {},
               ...metadataExtractor?.buildMetadata(),
             };

--- a/packages/openai-compatible/src/openai-compatible-metadata-extractor.ts
+++ b/packages/openai-compatible/src/openai-compatible-metadata-extractor.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV2ProviderMetadata } from '@ai-sdk/provider';
+import { SharedV2ProviderMetadata } from '@ai-sdk/provider';
 
 /**
 Extracts provider-specific metadata from API responses.
@@ -18,7 +18,7 @@ export type MetadataExtractor = {
     parsedBody,
   }: {
     parsedBody: unknown;
-  }) => LanguageModelV2ProviderMetadata | undefined;
+  }) => SharedV2ProviderMetadata | undefined;
 
   /**
    * Creates an extractor for handling streaming responses. The returned object provides
@@ -43,6 +43,6 @@ export type MetadataExtractor = {
      * @returns Provider-specific metadata or undefined if no metadata is available.
      *          The metadata should be under a key indicating the provider id.
      */
-    buildMetadata(): LanguageModelV2ProviderMetadata | undefined;
+    buildMetadata(): SharedV2ProviderMetadata | undefined;
   };
 };

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -5,7 +5,7 @@ import {
   LanguageModelV2CallWarning,
   LanguageModelV2FinishReason,
   LanguageModelV2LogProbs,
-  LanguageModelV2ProviderMetadata,
+  SharedV2ProviderMetadata,
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
 } from '@ai-sdk/provider';
@@ -324,7 +324,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
     // provider metadata:
     const completionTokenDetails = response.usage?.completion_tokens_details;
     const promptTokenDetails = response.usage?.prompt_tokens_details;
-    const providerMetadata: LanguageModelV2ProviderMetadata = { openai: {} };
+    const providerMetadata: SharedV2ProviderMetadata = { openai: {} };
     if (completionTokenDetails?.reasoning_tokens != null) {
       providerMetadata.openai.reasoningTokens =
         completionTokenDetails?.reasoning_tokens;
@@ -418,7 +418,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
     let logprobs: LanguageModelV2LogProbs;
     let isFirstChunk = true;
 
-    const providerMetadata: LanguageModelV2ProviderMetadata = { openai: {} };
+    const providerMetadata: SharedV2ProviderMetadata = { openai: {} };
 
     return {
       stream: response.pipeThrough(

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -2,9 +2,10 @@ export * from './embedding-model/index';
 export * from './errors/index';
 export * from './image-model/index';
 export * from './json-value/index';
-export * from './language-model/index';
 export * from './language-model-middleware/index';
+export * from './language-model/index';
 export * from './provider/index';
+export * from './shared/index';
 export * from './transcription-model/index';
 
 export type { JSONSchema7, JSONSchema7Definition } from 'json-schema';

--- a/packages/provider/src/language-model/v2/index.ts
+++ b/packages/provider/src/language-model/v2/index.ts
@@ -9,8 +9,6 @@ export * from './language-model-v2-function-tool-call';
 export * from './language-model-v2-logprobs';
 export * from './language-model-v2-prompt';
 export * from './language-model-v2-provider-defined-tool';
-export * from './language-model-v2-provider-metadata';
-export * from './language-model-v2-provider-options';
 export * from './language-model-v2-source';
 export * from './language-model-v2-tool-choice';
 export * from './language-model-v2-usage';

--- a/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
@@ -1,8 +1,8 @@
 import { JSONSchema7 } from 'json-schema';
+import { SharedV2ProviderOptions } from '../../shared/v2/shared-v2-provider-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
 import { LanguageModelV2Prompt } from './language-model-v2-prompt';
 import { LanguageModelV2ProviderDefinedTool } from './language-model-v2-provider-defined-tool';
-import { LanguageModelV2ProviderOptions } from './language-model-v2-provider-options';
 import { LanguageModelV2ToolChoice } from './language-model-v2-tool-choice';
 
 export type LanguageModelV2CallOptions = {
@@ -130,5 +130,5 @@ Only applicable for HTTP-based providers.
    * to the provider from the AI SDK and enable provider-specific
    * functionality that can be fully encapsulated in the provider.
    */
-  providerOptions?: LanguageModelV2ProviderOptions;
+  providerOptions?: SharedV2ProviderOptions;
 };

--- a/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
@@ -1,5 +1,5 @@
+import { SharedV2ProviderOptions } from '../../shared/v2/shared-v2-provider-options';
 import { LanguageModelV2DataContent } from './language-model-v2-data-content';
-import { LanguageModelV2ProviderOptions } from './language-model-v2-provider-options';
 
 /**
 A prompt is a list of messages.
@@ -45,7 +45,7 @@ export type LanguageModelV2Message =
      * to the provider from the AI SDK and enable provider-specific
      * functionality that can be fully encapsulated in the provider.
      */
-    providerOptions?: LanguageModelV2ProviderOptions;
+    providerOptions?: SharedV2ProviderOptions;
   };
 
 /**
@@ -64,7 +64,7 @@ The text content.
    * to the provider from the AI SDK and enable provider-specific
    * functionality that can be fully encapsulated in the provider.
    */
-  providerOptions?: LanguageModelV2ProviderOptions;
+  providerOptions?: SharedV2ProviderOptions;
 }
 
 /**
@@ -88,7 +88,7 @@ An optional signature for verifying that the reasoning originated from the model
    * to the provider from the AI SDK and enable provider-specific
    * functionality that can be fully encapsulated in the provider.
    */
-  providerOptions?: LanguageModelV2ProviderOptions;
+  providerOptions?: SharedV2ProviderOptions;
 }
 
 /**
@@ -107,7 +107,7 @@ Redacted reasoning data.
    * to the provider from the AI SDK and enable provider-specific
    * functionality that can be fully encapsulated in the provider.
    */
-  providerOptions?: LanguageModelV2ProviderOptions;
+  providerOptions?: SharedV2ProviderOptions;
 }
 
 /**
@@ -140,7 +140,7 @@ Can support wildcards, e.g. `image/*` (in which case the provider needs to take 
    * to the provider from the AI SDK and enable provider-specific
    * functionality that can be fully encapsulated in the provider.
    */
-  providerOptions?: LanguageModelV2ProviderOptions;
+  providerOptions?: SharedV2ProviderOptions;
 }
 
 /**
@@ -169,7 +169,7 @@ Arguments of the tool call. This is a JSON-serializable object that matches the 
    * to the provider from the AI SDK and enable provider-specific
    * functionality that can be fully encapsulated in the provider.
    */
-  providerOptions?: LanguageModelV2ProviderOptions;
+  providerOptions?: SharedV2ProviderOptions;
 }
 
 /**
@@ -233,5 +233,5 @@ IANA media type of the image.
    * to the provider from the AI SDK and enable provider-specific
    * functionality that can be fully encapsulated in the provider.
    */
-  providerOptions?: LanguageModelV2ProviderOptions;
+  providerOptions?: SharedV2ProviderOptions;
 }

--- a/packages/provider/src/language-model/v2/language-model-v2-source.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-source.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV2ProviderMetadata } from './language-model-v2-provider-metadata';
+import { SharedV2ProviderMetadata } from '../../shared/v2/shared-v2-provider-metadata';
 
 /**
  * A source that has been used as input to generate the response.
@@ -27,5 +27,5 @@ export type LanguageModelV2Source = {
   /**
    * Additional provider metadata for the source.
    */
-  providerMetadata?: LanguageModelV2ProviderMetadata;
+  providerMetadata?: SharedV2ProviderMetadata;
 };

--- a/packages/provider/src/language-model/v2/language-model-v2-usage.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-usage.ts
@@ -1,5 +1,3 @@
-import { LanguageModelV2ProviderMetadata } from './language-model-v2-provider-metadata';
-
 /**
  * Usage information for a language model call.
  */

--- a/packages/provider/src/language-model/v2/language-model-v2.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2.ts
@@ -1,10 +1,10 @@
+import { SharedV2ProviderMetadata } from '../../shared/v2/shared-v2-provider-metadata';
 import { LanguageModelV2CallOptions } from './language-model-v2-call-options';
 import { LanguageModelV2CallWarning } from './language-model-v2-call-warning';
 import { LanguageModelV2File } from './language-model-v2-file';
 import { LanguageModelV2FinishReason } from './language-model-v2-finish-reason';
 import { LanguageModelV2FunctionToolCall } from './language-model-v2-function-tool-call';
 import { LanguageModelV2LogProbs } from './language-model-v2-logprobs';
-import { LanguageModelV2ProviderMetadata } from './language-model-v2-provider-metadata';
 import { LanguageModelV2Source } from './language-model-v2-source';
 import { LanguageModelV2Usage } from './language-model-v2-usage';
 
@@ -157,7 +157,7 @@ Additional provider-specific metadata. They are passed through
 from the provider to the AI SDK and enable provider-specific
 results that can be fully encapsulated in the provider.
      */
-    providerMetadata?: LanguageModelV2ProviderMetadata;
+    providerMetadata?: SharedV2ProviderMetadata;
 
     /**
 Optional request information for telemetry and debugging purposes.
@@ -285,7 +285,7 @@ export type LanguageModelV2StreamPart =
   | {
       type: 'finish';
       finishReason: LanguageModelV2FinishReason;
-      providerMetadata?: LanguageModelV2ProviderMetadata;
+      providerMetadata?: SharedV2ProviderMetadata;
       usage: LanguageModelV2Usage;
 
       // @deprecated - will be changed into a provider-specific extension in v2

--- a/packages/provider/src/shared/index.ts
+++ b/packages/provider/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './v2/index';

--- a/packages/provider/src/shared/v2/index.ts
+++ b/packages/provider/src/shared/v2/index.ts
@@ -1,0 +1,2 @@
+export * from './shared-v2-provider-metadata';
+export * from './shared-v2-provider-options';

--- a/packages/provider/src/shared/v2/shared-v2-provider-metadata.ts
+++ b/packages/provider/src/shared/v2/shared-v2-provider-metadata.ts
@@ -21,7 +21,7 @@ import { JSONValue } from '../../json-value/json-value';
  * }
  * ```
  */
-export type LanguageModelV2ProviderMetadata = Record<
+export type SharedV2ProviderMetadata = Record<
   string,
   Record<string, JSONValue>
 >;

--- a/packages/provider/src/shared/v2/shared-v2-provider-options.ts
+++ b/packages/provider/src/shared/v2/shared-v2-provider-options.ts
@@ -21,7 +21,4 @@ import { JSONValue } from '../../json-value/json-value';
  * }
  * ```
  */
-export type LanguageModelV2ProviderOptions = Record<
-  string,
-  Record<string, JSONValue>
->;
+export type SharedV2ProviderOptions = Record<string, Record<string, JSONValue>>;


### PR DESCRIPTION
## Background

All models will support provider options and metadata in a similar way. They are a shared type.

## Summary

Extract provider options and metadata into `SharedV2ProviderOptions` and `SharedV2ProviderMetadata`.