### PR TITLE
fix (openai): structured output support for responses api model

### DIFF
--- a/.changeset/three-jars-fix.md
+++ b/.changeset/three-jars-fix.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix (openai): structure output for responses model

--- a/content/providers/01-ai-sdk-providers/02-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/02-openai.mdx
@@ -663,6 +663,42 @@ respond to questions about it.
 The PDF file should be passed using the `data` field,
 and the `mimeType` should be set to `'application/pdf'`.
 
+#### Structured Outputs
+
+The OpenAI Responses API supports structured outputs. To enforce structured outputs, you can use `generateObject` or `streamObject` which expose a `schema` option. Additionally, you can pass a Zod or JSON Schema object to the `experimental_output` option when using `generateText` or `streamText`.
+
+```ts
+// Using generateObject
+const result = await generateObject({
+  model: openai.responses('gpt-4.1'),
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(
+        z.object({
+          name: z.string(),
+          amount: z.string(),
+        }),
+      ),
+      steps: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate a lasagna recipe.',
+});
+
+// Using generateText
+const result = await generateText({
+  model: openai.responses('gpt-4.1'),
+  prompt: 'How do I make a pizza?',
+  experimental_output: Output.object({
+    schema: z.object({
+      ingredients: z.array(z.string()),
+      steps: z.array(z.string()),
+    }),
+  }),
+});
+```
+
 ### Completion Models
 
 You can create models that call the [OpenAI completions API](https://platform.openai.com/docs/api-reference/completions) using the `.completion()` factory method.

--- a/content/providers/01-ai-sdk-providers/02-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/02-openai.mdx
@@ -665,7 +665,7 @@ and the `mimeType` should be set to `'application/pdf'`.
 
 #### Structured Outputs
 
-The OpenAI Responses API supports structured outputs. To enforce structured outputs, you can use `generateObject` or `streamObject` which expose a `schema` option. Additionally, you can pass a Zod or JSON Schema object to the `experimental_output` option when using `generateText` or `streamText`.
+The OpenAI Responses API supports structured outputs. You can enforce structured outputs using `generateObject` or `streamObject`, which expose a `schema` option. Additionally, you can pass a Zod or JSON Schema object to the `experimental_output` option when using `generateText` or `streamText`.
 
 ```ts
 // Using generateObject

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -238,7 +238,6 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
     options: Parameters<LanguageModelV1['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args: body, warnings } = this.getArgs(options);
-    console.log(JSON.stringify(body, null, 2));
 
     const {
       responseHeaders,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -24,6 +24,7 @@ import { OpenAIResponsesModelId } from './openai-responses-settings';
 export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
   readonly specificationVersion = 'v1';
   readonly defaultObjectGenerationMode = 'json';
+  readonly supportsStructuredOutputs = true;
 
   readonly modelId: OpenAIResponsesModelId;
 
@@ -237,6 +238,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
     options: Parameters<LanguageModelV1['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV1['doGenerate']>>> {
     const { args: body, warnings } = this.getArgs(options);
+    console.log(JSON.stringify(body, null, 2));
 
     const {
       responseHeaders,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Addresses https://github.com/vercel/ai/issues/5788

## Summary

Adds `supportsStructuredOutputs` flag to the `OpenAIResponsesLanguageModel`. Because this was not defined, using `experimental_output` with `generateText` and `streamText` did not work due to the schema resolving to `undefined`.

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If required, a _patch_ changeset for relevant packages has been added
- [ ] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
