### PR TITLE
feat (ui/react): support resuming an ongoing stream

### DIFF
--- a/.changeset/nine-pillows-hug.md
+++ b/.changeset/nine-pillows-hug.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/ui-utils': patch
+'@ai-sdk/react': patch
+---
+
+feat (ui/react): support resuming an ongoing stream

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -634,6 +634,76 @@ messages.map(message => (
 ));
 ```
 
+## Resumable Streams (Experimental)
+
+The `useChat` hook has experimental support for resuming an ongoing chat generation stream by any client, either after a network disconnect or reloading the chat. This can be useful for building applications that involve long-running conversations or for ensuring that messages are not lost in case of network failures.
+
+The following are the pre-requisities for your chat application to support resumable streams:
+- Installing the [`resumable-stream`](https://www.npmjs.com/package/resumable-stream) package that helps create and manage the publisher/subscriber mechanism of the streams.
+- A [Redis](https://vercel.com/marketplace/redis) instance to store the stream state.
+- A table that tracks the stream IDs associated with a chat.
+
+To resume a chat stream, you can use the `experimental_resume` function returned by the `useChat` hook. You will typically call this function during the initial mount of the hook.
+
+```
+'use client'
+
+export function Chat() {
+  const { experimental_resume } = useChat({id});
+
+  useEffect(() => {
+    experimental_resume();
+
+    // we use an empty dependency array to
+    // ensure this effect runs only once
+  }, [])
+
+  return (
+    <div>
+      <Messages>
+      <Input/>
+    </div>
+  )
+}
+```
+
+The `experimental_resume` function makes a `GET` request to the api endpoint you've initialized the hook with (or `/api/chat` by default) and streams the contents of the stream if it is active or fails silently if it has ended.
+
+The `GET` request automatically appends the `chatId` query parameter to the URL to help identify the chat the request belongs to. Using the `chatId`, you can look up the most recent stream ID from the database and resume the stream. As a result, it is important to specify the `id` parameter in the `useChat` hook.
+
+Earlier, you must've implemented the `POST` method for `/api/chat` route to create new chat generations. When using `experimental_resume`, you must also implement the `GET` method for `/api/chat` route to resume a stream if it is active or fails silently if it has ended.
+
+```
+export async function GET() {
+  const { searchParams } = new URL(request.url);
+  const chatId = searchParams.get('chatId');
+
+  if (!chatId) {
+    return new Response('id is required', { status: 400 });
+  }
+
+  const streamIds = await loadStreams(chatId);
+
+  if (!streamIds.length) {
+    return new Response('No streams found', { status: 404 });
+  }
+
+  const recentStreamId = streamIds.at(-1);
+
+  if (!recentStreamId) {
+    return new Response('No recent stream found', { status: 404 });
+  }
+
+  const emptyDataStream = createDataStream({
+    execute: () => {},
+  });
+
+  return new Response(
+    await streamContext.resumableStream(recentStreamId, () => emptyDataStream),
+  );
+}
+```
+
 ## Attachments (Experimental)
 
 The `useChat` hook supports sending attachments along with a message as well as rendering them on the client. This can be useful for building applications that involve sending images, files, or other media content to the AI provider.

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -639,6 +639,7 @@ messages.map(message => (
 The `useChat` hook has experimental support for resuming an ongoing chat generation stream by any client, either after a network disconnect or reloading the chat. This can be useful for building applications that involve long-running conversations or for ensuring that messages are not lost in case of network failures.
 
 The following are the pre-requisities for your chat application to support resumable streams:
+
 - Installing the [`resumable-stream`](https://www.npmjs.com/package/resumable-stream) package that helps create and manage the publisher/subscriber mechanism of the streams.
 - A [Redis](https://vercel.com/marketplace/redis) instance to store the stream state.
 - A table that tracks the stream IDs associated with a chat.

--- a/examples/next-openai/.gitignore
+++ b/examples/next-openai/.gitignore
@@ -34,5 +34,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# chat persistence
+# persistence
 .chats
+.streams

--- a/examples/next-openai/app/api/use-chat-resume/route.ts
+++ b/examples/next-openai/app/api/use-chat-resume/route.ts
@@ -1,5 +1,18 @@
+import {
+  appendMessageToChat,
+  appendStreamId,
+  createChat,
+  loadStreams,
+  saveChat,
+} from '@/util/chat-store';
 import { openai } from '@ai-sdk/openai';
-import { createDataStream, streamText } from 'ai';
+import {
+  appendResponseMessages,
+  createDataStream,
+  generateId,
+  Message,
+  streamText,
+} from 'ai';
 import { after } from 'next/server';
 import { createResumableStreamContext } from 'resumable-stream';
 
@@ -17,41 +30,73 @@ const streamContext = createResumableStreamContext({
 });
 
 export async function POST(req: Request) {
-  const { id, messages } = await req.json();
+  const { id, messages }: { id: string; messages: Message[] } =
+    await req.json();
+
+  const streamId = generateId();
+
+  const recentUserMessage = messages
+    .filter(message => message.role === 'user')
+    .at(-1);
+
+  if (!recentUserMessage) {
+    throw new Error('No recent user message found');
+  }
+
+  await appendMessageToChat({ chatId: id, message: recentUserMessage });
+
+  await appendStreamId({ chatId: id, streamId });
 
   const stream = createDataStream({
-    execute: (dataStream) => {
+    execute: dataStream => {
       const result = streamText({
         model: openai('gpt-4o'),
         messages,
+        onFinish: async ({ response }) => {
+          await saveChat({
+            id,
+            messages: appendResponseMessages({
+              messages,
+              responseMessages: response.messages,
+            }),
+          });
+        },
       });
 
-      result.mergeIntoDataStream(dataStream)
-    }
-  })
-
-
-
-  return new Response(await streamContext.resumableStream(id, () => stream), {
-    headers: {
-      "Content-Type": "text/event-stream",
+      result.mergeIntoDataStream(dataStream);
     },
-  })
+  });
+
+  return new Response(
+    await streamContext.resumableStream(streamId, () => stream),
+  );
 }
 
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url)
-  const id = searchParams.get('id')
+  const { searchParams } = new URL(request.url);
+  const chatId = searchParams.get('chatId');
 
-  if (!id) {
-    return new Response("id is required", { status: 400 });
+  if (!chatId) {
+    return new Response('id is required', { status: 400 });
   }
 
-  const emptyStream = createDataStream({
-    execute: () => { }
-  })
+  const streamIds = await loadStreams(chatId);
 
-  // return new Response(await streamContext.resumableStream(id, () => emptyStream))
+  if (!streamIds.length) {
+    return new Response('No streams found', { status: 404 });
+  }
 
-  return new Response("wip")
+  const recentStreamId = streamIds.at(-1);
+
+  if (!recentStreamId) {
+    return new Response('No recent stream found', { status: 404 });
+  }
+
+  const emptyDataStream = createDataStream({
+    execute: () => {},
+  });
+
+  return new Response(
+    await streamContext.resumableStream(recentStreamId, () => emptyDataStream),
+  );
 }

--- a/examples/next-openai/app/api/use-chat-resume/route.ts
+++ b/examples/next-openai/app/api/use-chat-resume/route.ts
@@ -1,0 +1,57 @@
+import { openai } from '@ai-sdk/openai';
+import { createDataStream, streamText } from 'ai';
+import { after } from 'next/server';
+import { createResumableStreamContext } from 'resumable-stream';
+
+// Allow streaming responses up to 30 seconds
+export const maxDuration = 30;
+
+const redisUrl = process.env.KV_URL;
+
+if (!redisUrl) {
+  throw new Error('KV_URL environment variable is not set');
+}
+
+const streamContext = createResumableStreamContext({
+  waitUntil: after,
+});
+
+export async function POST(req: Request) {
+  const { id, messages } = await req.json();
+
+  const stream = createDataStream({
+    execute: (dataStream) => {
+      const result = streamText({
+        model: openai('gpt-4o'),
+        messages,
+      });
+
+      result.mergeIntoDataStream(dataStream)
+    }
+  })
+
+
+
+  return new Response(await streamContext.resumableStream(id, () => stream), {
+    headers: {
+      "Content-Type": "text/event-stream",
+    },
+  })
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+
+  if (!id) {
+    return new Response("id is required", { status: 400 });
+  }
+
+  const emptyStream = createDataStream({
+    execute: () => { }
+  })
+
+  // return new Response(await streamContext.resumableStream(id, () => emptyStream))
+
+  return new Response("wip")
+}

--- a/examples/next-openai/app/use-chat-resume/[id]/page.tsx
+++ b/examples/next-openai/app/use-chat-resume/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { Chat } from '../chat';
+
+
+export default async function Page({ params }: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params;
+
+  return (
+    <Chat chatId={id} />
+  );
+}

--- a/examples/next-openai/app/use-chat-resume/[id]/page.tsx
+++ b/examples/next-openai/app/use-chat-resume/[id]/page.tsx
@@ -1,12 +1,14 @@
+import { loadChat } from '@/util/chat-store';
 import { Chat } from '../chat';
 
-
-export default async function Page({ params }: {
-  params: Promise<{ id: string }>
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
 
-  return (
-    <Chat chatId={id} />
-  );
+  const messages = await loadChat(id);
+
+  return <Chat chatId={id} autoResume={true} initialMessages={messages} />;
 }

--- a/examples/next-openai/app/use-chat-resume/chat.tsx
+++ b/examples/next-openai/app/use-chat-resume/chat.tsx
@@ -50,7 +50,9 @@ export function Chat({
 
       {messages.map(message => (
         <div key={message.id} className="whitespace-pre-wrap flex flex-row">
-          <div className="min-w-12">{message.role === 'user' ? 'User: ' : 'AI: '}</div>
+          <div className="min-w-12">
+            {message.role === 'user' ? 'User: ' : 'AI: '}
+          </div>
 
           <div>
             <div className="text-sm text-zinc-500">{message.id}</div>
@@ -58,7 +60,9 @@ export function Chat({
               .filter(part => part.type !== 'source')
               .map((part, partIndex) => {
                 if (part.type === 'text') {
-                  return <div key={`${message.id}-${partIndex}`}>{part.text}</div>;
+                  return (
+                    <div key={`${message.id}-${partIndex}`}>{part.text}</div>
+                  );
                 }
               })}
           </div>

--- a/examples/next-openai/app/use-chat-resume/chat.tsx
+++ b/examples/next-openai/app/use-chat-resume/chat.tsx
@@ -1,10 +1,19 @@
-"use client"
+'use client';
 
-import { useChat } from "@ai-sdk/react";
-import Link from "next/link";
-import { useEffect } from "react";
+import { useChat } from '@ai-sdk/react';
+import { Message } from 'ai';
+import Link from 'next/link';
+import { useEffect } from 'react';
 
-export function Chat({ chatId }: { chatId: string }) {
+export function Chat({
+  chatId,
+  autoResume,
+  initialMessages = [],
+}: {
+  chatId: string;
+  autoResume: boolean;
+  initialMessages: Message[];
+}) {
   const {
     error,
     input,
@@ -14,18 +23,21 @@ export function Chat({ chatId }: { chatId: string }) {
     messages,
     reload,
     stop,
-    resume,
+    experimental_resume,
   } = useChat({
     id: chatId,
     api: '/api/use-chat-resume',
-    onError: (error) => {
+    initialMessages,
+    onError: error => {
       console.error('Error streaming text:', error);
     },
   });
 
   useEffect(() => {
-    resume();
-  }, [])
+    if (autoResume) {
+      experimental_resume();
+    }
+  }, []);
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch gap-8">

--- a/examples/next-openai/app/use-chat-resume/chat.tsx
+++ b/examples/next-openai/app/use-chat-resume/chat.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useChat } from "@ai-sdk/react";
+import Link from "next/link";
+import { useEffect } from "react";
+
+export function Chat({ chatId }: { chatId: string }) {
+  const {
+    error,
+    input,
+    status,
+    handleInputChange,
+    handleSubmit,
+    messages,
+    reload,
+    stop,
+    resume,
+  } = useChat({
+    id: chatId,
+    api: '/api/use-chat-resume',
+    onError: (error) => {
+      console.error('Error streaming text:', error);
+    },
+  });
+
+  useEffect(() => {
+    resume();
+  }, [])
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch gap-8">
+      <Link href={`/use-chat-resume/${chatId}`} target="_noblank">
+        Chat Id: {chatId}
+      </Link>
+
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap">
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts
+            .filter(part => part.type !== 'source')
+            .map((part, index) => {
+              if (part.type === 'text') {
+                return <div key={index}>{part.text}</div>;
+              }
+            })}
+        </div>
+      ))}
+
+      {(status === 'submitted' || status === 'streaming') && (
+        <div className="mt-4 text-gray-500">
+          {status === 'submitted' && <div>Loading...</div>}
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+            onClick={stop}
+          >
+            Stop
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4">
+          <div className="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+            onClick={() => reload()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <input
+          className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          value={input}
+          placeholder="Say something..."
+          onChange={handleInputChange}
+          disabled={status !== 'ready'}
+        />
+      </form>
+    </div>
+  );
+}

--- a/examples/next-openai/app/use-chat-resume/chat.tsx
+++ b/examples/next-openai/app/use-chat-resume/chat.tsx
@@ -28,6 +28,7 @@ export function Chat({
     id: chatId,
     api: '/api/use-chat-resume',
     initialMessages,
+    sendExtraMessageFields: true,
     onError: error => {
       console.error('Error streaming text:', error);
     },
@@ -45,16 +46,22 @@ export function Chat({
         Chat Id: {chatId}
       </Link>
 
+      <div>Status: {status}</div>
+
       {messages.map(message => (
-        <div key={message.id} className="whitespace-pre-wrap">
-          {message.role === 'user' ? 'User: ' : 'AI: '}
-          {message.parts
-            .filter(part => part.type !== 'source')
-            .map((part, index) => {
-              if (part.type === 'text') {
-                return <div key={index}>{part.text}</div>;
-              }
-            })}
+        <div key={message.id} className="whitespace-pre-wrap flex flex-row">
+          <div className="min-w-12">{message.role === 'user' ? 'User: ' : 'AI: '}</div>
+
+          <div>
+            <div className="text-sm text-zinc-500">{message.id}</div>
+            {message.parts
+              .filter(part => part.type !== 'source')
+              .map((part, partIndex) => {
+                if (part.type === 'text') {
+                  return <div key={`${message.id}-${partIndex}`}>{part.text}</div>;
+                }
+              })}
+          </div>
         </div>
       ))}
 

--- a/examples/next-openai/app/use-chat-resume/page.tsx
+++ b/examples/next-openai/app/use-chat-resume/page.tsx
@@ -1,11 +1,8 @@
 import { Chat } from './chat';
 import { generateId } from 'ai';
 
-
 export default function Page() {
   const chatId = generateId(32);
 
-  return (
-    <Chat chatId={chatId} />
-  );
+  return <Chat chatId={chatId} autoResume={false} initialMessages={[]} />;
 }

--- a/examples/next-openai/app/use-chat-resume/page.tsx
+++ b/examples/next-openai/app/use-chat-resume/page.tsx
@@ -1,0 +1,11 @@
+import { Chat } from './chat';
+import { generateId } from 'ai';
+
+
+export default function Page() {
+  const chatId = generateId(32);
+
+  return (
+    <Chat chatId={chatId} />
+  );
+}

--- a/examples/next-openai/package.json
+++ b/examples/next-openai/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^18",
     "react-markdown": "9.0.1",
     "redis": "^4.7.0",
-    "resumable-stream": "^1.0.6",
+    "resumable-stream": "^2.0.0",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/examples/next-openai/package.json
+++ b/examples/next-openai/package.json
@@ -12,12 +12,12 @@
     "@ai-sdk/anthropic": "1.2.10",
     "@ai-sdk/deepseek": "0.2.12",
     "@ai-sdk/fireworks": "0.2.12",
-    "@ai-sdk/openai": "1.3.16",
     "@ai-sdk/google": "1.2.12",
     "@ai-sdk/google-vertex": "2.2.16",
+    "@ai-sdk/openai": "1.3.16",
     "@ai-sdk/perplexity": "1.1.7",
-    "@ai-sdk/ui-utils": "1.2.8",
     "@ai-sdk/react": "1.2.9",
+    "@ai-sdk/ui-utils": "1.2.8",
     "@vercel/blob": "^0.26.0",
     "ai": "4.3.9",
     "next": "latest",
@@ -25,6 +25,8 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "9.0.1",
+    "redis": "^4.7.0",
+    "resumable-stream": "^1.0.6",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/examples/next-openai/util/chat-store.ts
+++ b/examples/next-openai/util/chat-store.ts
@@ -1,5 +1,5 @@
 import { generateId, Message } from 'ai';
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { readFile, writeFile } from 'fs/promises';
 import path from 'path';
 
@@ -23,12 +23,58 @@ export async function saveChat({
   await writeFile(getChatFile(id), JSON.stringify(messages, null, 2));
 }
 
+export async function appendMessageToChat({
+  chatId,
+  message,
+}: {
+  chatId: string;
+  message: Message;
+}): Promise<void> {
+  const file = getChatFile(chatId);
+  const messages = await loadChat(chatId);
+  messages.push(message);
+  await writeFile(file, JSON.stringify(messages, null, 2));
+}
+
 export async function loadChat(id: string): Promise<Message[]> {
   return JSON.parse(await readFile(getChatFile(id), 'utf8'));
 }
 
 function getChatFile(id: string): string {
   const chatDir = path.join(process.cwd(), '.chats');
+
   if (!existsSync(chatDir)) mkdirSync(chatDir, { recursive: true });
-  return path.join(chatDir, `${id}.json`);
+
+  const chatFile = path.join(chatDir, `${id}.json`);
+
+  if (!existsSync(chatFile)) {
+    writeFileSync(chatFile, '[]');
+  }
+
+  return chatFile;
+}
+
+export async function appendStreamId({
+  chatId,
+  streamId,
+}: {
+  chatId: string;
+  streamId: string;
+}) {
+  const file = getStreamsFile(chatId);
+  const streams = await loadStreams(chatId);
+  streams.push(streamId);
+  await writeFile(file, JSON.stringify(streams, null, 2));
+}
+
+export async function loadStreams(chatId: string): Promise<string[]> {
+  const file = getStreamsFile(chatId);
+  if (!existsSync(file)) return [];
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+
+function getStreamsFile(chatId: string): string {
+  const chatDir = path.join(process.cwd(), '.streams');
+  if (!existsSync(chatDir)) mkdirSync(chatDir, { recursive: true });
+  return path.join(chatDir, `${chatId}.json`);
 }

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -467,7 +467,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
 
       abortControllerRef.current = null;
 
-      mutateStatus('ready')
+      mutateStatus('ready');
     } catch (error) {
       // Ignore abort errors as they are expected.
       if ((error as any).name === 'AbortError') {

--- a/packages/ui-utils/src/call-chat-api.ts
+++ b/packages/ui-utils/src/call-chat-api.ts
@@ -106,3 +106,23 @@ export async function callChatApi({
     }
   }
 }
+
+export async function resumeChatApi({
+  api,
+  body,
+  fetch = getOriginalFetch(),
+}: {
+  api: string,
+  body: Record<string, any>,
+  fetch: ReturnType<typeof getOriginalFetch> | undefined;
+}) {
+  const { id } = body;
+
+  const response = await fetch(`${api}?id=${id}`, {
+    method: "GET",
+  })
+
+  console.log("invoked: resumeChatApi()")
+
+  return response;
+}

--- a/packages/ui-utils/src/call-chat-api.ts
+++ b/packages/ui-utils/src/call-chat-api.ts
@@ -111,18 +111,86 @@ export async function resumeChatApi({
   api,
   body,
   fetch = getOriginalFetch(),
+  onResponse,
+  restoreMessagesOnFailure,
+  streamProtocol = 'data',
+  onUpdate,
+  onFinish,
+  onToolCall,
+  generateId,
+  lastMessage,
 }: {
-  api: string,
-  body: Record<string, any>,
+  api: string;
+  body: Record<string, any>;
   fetch: ReturnType<typeof getOriginalFetch> | undefined;
+  onResponse: ((response: Response) => void | Promise<void>) | undefined;
+  restoreMessagesOnFailure: () => void;
+  streamProtocol: 'data' | 'text' | undefined;
+  onUpdate: (options: {
+    message: UIMessage;
+    data: JSONValue[] | undefined;
+    replaceLastMessage: boolean;
+  }) => void;
+  onFinish: UseChatOptions['onFinish'];
+  onToolCall: UseChatOptions['onToolCall'];
+  generateId: IdGenerator;
+  lastMessage: UIMessage | undefined;
 }) {
   const { id } = body;
 
-  const response = await fetch(`${api}?id=${id}`, {
-    method: "GET",
-  })
+  const response = await fetch(`${api}?chatId=${id}`, {
+    method: 'GET',
+  });
 
-  console.log("invoked: resumeChatApi()")
+  if (onResponse) {
+    try {
+      await onResponse(response);
+    } catch (err) {
+      throw err;
+    }
+  }
 
-  return response;
+  if (!response.ok) {
+    restoreMessagesOnFailure();
+    throw new Error(
+      (await response.text()) ?? 'Failed to fetch the chat response.',
+    );
+  }
+
+  if (!response.body) {
+    throw new Error('The response body is empty.');
+  }
+
+  switch (streamProtocol) {
+    case 'text': {
+      await processChatTextResponse({
+        stream: response.body,
+        update: onUpdate,
+        onFinish,
+        generateId,
+      });
+      return;
+    }
+
+    case 'data': {
+      await processChatResponse({
+        stream: response.body,
+        update: onUpdate,
+        lastMessage,
+        onToolCall,
+        onFinish({ message, finishReason, usage }) {
+          if (onFinish && message != null) {
+            onFinish(message, { usage, finishReason });
+          }
+        },
+        generateId,
+      });
+      return;
+    }
+
+    default: {
+      const exhaustiveCheck: never = streamProtocol;
+      throw new Error(`Unknown stream protocol: ${exhaustiveCheck}`);
+    }
+  }
 }

--- a/packages/ui-utils/src/index.ts
+++ b/packages/ui-utils/src/index.ts
@@ -13,7 +13,7 @@ export type {
   AssistantStreamPart,
   AssistantStreamString,
 } from './assistant-stream-parts';
-export { callChatApi } from './call-chat-api';
+export { callChatApi, resumeChatApi } from './call-chat-api';
 export { callCompletionApi } from './call-completion-api';
 export { formatDataStreamPart, parseDataStreamPart } from './data-stream-parts';
 export type { DataStreamPart, DataStreamString } from './data-stream-parts';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,7 +340,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.5.4)
       '@nestjs/testing':
         specifier: ^10.4.12
-        version: 10.4.12(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.2)(@nestjs/platform-express@10.4.9)
+        version: 10.4.12(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.2(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.9)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.9(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.2))
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
@@ -510,7 +510,7 @@ importers:
         version: link:../../packages/ai
       langchain:
         specifier: 0.1.36
-        version: 0.1.36(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.663.0)(@aws-sdk/credential-provider-node@3.662.0(@aws-sdk/client-sso-oidc@3.662.0(@aws-sdk/client-sts@3.662.0))(@aws-sdk/client-sts@3.662.0))(@smithy/util-utf8@2.3.0)(@upstash/redis@1.34.3)(@vercel/kv@0.2.4)(fast-xml-parser@4.4.1)(ignore@5.3.2)(ioredis@5.4.1)(jsdom@26.0.0)(lodash@4.17.21)(openai@4.52.6)(playwright@1.50.1)(ws@8.18.0)
+        version: 0.1.36(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.663.0)(@aws-sdk/credential-provider-node@3.662.0)(@smithy/util-utf8@2.3.0)(@upstash/redis@1.34.3)(@vercel/kv@0.2.4)(fast-xml-parser@4.4.1)(ignore@5.3.2)(ioredis@5.4.1)(jsdom@26.0.0)(lodash@4.17.21)(openai@4.52.6)(playwright@1.50.1)(redis@4.7.0)(ws@8.18.0)
       next:
         specifier: latest
         version: 15.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -599,6 +599,12 @@ importers:
       react-markdown:
         specifier: 9.0.1
         version: 9.0.1(@types/react@18.3.3)(react@18.3.1)
+      redis:
+        specifier: ^4.7.0
+        version: 4.7.0
+      resumable-stream:
+        specifier: ^1.0.6
+        version: 1.0.6
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -641,7 +647,7 @@ importers:
         version: link:../../packages/react
       '@vercel/functions':
         specifier: latest
-        version: 2.0.0(@aws-sdk/credential-provider-web-identity@3.662.0(@aws-sdk/client-sts@3.662.0))
+        version: 2.0.0(@aws-sdk/credential-provider-web-identity@3.662.0)
       ai:
         specifier: 4.3.9
         version: link:../../packages/ai
@@ -1008,7 +1014,7 @@ importers:
         version: 3.5.12
       nuxt:
         specifier: 3.14.159
-        version: 3.14.159(@parcel/watcher@2.4.1)(@types/node@20.17.24)(@upstash/redis@1.34.3)(eslint@9.21.0(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(terser@5.31.3)(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))(webpack-sources@3.2.3)
+        version: 3.14.159(@parcel/watcher@2.4.1)(@types/node@20.17.24)(@upstash/redis@1.34.3)(eslint@9.21.0)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(terser@5.31.3)(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))(webpack-sources@3.2.3)
       tailwindcss:
         specifier: 3.4.15
         version: 3.4.15(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.6.3))
@@ -2062,7 +2068,7 @@ importers:
         version: link:../../tools/tsconfig
       '@vitejs/plugin-vue':
         specifier: 5.2.0
-        version: 5.2.0(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.0(vite@5.4.11(@types/node@22.7.4)(terser@5.31.3))(vue@3.5.13(typescript@5.6.3))
       eslint:
         specifier: 8.57.1
         version: 8.57.1
@@ -2083,7 +2089,7 @@ importers:
         version: 5.6.3
       vite-plugin-solid:
         specifier: 2.7.2
-        version: 2.7.2(solid-js@1.8.7)
+        version: 2.7.2(solid-js@1.8.7)(vite@5.4.11(@types/node@22.7.4)(terser@5.31.3))
       vitest:
         specifier: 2.1.4
         version: 2.1.4(@edge-runtime/vm@5.0.0)(@types/node@20.17.24)(jsdom@24.0.0)(msw@2.6.4(@types/node@20.17.24)(typescript@5.6.3))(terser@5.31.3)
@@ -6413,6 +6419,35 @@ packages:
     resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
     engines: {node: '>=18'}
 
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.0':
+    resolution: {integrity: sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
 
@@ -10185,6 +10220,10 @@ packages:
     peerDependencies:
       next: '>=13.2.0'
 
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -13242,6 +13281,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  redis@4.7.0:
+    resolution: {integrity: sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -13331,6 +13373,9 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  resumable-stream@1.0.6:
+    resolution: {integrity: sha512-giPuLv6BPOlUylTc/l608VXcMkSZxJjMTbslu02KBv8yG6Z7X4VAW8UBw3cwvAtxdy7D5sQ11tiu06Ew/Ks/uA==}
 
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
@@ -17092,6 +17137,12 @@ snapshots:
       eslint: 9.21.0(jiti@2.4.0)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.21.0)':
+    dependencies:
+      eslint: 9.21.0
+      eslint-visitor-keys: 3.4.3
+    optional: true
+
   '@eslint-community/regexpp@4.11.0': {}
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -18091,7 +18142,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.663.0)(@aws-sdk/credential-provider-node@3.662.0(@aws-sdk/client-sso-oidc@3.662.0(@aws-sdk/client-sts@3.662.0))(@aws-sdk/client-sts@3.662.0))(@smithy/util-utf8@2.3.0)(@upstash/redis@1.34.3)(@vercel/kv@0.2.4)(ioredis@5.4.1)(jsdom@26.0.0)(lodash@4.17.21)(openai@4.52.6)(ws@8.18.0)':
+  '@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.663.0)(@aws-sdk/credential-provider-node@3.662.0)(@smithy/util-utf8@2.3.0)(@upstash/redis@1.34.3)(@vercel/kv@0.2.4)(ioredis@5.4.1)(jsdom@26.0.0)(lodash@4.17.21)(openai@4.52.6)(redis@4.7.0)(ws@8.18.0)':
     dependencies:
       '@langchain/core': 0.1.63(openai@4.52.6)
       '@langchain/openai': 0.0.28
@@ -18111,6 +18162,7 @@ snapshots:
       ioredis: 5.4.1
       jsdom: 26.0.0
       lodash: 4.17.21
+      redis: 4.7.0
       ws: 8.18.0
     transitivePeerDependencies:
       - encoding
@@ -18333,7 +18385,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@10.4.12(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.2)(@nestjs/platform-express@10.4.9)':
+  '@nestjs/testing@10.4.12(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.2(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.9)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.9(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.2))':
     dependencies:
       '@nestjs/common': 10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.2(@nestjs/common@10.4.15(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.9)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -18643,7 +18695,7 @@ snapshots:
 
   '@nuxt/ui-templates@1.3.4': {}
 
-  '@nuxt/vite-builder@3.14.159(@types/node@20.17.24)(eslint@9.21.0(jiti@2.4.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(terser@5.31.3)(typescript@5.6.3)(vue@3.5.13(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@nuxt/vite-builder@3.14.159(@types/node@20.17.24)(eslint@9.21.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(terser@5.31.3)(typescript@5.6.3)(vue@3.5.13(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
       '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.34.9)
       '@rollup/plugin-replace': 6.0.1(rollup@4.34.9)
@@ -18677,7 +18729,7 @@ snapshots:
       unplugin: 1.15.0(webpack-sources@3.2.3)
       vite: 5.4.11(@types/node@20.17.24)(terser@5.31.3)
       vite-node: 2.1.4(@types/node@20.17.24)(terser@5.31.3)
-      vite-plugin-checker: 0.8.0(eslint@9.21.0(jiti@2.4.0))(optionator@0.9.4)(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))
+      vite-plugin-checker: 0.8.0(eslint@9.21.0)(optionator@0.9.4)(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))
       vue: 3.5.13(typescript@5.6.3)
       vue-bundle-renderer: 2.1.1
     transitivePeerDependencies:
@@ -19964,6 +20016,32 @@ snapshots:
   '@protobufjs/utf8@1.1.0': {}
 
   '@publint/pack@0.1.2': {}
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/client@1.6.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/json@1.0.7(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/search@1.2.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
 
   '@redocly/ajv@8.11.2':
     dependencies:
@@ -21609,7 +21687,7 @@ snapshots:
       throttleit: 2.1.0
       undici: 5.28.4
 
-  '@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.662.0(@aws-sdk/client-sts@3.662.0))':
+  '@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.662.0)':
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.662.0(@aws-sdk/client-sts@3.662.0)
 
@@ -21753,6 +21831,11 @@ snapshots:
   '@vitejs/plugin-vue@5.2.0(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))(vue@3.5.13(typescript@5.6.3))':
     dependencies:
       vite: 5.4.11(@types/node@20.17.24)(terser@5.31.3)
+      vue: 3.5.13(typescript@5.6.3)
+
+  '@vitejs/plugin-vue@5.2.0(vite@5.4.11(@types/node@22.7.4)(terser@5.31.3))(vue@3.5.13(typescript@5.6.3))':
+    dependencies:
+      vite: 5.4.11(@types/node@22.7.4)(terser@5.31.3)
       vue: 3.5.13(typescript@5.6.3)
 
   '@vitejs/plugin-vue@5.2.0(vite@6.0.3(@types/node@20.17.24)(jiti@2.4.0)(terser@5.31.3)(tsx@4.19.2)(yaml@2.7.0))(vue@3.3.8(typescript@5.6.3))':
@@ -24068,7 +24151,7 @@ snapshots:
       debug: 4.4.0(supports-color@9.4.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -24102,7 +24185,7 @@ snapshots:
       debug: 4.4.0(supports-color@9.4.0)
       enhanced-resolve: 5.17.1
       eslint: 9.21.0(jiti@2.4.0)
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.21.0(jiti@2.4.0))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.21.0(jiti@2.4.0)))(eslint@9.21.0(jiti@2.4.0))
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.21.0(jiti@2.4.0))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -24114,7 +24197,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -24136,7 +24219,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.21.0(jiti@2.4.0)):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.21.0(jiti@2.4.0)))(eslint@9.21.0(jiti@2.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -24147,7 +24230,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -24169,7 +24252,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.21.0(jiti@2.4.0)):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.21.0(jiti@2.4.0)))(eslint@9.21.0(jiti@2.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -24190,7 +24273,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -24244,7 +24327,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.21.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.21.0(jiti@2.4.0))
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.21.0(jiti@2.4.0)))(eslint@9.21.0(jiti@2.4.0))
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -24469,6 +24552,46 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  eslint@9.21.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.19.2
+      '@eslint/core': 0.12.0
+      '@eslint/eslintrc': 3.3.0
+      '@eslint/js': 9.21.0
+      '@eslint/plugin-kit': 0.2.7
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.2
+      '@types/estree': 1.0.6
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0(supports-color@9.4.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.2.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   eslint@9.21.0(jiti@2.4.0):
     dependencies:
@@ -25070,6 +25193,8 @@ snapshots:
   geist@1.3.1(next@15.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       next: 15.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  generic-pool@3.9.0: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -26529,10 +26654,10 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  langchain@0.1.36(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.663.0)(@aws-sdk/credential-provider-node@3.662.0(@aws-sdk/client-sso-oidc@3.662.0(@aws-sdk/client-sts@3.662.0))(@aws-sdk/client-sts@3.662.0))(@smithy/util-utf8@2.3.0)(@upstash/redis@1.34.3)(@vercel/kv@0.2.4)(fast-xml-parser@4.4.1)(ignore@5.3.2)(ioredis@5.4.1)(jsdom@26.0.0)(lodash@4.17.21)(openai@4.52.6)(playwright@1.50.1)(ws@8.18.0):
+  langchain@0.1.36(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.663.0)(@aws-sdk/credential-provider-node@3.662.0)(@smithy/util-utf8@2.3.0)(@upstash/redis@1.34.3)(@vercel/kv@0.2.4)(fast-xml-parser@4.4.1)(ignore@5.3.2)(ioredis@5.4.1)(jsdom@26.0.0)(lodash@4.17.21)(openai@4.52.6)(playwright@1.50.1)(redis@4.7.0)(ws@8.18.0):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1
-      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.663.0)(@aws-sdk/credential-provider-node@3.662.0(@aws-sdk/client-sso-oidc@3.662.0(@aws-sdk/client-sts@3.662.0))(@aws-sdk/client-sts@3.662.0))(@smithy/util-utf8@2.3.0)(@upstash/redis@1.34.3)(@vercel/kv@0.2.4)(ioredis@5.4.1)(jsdom@26.0.0)(lodash@4.17.21)(openai@4.52.6)(ws@8.18.0)
+      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.663.0)(@aws-sdk/credential-provider-node@3.662.0)(@smithy/util-utf8@2.3.0)(@upstash/redis@1.34.3)(@vercel/kv@0.2.4)(ioredis@5.4.1)(jsdom@26.0.0)(lodash@4.17.21)(openai@4.52.6)(redis@4.7.0)(ws@8.18.0)
       '@langchain/core': 0.1.63(openai@4.52.6)
       '@langchain/openai': 0.0.28
       '@langchain/textsplitters': 0.0.2(openai@4.52.6)
@@ -26557,6 +26682,7 @@ snapshots:
       ioredis: 5.4.1
       jsdom: 26.0.0
       playwright: 1.50.1
+      redis: 4.7.0
       ws: 8.18.0
     transitivePeerDependencies:
       - '@aws-crypto/sha256-js'
@@ -27698,14 +27824,14 @@ snapshots:
 
   nuxi@3.15.0: {}
 
-  nuxt@3.14.159(@parcel/watcher@2.4.1)(@types/node@20.17.24)(@upstash/redis@1.34.3)(eslint@9.21.0(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(terser@5.31.3)(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))(webpack-sources@3.2.3):
+  nuxt@3.14.159(@parcel/watcher@2.4.1)(@types/node@20.17.24)(@upstash/redis@1.34.3)(eslint@9.21.0)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(terser@5.31.3)(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))(webpack-sources@3.2.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 1.6.3(rollup@4.34.9)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3))(vue@3.5.13(typescript@5.6.3))
       '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.34.9)
       '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.34.9)
       '@nuxt/telemetry': 2.6.0(magicast@0.3.5)(rollup@4.34.9)
-      '@nuxt/vite-builder': 3.14.159(@types/node@20.17.24)(eslint@9.21.0(jiti@2.4.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(terser@5.31.3)(typescript@5.6.3)(vue@3.5.13(typescript@5.6.3))(webpack-sources@3.2.3)
+      '@nuxt/vite-builder': 3.14.159(@types/node@20.17.24)(eslint@9.21.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.9)(terser@5.31.3)(typescript@5.6.3)(vue@3.5.13(typescript@5.6.3))(webpack-sources@3.2.3)
       '@unhead/dom': 1.11.11
       '@unhead/shared': 1.11.11
       '@unhead/ssr': 1.11.11
@@ -28899,6 +29025,15 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  redis@4.7.0:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.0)
+      '@redis/client': 1.6.0
+      '@redis/graph': 1.1.1(@redis/client@1.6.0)
+      '@redis/json': 1.0.7(@redis/client@1.6.0)
+      '@redis/search': 1.2.0(@redis/client@1.6.0)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.0)
+
   reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.4:
@@ -29007,6 +29142,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  resumable-stream@1.0.6: {}
 
   ret@0.5.0: {}
 
@@ -30949,7 +31086,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.8.0(eslint@9.21.0(jiti@2.4.0))(optionator@0.9.4)(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3)):
+  vite-plugin-checker@0.8.0(eslint@9.21.0)(optionator@0.9.4)(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.24)(terser@5.31.3)):
     dependencies:
       '@babel/code-frame': 7.26.2
       ansi-escapes: 4.3.2
@@ -30967,7 +31104,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
     optionalDependencies:
-      eslint: 9.21.0(jiti@2.4.0)
+      eslint: 9.21.0
       optionator: 0.9.4
       typescript: 5.6.3
 
@@ -31004,7 +31141,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.7.2(solid-js@1.8.7):
+  vite-plugin-solid@2.7.2(solid-js@1.8.7)(vite@5.4.11(@types/node@22.7.4)(terser@5.31.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
@@ -31013,7 +31150,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.8.7
       solid-refresh: 0.5.3(solid-js@1.8.7)
-      vitefu: 0.2.5(vite@6.0.3(@types/node@22.7.4)(jiti@2.4.0)(terser@5.31.3)(tsx@4.19.2)(yaml@2.7.0))
+      vite: 5.4.11(@types/node@22.7.4)(terser@5.31.3)
+      vitefu: 0.2.5(vite@5.4.11(@types/node@22.7.4)(terser@5.31.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -31077,6 +31215,10 @@ snapshots:
       terser: 5.31.3
       tsx: 4.19.2
       yaml: 2.7.0
+
+  vitefu@0.2.5(vite@5.4.11(@types/node@22.7.4)(terser@5.31.3)):
+    optionalDependencies:
+      vite: 5.4.11(@types/node@22.7.4)(terser@5.31.3)
 
   vitefu@0.2.5(vite@6.0.3(@types/node@22.7.4)(jiti@2.4.0)(terser@5.31.3)(tsx@4.19.2)(yaml@2.7.0)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,8 +603,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0
       resumable-stream:
-        specifier: ^1.0.6
-        version: 1.0.6
+        specifier: ^2.0.0
+        version: 2.0.0
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -13374,8 +13374,8 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
-  resumable-stream@1.0.6:
-    resolution: {integrity: sha512-giPuLv6BPOlUylTc/l608VXcMkSZxJjMTbslu02KBv8yG6Z7X4VAW8UBw3cwvAtxdy7D5sQ11tiu06Ew/Ks/uA==}
+  resumable-stream@2.0.0:
+    resolution: {integrity: sha512-D7E0wDUnfoy+Lerba/gyuD44OG3G0APqDcQ9soMSerujaVujPLWc5sSCLXf/ZFQPreLb3MKDjSm3TOPXpNtpZw==}
 
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
@@ -29143,7 +29143,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  resumable-stream@1.0.6: {}
+  resumable-stream@2.0.0: {}
 
   ret@0.5.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,14 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["CI", "PORT"],
+  "globalEnv": [
+    "CI",
+    "PORT"
+  ],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "env": [
         "ANTHROPIC_API_KEY",
         "ASSISTANT_ID",
@@ -42,7 +47,8 @@
         "SENTRY_PROJECT",
         "TOGETHER_AI_API_KEY",
         "VERCEL_URL",
-        "XAI_API_KEY"
+        "XAI_API_KEY",
+        "KV_URL"
       ],
       "outputs": [
         "dist/**",
@@ -54,19 +60,32 @@
       ]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": [
+        "^lint"
+      ]
     },
     "type-check": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": [
+        "^build",
+        "build"
+      ]
     },
     "test": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": [
+        "^build",
+        "build"
+      ]
     },
     "publint": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": [
+        "^build",
+        "build"
+      ]
     },
     "clean": {
-      "dependsOn": ["^clean"]
+      "dependsOn": [
+        "^clean"
+      ]
     },
     "dev": {
       "cache": false,
@@ -74,7 +93,10 @@
     },
     "prettier-check": {},
     "integration-test": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": [
+        "^build",
+        "build"
+      ]
     }
   }
 }


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

This pull request adds the ability for clients to resume an ongoing chat generation stream after a network disconnect. 

## Summary

This pull request adds support for the `useChat` hook to resume an ongoing chat generation stream by exposing `experimental_resume()` that can be called by any client, typically during the initial mount of the hook. 

The `experimental_resume` function makes a `GET` request to the api endpoint you've initialized the hook with (or `/api/chat` by default) and streams the contents of the stream if it is active or fails silently if it has ended.

In order for `experimental_resume` to work as intended, it requires the usage of the [`resumable-stream`](https://www.npmjs.com/package/resumable-stream) package for stream creation and a redis instance for the package to manage the pub/sub mechanism.

An example has been added at `examples/next-openai/resume-chat` for reference.

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work
N/A