### PR TITLE
fix (provider): remove obsolete `.rawCall` from `doStream()` and `doGenerate()` results (now there is request)

### DIFF
--- a/.changeset/fuzzy-spiders-give.md
+++ b/.changeset/fuzzy-spiders-give.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+remove obsolete `.rawCall` from `doStream()` and `doGenerate()` results (now there is request)

--- a/packages/provider/src/language-model/v1/language-model-v1.ts
+++ b/packages/provider/src/language-model/v1/language-model-v1.ts
@@ -146,24 +146,6 @@ Finish reason.
     };
 
     /**
-Raw prompt and setting information for observability provider integration.
-     */
-    // TODO v2: remove in v2 (now there is request)
-    rawCall: {
-      /**
-Raw prompt after expansion and conversion to the format that the
-provider uses to send the information to their API.
-       */
-      rawPrompt: unknown;
-
-      /**
-Raw settings that are used for the API call. Includes provider-specific
-settings.
-       */
-      rawSettings: Record<string, unknown>;
-    };
-
-    /**
 Optional response information for telemetry and debugging purposes.
      */
     // TODO rename to `response` in v2
@@ -244,24 +226,6 @@ by the user.
    */
   doStream(options: LanguageModelV1CallOptions): PromiseLike<{
     stream: ReadableStream<LanguageModelV1StreamPart>;
-
-    /**
-Raw prompt and setting information for observability provider integration.
-     */
-    // TODO remove in v2 (there is now request)
-    rawCall: {
-      /**
-Raw prompt after expansion and conversion to the format that the
-provider uses to send the information to their API.
-       */
-      rawPrompt: unknown;
-
-      /**
-Raw settings that are used for the API call. Includes provider-specific
-settings.
-       */
-      rawSettings: Record<string, unknown>;
-    };
 
     /**
 Optional raw response data.


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Towards #5765

## Summary

Obsolete `.rawCall` from `doStream()` and `doGenerate()` results has been removed. Use `.request` instead.

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] n/a ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] n/a ~~Docs have been added / updated (for bug fixes / features)~~
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues