### PR TITLE
feat (providers/google): add thinking config to provider options

### DIFF
--- a/.changeset/five-ravens-hammer.md
+++ b/.changeset/five-ravens-hammer.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat (providers/google): add thinking config to provider options

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -150,10 +150,41 @@ const { text } = await generateText({
 });
 ```
 
+Another example showing the use of provider options to specify the thinking budget for a Google Generative AI thinking model:
+
+```ts
+import { google } from '@ai-sdk/google';
+import { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: google('gemini-2.5-flash-preview-04-17'),
+  providerOptions: {
+    google: {
+      thinkingConfig: {
+        thinkingBudget: 2048,
+      },
+    } satisfies GoogleGenerativeAIProviderOptions,
+  },
+  // ...
+});
+```
+
 The following provider options are available:
 
 - **responseModalities** _string[]_
   The modalities to use for the response. The following modalities are supported: `TEXT`, `IMAGE`. When not defined or empty, the model defaults to returning only text.
+
+- **thinkingConfig** _\{ thinkingBudget: number; \}_
+
+  Optional. Configuration for the model's thinking process. Only supported by specific [Google Generative AI models](https://ai.google.dev/gemini-api/docs/thinking).
+
+  - **thinkingBudget** _number_
+
+    Optional. Gives the model guidance on the number of thinking tokens it can use when
+    generating a response. Must be an integer in the range 0 to 24576. Setting it to 0
+    disables thinking. Budgets from 1 to 1024 tokens will be set to 1024.
+    For more information see [Google Generative AI documentation](https://ai.google.dev/gemini-api/docs/thinking).
 
 You can use Google Generative AI language models to generate text with the `generateText` function:
 

--- a/examples/ai-core/src/stream-text/google-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-reasoning.ts
@@ -1,0 +1,37 @@
+import { google } from '@ai-sdk/google';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: google('gemini-2.5-flash-preview-04-17'),
+    prompt: 'Tell me the history of the San Francisco Mission-style burrito.',
+    providerOptions: {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: 1024,
+        },
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    console.log(part);
+    // if (part.type === 'reasoning') {
+    //   process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
+    // } else if (part.type === 'text-delta') {
+    //   process.stdout.write(part.textDelta);
+    // }
+  }
+
+  console.log();
+  console.log('Warnings:', await result.warnings);
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);
+
+// thoughts_token_count in usage

--- a/examples/ai-core/src/stream-text/google-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-reasoning.ts
@@ -16,12 +16,11 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    console.log(part);
-    // if (part.type === 'reasoning') {
-    //   process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
-    // } else if (part.type === 'text-delta') {
-    //   process.stdout.write(part.textDelta);
-    // }
+    if (part.type === 'reasoning') {
+      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.textDelta);
+    }
   }
 
   console.log();
@@ -33,5 +32,3 @@ async function main() {
 }
 
 main().catch(console.error);
-
-// thoughts_token_count in usage

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -331,7 +331,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
             }
 
             const value = chunk.value;
-            // console.log('value', JSON.stringify(value, null, 2));
 
             const usageMetadata = value.usageMetadata;
 

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -119,6 +119,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
 
       // provider options:
       responseModalities: googleOptions?.responseModalities,
+      thinkingConfig: googleOptions?.thinkingConfig,
     };
 
     const { contents, systemInstruction } =
@@ -330,6 +331,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
             }
 
             const value = chunk.value;
+            // console.log('value', JSON.stringify(value, null, 2));
 
             const usageMetadata = value.usageMetadata;
 
@@ -624,6 +626,11 @@ const chunkSchema = z.object({
 
 const googleGenerativeAIProviderOptionsSchema = z.object({
   responseModalities: z.array(z.enum(['TEXT', 'IMAGE'])).nullish(),
+  thinkingConfig: z
+    .object({
+      thinkingBudget: z.number().nullish(),
+    })
+    .nullish(),
 });
 export type GoogleGenerativeAIProviderOptions = z.infer<
   typeof googleGenerativeAIProviderOptionsSchema


### PR DESCRIPTION
## Background

For the new Gemini 2.5 Flash model support for thinking:
https://developers.googleblog.com/en/start-building-with-gemini-25-flash/

This change adds a provider option to allow specifying the thinking budget, brief docs on the option, and a simple example script showing use.

Note:
- the Gemini API does not yet seem to provide any thinking text for inclusion in `reasoning` text for AI SDK
- there are thinking token usage metrics newly returned in the Gemini API response not yet incorporated in this change

## Summary

- add `thinkingBudget` to `providerOptions`
- add an example script for testing a google thinking model. Note no reasoning text is yet provided as it does not appear available via the API.

## Tasks

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues