### PR TITLE
fix (ai): remove deprecated `options.throwErrorForEmptyVectors` from `cosineSimilarity()`

### DIFF
--- a/.changeset/tricky-zebras-cover.md
+++ b/.changeset/tricky-zebras-cover.md
@@ -1,0 +1,10 @@
+---
+'ai': patch
+---
+
+Removed deprecated `options.throwErrorForEmptyVectors` from `cosineSimilarity()`. Since `throwErrorForEmptyVectors` was the only option the entire `options` argument was removed.
+
+```diff
+- cosineSimilarity(vector1, vector2, options)
++cosineSimilarity(vector1, vector2)
+```

--- a/content/docs/07-reference/01-ai-sdk-core/50-cosine-similarity.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/50-cosine-similarity.mdx
@@ -45,26 +45,6 @@ console.log(
       type: 'number[]',
       description: 'The second vector to compare',
     },
-    {
-      name: 'options',
-      type: 'Object',
-      isOptional: true,
-      description: 'Optional configuration.',
-      properties: [
-        {
-          type: 'Object',
-          parameters: [
-            {
-              name: 'throwErrorForEmptyVectors',
-              type: 'boolean',
-              isOptional: true,
-              description:
-                'Set throwErrorForEmptyVectors to true to throw an error when vectors are empty (default: false)',
-            },
-          ],
-        },
-      ],
-    },
   ]}
 />
 

--- a/packages/ai/core/util/cosine-similarity.test.ts
+++ b/packages/ai/core/util/cosine-similarity.test.ts
@@ -40,15 +40,6 @@ it('should give 0 when one of the vectors is a zero vector', () => {
   expect(result2).toBe(0);
 });
 
-it('should throw an error when vectors are empty', () => {
-  const vector1: number[] = [];
-  const vector2: number[] = [];
-
-  expect(() =>
-    cosineSimilarity(vector1, vector2, { throwErrorForEmptyVectors: true }),
-  ).toThrowError();
-});
-
 it('should handle vectors with very small magnitudes', () => {
   const vector1 = [1e-10, 0, 0];
   const vector2 = [2e-10, 0, 0];

--- a/packages/ai/core/util/cosine-similarity.ts
+++ b/packages/ai/core/util/cosine-similarity.ts
@@ -6,26 +6,13 @@ import { InvalidArgumentError } from '../../errors/invalid-argument-error';
  *
  * @param vector1 - The first vector.
  * @param vector2 - The second vector.
- * @param options - Optional configuration.
- * @param options.throwErrorForEmptyVectors - If true, throws an error for empty vectors. Default: false.
  *
  * @returns The cosine similarity between vector1 and vector2.
  * @returns 0 if either vector is the zero vector.
  *
- * @throws {InvalidArgumentError} If throwErrorForEmptyVectors is true and vectors are empty.
  * @throws {InvalidArgumentError} If the vectors do not have the same length.
  */
-export function cosineSimilarity(
-  vector1: number[],
-  vector2: number[],
-  // TODO remove throw option in 5.0
-  options?: {
-    /**
-     * @deprecated will be removed in 5.0
-     */
-    throwErrorForEmptyVectors?: boolean;
-  },
-): number {
+export function cosineSimilarity(vector1: number[], vector2: number[]): number {
   if (vector1.length !== vector2.length) {
     throw new InvalidArgumentError({
       parameter: 'vector1,vector2',
@@ -37,14 +24,6 @@ export function cosineSimilarity(
   const n = vector1.length;
 
   if (n === 0) {
-    if (options?.throwErrorForEmptyVectors) {
-      throw new InvalidArgumentError({
-        parameter: 'vector1',
-        value: vector1,
-        message: 'Vectors cannot be empty',
-      });
-    }
-
     return 0; // Return 0 for empty vectors if no error is thrown
   }
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

towards  #5765 

## Summary

Removed deprecated `options.throwErrorForEmptyVectors` from `cosineSimilarity()`. Since `throwErrorForEmptyVectors` was the only option, I removed the entire `options` argument

```diff
- cosineSimilarity(vector1, vector2, options)
+ cosineSimilarity(vector1, vector2)
```

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] n/a ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues