### PR TITLE
fix (provider): remove deprecated `Experimental_LanguageModelV2Middleware`

### DIFF
--- a/.changeset/tricky-hats-fly.md
+++ b/.changeset/tricky-hats-fly.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+Remove `Experimental_LanguageModelV2Middleware` type

--- a/packages/provider/src/language-model-middleware/v2/language-model-v2-middleware.ts
+++ b/packages/provider/src/language-model-middleware/v2/language-model-v2-middleware.ts
@@ -59,9 +59,3 @@ export type LanguageModelV2Middleware = {
     model: LanguageModelV2;
   }) => PromiseLike<Awaited<ReturnType<LanguageModelV2['doStream']>>>;
 };
-
-/**
- * @deprecated Use `LanguageModelV2Middleware` instead.
- */
-// TODO remove in v5
-export type Experimental_LanguageModelV2Middleware = LanguageModelV2Middleware;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Towards #5765 

## Summary

The deprecated `Experimental_LanguageModelV2Middleware` type has been removed from `@ai-sdk/provider`

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] n/a ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] n/a ~~Docs have been added / updated (for bug fixes / features)~~
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues