### PR TITLE
fix(ai/mcp-stdio): make `createChildProcess` synchronous to prevent spawn race condition (#5852)

### DIFF
--- a/packages/ai/.changeset/quick-toys-study.md
+++ b/packages/ai/.changeset/quick-toys-study.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai/mcp-stdio): make `createChildProcess` synchronous to prevent spawn race condition

--- a/packages/ai/mcp-stdio/create-child-process.test.ts
+++ b/packages/ai/mcp-stdio/create-child-process.test.ts
@@ -26,7 +26,7 @@ describe('createChildProcess', () => {
   });
 
   it('should spawn a child process', async () => {
-    const childProcess = await createChildProcess(
+    const childProcess = createChildProcess(
       { command: process.execPath },
       new AbortController().signal,
     );
@@ -38,7 +38,7 @@ describe('createChildProcess', () => {
 
   it('should spawn a child process with custom env', async () => {
     const customEnv = { FOO: 'bar' };
-    const childProcessWithCustomEnv = await createChildProcess(
+    const childProcessWithCustomEnv = createChildProcess(
       { command: process.execPath, env: customEnv },
       new AbortController().signal,
     );
@@ -53,7 +53,7 @@ describe('createChildProcess', () => {
   });
 
   it('should spawn a child process with args', async () => {
-    const childProcessWithArgs = await createChildProcess(
+    const childProcessWithArgs = createChildProcess(
       { command: process.execPath, args: ['-c', 'echo', 'test'] },
       new AbortController().signal,
     );
@@ -66,11 +66,12 @@ describe('createChildProcess', () => {
       'echo',
       'test',
     ]);
+
     childProcessWithArgs.kill();
   });
 
   it('should spawn a child process with cwd', async () => {
-    const childProcessWithCwd = await createChildProcess(
+    const childProcessWithCwd = createChildProcess(
       { command: process.execPath, cwd: '/tmp' },
       new AbortController().signal,
     );
@@ -80,7 +81,7 @@ describe('createChildProcess', () => {
   });
 
   it('should spawn a child process with stderr', async () => {
-    const childProcessWithStderr = await createChildProcess(
+    const childProcessWithStderr = createChildProcess(
       { command: process.execPath, stderr: 'pipe' },
       new AbortController().signal,
     );

--- a/packages/ai/mcp-stdio/create-child-process.ts
+++ b/packages/ai/mcp-stdio/create-child-process.ts
@@ -2,10 +2,10 @@ import { ChildProcess, spawn } from 'node:child_process';
 import { getEnvironment } from './get-environment';
 import { StdioConfig } from './mcp-stdio-transport';
 
-export async function createChildProcess(
+export function createChildProcess(
   config: StdioConfig,
   signal: AbortSignal,
-): Promise<ChildProcess> {
+): ChildProcess {
   return spawn(config.command, config.args ?? [], {
     env: getEnvironment(config.env),
     stdio: ['pipe', 'pipe', config.stderr ?? 'inherit'],

--- a/packages/ai/mcp-stdio/mcp-stdio-transport.test.ts
+++ b/packages/ai/mcp-stdio/mcp-stdio-transport.test.ts
@@ -35,7 +35,7 @@ describe('StdioMCPTransport', () => {
       removeAllListeners: vi.fn(),
     };
 
-    vi.mocked(createChildProcess).mockResolvedValue(
+    vi.mocked(createChildProcess).mockReturnValue(
       mockChildProcess as unknown as ChildProcess,
     );
 
@@ -114,19 +114,6 @@ describe('StdioMCPTransport', () => {
       const startPromise = transport.start();
       await expect(startPromise).rejects.toThrow('Spawn failed');
       expect(onErrorSpy).toHaveBeenCalledWith(error);
-    });
-
-    it('should handle child_process import errors', async () => {
-      vi.mocked(createChildProcess).mockRejectedValue(
-        new MCPClientError({
-          message: 'Failed to load child_process module dynamically',
-        }),
-      );
-
-      const startPromise = transport.start();
-      await expect(startPromise).rejects.toThrow(
-        'Failed to load child_process module dynamically',
-      );
     });
   });
 

--- a/packages/ai/mcp-stdio/mcp-stdio-transport.ts
+++ b/packages/ai/mcp-stdio/mcp-stdio-transport.ts
@@ -37,9 +37,9 @@ export class StdioMCPTransport implements MCPTransport {
       });
     }
 
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       try {
-        const process = await createChildProcess(
+        const process = createChildProcess(
           this.serverParams,
           this.abortController.signal,
         );


### PR DESCRIPTION

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this necessary? -->

## Summary

<!-- What did you change? -->

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If required, a _patch_ changeset for relevant packages has been added
- [ ] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
