### PR TITLE
fix(providers/xai): return actual usage when streaming instead of NaN

### DIFF
--- a/.changeset/fast-students-turn.md
+++ b/.changeset/fast-students-turn.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/xai': patch
+---
+
+fix(providers/xai): return actual usage when streaming instead of NaN

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -646,6 +646,34 @@ describe('doGenerate', () => {
       expect(warnings).toEqual([]);
     });
 
+    it('should respect the includeUsage option', async () => {
+      prepareJsonResponse({ content: '{"value":"Spark"}' });
+
+      const model = new OpenAICompatibleChatLanguageModel(
+        'gpt-4o-2024-08-06',
+        {},
+        {
+          provider: 'test-provider',
+          url: () => 'https://my.api.com/v1/chat/completions',
+          headers: () => ({}),
+          includeUsage: true,
+        },
+      );
+
+      const { warnings } = await model.doStream({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+      });
+
+      const body = await server.calls[0].requestBody;
+
+      expect(body.stream).toBe(true);
+      expect(body.stream_options).toStrictEqual({ include_usage: true });
+
+      expect(warnings).toEqual([]);
+    });
+
     it('should use json_schema & strict in object-json mode when structuredOutputs are enabled', async () => {
       prepareJsonResponse({ content: '{"value":"Spark"}' });
 

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -647,7 +647,7 @@ describe('doGenerate', () => {
     });
 
     it('should respect the includeUsage option', async () => {
-      prepareJsonResponse({ content: '{"value":"Spark"}' });
+      prepareJsonResponse({ content: '{"value":"test"}' });
 
       const model = new OpenAICompatibleChatLanguageModel(
         'gpt-4o-2024-08-06',

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -40,7 +40,7 @@ export type OpenAICompatibleChatConfig = {
   headers: () => Record<string, string | undefined>;
   url: (options: { modelId: string; path: string }) => string;
   fetch?: FetchFunction;
-  includeUsgae?: boolean;
+  includeUsage?: boolean;
   errorStructure?: ProviderErrorStructure<any>;
   metadataExtractor?: MetadataExtractor;
 
@@ -381,7 +381,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV1 {
       stream: true,
 
       // only include stream_options when in strict compatibility mode:
-      stream_options: this.config.includeUsgae
+      stream_options: this.config.includeUsage
         ? { include_usage: true }
         : undefined,
     };

--- a/packages/openai-compatible/src/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-completion-language-model.ts
@@ -31,6 +31,7 @@ import {
 
 type OpenAICompatibleCompletionConfig = {
   provider: string;
+  includeUsage?: boolean;
   headers: () => Record<string, string | undefined>;
   url: (options: { modelId: string; path: string }) => string;
   fetch?: FetchFunction;
@@ -227,6 +228,11 @@ export class OpenAICompatibleCompletionLanguageModel
     const body = {
       ...args,
       stream: true,
+
+      // only include stream_options when in strict compatibility mode:
+      stream_options: this.config.includeUsage
+        ? { include_usage: true }
+        : undefined,
     };
 
     const { responseHeaders, value: response } = await postJsonToApi({

--- a/packages/xai/src/xai-provider.test.ts
+++ b/packages/xai/src/xai-provider.test.ts
@@ -89,7 +89,7 @@ describe('xAIProvider', () => {
       expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
     });
 
-    it('should pass strict compatibility mode to the chat model, to enable usage on streaming', () => {
+    it('should pass the includeUsage option to the chat model, to make sure usage is reported while streaming', () => {
       const provider = createXai();
       const modelId = 'xai-chat-model';
       const settings = { user: 'foo-user' };

--- a/packages/xai/src/xai-provider.test.ts
+++ b/packages/xai/src/xai-provider.test.ts
@@ -88,6 +88,22 @@ describe('xAIProvider', () => {
 
       expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
     });
+
+    it('should pass strict compatibility mode to the chat model, to enable usage on streaming', () => {
+      const provider = createXai();
+      const modelId = 'xai-chat-model';
+      const settings = { user: 'foo-user' };
+
+      const model = provider.chat(modelId, settings);
+
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+
+      expect(constructorCall[0]).toBe(modelId);
+      expect(constructorCall[2].includeUsage).toBe(true);
+    });
   });
 
   describe('imageModel', () => {

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -113,6 +113,7 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
       defaultObjectGenerationMode: structuredOutputs ? 'json' : 'tool',
       errorStructure: xaiErrorStructure,
       supportsStructuredOutputs: structuredOutputs,
+      includeUsage: true,
     });
   };
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

To resolve #5736

## Summary

Added support for `includeUsage: boolean` in openai-compatible, and use this new option inside the xai provider to return proper usage instead of NaN numbers

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
