### PR TITLE
chore: update test expectations and guide to node 22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ We welcome your contributions to our code and documentation. Here's how you can 
 
 ### Environment Setup
 
-AI SDK development requires PNPM v9 (lockfile version) or higher and Node v20 or higher.
+AI SDK development requires PNPM v9 (lockfile version) or higher and Node v22.
 
 ### Setting Up the Repository Locally
 
@@ -40,7 +40,7 @@ To set up the repository on your local machine, follow these steps:
 
 1. **Fork the Repository**: Make a copy of the repository to your GitHub account.
 2. **Clone the Repository**: Clone the repository to your local machine, e.g. using `git clone`.
-3. **Install Node**: If you haven't already, install Node v20.
+3. **Install Node**: If you haven't already, install Node v22.
 4. **Install pnpm**: If you haven't already, install pnpm v9. You can do this by running `npm install -g pnpm@9` if you're using npm. Alternatively, if you're using Homebrew (Mac), you can run `brew install pnpm`. For more see [the pnpm site](https://pnpm.io/installation).
 5. **Install Dependencies**: Navigate to the project directory and run `pnpm install` to install all necessary dependencies.
 6. **Build the Project**: Run `pnpm build` in the root to build all packages.

--- a/packages/ai/core/util/merge-streams.test.ts
+++ b/packages/ai/core/util/merge-streams.test.ts
@@ -1,6 +1,7 @@
 import {
   convertArrayToReadableStream,
   convertReadableStreamToArray,
+  isNodeVersion,
 } from '@ai-sdk/provider-utils/test';
 import { expect, it } from 'vitest';
 import { mergeStreams } from './merge-streams';
@@ -21,69 +22,74 @@ it('should prioritize the first stream over the second stream', async () => {
   ]);
 });
 
