### PR TITLE
chore (ai): remove provider re-exports

### DIFF
--- a/.changeset/brown-poems-boil.md
+++ b/.changeset/brown-poems-boil.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore (ai): remove provider re-exports

--- a/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
+++ b/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
@@ -1,5 +1,3 @@
-import 'dotenv/config';
-import { describe, it, expect } from 'vitest';
 import {
   createVertexAnthropic as createVertexAnthropicNode,
   vertexAnthropic,
@@ -9,8 +7,11 @@ import {
   createVertexAnthropic as createVertexAnthropicEdge,
   vertexAnthropic as vertexAnthropicEdge,
 } from '@ai-sdk/google-vertex/anthropic/edge';
-import { generateText, APICallError, LanguageModelV2 } from 'ai';
+import { LanguageModelV2 } from '@ai-sdk/provider';
+import { APICallError, generateText } from 'ai';
+import 'dotenv/config';
 import fs from 'fs';
+import { describe, expect, it } from 'vitest';
 import {
   createFeatureTestSuite,
   createLanguageModelWithCapabilities,

--- a/examples/ai-core/src/e2e/google-vertex.test.ts
+++ b/examples/ai-core/src/e2e/google-vertex.test.ts
@@ -1,12 +1,9 @@
+import { vertex as vertexNode } from '@ai-sdk/google-vertex';
+import { vertex as vertexEdge } from '@ai-sdk/google-vertex/edge';
+import { ImageModelV1, LanguageModelV2 } from '@ai-sdk/provider';
+import { APICallError, experimental_generateImage as generateImage } from 'ai';
 import 'dotenv/config';
 import { describe, expect, it, vi } from 'vitest';
-import { vertex as vertexEdge } from '@ai-sdk/google-vertex/edge';
-import { vertex as vertexNode } from '@ai-sdk/google-vertex';
-import {
-  APICallError,
-  LanguageModelV2,
-  experimental_generateImage as generateImage,
-} from 'ai';
 import {
   createEmbeddingModelWithCapabilities,
   createFeatureTestSuite,
@@ -15,7 +12,6 @@ import {
   defaultChatModelCapabilities,
   ModelWithCapabilities,
 } from './feature-test-suite';
-import { ImageModelV1 } from '@ai-sdk/provider';
 
 const RUNTIME_VARIANTS = {
   edge: {

--- a/examples/ai-core/src/e2e/google.test.ts
+++ b/examples/ai-core/src/e2e/google.test.ts
@@ -1,7 +1,8 @@
+import { GoogleErrorData, google as provider } from '@ai-sdk/google';
+import { LanguageModelV2 } from '@ai-sdk/provider';
+import { APICallError } from 'ai';
 import 'dotenv/config';
 import { expect } from 'vitest';
-import { GoogleErrorData, google as provider } from '@ai-sdk/google';
-import { APICallError, LanguageModelV2 } from 'ai';
 import {
   ModelWithCapabilities,
   createEmbeddingModelWithCapabilities,

--- a/examples/ai-core/src/e2e/openai.test.ts
+++ b/examples/ai-core/src/e2e/openai.test.ts
@@ -1,7 +1,8 @@
+import { openai as provider } from '@ai-sdk/openai';
+import { LanguageModelV2 } from '@ai-sdk/provider';
+import { APICallError } from 'ai';
 import 'dotenv/config';
 import { expect } from 'vitest';
-import { openai as provider } from '@ai-sdk/openai';
-import { APICallError, LanguageModelV2 } from 'ai';
 import {
   ModelWithCapabilities,
   createEmbeddingModelWithCapabilities,

--- a/examples/ai-core/src/middleware/add-to-last-user-message.ts
+++ b/examples/ai-core/src/middleware/add-to-last-user-message.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV2CallOptions } from 'ai';
+import { LanguageModelV2CallOptions } from '@ai-sdk/provider';
 
 export function addToLastUserMessage({
   text,

--- a/examples/ai-core/src/middleware/get-last-user-message-text.ts
+++ b/examples/ai-core/src/middleware/get-last-user-message-text.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV2Prompt } from 'ai';
+import { LanguageModelV2Prompt } from '@ai-sdk/provider';
 
 export function getLastUserMessageText({
   prompt,

--- a/packages/ai/core/generate-text/output.ts
+++ b/packages/ai/core/generate-text/output.ts
@@ -1,13 +1,10 @@
+import { LanguageModelV2CallOptions } from '@ai-sdk/provider';
 import { safeParseJSON, safeValidateTypes } from '@ai-sdk/provider-utils';
-import { asSchema, DeepPartial, parsePartialJson, Schema } from '../../core';
 import { z } from 'zod';
+import { asSchema, DeepPartial, parsePartialJson, Schema } from '../../core';
 import { NoObjectGeneratedError } from '../../errors';
 import { injectJsonInstruction } from '../generate-object/inject-json-instruction';
-import {
-  FinishReason,
-  LanguageModel,
-  LanguageModelV2CallOptions,
-} from '../types/language-model';
+import { FinishReason, LanguageModel } from '../types/language-model';
 import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
 import { LanguageModelUsage } from '../types/usage';
 

--- a/packages/ai/core/types/index.ts
+++ b/packages/ai/core/types/index.ts
@@ -9,10 +9,6 @@ export type {
   CoreToolChoice,
   FinishReason,
   LanguageModel,
-  LanguageModelV2,
-  LanguageModelV2CallOptions,
-  LanguageModelV2Prompt,
-  LanguageModelV2StreamPart,
   LogProbs,
   ToolChoice,
 } from './language-model';

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -6,27 +6,6 @@ import {
   LanguageModelV2Source,
 } from '@ai-sdk/provider';
 
-// Re-export LanguageModelV2 types for the middleware:
-// TODO remove in v5
-export type {
-  LanguageModelV2,
-  LanguageModelV2CallOptions,
-  LanguageModelV2CallWarning,
-  LanguageModelV2FilePart,
-  LanguageModelV2FinishReason,
-  LanguageModelV2FunctionToolCall,
-  LanguageModelV2Message,
-  LanguageModelV2ObjectGenerationMode,
-  LanguageModelV2Prompt,
-  LanguageModelV2ProviderDefinedTool,
-  SharedV2ProviderMetadata,
-  LanguageModelV2StreamPart,
-  LanguageModelV2TextPart,
-  LanguageModelV2ToolCallPart,
-  LanguageModelV2ToolChoice,
-  LanguageModelV2ToolResultPart,
-} from '@ai-sdk/provider';
-
 /**
 Language model that is used by the AI SDK Core functions.
 */


### PR DESCRIPTION
## Background
`LanguageModelV2Middleware` is now part of `@ai-sdk/provider` and therefore re-exports are no longer needed.

## Summary
Remove `LanguageModelV2*` re-exports.