### PR TITLE
fix (ai): remove deprecated `CoreTool*` types

### DIFF
--- a/.changeset/old-moons-kiss.md
+++ b/.changeset/old-moons-kiss.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+remove deprecated `CoreTool*` types

--- a/packages/ai/core/generate-text/index.ts
+++ b/packages/ai/core/generate-text/index.ts
@@ -21,11 +21,7 @@ export type {
   StreamTextResult,
   TextStreamPart,
 } from './stream-text-result';
-export type {
-  CoreToolCall,
-  ToolCall,
-  ToolCallUnion,
-} from './tool-call';
+export type { CoreToolCall, ToolCall, ToolCallUnion } from './tool-call';
 export type { ToolCallRepairFunction } from './tool-call-repair';
 export type {
   CoreToolResult,

--- a/packages/ai/core/generate-text/index.ts
+++ b/packages/ai/core/generate-text/index.ts
@@ -23,7 +23,6 @@ export type {
 } from './stream-text-result';
 export type {
   CoreToolCall,
-  CoreToolCallUnion,
   ToolCall,
   ToolCallUnion,
 } from './tool-call';

--- a/packages/ai/core/generate-text/index.ts
+++ b/packages/ai/core/generate-text/index.ts
@@ -29,7 +29,6 @@ export type {
 export type { ToolCallRepairFunction } from './tool-call-repair';
 export type {
   CoreToolResult,
-  CoreToolResultUnion,
   ToolResult,
   ToolResultUnion,
 } from './tool-result';

--- a/packages/ai/core/generate-text/tool-call.ts
+++ b/packages/ai/core/generate-text/tool-call.ts
@@ -14,10 +14,4 @@ export type ToolCallUnion<TOOLS extends ToolSet> = ValueOf<{
   };
 }>;
 
-/**
- * @deprecated Use `ToolCallUnion` instead.
- */
-// TODO remove in v5
-export type CoreToolCallUnion<TOOLS extends ToolSet> = ToolCallUnion<ToolSet>;
-
 export type ToolCallArray<TOOLS extends ToolSet> = Array<ToolCallUnion<TOOLS>>;

--- a/packages/ai/core/generate-text/tool-result.ts
+++ b/packages/ai/core/generate-text/tool-result.ts
@@ -7,8 +7,8 @@ export type { CoreToolResult, ToolResult } from '@ai-sdk/provider-utils';
 // limits the tools to those that have execute !== undefined
 export type ToToolsWithDefinedExecute<TOOLS extends ToolSet> = {
   [K in keyof TOOLS as TOOLS[K]['execute'] extends undefined
-    ? never
-    : K]: TOOLS[K];
+  ? never
+  : K]: TOOLS[K];
 };
 
 // transforms the tools into a tool result union
@@ -25,12 +25,6 @@ type ToToolResultObject<TOOLS extends ToolSet> = ValueOf<{
 export type ToolResultUnion<TOOLS extends ToolSet> = ToToolResultObject<
   ToToolsWithDefinedExecute<TOOLS>
 >;
-
-/**
- * @deprecated Use `ToolResultUnion` instead.
- */
-// TODO remove in v5
-export type CoreToolResultUnion<TOOLS extends ToolSet> = ToolResultUnion<TOOLS>;
 
 export type ToolResultArray<TOOLS extends ToolSet> = Array<
   ToolResultUnion<TOOLS>

--- a/packages/ai/core/generate-text/tool-result.ts
+++ b/packages/ai/core/generate-text/tool-result.ts
@@ -7,8 +7,8 @@ export type { CoreToolResult, ToolResult } from '@ai-sdk/provider-utils';
 // limits the tools to those that have execute !== undefined
 export type ToToolsWithDefinedExecute<TOOLS extends ToolSet> = {
   [K in keyof TOOLS as TOOLS[K]['execute'] extends undefined
-  ? never
-  : K]: TOOLS[K];
+    ? never
+    : K]: TOOLS[K];
 };
 
 // transforms the tools into a tool result union

