### PR TITLE
chore: refactor reasoning parts (spec)

### DIFF
--- a/.changeset/metal-insects-tease.md
+++ b/.changeset/metal-insects-tease.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': major
+---
+
+chore: refactor reasoning parts (spec)

--- a/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
@@ -25,11 +25,13 @@ async function main() {
   for await (const part of result.fullStream) {
     switch (part.type) {
       case 'reasoning': {
-        if (!enteredReasoning) {
-          enteredReasoning = true;
-          console.log('\nREASONING:\n');
+        if (part.reasoningType === 'text') {
+          if (!enteredReasoning) {
+            enteredReasoning = true;
+            console.log('\nREASONING:\n');
+          }
+          process.stdout.write(part.text);
         }
-        process.stdout.write(part.textDelta);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
@@ -60,9 +60,12 @@ async function main() {
 
     process.stdout.write('\nAssistant: ');
     for await (const part of result.fullStream) {
-      if (part.type === 'reasoning') {
-        process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
-      } else if (part.type === 'redacted-reasoning') {
+      if (part.type === 'reasoning' && part.reasoningType === 'text') {
+        process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+      } else if (
+        part.type === 'reasoning' &&
+        part.reasoningType === 'redacted'
+      ) {
         process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
       } else if (part.type === 'text-delta') {
         process.stdout.write(part.textDelta);

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
@@ -27,11 +27,13 @@ async function main() {
   for await (const part of result.fullStream) {
     switch (part.type) {
       case 'reasoning': {
-        if (!enteredReasoning) {
-          enteredReasoning = true;
-          console.log('\nREASONING:\n');
+        if (part.reasoningType === 'text') {
+          if (!enteredReasoning) {
+            enteredReasoning = true;
+            console.log('\nREASONING:\n');
+          }
+          process.stdout.write(part.text);
         }
-        process.stdout.write(part.textDelta);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
@@ -20,9 +20,9 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
-      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
-    } else if (part.type === 'redacted-reasoning') {
+    if (part.type === 'reasoning' && part.reasoningType === 'text') {
+      process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+    } else if (part.type === 'reasoning' && part.reasoningType === 'redacted') {
       process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
     } else if (part.type === 'text-delta') {
       process.stdout.write(part.textDelta);

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-chatbot.ts
@@ -60,9 +60,12 @@ async function main() {
 
     process.stdout.write('\nAssistant: ');
     for await (const part of result.fullStream) {
-      if (part.type === 'reasoning') {
-        process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
-      } else if (part.type === 'redacted-reasoning') {
+      if (part.type === 'reasoning' && part.reasoningType === 'text') {
+        process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+      } else if (
+        part.type === 'reasoning' &&
+        part.reasoningType === 'redacted'
+      ) {
         process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
       } else if (part.type === 'text-delta') {
         process.stdout.write(part.textDelta);

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
@@ -36,11 +36,13 @@ async function main() {
   for await (const part of result.fullStream) {
     switch (part.type) {
       case 'reasoning': {
-        if (!enteredReasoning) {
-          enteredReasoning = true;
-          console.log('\nREASONING:\n');
+        if (part.reasoningType === 'text') {
+          if (!enteredReasoning) {
+            enteredReasoning = true;
+            console.log('\nREASONING:\n');
+          }
+          process.stdout.write(part.text);
         }
-        process.stdout.write(part.textDelta);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/anthropic-reasoning.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning.ts
@@ -19,9 +19,9 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
-      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
-    } else if (part.type === 'redacted-reasoning') {
+    if (part.type === 'reasoning' && part.reasoningType === 'text') {
+      process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+    } else if (part.type === 'reasoning' && part.reasoningType === 'redacted') {
       process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
     } else if (part.type === 'text-delta') {
       process.stdout.write(part.textDelta);

--- a/examples/ai-core/src/stream-text/deepseek-reasoning.ts
+++ b/examples/ai-core/src/stream-text/deepseek-reasoning.ts
@@ -9,8 +9,8 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
-      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
+    if (part.type === 'reasoning' && part.reasoningType === 'text') {
+      process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'text-delta') {
       process.stdout.write(part.textDelta);
     }

--- a/examples/ai-core/src/stream-text/fireworks-reasoning.ts
+++ b/examples/ai-core/src/stream-text/fireworks-reasoning.ts
@@ -17,12 +17,12 @@ async function main() {
   let enteredReasoning = false;
   let enteredText = false;
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning' && part.reasoningType === 'text') {
       if (!enteredReasoning) {
         enteredReasoning = true;
         console.log('\nREASONING:\n');
       }
-      process.stdout.write(part.textDelta);
+      process.stdout.write(part.text);
     } else if (part.type === 'text-delta') {
       if (!enteredText) {
         enteredText = true;

--- a/examples/ai-core/src/stream-text/groq-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/groq-reasoning-fullstream.ts
@@ -14,12 +14,12 @@ async function main() {
   let enteredReasoning = false;
   let enteredText = false;
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning' && part.reasoningType === 'text') {
       if (!enteredReasoning) {
         enteredReasoning = true;
         console.log('\nREASONING:\n');
       }
-      process.stdout.write(part.textDelta);
+      process.stdout.write(part.text);
     } else if (part.type === 'text-delta') {
       if (!enteredText) {
         enteredText = true;

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -502,7 +502,8 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > should 
     "warnings": [],
   },
   {
-    "textDelta": "thinking",
+    "reasoningType": "text",
+    "text": "thinking",
     "type": "reasoning",
   },
   {
@@ -2132,7 +2133,8 @@ exports[`streamText > options.onChunk > should return events in order 1`] = `
     "type": "tool-call-delta",
   },
   {
-    "textDelta": "Feeling clever",
+    "reasoningType": "text",
+    "text": "Feeling clever",
     "type": "reasoning",
   },
   {
@@ -3439,32 +3441,39 @@ exports[`streamText > result.fullStream > should send reasoning deltas 1`] = `
     "warnings": [],
   },
   {
-    "textDelta": "I will open the conversation",
+    "reasoningType": "text",
+    "text": "I will open the conversation",
     "type": "reasoning",
   },
   {
-    "textDelta": " with witty banter. ",
+    "reasoningType": "text",
+    "text": " with witty banter. ",
     "type": "reasoning",
   },
   {
+    "reasoningType": "signature",
     "signature": "1234567890",
-    "type": "reasoning-signature",
+    "type": "reasoning",
   },
   {
     "data": "redacted-reasoning-data",
-    "type": "redacted-reasoning",
-  },
-  {
-    "textDelta": "Once the user has relaxed,",
+    "reasoningType": "redacted",
     "type": "reasoning",
   },
   {
-    "textDelta": " I will pry for valuable information.",
+    "reasoningType": "text",
+    "text": "Once the user has relaxed,",
     "type": "reasoning",
   },
   {
+    "reasoningType": "text",
+    "text": " I will pry for valuable information.",
+    "type": "reasoning",
+  },
+  {
+    "reasoningType": "signature",
     "signature": "1234567890",
-    "type": "reasoning-signature",
+    "type": "reasoning",
   },
   {
     "textDelta": "Hi",

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -64,12 +64,18 @@ const modelWithReasoning = new MockLanguageModelV2({
     ...dummyResponseValues,
     reasoning: [
       {
-        type: 'text',
+        type: 'reasoning',
+        reasoningType: 'text',
         text: 'I will open the conversation with witty banter.',
+      },
+      {
+        type: 'reasoning',
+        reasoningType: 'signature',
         signature: 'signature',
       },
       {
-        type: 'redacted',
+        type: 'reasoning',
+        reasoningType: 'redacted',
         data: 'redacted-reasoning-data',
       },
     ],

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -36,6 +36,7 @@ import { ToolCallArray } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair';
 import { ToolResultArray } from './tool-result';
 import { ToolSet } from './tool-set';
+import { LanguageModelV2Reasoning } from '@ai-sdk/provider';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -779,13 +780,7 @@ class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
 }
 
 function asReasoningDetails(
-  reasoning:
-    | string
-    | Array<
-        | { type: 'text'; text: string; signature?: string }
-        | { type: 'redacted'; data: string }
-      >
-    | undefined,
+  reasoning: Array<LanguageModelV2Reasoning> | undefined,
 ): Array<
   | { type: 'text'; text: string; signature?: string }
   | { type: 'redacted'; data: string }
@@ -794,11 +789,37 @@ function asReasoningDetails(
     return [];
   }
 
-  if (typeof reasoning === 'string') {
-    return [{ type: 'text', text: reasoning }];
+  const result: Array<
+    | { type: 'text'; text: string; signature?: string }
+    | { type: 'redacted'; data: string }
+  > = [];
+
+  let activeReasoningText:
+    | { type: 'text'; text: string; signature?: string }
+    | undefined;
+
+  for (const part of reasoning) {
+    if (part.reasoningType === 'text') {
+      if (activeReasoningText == null) {
+        activeReasoningText = { type: 'text', text: part.text };
+        result.push(activeReasoningText);
+      } else {
+        activeReasoningText.text += part.text;
+      }
+    } else if (part.reasoningType === 'signature') {
+      if (activeReasoningText == null) {
+        activeReasoningText = { type: 'text', text: '' };
+        result.push(activeReasoningText);
+      }
+
+      activeReasoningText.signature = part.signature;
+      activeReasoningText = undefined; // signature concludes reasoning part
+    } else if (part.reasoningType === 'redacted') {
+      result.push({ type: 'redacted', data: part.data });
+    }
   }
 
-  return reasoning;
+  return result;
 }
 
 function asFiles(

--- a/packages/ai/core/generate-text/run-tools-transformation.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.ts
@@ -27,18 +27,9 @@ export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
       type: 'text-delta';
       textDelta: string;
     }
-  | {
-      type: 'reasoning';
-      textDelta: string;
-    }
-  | {
-      type: 'reasoning-signature';
-      signature: string;
-    }
-  | {
-      type: 'redacted-reasoning';
-      data: string;
-    }
+  | { type: 'reasoning'; reasoningType: 'text'; text: string }
+  | { type: 'reasoning'; reasoningType: 'signature'; signature: string }
+  | { type: 'reasoning'; reasoningType: 'redacted'; data: string }
   | { type: 'file'; file: GeneratedFile }
   | ({ type: 'source' } & Source)
   | ({ type: 'tool-call' } & ToolCallUnion<TOOLS>)
@@ -149,8 +140,6 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
         // forward:
         case 'text-delta':
         case 'reasoning':
-        case 'reasoning-signature':
-        case 'redacted-reasoning':
         case 'source':
         case 'response-metadata':
         case 'error': {

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -301,18 +301,9 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       type: 'text-delta';
       textDelta: string;
     }
-  | {
-      type: 'reasoning';
-      textDelta: string;
-    }
-  | {
-      type: 'reasoning-signature';
-      signature: string;
-    }
-  | {
-      type: 'redacted-reasoning';
-      data: string;
-    }
+  | { type: 'reasoning'; reasoningType: 'text'; text: string }
+  | { type: 'reasoning'; reasoningType: 'signature'; signature: string }
+  | { type: 'reasoning'; reasoningType: 'redacted'; data: string }
   | ({ type: 'source' } & Source)
   | { type: 'file'; file: GeneratedFile } // different because of GeneratedFile object
   | ({ type: 'tool-call' } & ToolCallUnion<TOOLS>)

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -134,16 +134,36 @@ const modelWithReasoning = new MockLanguageModelV2({
         modelId: 'mock-model-id',
         timestamp: new Date(0),
       },
-      { type: 'reasoning', textDelta: 'I will open the conversation' },
-      { type: 'reasoning', textDelta: ' with witty banter. ' },
-      { type: 'reasoning-signature', signature: '1234567890' },
-      { type: 'redacted-reasoning', data: 'redacted-reasoning-data' },
-      { type: 'reasoning', textDelta: 'Once the user has relaxed,' },
       {
         type: 'reasoning',
-        textDelta: ' I will pry for valuable information.',
+        reasoningType: 'text',
+        text: 'I will open the conversation with witty banter. ',
       },
-      { type: 'reasoning-signature', signature: '1234567890' },
+      {
+        type: 'reasoning',
+        reasoningType: 'signature',
+        signature: '1234567890',
+      },
+      {
+        type: 'reasoning',
+        reasoningType: 'redacted',
+        data: 'redacted-reasoning-data',
+      },
+      {
+        type: 'reasoning',
+        reasoningType: 'text',
+        text: 'Once the user has relaxed,',
+      },
+      {
+        type: 'reasoning',
+        reasoningType: 'text',
+        text: ' I will pry for valuable information.',
+      },
+      {
+        type: 'reasoning',
+        reasoningType: 'signature',
+        signature: '1234567890',
+      },
       { type: 'text-delta', textDelta: 'Hi' },
       { type: 'text-delta', textDelta: ' there!' },
       {
@@ -2015,7 +2035,8 @@ describe('streamText', () => {
             },
             {
               type: 'reasoning',
-              textDelta: 'Feeling clever',
+              reasoningType: 'text',
+              text: 'Feeling clever',
             },
             {
               type: 'tool-call-delta',
@@ -2327,7 +2348,8 @@ describe('streamText', () => {
                       },
                       {
                         type: 'reasoning',
-                        textDelta: 'thinking',
+                        reasoningType: 'text',
+                        text: 'thinking',
                       },
                       {
                         type: 'tool-call',
@@ -3953,7 +3975,11 @@ describe('streamText', () => {
           model: createTestModel({
             stream: convertArrayToReadableStream([
               { type: 'text-delta', textDelta: 'Hello' },
-              { type: 'reasoning', textDelta: 'Feeling clever' },
+              {
+                type: 'reasoning',
+                reasoningType: 'text',
+                text: 'Feeling clever',
+              },
               {
                 type: 'tool-call-delta',
                 toolCallId: '1',

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -137,7 +137,12 @@ const modelWithReasoning = new MockLanguageModelV2({
       {
         type: 'reasoning',
         reasoningType: 'text',
-        text: 'I will open the conversation with witty banter. ',
+        text: 'I will open the conversation',
+      },
+      {
+        type: 'reasoning',
+        reasoningType: 'text',
+        text: ' with witty banter. ',
       },
       {
         type: 'reasoning',
@@ -4032,50 +4037,63 @@ describe('streamText', () => {
 
         await resultObject.consumeStream();
 
-        expect(result).toStrictEqual([
-          { type: 'text-delta', textDelta: 'HELLO' },
-          {
-            type: 'reasoning',
-            textDelta: 'Feeling clever',
-          },
-          {
-            type: 'tool-call-streaming-start',
-            toolCallId: '1',
-            toolName: 'tool1',
-          },
-          {
-            type: 'tool-call-delta',
-            argsTextDelta: '{"VALUE": "',
-            toolCallId: '1',
-            toolName: 'tool1',
-          },
-          {
-            type: 'tool-call-delta',
-            argsTextDelta: 'TEST',
-            toolCallId: '1',
-            toolName: 'tool1',
-          },
-          {
-            type: 'tool-call-delta',
-            argsTextDelta: '"}',
-            toolCallId: '1',
-            toolName: 'tool1',
-          },
-          {
-            type: 'tool-call',
-            toolCallId: '1',
-            toolName: 'tool1',
-            args: { value: 'TEST' },
-          },
-          {
-            type: 'tool-result',
-            toolCallId: '1',
-            toolName: 'tool1',
-            args: { value: 'TEST' },
-            result: 'TEST-RESULT',
-          },
-          { type: 'text-delta', textDelta: ' WORLD' },
-        ]);
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "textDelta": "HELLO",
+              "type": "text-delta",
+            },
+            {
+              "reasoningType": "text",
+              "text": "Feeling clever",
+              "type": "reasoning",
+            },
+            {
+              "toolCallId": "1",
+              "toolName": "tool1",
+              "type": "tool-call-streaming-start",
+            },
+            {
+              "argsTextDelta": "{"VALUE": "",
+              "toolCallId": "1",
+              "toolName": "tool1",
+              "type": "tool-call-delta",
+            },
+            {
+              "argsTextDelta": "TEST",
+              "toolCallId": "1",
+              "toolName": "tool1",
+              "type": "tool-call-delta",
+            },
+            {
+              "argsTextDelta": ""}",
+              "toolCallId": "1",
+              "toolName": "tool1",
+              "type": "tool-call-delta",
+            },
+            {
+              "args": {
+                "value": "TEST",
+              },
+              "toolCallId": "1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+            {
+              "args": {
+                "value": "TEST",
+              },
+              "result": "TEST-RESULT",
+              "toolCallId": "1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+            {
+              "textDelta": " WORLD",
+              "type": "text-delta",
+            },
+          ]
+        `);
       });
     });
 

--- a/packages/ai/core/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
+++ b/packages/ai/core/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
@@ -129,12 +129,14 @@ exports[`simulateStreamingMiddleware > should simulate streaming with reasoning 
     "warnings": [],
   },
   {
-    "textDelta": "First reasoning step",
+    "reasoningType": "text",
+    "text": "First reasoning step",
     "type": "reasoning",
   },
   {
     "data": "data",
-    "type": "redacted-reasoning",
+    "reasoningType": "redacted",
+    "type": "reasoning",
   },
   {
     "textDelta": "This is a test response",
@@ -190,16 +192,19 @@ exports[`simulateStreamingMiddleware > should simulate streaming with reasoning 
     "warnings": [],
   },
   {
-    "textDelta": "First reasoning step",
+    "reasoningType": "text",
+    "text": "First reasoning step",
     "type": "reasoning",
   },
   {
-    "textDelta": "Second reasoning step",
+    "reasoningType": "text",
+    "text": "Second reasoning step",
     "type": "reasoning",
   },
   {
+    "reasoningType": "signature",
     "signature": "abc",
-    "type": "reasoning-signature",
+    "type": "reasoning",
   },
   {
     "textDelta": "This is a test response",
@@ -255,7 +260,8 @@ exports[`simulateStreamingMiddleware > should simulate streaming with reasoning 
     "warnings": [],
   },
   {
-    "textDelta": "This is the reasoning process",
+    "reasoningType": "text",
+    "text": "This is the reasoning process",
     "type": "reasoning",
   },
   {

--- a/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
@@ -186,69 +186,71 @@ describe('extractReasoningMiddleware', () => {
 
       expect(await convertAsyncIterableToArray(result.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "messageId": "msg-0",
-            "request": {},
-            "type": "step-start",
-            "warnings": [],
-          },
-          {
-            "textDelta": "ana",
-            "type": "reasoning",
-          },
-          {
-            "textDelta": "lyzing the request",
-            "type": "reasoning",
-          },
-          {
-            "textDelta": "Here",
-            "type": "text-delta",
-          },
-          {
-            "textDelta": " is the response",
-            "type": "text-delta",
-          },
-          {
-            "finishReason": "stop",
-            "isContinued": false,
-            "logprobs": undefined,
-            "messageId": "msg-0",
-            "providerMetadata": undefined,
-            "request": {},
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+          [
+            {
+              "messageId": "msg-0",
+              "request": {},
+              "type": "step-start",
+              "warnings": [],
             },
-            "type": "step-finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "reasoningType": "text",
+              "text": "ana",
+              "type": "reasoning",
             },
-            "warnings": undefined,
-          },
-          {
-            "finishReason": "stop",
-            "logprobs": undefined,
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+            {
+              "reasoningType": "text",
+              "text": "lyzing the request",
+              "type": "reasoning",
             },
-            "type": "finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "textDelta": "Here",
+              "type": "text-delta",
             },
-          },
-        ]
-      `);
+            {
+              "textDelta": " is the response",
+              "type": "text-delta",
+            },
+            {
+              "finishReason": "stop",
+              "isContinued": false,
+              "logprobs": undefined,
+              "messageId": "msg-0",
+              "providerMetadata": undefined,
+              "request": {},
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "step-finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+              "warnings": undefined,
+            },
+            {
+              "finishReason": "stop",
+              "logprobs": undefined,
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+            },
+          ]
+        `);
     });
 
     it('should extract reasoning from single chunk with multiple <think> tags', async () => {
@@ -289,71 +291,73 @@ describe('extractReasoningMiddleware', () => {
 
       expect(await convertAsyncIterableToArray(result.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "messageId": "msg-0",
-            "request": {},
-            "type": "step-start",
-            "warnings": [],
-          },
-          {
-            "textDelta": "analyzing the request",
-            "type": "reasoning",
-          },
-          {
-            "textDelta": "Here is the response",
-            "type": "text-delta",
-          },
-          {
-            "textDelta": "
-        thinking about the response",
-            "type": "reasoning",
-          },
-          {
-            "textDelta": "
-        more",
-            "type": "text-delta",
-          },
-          {
-            "finishReason": "stop",
-            "isContinued": false,
-            "logprobs": undefined,
-            "messageId": "msg-0",
-            "providerMetadata": undefined,
-            "request": {},
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+          [
+            {
+              "messageId": "msg-0",
+              "request": {},
+              "type": "step-start",
+              "warnings": [],
             },
-            "type": "step-finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "reasoningType": "text",
+              "text": "analyzing the request",
+              "type": "reasoning",
             },
-            "warnings": undefined,
-          },
-          {
-            "finishReason": "stop",
-            "logprobs": undefined,
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+            {
+              "textDelta": "Here is the response",
+              "type": "text-delta",
             },
-            "type": "finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "reasoningType": "text",
+              "text": "
+          thinking about the response",
+              "type": "reasoning",
             },
-          },
-        ]
-      `);
+            {
+              "textDelta": "
+          more",
+              "type": "text-delta",
+            },
+            {
+              "finishReason": "stop",
+              "isContinued": false,
+              "logprobs": undefined,
+              "messageId": "msg-0",
+              "providerMetadata": undefined,
+              "request": {},
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "step-finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+              "warnings": undefined,
+            },
+            {
+              "finishReason": "stop",
+              "logprobs": undefined,
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+            },
+          ]
+        `);
     });
 
     it('should extract reasoning from <think> when there is no text', async () => {
@@ -393,62 +397,64 @@ describe('extractReasoningMiddleware', () => {
 
       expect(await convertAsyncIterableToArray(result.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "messageId": "msg-0",
-            "request": {},
-            "type": "step-start",
-            "warnings": [],
-          },
-          {
-            "textDelta": "ana",
-            "type": "reasoning",
-          },
-          {
-            "textDelta": "lyzing the request
-        ",
-            "type": "reasoning",
-          },
-          {
-            "finishReason": "stop",
-            "isContinued": false,
-            "logprobs": undefined,
-            "messageId": "msg-0",
-            "providerMetadata": undefined,
-            "request": {},
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+          [
+            {
+              "messageId": "msg-0",
+              "request": {},
+              "type": "step-start",
+              "warnings": [],
             },
-            "type": "step-finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "reasoningType": "text",
+              "text": "ana",
+              "type": "reasoning",
             },
-            "warnings": undefined,
-          },
-          {
-            "finishReason": "stop",
-            "logprobs": undefined,
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+            {
+              "reasoningType": "text",
+              "text": "lyzing the request
+          ",
+              "type": "reasoning",
             },
-            "type": "finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "finishReason": "stop",
+              "isContinued": false,
+              "logprobs": undefined,
+              "messageId": "msg-0",
+              "providerMetadata": undefined,
+              "request": {},
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "step-finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+              "warnings": undefined,
             },
-          },
-        ]
-      `);
+            {
+              "finishReason": "stop",
+              "logprobs": undefined,
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+            },
+          ]
+        `);
     });
 
     it('should prepend <think> tag IFF startWithReasoning is true', async () => {
@@ -500,66 +506,68 @@ describe('extractReasoningMiddleware', () => {
 
       expect(await convertAsyncIterableToArray(resultTrue.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "messageId": "msg-0",
-            "request": {},
-            "type": "step-start",
-            "warnings": [],
-          },
-          {
-            "textDelta": "ana",
-            "type": "reasoning",
-          },
-          {
-            "textDelta": "lyzing the request
-        ",
-            "type": "reasoning",
-          },
-          {
-            "textDelta": "this is the response",
-            "type": "text-delta",
-          },
-          {
-            "finishReason": "stop",
-            "isContinued": false,
-            "logprobs": undefined,
-            "messageId": "msg-0",
-            "providerMetadata": undefined,
-            "request": {},
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+          [
+            {
+              "messageId": "msg-0",
+              "request": {},
+              "type": "step-start",
+              "warnings": [],
             },
-            "type": "step-finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "reasoningType": "text",
+              "text": "ana",
+              "type": "reasoning",
             },
-            "warnings": undefined,
-          },
-          {
-            "finishReason": "stop",
-            "logprobs": undefined,
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+            {
+              "reasoningType": "text",
+              "text": "lyzing the request
+          ",
+              "type": "reasoning",
             },
-            "type": "finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "textDelta": "this is the response",
+              "type": "text-delta",
             },
-          },
-        ]
-      `);
+            {
+              "finishReason": "stop",
+              "isContinued": false,
+              "logprobs": undefined,
+              "messageId": "msg-0",
+              "providerMetadata": undefined,
+              "request": {},
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "step-finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+              "warnings": undefined,
+            },
+            {
+              "finishReason": "stop",
+              "logprobs": undefined,
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+            },
+          ]
+        `);
 
       expect(await convertAsyncIterableToArray(resultFalse.fullStream))
         .toMatchInlineSnapshot(`

--- a/packages/ai/core/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/core/middleware/simulate-streaming-middleware.test.ts
@@ -85,6 +85,11 @@ describe('simulateStreamingMiddleware', () => {
             },
             {
               type: 'reasoning',
+              reasoningType: 'text',
+              text: 'Second reasoning step',
+            },
+            {
+              type: 'reasoning',
               reasoningType: 'signature',
               signature: 'abc',
             },

--- a/packages/ai/core/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/core/middleware/simulate-streaming-middleware.test.ts
@@ -46,7 +46,13 @@ describe('simulateStreamingMiddleware', () => {
       async doGenerate() {
         return {
           text: 'This is a test response',
-          reasoning: 'This is the reasoning process',
+          reasoning: [
+            {
+              type: 'reasoning',
+              reasoningType: 'text',
+              text: 'This is the reasoning process',
+            },
+          ],
           finishReason: 'stop',
           usage: { inputTokens: 10, outputTokens: 10 },
         };
@@ -72,8 +78,16 @@ describe('simulateStreamingMiddleware', () => {
         return {
           text: 'This is a test response',
           reasoning: [
-            { type: 'text', text: 'First reasoning step' },
-            { type: 'text', text: 'Second reasoning step', signature: 'abc' },
+            {
+              type: 'reasoning',
+              reasoningType: 'text',
+              text: 'First reasoning step',
+            },
+            {
+              type: 'reasoning',
+              reasoningType: 'signature',
+              signature: 'abc',
+            },
           ],
           finishReason: 'stop',
           usage: { inputTokens: 10, outputTokens: 10 },
@@ -100,8 +114,16 @@ describe('simulateStreamingMiddleware', () => {
         return {
           text: 'This is a test response',
           reasoning: [
-            { type: 'text', text: 'First reasoning step' },
-            { type: 'redacted', data: 'data' },
+            {
+              type: 'reasoning',
+              reasoningType: 'text',
+              text: 'First reasoning step',
+            },
+            {
+              type: 'reasoning',
+              reasoningType: 'redacted',
+              data: 'data',
+            },
           ],
           finishReason: 'stop',
           usage: { inputTokens: 10, outputTokens: 10 },

--- a/packages/ai/core/middleware/simulate-streaming-middleware.ts
+++ b/packages/ai/core/middleware/simulate-streaming-middleware.ts
@@ -17,36 +17,8 @@ export function simulateStreamingMiddleware(): LanguageModelV2Middleware {
           controller.enqueue({ type: 'response-metadata', ...result.response });
 
           if (result.reasoning) {
-            if (typeof result.reasoning === 'string') {
-              controller.enqueue({
-                type: 'reasoning',
-                textDelta: result.reasoning,
-              });
-            } else {
-              for (const reasoning of result.reasoning) {
-                switch (reasoning.type) {
-                  case 'text': {
-                    controller.enqueue({
-                      type: 'reasoning',
-                      textDelta: reasoning.text,
-                    });
-                    if (reasoning.signature != null) {
-                      controller.enqueue({
-                        type: 'reasoning-signature',
-                        signature: reasoning.signature,
-                      });
-                    }
-                    break;
-                  }
-                  case 'redacted': {
-                    controller.enqueue({
-                      type: 'redacted-reasoning',
-                      data: reasoning.data,
-                    });
-                    break;
-                  }
-                }
-              }
+            for (const reasoningPart of result.reasoning) {
+              controller.enqueue(reasoningPart);
             }
           }
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -980,20 +980,37 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      { type: 'reasoning', textDelta: 'I am thinking' },
-      { type: 'reasoning', textDelta: ' about this problem...' },
-      { type: 'reasoning-signature', signature: 'abc123signature' },
-      {
-        type: 'text-delta',
-        textDelta: 'Based on my reasoning, the answer is 42.',
-      },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: undefined, outputTokens: undefined },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "reasoningType": "text",
+          "text": "I am thinking",
+          "type": "reasoning",
+        },
+        {
+          "reasoningType": "text",
+          "text": " about this problem...",
+          "type": "reasoning",
+        },
+        {
+          "reasoningType": "signature",
+          "signature": "abc123signature",
+          "type": "reasoning",
+        },
+        {
+          "textDelta": "Based on my reasoning, the answer is 42.",
+          "type": "text-delta",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": undefined,
+            "outputTokens": undefined,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream redacted reasoning', async () => {
@@ -1028,15 +1045,27 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      { type: 'redacted-reasoning', data: 'redacted-reasoning-data' },
-      { type: 'text-delta', textDelta: 'Here is my answer.' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: undefined, outputTokens: undefined },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "data": "redacted-reasoning-data",
+          "reasoningType": "redacted",
+          "type": "reasoning",
+        },
+        {
+          "textDelta": "Here is my answer.",
+          "type": "text-delta",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": undefined,
+            "outputTokens": undefined,
+          },
+        },
+      ]
+    `);
   });
 });
 
@@ -1465,13 +1494,20 @@ describe('doGenerate', () => {
     });
 
     expect(text).toStrictEqual('The answer is 42.');
-    expect(reasoning).toStrictEqual([
-      {
-        type: 'text',
-        text: reasoningText,
-        signature: signature,
-      },
-    ]);
+    expect(reasoning).toMatchInlineSnapshot(`
+      [
+        {
+          "reasoningType": "text",
+          "text": "I need to think about this problem carefully...",
+          "type": "reasoning",
+        },
+        {
+          "reasoningType": "signature",
+          "signature": "abc123signature",
+          "type": "reasoning",
+        },
+      ]
+    `);
   });
 
   it('should extract reasoning text without signature', async () => {
@@ -1496,12 +1532,15 @@ describe('doGenerate', () => {
     });
 
     expect(text).toStrictEqual('The answer is 42.');
-    expect(reasoning).toStrictEqual([
-      {
-        type: 'text',
-        text: reasoningText,
-      },
-    ]);
+    expect(reasoning).toMatchInlineSnapshot(`
+      [
+        {
+          "reasoningType": "text",
+          "text": "I need to think about this problem carefully...",
+          "type": "reasoning",
+        },
+      ]
+    `);
   });
 
   it('should extract redacted reasoning', async () => {
@@ -1524,12 +1563,15 @@ describe('doGenerate', () => {
     });
 
     expect(text).toStrictEqual('The answer is 42.');
-    expect(reasoning).toStrictEqual([
-      {
-        type: 'redacted',
-        data: 'redacted-reasoning-data',
-      },
-    ]);
+    expect(reasoning).toMatchInlineSnapshot(`
+      [
+        {
+          "data": "redacted-reasoning-data",
+          "reasoningType": "redacted",
+          "type": "reasoning",
+        },
+      ]
+    `);
   });
 
   it('should handle multiple reasoning blocks', async () => {
@@ -1560,16 +1602,24 @@ describe('doGenerate', () => {
     });
 
     expect(text).toStrictEqual('The answer is 42.');
-    expect(reasoning).toStrictEqual([
-      {
-        type: 'text',
-        text: 'First reasoning block',
-        signature: 'sig1',
-      },
-      {
-        type: 'redacted',
-        data: 'redacted-data',
-      },
-    ]);
+    expect(reasoning).toMatchInlineSnapshot(`
+      [
+        {
+          "reasoningType": "text",
+          "text": "First reasoning block",
+          "type": "reasoning",
+        },
+        {
+          "reasoningType": "signature",
+          "signature": "sig1",
+          "type": "reasoning",
+        },
+        {
+          "data": "redacted-data",
+          "reasoningType": "redacted",
+          "type": "reasoning",
+        },
+      ]
+    `);
   });
 });

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -143,13 +143,20 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(reasoning).toStrictEqual([
-        {
-          type: 'text',
-          text: 'I am thinking...',
-          signature: '1234567890',
-        },
-      ]);
+      expect(reasoning).toMatchInlineSnapshot(`
+        [
+          {
+            "reasoningType": "text",
+            "text": "I am thinking...",
+            "type": "reasoning",
+          },
+          {
+            "reasoningType": "signature",
+            "signature": "1234567890",
+            "type": "reasoning",
+          },
+        ]
+      `);
       expect(text).toStrictEqual('Hello, World!');
     });
 
@@ -553,28 +560,50 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          type: 'response-metadata',
-          id: 'msg_01KfpJoAEabmH2iHRRFjQMAG',
-          modelId: 'claude-3-haiku-20240307',
-        },
-        { type: 'reasoning', textDelta: 'I am' },
-        { type: 'reasoning', textDelta: 'thinking...' },
-        { type: 'reasoning-signature', signature: '1234567890' },
-        { type: 'text-delta', textDelta: 'Hello, World!' },
-        {
-          finishReason: 'stop',
-          providerMetadata: {
-            anthropic: {
-              cacheCreationInputTokens: null,
-              cacheReadInputTokens: null,
+      expect(
+        await convertReadableStreamToArray(stream),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "msg_01KfpJoAEabmH2iHRRFjQMAG",
+            "modelId": "claude-3-haiku-20240307",
+            "type": "response-metadata",
+          },
+          {
+            "reasoningType": "text",
+            "text": "I am",
+            "type": "reasoning",
+          },
+          {
+            "reasoningType": "text",
+            "text": "thinking...",
+            "type": "reasoning",
+          },
+          {
+            "reasoningType": "signature",
+            "signature": "1234567890",
+            "type": "reasoning",
+          },
+          {
+            "textDelta": "Hello, World!",
+            "type": "text-delta",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "anthropic": {
+                "cacheCreationInputTokens": null,
+                "cacheReadInputTokens": null,
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 17,
+              "outputTokens": 227,
             },
           },
-          type: 'finish',
-          usage: { inputTokens: 17, outputTokens: 227 },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should stream redacted reasoning', async () => {
@@ -597,26 +626,40 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          type: 'response-metadata',
-          id: 'msg_01KfpJoAEabmH2iHRRFjQMAG',
-          modelId: 'claude-3-haiku-20240307',
-        },
-        { type: 'redacted-reasoning', data: 'redacted-thinking-data' },
-        { type: 'text-delta', textDelta: 'Hello, World!' },
-        {
-          finishReason: 'stop',
-          providerMetadata: {
-            anthropic: {
-              cacheCreationInputTokens: null,
-              cacheReadInputTokens: null,
+      expect(
+        await convertReadableStreamToArray(stream),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "msg_01KfpJoAEabmH2iHRRFjQMAG",
+            "modelId": "claude-3-haiku-20240307",
+            "type": "response-metadata",
+          },
+          {
+            "data": "redacted-thinking-data",
+            "reasoningType": "redacted",
+            "type": "reasoning",
+          },
+          {
+            "textDelta": "Hello, World!",
+            "type": "text-delta",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "anthropic": {
+                "cacheCreationInputTokens": null,
+                "cacheReadInputTokens": null,
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 17,
+              "outputTokens": 227,
             },
           },
-          type: 'finish',
-          usage: { inputTokens: 17, outputTokens: 227 },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should ignore signatures on text deltas', async () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -560,9 +560,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(
-        await convertReadableStreamToArray(stream),
-      ).toMatchInlineSnapshot(`
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
         [
           {
             "id": "msg_01KfpJoAEabmH2iHRRFjQMAG",
@@ -626,9 +624,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(
-        await convertReadableStreamToArray(stream),
-      ).toMatchInlineSnapshot(`
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
         [
           {
             "id": "msg_01KfpJoAEabmH2iHRRFjQMAG",

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -130,7 +130,15 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(reasoning).toStrictEqual('This is a test reasoning');
+    expect(reasoning).toMatchInlineSnapshot(`
+      [
+        {
+          "reasoningType": "text",
+          "text": "This is a test reasoning",
+          "type": "reasoning",
+        },
+      ]
+    `);
   });
 
   it('should extract usage', async () => {
@@ -532,23 +540,38 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    // note: space moved to last chunk bc of trimming
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798',
-        modelId: 'gemma2-9b-it',
-        timestamp: new Date('2023-12-15T16:17:00.000Z'),
-      },
-      { type: 'reasoning', textDelta: 'I think,' },
-      { type: 'reasoning', textDelta: 'therefore I am.' },
-      { type: 'text-delta', textDelta: 'Hello' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 18, outputTokens: 439 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "gemma2-9b-it",
+          "timestamp": 2023-12-15T16:17:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "reasoningType": "text",
+          "text": "I think,",
+          "type": "reasoning",
+        },
+        {
+          "reasoningType": "text",
+          "text": "therefore I am.",
+          "type": "reasoning",
+        },
+        {
+          "textDelta": "Hello",
+          "type": "text-delta",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 18,
+            "outputTokens": 439,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream tool deltas', async () => {

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -187,7 +187,15 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
 
     return {
       text: choice.message.content ?? undefined,
-      reasoning: choice.message.reasoning ?? undefined,
+      reasoning: choice.message.reasoning
+        ? [
+            {
+              type: 'reasoning',
+              reasoningType: 'text',
+              text: choice.message.reasoning,
+            },
+          ]
+        : undefined,
       toolCalls: choice.message.tool_calls?.map(toolCall => ({
         type: 'tool-call',
         toolCallType: 'function',
@@ -305,7 +313,8 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
             if (delta.reasoning != null && delta.reasoning.length > 0) {
               controller.enqueue({
                 type: 'reasoning',
-                textDelta: delta.reasoning,
+                reasoningType: 'text',
+                text: delta.reasoning,
               });
             }
 

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -182,9 +182,15 @@ describe('doGenerate', () => {
     });
 
     expect(text).toStrictEqual('Hello, World!');
-    expect(reasoning).toStrictEqual(
-      'This is the reasoning behind the response',
-    );
+    expect(reasoning).toMatchInlineSnapshot(`
+      [
+        {
+          "reasoningType": "text",
+          "text": "This is the reasoning behind the response",
+          "type": "reasoning",
+        },
+      ]
+    `);
   });
 
   it('should extract usage', async () => {
@@ -961,38 +967,45 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798',
-        modelId: 'grok-beta',
-        timestamp: new Date('2024-03-25T09:06:38.000Z'),
-      },
-      {
-        type: 'reasoning',
-        textDelta: 'Let me think',
-      },
-      {
-        type: 'reasoning',
-        textDelta: ' about this',
-      },
-      {
-        type: 'text-delta',
-        textDelta: "Here's",
-      },
-      {
-        type: 'text-delta',
-        textDelta: ' my response',
-      },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 18, outputTokens: 439 },
-        providerMetadata: {
-          'test-provider': {},
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
         },
-      },
-    ]);
+        {
+          "reasoningType": "text",
+          "text": "Let me think",
+          "type": "reasoning",
+        },
+        {
+          "reasoningType": "text",
+          "text": " about this",
+          "type": "reasoning",
+        },
+        {
+          "textDelta": "Here's",
+          "type": "text-delta",
+        },
+        {
+          "textDelta": " my response",
+          "type": "text-delta",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 18,
+            "outputTokens": 439,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream tool deltas', async () => {

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -245,7 +245,15 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
 
     return {
       text: choice.message.content ?? undefined,
-      reasoning: choice.message.reasoning_content ?? undefined,
+      reasoning: choice.message.reasoning_content
+        ? [
+            {
+              type: 'reasoning',
+              reasoningType: 'text',
+              text: choice.message.reasoning_content,
+            },
+          ]
+        : undefined,
       toolCalls: choice.message.tool_calls?.map(toolCall => ({
         type: 'tool-call',
         toolCallType: 'function',
@@ -418,7 +426,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
             if (delta.reasoning_content != null) {
               controller.enqueue({
                 type: 'reasoning',
-                textDelta: delta.reasoning_content,
+                reasoningType: 'text',
+                text: delta.reasoning_content,
               });
             }
 

--- a/packages/provider/src/language-model/v2/index.ts
+++ b/packages/provider/src/language-model/v2/index.ts
@@ -8,6 +8,7 @@ export * from './language-model-v2-function-tool';
 export * from './language-model-v2-logprobs';
 export * from './language-model-v2-prompt';
 export * from './language-model-v2-provider-defined-tool';
+export * from './language-model-v2-reasoning';
 export * from './language-model-v2-source';
 export * from './language-model-v2-tool-call';
 export * from './language-model-v2-tool-call-delta';

--- a/packages/provider/src/language-model/v2/language-model-v2-reasoning.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-reasoning.ts
@@ -1,0 +1,16 @@
+export type LanguageModelV2Reasoning =
+  | {
+      type: 'reasoning';
+      reasoningType: 'text';
+      text: string;
+    }
+  | {
+      type: 'reasoning';
+      reasoningType: 'signature';
+      signature: string;
+    }
+  | {
+      type: 'reasoning';
+      reasoningType: 'redacted';
+      data: string;
+    };

--- a/packages/provider/src/language-model/v2/language-model-v2.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2.ts
@@ -4,6 +4,7 @@ import { LanguageModelV2CallWarning } from './language-model-v2-call-warning';
 import { LanguageModelV2File } from './language-model-v2-file';
 import { LanguageModelV2FinishReason } from './language-model-v2-finish-reason';
 import { LanguageModelV2LogProbs } from './language-model-v2-logprobs';
+import { LanguageModelV2Reasoning } from './language-model-v2-reasoning';
 import { LanguageModelV2Source } from './language-model-v2-source';
 import { LanguageModelV2ToolCall } from './language-model-v2-tool-call';
 import { LanguageModelV2ToolCallDelta } from './language-model-v2-tool-call-delta';
@@ -98,24 +99,7 @@ Can be undefined if the model did not generate any text.
 Reasoning that the model has generated.
 Can be undefined if the model does not support reasoning.
      */
-    // TODO v2: remove string option
-    reasoning?:
-      | string
-      | Array<
-          | {
-              type: 'text';
-              text: string;
-
-              /**
-An optional signature for verifying that the reasoning originated from the model.
-   */
-              signature?: string;
-            }
-          | {
-              type: 'redacted';
-              data: string;
-            }
-        >;
+    reasoning?: Array<LanguageModelV2Reasoning>;
 
     /**
 Generated files as base64 encoded strings or binary data.
@@ -248,10 +232,8 @@ export type LanguageModelV2StreamPart =
   // Basic text deltas:
   | { type: 'text-delta'; textDelta: string }
 
-  // Reasoning text deltas:
-  | { type: 'reasoning'; textDelta: string }
-  | { type: 'reasoning-signature'; signature: string }
-  | { type: 'redacted-reasoning'; data: string }
+  // Reasoning:
+  | LanguageModelV2Reasoning
 
   // Sources:
   | LanguageModelV2Source


### PR DESCRIPTION
## Background
`doGenerate` will in the future move to returning parts as an array, requiring type annotations. Furthermore, the `reasoning` parts have been inconsistent due to feature evolution.

## Summary
Restructure `reasoning` parts.