### PR TITLE
fix (provider/cohere): tool calling

### DIFF
--- a/.changeset/curly-peaches-clap.md
+++ b/.changeset/curly-peaches-clap.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cohere': patch
+---
+
+fix (provider/cohere): tool calling

--- a/packages/cohere/src/convert-to-cohere-chat-prompt.test.ts
+++ b/packages/cohere/src/convert-to-cohere-chat-prompt.test.ts
@@ -22,7 +22,7 @@ describe('tool messages', () => {
 
     expect(result).toEqual([
       {
-        content: 'Calling a tool',
+        content: undefined,
         role: 'assistant',
         tool_calls: [
           {

--- a/packages/cohere/src/convert-to-cohere-chat-prompt.ts
+++ b/packages/cohere/src/convert-to-cohere-chat-prompt.ts
@@ -63,10 +63,7 @@ export function convertToCohereChatPrompt(
 
         messages.push({
           role: 'assistant',
-          // note: this is a workaround for a Cohere API bug
-          // that requires content to be provided
-          // even if there are tool calls
-          content: text !== '' ? text : 'call tool',
+          content: toolCalls.length > 0 ? undefined : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           tool_plan: undefined,
         });


### PR DESCRIPTION
## Background

Tool calling is not working with the Cohere provider. Our previous fix is now rejected by the Cohere API.

## Summary

Remove tool calling fix and pass empty content when tool calls are available.