### PR TITLE
feat(providers/xai): add reasoningEffort option

### DIFF
--- a/.changeset/hungry-frogs-raise.md
+++ b/.changeset/hungry-frogs-raise.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+feat(providers/xai): add reasoningEffort provider option

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -111,6 +111,29 @@ The following optional settings are available for xAI chat models:
   A unique identifier representing your end-user, which can help xAI to
   monitor and detect abuse.
 
+xAI chat models also support some model specific provider options. You can pass them in `providerOptions` argument:
+
+```ts
+const model = xai('grok-3');
+
+await generateText({
+  model,
+  providerOptions: {
+    xai: {
+      reasoningEffort: 'high',
+    },
+  },
+});
+```
+
+The following optional provider options are available for xAI chat models:
+
+- **reasoningEffort** _'low' | 'medium' | 'high'_
+
+  Reasoning effort for reasoning models. Defaults to `medium`. If you use
+  `providerOptions` to set the `reasoningEffort` option, this
+  model setting will be ignored.
+
 ## Model Capabilities
 
 | Model                | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -646,7 +646,7 @@ describe('doGenerate', () => {
       expect(warnings).toEqual([]);
     });
 
-    it('should respect the includeUsage option', async () => {
+    it('should respect the reasoningEffort provider option', async () => {
       prepareJsonResponse({ content: '{"value":"test"}' });
 
       const model = new OpenAICompatibleChatLanguageModel(
@@ -656,22 +656,23 @@ describe('doGenerate', () => {
           provider: 'test-provider',
           url: () => 'https://my.api.com/v1/chat/completions',
           headers: () => ({}),
-          includeUsage: true,
         },
       );
 
-      const { warnings } = await model.doStream({
+      await model.doGenerate({
         inputFormat: 'prompt',
         mode: { type: 'regular' },
         prompt: TEST_PROMPT,
+        providerMetadata: {
+          'openai-compatible': {
+            reasoningEffort: 'low',
+          },
+        },
       });
 
       const body = await server.calls[0].requestBody;
 
-      expect(body.stream).toBe(true);
-      expect(body.stream_options).toStrictEqual({ include_usage: true });
-
-      expect(warnings).toEqual([]);
+      expect(body.reasoning_effort).toBe('low');
     });
 
     it('should use json_schema & strict in object-json mode when structuredOutputs are enabled', async () => {
@@ -1011,6 +1012,37 @@ describe('doStream', () => {
       ],
     };
   }
+
+  it('should respect the includeUsage option', async () => {
+    prepareStreamResponse({
+      content: ['Hello', ', ', 'World!'],
+      finish_reason: 'stop',
+    });
+
+    const model = new OpenAICompatibleChatLanguageModel(
+      'gpt-4o-2024-08-06',
+      {},
+      {
+        provider: 'test-provider',
+        url: () => 'https://my.api.com/v1/chat/completions',
+        headers: () => ({}),
+        includeUsage: true,
+      },
+    );
+
+    const { warnings } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    const body = await server.calls[0].requestBody;
+
+    expect(body.stream).toBe(true);
+    expect(body.stream_options).toStrictEqual({ include_usage: true });
+
+    expect(warnings).toEqual([]);
+  });
 
   it('should stream text deltas', async () => {
     prepareStreamResponse({

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -171,6 +171,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV1 {
       seed,
       ...providerMetadata?.[this.providerOptionsName],
 
+      reasoning_effort:
+        providerMetadata?.[this.providerOptionsName]?.reasoningEffort ??
+        providerMetadata?.['openai-compatible']?.reasoningEffort,
+
       // messages:
       messages: convertToOpenAICompatibleChatMessages(prompt),
     };


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

As brought up in https://github.com/vercel/ai/issues/5857, xAI now supports reasoning effort

closes #5857

## Summary

Introduced the reasoningEffort param to openai-compatible so the xAI provider can use it.

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If required, a _patch_ changeset for relevant packages has been added
- [x] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
