### PR TITLE
fix(openai-compatible): change tool_call type schema to nullish

### DIFF
--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -760,7 +760,7 @@ const createOpenAICompatibleChatChunkSchema = <ERROR_SCHEMA extends z.ZodType>(
                   z.object({
                     index: z.number(),
                     id: z.string().nullish(),
-                    type: z.literal('function').optional(),
+                    type: z.literal('function').nullish(),
                     function: z.object({
                       name: z.string().nullish(),
                       arguments: z.string().nullish(),


### PR DESCRIPTION
According to [OpenAI documentation](https://platform.openai.com/docs/guides/function-calling?api-mode=chat&lang=javascript#streaming), `type` in `delta.tool_calls[]` might be `null`:

<img width="782" alt="image" src="https://github.com/user-attachments/assets/fd7ddf72-9eee-4548-824d-d88d555fc407" />
