### PR TITLE
feat (providers/openai): add support for reasoning summaries

### DIFF
--- a/.changeset/mean-monkeys-sip.md
+++ b/.changeset/mean-monkeys-sip.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat (providers/openai): add support for reasoning summaries

--- a/content/providers/01-ai-sdk-providers/02-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/02-openai.mdx
@@ -577,6 +577,9 @@ The following provider options are available:
 - **reasoningEffort** _'low' | 'medium' | 'high'_
   Reasoning effort for reasoning models. Defaults to `medium`. If you use `providerOptions` to set the `reasoningEffort` option, this model setting will be ignored.
 
+- **reasoningSummary** _'auto' | 'detailed'_
+  Controls whether the model returns its reasoning process. Set to `'auto'` for a condensed summary, `'detailed'` for more comprehensive reasoning. Defaults to `undefined` (no reasoning summaries). When enabled, reasoning summaries appear in the stream as events with type `'reasoning'` and in non-streaming responses within the `reasoning` field.
+
 - **strictSchemas** _boolean_
   Whether to use strict JSON schemas in tools and when generating JSON outputs. Defaults to `true`.
 
@@ -629,6 +632,55 @@ const result = await generateText({
 // URL sources
 const sources = result.sources;
 ```
+
+#### Reasoning Summaries
+
+For reasoning models like `o3-mini`, `o3`, and `o4-mini`, you can enable reasoning summaries to see the model's thought process:
+
+```ts highlight="8-9,17-19"
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: openai.responses('o3-mini'),
+  prompt: 'Tell me about the Mission burrito debate in San Francisco.',
+  providerOptions: {
+    openai: {
+      reasoningSummary: 'detailed', // 'auto' for condensed or 'detailed' for comprehensive
+    },
+  },
+});
+
+// Process the stream
+for await (const part of result.fullStream) {
+  if (part.type === 'reasoning') {
+    // Display reasoning summaries in blue
+    console.log('\x1b[34m%s\x1b[0m', `Reasoning: ${part.textDelta}`);
+  } else if (part.type === 'text-delta') {
+    process.stdout.write(part.textDelta);
+  }
+}
+```
+
+For non-streaming calls with `generateText`, the reasoning summaries are available in the `reasoning` field of the response:
+
+```ts highlight="8-9,12"
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: openai.responses('o3-mini'),
+  prompt: 'Tell me about the Mission burrito debate in San Francisco.',
+  providerOptions: {
+    openai: {
+      reasoningSummary: 'detailed',
+    },
+  },
+});
+console.log('Reasoning:', result.reasoning);
+```
+
+Learn more about reasoning summaries in the [OpenAI documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries).
 
 #### PDF support
 

--- a/content/providers/01-ai-sdk-providers/02-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/02-openai.mdx
@@ -637,7 +637,7 @@ const sources = result.sources;
 
 For reasoning models like `o3-mini`, `o3`, and `o4-mini`, you can enable reasoning summaries to see the model's thought process:
 
-```ts highlight="8-9,17-19"
+```ts highlight="8-9,16"
 import { openai } from '@ai-sdk/openai';
 import { streamText } from 'ai';
 
@@ -651,11 +651,9 @@ const result = streamText({
   },
 });
 
-// Process the stream
 for await (const part of result.fullStream) {
   if (part.type === 'reasoning') {
-    // Display reasoning summaries in blue
-    console.log('\x1b[34m%s\x1b[0m', `Reasoning: ${part.textDelta}`);
+    console.log(`Reasoning: ${part.textDelta}`);
   } else if (part.type === 'text-delta') {
     process.stdout.write(part.textDelta);
   }
@@ -664,7 +662,7 @@ for await (const part of result.fullStream) {
 
 For non-streaming calls with `generateText`, the reasoning summaries are available in the `reasoning` field of the response:
 
-```ts highlight="8-9,12"
+```ts highlight="8-9,13"
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 

--- a/examples/ai-core/src/generate-text/openai-responses-reasoning-summary.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-reasoning-summary.ts
@@ -1,0 +1,31 @@
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: openai.responses('o3-mini'),
+    prompt:
+      'Tell me about the debate over Taqueria La Cumbre and El Farolito and who created the San Francisco Mission-style burrito.',
+    providerOptions: {
+      openai: {
+        // https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries
+        reasoningSummary: 'auto', // 'detailed'
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  console.log(result.reasoning);
+  console.log(result.text);
+  console.log();
+  console.log('Finish reason:', result.finishReason);
+  console.log('Usage:', {
+    ...result.usage,
+    reasoningTokens: result.providerMetadata?.openai?.reasoningTokens,
+  });
+  console.log();
+  console.log('Request:', JSON.stringify(result.request, null, 2));
+  console.log('Response:', JSON.stringify(result.response, null, 2));
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-responses-reasoning-summary.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-reasoning-summary.ts
@@ -4,6 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
+    // supported: o4-mini, o3, o3-mini and o1
     model: openai.responses('o3-mini'),
     prompt:
       'Tell me about the debate over Taqueria La Cumbre and El Farolito and who created the San Francisco Mission-style burrito.',
@@ -15,7 +16,9 @@ async function main() {
     },
   });
 
+  process.stdout.write('\x1b[34m');
   console.log(result.reasoning);
+  process.stdout.write('\x1b[0m');
   console.log(result.text);
   console.log();
   console.log('Finish reason:', result.finishReason);

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts
@@ -1,0 +1,34 @@
+import 'dotenv/config';
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+
+async function main() {
+  const result = streamText({
+    // supported: o4-mini, o3, o3-mini and o1
+    model: openai.responses('o3-mini'),
+    system: 'You are a helpful assistant.',
+    prompt:
+      'Tell me about the debate over Taqueria La Cumbre and El Farolito and who created the San Francisco Mission-style burrito.',
+    providerOptions: {
+      openai: {
+        // https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries
+        // reasoningSummary: 'auto', // 'detailed'
+        reasoningSummary: 'detailed',
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'reasoning') {
+      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.textDelta);
+    }
+  }
+
+  console.log();
+  console.log('Finish reason:', await result.finishReason);
+  console.log('Usage:', await result.usage);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts
@@ -29,6 +29,7 @@ async function main() {
   console.log();
   console.log('Finish reason:', await result.finishReason);
   console.log('Usage:', await result.usage);
+  console.log('Provider metadata:', await result.providerMetadata);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning.ts
@@ -7,11 +7,20 @@ async function main() {
     model: openai.responses('o3-mini'),
     system: 'You are a helpful assistant.',
     prompt: 'Invent a new holiday and describe its traditions.',
+    providerOptions: {
+      openai: {
+        reasoningSummary: 'auto',
+      },
+    },
   });
 
-  for await (const textPart of result.textStream) {
-    process.stdout.write(textPart);
+  for await (const part of result.fullStream) {
+    console.log(part);
   }
+
+  // for await (const textPart of result.textStream) {
+  //   process.stdout.write(textPart);
+  // }
 
   console.log();
   console.log('Finish reason:', await result.finishReason);

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning.ts
@@ -4,19 +4,32 @@ import { streamText } from 'ai';
 
 async function main() {
   const result = streamText({
+    // supported: o4-mini, o3, o3-mini and o1
     model: openai.responses('o3-mini'),
     system: 'You are a helpful assistant.',
-    prompt: 'Invent a new holiday and describe its traditions.',
+    prompt:
+      'Tell me about the debate over Taqueria La Cumbre and El Farolito and who created the San Francisco Mission-style burrito.',
     providerOptions: {
       openai: {
-        reasoningSummary: 'auto',
+        // https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries
+        reasoningSummary: 'auto', // 'detailed'
       },
     },
   });
 
+  // TODO: 'summary' reasoning isn't demarcated as different from regular
+  // 'reasoning' currently due to no specific or extensible stream part type.
   for await (const part of result.fullStream) {
-    console.log(part);
+    if (part.type === 'reasoning') {
+      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.textDelta);
+    }
   }
+
+  // for await (const part of result.fullStream) {
+  //   console.log(part);
+  // }
 
   // for await (const textPart of result.textStream) {
   //   process.stdout.write(textPart);

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning.ts
@@ -4,36 +4,14 @@ import { streamText } from 'ai';
 
 async function main() {
   const result = streamText({
-    // supported: o4-mini, o3, o3-mini and o1
     model: openai.responses('o3-mini'),
     system: 'You are a helpful assistant.',
-    prompt:
-      'Tell me about the debate over Taqueria La Cumbre and El Farolito and who created the San Francisco Mission-style burrito.',
-    providerOptions: {
-      openai: {
-        // https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries
-        reasoningSummary: 'auto', // 'detailed'
-      },
-    },
+    prompt: 'Invent a new holiday and describe its traditions.',
   });
 
-  // TODO: 'summary' reasoning isn't demarcated as different from regular
-  // 'reasoning' currently due to no specific or extensible stream part type.
-  for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
-      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
-    } else if (part.type === 'text-delta') {
-      process.stdout.write(part.textDelta);
-    }
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
   }
-
-  // for await (const part of result.fullStream) {
-  //   console.log(part);
-  // }
-
-  // for await (const textPart of result.textStream) {
-  //   process.stdout.write(textPart);
-  // }
 
   console.log();
   console.log('Finish reason:', await result.finishReason);

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1373,5 +1373,194 @@ describe('OpenAIResponsesLanguageModel', () => {
         },
       ]);
     });
+
+    describe('reasoning summary', () => {
+      beforeEach(() => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_67c97c0203188190a025beb4a75242bc',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            incomplete_details: null,
+            input: [],
+            instructions: null,
+            max_output_tokens: null,
+            model: 'o3-mini-2025-01-31',
+            output: [
+              {
+                id: 'msg_67c97c02656c81908e080dfdf4a03cd1',
+                type: 'message',
+                status: 'completed',
+                role: 'assistant',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'answer text',
+                    annotations: [],
+                  },
+                ],
+              },
+              {
+                id: 'rs_6808709f6fcc8191ad2e2fdd784017b3',
+                type: 'reasoning',
+                summary: [
+                  {
+                    type: 'summary_text',
+                    text: '**Exploring burrito origins**\n\nThe user is curious about the debate regarding Taqueria La Cumbre and El Farolito.',
+                  },
+                  {
+                    type: 'summary_text',
+                    text: "**Investigating burrito origins**\n\nThere's a fascinating debate about who created the Mission burrito.",
+                  },
+                ],
+              },
+            ],
+            parallel_tool_calls: true,
+            previous_response_id: null,
+            reasoning: {
+              effort: 'low',
+              summary: 'auto',
+            },
+            store: true,
+            temperature: 1,
+            text: {
+              format: {
+                type: 'text',
+              },
+            },
+            tool_choice: 'auto',
+            tools: [],
+            top_p: 1,
+            truncation: 'disabled',
+            usage: {
+              input_tokens: 34,
+              input_tokens_details: {
+                cached_tokens: 0,
+              },
+              output_tokens: 538,
+              output_tokens_details: {
+                reasoning_tokens: 320,
+              },
+              total_tokens: 572,
+            },
+            user: null,
+            metadata: {},
+          },
+        };
+      });
+
+      it('should extract reasoning summary in doGenerate', async () => {
+        const result = await createModel('o3-mini').doGenerate({
+          prompt: TEST_PROMPT,
+          inputFormat: 'prompt',
+          mode: { type: 'regular' },
+          providerMetadata: {
+            openai: {
+              reasoningEffort: 'low',
+              reasoningSummary: 'auto',
+            },
+          },
+        });
+
+        expect(result.reasoning).toStrictEqual([
+          {
+            type: 'text',
+            text: '**Exploring burrito origins**\n\nThe user is curious about the debate regarding Taqueria La Cumbre and El Farolito.',
+          },
+          {
+            type: 'text',
+            text: "**Investigating burrito origins**\n\nThere's a fascinating debate about who created the Mission burrito.",
+          },
+        ]);
+
+        expect(result.providerMetadata).toStrictEqual({
+          openai: {
+            responseId: 'resp_67c97c0203188190a025beb4a75242bc',
+            cachedPromptTokens: 0,
+            reasoningTokens: 320,
+          },
+        });
+
+        expect(await server.calls[0].requestBody).toMatchObject({
+          model: 'o3-mini',
+          reasoning: {
+            effort: 'low',
+            summary: 'auto',
+          },
+        });
+      });
+    });
+
+    it('should stream reasoning summary', async () => {
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.created","response":{"id":"resp_67c9a81b6a048190a9ee441c5755a4e8","object":"response","created_at":1741269019,"status":"in_progress","error":null,"incomplete_details":null,"input":[],"instructions":null,"max_output_tokens":null,"model":"o3-mini-2025-01-31","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":"low","summary":"auto"},"store":true,"temperature":null,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":null,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+          `data:{"type":"response.reasoning_summary_text.delta","item_id":"rs_68082c0556348191af675cee0453109b","output_index":0,"summary_index":0,"delta":"**Exploring burrito origins**\\n\\nThe user is"}\n\n`,
+          `data:{"type":"response.reasoning_summary_text.delta","item_id":"rs_68082c0556348191af675cee0453109b","output_index":0,"summary_index":0,"delta":" curious about the debate regarding Taqueria La Cumbre and El Farolito."}\n\n`,
+          `data:{"type":"response.reasoning_summary_text.done","item_id":"rs_68082c0556348191af675cee0453109b","output_index":0,"summary_index":0,"text":"**Exploring burrito origins**\\n\\nThe user is curious about the debate regarding Taqueria La Cumbre and El Farolito."}\n\n`,
+          `data:{"type":"response.reasoning_summary_text.delta","item_id":"rs_68082c0556348191af675cee0453109b","output_index":0,"summary_index":1,"delta":"**Investigating burrito origins**\\n\\nThere's a fascinating debate about who created the Mission burrito."}\n\n`,
+          `data:{"type":"response.reasoning_summary_part.done","item_id":"rs_68082c0556348191af675cee0453109b","output_index":0,"summary_index":1,"part":{"type":"summary_text","text":"**Investigating burrito origins**\\n\\nThere's a fascinating debate about who created the Mission burrito."}}\n\n`,
+          `data:{"type":"response.output_item.added","output_index":1,"item":{"id":"msg_67c9a81dea8c8190b79651a2b3adf91e","type":"message","status":"in_progress","role":"assistant","content":[]}}\n\n`,
+          `data:{"type":"response.content_part.added","item_id":"msg_67c9a81dea8c8190b79651a2b3adf91e","output_index":1,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_67c9a81dea8c8190b79651a2b3adf91e","output_index":1,"content_index":0,"delta":"Taqueria La Cumbre"}\n\n`,
+          `data:{"type":"response.completed","response":{"id":"resp_67c9a81b6a048190a9ee441c5755a4e8","object":"response","created_at":1741269019,"status":"completed","error":null,"incomplete_details":null,"input":[],"instructions":null,"max_output_tokens":null,"model":"o3-mini-2025-01-31","output":[{"id":"rs_68082c0556348191af675cee0453109b","type":"reasoning","summary":[{"type":"summary_text","text":"**Exploring burrito origins**\\n\\nThe user is curious about the debate regarding Taqueria La Cumbre and El Farolito."},{"type":"summary_text","text":"**Investigating burrito origins**\\n\\nThere's a fascinating debate about who created the Mission burrito."}]},{"id":"msg_67c9a81dea8c8190b79651a2b3adf91e","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Taqueria La Cumbre","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":"low","summary":"auto"},"store":true,"temperature":null,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":null,"truncation":"disabled","usage":{"input_tokens":543,"input_tokens_details":{"cached_tokens":234},"output_tokens":478,"output_tokens_details":{"reasoning_tokens":350},"total_tokens":1021},"user":null,"metadata":{}}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel('o3-mini').doStream({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+        providerMetadata: {
+          openai: {
+            reasoningEffort: 'low',
+            reasoningSummary: 'auto',
+          },
+        },
+      });
+
+      const streamResults = await convertReadableStreamToArray(stream);
+
+      expect(streamResults).toContainEqual({
+        type: 'reasoning',
+        textDelta: '**Exploring burrito origins**\n\nThe user is',
+      });
+
+      expect(streamResults).toContainEqual({
+        type: 'reasoning',
+        textDelta:
+          ' curious about the debate regarding Taqueria La Cumbre and El Farolito.',
+      });
+
+      expect(streamResults).toContainEqual({
+        type: 'reasoning',
+        textDelta:
+          "**Investigating burrito origins**\n\nThere's a fascinating debate about who created the Mission burrito.",
+      });
+
+      const finishEvent = streamResults.find(event => event.type === 'finish');
+      expect(finishEvent).toBeDefined();
+
+      expect(finishEvent?.providerMetadata).toMatchObject({
+        openai: {
+          responseId: 'resp_67c9a81b6a048190a9ee441c5755a4e8',
+          cachedPromptTokens: 234,
+          reasoningTokens: 350,
+        },
+      });
+
+      expect(await server.calls[0].requestBody).toMatchObject({
+        model: 'o3-mini',
+        reasoning: {
+          effort: 'low',
+          summary: 'auto',
+        },
+        stream: true,
+      });
+    });
   });
 });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -418,7 +418,6 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV1 {
     let cachedPromptTokens: number | null = null;
     let reasoningTokens: number | null = null;
     let responseId: string | null = null;
-
     const ongoingToolCalls: Record<
       number,
       { toolName: string; toolCallId: string } | undefined
@@ -646,25 +645,6 @@ const responseReasoningSummaryTextDeltaSchema = z.object({
   delta: z.string(),
 });
 
-const responseReasoningSummaryTextDoneSchema = z.object({
-  type: z.literal('response.reasoning_summary_text.done'),
-  item_id: z.string(),
-  output_index: z.number(),
-  summary_index: z.number(),
-  text: z.string(),
-});
-
-const responseReasoningSummaryPartDoneSchema = z.object({
-  type: z.literal('response.reasoning_summary_part.done'),
-  item_id: z.string(),
-  output_index: z.number(),
-  summary_index: z.number(),
-  part: z.object({
-    type: z.literal('summary_text'),
-    text: z.string(),
-  }),
-});
-
 const openaiResponsesChunkSchema = z.union([
   textDeltaChunkSchema,
   responseFinishedChunkSchema,
@@ -674,8 +654,6 @@ const openaiResponsesChunkSchema = z.union([
   responseOutputItemAddedSchema,
   responseAnnotationAddedSchema,
   responseReasoningSummaryTextDeltaSchema,
-  responseReasoningSummaryTextDoneSchema,
-  responseReasoningSummaryPartDoneSchema,
   z.object({ type: z.string() }).passthrough(), // fallback for unknown chunks
 ]);
 
@@ -727,18 +705,6 @@ function isResponseReasoningSummaryTextDeltaChunk(
   chunk: z.infer<typeof openaiResponsesChunkSchema>,
 ): chunk is z.infer<typeof responseReasoningSummaryTextDeltaSchema> {
   return chunk.type === 'response.reasoning_summary_text.delta';
-}
-
-function isResponseReasoningSummaryTextDoneChunk(
-  chunk: z.infer<typeof openaiResponsesChunkSchema>,
-): chunk is z.infer<typeof responseReasoningSummaryTextDoneSchema> {
-  return chunk.type === 'response.reasoning_summary_text.done';
-}
-
-function isResponseReasoningSummaryPartDoneChunk(
-  chunk: z.infer<typeof openaiResponsesChunkSchema>,
-): chunk is z.infer<typeof responseReasoningSummaryPartDoneSchema> {
-  return chunk.type === 'response.reasoning_summary_part.done';
 }
 
 type ResponsesModelConfig = {


### PR DESCRIPTION
## Background

OpenAI reasoning models now expose "reasoning summary" text per https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries

Developers would like to be able to surface this content to users.

## Summary

Add support for parsing and processing reasoning summary content into the 'reasoning' field for generate and stream output. Fixes #5813.

## Tasks

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If required, a _patch_ changeset for relevant packages has been added
- [ ] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

Consider adding a separate field for "reasoning summary" separate from "reasoning", or a way to tag this reasoning content as a "summary" variant. For the time being, as this is the only reasoning content made available by the OpenAI API, it seems like a sufficient fit for the existing `reasoning` fields.