### PR TITLE
fix (docs): fix OpenRouter code examples

### DIFF
--- a/content/providers/03-community-providers/12-openrouter.mdx
+++ b/content/providers/03-community-providers/12-openrouter.mdx
@@ -48,14 +48,14 @@ You can obtain your OpenRouter API key from the [OpenRouter Dashboard](https://o
 
 ## Language Models
 
-OpenRouter supports both chat and completion models. Use `openrouter.chatModel()` for chat models and `openrouter.completionModel()` for completion models:
+OpenRouter supports both chat and completion models. Use `openrouter.chat()` for chat models and `openrouter.completion()` for completion models:
 
 ```typescript
 // Chat models (recommended)
-const chatModel = openrouter.chatModel('anthropic/claude-3.5-sonnet');
+const chatModel = openrouter.chat('anthropic/claude-3.5-sonnet');
 
 // Completion models
-const completionModel = openrouter.completionModel(
+const completionModel = openrouter.completion(
   'meta-llama/llama-3.1-405b-instruct',
 );
 ```
@@ -77,7 +77,7 @@ const openrouter = createOpenRouter({
 });
 
 const { text } = await generateText({
-  model: openrouter.chatModel('anthropic/claude-3.5-sonnet'),
+  model: openrouter.chat('anthropic/claude-3.5-sonnet'),
   prompt: 'What is OpenRouter?',
 });
 
@@ -95,7 +95,7 @@ const openrouter = createOpenRouter({
 });
 
 const result = streamText({
-  model: openrouter.chatModel('meta-llama/llama-3.1-405b-instruct'),
+  model: openrouter.chat('meta-llama/llama-3.1-405b-instruct'),
   prompt: 'Write a short story about AI.',
 });
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Whilst working with @openrouter/ai-sdk-provider version 0.4.5 I found a few issues with the OpenRouter code examples in the documentation.

Some of the functions used in the examples are incorrect i.e. they do not exist e.g. `chatModel` should be `chat` and `completionModel` should be `completion`. You can see the correct definitions of these functions in the [ai-sdk-provider](https://github.com/OpenRouterTeam/ai-sdk-provider) library [here](https://github.com/OpenRouterTeam/ai-sdk-provider/blob/dbd1e47def8e819de8dae017aa3083275a3f6c05/src/openrouter-provider.ts#L39).

## Summary

This PR fixes the wrongly named functions i.e. `chatModel` changed to `chat` and `completionModel` changed to `completion`.

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If required, a _patch_ changeset for relevant packages has been added
- [ ] You've run `pnpm prettier-fix` to fix any formatting issues