--- a/packages/ai/core/tool/index.ts
+++ b/packages/ai/core/tool/index.ts
@@ -8,4 +8,4 @@ export type {
 export { createMCPClient as experimental_createMCPClient } from './mcp/mcp-client';
 export type { MCPTransport } from './mcp/mcp-transport';
 export { tool } from './tool';
-export type { CoreTool, Tool, ToolExecutionOptions } from './tool';
+export type { Tool, ToolExecutionOptions } from './tool';

--- a/packages/ai/core/tool/tool.ts
+++ b/packages/ai/core/tool/tool.ts
@@ -27,8 +27,8 @@ export interface ToolExecutionOptions {
 type NeverOptional<N, T> = 0 extends 1 & N
   ? Partial<T>
   : [N] extends [never]
-  ? Partial<Record<keyof T, undefined>>
-  : T;
+    ? Partial<Record<keyof T, undefined>>
+    : T;
 
 /**
 A tool contains the description and the schema of the input that the tool expects.
@@ -80,27 +80,27 @@ If not provided, the tool will not be executed automatically.
   > &
   (
     | {
-      /**
+        /**
 Function tool.
      */
-      type?: undefined | 'function';
-    }
+        type?: undefined | 'function';
+      }
     | {
-      /**
+        /**
 Provider-defined tool.
      */
-      type: 'provider-defined';
+        type: 'provider-defined';
 
-      /**
+        /**
 The ID of the tool. Should follow the format `<provider-name>.<tool-name>`.
      */
-      id: `${string}.${string}`;
+        id: `${string}.${string}`;
 
-      /**
+        /**
 The arguments for configuring the tool. Must match the expected arguments defined by the provider for this tool.
      */
-      args: Record<string, unknown>;
-    }
+        args: Record<string, unknown>;
+      }
   );
 
 /**
@@ -120,7 +120,7 @@ export function tool(tool: any): any {
 
 export type MappedTool<T extends Tool | JSONObject, RESULT extends any> =
   T extends Tool<infer P>
-  ? Tool<P, RESULT>
-  : T extends JSONObject
-  ? Tool<T, RESULT>
-  : never;
+    ? Tool<P, RESULT>
+    : T extends JSONObject
+      ? Tool<T, RESULT>
+      : never;

--- a/packages/ai/core/tool/tool.ts
+++ b/packages/ai/core/tool/tool.ts
@@ -27,8 +27,8 @@ export interface ToolExecutionOptions {
 type NeverOptional<N, T> = 0 extends 1 & N
   ? Partial<T>
   : [N] extends [never]
-    ? Partial<Record<keyof T, undefined>>
-    : T;
+  ? Partial<Record<keyof T, undefined>>
+  : T;
 
 /**
 A tool contains the description and the schema of the input that the tool expects.
@@ -80,37 +80,28 @@ If not provided, the tool will not be executed automatically.
   > &
   (
     | {
-        /**
+      /**
 Function tool.
-       */
-        type?: undefined | 'function';
-      }
+     */
+      type?: undefined | 'function';
+    }
     | {
-        /**
+      /**
 Provider-defined tool.
-       */
-        type: 'provider-defined';
+     */
+      type: 'provider-defined';
 
-        /**
+      /**
 The ID of the tool. Should follow the format `<provider-name>.<tool-name>`.
-       */
-        id: `${string}.${string}`;
+     */
+      id: `${string}.${string}`;
 
-        /**
+      /**
 The arguments for configuring the tool. Must match the expected arguments defined by the provider for this tool.
-       */
-        args: Record<string, unknown>;
-      }
+     */
+      args: Record<string, unknown>;
+    }
   );
-
-/**
- * @deprecated Use `Tool` instead.
- */
-// TODO remove in v5
-export type CoreTool<
-  PARAMETERS extends ToolParameters = any,
-  RESULT = any,
-> = Tool<PARAMETERS, RESULT>;
 
 /**
 Helper function for inferring the execute args of a tool.
@@ -129,7 +120,7 @@ export function tool(tool: any): any {
 
 export type MappedTool<T extends Tool | JSONObject, RESULT extends any> =
   T extends Tool<infer P>
-    ? Tool<P, RESULT>
-    : T extends JSONObject
-      ? Tool<T, RESULT>
-      : never;
+  ? Tool<P, RESULT>
+  : T extends JSONObject
+  ? Tool<T, RESULT>
+  : never;

--- a/packages/ai/core/types/index.ts
+++ b/packages/ai/core/types/index.ts
@@ -6,7 +6,6 @@ export type {
 export type { ImageModelResponseMetadata } from './image-model-response-metadata';
 export type {
   CallWarning,
-  CoreToolChoice,
   FinishReason,
   LanguageModel,
   LogProbs,

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -55,10 +55,3 @@ export type ToolChoice<TOOLS extends Record<string, unknown>> =
   | 'none'
   | 'required'
   | { type: 'tool'; toolName: Extract<keyof TOOLS, string> };
-
-/**
- * @deprecated Use `ToolChoice` instead.
- */
-// TODO remove in v5
-export type CoreToolChoice<TOOLS extends Record<string, unknown>> =
-  ToolChoice<TOOLS>;


### PR DESCRIPTION
## Background

Towards #5765

## Summary

Removed

- `CoreToolChoice` type
- `CoreTool` type
- `CoreToolResultUnion` type
- `CoreToolCallUnion` type

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~ n/a
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~ n/a
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues