### PR TITLE
fix (providers/fal): improve model compatibility

### DIFF
--- a/.changeset/slimy-chefs-play.md
+++ b/.changeset/slimy-chefs-play.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fal': patch
+---
+
+fix (providers/fal): improve model compatibility

--- a/examples/ai-core/src/generate-image/fal-photon.ts
+++ b/examples/ai-core/src/generate-image/fal-photon.ts
@@ -1,0 +1,14 @@
+import { fal } from '@ai-sdk/fal';
+import { experimental_generateImage as generateImage } from 'ai';
+import { presentImages } from '../lib/present-image';
+import 'dotenv/config';
+
+async function main() {
+  const { images } = await generateImage({
+    model: fal.image('fal-ai/luma-photon'),
+    prompt: 'A hyrax atop a stump in a forest among fireflies at dusk',
+  });
+  await presentImages(images);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-image/fal-recraft.ts
+++ b/examples/ai-core/src/generate-image/fal-recraft.ts
@@ -1,0 +1,15 @@
+import { fal } from '@ai-sdk/fal';
+import { experimental_generateImage as generateImage } from 'ai';
+import { presentImages } from '../lib/present-image';
+import 'dotenv/config';
+
+async function main() {
+  const { images } = await generateImage({
+    model: fal.image('fal-ai/recraft-v3'),
+    prompt:
+      'A Sumatran rhino meandering through a dense forest among fireflies at dusk',
+  });
+  await presentImages(images);
+}
+
+main().catch(console.error);

--- a/packages/fal/src/fal-image-model.ts
+++ b/packages/fal/src/fal-image-model.ts
@@ -173,8 +173,6 @@ const falErrorSchema = z.union([falValidationErrorSchema, falHttpErrorSchema]);
 
 const falImageSchema = z.object({
   url: z.string(),
-  width: z.number(),
-  height: z.number(),
   content_type: z.string(),
 });
 


### PR DESCRIPTION
## Background

Some models on fal.ai do not return image width/height in the API response. The fal image response schema has these noted as required fields, causing otherwise-successful image responses to fail due to missing dimensions.

## Summary

This change removes the width/height fields from the expected response schema. We don't currently use these values, so though we could mark them `nullish` and have them available when possible, we may as well just omit them entirely until we have a use.

Also adds two example scripts for popular models 'recraft-v3' and `luma-photon' that exhibit the responses lacking dimensions.

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues
