### PR TITLE
Remove duplicate .gitignore value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ dist-ssr
 .cache
 server/dist
 public/dist
-.turbo
 test-results


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

.turbo is in the `.gitignore` twice and this is unnecessary.

## Summary

Removed the second iteration of .turbo from the `.gitignore` file

## Tasks

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [X] If required, a _patch_ changeset for relevant packages has been added
- [X] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
