### PR TITLE
chore: refactor text parts (spec)

### DIFF
--- a/.changeset/rotten-walls-provide.md
+++ b/.changeset/rotten-walls-provide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': major
+---
+
+chore: refactor text parts (spec)

--- a/examples/ai-core/src/generate-object/mock-error.ts
+++ b/examples/ai-core/src/generate-object/mock-error.ts
@@ -16,7 +16,7 @@ async function main() {
           },
           finishReason: 'stop',
           usage: { inputTokens: 10, outputTokens: 20 },
-          text: `{"content":"Hello broken json`,
+          text: { type: 'text', text: `{"content":"Hello broken json` },
         }),
       }),
       schema: z.object({ content: z.string() }),

--- a/examples/ai-core/src/generate-object/mock-repair-add-close.ts
+++ b/examples/ai-core/src/generate-object/mock-repair-add-close.ts
@@ -9,7 +9,7 @@ async function main() {
       doGenerate: async () => ({
         usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'tool-calls',
-        text: `{ "content": "provider metadata test"`,
+        text: { type: 'text', text: `{ "content": "provider metadata test"` },
       }),
     }),
     schema: z.object({ content: z.string() }),

--- a/examples/ai-core/src/generate-object/mock.ts
+++ b/examples/ai-core/src/generate-object/mock.ts
@@ -8,7 +8,7 @@ async function main() {
     model: new MockLanguageModelV2({
       defaultObjectGenerationMode: 'json',
       doGenerate: async () => ({
-        text: `{"content":"Hello, world!"}`,
+        text: { type: 'text', text: `{"content":"Hello, world!"}` },
         finishReason: 'stop',
         usage: { inputTokens: 10, outputTokens: 20 },
       }),

--- a/examples/ai-core/src/generate-text/mock.ts
+++ b/examples/ai-core/src/generate-text/mock.ts
@@ -6,7 +6,7 @@ async function main() {
   const { text, usage } = await generateText({
     model: new MockLanguageModelV2({
       doGenerate: async () => ({
-        text: `Hello, world!`,
+        text: { type: 'text', text: `Hello, world!` },
         finishReason: 'stop',
         usage: { inputTokens: 10, outputTokens: 20 },
       }),

--- a/examples/ai-core/src/middleware/your-guardrail-middleware.ts
+++ b/examples/ai-core/src/middleware/your-guardrail-middleware.ts
@@ -5,9 +5,13 @@ export const yourGuardrailMiddleware: LanguageModelV2Middleware = {
     const { text, ...rest } = await doGenerate();
 
     // filtering approach, e.g. for PII or other sensitive information:
-    const cleanedText = text?.replace(/badword/g, '<REDACTED>');
+    const cleanedText = text?.text?.replace(/badword/g, '<REDACTED>');
 
-    return { text: cleanedText, ...rest };
+    return {
+      text:
+        cleanedText != null ? { type: 'text', text: cleanedText } : undefined,
+      ...rest,
+    };
   },
 
   // here you would implement the guardrail logic for streaming

--- a/examples/ai-core/src/middleware/your-log-middleware.ts
+++ b/examples/ai-core/src/middleware/your-log-middleware.ts
@@ -29,8 +29,8 @@ export const yourLogMiddleware: LanguageModelV2Middleware = {
       LanguageModelV2StreamPart
     >({
       transform(chunk, controller) {
-        if (chunk.type === 'text-delta') {
-          generatedText += chunk.textDelta;
+        if (chunk.type === 'text') {
+          generatedText += chunk.text;
         }
 
         controller.enqueue(chunk);

--- a/examples/ai-core/src/stream-object/mock.ts
+++ b/examples/ai-core/src/stream-object/mock.ts
@@ -9,12 +9,12 @@ async function main() {
       defaultObjectGenerationMode: 'json',
       doStream: async () => ({
         stream: convertArrayToReadableStream([
-          { type: 'text-delta', textDelta: '{ ' },
-          { type: 'text-delta', textDelta: '"content": ' },
-          { type: 'text-delta', textDelta: `"Hello, ` },
-          { type: 'text-delta', textDelta: `world` },
-          { type: 'text-delta', textDelta: `!"` },
-          { type: 'text-delta', textDelta: ' }' },
+          { type: 'text', text: '{ ' },
+          { type: 'text', text: '"content": ' },
+          { type: 'text', text: `"Hello, ` },
+          { type: 'text', text: `world` },
+          { type: 'text', text: `!"` },
+          { type: 'text', text: ' }' },
           {
             type: 'finish',
             finishReason: 'stop',

--- a/examples/ai-core/src/stream-text/amazon-bedrock-cache-point-tool-call.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-cache-point-tool-call.ts
@@ -156,9 +156,9 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
@@ -35,12 +35,12 @@ async function main() {
         break;
       }
 
-      case 'text-delta': {
+      case 'text': {
         if (!enteredText) {
           enteredText = true;
           console.log('\nTEXT:\n');
         }
-        process.stdout.write(part.textDelta);
+        process.stdout.write(part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
@@ -67,8 +67,8 @@ async function main() {
         part.reasoningType === 'redacted'
       ) {
         process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
-      } else if (part.type === 'text-delta') {
-        process.stdout.write(part.textDelta);
+      } else if (part.type === 'text') {
+        process.stdout.write(part.text);
       }
     }
     process.stdout.write('\n\n');

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
@@ -37,12 +37,12 @@ async function main() {
         break;
       }
 
-      case 'text-delta': {
+      case 'text': {
         if (!enteredText) {
           enteredText = true;
           console.log('\nTEXT:\n');
         }
-        process.stdout.write(part.textDelta);
+        process.stdout.write(part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
@@ -24,8 +24,8 @@ async function main() {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'reasoning' && part.reasoningType === 'redacted') {
       process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
-    } else if (part.type === 'text-delta') {
-      process.stdout.write(part.textDelta);
+    } else if (part.type === 'text') {
+      process.stdout.write(part.text);
     }
   }
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-tool-call.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-tool-call.ts
@@ -25,9 +25,9 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/anthropic-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-fullstream.ts
@@ -18,8 +18,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-chatbot.ts
@@ -67,8 +67,8 @@ async function main() {
         part.reasoningType === 'redacted'
       ) {
         process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
-      } else if (part.type === 'text-delta') {
-        process.stdout.write(part.textDelta);
+      } else if (part.type === 'text') {
+        process.stdout.write(part.text);
       }
     }
     process.stdout.write('\n\n');

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
@@ -46,12 +46,12 @@ async function main() {
         break;
       }
 
-      case 'text-delta': {
+      case 'text': {
         if (!enteredText) {
           enteredText = true;
           console.log('\nTEXT:\n');
         }
-        process.stdout.write(part.textDelta);
+        process.stdout.write(part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/anthropic-reasoning.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning.ts
@@ -23,8 +23,8 @@ async function main() {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
     } else if (part.type === 'reasoning' && part.reasoningType === 'redacted') {
       process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
-    } else if (part.type === 'text-delta') {
-      process.stdout.write(part.textDelta);
+    } else if (part.type === 'text') {
+      process.stdout.write(part.text);
     }
   }
 

--- a/examples/ai-core/src/stream-text/azure-fullstream-logprobs.ts
+++ b/examples/ai-core/src/stream-text/azure-fullstream-logprobs.ts
@@ -15,8 +15,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/azure-fullstream.ts
+++ b/examples/ai-core/src/stream-text/azure-fullstream.ts
@@ -18,8 +18,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/cerebras-tool-call.ts
+++ b/examples/ai-core/src/stream-text/cerebras-tool-call.ts
@@ -25,9 +25,9 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/cohere-tool-call-empty-params.ts
+++ b/examples/ai-core/src/stream-text/cohere-tool-call-empty-params.ts
@@ -37,9 +37,9 @@ async function main() {
     console.log(delta);
 
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/cohere-tool-call.ts
+++ b/examples/ai-core/src/stream-text/cohere-tool-call.ts
@@ -26,9 +26,9 @@ async function main() {
     console.log(delta);
 
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/deepseek-reasoning.ts
+++ b/examples/ai-core/src/stream-text/deepseek-reasoning.ts
@@ -11,8 +11,8 @@ async function main() {
   for await (const part of result.fullStream) {
     if (part.type === 'reasoning' && part.reasoningType === 'text') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
-    } else if (part.type === 'text-delta') {
-      process.stdout.write(part.textDelta);
+    } else if (part.type === 'text') {
+      process.stdout.write(part.text);
     }
   }
 }

--- a/examples/ai-core/src/stream-text/deepseek-tool-call.ts
+++ b/examples/ai-core/src/stream-text/deepseek-tool-call.ts
@@ -25,9 +25,9 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/fireworks-reasoning.ts
+++ b/examples/ai-core/src/stream-text/fireworks-reasoning.ts
@@ -23,12 +23,12 @@ async function main() {
         console.log('\nREASONING:\n');
       }
       process.stdout.write(part.text);
-    } else if (part.type === 'text-delta') {
+    } else if (part.type === 'text') {
       if (!enteredText) {
         enteredText = true;
         console.log('\nTEXT:\n');
       }
-      process.stdout.write(part.textDelta);
+      process.stdout.write(part.text);
     }
   }
 }

--- a/examples/ai-core/src/stream-text/google-chatbot-image-output.ts
+++ b/examples/ai-core/src/stream-text/google-chatbot-image-output.ts
@@ -26,8 +26,8 @@ async function main() {
     process.stdout.write('\nAssistant: ');
     for await (const delta of result.fullStream) {
       switch (delta.type) {
-        case 'text-delta': {
-          process.stdout.write(delta.textDelta);
+        case 'text': {
+          process.stdout.write(delta.text);
           break;
         }
 

--- a/examples/ai-core/src/stream-text/google-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-fullstream.ts
@@ -18,8 +18,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/google-grounding.ts
+++ b/examples/ai-core/src/stream-text/google-grounding.ts
@@ -9,8 +9,8 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'text-delta') {
-      process.stdout.write(part.textDelta);
+    if (part.type === 'text') {
+      process.stdout.write(part.text);
     }
 
     if (part.type === 'source' && part.sourceType === 'url') {

--- a/examples/ai-core/src/stream-text/google-image-output.ts
+++ b/examples/ai-core/src/stream-text/google-image-output.ts
@@ -14,8 +14,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        process.stdout.write(part.textDelta);
+      case 'text': {
+        process.stdout.write(part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/google-vertex-anthropic-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-anthropic-fullstream.ts
@@ -18,8 +18,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/google-vertex-anthropic-tool-call.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-anthropic-tool-call.ts
@@ -25,9 +25,9 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/google-vertex-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-fullstream.ts
@@ -18,8 +18,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/groq-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/groq-reasoning-fullstream.ts
@@ -20,12 +20,12 @@ async function main() {
         console.log('\nREASONING:\n');
       }
       process.stdout.write(part.text);
-    } else if (part.type === 'text-delta') {
+    } else if (part.type === 'text') {
       if (!enteredText) {
         enteredText = true;
         console.log('\nTEXT:\n');
       }
-      process.stdout.write(part.textDelta);
+      process.stdout.write(part.text);
     }
   }
 }

--- a/examples/ai-core/src/stream-text/mistral-fullstream.ts
+++ b/examples/ai-core/src/stream-text/mistral-fullstream.ts
@@ -18,8 +18,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/mock.ts
+++ b/examples/ai-core/src/stream-text/mock.ts
@@ -7,9 +7,9 @@ async function main() {
     model: new MockLanguageModelV2({
       doStream: async () => ({
         stream: convertArrayToReadableStream([
-          { type: 'text-delta', textDelta: 'Hello' },
-          { type: 'text-delta', textDelta: ', ' },
-          { type: 'text-delta', textDelta: `world!` },
+          { type: 'text', text: 'Hello' },
+          { type: 'text', text: ', ' },
+          { type: 'text', text: `world!` },
           {
             type: 'finish',
             finishReason: 'stop',

--- a/examples/ai-core/src/stream-text/openai-compatible-togetherai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-compatible-togetherai-tool-call.ts
@@ -35,9 +35,9 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/openai-fullstream.ts
+++ b/examples/ai-core/src/stream-text/openai-fullstream.ts
@@ -18,8 +18,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/openai-responses-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-tool-call.ts
@@ -31,8 +31,8 @@ async function main() {
 
   for await (const chunk of result.fullStream) {
     switch (chunk.type) {
-      case 'text-delta': {
-        process.stdout.write(chunk.textDelta);
+      case 'text': {
+        process.stdout.write(chunk.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/openai-tool-call-raw-json-schema.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call-raw-json-schema.ts
@@ -36,8 +36,8 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text-delta': {
-        console.log('Text delta:', part.textDelta);
+      case 'text': {
+        console.log('Text:', part.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/openai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call.ts
@@ -26,8 +26,8 @@ async function main() {
 
   for await (const chunk of result.fullStream) {
     switch (chunk.type) {
-      case 'text-delta': {
-        process.stdout.write(chunk.textDelta);
+      case 'text': {
+        process.stdout.write(chunk.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/openai-web-search-tool.ts
+++ b/examples/ai-core/src/stream-text/openai-web-search-tool.ts
@@ -17,8 +17,8 @@ async function main() {
 
   for await (const chunk of result.fullStream) {
     switch (chunk.type) {
-      case 'text-delta': {
-        process.stdout.write(chunk.textDelta);
+      case 'text': {
+        process.stdout.write(chunk.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-chinese.ts
@@ -7,11 +7,11 @@ async function main() {
       doStream: async () => ({
         stream: simulateReadableStream({
           chunks: [
-            { type: 'text-delta', textDelta: '你好你好你好你好你好' },
-            { type: 'text-delta', textDelta: '你好你好你好你好你好' },
-            { type: 'text-delta', textDelta: '你好你好你好你好你好' },
-            { type: 'text-delta', textDelta: '你好你好你好你好你好' },
-            { type: 'text-delta', textDelta: '你好你好你好你好你好' },
+            { type: 'text', text: '你好你好你好你好你好' },
+            { type: 'text', text: '你好你好你好你好你好' },
+            { type: 'text', text: '你好你好你好你好你好' },
+            { type: 'text', text: '你好你好你好你好你好' },
+            { type: 'text', text: '你好你好你好你好你好' },
             {
               type: 'finish',
               finishReason: 'stop',

--- a/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
+++ b/examples/ai-core/src/stream-text/smooth-stream-japanese.ts
@@ -7,11 +7,11 @@ async function main() {
       doStream: async () => ({
         stream: simulateReadableStream({
           chunks: [
-            { type: 'text-delta', textDelta: 'こんにちは' },
-            { type: 'text-delta', textDelta: 'こんにちは' },
-            { type: 'text-delta', textDelta: 'こんにちは' },
-            { type: 'text-delta', textDelta: 'こんにちは' },
-            { type: 'text-delta', textDelta: 'こんにちは' },
+            { type: 'text', text: 'こんにちは' },
+            { type: 'text', text: 'こんにちは' },
+            { type: 'text', text: 'こんにちは' },
+            { type: 'text', text: 'こんにちは' },
+            { type: 'text', text: 'こんにちは' },
             {
               type: 'finish',
               finishReason: 'stop',

--- a/examples/ai-core/src/stream-text/togetherai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/togetherai-tool-call.ts
@@ -25,9 +25,9 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/xai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/xai-tool-call.ts
@@ -25,9 +25,9 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text-delta': {
-        fullResponse += delta.textDelta;
-        process.stdout.write(delta.textDelta);
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
         break;
       }
 

--- a/examples/ai-core/src/test/response-format.ts
+++ b/examples/ai-core/src/test/response-format.ts
@@ -35,8 +35,8 @@ async function main() {
       break;
     }
 
-    if (value.type === 'text-delta') {
-      process.stdout.write(value.textDelta);
+    if (value.type === 'text') {
+      process.stdout.write(value.text);
     }
   }
 }

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -50,7 +50,7 @@ describe('output = "object"', () => {
 
             return {
               ...dummyResponseValues,
-              text: `{ "content": "Hello, world!" }`,
+              text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             };
           },
         }),
@@ -90,7 +90,7 @@ describe('output = "object"', () => {
 
             return {
               ...dummyResponseValues,
-              text: `{ "content": "Hello, world!" }`,
+              text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             };
           },
         }),
@@ -130,7 +130,7 @@ describe('output = "object"', () => {
 
             return {
               ...dummyResponseValues,
-              text: `{ "content": "Hello, world!" }`,
+              text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             };
           },
         }),
@@ -253,7 +253,7 @@ describe('output = "object"', () => {
         model: new MockLanguageModelV2({
           doGenerate: async () => ({
             ...dummyResponseValues,
-            text: `{ "content": "Hello, world!" }`,
+            text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             request: {
               body: 'test body',
             },
@@ -305,7 +305,7 @@ describe('output = "object"', () => {
         model: new MockLanguageModelV2({
           doGenerate: async () => ({
             ...dummyResponseValues,
-            text: `{ "content": "Hello, world!" }`,
+            text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             response: {
               id: 'test-id-from-model',
               timestamp: new Date(10000),
@@ -409,7 +409,7 @@ describe('output = "object"', () => {
 
             return {
               ...dummyResponseValues,
-              text: `{ "content": "Hello, world!" }`,
+              text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             };
           },
         }),
@@ -456,7 +456,7 @@ describe('output = "object"', () => {
 
             return {
               ...dummyResponseValues,
-              text: `{ "content": "Hello, world!" }`,
+              text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             };
           },
         }),
@@ -507,7 +507,7 @@ describe('output = "object"', () => {
 
             return {
               ...dummyResponseValues,
-              text: `{ "content": "Hello, world!" }`,
+              text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             };
           },
         }),
@@ -531,7 +531,7 @@ describe('output = "object"', () => {
         model: new MockLanguageModelV2({
           doGenerate: async ({}) => ({
             ...dummyResponseValues,
-            text: `{ "content": "Hello, world!" }`,
+            text: { type: 'text', text: '{ "content": "Hello, world!" }' },
           }),
         }),
         schema: z.object({ content: z.string() }),
@@ -562,7 +562,7 @@ describe('output = "object"', () => {
         model: new MockLanguageModelV2({
           doGenerate: async ({}) => ({
             ...dummyResponseValues,
-            text: `{ "content": "Hello, world!" }`,
+            text: { type: 'text', text: '{ "content": "Hello, world!" }' },
             providerMetadata: {
               anthropic: {
                 cacheCreationInputTokens: 10,
@@ -596,7 +596,7 @@ describe('output = "object"', () => {
 
             return {
               ...dummyResponseValues,
-              text: `{ "content": "headers test" }`,
+              text: { type: 'text', text: '{ "content": "headers test" }' },
             };
           },
         }),
@@ -648,7 +648,10 @@ describe('output = "object"', () => {
           doGenerate: async ({}) => {
             return {
               ...dummyResponseValues,
-              text: `{ "content": "provider metadata test" `,
+              text: {
+                type: 'text',
+                text: '{ "content": "provider metadata test" ',
+              },
             };
           },
         }),
@@ -673,7 +676,10 @@ describe('output = "object"', () => {
           doGenerate: async ({}) => {
             return {
               ...dummyResponseValues,
-              text: `{ "content-a": "provider metadata test" }`,
+              text: {
+                type: 'text',
+                text: '{ "content-a": "provider metadata test" }',
+              },
             };
           },
         }),
@@ -700,7 +706,10 @@ describe('output = "object"', () => {
           doGenerate: async ({}) => {
             return {
               ...dummyResponseValues,
-              text: `{ "content-a": "provider metadata test" }`,
+              text: {
+                type: 'text',
+                text: '{ "content-a": "provider metadata test" }',
+              },
             };
           },
         }),
@@ -733,7 +742,10 @@ describe('output = "object"', () => {
 
             return {
               ...dummyResponseValues,
-              text: `{ "content": "provider metadata test" }`,
+              text: {
+                type: 'text',
+                text: '{ "content": "provider metadata test" }',
+              },
             };
           },
         }),
@@ -843,7 +855,7 @@ describe('output = "object"', () => {
           model: new MockLanguageModelV2({
             doGenerate: async ({}) => ({
               ...dummyResponseValues,
-              text: `{ "content": 123 }`,
+              text: { type: 'text', text: '{ "content": 123 }' },
             }),
           }),
           schema: z.object({ content: z.string() }),
@@ -895,7 +907,7 @@ describe('output = "object"', () => {
           model: new MockLanguageModelV2({
             doGenerate: async ({}) => ({
               ...dummyResponseValues,
-              text: '{ broken json',
+              text: { type: 'text', text: '{ broken json' },
             }),
           }),
           schema: z.object({ content: z.string() }),
@@ -917,7 +929,7 @@ describe('output = "object"', () => {
           model: new MockLanguageModelV2({
             doGenerate: async ({}) => ({
               ...dummyResponseValues,
-              text: '{ broken json',
+              text: { type: 'text', text: '{ broken json' },
             }),
           }),
           schema: z.object({ content: z.string() }),
@@ -1026,13 +1038,16 @@ describe('output = "array"', () => {
 
           return {
             ...dummyResponseValues,
-            text: JSON.stringify({
-              elements: [
-                { content: 'element 1' },
-                { content: 'element 2' },
-                { content: 'element 3' },
-              ],
-            }),
+            text: {
+              type: 'text',
+              text: JSON.stringify({
+                elements: [
+                  { content: 'element 1' },
+                  { content: 'element 2' },
+                  { content: 'element 3' },
+                ],
+              }),
+            },
           };
         },
       }),
@@ -1087,7 +1102,7 @@ describe('output = "enum"', () => {
 
           return {
             ...dummyResponseValues,
-            text: JSON.stringify({ result: 'sunny' }),
+            text: { type: 'text', text: JSON.stringify({ result: 'sunny' }) },
           };
         },
       }),
@@ -1124,7 +1139,7 @@ describe('output = "no-schema"', () => {
 
           return {
             ...dummyResponseValues,
-            text: `{ "content": "Hello, world!" }`,
+            text: { type: 'text', text: '{ "content": "Hello, world!" }' },
           };
         },
       }),
@@ -1148,7 +1163,7 @@ describe('telemetry', () => {
       model: new MockLanguageModelV2({
         doGenerate: async () => ({
           ...dummyResponseValues,
-          text: `{ "content": "Hello, world!" }`,
+          text: { type: 'text', text: '{ "content": "Hello, world!" }' },
         }),
       }),
       schema: z.object({ content: z.string() }),
@@ -1164,7 +1179,7 @@ describe('telemetry', () => {
       model: new MockLanguageModelV2({
         doGenerate: async () => ({
           ...dummyResponseValues,
-          text: `{ "content": "Hello, world!" }`,
+          text: { type: 'text', text: '{ "content": "Hello, world!" }' },
           response: {
             id: 'test-id-from-model',
             timestamp: new Date(10000),
@@ -1254,7 +1269,7 @@ describe('telemetry', () => {
       model: new MockLanguageModelV2({
         doGenerate: async () => ({
           ...dummyResponseValues,
-          text: `{ "content": "Hello, world!" }`,
+          text: { type: 'text', text: '{ "content": "Hello, world!" }' },
           response: {
             id: 'test-id-from-model',
             timestamp: new Date(10000),
@@ -1369,7 +1384,7 @@ describe('options.messages', () => {
 
           return {
             ...dummyResponseValues,
-            text: `{ "content": "Hello, world!" }`,
+            text: { type: 'text', text: '{ "content": "Hello, world!" }' },
           };
         },
       }),
@@ -1413,7 +1428,7 @@ describe('options.messages', () => {
           },
           doGenerate: async () => ({
             ...dummyResponseValues,
-            text: `{ "content": "Hello, world!" }`,
+            text: { type: 'text', text: '{ "content": "Hello, world!" }' },
           }),
         });
       }

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -375,7 +375,7 @@ export async function generateObject<SCHEMA, RESULT>({
                     telemetry,
                     attributes: {
                       'ai.response.finishReason': result.finishReason,
-                      'ai.response.object': { output: () => result.text },
+                      'ai.response.object': { output: () => result.text?.text },
                       'ai.response.id': responseData.id,
                       'ai.response.model': responseData.modelId,
                       'ai.response.timestamp':
@@ -400,7 +400,7 @@ export async function generateObject<SCHEMA, RESULT>({
             }),
           );
 
-          result = generateResult.objectText;
+          result = generateResult.objectText?.text;
           finishReason = generateResult.finishReason;
           usage = generateResult.usage;
           warnings = generateResult.warnings;

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -54,12 +54,12 @@ describe('streamObject', () => {
 
               return {
                 stream: convertArrayToReadableStream([
-                  { type: 'text-delta', textDelta: '{ ' },
-                  { type: 'text-delta', textDelta: '"content": ' },
-                  { type: 'text-delta', textDelta: `"Hello, ` },
-                  { type: 'text-delta', textDelta: `world` },
-                  { type: 'text-delta', textDelta: `!"` },
-                  { type: 'text-delta', textDelta: ' }' },
+                  { type: 'text', text: '{ ' },
+                  { type: 'text', text: '"content": ' },
+                  { type: 'text', text: `"Hello, ` },
+                  { type: 'text', text: `world` },
+                  { type: 'text', text: `!"` },
+                  { type: 'text', text: ' }' },
                   {
                     type: 'finish',
                     finishReason: 'stop',
@@ -112,12 +112,12 @@ describe('streamObject', () => {
               ]);
               return {
                 stream: convertArrayToReadableStream([
-                  { type: 'text-delta', textDelta: '{ ' },
-                  { type: 'text-delta', textDelta: '"content": ' },
-                  { type: 'text-delta', textDelta: `"Hello, ` },
-                  { type: 'text-delta', textDelta: `world` },
-                  { type: 'text-delta', textDelta: `!"` },
-                  { type: 'text-delta', textDelta: ' }' },
+                  { type: 'text', text: '{ ' },
+                  { type: 'text', text: '"content": ' },
+                  { type: 'text', text: `"Hello, ` },
+                  { type: 'text', text: `world` },
+                  { type: 'text', text: `!"` },
+                  { type: 'text', text: ' }' },
                   {
                     type: 'finish',
                     finishReason: 'stop',
@@ -171,12 +171,12 @@ describe('streamObject', () => {
 
               return {
                 stream: convertArrayToReadableStream([
-                  { type: 'text-delta', textDelta: '{ ' },
-                  { type: 'text-delta', textDelta: '"content": ' },
-                  { type: 'text-delta', textDelta: `"Hello, ` },
-                  { type: 'text-delta', textDelta: `world` },
-                  { type: 'text-delta', textDelta: `!"` },
-                  { type: 'text-delta', textDelta: ' }' },
+                  { type: 'text', text: '{ ' },
+                  { type: 'text', text: '"content": ' },
+                  { type: 'text', text: `"Hello, ` },
+                  { type: 'text', text: `world` },
+                  { type: 'text', text: `!"` },
+                  { type: 'text', text: ' }' },
                   {
                     type: 'finish',
                     finishReason: 'stop',
@@ -452,12 +452,12 @@ describe('streamObject', () => {
                   modelId: 'mock-model-id',
                   timestamp: new Date(0),
                 },
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"content": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -484,12 +484,12 @@ describe('streamObject', () => {
           model: new MockLanguageModelV2({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"content": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -516,12 +516,12 @@ describe('streamObject', () => {
           model: new MockLanguageModelV2({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"content": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -560,12 +560,12 @@ describe('streamObject', () => {
           model: new MockLanguageModelV2({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"content": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -604,8 +604,8 @@ describe('streamObject', () => {
             doStream: async () => ({
               stream: convertArrayToReadableStream([
                 {
-                  type: 'text-delta',
-                  textDelta: '{ "content": "Hello, world!" }',
+                  type: 'text',
+                  text: '{ "content": "Hello, world!" }',
                 },
                 {
                   type: 'finish',
@@ -638,8 +638,8 @@ describe('streamObject', () => {
             doStream: async () => ({
               stream: convertArrayToReadableStream([
                 {
-                  type: 'text-delta',
-                  textDelta: '{ "content": "Hello, world!" }',
+                  type: 'text',
+                  text: '{ "content": "Hello, world!" }',
                 },
                 {
                   type: 'finish',
@@ -679,8 +679,8 @@ describe('streamObject', () => {
                   timestamp: new Date(0),
                 },
                 {
-                  type: 'text-delta',
-                  textDelta: '{"content": "Hello, world!"}',
+                  type: 'text',
+                  text: '{"content": "Hello, world!"}',
                 },
                 {
                   type: 'finish',
@@ -766,8 +766,8 @@ describe('streamObject', () => {
                   timestamp: new Date(0),
                 },
                 {
-                  type: 'text-delta',
-                  textDelta: '{"content": "Hello, world!"}',
+                  type: 'text',
+                  text: '{"content": "Hello, world!"}',
                 },
                 {
                   type: 'finish',
@@ -840,12 +840,12 @@ describe('streamObject', () => {
           model: new MockLanguageModelV2({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"content": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -872,12 +872,12 @@ describe('streamObject', () => {
           model: new MockLanguageModelV2({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"invalid": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"invalid": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -902,12 +902,12 @@ describe('streamObject', () => {
           model: new MockLanguageModelV2({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"invalid": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"invalid": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -945,8 +945,8 @@ describe('streamObject', () => {
                   timestamp: new Date(0),
                 },
                 {
-                  type: 'text-delta',
-                  textDelta: '{ "content": "Hello, world!" }',
+                  type: 'text',
+                  text: '{ "content": "Hello, world!" }',
                 },
                 {
                   type: 'finish',
@@ -988,12 +988,12 @@ describe('streamObject', () => {
                   modelId: 'mock-model-id',
                   timestamp: new Date(0),
                 },
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"invalid": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"invalid": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -1032,8 +1032,8 @@ describe('streamObject', () => {
               return {
                 stream: convertArrayToReadableStream([
                   {
-                    type: 'text-delta',
-                    textDelta: `{ "content": "headers test" }`,
+                    type: 'text',
+                    text: `{ "content": "headers test" }`,
                   },
                   {
                     type: 'finish',
@@ -1105,8 +1105,8 @@ describe('streamObject', () => {
               return {
                 stream: convertArrayToReadableStream([
                   {
-                    type: 'text-delta',
-                    textDelta: `{ "content": "provider metadata test" }`,
+                    type: 'text',
+                    text: `{ "content": "provider metadata test" }`,
                   },
                   {
                     type: 'finish',
@@ -1204,12 +1204,12 @@ describe('streamObject', () => {
 
               return {
                 stream: convertArrayToReadableStream([
-                  { type: 'text-delta', textDelta: '{ ' },
-                  { type: 'text-delta', textDelta: '"content": ' },
-                  { type: 'text-delta', textDelta: `"Hello, ` },
-                  { type: 'text-delta', textDelta: `world` },
-                  { type: 'text-delta', textDelta: `!"` },
-                  { type: 'text-delta', textDelta: ' }' },
+                  { type: 'text', text: '{ ' },
+                  { type: 'text', text: '"content": ' },
+                  { type: 'text', text: `"Hello, ` },
+                  { type: 'text', text: `world` },
+                  { type: 'text', text: `!"` },
+                  { type: 'text', text: ' }' },
                   {
                     type: 'finish',
                     finishReason: 'stop',
@@ -1296,7 +1296,7 @@ describe('streamObject', () => {
           model: new MockLanguageModelV2({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ "content": 123 }' },
+                { type: 'text', text: '{ "content": 123 }' },
                 {
                   type: 'response-metadata',
                   id: 'id-1',
@@ -1388,7 +1388,7 @@ describe('streamObject', () => {
           model: new MockLanguageModelV2({
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ broken json' },
+                { type: 'text', text: '{ broken json' },
                 {
                   type: 'response-metadata',
                   id: 'id-1',
@@ -1569,25 +1569,25 @@ describe('streamObject', () => {
 
               return {
                 stream: convertArrayToReadableStream([
-                  { type: 'text-delta', textDelta: '{"elements":[' },
+                  { type: 'text', text: '{"elements":[' },
                   // first element:
-                  { type: 'text-delta', textDelta: '{' },
-                  { type: 'text-delta', textDelta: '"content":' },
-                  { type: 'text-delta', textDelta: `"element 1"` },
-                  { type: 'text-delta', textDelta: '},' },
+                  { type: 'text', text: '{' },
+                  { type: 'text', text: '"content":' },
+                  { type: 'text', text: `"element 1"` },
+                  { type: 'text', text: '},' },
                   // second element:
-                  { type: 'text-delta', textDelta: '{ ' },
-                  { type: 'text-delta', textDelta: '"content": ' },
-                  { type: 'text-delta', textDelta: `"element 2"` },
-                  { type: 'text-delta', textDelta: '},' },
+                  { type: 'text', text: '{ ' },
+                  { type: 'text', text: '"content": ' },
+                  { type: 'text', text: `"element 2"` },
+                  { type: 'text', text: '},' },
                   // third element:
-                  { type: 'text-delta', textDelta: '{' },
-                  { type: 'text-delta', textDelta: '"content":' },
-                  { type: 'text-delta', textDelta: `"element 3"` },
-                  { type: 'text-delta', textDelta: '}' },
+                  { type: 'text', text: '{' },
+                  { type: 'text', text: '"content":' },
+                  { type: 'text', text: `"element 3"` },
+                  { type: 'text', text: '}' },
                   // end of array
-                  { type: 'text-delta', textDelta: ']' },
-                  { type: 'text-delta', textDelta: '}' },
+                  { type: 'text', text: ']' },
+                  { type: 'text', text: '}' },
                   // finish
                   {
                     type: 'finish',
@@ -1724,9 +1724,8 @@ describe('streamObject', () => {
               return {
                 stream: convertArrayToReadableStream([
                   {
-                    type: 'text-delta',
-                    textDelta:
-                      '{"elements":[{"content":"element 1"},{"content":"element 2"}]}',
+                    type: 'text',
+                    text: '{"elements":[{"content":"element 1"},{"content":"element 2"}]}',
                   },
                   // finish
                   {
@@ -1814,12 +1813,12 @@ describe('streamObject', () => {
 
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"content": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -1863,12 +1862,12 @@ describe('streamObject', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"content": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world` },
+              { type: 'text', text: `!"` },
+              { type: 'text', text: ' }' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -1900,12 +1899,12 @@ describe('streamObject', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"content": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world` },
+              { type: 'text', text: `!"` },
+              { type: 'text', text: ' }' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -2050,12 +2049,12 @@ describe('streamObject', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"content": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"content": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world` },
+              { type: 'text', text: `!"` },
+              { type: 'text', text: ' }' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -2219,12 +2218,12 @@ describe('streamObject', () => {
 
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: '{ ' },
-                { type: 'text-delta', textDelta: '"content": ' },
-                { type: 'text-delta', textDelta: `"Hello, ` },
-                { type: 'text-delta', textDelta: `world` },
-                { type: 'text-delta', textDelta: `!"` },
-                { type: 'text-delta', textDelta: ' }' },
+                { type: 'text', text: '{ ' },
+                { type: 'text', text: '"content": ' },
+                { type: 'text', text: `"Hello, ` },
+                { type: 'text', text: `world` },
+                { type: 'text', text: `!"` },
+                { type: 'text', text: ' }' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -2282,8 +2281,8 @@ describe('streamObject', () => {
             doStream: async () => ({
               stream: convertArrayToReadableStream([
                 {
-                  type: 'text-delta',
-                  textDelta: '{ "content": "Hello, world!" }',
+                  type: 'text',
+                  text: '{ "content": "Hello, world!" }',
                 },
                 {
                   type: 'finish',

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -600,8 +600,8 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
             transformer = {
               transform: (chunk, controller) => {
                 switch (chunk.type) {
-                  case 'text-delta':
-                    controller.enqueue(chunk.textDelta);
+                  case 'text':
+                    controller.enqueue(chunk.text);
                     break;
                   case 'response-metadata':
                   case 'finish':

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -24,16 +24,16 @@ exports[`streamText > multiple stream consumption > should support text stream, 
       "warnings": [],
     },
     {
-      "textDelta": "Hello",
-      "type": "text-delta",
+      "text": "Hello",
+      "type": "text",
     },
     {
-      "textDelta": ", ",
-      "type": "text-delta",
+      "text": ", ",
+      "type": "text",
     },
     {
-      "textDelta": "world!",
-      "type": "text-delta",
+      "text": "world!",
+      "type": "text",
     },
     {
       "finishReason": "stop",
@@ -553,12 +553,12 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > should 
     "warnings": [],
   },
   {
-    "textDelta": "Hello, ",
-    "type": "text-delta",
+    "text": "Hello, ",
+    "type": "text",
   },
   {
-    "textDelta": "world!",
-    "type": "text-delta",
+    "text": "world!",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -1465,17 +1465,17 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "warnings": [],
   },
   {
-    "textDelta": "part ",
-    "type": "text-delta",
+    "text": "part ",
+    "type": "text",
   },
   {
-    "textDelta": "1 
+    "text": "1 
 ",
-    "type": "text-delta",
+    "type": "text",
   },
   {
-    "textDelta": " ",
-    "type": "text-delta",
+    "text": " ",
+    "type": "text",
   },
   {
     "finishReason": "length",
@@ -1517,8 +1517,8 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "url": "https://example.com",
   },
   {
-    "textDelta": "no-whitespace",
-    "type": "text-delta",
+    "text": "no-whitespace",
+    "type": "text",
   },
   {
     "finishReason": "length",
@@ -1560,8 +1560,8 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "url": "https://example.com/2",
   },
   {
-    "textDelta": "immediatefollow  ",
-    "type": "text-delta",
+    "text": "immediatefollow  ",
+    "type": "text",
   },
   {
     "id": "789",
@@ -1605,21 +1605,21 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
     "warnings": [],
   },
   {
-    "textDelta": "final ",
-    "type": "text-delta",
+    "text": "final ",
+    "type": "text",
   },
   {
-    "textDelta": "value keep all ",
-    "type": "text-delta",
+    "text": "value keep all ",
+    "type": "text",
   },
   {
-    "textDelta": "whitespace
+    "text": "whitespace
  ",
-    "type": "text-delta",
+    "type": "text",
   },
   {
-    "textDelta": "end",
-    "type": "text-delta",
+    "text": "end",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -2118,8 +2118,8 @@ exports[`streamText > options.maxSteps > 4 steps: initial, continue, continue, c
 exports[`streamText > options.onChunk > should return events in order 1`] = `
 [
   {
-    "textDelta": "Hello",
-    "type": "text-delta",
+    "text": "Hello",
+    "type": "text",
   },
   {
     "toolCallId": "1",
@@ -2179,8 +2179,8 @@ exports[`streamText > options.onChunk > should return events in order 1`] = `
     "type": "tool-result",
   },
   {
-    "textDelta": " World",
-    "type": "text-delta",
+    "text": " World",
+    "type": "text",
   },
 ]
 `;
@@ -3186,16 +3186,16 @@ exports[`streamText > result.fullStream > should filter out empty text deltas 1`
     "warnings": [],
   },
   {
-    "textDelta": "Hello",
-    "type": "text-delta",
+    "text": "Hello",
+    "type": "text",
   },
   {
-    "textDelta": ", ",
-    "type": "text-delta",
+    "text": ", ",
+    "type": "text",
   },
   {
-    "textDelta": "world!",
-    "type": "text-delta",
+    "text": "world!",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -3379,8 +3379,8 @@ exports[`streamText > result.fullStream > should send files 1`] = `
     "type": "file",
   },
   {
-    "textDelta": "Hello!",
-    "type": "text-delta",
+    "text": "Hello!",
+    "type": "text",
   },
   {
     "file": DefaultGeneratedFileWithType {
@@ -3476,12 +3476,12 @@ exports[`streamText > result.fullStream > should send reasoning deltas 1`] = `
     "type": "reasoning",
   },
   {
-    "textDelta": "Hi",
-    "type": "text-delta",
+    "text": "Hi",
+    "type": "text",
   },
   {
-    "textDelta": " there!",
-    "type": "text-delta",
+    "text": " there!",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -3545,8 +3545,8 @@ exports[`streamText > result.fullStream > should send sources 1`] = `
     "url": "https://example.com",
   },
   {
-    "textDelta": "Hello!",
-    "type": "text-delta",
+    "text": "Hello!",
+    "type": "text",
   },
   {
     "id": "456",
@@ -3610,16 +3610,16 @@ exports[`streamText > result.fullStream > should send text deltas 1`] = `
     "warnings": [],
   },
   {
-    "textDelta": "Hello",
-    "type": "text-delta",
+    "text": "Hello",
+    "type": "text",
   },
   {
-    "textDelta": ", ",
-    "type": "text-delta",
+    "text": ", ",
+    "type": "text",
   },
   {
-    "textDelta": "world!",
-    "type": "text-delta",
+    "text": "world!",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -3898,16 +3898,16 @@ exports[`streamText > result.fullStream > should use fallback response metadata 
     "warnings": [],
   },
   {
-    "textDelta": "Hello",
-    "type": "text-delta",
+    "text": "Hello",
+    "type": "text",
   },
   {
-    "textDelta": ", ",
-    "type": "text-delta",
+    "text": ", ",
+    "type": "text",
   },
   {
-    "textDelta": "world!",
-    "type": "text-delta",
+    "text": "world!",
+    "type": "text",
   },
   {
     "finishReason": "stop",

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -79,7 +79,7 @@ const modelWithReasoning = new MockLanguageModelV2({
         data: 'redacted-reasoning-data',
       },
     ],
-    text: 'Hello, world!',
+    text: { type: 'text', text: 'Hello, world!' },
   }),
 });
 
@@ -98,7 +98,7 @@ describe('result.text', () => {
 
           return {
             ...dummyResponseValues,
-            text: `Hello, world!`,
+            text: { type: 'text', text: 'Hello, world!' },
           };
         },
       }),
@@ -380,7 +380,7 @@ describe('result.response.messages', () => {
       model: new MockLanguageModelV2({
         doGenerate: async () => ({
           ...dummyResponseValues,
-          text: 'Hello, world!',
+          text: { type: 'text', text: 'Hello, world!' },
         }),
       }),
       prompt: 'test-input',
@@ -395,7 +395,7 @@ describe('result.response.messages', () => {
       model: new MockLanguageModelV2({
         doGenerate: async () => ({
           ...dummyResponseValues,
-          text: 'Hello, world!',
+          text: { type: 'text', text: 'Hello, world!' },
           toolCalls: [
             {
               type: 'tool-call',
@@ -451,7 +451,7 @@ describe('result.request', () => {
       model: new MockLanguageModelV2({
         doGenerate: async ({}) => ({
           ...dummyResponseValues,
-          text: `Hello, world!`,
+          text: { type: 'text', text: 'Hello, world!' },
           request: {
             body: 'test body',
           },
@@ -472,7 +472,7 @@ describe('result.response', () => {
       model: new MockLanguageModelV2({
         doGenerate: async ({}) => ({
           ...dummyResponseValues,
-          text: `Hello, world!`,
+          text: { type: 'text', text: 'Hello, world!' },
           response: {
             id: 'test-id-from-model',
             timestamp: new Date(10000),
@@ -614,7 +614,7 @@ describe('options.maxSteps', () => {
                 ]);
                 return {
                   ...dummyResponseValues,
-                  text: 'Hello, world!',
+                  text: { type: 'text', text: 'Hello, world!' },
                   response: {
                     id: 'test-id-2-from-model',
                     timestamp: new Date(10000),
@@ -707,7 +707,7 @@ describe('options.maxSteps', () => {
                 return {
                   ...dummyResponseValues,
                   // trailing text is to be discarded, trailing whitespace is to be kept:
-                  text: 'part 1 \n to-be-discarded',
+                  text: { type: 'text', text: 'part 1 \n to-be-discarded' },
                   finishReason: 'length', // trigger continue
                   usage: { inputTokens: 10, outputTokens: 20 },
                   response: {
@@ -740,7 +740,7 @@ describe('options.maxSteps', () => {
                 return {
                   ...dummyResponseValues,
                   // case where there is no leading nor trailing whitespace:
-                  text: 'no-whitespace',
+                  text: { type: 'text', text: 'no-whitespace' },
                   finishReason: 'length',
                   response: {
                     id: 'test-id-2-from-model',
@@ -800,7 +800,7 @@ describe('options.maxSteps', () => {
                 return {
                   ...dummyResponseValues,
                   // set up trailing whitespace for next step:
-                  text: 'immediatefollow  ',
+                  text: { type: 'text', text: 'immediatefollow  ' },
                   finishReason: 'length',
                   sources: [
                     {
@@ -862,7 +862,10 @@ describe('options.maxSteps', () => {
                   ...dummyResponseValues,
                   // leading whitespace is to be discarded when there is whitespace from previous step
                   // (for models such as Anthropic that trim trailing whitespace in their inputs):
-                  text: '  final value keep all whitespace\n end',
+                  text: {
+                    type: 'text',
+                    text: '  final value keep all whitespace\n end',
+                  },
                   finishReason: 'stop',
                   files: [
                     {
@@ -965,7 +968,7 @@ describe('options.headers', () => {
 
           return {
             ...dummyResponseValues,
-            text: 'Hello, world!',
+            text: { type: 'text', text: 'Hello, world!' },
           };
         },
       }),
@@ -986,7 +989,10 @@ describe('options.providerOptions', () => {
             aProvider: { someKey: 'someValue' },
           });
 
-          return { ...dummyResponseValues, text: 'provider metadata test' };
+          return {
+            ...dummyResponseValues,
+            text: { type: 'text', text: 'provider metadata test' },
+          };
         },
       }),
       prompt: 'test-input',
@@ -1057,7 +1063,7 @@ describe('telemetry', () => {
       model: new MockLanguageModelV2({
         doGenerate: async ({}) => ({
           ...dummyResponseValues,
-          text: `Hello, world!`,
+          text: { type: 'text', text: 'Hello, world!' },
         }),
       }),
       prompt: 'prompt',
@@ -1072,7 +1078,7 @@ describe('telemetry', () => {
       model: new MockLanguageModelV2({
         doGenerate: async ({}) => ({
           ...dummyResponseValues,
-          text: `Hello, world!`,
+          text: { type: 'text', text: 'Hello, world!' },
           response: {
             id: 'test-id-from-model',
             timestamp: new Date(10000),
@@ -1327,7 +1333,7 @@ describe('options.messages', () => {
 
           return {
             ...dummyResponseValues,
-            text: `Hello, world!`,
+            text: { type: 'text', text: 'Hello, world!' },
           };
         },
       }),
@@ -1369,7 +1375,7 @@ describe('options.messages', () => {
           },
           doGenerate: async () => ({
             ...dummyResponseValues,
-            text: 'Hello, world!',
+            text: { type: 'text', text: 'Hello, world!' },
           }),
         });
       }
@@ -1399,7 +1405,7 @@ describe('options.output', () => {
         model: new MockLanguageModelV2({
           doGenerate: async () => ({
             ...dummyResponseValues,
-            text: `Hello, world!`,
+            text: { type: 'text', text: `Hello, world!` },
           }),
         }),
         prompt: 'prompt',
@@ -1417,7 +1423,7 @@ describe('options.output', () => {
         model: new MockLanguageModelV2({
           doGenerate: async () => ({
             ...dummyResponseValues,
-            text: `Hello, world!`,
+            text: { type: 'text', text: `Hello, world!` },
           }),
         }),
         prompt: 'prompt',
@@ -1436,7 +1442,7 @@ describe('options.output', () => {
             callOptions = args;
             return {
               ...dummyResponseValues,
-              text: `Hello, world!`,
+              text: { type: 'text', text: `Hello, world!` },
             };
           },
         }),
@@ -1467,7 +1473,7 @@ describe('options.output', () => {
             supportsStructuredOutputs: false,
             doGenerate: async () => ({
               ...dummyResponseValues,
-              text: `{ "value": "test-value" }`,
+              text: { type: 'text', text: `{ "value": "test-value" }` },
             }),
           }),
           prompt: 'prompt',
@@ -1489,7 +1495,7 @@ describe('options.output', () => {
               callOptions = args;
               return {
                 ...dummyResponseValues,
-                text: `{ "value": "test-value" }`,
+                text: { type: 'text', text: `{ "value": "test-value" }` },
               };
             },
           }),
@@ -1528,7 +1534,7 @@ describe('options.output', () => {
             supportsStructuredOutputs: true,
             doGenerate: async () => ({
               ...dummyResponseValues,
-              text: `{ "value": "test-value" }`,
+              text: { type: 'text', text: `{ "value": "test-value" }` },
             }),
           }),
           prompt: 'prompt',
@@ -1550,7 +1556,7 @@ describe('options.output', () => {
               callOptions = args;
               return {
                 ...dummyResponseValues,
-                text: `{ "value": "test-value" }`,
+                text: { type: 'text', text: `{ "value": "test-value" }` },
               };
             },
           }),

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -369,7 +369,7 @@ A function that attempts to repair a tool call that failed to parse.
                   attributes: {
                     'ai.response.finishReason': result.finishReason,
                     'ai.response.text': {
-                      output: () => result.text,
+                      output: () => result.text?.text,
                     },
                     'ai.response.toolCalls': {
                       output: () =>
@@ -551,7 +551,7 @@ A function that attempts to repair a tool call that failed to parse.
           attributes: {
             'ai.response.finishReason': currentModelResponse.finishReason,
             'ai.response.text': {
-              output: () => currentModelResponse.text,
+              output: () => currentModelResponse.text?.text,
             },
             'ai.response.toolCalls': {
               output: () =>

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -459,7 +459,7 @@ A function that attempts to repair a tool call that failed to parse.
         }
 
         // text:
-        const originalText = currentModelResponse.text ?? '';
+        const originalText = currentModelResponse.text?.text ?? '';
         const stepTextLeadingWhitespaceTrimmed =
           stepType === 'continue' && // only for continue steps
           text.trimEnd() !== text // only trim when there is preceding whitespace

--- a/packages/ai/core/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.test.ts
@@ -12,7 +12,7 @@ import { runToolsTransformation } from './run-tools-transformation';
 it('should forward text deltas correctly', async () => {
   const inputStream: ReadableStream<LanguageModelV2StreamPart> =
     convertArrayToReadableStream([
-      { type: 'text-delta', textDelta: 'text' },
+      { type: 'text', text: 'text' },
       {
         type: 'finish',
         finishReason: 'stop',
@@ -36,7 +36,7 @@ it('should forward text deltas correctly', async () => {
   const result = await convertReadableStreamToArray(transformedStream);
 
   expect(result).toEqual([
-    { type: 'text-delta', textDelta: 'text' },
+    { type: 'text', text: 'text' },
     {
       type: 'finish',
       finishReason: 'stop',

--- a/packages/ai/core/generate-text/run-tools-transformation.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.ts
@@ -23,10 +23,7 @@ import { ToolResultUnion } from './tool-result';
 import { ToolSet } from './tool-set';
 
 export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
-  | {
-      type: 'text-delta';
-      textDelta: string;
-    }
+  | { type: 'text'; text: string }
   | { type: 'reasoning'; reasoningType: 'text'; text: string }
   | { type: 'reasoning'; reasoningType: 'signature'; signature: string }
   | { type: 'reasoning'; reasoningType: 'redacted'; data: string }
@@ -138,7 +135,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
 
       switch (chunkType) {
         // forward:
-        case 'text-delta':
+        case 'text':
         case 'reasoning':
         case 'source':
         case 'response-metadata':

--- a/packages/ai/core/generate-text/smooth-stream.test.ts
+++ b/packages/ai/core/generate-text/smooth-stream.test.ts
@@ -44,9 +44,9 @@ describe('smoothStream', () => {
   describe('word chunking', () => {
     it('should combine partial words', async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'Hello', type: 'text-delta' },
-        { textDelta: ', ', type: 'text-delta' },
-        { textDelta: 'world!', type: 'text-delta' },
+        { text: 'Hello', type: 'text' },
+        { text: ', ', type: 'text' },
+        { text: 'world!', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -61,12 +61,12 @@ describe('smoothStream', () => {
       expect(events).toEqual([
         'delay 10',
         {
-          textDelta: 'Hello, ',
-          type: 'text-delta',
+          text: 'Hello, ',
+          type: 'text',
         },
         {
-          textDelta: 'world!',
-          type: 'text-delta',
+          text: 'world!',
+          type: 'text',
         },
         {
           type: 'step-finish',
@@ -80,8 +80,8 @@ describe('smoothStream', () => {
     it('should split larger text chunks', async () => {
       const stream = convertArrayToReadableStream([
         {
-          textDelta: 'Hello, World! This is an example text.',
-          type: 'text-delta',
+          text: 'Hello, World! This is an example text.',
+          type: 'text',
         },
         { type: 'step-finish' },
         { type: 'finish' },
@@ -97,37 +97,37 @@ describe('smoothStream', () => {
       expect(events).toEqual([
         'delay 10',
         {
-          textDelta: 'Hello, ',
-          type: 'text-delta',
+          text: 'Hello, ',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'World! ',
-          type: 'text-delta',
+          text: 'World! ',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'This ',
-          type: 'text-delta',
+          text: 'This ',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'is ',
-          type: 'text-delta',
+          text: 'is ',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'an ',
-          type: 'text-delta',
+          text: 'an ',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'example ',
-          type: 'text-delta',
+          text: 'example ',
+          type: 'text',
         },
         {
-          textDelta: 'text.',
-          type: 'text-delta',
+          text: 'text.',
+          type: 'text',
         },
         {
           type: 'step-finish',
@@ -140,11 +140,11 @@ describe('smoothStream', () => {
 
     it('should keep longer whitespace sequences together', async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'First line', type: 'text-delta' },
-        { textDelta: ' \n\n', type: 'text-delta' },
-        { textDelta: '  ', type: 'text-delta' },
-        { textDelta: '  Multiple spaces', type: 'text-delta' },
-        { textDelta: '\n    Indented', type: 'text-delta' },
+        { text: 'First line', type: 'text' },
+        { text: ' \n\n', type: 'text' },
+        { text: '  ', type: 'text' },
+        { text: '  Multiple spaces', type: 'text' },
+        { text: '\n    Indented', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -159,29 +159,29 @@ describe('smoothStream', () => {
       expect(events).toEqual([
         'delay 10',
         {
-          textDelta: 'First ',
-          type: 'text-delta',
+          text: 'First ',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'line \n\n',
-          type: 'text-delta',
+          text: 'line \n\n',
+          type: 'text',
         },
         'delay 10',
         {
           // note: leading whitespace is included here
           // because it is part of the new chunk:
-          textDelta: '    Multiple ',
-          type: 'text-delta',
+          text: '    Multiple ',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'spaces\n    ',
-          type: 'text-delta',
+          text: 'spaces\n    ',
+          type: 'text',
         },
         {
-          textDelta: 'Indented',
-          type: 'text-delta',
+          text: 'Indented',
+          type: 'text',
         },
         {
           type: 'step-finish',
@@ -194,9 +194,9 @@ describe('smoothStream', () => {
 
     it('should send remaining text buffer before tool call starts', async () => {
       const stream = convertArrayToReadableStream([
-        { type: 'text-delta', textDelta: 'I will check the' },
-        { type: 'text-delta', textDelta: ' weather in Lon' },
-        { type: 'text-delta', textDelta: 'don.' },
+        { type: 'text', text: 'I will check the' },
+        { type: 'text', text: ' weather in Lon' },
+        { type: 'text', text: 'don.' },
         { type: 'tool-call', name: 'weather', args: { city: 'London' } },
         { type: 'step-finish' },
         { type: 'finish' },
@@ -213,37 +213,37 @@ describe('smoothStream', () => {
         [
           "delay 10",
           {
-            "textDelta": "I ",
-            "type": "text-delta",
+            "text": "I ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "will ",
-            "type": "text-delta",
+            "text": "will ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "check ",
-            "type": "text-delta",
+            "text": "check ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "the ",
-            "type": "text-delta",
+            "text": "the ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "weather ",
-            "type": "text-delta",
+            "text": "weather ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "in ",
-            "type": "text-delta",
+            "text": "in ",
+            "type": "text",
           },
           {
-            "textDelta": "London.",
-            "type": "text-delta",
+            "text": "London.",
+            "type": "text",
           },
           {
             "args": {
@@ -264,9 +264,9 @@ describe('smoothStream', () => {
 
     it('should send remaining text buffer before tool call starts and tool call streaming is enabled', async () => {
       const stream = convertArrayToReadableStream([
-        { type: 'text-delta', textDelta: 'I will check the' },
-        { type: 'text-delta', textDelta: ' weather in Lon' },
-        { type: 'text-delta', textDelta: 'don.' },
+        { type: 'text', text: 'I will check the' },
+        { type: 'text', text: ' weather in Lon' },
+        { type: 'text', text: 'don.' },
         {
           type: 'tool-call-streaming-start',
           name: 'weather',
@@ -289,37 +289,37 @@ describe('smoothStream', () => {
         [
           "delay 10",
           {
-            "textDelta": "I ",
-            "type": "text-delta",
+            "text": "I ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "will ",
-            "type": "text-delta",
+            "text": "will ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "check ",
-            "type": "text-delta",
+            "text": "check ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "the ",
-            "type": "text-delta",
+            "text": "the ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "weather ",
-            "type": "text-delta",
+            "text": "weather ",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "in ",
-            "type": "text-delta",
+            "text": "in ",
+            "type": "text",
           },
           {
-            "textDelta": "London.",
-            "type": "text-delta",
+            "text": "London.",
+            "type": "text",
           },
           {
             "args": {
@@ -354,10 +354,10 @@ describe('smoothStream', () => {
 
     it(`doesn't return chunks with just spaces`, async () => {
       const stream = convertArrayToReadableStream([
-        { type: 'text-delta', textDelta: ' ' },
-        { type: 'text-delta', textDelta: ' ' },
-        { type: 'text-delta', textDelta: ' ' },
-        { type: 'text-delta', textDelta: 'foo' },
+        { type: 'text', text: ' ' },
+        { type: 'text', text: ' ' },
+        { type: 'text', text: ' ' },
+        { type: 'text', text: 'foo' },
 
         { type: 'step-finish' },
         { type: 'finish' },
@@ -373,8 +373,8 @@ describe('smoothStream', () => {
       expect(events).toMatchInlineSnapshot(`
         [
           {
-            "textDelta": "   foo",
-            "type": "text-delta",
+            "text": "   foo",
+            "type": "text",
           },
           {
             "type": "step-finish",
@@ -391,11 +391,11 @@ describe('smoothStream', () => {
     it('should split text by lines when using line chunking mode', async () => {
       const stream = convertArrayToReadableStream([
         {
-          textDelta: 'First line\nSecond line\nThird line with more text\n',
-          type: 'text-delta',
+          text: 'First line\nSecond line\nThird line with more text\n',
+          type: 'text',
         },
-        { textDelta: 'Partial line', type: 'text-delta' },
-        { textDelta: ' continues\nFinal line\n', type: 'text-delta' },
+        { text: 'Partial line', type: 'text' },
+        { text: ' continues\nFinal line\n', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -411,28 +411,28 @@ describe('smoothStream', () => {
       expect(events).toEqual([
         'delay 10',
         {
-          textDelta: 'First line\n',
-          type: 'text-delta',
+          text: 'First line\n',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'Second line\n',
-          type: 'text-delta',
+          text: 'Second line\n',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'Third line with more text\n',
-          type: 'text-delta',
+          text: 'Third line with more text\n',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'Partial line continues\n',
-          type: 'text-delta',
+          text: 'Partial line continues\n',
+          type: 'text',
         },
         'delay 10',
         {
-          textDelta: 'Final line\n',
-          type: 'text-delta',
+          text: 'Final line\n',
+          type: 'text',
         },
         {
           type: 'step-finish',
@@ -445,9 +445,9 @@ describe('smoothStream', () => {
 
     it('should handle text without line endings in line chunking mode', async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'Text without', type: 'text-delta' },
-        { textDelta: ' any line', type: 'text-delta' },
-        { textDelta: ' breaks', type: 'text-delta' },
+        { text: 'Text without', type: 'text' },
+        { text: ' any line', type: 'text' },
+        { text: ' breaks', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -461,8 +461,8 @@ describe('smoothStream', () => {
 
       expect(events).toEqual([
         {
-          textDelta: 'Text without any line breaks',
-          type: 'text-delta',
+          text: 'Text without any line breaks',
+          type: 'text',
         },
         {
           type: 'step-finish',
@@ -477,7 +477,7 @@ describe('smoothStream', () => {
   describe('custom chunking', () => {
     it(`should return correct result for regexes that don't match from the exact start onwards`, async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'Hello_, world!', type: 'text-delta' },
+        { text: 'Hello_, world!', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -494,12 +494,12 @@ describe('smoothStream', () => {
         [
           "delay 10",
           {
-            "textDelta": "Hello_",
-            "type": "text-delta",
+            "text": "Hello_",
+            "type": "text",
           },
           {
-            "textDelta": ", world!",
-            "type": "text-delta",
+            "text": ", world!",
+            "type": "text",
           },
           {
             "type": "step-finish",
@@ -513,7 +513,7 @@ describe('smoothStream', () => {
 
     it('should support custom chunking regexps (character-level)', async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'Hello, world!', type: 'text-delta' },
+        { text: 'Hello, world!', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -528,31 +528,31 @@ describe('smoothStream', () => {
 
       expect(events).toEqual([
         'delay 10',
-        { textDelta: 'H', type: 'text-delta' },
+        { text: 'H', type: 'text' },
         'delay 10',
-        { textDelta: 'e', type: 'text-delta' },
+        { text: 'e', type: 'text' },
         'delay 10',
-        { textDelta: 'l', type: 'text-delta' },
+        { text: 'l', type: 'text' },
         'delay 10',
-        { textDelta: 'l', type: 'text-delta' },
+        { text: 'l', type: 'text' },
         'delay 10',
-        { textDelta: 'o', type: 'text-delta' },
+        { text: 'o', type: 'text' },
         'delay 10',
-        { textDelta: ',', type: 'text-delta' },
+        { text: ',', type: 'text' },
         'delay 10',
-        { textDelta: ' ', type: 'text-delta' },
+        { text: ' ', type: 'text' },
         'delay 10',
-        { textDelta: 'w', type: 'text-delta' },
+        { text: 'w', type: 'text' },
         'delay 10',
-        { textDelta: 'o', type: 'text-delta' },
+        { text: 'o', type: 'text' },
         'delay 10',
-        { textDelta: 'r', type: 'text-delta' },
+        { text: 'r', type: 'text' },
         'delay 10',
-        { textDelta: 'l', type: 'text-delta' },
+        { text: 'l', type: 'text' },
         'delay 10',
-        { textDelta: 'd', type: 'text-delta' },
+        { text: 'd', type: 'text' },
         'delay 10',
-        { textDelta: '!', type: 'text-delta' },
+        { text: '!', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]);
@@ -562,8 +562,8 @@ describe('smoothStream', () => {
   describe('custom callback chunking', () => {
     it('should support custom chunking callback', async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'He_llo, ', type: 'text-delta' },
-        { textDelta: 'w_orld!', type: 'text-delta' },
+        { text: 'He_llo, ', type: 'text' },
+        { text: 'w_orld!', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -579,17 +579,17 @@ describe('smoothStream', () => {
         [
           "delay 10",
           {
-            "textDelta": "He_",
-            "type": "text-delta",
+            "text": "He_",
+            "type": "text",
           },
           "delay 10",
           {
-            "textDelta": "llo, w_",
-            "type": "text-delta",
+            "text": "llo, w_",
+            "type": "text",
           },
           {
-            "textDelta": "orld!",
-            "type": "text-delta",
+            "text": "orld!",
+            "type": "text",
           },
           {
             "type": "step-finish",
@@ -604,7 +604,7 @@ describe('smoothStream', () => {
     describe('throws errors if the chunking function invalid matches', async () => {
       it('throws empty match error', async () => {
         const stream = convertArrayToReadableStream([
-          { textDelta: 'Hello, world!', type: 'text-delta' },
+          { text: 'Hello, world!', type: 'text' },
           { type: 'step-finish' },
           { type: 'finish' },
         ]).pipeThrough(
@@ -622,7 +622,7 @@ describe('smoothStream', () => {
 
       it('throws match prefix error', async () => {
         const stream = convertArrayToReadableStream([
-          { textDelta: 'Hello, world!', type: 'text-delta' },
+          { text: 'Hello, world!', type: 'text' },
           { type: 'step-finish' },
           { type: 'finish' },
         ]).pipeThrough(
@@ -643,7 +643,7 @@ describe('smoothStream', () => {
   describe('delay', () => {
     it('should default to 10ms', async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'Hello, world!', type: 'text-delta' },
+        { text: 'Hello, world!', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -654,28 +654,30 @@ describe('smoothStream', () => {
 
       await consumeStream(stream);
 
-      expect(events).toEqual([
-        'delay 10',
-        {
-          textDelta: 'Hello, ',
-          type: 'text-delta',
-        },
-        {
-          textDelta: 'world!',
-          type: 'text-delta',
-        },
-        {
-          type: 'step-finish',
-        },
-        {
-          type: 'finish',
-        },
-      ]);
+      expect(events).toMatchInlineSnapshot(`
+        [
+          "delay 10",
+          {
+            "text": "Hello, ",
+            "type": "text",
+          },
+          {
+            "text": "world!",
+            "type": "text",
+          },
+          {
+            "type": "step-finish",
+          },
+          {
+            "type": "finish",
+          },
+        ]
+      `);
     });
 
     it('should support different number of milliseconds delay', async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'Hello, world!', type: 'text-delta' },
+        { text: 'Hello, world!', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -687,28 +689,30 @@ describe('smoothStream', () => {
 
       await consumeStream(stream);
 
-      expect(events).toEqual([
-        'delay 20',
-        {
-          textDelta: 'Hello, ',
-          type: 'text-delta',
-        },
-        {
-          textDelta: 'world!',
-          type: 'text-delta',
-        },
-        {
-          type: 'step-finish',
-        },
-        {
-          type: 'finish',
-        },
-      ]);
+      expect(events).toMatchInlineSnapshot(`
+        [
+          "delay 20",
+          {
+            "text": "Hello, ",
+            "type": "text",
+          },
+          {
+            "text": "world!",
+            "type": "text",
+          },
+          {
+            "type": "step-finish",
+          },
+          {
+            "type": "finish",
+          },
+        ]
+      `);
     });
 
     it('should support null delay', async () => {
       const stream = convertArrayToReadableStream([
-        { textDelta: 'Hello, world!', type: 'text-delta' },
+        { text: 'Hello, world!', type: 'text' },
         { type: 'step-finish' },
         { type: 'finish' },
       ]).pipeThrough(
@@ -720,23 +724,25 @@ describe('smoothStream', () => {
 
       await consumeStream(stream);
 
-      expect(events).toEqual([
-        'delay null',
-        {
-          textDelta: 'Hello, ',
-          type: 'text-delta',
-        },
-        {
-          textDelta: 'world!',
-          type: 'text-delta',
-        },
-        {
-          type: 'step-finish',
-        },
-        {
-          type: 'finish',
-        },
-      ]);
+      expect(events).toMatchInlineSnapshot(`
+        [
+          "delay null",
+          {
+            "text": "Hello, ",
+            "type": "text",
+          },
+          {
+            "text": "world!",
+            "type": "text",
+          },
+          {
+            "type": "step-finish",
+          },
+          {
+            "type": "finish",
+          },
+        ]
+      `);
     });
   });
 });

--- a/packages/ai/core/generate-text/smooth-stream.ts
+++ b/packages/ai/core/generate-text/smooth-stream.ts
@@ -90,9 +90,9 @@ export function smoothStream<TOOLS extends ToolSet>({
 
     return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
       async transform(chunk, controller) {
-        if (chunk.type !== 'text-delta') {
+        if (chunk.type !== 'text') {
           if (buffer.length > 0) {
-            controller.enqueue({ type: 'text-delta', textDelta: buffer });
+            controller.enqueue({ type: 'text', text: buffer });
             buffer = '';
           }
 
@@ -100,12 +100,12 @@ export function smoothStream<TOOLS extends ToolSet>({
           return;
         }
 
-        buffer += chunk.textDelta;
+        buffer += chunk.text;
 
         let match;
 
         while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type: 'text-delta', textDelta: match });
+          controller.enqueue({ type: 'text', text: match });
           buffer = buffer.slice(match.length);
 
           await delay(delayInMs);

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -297,10 +297,7 @@ If an error occurs, it is passed to the optional `onError` callback.
 }
 
 export type TextStreamPart<TOOLS extends ToolSet> =
-  | {
-      type: 'text-delta';
-      textDelta: string;
-    }
+  | { type: 'text'; text: string }
   | { type: 'reasoning'; reasoningType: 'text'; text: string }
   | { type: 'reasoning'; reasoningType: 'signature'; signature: string }
   | { type: 'reasoning'; reasoningType: 'redacted'; data: string }

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -47,9 +47,9 @@ function createTestModel({
       modelId: 'mock-model-id',
       timestamp: new Date(0),
     },
-    { type: 'text-delta', textDelta: 'Hello' },
-    { type: 'text-delta', textDelta: ', ' },
-    { type: 'text-delta', textDelta: `world!` },
+    { type: 'text', text: 'Hello' },
+    { type: 'text', text: ', ' },
+    { type: 'text', text: `world!` },
     {
       type: 'finish',
       finishReason: 'stop',
@@ -82,7 +82,7 @@ const modelWithSources = new MockLanguageModelV2({
         title: 'Example',
         providerMetadata: { provider: { custom: 'value' } },
       },
-      { type: 'text-delta', textDelta: 'Hello!' },
+      { type: 'text', text: 'Hello!' },
       {
         type: 'source',
         sourceType: 'url',
@@ -109,7 +109,7 @@ const modelWithFiles = new MockLanguageModelV2({
         data: 'Hello World',
         mediaType: 'text/plain',
       },
-      { type: 'text-delta', textDelta: 'Hello!' },
+      { type: 'text', text: 'Hello!' },
       {
         type: 'file',
         data: 'QkFVRw==',
@@ -169,8 +169,8 @@ const modelWithReasoning = new MockLanguageModelV2({
         reasoningType: 'signature',
         signature: '1234567890',
       },
-      { type: 'text-delta', textDelta: 'Hi' },
-      { type: 'text-delta', textDelta: ' there!' },
+      { type: 'text', text: 'Hi' },
+      { type: 'text', text: ' there!' },
       {
         type: 'finish',
         finishReason: 'stop',
@@ -197,9 +197,9 @@ describe('streamText', () => {
 
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'Hello' },
-                { type: 'text-delta', textDelta: ', ' },
-                { type: 'text-delta', textDelta: `world!` },
+                { type: 'text', text: 'Hello' },
+                { type: 'text', text: ', ' },
+                { type: 'text', text: `world!` },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -222,13 +222,13 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: '' },
-            { type: 'text-delta', textDelta: 'Hello' },
-            { type: 'text-delta', textDelta: '' },
-            { type: 'text-delta', textDelta: ', ' },
-            { type: 'text-delta', textDelta: '' },
-            { type: 'text-delta', textDelta: 'world!' },
-            { type: 'text-delta', textDelta: '' },
+            { type: 'text', text: '' },
+            { type: 'text', text: 'Hello' },
+            { type: 'text', text: '' },
+            { type: 'text', text: ', ' },
+            { type: 'text', text: '' },
+            { type: 'text', text: 'world!' },
+            { type: 'text', text: '' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -293,9 +293,9 @@ describe('streamText', () => {
                   modelId: 'response-model-id',
                   timestamp: new Date(5000),
                 },
-                { type: 'text-delta', textDelta: 'Hello' },
-                { type: 'text-delta', textDelta: ', ' },
-                { type: 'text-delta', textDelta: `world!` },
+                { type: 'text', text: 'Hello' },
+                { type: 'text', text: ', ' },
+                { type: 'text', text: `world!` },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -362,9 +362,9 @@ describe('streamText', () => {
 
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'Hello' },
-                { type: 'text-delta', textDelta: ', ' },
-                { type: 'text-delta', textDelta: `world!` },
+                { type: 'text', text: 'Hello' },
+                { type: 'text', text: ', ' },
+                { type: 'text', text: `world!` },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -764,13 +764,13 @@ describe('streamText', () => {
               modelId: 'mock-model-id',
               timestamp: new Date(0),
             },
-            { type: 'text-delta', textDelta: '' },
-            { type: 'text-delta', textDelta: 'Hello' },
-            { type: 'text-delta', textDelta: '' },
-            { type: 'text-delta', textDelta: ', ' },
-            { type: 'text-delta', textDelta: '' },
-            { type: 'text-delta', textDelta: 'world!' },
-            { type: 'text-delta', textDelta: '' },
+            { type: 'text', text: '' },
+            { type: 'text', text: 'Hello' },
+            { type: 'text', text: '' },
+            { type: 'text', text: ', ' },
+            { type: 'text', text: '' },
+            { type: 'text', text: 'world!' },
+            { type: 'text', text: '' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -938,7 +938,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello, World!' },
+            { type: 'text', text: 'Hello, World!' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -963,7 +963,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello, World!' },
+            { type: 'text', text: 'Hello, World!' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1055,9 +1055,9 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello' },
-            { type: 'text-delta', textDelta: ', ' },
-            { type: 'text-delta', textDelta: 'world!' },
+            { type: 'text', text: 'Hello' },
+            { type: 'text', text: ', ' },
+            { type: 'text', text: 'world!' },
           ]),
         }),
         prompt: 'test-input',
@@ -1257,7 +1257,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello, World!' },
+            { type: 'text', text: 'Hello, World!' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1281,7 +1281,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello, World!' },
+            { type: 'text', text: 'Hello, World!' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1453,7 +1453,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello, World!' },
+            { type: 'text', text: 'Hello, World!' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1537,7 +1537,7 @@ describe('streamText', () => {
         model: createTestModel({
           stream: new ReadableStream({
             start(controller) {
-              controller.enqueue({ type: 'text-delta', textDelta: 'Hello' });
+              controller.enqueue({ type: 'text', text: 'Hello' });
               queueMicrotask(() => {
                 controller.error(
                   Object.assign(new Error('Stream aborted'), {
@@ -1559,7 +1559,7 @@ describe('streamText', () => {
         model: createTestModel({
           stream: new ReadableStream({
             start(controller) {
-              controller.enqueue({ type: 'text-delta', textDelta: 'Hello' });
+              controller.enqueue({ type: 'text', text: 'Hello' });
               queueMicrotask(() => {
                 controller.error(
                   Object.assign(new Error('Response aborted'), {
@@ -1581,7 +1581,7 @@ describe('streamText', () => {
         model: createTestModel({
           stream: new ReadableStream({
             start(controller) {
-              controller.enqueue({ type: 'text-delta', textDelta: 'Hello' });
+              controller.enqueue({ type: 'text', text: 'Hello' });
               queueMicrotask(() => {
                 controller.error(Object.assign(new Error('Some error')));
               });
@@ -1600,7 +1600,7 @@ describe('streamText', () => {
         model: createTestModel({
           stream: new ReadableStream({
             start(controller) {
-              controller.enqueue({ type: 'text-delta', textDelta: 'Hello' });
+              controller.enqueue({ type: 'text', text: 'Hello' });
               queueMicrotask(() => {
                 controller.error(Object.assign(new Error('Some error')));
               });
@@ -1628,9 +1628,9 @@ describe('streamText', () => {
               modelId: 'mock-model-id',
               timestamp: new Date(0),
             },
-            { type: 'text-delta', textDelta: 'Hello' },
-            { type: 'text-delta', textDelta: ', ' },
-            { type: 'text-delta', textDelta: 'world!' },
+            { type: 'text', text: 'Hello' },
+            { type: 'text', text: ', ' },
+            { type: 'text', text: 'world!' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1675,7 +1675,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello' },
+            { type: 'text', text: 'Hello' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1702,7 +1702,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello' },
+            { type: 'text', text: 'Hello' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1725,7 +1725,7 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello' },
+            { type: 'text', text: 'Hello' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1772,7 +1772,7 @@ describe('streamText', () => {
               modelId: 'mock-model-id',
               timestamp: new Date(0),
             },
-            { type: 'text-delta', textDelta: 'Hello' },
+            { type: 'text', text: 'Hello' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -1804,7 +1804,7 @@ describe('streamText', () => {
               modelId: 'mock-model-id',
               timestamp: new Date(0),
             },
-            { type: 'text-delta', textDelta: 'Hello' },
+            { type: 'text', text: 'Hello' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -2030,7 +2030,7 @@ describe('streamText', () => {
       const resultObject = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello' },
+            { type: 'text', text: 'Hello' },
             {
               type: 'tool-call-delta',
               toolCallId: '1',
@@ -2072,7 +2072,7 @@ describe('streamText', () => {
               toolName: 'tool1',
               args: `{ "value": "test" }`,
             },
-            { type: 'text-delta', textDelta: ' World' },
+            { type: 'text', text: ' World' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -2138,8 +2138,8 @@ describe('streamText', () => {
               modelId: 'mock-model-id',
               timestamp: new Date(0),
             },
-            { type: 'text-delta', textDelta: 'Hello' },
-            { type: 'text-delta', textDelta: ', ' },
+            { type: 'text', text: 'Hello' },
+            { type: 'text', text: ', ' },
             {
               type: 'tool-call',
               toolCallType: 'function',
@@ -2147,7 +2147,7 @@ describe('streamText', () => {
               toolName: 'tool1',
               args: `{ "value": "value" }`,
             },
-            { type: 'text-delta', textDelta: `world!` },
+            { type: 'text', text: `world!` },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -2240,8 +2240,8 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello, ' },
-            { type: 'text-delta', textDelta: 'world!' },
+            { type: 'text', text: 'Hello, ' },
+            { type: 'text', text: 'world!' },
             {
               type: 'finish',
               finishReason: 'stop',
@@ -2262,8 +2262,8 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
-            { type: 'text-delta', textDelta: 'Hello, ' },
-            { type: 'text-delta', textDelta: 'world!' },
+            { type: 'text', text: 'Hello, ' },
+            { type: 'text', text: 'world!' },
             {
               type: 'tool-call',
               toolCallType: 'function',
@@ -2441,8 +2441,8 @@ describe('streamText', () => {
                         modelId: 'mock-model-id',
                         timestamp: new Date(1000),
                       },
-                      { type: 'text-delta', textDelta: 'Hello, ' },
-                      { type: 'text-delta', textDelta: `world!` },
+                      { type: 'text', text: 'Hello, ' },
+                      { type: 'text', text: `world!` },
                       {
                         type: 'finish',
                         finishReason: 'stop',
@@ -2568,12 +2568,12 @@ describe('streamText', () => {
                         timestamp: new Date(0),
                       },
                       // trailing text is to be discarded, trailing whitespace is to be kept:
-                      { type: 'text-delta', textDelta: 'pa' },
-                      { type: 'text-delta', textDelta: 'rt ' },
-                      { type: 'text-delta', textDelta: '1 \n' },
-                      { type: 'text-delta', textDelta: ' to-be' },
-                      { type: 'text-delta', textDelta: '-discar' },
-                      { type: 'text-delta', textDelta: 'ded' },
+                      { type: 'text', text: 'pa' },
+                      { type: 'text', text: 'rt ' },
+                      { type: 'text', text: '1 \n' },
+                      { type: 'text', text: ' to-be' },
+                      { type: 'text', text: '-discar' },
+                      { type: 'text', text: 'ded' },
                       {
                         type: 'finish',
                         finishReason: 'length',
@@ -2612,7 +2612,7 @@ describe('streamText', () => {
                         timestamp: new Date(1000),
                       },
                       // case where there is no leading nor trailing whitespace:
-                      { type: 'text-delta', textDelta: 'no-' },
+                      { type: 'text', text: 'no-' },
                       {
                         type: 'source',
                         sourceType: 'url' as const,
@@ -2621,7 +2621,7 @@ describe('streamText', () => {
                         title: 'Example',
                         providerMetadata: { provider: { custom: 'value' } },
                       },
-                      { type: 'text-delta', textDelta: 'whitespace' },
+                      { type: 'text', text: 'whitespace' },
                       {
                         type: 'finish',
                         finishReason: 'length',
@@ -2673,7 +2673,7 @@ describe('streamText', () => {
                         providerMetadata: { provider: { custom: 'value2' } },
                       },
                       // set up trailing whitespace for next step:
-                      { type: 'text-delta', textDelta: 'immediatefollow  ' },
+                      { type: 'text', text: 'immediatefollow  ' },
                       {
                         type: 'source',
                         sourceType: 'url' as const,
@@ -2732,14 +2732,14 @@ describe('streamText', () => {
                       },
                       // leading whitespace is to be discarded when there is whitespace from previous step
                       // (for models such as Anthropic that trim trailing whitespace in their inputs):
-                      { type: 'text-delta', textDelta: ' ' }, // split into 2 chunks for test coverage
-                      { type: 'text-delta', textDelta: '  final' },
-                      { type: 'text-delta', textDelta: ' va' },
-                      { type: 'text-delta', textDelta: 'lue keep all w' },
-                      { type: 'text-delta', textDelta: 'hitespace' },
-                      { type: 'text-delta', textDelta: '\n ' },
-                      { type: 'text-delta', textDelta: 'en' },
-                      { type: 'text-delta', textDelta: 'd' },
+                      { type: 'text', text: ' ' }, // split into 2 chunks for test coverage
+                      { type: 'text', text: '  final' },
+                      { type: 'text', text: ' va' },
+                      { type: 'text', text: 'lue keep all w' },
+                      { type: 'text', text: 'hitespace' },
+                      { type: 'text', text: '\n ' },
+                      { type: 'text', text: 'en' },
+                      { type: 'text', text: 'd' },
                       {
                         type: 'finish',
                         finishReason: 'stop',
@@ -2872,9 +2872,9 @@ describe('streamText', () => {
 
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'Hello' },
-                { type: 'text-delta', textDelta: ', ' },
-                { type: 'text-delta', textDelta: `world!` },
+                { type: 'text', text: 'Hello' },
+                { type: 'text', text: ', ' },
+                { type: 'text', text: `world!` },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -2907,7 +2907,7 @@ describe('streamText', () => {
 
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'provider metadata test' },
+                { type: 'text', text: 'provider metadata test' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -3245,7 +3245,7 @@ describe('streamText', () => {
 
             return {
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'Hello' },
+                { type: 'text', text: 'Hello' },
                 {
                   type: 'finish',
                   finishReason: 'stop',
@@ -3296,9 +3296,9 @@ describe('streamText', () => {
             },
             doStream: async () => ({
               stream: convertArrayToReadableStream([
-                { type: 'text-delta', textDelta: 'Hello' },
-                { type: 'text-delta', textDelta: ', ' },
-                { type: 'text-delta', textDelta: 'world!' },
+                { type: 'text', text: 'Hello' },
+                { type: 'text', text: ', ' },
+                { type: 'text', text: 'world!' },
               ]),
             }),
           });
@@ -3436,8 +3436,8 @@ describe('streamText', () => {
           TextStreamPart<{ tool1: Tool<{ value: string }> }>
         >({
           transform(chunk, controller) {
-            if (chunk.type === 'text-delta') {
-              chunk.textDelta = chunk.textDelta.toUpperCase();
+            if (chunk.type === 'text') {
+              chunk.text = chunk.text.toUpperCase();
             }
 
             if (chunk.type === 'tool-call-delta') {
@@ -3537,7 +3537,7 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello' },
+              { type: 'text', text: 'Hello' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -3575,7 +3575,7 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello' },
+              { type: 'text', text: 'Hello' },
               {
                 type: 'finish',
                 finishReason: 'length',
@@ -3605,8 +3605,8 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello, ' },
-              { type: 'text-delta', textDelta: 'world!' },
+              { type: 'text', text: 'Hello, ' },
+              { type: 'text', text: 'world!' },
               {
                 type: 'tool-call',
                 toolCallType: 'function',
@@ -3647,8 +3647,8 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello, ' },
-              { type: 'text-delta', textDelta: 'world!' },
+              { type: 'text', text: 'Hello, ' },
+              { type: 'text', text: 'world!' },
               {
                 type: 'tool-call',
                 toolCallType: 'function',
@@ -3696,8 +3696,8 @@ describe('streamText', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: 'Hello, ' },
-              { type: 'text-delta', textDelta: 'world!' },
+              { type: 'text', text: 'Hello, ' },
+              { type: 'text', text: 'world!' },
               {
                 type: 'tool-call',
                 toolCallType: 'function',
@@ -3738,7 +3738,7 @@ describe('streamText', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: 'Hello' },
+              { type: 'text', text: 'Hello' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -3769,7 +3769,7 @@ describe('streamText', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: 'Hello' },
+              { type: 'text', text: 'Hello' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -3813,8 +3813,8 @@ describe('streamText', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: 'Hello' },
-              { type: 'text-delta', textDelta: ', ' },
+              { type: 'text', text: 'Hello' },
+              { type: 'text', text: ', ' },
               {
                 type: 'tool-call',
                 toolCallType: 'function',
@@ -3822,7 +3822,7 @@ describe('streamText', () => {
                 toolName: 'tool1',
                 args: `{ "value": "value" }`,
               },
-              { type: 'text-delta', textDelta: `world!` },
+              { type: 'text', text: `world!` },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -3868,8 +3868,8 @@ describe('streamText', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: 'Hello' },
-              { type: 'text-delta', textDelta: ', ' },
+              { type: 'text', text: 'Hello' },
+              { type: 'text', text: ', ' },
               {
                 type: 'tool-call',
                 toolCallType: 'function',
@@ -3877,7 +3877,7 @@ describe('streamText', () => {
                 toolName: 'tool1',
                 args: `{ "value": "value" }`,
               },
-              { type: 'text-delta', textDelta: `world!` },
+              { type: 'text', text: `world!` },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -3921,8 +3921,8 @@ describe('streamText', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: 'Hello' },
-              { type: 'text-delta', textDelta: ', ' },
+              { type: 'text', text: 'Hello' },
+              { type: 'text', text: ', ' },
               {
                 type: 'tool-call',
                 toolCallType: 'function',
@@ -3930,7 +3930,7 @@ describe('streamText', () => {
                 toolName: 'tool1',
                 args: `{ "value": "value" }`,
               },
-              { type: 'text-delta', textDelta: `world!` },
+              { type: 'text', text: `world!` },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -3979,7 +3979,7 @@ describe('streamText', () => {
         const resultObject = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello' },
+              { type: 'text', text: 'Hello' },
               {
                 type: 'reasoning',
                 reasoningType: 'text',
@@ -4013,7 +4013,7 @@ describe('streamText', () => {
                 toolName: 'tool1',
                 args: `{ "value": "test" }`,
               },
-              { type: 'text-delta', textDelta: ' World' },
+              { type: 'text', text: ' World' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4103,14 +4103,14 @@ describe('streamText', () => {
         (options: { tools: TOOLS }) =>
           new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
             transform(chunk, controller) {
-              if (chunk.type !== 'text-delta') {
+              if (chunk.type !== 'text') {
                 controller.enqueue(chunk);
                 return;
               }
 
               controller.enqueue({
                 ...chunk,
-                textDelta: `${chunk.textDelta.toUpperCase()},`,
+                text: `${chunk.text.toUpperCase()},`,
               });
             },
           });
@@ -4120,14 +4120,14 @@ describe('streamText', () => {
         (options: { tools: TOOLS }) =>
           new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
             transform(chunk, controller) {
-              if (chunk.type !== 'text-delta') {
+              if (chunk.type !== 'text') {
                 controller.enqueue(chunk);
                 return;
               }
 
               controller.enqueue({
                 ...chunk,
-                textDelta: chunk.textDelta.replaceAll(',', ''),
+                text: chunk.text.replaceAll(',', ''),
               });
             },
           });
@@ -4158,12 +4158,12 @@ describe('streamText', () => {
             // stream buffering and scanning to correctly emit prior text
             // and to detect all STOP occurrences.
             transform(chunk, controller) {
-              if (chunk.type !== 'text-delta') {
+              if (chunk.type !== 'text') {
                 controller.enqueue(chunk);
                 return;
               }
 
-              if (chunk.textDelta.includes('STOP')) {
+              if (chunk.text.includes('STOP')) {
                 stopStream();
 
                 controller.enqueue({
@@ -4215,9 +4215,9 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello, ' },
-              { type: 'text-delta', textDelta: 'STOP' },
-              { type: 'text-delta', textDelta: ' World' },
+              { type: 'text', text: 'Hello, ' },
+              { type: 'text', text: 'STOP' },
+              { type: 'text', text: ' World' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4240,7 +4240,7 @@ describe('streamText', () => {
             request: {},
             warnings: [],
           },
-          { type: 'text-delta', textDelta: 'Hello, ' },
+          { type: 'text', text: 'Hello, ' },
           {
             type: 'step-finish',
             providerMetadata: undefined,
@@ -4288,9 +4288,9 @@ describe('streamText', () => {
         const resultObject = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello, ' },
-              { type: 'text-delta', textDelta: 'STOP' },
-              { type: 'text-delta', textDelta: ' World' },
+              { type: 'text', text: 'Hello, ' },
+              { type: 'text', text: 'STOP' },
+              { type: 'text', text: ' World' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4320,12 +4320,12 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"value": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"value": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world` },
+              { type: 'text', text: `!"` },
+              { type: 'text', text: ' }' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4349,9 +4349,9 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello, ' },
-              { type: 'text-delta', textDelta: ',' },
-              { type: 'text-delta', textDelta: ' world!' },
+              { type: 'text', text: 'Hello, ' },
+              { type: 'text', text: ',' },
+              { type: 'text', text: ' world!' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4382,12 +4382,12 @@ describe('streamText', () => {
               callOptions = args;
               return {
                 stream: convertArrayToReadableStream([
-                  { type: 'text-delta', textDelta: '{ ' },
-                  { type: 'text-delta', textDelta: '"value": ' },
-                  { type: 'text-delta', textDelta: `"Hello, ` },
-                  { type: 'text-delta', textDelta: `world` },
-                  { type: 'text-delta', textDelta: `!"` },
-                  { type: 'text-delta', textDelta: ' }' },
+                  { type: 'text', text: '{ ' },
+                  { type: 'text', text: '"value": ' },
+                  { type: 'text', text: `"Hello, ` },
+                  { type: 'text', text: `world` },
+                  { type: 'text', text: `!"` },
+                  { type: 'text', text: ' }' },
                   {
                     type: 'finish',
                     finishReason: 'stop',
@@ -4430,12 +4430,12 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"value": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"value": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world` },
+              { type: 'text', text: `!"` },
+              { type: 'text', text: ' }' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4465,12 +4465,12 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"value": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world` },
-              { type: 'text-delta', textDelta: `!"` },
-              { type: 'text-delta', textDelta: ' }' },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"value": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world` },
+              { type: 'text', text: `!"` },
+              { type: 'text', text: ' }' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4500,10 +4500,10 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"value": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world!" }` },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"value": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world!" }` },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4528,11 +4528,11 @@ describe('streamText', () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"value": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world!" ` },
-              { type: 'text-delta', textDelta: '}' },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"value": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world!" ` },
+              { type: 'text', text: '}' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -4559,11 +4559,11 @@ describe('streamText', () => {
         const resultObject = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: '{ ' },
-              { type: 'text-delta', textDelta: '"value": ' },
-              { type: 'text-delta', textDelta: `"Hello, ` },
-              { type: 'text-delta', textDelta: `world!" ` },
-              { type: 'text-delta', textDelta: '}' },
+              { type: 'text', text: '{ ' },
+              { type: 'text', text: '"value": ' },
+              { type: 'text', text: `"Hello, ` },
+              { type: 'text', text: `world!" ` },
+              { type: 'text', text: '}' },
               {
                 type: 'finish',
                 finishReason: 'stop',

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -4089,8 +4089,8 @@ describe('streamText', () => {
               "type": "tool-result",
             },
             {
-              "textDelta": " WORLD",
-              "type": "text-delta",
+              "text": " WORLD",
+              "type": "text",
             },
           ]
         `);

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -2013,7 +2013,7 @@ describe('streamText', () => {
         TextStreamPart<any>,
         {
           type:
-            | 'text-delta'
+            | 'text'
             | 'reasoning'
             | 'source'
             | 'tool-call'
@@ -3965,7 +3965,7 @@ describe('streamText', () => {
             TextStreamPart<any>,
             {
               type:
-                | 'text-delta'
+                | 'text'
                 | 'reasoning'
                 | 'source'
                 | 'tool-call'
@@ -4040,8 +4040,8 @@ describe('streamText', () => {
         expect(result).toMatchInlineSnapshot(`
           [
             {
-              "textDelta": "HELLO",
-              "type": "text-delta",
+              "text": "HELLO",
+              "type": "text",
             },
             {
               "reasoningType": "text",

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -114,7 +114,7 @@ export type StreamTextOnChunkCallback<TOOLS extends ToolSet> = (event: {
     TextStreamPart<TOOLS>,
     {
       type:
-        | 'text-delta'
+        | 'text'
         | 'reasoning'
         | 'source'
         | 'tool-call'

--- a/packages/ai/core/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
+++ b/packages/ai/core/middleware/__snapshots__/simulate-streaming-middleware.test.ts.snap
@@ -68,8 +68,8 @@ exports[`simulateStreamingMiddleware > should preserve additional metadata in th
     "warnings": [],
   },
   {
-    "textDelta": "This is a test response",
-    "type": "text-delta",
+    "text": "This is a test response",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -139,8 +139,8 @@ exports[`simulateStreamingMiddleware > should simulate streaming with reasoning 
     "type": "reasoning",
   },
   {
-    "textDelta": "This is a test response",
-    "type": "text-delta",
+    "text": "This is a test response",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -207,8 +207,8 @@ exports[`simulateStreamingMiddleware > should simulate streaming with reasoning 
     "type": "reasoning",
   },
   {
-    "textDelta": "This is a test response",
-    "type": "text-delta",
+    "text": "This is a test response",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -265,8 +265,8 @@ exports[`simulateStreamingMiddleware > should simulate streaming with reasoning 
     "type": "reasoning",
   },
   {
-    "textDelta": "This is a test response",
-    "type": "text-delta",
+    "text": "This is a test response",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -318,8 +318,8 @@ exports[`simulateStreamingMiddleware > should simulate streaming with text respo
     "warnings": [],
   },
   {
-    "textDelta": "This is a test response",
-    "type": "text-delta",
+    "text": "This is a test response",
+    "type": "text",
   },
   {
     "finishReason": "stop",
@@ -371,8 +371,8 @@ exports[`simulateStreamingMiddleware > should simulate streaming with tool calls
     "warnings": [],
   },
   {
-    "textDelta": "This is a test response",
-    "type": "text-delta",
+    "text": "This is a test response",
+    "type": "text",
   },
   {
     "error": [AI_NoSuchToolError: Model tried to call unavailable tool 'calculator'. No tools are available.],

--- a/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
@@ -14,7 +14,10 @@ describe('extractReasoningMiddleware', () => {
       const mockModel = new MockLanguageModelV2({
         async doGenerate() {
           return {
-            text: '<think>analyzing the request</think>Here is the response',
+            text: {
+              type: 'text',
+              text: '<think>analyzing the request</think>Here is the response',
+            },
             finishReason: 'stop',
             usage: { inputTokens: 10, outputTokens: 10 },
           };
@@ -37,7 +40,10 @@ describe('extractReasoningMiddleware', () => {
       const mockModel = new MockLanguageModelV2({
         async doGenerate() {
           return {
-            text: '<think>analyzing the request\n</think>',
+            text: {
+              type: 'text',
+              text: '<think>analyzing the request\n</think>',
+            },
             finishReason: 'stop',
             usage: { inputTokens: 10, outputTokens: 10 },
           };
@@ -60,7 +66,10 @@ describe('extractReasoningMiddleware', () => {
       const mockModel = new MockLanguageModelV2({
         async doGenerate() {
           return {
-            text: '<think>analyzing the request</think>Here is the response<think>thinking about the response</think>more',
+            text: {
+              type: 'text',
+              text: '<think>analyzing the request</think>Here is the response<think>thinking about the response</think>more',
+            },
             finishReason: 'stop',
             usage: { inputTokens: 10, outputTokens: 10 },
           };
@@ -85,7 +94,10 @@ describe('extractReasoningMiddleware', () => {
       const mockModel = new MockLanguageModelV2({
         async doGenerate() {
           return {
-            text: 'analyzing the request</think>Here is the response',
+            text: {
+              type: 'text',
+              text: 'analyzing the request</think>Here is the response',
+            },
             finishReason: 'stop',
             usage: { inputTokens: 10, outputTokens: 10 },
           };
@@ -125,7 +137,10 @@ describe('extractReasoningMiddleware', () => {
       const mockModel = new MockLanguageModelV2({
         async doGenerate() {
           return {
-            text: '<think>analyzing the request</think>Here is the response',
+            text: {
+              type: 'text',
+              text: '<think>analyzing the request</think>Here is the response',
+            },
             finishReason: 'stop',
             usage: { inputTokens: 10, outputTokens: 10 },
             reasoning: undefined,
@@ -158,12 +173,12 @@ describe('extractReasoningMiddleware', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: '<thi' },
-              { type: 'text-delta', textDelta: 'nk>ana' },
-              { type: 'text-delta', textDelta: 'lyzing the request' },
-              { type: 'text-delta', textDelta: '</thi' },
-              { type: 'text-delta', textDelta: 'nk>Here' },
-              { type: 'text-delta', textDelta: ' is the response' },
+              { type: 'text', text: '<think>' },
+              { type: 'text', text: 'ana' },
+              { type: 'text', text: 'lyzing the request' },
+              { type: 'text', text: '</think>' },
+              { type: 'text', text: 'Here' },
+              { type: 'text', text: ' is the response' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -265,9 +280,8 @@ describe('extractReasoningMiddleware', () => {
                 timestamp: new Date(0),
               },
               {
-                type: 'text-delta',
-                textDelta:
-                  '<think>analyzing the request</think>Here is the response<think>thinking about the response</think>more',
+                type: 'text',
+                text: '<think>analyzing the request</think>Here is the response<think>thinking about the response</think>more',
               },
               {
                 type: 'finish',
@@ -371,10 +385,10 @@ describe('extractReasoningMiddleware', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: '<think>' },
-              { type: 'text-delta', textDelta: 'ana' },
-              { type: 'text-delta', textDelta: 'lyzing the request\n' },
-              { type: 'text-delta', textDelta: '</think>' },
+              { type: 'text', text: '<think>' },
+              { type: 'text', text: 'ana' },
+              { type: 'text', text: 'lyzing the request\n' },
+              { type: 'text', text: '</think>' },
               {
                 type: 'finish',
                 finishReason: 'stop',
@@ -468,10 +482,10 @@ describe('extractReasoningMiddleware', () => {
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               },
-              { type: 'text-delta', textDelta: 'ana' },
-              { type: 'text-delta', textDelta: 'lyzing the request\n' },
-              { type: 'text-delta', textDelta: '</think>' },
-              { type: 'text-delta', textDelta: 'this is the response' },
+              { type: 'text', text: 'ana' },
+              { type: 'text', text: 'lyzing the request\n' },
+              { type: 'text', text: '</think>' },
+              { type: 'text', text: 'this is the response' },
               {
                 type: 'finish',
                 finishReason: 'stop',

--- a/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
@@ -219,12 +219,12 @@ describe('extractReasoningMiddleware', () => {
               "type": "reasoning",
             },
             {
-              "textDelta": "Here",
-              "type": "text-delta",
+              "text": "Here",
+              "type": "text",
             },
             {
-              "textDelta": " is the response",
-              "type": "text-delta",
+              "text": " is the response",
+              "type": "text",
             },
             {
               "finishReason": "stop",
@@ -318,8 +318,8 @@ describe('extractReasoningMiddleware', () => {
               "type": "reasoning",
             },
             {
-              "textDelta": "Here is the response",
-              "type": "text-delta",
+              "text": "Here is the response",
+              "type": "text",
             },
             {
               "reasoningType": "text",
@@ -328,9 +328,9 @@ describe('extractReasoningMiddleware', () => {
               "type": "reasoning",
             },
             {
-              "textDelta": "
+              "text": "
           more",
-              "type": "text-delta",
+              "type": "text",
             },
             {
               "finishReason": "stop",
@@ -539,8 +539,8 @@ describe('extractReasoningMiddleware', () => {
               "type": "reasoning",
             },
             {
-              "textDelta": "this is the response",
-              "type": "text-delta",
+              "text": "this is the response",
+              "type": "text",
             },
             {
               "finishReason": "stop",
@@ -585,70 +585,70 @@ describe('extractReasoningMiddleware', () => {
 
       expect(await convertAsyncIterableToArray(resultFalse.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "messageId": "msg-0",
-            "request": {},
-            "type": "step-start",
-            "warnings": [],
-          },
-          {
-            "textDelta": "ana",
-            "type": "text-delta",
-          },
-          {
-            "textDelta": "lyzing the request
-        ",
-            "type": "text-delta",
-          },
-          {
-            "textDelta": "</think>",
-            "type": "text-delta",
-          },
-          {
-            "textDelta": "this is the response",
-            "type": "text-delta",
-          },
-          {
-            "finishReason": "stop",
-            "isContinued": false,
-            "logprobs": undefined,
-            "messageId": "msg-0",
-            "providerMetadata": undefined,
-            "request": {},
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+          [
+            {
+              "messageId": "msg-0",
+              "request": {},
+              "type": "step-start",
+              "warnings": [],
             },
-            "type": "step-finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "text": "ana",
+              "type": "text",
             },
-            "warnings": undefined,
-          },
-          {
-            "finishReason": "stop",
-            "logprobs": undefined,
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+            {
+              "text": "lyzing the request
+          ",
+              "type": "text",
             },
-            "type": "finish",
-            "usage": {
-              "completionTokens": 10,
-              "promptTokens": 3,
-              "totalTokens": 13,
+            {
+              "text": "</think>",
+              "type": "text",
             },
-          },
-        ]
-      `);
+            {
+              "text": "this is the response",
+              "type": "text",
+            },
+            {
+              "finishReason": "stop",
+              "isContinued": false,
+              "logprobs": undefined,
+              "messageId": "msg-0",
+              "providerMetadata": undefined,
+              "request": {},
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "step-finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+              "warnings": undefined,
+            },
+            {
+              "finishReason": "stop",
+              "logprobs": undefined,
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish",
+              "usage": {
+                "completionTokens": 10,
+                "promptTokens": 3,
+                "totalTokens": 13,
+              },
+            },
+          ]
+        `);
     });
   });
 });

--- a/packages/ai/core/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/core/middleware/simulate-streaming-middleware.test.ts
@@ -21,7 +21,7 @@ describe('simulateStreamingMiddleware', () => {
     const mockModel = new MockLanguageModelV2({
       async doGenerate() {
         return {
-          text: 'This is a test response',
+          text: { type: 'text', text: 'This is a test response' },
           finishReason: 'stop',
           usage: { inputTokens: 10, outputTokens: 10 },
         };
@@ -45,7 +45,7 @@ describe('simulateStreamingMiddleware', () => {
     const mockModel = new MockLanguageModelV2({
       async doGenerate() {
         return {
-          text: 'This is a test response',
+          text: { type: 'text', text: 'This is a test response' },
           reasoning: [
             {
               type: 'reasoning',
@@ -76,7 +76,7 @@ describe('simulateStreamingMiddleware', () => {
     const mockModel = new MockLanguageModelV2({
       async doGenerate() {
         return {
-          text: 'This is a test response',
+          text: { type: 'text', text: 'This is a test response' },
           reasoning: [
             {
               type: 'reasoning',
@@ -117,7 +117,7 @@ describe('simulateStreamingMiddleware', () => {
     const mockModel = new MockLanguageModelV2({
       async doGenerate() {
         return {
-          text: 'This is a test response',
+          text: { type: 'text', text: 'This is a test response' },
           reasoning: [
             {
               type: 'reasoning',
@@ -153,7 +153,7 @@ describe('simulateStreamingMiddleware', () => {
     const mockModel = new MockLanguageModelV2({
       async doGenerate() {
         return {
-          text: 'This is a test response',
+          text: { type: 'text', text: 'This is a test response' },
           toolCalls: [
             {
               type: 'tool-call',
@@ -193,7 +193,7 @@ describe('simulateStreamingMiddleware', () => {
     const mockModel = new MockLanguageModelV2({
       async doGenerate() {
         return {
-          text: 'This is a test response',
+          text: { type: 'text', text: 'This is a test response' },
           finishReason: 'stop',
           usage: { inputTokens: 10, outputTokens: 10 },
           providerMetadata: { custom: { key: 'value' } },
@@ -218,7 +218,7 @@ describe('simulateStreamingMiddleware', () => {
     const mockModel = new MockLanguageModelV2({
       async doGenerate() {
         return {
-          text: '',
+          text: { type: 'text', text: '' },
           finishReason: 'stop',
           usage: { inputTokens: 10, outputTokens: 0 },
         };
@@ -242,7 +242,7 @@ describe('simulateStreamingMiddleware', () => {
     const mockModel = new MockLanguageModelV2({
       async doGenerate() {
         return {
-          text: 'This is a test response',
+          text: { type: 'text', text: 'This is a test response' },
           finishReason: 'stop',
           usage: { inputTokens: 10, outputTokens: 10 },
           warnings: [

--- a/packages/ai/core/middleware/simulate-streaming-middleware.ts
+++ b/packages/ai/core/middleware/simulate-streaming-middleware.ts
@@ -23,10 +23,7 @@ export function simulateStreamingMiddleware(): LanguageModelV2Middleware {
           }
 
           if (result.text) {
-            controller.enqueue({
-              type: 'text-delta',
-              textDelta: result.text,
-            });
+            controller.enqueue(result.text);
           }
 
           if (result.toolCalls) {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -169,16 +169,30 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'World!' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 4, outputTokens: 34 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "World!",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 4,
+            "outputTokens": 34,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream tool deltas', async () => {
@@ -673,19 +687,52 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      { type: 'text-delta', textDelta: 'Hello' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 4, outputTokens: 34 },
-        providerMetadata: {
-          bedrock: {
-            trace: mockTrace,
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "bedrock": {
+              "trace": {
+                "guardrail": {
+                  "inputAssessment": {
+                    "1abcd2ef34gh": {
+                      "contentPolicy": {
+                        "filters": [
+                          {
+                            "action": "BLOCKED",
+                            "confidence": "LOW",
+                            "type": "INSULTS",
+                          },
+                        ],
+                      },
+                      "wordPolicy": {
+                        "managedWordLists": [
+                          {
+                            "action": "BLOCKED",
+                            "match": "<rude word>",
+                            "type": "PROFANITY",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 4,
+            "outputTokens": 34,
           },
         },
-      },
-    ]);
+      ]
+    `);
   });
 
   it('should include response headers in rawResponse', async () => {
@@ -876,22 +923,30 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      { type: 'text-delta', textDelta: 'Hello' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 4, outputTokens: 34 },
-        providerMetadata: {
-          bedrock: {
-            usage: {
-              cacheReadInputTokens: 2,
-              cacheWriteInputTokens: 3,
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "bedrock": {
+              "usage": {
+                "cacheReadInputTokens": 2,
+                "cacheWriteInputTokens": 3,
+              },
             },
           },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 4,
+            "outputTokens": 34,
+          },
         },
-      },
-    ]);
+      ]
+    `);
   });
 
   it('should handle system messages with cache points', async () => {
@@ -998,8 +1053,8 @@ describe('doStream', () => {
           "type": "reasoning",
         },
         {
-          "textDelta": "Based on my reasoning, the answer is 42.",
-          "type": "text-delta",
+          "text": "Based on my reasoning, the answer is 42.",
+          "type": "text",
         },
         {
           "finishReason": "stop",
@@ -1053,8 +1108,8 @@ describe('doStream', () => {
           "type": "reasoning",
         },
         {
-          "textDelta": "Here is my answer.",
-          "type": "text-delta",
+          "text": "Here is my answer.",
+          "type": "text",
         },
         {
           "finishReason": "stop",
@@ -1134,7 +1189,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract usage', async () => {
@@ -1493,7 +1553,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('The answer is 42.');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "The answer is 42.",
+        "type": "text",
+      }
+    `);
     expect(reasoning).toMatchInlineSnapshot(`
       [
         {
@@ -1531,7 +1596,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('The answer is 42.');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "The answer is 42.",
+        "type": "text",
+      }
+    `);
     expect(reasoning).toMatchInlineSnapshot(`
       [
         {
@@ -1562,7 +1632,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('The answer is 42.');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "The answer is 42.",
+        "type": "text",
+      }
+    `);
     expect(reasoning).toMatchInlineSnapshot(`
       [
         {
@@ -1601,7 +1676,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('The answer is 42.');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "The answer is 42.",
+        "type": "text",
+      }
+    `);
     expect(reasoning).toMatchInlineSnapshot(`
       [
         {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -413,8 +413,8 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
               value.contentBlockDelta.delta.text
             ) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: value.contentBlockDelta.delta.text,
+                type: 'text',
+                text: value.contentBlockDelta.delta.text,
               });
             }
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -255,11 +255,12 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
       }
     }
 
+    const text = response.output?.message?.content
+      ?.map(part => part.text ?? '')
+      .join('');
+
     return {
-      text:
-        response.output?.message?.content
-          ?.map(part => part.text ?? '')
-          .join('') ?? undefined,
+      text: text != null ? { type: 'text', text } : undefined,
       toolCalls: response.output?.message?.content
         ?.filter(part => !!part.toolUse)
         ?.map(part => ({

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -123,7 +123,12 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(text).toStrictEqual('Hello, World!');
+      expect(text).toMatchInlineSnapshot(`
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        }
+      `);
     });
 
     it('should extract reasoning response', async () => {
@@ -157,7 +162,12 @@ describe('AnthropicMessagesLanguageModel', () => {
           },
         ]
       `);
-      expect(text).toStrictEqual('Hello, World!');
+      expect(text).toMatchInlineSnapshot(`
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        }
+      `);
     });
 
     it('should return undefined reasoning when no thinking is present', async () => {
@@ -218,7 +228,14 @@ describe('AnthropicMessagesLanguageModel', () => {
           },
         ]
       `);
-      expect(text).toStrictEqual('Some text\n\n');
+      expect(text).toMatchInlineSnapshot(`
+        {
+          "text": "Some text
+
+        ",
+          "type": "text",
+        }
+      `);
       expect(finishReason).toStrictEqual('tool-calls');
     });
 
@@ -514,27 +531,41 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          id: 'msg_01KfpJoAEabmH2iHRRFjQMAG',
-          modelId: 'claude-3-haiku-20240307',
-          type: 'response-metadata',
-        },
-        { textDelta: 'Hello', type: 'text-delta' },
-        { textDelta: ', ', type: 'text-delta' },
-        { textDelta: 'World!', type: 'text-delta' },
-        {
-          finishReason: 'stop',
-          providerMetadata: {
-            anthropic: {
-              cacheCreationInputTokens: null,
-              cacheReadInputTokens: null,
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "msg_01KfpJoAEabmH2iHRRFjQMAG",
+            "modelId": "claude-3-haiku-20240307",
+            "type": "response-metadata",
+          },
+          {
+            "text": "Hello",
+            "type": "text",
+          },
+          {
+            "text": ", ",
+            "type": "text",
+          },
+          {
+            "text": "World!",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "anthropic": {
+                "cacheCreationInputTokens": null,
+                "cacheReadInputTokens": null,
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 17,
+              "outputTokens": 227,
             },
           },
-          type: 'finish',
-          usage: { inputTokens: 17, outputTokens: 227 },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should stream reasoning deltas', async () => {
@@ -583,8 +614,8 @@ describe('AnthropicMessagesLanguageModel', () => {
             "type": "reasoning",
           },
           {
-            "textDelta": "Hello, World!",
-            "type": "text-delta",
+            "text": "Hello, World!",
+            "type": "text",
           },
           {
             "finishReason": "stop",
@@ -637,8 +668,8 @@ describe('AnthropicMessagesLanguageModel', () => {
             "type": "reasoning",
           },
           {
-            "textDelta": "Hello, World!",
-            "type": "text-delta",
+            "text": "Hello, World!",
+            "type": "text",
           },
           {
             "finishReason": "stop",
@@ -677,25 +708,33 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          type: 'response-metadata',
-          id: 'msg_01KfpJoAEabmH2iHRRFjQMAG',
-          modelId: 'claude-3-haiku-20240307',
-        },
-        { type: 'text-delta', textDelta: 'Hello, World!' },
-        {
-          finishReason: 'stop',
-          providerMetadata: {
-            anthropic: {
-              cacheCreationInputTokens: null,
-              cacheReadInputTokens: null,
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "msg_01KfpJoAEabmH2iHRRFjQMAG",
+            "modelId": "claude-3-haiku-20240307",
+            "type": "response-metadata",
+          },
+          {
+            "text": "Hello, World!",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "anthropic": {
+                "cacheCreationInputTokens": null,
+                "cacheReadInputTokens": null,
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 17,
+              "outputTokens": 227,
             },
           },
-          type: 'finish',
-          usage: { inputTokens: 17, outputTokens: 227 },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should stream tool deltas', async () => {
@@ -739,81 +778,86 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          type: 'response-metadata',
-          id: 'msg_01GouTqNCGXzrj5LQ5jEkw67',
-          modelId: 'claude-3-haiku-20240307',
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'Okay',
-        },
-        {
-          type: 'text-delta',
-          textDelta: '!',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'toolu_01DBsB4vvYLnBDzZ5rBSxSLs',
-          toolCallType: 'function',
-          toolName: 'test-tool',
-          argsTextDelta: '',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'toolu_01DBsB4vvYLnBDzZ5rBSxSLs',
-          toolCallType: 'function',
-          toolName: 'test-tool',
-          argsTextDelta: '{"value',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'toolu_01DBsB4vvYLnBDzZ5rBSxSLs',
-          toolCallType: 'function',
-          toolName: 'test-tool',
-          argsTextDelta: '":',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'toolu_01DBsB4vvYLnBDzZ5rBSxSLs',
-          toolCallType: 'function',
-          toolName: 'test-tool',
-          argsTextDelta: '"Spark',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'toolu_01DBsB4vvYLnBDzZ5rBSxSLs',
-          toolCallType: 'function',
-          toolName: 'test-tool',
-          argsTextDelta: 'le',
-        },
-        {
-          type: 'tool-call-delta',
-          toolCallId: 'toolu_01DBsB4vvYLnBDzZ5rBSxSLs',
-          toolCallType: 'function',
-          toolName: 'test-tool',
-          argsTextDelta: ' Day"}',
-        },
-        {
-          type: 'tool-call',
-          toolCallId: 'toolu_01DBsB4vvYLnBDzZ5rBSxSLs',
-          toolCallType: 'function',
-          toolName: 'test-tool',
-          args: '{"value":"Sparkle Day"}',
-        },
-        {
-          finishReason: 'tool-calls',
-          providerMetadata: {
-            anthropic: {
-              cacheCreationInputTokens: null,
-              cacheReadInputTokens: null,
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "msg_01GouTqNCGXzrj5LQ5jEkw67",
+            "modelId": "claude-3-haiku-20240307",
+            "type": "response-metadata",
+          },
+          {
+            "text": "Okay",
+            "type": "text",
+          },
+          {
+            "text": "!",
+            "type": "text",
+          },
+          {
+            "argsTextDelta": "",
+            "toolCallId": "toolu_01DBsB4vvYLnBDzZ5rBSxSLs",
+            "toolCallType": "function",
+            "toolName": "test-tool",
+            "type": "tool-call-delta",
+          },
+          {
+            "argsTextDelta": "{"value",
+            "toolCallId": "toolu_01DBsB4vvYLnBDzZ5rBSxSLs",
+            "toolCallType": "function",
+            "toolName": "test-tool",
+            "type": "tool-call-delta",
+          },
+          {
+            "argsTextDelta": "":",
+            "toolCallId": "toolu_01DBsB4vvYLnBDzZ5rBSxSLs",
+            "toolCallType": "function",
+            "toolName": "test-tool",
+            "type": "tool-call-delta",
+          },
+          {
+            "argsTextDelta": ""Spark",
+            "toolCallId": "toolu_01DBsB4vvYLnBDzZ5rBSxSLs",
+            "toolCallType": "function",
+            "toolName": "test-tool",
+            "type": "tool-call-delta",
+          },
+          {
+            "argsTextDelta": "le",
+            "toolCallId": "toolu_01DBsB4vvYLnBDzZ5rBSxSLs",
+            "toolCallType": "function",
+            "toolName": "test-tool",
+            "type": "tool-call-delta",
+          },
+          {
+            "argsTextDelta": " Day"}",
+            "toolCallId": "toolu_01DBsB4vvYLnBDzZ5rBSxSLs",
+            "toolCallType": "function",
+            "toolName": "test-tool",
+            "type": "tool-call-delta",
+          },
+          {
+            "args": "{"value":"Sparkle Day"}",
+            "toolCallId": "toolu_01DBsB4vvYLnBDzZ5rBSxSLs",
+            "toolCallType": "function",
+            "toolName": "test-tool",
+            "type": "tool-call",
+          },
+          {
+            "finishReason": "tool-calls",
+            "providerMetadata": {
+              "anthropic": {
+                "cacheCreationInputTokens": null,
+                "cacheReadInputTokens": null,
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 441,
+              "outputTokens": 65,
             },
           },
-          type: 'finish',
-          usage: { inputTokens: 441, outputTokens: 65 },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should forward error chunks', async () => {
@@ -963,26 +1007,33 @@ describe('AnthropicMessagesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      // note: space moved to last chunk bc of trimming
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          type: 'response-metadata',
-          id: 'msg_01KfpJoAEabmH2iHRRFjQMAG',
-          modelId: 'claude-3-haiku-20240307',
-        },
-        { type: 'text-delta', textDelta: 'Hello' },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { inputTokens: 17, outputTokens: 227 },
-          providerMetadata: {
-            anthropic: {
-              cacheCreationInputTokens: 10,
-              cacheReadInputTokens: 5,
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "msg_01KfpJoAEabmH2iHRRFjQMAG",
+            "modelId": "claude-3-haiku-20240307",
+            "type": "response-metadata",
+          },
+          {
+            "text": "Hello",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "anthropic": {
+                "cacheCreationInputTokens": 10,
+                "cacheReadInputTokens": 5,
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 17,
+              "outputTokens": 227,
             },
           },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should send request body', async () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -306,7 +306,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
     }
 
     return {
-      text,
+      text: text != null ? { type: 'text', text } : undefined,
       reasoning: reasoning.length > 0 ? reasoning : undefined,
       toolCalls,
       finishReason: mapAnthropicStopReason(response.stop_reason),
@@ -457,8 +457,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
                 switch (deltaType) {
                   case 'text_delta': {
                     controller.enqueue({
-                      type: 'text-delta',
-                      textDelta: value.delta.text,
+                      type: 'text',
+                      text: value.delta.text,
                     });
 
                     return;

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -72,7 +72,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract tool calls', async () => {
@@ -119,7 +124,12 @@ describe('doGenerate', () => {
         },
       ]
     `);
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
     expect(finishReason).toStrictEqual('stop');
   });
 
@@ -489,18 +499,34 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    // note: space moved to last chunk bc of trimming
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      { type: 'response-metadata', id: '586ac33f-9c64-452c-8f8d-e5890e73b6fb' },
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'World!' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 34, outputTokens: 12 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "586ac33f-9c64-452c-8f8d-e5890e73b6fb",
+          "type": "response-metadata",
+        },
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "World!",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 34,
+            "outputTokens": 12,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream tool deltas', async () => {

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -127,10 +127,10 @@ export class CohereChatLanguageModel implements LanguageModelV2 {
       fetch: this.config.fetch,
     });
 
-    const text = response.message.content?.[0]?.text ?? '';
+    const text = response.message.content?.[0]?.text;
 
     return {
-      text,
+      text: text != null ? { type: 'text', text } : undefined,
       toolCalls: response.message.tool_calls
         ? response.message.tool_calls.map(toolCall => ({
             type: 'tool-call' as const,
@@ -211,8 +211,8 @@ export class CohereChatLanguageModel implements LanguageModelV2 {
             switch (type) {
               case 'content-delta': {
                 controller.enqueue({
-                  type: 'text-delta',
-                  textDelta: value.delta.message.content.text,
+                  type: 'text',
+                  text: value.delta.message.content.text,
                 });
                 return;
               }

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -248,7 +248,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract usage', async () => {
@@ -1131,7 +1136,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Here is an image:And another image:');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Here is an image:And another image:",
+        "type": "text",
+      }
+    `);
     expect(files).toMatchInlineSnapshot(`
       [
         {
@@ -1265,7 +1275,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Here is content:');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Here is content:",
+        "type": "text",
+      }
+    `);
     expect(files).toMatchInlineSnapshot(`
       [
         {
@@ -1433,39 +1448,53 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'world!' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        providerMetadata: {
-          google: {
-            groundingMetadata: null,
-            safetyRatings: [
-              {
-                category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-                probability: 'NEGLIGIBLE',
-              },
-              {
-                category: 'HARM_CATEGORY_HATE_SPEECH',
-                probability: 'NEGLIGIBLE',
-              },
-              {
-                category: 'HARM_CATEGORY_HARASSMENT',
-                probability: 'NEGLIGIBLE',
-              },
-              {
-                category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-                probability: 'NEGLIGIBLE',
-              },
-            ],
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "world!",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "google": {
+              "groundingMetadata": null,
+              "safetyRatings": [
+                {
+                  "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_HATE_SPEECH",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_HARASSMENT",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                  "probability": "NEGLIGIBLE",
+                },
+              ],
+            },
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 294,
+            "outputTokens": 233,
           },
         },
-        usage: { inputTokens: 294, outputTokens: 233 },
-      },
-    ]);
+      ]
+    `);
   });
 
   it('should expose the raw response headers', async () => {
@@ -1577,37 +1606,45 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      { type: 'text-delta', textDelta: 'test' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        providerMetadata: {
-          google: {
-            groundingMetadata: null,
-            safetyRatings: [
-              {
-                category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-                probability: 'NEGLIGIBLE',
-              },
-              {
-                category: 'HARM_CATEGORY_HATE_SPEECH',
-                probability: 'NEGLIGIBLE',
-              },
-              {
-                category: 'HARM_CATEGORY_HARASSMENT',
-                probability: 'NEGLIGIBLE',
-              },
-              {
-                category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-                probability: 'NEGLIGIBLE',
-              },
-            ],
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "test",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "google": {
+              "groundingMetadata": null,
+              "safetyRatings": [
+                {
+                  "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_HATE_SPEECH",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_HARASSMENT",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                  "probability": "NEGLIGIBLE",
+                },
+              ],
+            },
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 294,
+            "outputTokens": 233,
           },
         },
-        usage: { inputTokens: 294, outputTokens: 233 },
-      },
-    ]);
+      ]
+    `);
   });
 
   it('should expose safety ratings in provider metadata on finish', async () => {

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -299,10 +299,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
             if (content != null) {
               const deltaText = getTextFromParts(content.parts);
               if (deltaText != null) {
-                controller.enqueue({
-                  type: 'text-delta',
-                  textDelta: deltaText,
-                });
+                controller.enqueue(deltaText);
               }
 
               const inlineDataParts = getInlineDataParts(content.parts);
@@ -419,7 +416,10 @@ function getTextFromParts(parts: z.infer<typeof contentSchema>['parts']) {
 
   return textParts == null || textParts.length === 0
     ? undefined
-    : textParts.map(part => part.text).join('');
+    : {
+        type: 'text' as const,
+        text: textParts.map(part => part.text).join(''),
+      };
 }
 
 function getInlineDataParts(parts: z.infer<typeof contentSchema>['parts']) {

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -117,7 +117,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract reasoning', async () => {
@@ -495,22 +500,36 @@ describe('doStream', () => {
     });
 
     // note: space moved to last chunk bc of trimming
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798',
-        modelId: 'gemma2-9b-it',
-        timestamp: new Date('2023-12-15T16:17:00.000Z'),
-      },
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'World!' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 18, outputTokens: 439 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "gemma2-9b-it",
+          "timestamp": 2023-12-15T16:17:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "World!",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 18,
+            "outputTokens": 439,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream reasoning deltas', async () => {
@@ -559,8 +578,8 @@ describe('doStream', () => {
           "type": "reasoning",
         },
         {
-          "textDelta": "Hello",
-          "type": "text-delta",
+          "text": "Hello",
+          "type": "text",
         },
         {
           "finishReason": "stop",

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -186,7 +186,10 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
     const choice = response.choices[0];
 
     return {
-      text: choice.message.content ?? undefined,
+      text:
+        choice.message.content != null
+          ? { type: 'text', text: choice.message.content }
+          : undefined,
       reasoning: choice.message.reasoning
         ? [
             {
@@ -320,8 +323,8 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
 
             if (delta.content != null && delta.content.length > 0) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: delta.content,
+                type: 'text',
+                text: delta.content,
               });
             }
 

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -73,7 +73,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should avoid duplication when there is a trailing assistant message', async () => {
@@ -90,7 +95,12 @@ describe('doGenerate', () => {
       ],
     });
 
-    expect(text).toStrictEqual('and more content');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "and more content",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract tool call response', async () => {
@@ -361,7 +371,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello from object');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello from object",
+        "type": "text",
+      }
+    `);
   });
 });
 
@@ -404,24 +419,44 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: '6e2cd91750904b7092f49bdca9083de1',
-        timestamp: new Date(1711097175 * 1000),
-        modelId: 'mistral-small-latest',
-      },
-      { type: 'text-delta', textDelta: '' },
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'world!' },
-      { type: 'text-delta', textDelta: '' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 4, outputTokens: 32 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "6e2cd91750904b7092f49bdca9083de1",
+          "modelId": "mistral-small-latest",
+          "timestamp": 2024-03-22T08:46:15.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "world!",
+          "type": "text",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 4,
+            "outputTokens": 32,
+          },
+        },
+      ]
+    `);
   });
 
   it('should avoid duplication when there is a trailing assistant message', async () => {
@@ -438,23 +473,40 @@ describe('doStream', () => {
       ],
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: '6e2cd91750904b7092f49bdca9083de1',
-        timestamp: new Date(1711097175 * 1000),
-        modelId: 'mistral-small-latest',
-      },
-      { type: 'text-delta', textDelta: '' },
-      { type: 'text-delta', textDelta: 'and' },
-      { type: 'text-delta', textDelta: ' more content' },
-      { type: 'text-delta', textDelta: '' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 4, outputTokens: 32 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "6e2cd91750904b7092f49bdca9083de1",
+          "modelId": "mistral-small-latest",
+          "timestamp": 2024-03-22T08:46:15.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "text": "and",
+          "type": "text",
+        },
+        {
+          "text": " more content",
+          "type": "text",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 4,
+            "outputTokens": 32,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream tool deltas', async () => {
@@ -493,34 +545,42 @@ describe('doStream', () => {
         prompt: TEST_PROMPT,
       });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'ad6f7ce6543c4d0890280ae184fe4dd8',
-        timestamp: new Date(1711365023 * 1000),
-        modelId: 'mistral-large-latest',
-      },
-      { type: 'text-delta', textDelta: '' },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'yfBEybNYi',
-        toolCallType: 'function',
-        toolName: 'test-tool',
-        argsTextDelta: '{"value":"Sparkle Day"}',
-      },
-      {
-        type: 'tool-call',
-        toolCallId: 'yfBEybNYi',
-        toolCallType: 'function',
-        toolName: 'test-tool',
-        args: '{"value":"Sparkle Day"}',
-      },
-      {
-        type: 'finish',
-        finishReason: 'tool-calls',
-        usage: { inputTokens: 183, outputTokens: 133 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "ad6f7ce6543c4d0890280ae184fe4dd8",
+          "modelId": "mistral-large-latest",
+          "timestamp": 2024-03-25T11:10:23.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "argsTextDelta": "{"value":"Sparkle Day"}",
+          "toolCallId": "yfBEybNYi",
+          "toolCallType": "function",
+          "toolName": "test-tool",
+          "type": "tool-call-delta",
+        },
+        {
+          "args": "{"value":"Sparkle Day"}",
+          "toolCallId": "yfBEybNYi",
+          "toolCallType": "function",
+          "toolName": "test-tool",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": "tool-calls",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 183,
+            "outputTokens": 133,
+          },
+        },
+      ]
+    `);
   });
 
   it('should expose the raw response headers', async () => {
@@ -643,21 +703,35 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'stream-object-id',
-        timestamp: new Date(1711097175 * 1000),
-        modelId: 'mistral-small-latest',
-      },
-      { type: 'text-delta', textDelta: '' },
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', world!' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 4, outputTokens: 32 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "stream-object-id",
+          "modelId": "mistral-small-latest",
+          "timestamp": 2024-03-22T08:46:15.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", world!",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 4,
+            "outputTokens": 32,
+          },
+        },
+      ]
+    `);
   });
 });

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -202,7 +202,7 @@ export class MistralChatLanguageModel implements LanguageModelV2 {
     }
 
     return {
-      text,
+      text: text != null ? { type: 'text', text } : undefined,
       toolCalls: choice.message.tool_calls?.map(toolCall => ({
         type: 'tool-call',
         toolCallType: 'function',
@@ -318,10 +318,8 @@ export class MistralChatLanguageModel implements LanguageModelV2 {
 
             if (textContent != null) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: trimLeadingSpace
-                  ? textContent.trimStart()
-                  : textContent,
+                type: 'text',
+                text: trimLeadingSpace ? textContent.trimStart() : textContent,
               });
 
               trimLeadingSpace = false;

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -167,7 +167,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract reasoning content', async () => {
@@ -181,7 +186,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
     expect(reasoning).toMatchInlineSnapshot(`
       [
         {
@@ -921,26 +931,43 @@ describe('doStream', () => {
     });
 
     // note: space moved to last chunk bc of trimming
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798',
-        modelId: 'grok-beta',
-        timestamp: new Date('2023-12-15T16:17:00.000Z'),
-      },
-      { type: 'text-delta', textDelta: '' },
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'World!' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 18, outputTokens: 439 },
-        providerMetadata: {
-          'test-provider': {},
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2023-12-15T16:17:00.000Z,
+          "type": "response-metadata",
         },
-      },
-    ]);
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "World!",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 18,
+            "outputTokens": 439,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream reasoning content before text deltas', async () => {
@@ -986,12 +1013,12 @@ describe('doStream', () => {
           "type": "reasoning",
         },
         {
-          "textDelta": "Here's",
-          "type": "text-delta",
+          "text": "Here's",
+          "type": "text",
         },
         {
-          "textDelta": " my response",
-          "type": "text-delta",
+          "text": " my response",
+          "type": "text",
         },
         {
           "finishReason": "stop",
@@ -1334,68 +1361,73 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'chat-2267f7e2910a4254bac0650ba74cfc1c',
-        modelId: 'meta/llama-3.1-8b-instruct:fp8',
-        timestamp: new Date('2024-12-02T17:57:21.000Z'),
-      },
-      {
-        type: 'text-delta',
-        textDelta: '',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: '{"query": "',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: 'latest',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: ' news',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: ' on',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: ' ai"}',
-      },
-      {
-        type: 'tool-call',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        args: '{"query": "latest news on ai"}',
-      },
-      {
-        type: 'finish',
-        finishReason: 'tool-calls',
-        usage: { inputTokens: 226, outputTokens: 20 },
-        providerMetadata: {
-          'test-provider': {},
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "chat-2267f7e2910a4254bac0650ba74cfc1c",
+          "modelId": "meta/llama-3.1-8b-instruct:fp8",
+          "timestamp": 2024-12-02T17:57:21.000Z,
+          "type": "response-metadata",
         },
-      },
-    ]);
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "argsTextDelta": "{"query": "",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "argsTextDelta": "latest",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "argsTextDelta": " news",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "argsTextDelta": " on",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "argsTextDelta": " ai"}",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "args": "{"query": "latest news on ai"}",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": "tool-calls",
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 226,
+            "outputTokens": 20,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream tool call that is sent in one chunk', async () => {

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -244,7 +244,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
     }
 
     return {
-      text: choice.message.content ?? undefined,
+      text:
+        choice.message.content != null
+          ? { type: 'text', text: choice.message.content }
+          : undefined,
       reasoning: choice.message.reasoning_content
         ? [
             {
@@ -433,8 +436,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
 
             if (delta.content != null) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: delta.content,
+                type: 'text',
+                text: delta.content,
               });
             }
 

--- a/packages/openai-compatible/src/openai-compatible-completion-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-completion-language-model.test.ts
@@ -122,7 +122,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract usage', async () => {
@@ -403,23 +408,40 @@ describe('doStream', () => {
     });
 
     // note: space moved to last chunk bc of trimming
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        id: 'cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT',
-        modelId: 'gpt-3.5-turbo-instruct',
-        timestamp: new Date('2024-03-25T10:44:00.000Z'),
-        type: 'response-metadata',
-      },
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'World!' },
-      { type: 'text-delta', textDelta: '' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        usage: { inputTokens: 10, outputTokens: 362 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT",
+          "modelId": "gpt-3.5-turbo-instruct",
+          "timestamp": 2024-03-25T10:44:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "World!",
+          "type": "text",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "type": "finish",
+          "usage": {
+            "inputTokens": 10,
+            "outputTokens": 362,
+          },
+        },
+      ]
+    `);
   });
 
   it('should handle error stream parts', async () => {

--- a/packages/openai-compatible/src/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-completion-language-model.ts
@@ -176,7 +176,7 @@ export class OpenAICompatibleCompletionLanguageModel
     const choice = response.choices[0];
 
     return {
-      text: choice.text,
+      text: { type: 'text', text: choice.text },
       usage: {
         inputTokens: response.usage?.prompt_tokens ?? undefined,
         outputTokens: response.usage?.completion_tokens ?? undefined,
@@ -271,8 +271,8 @@ export class OpenAICompatibleCompletionLanguageModel
 
             if (choice?.text != null) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: choice.text,
+                type: 'text',
+                text: choice.text,
               });
             }
           },

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -230,7 +230,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract usage', async () => {
@@ -1401,26 +1406,135 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    // note: space moved to last chunk bc of trimming
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
-        modelId: 'gpt-3.5-turbo-0613',
-        timestamp: new Date('2023-12-15T16:17:00.000Z'),
-      },
-      { type: 'text-delta', textDelta: '' },
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'World!' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        logprobs: mapOpenAIChatLogProbsOutput(TEST_LOGPROBS),
-        usage: { inputTokens: 17, outputTokens: 227 },
-        providerMetadata: { openai: {} },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP",
+          "modelId": "gpt-3.5-turbo-0613",
+          "timestamp": 2023-12-15T16:17:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "World!",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "logprobs": [
+            {
+              "logprob": -0.0009994634,
+              "token": "Hello",
+              "topLogprobs": [
+                {
+                  "logprob": -0.0009994634,
+                  "token": "Hello",
+                },
+              ],
+            },
+            {
+              "logprob": -0.13410144,
+              "token": "!",
+              "topLogprobs": [
+                {
+                  "logprob": -0.13410144,
+                  "token": "!",
+                },
+              ],
+            },
+            {
+              "logprob": -0.0009250381,
+              "token": " How",
+              "topLogprobs": [
+                {
+                  "logprob": -0.0009250381,
+                  "token": " How",
+                },
+              ],
+            },
+            {
+              "logprob": -0.047709424,
+              "token": " can",
+              "topLogprobs": [
+                {
+                  "logprob": -0.047709424,
+                  "token": " can",
+                },
+              ],
+            },
+            {
+              "logprob": -0.000009014684,
+              "token": " I",
+              "topLogprobs": [
+                {
+                  "logprob": -0.000009014684,
+                  "token": " I",
+                },
+              ],
+            },
+            {
+              "logprob": -0.009125131,
+              "token": " assist",
+              "topLogprobs": [
+                {
+                  "logprob": -0.009125131,
+                  "token": " assist",
+                },
+              ],
+            },
+            {
+              "logprob": -0.0000066306106,
+              "token": " you",
+              "topLogprobs": [
+                {
+                  "logprob": -0.0000066306106,
+                  "token": " you",
+                },
+              ],
+            },
+            {
+              "logprob": -0.00011093382,
+              "token": " today",
+              "topLogprobs": [
+                {
+                  "logprob": -0.00011093382,
+                  "token": " today",
+                },
+              ],
+            },
+            {
+              "logprob": -0.00004596782,
+              "token": "?",
+              "topLogprobs": [
+                {
+                  "logprob": -0.00004596782,
+                  "token": "?",
+                },
+              ],
+            },
+          ],
+          "providerMetadata": {
+            "openai": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 17,
+            "outputTokens": 227,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream tool deltas', async () => {
@@ -1747,67 +1861,74 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        type: 'response-metadata',
-        id: 'chat-2267f7e2910a4254bac0650ba74cfc1c',
-        modelId: 'meta/llama-3.1-8b-instruct:fp8',
-        timestamp: new Date('2024-12-02T17:57:21.000Z'),
-      },
-      {
-        type: 'text-delta',
-        textDelta: '',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: '{"query": "',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: 'latest',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: ' news',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: ' on',
-      },
-      {
-        type: 'tool-call-delta',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        argsTextDelta: ' ai"}',
-      },
-      {
-        type: 'tool-call',
-        toolCallId: 'chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa',
-        toolCallType: 'function',
-        toolName: 'searchGoogle',
-        args: '{"query": "latest news on ai"}',
-      },
-      {
-        type: 'finish',
-        finishReason: 'tool-calls',
-        logprobs: undefined,
-        usage: { inputTokens: 226, outputTokens: 20 },
-        providerMetadata: { openai: {} },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "chat-2267f7e2910a4254bac0650ba74cfc1c",
+          "modelId": "meta/llama-3.1-8b-instruct:fp8",
+          "timestamp": 2024-12-02T17:57:21.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "argsTextDelta": "{"query": "",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "argsTextDelta": "latest",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "argsTextDelta": " news",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "argsTextDelta": " on",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "argsTextDelta": " ai"}",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call-delta",
+        },
+        {
+          "args": "{"query": "latest news on ai"}",
+          "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
+          "toolCallType": "function",
+          "toolName": "searchGoogle",
+          "type": "tool-call",
+        },
+        {
+          "finishReason": "tool-calls",
+          "logprobs": undefined,
+          "providerMetadata": {
+            "openai": {},
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": 226,
+            "outputTokens": 20,
+          },
+        },
+      ]
+    `);
   });
 
   it('should stream tool call that is sent in one chunk', async () => {
@@ -2189,23 +2310,36 @@ describe('doStream', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          type: 'response-metadata',
-          id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
-          modelId: 'o1-preview',
-          timestamp: expect.any(Date),
-        },
-        { type: 'text-delta', textDelta: '' },
-        { type: 'text-delta', textDelta: 'Hello, World!' },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { inputTokens: 17, outputTokens: 227 },
-          logprobs: undefined,
-          providerMetadata: { openai: {} },
-        },
-      ]);
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP",
+            "modelId": "o1-preview",
+            "timestamp": 2023-12-15T16:17:00.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "text": "",
+            "type": "text",
+          },
+          {
+            "text": "Hello, World!",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "logprobs": undefined,
+            "providerMetadata": {
+              "openai": {},
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 17,
+              "outputTokens": 227,
+            },
+          },
+        ]
+      `);
     });
 
     it('should send reasoning tokens', async () => {
@@ -2229,27 +2363,38 @@ describe('doStream', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          type: 'response-metadata',
-          id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
-          modelId: 'o1-preview',
-          timestamp: expect.any(Date),
-        },
-        { type: 'text-delta', textDelta: '' },
-        { type: 'text-delta', textDelta: 'Hello, World!' },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { inputTokens: 15, outputTokens: 20 },
-          logprobs: undefined,
-          providerMetadata: {
-            openai: {
-              reasoningTokens: 10,
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP",
+            "modelId": "o1-preview",
+            "timestamp": 2023-12-15T16:17:00.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "text": "",
+            "type": "text",
+          },
+          {
+            "text": "Hello, World!",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "logprobs": undefined,
+            "providerMetadata": {
+              "openai": {
+                "reasoningTokens": 10,
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 15,
+              "outputTokens": 20,
             },
           },
-        },
-      ]);
+        ]
+      `);
     });
   });
 });

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -343,7 +343,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
     }
 
     return {
-      text: choice.message.content ?? undefined,
+      text:
+        choice.message.content != null
+          ? { type: 'text', text: choice.message.content }
+          : undefined,
       toolCalls: choice.message.tool_calls?.map(toolCall => ({
         type: 'tool-call' as const,
         toolCallType: 'function',
@@ -500,8 +503,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
 
             if (delta.content != null) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: delta.content,
+                type: 'text',
+                text: delta.content,
               });
             }
 

--- a/packages/openai/src/openai-completion-language-model.test.ts
+++ b/packages/openai/src/openai-completion-language-model.test.ts
@@ -109,7 +109,12 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(text).toStrictEqual('Hello, World!');
+    expect(text).toMatchInlineSnapshot(`
+      {
+        "text": "Hello, World!",
+        "type": "text",
+      }
+    `);
   });
 
   it('should extract usage', async () => {
@@ -360,25 +365,106 @@ describe('doStream', () => {
       prompt: TEST_PROMPT,
     });
 
-    // note: space moved to last chunk bc of trimming
-    expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-      {
-        id: 'cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT',
-        modelId: 'gpt-3.5-turbo-instruct',
-        timestamp: new Date('2024-03-25T10:44:00.000Z'),
-        type: 'response-metadata',
-      },
-      { type: 'text-delta', textDelta: 'Hello' },
-      { type: 'text-delta', textDelta: ', ' },
-      { type: 'text-delta', textDelta: 'World!' },
-      { type: 'text-delta', textDelta: '' },
-      {
-        type: 'finish',
-        finishReason: 'stop',
-        logprobs: mapOpenAICompletionLogProbs(TEST_LOGPROBS),
-        usage: { inputTokens: 10, outputTokens: 362 },
-      },
-    ]);
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "cmpl-96c64EdfhOw8pjFFgVpLuT8k2MtdT",
+          "modelId": "gpt-3.5-turbo-instruct",
+          "timestamp": 2024-03-25T10:44:00.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "World!",
+          "type": "text",
+        },
+        {
+          "text": "",
+          "type": "text",
+        },
+        {
+          "finishReason": "stop",
+          "logprobs": [
+            {
+              "logprob": -0.0664508,
+              "token": " ever",
+              "topLogprobs": [
+                {
+                  "logprob": -0.0664508,
+                  "token": " ever",
+                },
+              ],
+            },
+            {
+              "logprob": -0.014520033,
+              "token": " after",
+              "topLogprobs": [
+                {
+                  "logprob": -0.014520033,
+                  "token": " after",
+                },
+              ],
+            },
+            {
+              "logprob": -1.3820221,
+              "token": ".
+
+      ",
+              "topLogprobs": [
+                {
+                  "logprob": -1.3820221,
+                  "token": ".
+
+      ",
+                },
+              ],
+            },
+            {
+              "logprob": -0.7890417,
+              "token": "The",
+              "topLogprobs": [
+                {
+                  "logprob": -0.7890417,
+                  "token": "The",
+                },
+              ],
+            },
+            {
+              "logprob": -0.5323165,
+              "token": " end",
+              "topLogprobs": [
+                {
+                  "logprob": -0.5323165,
+                  "token": " end",
+                },
+              ],
+            },
+            {
+              "logprob": -0.10247037,
+              "token": ".",
+              "topLogprobs": [
+                {
+                  "logprob": -0.10247037,
+                  "token": ".",
+                },
+              ],
+            },
+          ],
+          "type": "finish",
+          "usage": {
+            "inputTokens": 10,
+            "outputTokens": 362,
+          },
+        },
+      ]
+    `);
   });
 
   it('should handle error stream parts', async () => {

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -165,7 +165,7 @@ export class OpenAICompletionLanguageModel implements LanguageModelV2 {
     const choice = response.choices[0];
 
     return {
-      text: choice.text,
+      text: { type: 'text', text: choice.text },
       usage: {
         inputTokens: response.usage.prompt_tokens,
         outputTokens: response.usage.completion_tokens,
@@ -266,8 +266,8 @@ export class OpenAICompletionLanguageModel implements LanguageModelV2 {
 
             if (choice?.text != null) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: choice.text,
+                type: 'text',
+                text: choice.text,
               });
             }
 

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -121,7 +121,12 @@ describe('OpenAIResponsesLanguageModel', () => {
           inputFormat: 'prompt',
         });
 
-        expect(result.text).toStrictEqual('answer text');
+        expect(result.text).toMatchInlineSnapshot(`
+          {
+            "text": "answer text",
+            "type": "text",
+          }
+        `);
       });
 
       it('should extract usage', async () => {
@@ -954,7 +959,38 @@ describe('OpenAIResponsesLanguageModel', () => {
           inputFormat: 'prompt',
         });
 
-        expect(result.text).toStrictEqual(outputText);
+        expect(result.text).toMatchInlineSnapshot(`
+          {
+            "text": "Last week in San Francisco, several notable events and developments took place:
+
+          **Bruce Lee Statue in Chinatown**
+
+          The Chinese Historical Society of America Museum announced plans to install a Bruce Lee statue in Chinatown. This initiative, supported by the Rose Pak Community Fund, the Bruce Lee Foundation, and Stand With Asians, aims to honor Lee's contributions to film and martial arts. Artist Arnie Kim has been commissioned for the project, with a fundraising goal of $150,000. ([axios.com](https://www.axios.com/local/san-francisco/2025/03/07/bruce-lee-statue-sf-chinatown?utm_source=chatgpt.com))
+
+          **Office Leasing Revival**
+
+          The Bay Area experienced a resurgence in office leasing, securing 11 of the largest U.S. office leases in 2024. This trend, driven by the tech industry's growth and advancements in generative AI, suggests a potential boost to downtown recovery through increased foot traffic. ([axios.com](https://www.axios.com/local/san-francisco/2025/03/03/bay-area-office-leasing-activity?utm_source=chatgpt.com))
+
+          **Spring Blooms in the Bay Area**
+
+          With the arrival of spring, several locations in the Bay Area are showcasing vibrant blooms. Notable spots include the Conservatory of Flowers, Japanese Tea Garden, Queen Wilhelmina Tulip Garden, and the San Francisco Botanical Garden, each offering unique floral displays. ([axios.com](https://www.axios.com/local/san-francisco/2025/03/03/where-to-see-spring-blooms-bay-area?utm_source=chatgpt.com))
+
+          **Oceanfront Great Highway Park**
+
+          San Francisco's long-awaited Oceanfront Great Highway park is set to open on April 12. This 43-acre, car-free park will span a two-mile stretch of the Great Highway from Lincoln Way to Sloat Boulevard, marking the largest pedestrianization project in California's history. The park follows voter approval of Proposition K, which permanently bans cars on part of the highway. ([axios.com](https://www.axios.com/local/san-francisco/2025/03/03/great-highway-park-opening-april-recall-campaign?utm_source=chatgpt.com))
+
+          **Warmer Spring Seasons**
+
+          An analysis by Climate Central revealed that San Francisco, along with most U.S. cities, is experiencing increasingly warmer spring seasons. Over a 55-year period from 1970 to 2024, the national average temperature during March through May rose by 2.4°F. This warming trend poses various risks, including early snowmelt and increased wildfire threats. ([axios.com](https://www.axios.com/local/san-francisco/2025/03/03/climate-weather-spring-temperatures-warmer-sf?utm_source=chatgpt.com))
+
+
+          # Key San Francisco Developments Last Week:
+          - [Bruce Lee statue to be installed in SF Chinatown](https://www.axios.com/local/san-francisco/2025/03/07/bruce-lee-statue-sf-chinatown?utm_source=chatgpt.com)
+          - [The Bay Area is set to make an office leasing comeback](https://www.axios.com/local/san-francisco/2025/03/03/bay-area-office-leasing-activity?utm_source=chatgpt.com)
+          - [Oceanfront Great Highway park set to open in April](https://www.axios.com/local/san-francisco/2025/03/03/great-highway-park-opening-april-recall-campaign?utm_source=chatgpt.com)",
+            "type": "text",
+          }
+        `);
       });
 
       it('should return sources', async () => {
@@ -1029,28 +1065,39 @@ describe('OpenAIResponsesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          id: 'resp_67c9a81b6a048190a9ee441c5755a4e8',
-          modelId: 'gpt-4o-2024-07-18',
-          timestamp: new Date('2025-03-06T13:50:19.000Z'),
-          type: 'response-metadata',
-        },
-        { type: 'text-delta', textDelta: 'Hello,' },
-        { type: 'text-delta', textDelta: ' World!' },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { inputTokens: 543, outputTokens: 478 },
-          providerMetadata: {
-            openai: {
-              responseId: 'resp_67c9a81b6a048190a9ee441c5755a4e8',
-              cachedPromptTokens: 234,
-              reasoningTokens: 123,
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "resp_67c9a81b6a048190a9ee441c5755a4e8",
+            "modelId": "gpt-4o-2024-07-18",
+            "timestamp": 2025-03-06T13:50:19.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "text": "Hello,",
+            "type": "text",
+          },
+          {
+            "text": " World!",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "openai": {
+                "cachedPromptTokens": 234,
+                "reasoningTokens": 123,
+                "responseId": "resp_67c9a81b6a048190a9ee441c5755a4e8",
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 543,
+              "outputTokens": 478,
             },
           },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should send finish reason for incomplete response', async () => {
@@ -1074,27 +1121,35 @@ describe('OpenAIResponsesLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await convertReadableStreamToArray(stream)).toStrictEqual([
-        {
-          id: 'resp_67c9a81b6a048190a9ee441c5755a4e8',
-          modelId: 'gpt-4o-2024-07-18',
-          timestamp: new Date('2025-03-06T13:50:19.000Z'),
-          type: 'response-metadata',
-        },
-        { type: 'text-delta', textDelta: 'Hello,' },
-        {
-          type: 'finish',
-          finishReason: 'length',
-          usage: { inputTokens: 0, outputTokens: 0 },
-          providerMetadata: {
-            openai: {
-              responseId: 'resp_67c9a81b6a048190a9ee441c5755a4e8',
-              cachedPromptTokens: 0,
-              reasoningTokens: 0,
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "resp_67c9a81b6a048190a9ee441c5755a4e8",
+            "modelId": "gpt-4o-2024-07-18",
+            "timestamp": 2025-03-06T13:50:19.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "text": "Hello,",
+            "type": "text",
+          },
+          {
+            "finishReason": "length",
+            "providerMetadata": {
+              "openai": {
+                "cachedPromptTokens": 0,
+                "reasoningTokens": 0,
+                "responseId": "resp_67c9a81b6a048190a9ee441c5755a4e8",
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 0,
+              "outputTokens": 0,
             },
           },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should send streaming tool calls', async () => {
@@ -1258,12 +1313,12 @@ describe('OpenAIResponsesLanguageModel', () => {
             "type": "response-metadata",
           },
           {
-            "textDelta": "Last week",
-            "type": "text-delta",
+            "text": "Last week",
+            "type": "text",
           },
           {
-            "textDelta": " in San Francisco",
-            "type": "text-delta",
+            "text": " in San Francisco",
+            "type": "text",
           },
           {
             "id": "id-0",
@@ -1273,12 +1328,12 @@ describe('OpenAIResponsesLanguageModel', () => {
             "url": "https://www.sftourismtips.com/san-francisco-events-in-march.html?utm_source=chatgpt.com",
           },
           {
-            "textDelta": " a themed party",
-            "type": "text-delta",
+            "text": " a themed party",
+            "type": "text",
           },
           {
-            "textDelta": "([axios.com](https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com))",
-            "type": "text-delta",
+            "text": "([axios.com](https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com))",
+            "type": "text",
           },
           {
             "id": "id-1",
@@ -1288,8 +1343,8 @@ describe('OpenAIResponsesLanguageModel', () => {
             "url": "https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com",
           },
           {
-            "textDelta": ".",
-            "type": "text-delta",
+            "text": ".",
+            "type": "text",
           },
           {
             "finishReason": "stop",

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -265,7 +265,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       }));
 
     return {
-      text: outputTextElements.map(content => content.text).join('\n'),
+      text: {
+        type: 'text',
+        text: outputTextElements.map(content => content.text).join('\n'),
+      },
       sources: outputTextElements.flatMap(content =>
         content.annotations.map(annotation => ({
           type: 'source',

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -397,8 +397,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               });
             } else if (isTextDeltaChunk(value)) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: value.delta,
+                type: 'text',
+                text: value.delta,
               });
             } else if (
               isResponseOutputItemDoneChunk(value) &&

--- a/packages/perplexity/src/perplexity-language-model.test.ts
+++ b/packages/perplexity/src/perplexity-language-model.test.ts
@@ -97,7 +97,12 @@ describe('PerplexityLanguageModel', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(result.text).toBe('Hello, World!');
+      expect(result.text).toMatchInlineSnapshot(`
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        }
+      `);
       expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 20 });
       expect({
         id: result.response?.id,
@@ -353,40 +358,45 @@ describe('PerplexityLanguageModel', () => {
 
       const result = await convertReadableStreamToArray(stream);
 
-      expect(result).toEqual([
-        {
-          type: 'response-metadata',
-          id: 'stream-id',
-          timestamp: new Date(1680003600 * 1000),
-          modelId,
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'Hello',
-        },
-        {
-          type: 'text-delta',
-          textDelta: ', ',
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'World!',
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { inputTokens: 10, outputTokens: 20 },
-          providerMetadata: {
-            perplexity: {
-              images: null,
-              usage: {
-                citationTokens: null,
-                numSearchQueries: null,
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "stream-id",
+            "modelId": "perplexity-001",
+            "timestamp": 2023-03-28T11:40:00.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "text": "Hello",
+            "type": "text",
+          },
+          {
+            "text": ", ",
+            "type": "text",
+          },
+          {
+            "text": "World!",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "perplexity": {
+                "images": null,
+                "usage": {
+                  "citationTokens": null,
+                  "numSearchQueries": null,
+                },
               },
             },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 10,
+              "outputTokens": 20,
+            },
           },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should stream sources', async () => {
@@ -423,16 +433,16 @@ describe('PerplexityLanguageModel', () => {
             "url": "https://example.com/456",
           },
           {
-            "textDelta": "Hello",
-            "type": "text-delta",
+            "text": "Hello",
+            "type": "text",
           },
           {
-            "textDelta": ", ",
-            "type": "text-delta",
+            "text": ", ",
+            "type": "text",
           },
           {
-            "textDelta": "World!",
-            "type": "text-delta",
+            "text": "World!",
+            "type": "text",
           },
           {
             "finishReason": "stop",
@@ -490,47 +500,52 @@ describe('PerplexityLanguageModel', () => {
 
       const result = await convertReadableStreamToArray(stream);
 
-      expect(result).toEqual([
-        {
-          id: 'stream-id',
-          modelId: 'perplexity-001',
-          timestamp: new Date('2023-03-28T11:40:00.000Z'),
-          type: 'response-metadata',
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'Hello',
-        },
-        {
-          type: 'text-delta',
-          textDelta: ', ',
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'World!',
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { inputTokens: 10, outputTokens: 20 },
-          providerMetadata: {
-            perplexity: {
-              images: [
-                {
-                  imageUrl: 'https://example.com/image.jpg',
-                  originUrl: 'https://example.com/image.jpg',
-                  height: 100,
-                  width: 100,
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "stream-id",
+            "modelId": "perplexity-001",
+            "timestamp": 2023-03-28T11:40:00.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "text": "Hello",
+            "type": "text",
+          },
+          {
+            "text": ", ",
+            "type": "text",
+          },
+          {
+            "text": "World!",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "perplexity": {
+                "images": [
+                  {
+                    "height": 100,
+                    "imageUrl": "https://example.com/image.jpg",
+                    "originUrl": "https://example.com/image.jpg",
+                    "width": 100,
+                  },
+                ],
+                "usage": {
+                  "citationTokens": null,
+                  "numSearchQueries": null,
                 },
-              ],
-              usage: {
-                citationTokens: null,
-                numSearchQueries: null,
               },
             },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 10,
+              "outputTokens": 20,
+            },
           },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should send images', async () => {
@@ -551,40 +566,45 @@ describe('PerplexityLanguageModel', () => {
 
       const result = await convertReadableStreamToArray(stream);
 
-      expect(result).toStrictEqual([
-        {
-          id: 'stream-id',
-          modelId: 'perplexity-001',
-          timestamp: new Date('2023-03-28T11:40:00.000Z'),
-          type: 'response-metadata',
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'Hello',
-        },
-        {
-          type: 'text-delta',
-          textDelta: ', ',
-        },
-        {
-          type: 'text-delta',
-          textDelta: 'World!',
-        },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { inputTokens: 11, outputTokens: 21 },
-          providerMetadata: {
-            perplexity: {
-              images: null,
-              usage: {
-                citationTokens: 30,
-                numSearchQueries: 40,
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "stream-id",
+            "modelId": "perplexity-001",
+            "timestamp": 2023-03-28T11:40:00.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "text": "Hello",
+            "type": "text",
+          },
+          {
+            "text": ", ",
+            "type": "text",
+          },
+          {
+            "text": "World!",
+            "type": "text",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "perplexity": {
+                "images": null,
+                "usage": {
+                  "citationTokens": 30,
+                  "numSearchQueries": 40,
+                },
               },
             },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 11,
+              "outputTokens": 21,
+            },
           },
-        },
-      ]);
+        ]
+      `);
     });
 
     it('should pass headers', async () => {

--- a/packages/perplexity/src/perplexity-language-model.ts
+++ b/packages/perplexity/src/perplexity-language-model.ts
@@ -141,7 +141,7 @@ export class PerplexityLanguageModel implements LanguageModelV2 {
     const text = choice.message.content;
 
     return {
-      text,
+      text: { type: 'text', text },
       toolCalls: [],
       finishReason: mapPerplexityFinishReason(choice.finish_reason),
       usage: {
@@ -298,8 +298,8 @@ export class PerplexityLanguageModel implements LanguageModelV2 {
 
             if (textContent != null) {
               controller.enqueue({
-                type: 'text-delta',
-                textDelta: textContent,
+                type: 'text',
+                text: textContent,
               });
             }
           },

--- a/packages/provider/src/language-model/v2/index.ts
+++ b/packages/provider/src/language-model/v2/index.ts
@@ -10,6 +10,7 @@ export * from './language-model-v2-prompt';
 export * from './language-model-v2-provider-defined-tool';
 export * from './language-model-v2-reasoning';
 export * from './language-model-v2-source';
+export * from './language-model-v2-text';
 export * from './language-model-v2-tool-call';
 export * from './language-model-v2-tool-call-delta';
 export * from './language-model-v2-tool-choice';

--- a/packages/provider/src/language-model/v2/language-model-v2-text.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-text.ts
@@ -1,0 +1,8 @@
+export type LanguageModelV2Text = {
+  type: 'text';
+
+  /**
+The text content.
+   */
+  text: string;
+};

--- a/packages/provider/src/language-model/v2/language-model-v2.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2.ts
@@ -6,6 +6,7 @@ import { LanguageModelV2FinishReason } from './language-model-v2-finish-reason';
 import { LanguageModelV2LogProbs } from './language-model-v2-logprobs';
 import { LanguageModelV2Reasoning } from './language-model-v2-reasoning';
 import { LanguageModelV2Source } from './language-model-v2-source';
+import { LanguageModelV2Text } from './language-model-v2-text';
 import { LanguageModelV2ToolCall } from './language-model-v2-tool-call';
 import { LanguageModelV2ToolCallDelta } from './language-model-v2-tool-call-delta';
 import { LanguageModelV2Usage } from './language-model-v2-usage';
@@ -93,7 +94,7 @@ by the user.
 Text that the model has generated.
 Can be undefined if the model did not generate any text.
      */
-    text?: string;
+    text?: LanguageModelV2Text;
 
     /**
 Reasoning that the model has generated.
@@ -229,8 +230,8 @@ Warnings for the call, e.g. unsupported settings.
 };
 
 export type LanguageModelV2StreamPart =
-  // Basic text deltas:
-  | { type: 'text-delta'; textDelta: string }
+  // Text:
+  | LanguageModelV2Text
 
   // Reasoning:
   | LanguageModelV2Reasoning

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -295,11 +295,11 @@ functionality that can be fully encapsulated in the provider.
         if (done) break;
 
         switch (value.type) {
-          case 'text-delta': {
-            content += value.textDelta;
+          case 'text': {
+            content += value.text;
             render({
               renderer: textRender,
-              args: [{ content, done: false, delta: value.textDelta }],
+              args: [{ content, done: false, delta: value.text }],
               streamableUI: ui,
             });
             break;

--- a/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
@@ -54,12 +54,12 @@ const mockTextModel = new MockLanguageModelV2({
   doStream: async () => {
     return {
       stream: convertArrayToReadableStream([
-        { type: 'text-delta', textDelta: '{ ' },
-        { type: 'text-delta', textDelta: '"content": ' },
-        { type: 'text-delta', textDelta: `"Hello, ` },
-        { type: 'text-delta', textDelta: `world` },
-        { type: 'text-delta', textDelta: `!"` },
-        { type: 'text-delta', textDelta: ' }' },
+        { type: 'text', text: '{ ' },
+        { type: 'text', text: '"content": ' },
+        { type: 'text', text: `"Hello, ` },
+        { type: 'text', text: `world` },
+        { type: 'text', text: `!"` },
+        { type: 'text', text: ' }' },
         {
           type: 'finish',
           finishReason: 'stop',
@@ -241,8 +241,8 @@ describe('options.headers', () => {
           return {
             stream: convertArrayToReadableStream([
               {
-                type: 'text-delta',
-                textDelta: '{ "content": "headers test" }',
+                type: 'text',
+                text: '{ "content": "headers test" }',
               },
               {
                 type: 'finish',
@@ -274,8 +274,8 @@ describe('options.providerMetadata', () => {
           return {
             stream: convertArrayToReadableStream([
               {
-                type: 'text-delta',
-                textDelta: '{ "content": "provider metadata test" }',
+                type: 'text',
+                text: '{ "content": "provider metadata test" }',
               },
               {
                 type: 'finish',
@@ -313,9 +313,9 @@ describe('model.supportsUrl binding', () => {
           },
           doStream: async () => ({
             stream: convertArrayToReadableStream([
-              { type: 'text-delta', textDelta: 'Hello' },
-              { type: 'text-delta', textDelta: ', ' },
-              { type: 'text-delta', textDelta: 'world!' },
+              { type: 'text', text: 'Hello' },
+              { type: 'text', text: ', ' },
+              { type: 'text', text: 'world!' },
               {
                 type: 'finish',
                 finishReason: 'stop',


### PR DESCRIPTION
## Background
`doGenerate` will in the future move to returning parts as an array, requiring type annotations.

## Summary
Introduce structured `text` parts. Change `text-delta` parts to `text` parts to align `doStream` with `doGenerate`.