-it.skip('should return values from the 2nd stream until the 1st stream has values', async () => {
-  let stream1Controller: ReadableStreamDefaultController<string> | undefined;
-  const stream1 = new ReadableStream({
-    start(controller) {
-      stream1Controller = controller;
-    },
-  });
+it.skipIf(isNodeVersion(20))(
+  'should return values from the 2nd stream until the 1st stream has values',
+  async () => {
+    let stream1Controller: ReadableStreamDefaultController<string> | undefined;
+    const stream1 = new ReadableStream({
+      start(controller) {
+        stream1Controller = controller;
+      },
+    });
 
-  let stream2Controller: ReadableStreamDefaultController<string> | undefined;
-  const stream2 = new ReadableStream({
-    start(controller) {
-      stream2Controller = controller;
-    },
-  });
+    let stream2Controller: ReadableStreamDefaultController<string> | undefined;
+    const stream2 = new ReadableStream({
+      start(controller) {
+        stream2Controller = controller;
+      },
+    });
 
-  const mergedStream = mergeStreams(stream1, stream2);
+    const mergedStream = mergeStreams(stream1, stream2);
 
-  const result: string[] = [];
-  const reader = mergedStream.getReader();
+    const result: string[] = [];
+    const reader = mergedStream.getReader();
 
-  async function pull() {
-    const { value, done } = await reader.read();
-    result.push(value!);
-  }
+    async function pull() {
+      const { value, done } = await reader.read();
+      result.push(value!);
+    }
 
-  stream2Controller!.enqueue('2a');
-  stream2Controller!.enqueue('2b');
+    stream2Controller!.enqueue('2a');
+    stream2Controller!.enqueue('2b');
 
-  await pull();
-  await pull();
+    await pull();
+    await pull();
 
-  stream2Controller!.enqueue('2c');
-  stream2Controller!.enqueue('2d'); // comes later
-  stream1Controller!.enqueue('1a');
-  stream2Controller!.enqueue('2e'); // comes later
-  stream1Controller!.enqueue('1b');
-  stream1Controller!.enqueue('1c');
-  stream2Controller!.enqueue('2f');
+    stream2Controller!.enqueue('2c'); // comes later
+    stream2Controller!.enqueue('2d'); // comes later
+    stream1Controller!.enqueue('1a');
+    stream2Controller!.enqueue('2e'); // comes later
+    stream1Controller!.enqueue('1b');
+    stream1Controller!.enqueue('1c');
+    stream2Controller!.enqueue('2f');
 
-  await pull();
-  await pull();
-  await pull();
-  await pull();
-  await pull();
+    await pull();
+    await pull();
+    await pull();
+    await pull();
+    await pull();
 
-  stream1Controller!.close();
-  stream2Controller!.close();
+    stream1Controller!.close();
+    stream2Controller!.close();
 
-  await pull();
-  await pull();
+    await pull();
+    await pull();
 
-  expect(result).toEqual([
-    '2a',
-    '2b',
-    '2c',
-    '1a',
-    '1b',
-    '1c',
-    '2d',
-    '2e',
-    '2f',
-  ]);
-});
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "2a",
+        "2b",
+        "1a",
+        "1b",
+        "1c",
+        "2c",
+        "2d",
+        "2e",
+        "2f",
+      ]
+    `);
+  },
+);
 
 it('should not duplicate last value when parallel calls happen', async () => {
   let stream1Controller: ReadableStreamDefaultController<string> | undefined;

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -707,26 +707,26 @@ describe('doStream', () => {
       });
 
       expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-      Error message: Expected property name or '}' in JSON at position 1],
-          "type": "error",
-        },
-        {
-          "finishReason": "error",
-          "type": "finish",
-          "usage": {
-            "inputTokens": undefined,
-            "outputTokens": undefined,
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
           },
-        },
-      ]
-    `);
+          {
+            "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
+        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+            "type": "error",
+          },
+          {
+            "finishReason": "error",
+            "type": "finish",
+            "usage": {
+              "inputTokens": undefined,
+              "outputTokens": undefined,
+            },
+          },
+        ]
+      `);
     },
   );
 

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -693,7 +693,7 @@ describe('doStream', () => {
     expect(new Set(toolCallIds)).toStrictEqual(new Set(['test-id-1']));
   });
 
-  it.skipIf(isNodeVersion(22))(
+  it.skipIf(isNodeVersion(20))(
     'should handle unparsable stream parts',
     async () => {
       server.urls['https://api.cohere.com/v2/chat'].response = {

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -1134,26 +1134,26 @@ describe('doStream', () => {
       });
 
       expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-      Error message: Expected property name or '}' in JSON at position 1],
-          "type": "error",
-        },
-        {
-          "finishReason": "error",
-          "type": "finish",
-          "usage": {
-            "inputTokens": undefined,
-            "outputTokens": undefined,
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
           },
-        },
-      ]
-    `);
+          {
+            "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
+        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+            "type": "error",
+          },
+          {
+            "finishReason": "error",
+            "type": "finish",
+            "usage": {
+              "inputTokens": undefined,
+              "outputTokens": undefined,
+            },
+          },
+        ]
+      `);
     },
   );
 

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -1119,7 +1119,7 @@ describe('doStream', () => {
     `);
   });
 
