### PR TITLE
docs: update chat-with-pdf page to include updated provider information

### DIFF
--- a/content/cookbook/01-next/23-chat-with-pdf.mdx
+++ b/content/cookbook/01-next/23-chat-with-pdf.mdx
@@ -10,8 +10,7 @@ Some language models like Anthropic's Claude Sonnet 3.5 and Google's Gemini 2.0 
 
 <Note>
   This example requires a provider that supports PDFs, such as Anthropic's
-  Claude Sonnet 3.5 or Google's Gemini 2.0. Note OpenAI's GPT-4o does not
-  currently support PDFs. Check the [provider
+  Claude 3.7, Google's Gemini 2.5, or OpenAI's GPT-4.1. Check the [provider
   documentation](/providers/ai-sdk-providers) for up-to-date support
   information.
 </Note>


### PR DESCRIPTION
## Background

This page says that GPT-4o does not support PDF attachments, which is [no longer true](https://sdk.vercel.ai/providers/ai-sdk-providers/openai#pdf-support).

## Summary

I've updated the note at the top to acknowledge the new abilities in the OpenAI API.

## Tasks

- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] ~~If required, a _patch_ changeset for relevant packages has been added~~
- [ ] ~~You've run `pnpm prettier-fix` to fix any formatting issues~~