-  it.skipIf(isNodeVersion(22))(
+  it.skipIf(isNodeVersion(20))(
     'should handle unparsable stream parts',
     async () => {
       server.urls['https://api.groq.com/openai/v1/chat/completions'].response =

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -1569,29 +1569,29 @@ describe('doStream', () => {
       });
 
       expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-      Error message: Expected property name or '}' in JSON at position 1],
-          "type": "error",
-        },
-        {
-          "finishReason": "error",
-          "providerMetadata": {
-            "test-provider": {},
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
           },
-          "type": "finish",
-          "usage": {
-            "inputTokens": undefined,
-            "outputTokens": undefined,
+          {
+            "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
+        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+            "type": "error",
           },
-        },
-      ]
-    `);
+          {
+            "finishReason": "error",
+            "providerMetadata": {
+              "test-provider": {},
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": undefined,
+              "outputTokens": undefined,
+            },
+          },
+        ]
+      `);
     },
   );
 

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -1555,7 +1555,7 @@ describe('doStream', () => {
     `);
   });
 
-  it.skipIf(isNodeVersion(22))(
+  it.skipIf(isNodeVersion(20))(
     'should handle unparsable stream parts',
     async () => {
       server.urls['https://my.api.com/v1/chat/completions'].response = {

--- a/packages/openai-compatible/src/openai-compatible-completion-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-completion-language-model.test.ts
@@ -499,26 +499,26 @@ describe('doStream', () => {
       });
 
       expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-      Error message: Expected property name or '}' in JSON at position 1],
-          "type": "error",
-        },
-        {
-          "finishReason": "error",
-          "type": "finish",
-          "usage": {
-            "inputTokens": undefined,
-            "outputTokens": undefined,
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
           },
-        },
-      ]
-    `);
+          {
+            "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
+        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+            "type": "error",
+          },
+          {
+            "finishReason": "error",
+            "type": "finish",
+            "usage": {
+              "inputTokens": undefined,
+              "outputTokens": undefined,
+            },
+          },
+        ]
+      `);
     },
   );
 

--- a/packages/openai-compatible/src/openai-compatible-completion-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-completion-language-model.test.ts
@@ -485,7 +485,7 @@ describe('doStream', () => {
     `);
   });
 
-  it.skipIf(isNodeVersion(22))(
+  it.skipIf(isNodeVersion(20))(
     'should handle unparsable stream parts',
     async () => {
       server.urls['https://my.api.com/v1/completions'].response = {

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -2100,30 +2100,30 @@ describe('doStream', () => {
       });
 
       expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-      Error message: Expected property name or '}' in JSON at position 1],
-          "type": "error",
-        },
-        {
-          "finishReason": "error",
-          "logprobs": undefined,
-          "providerMetadata": {
-            "openai": {},
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
           },
-          "type": "finish",
-          "usage": {
-            "inputTokens": undefined,
-            "outputTokens": undefined,
+          {
+            "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
+        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+            "type": "error",
           },
-        },
-      ]
-    `);
+          {
+            "finishReason": "error",
+            "logprobs": undefined,
+            "providerMetadata": {
+              "openai": {},
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": undefined,
+              "outputTokens": undefined,
+            },
+          },
+        ]
+      `);
     },
   );
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -2086,7 +2086,7 @@ describe('doStream', () => {
     `);
   });
 
-  it.skipIf(isNodeVersion(22))(
+  it.skipIf(isNodeVersion(20))(
     'should handle unparsable stream parts',
     async () => {
       server.urls['https://api.openai.com/v1/chat/completions'].response = {

--- a/packages/openai/src/openai-completion-language-model.test.ts
+++ b/packages/openai/src/openai-completion-language-model.test.ts
@@ -531,27 +531,27 @@ describe('doStream', () => {
       });
 
       expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-      Error message: Expected property name or '}' in JSON at position 1],
-          "type": "error",
-        },
-        {
-          "finishReason": "error",
-          "logprobs": undefined,
-          "type": "finish",
-          "usage": {
-            "inputTokens": undefined,
-            "outputTokens": undefined,
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
           },
-        },
-      ]
-    `);
+          {
+            "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
+        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+            "type": "error",
+          },
+          {
+            "finishReason": "error",
+            "logprobs": undefined,
+            "type": "finish",
+            "usage": {
+              "inputTokens": undefined,
+              "outputTokens": undefined,
+            },
+          },
+        ]
+      `);
     },
   );
 

--- a/packages/openai/src/openai-completion-language-model.test.ts
+++ b/packages/openai/src/openai-completion-language-model.test.ts
@@ -517,7 +517,7 @@ describe('doStream', () => {
     `);
   });
 
-  it.skipIf(isNodeVersion(22))(
+  it.skipIf(isNodeVersion(20))(
     'should handle unparsable stream parts',
     async () => {
       server.urls['https://api.openai.com/v1/completions'].response = {


### PR DESCRIPTION
## Background
Some test results are different between Node 20 and Node 22.

## Summary
- update test expectations to Node 22
- skip Node 22-specific tests in Node 20
- update contributor docs to require Node 22