### PR TITLE
chore (automation): enforce patch bumps in `.changeset/*.md files`

### DIFF
--- a/.github/workflows/actions/verify-changesets/index.js
+++ b/.github/workflows/actions/verify-changesets/index.js
@@ -1,0 +1,137 @@
+import fs from 'node:fs/promises';
+
+const BYPASS_LABELS = ['minor', 'major'];
+
+// check if current file is the entry point
+if (import.meta.url.endsWith(process.argv[1])) {
+  // https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request
+  const pullRequestEvent = JSON.parse(
+    await fs.readFile(process.env.GITHUB_EVENT_PATH, 'utf-8'),
+  );
+
+  try {
+    const message = await verifyChangesets(
+      pullRequestEvent,
+      process.env,
+      fs.readFile,
+    );
+    await fs.writeFile(
+      process.env.GITHUB_STEP_SUMMARY,
+      `## Changeset verification passed ✅\n\n${message || ''}`,
+    );
+  } catch (error) {
+    // write error to summary
+    console.error(error.message);
+    await fs.writeFile(
+      process.env.GITHUB_STEP_SUMMARY,
+      `## Changeset verification failed ❌
+
+${error.message}`,
+    );
+
+    if (error.path) {
+      await fs.appendFile(
+        process.env.GITHUB_STEP_SUMMARY,
+        `\n\nFile: \`${error.path}\``,
+      );
+    }
+
+    if (error.content) {
+      await fs.appendFile(
+        process.env.GITHUB_STEP_SUMMARY,
+        `\n\n\`\`\`yaml\n${error.content}\n\`\`\``,
+      );
+    }
+
+    process.exit(1);
+  }
+}
+
+export async function verifyChangesets(
+  event,
+  env = process.env,
+  readFile = fs.readFile,
+) {
+  // Skip check if pull request has "minor-release" label
+  const byPassLabel = event.pull_request.labels.find(label =>
+    BYPASS_LABELS.includes(label.name),
+  );
+  if (byPassLabel) {
+    return `Skipping changeset verification - "${byPassLabel.name}" label found`;
+  }
+
+  // Iterate through all changed .changeset/*.md files
+  for (const path of env.CHANGED_FILES.trim().split(' ')) {
+    // ignore README.md file
+    if (path === '.changeset/README.md') continue;
+
+    // Check if the file is a .changeset file
+    if (!/^\.changeset\/[a-z-]+\.md/.test(path)) {
+      throw Object.assign(new Error(`Invalid file - not a .changeset file`), {
+        path,
+      });
+    }
+
+    // find frontmatter
+    const content = await readFile(`../../../../${path}`, 'utf-8');
+    const result = content.match(/---\n([\s\S]+?)\n---/);
+    if (!result) {
+      throw Object.assign(
+        new Error(`Invalid .changeset file - no frontmatter found`),
+        {
+          path,
+          content,
+        },
+      );
+    }
+
+    const [frontmatter] = result;
+
+    // Find version bump by package. `frontmatter` looks like this:
+    //
+    // ```yaml
+    // 'ai': patch
+    // '@ai-sdk/provider': patch
+    // ```
+    const lines = frontmatter.split('\n').slice(1, -1);
+    const versionBumps = {};
+    for (const line of lines) {
+      const [packageName, versionBump] = line.split(':').map(s => s.trim());
+      if (!packageName || !versionBump) {
+        throw Object.assign(
+          new Error(`Invalid .changeset file - invalid frontmatter`, {
+            path,
+            content,
+          }),
+        );
+      }
+
+      // Check if packageName is already set
+      if (versionBumps[packageName]) {
+        throw Object.assign(
+          new Error(
+            `Invalid .changeset file - duplicate package name "${packageName}"`,
+          ),
+          { path, content },
+        );
+      }
+
+      versionBumps[packageName] = versionBump;
+    }
+
+    // check if any of the version bumps are not "patch"
+    const invalidVersionBumps = Object.entries(versionBumps).filter(
+      ([, versionBump]) => versionBump !== 'patch',
+    );
+
+    if (invalidVersionBumps.length > 0) {
+      throw Object.assign(
+        new Error(
+          `Invalid .changeset file - invalid version bump (only "patch" is allowed, see https://sdk.vercel.ai/docs/migration-guides/versioning). To bypass, add one of the following labels: ${BYPASS_LABELS.join(', ')}`,
+        ),
+
+        { path, content },
+      );
+    }
+  }
+}

--- a/.github/workflows/actions/verify-changesets/package.json
+++ b/.github/workflows/actions/verify-changesets/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "verify-changesets-action",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test.js"
+  }
+}

--- a/.github/workflows/actions/verify-changesets/test.js
+++ b/.github/workflows/actions/verify-changesets/test.js
@@ -1,0 +1,193 @@
+import assert from 'node:assert';
+import { mock, test } from 'node:test';
+
+import { verifyChangesets } from './index.js';
+
+test('happy path', async () => {
+  const event = {
+    pull_request: {
+      labels: [],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/some-happy-path.md',
+  };
+
+  const readFile = mock.fn(async path => {
+    return `---\nai: patch\n@ai-sdk/provider: patch\n---\n## Test changeset`;
+  });
+
+  await verifyChangesets(event, env, readFile);
+
+  assert.strictEqual(readFile.mock.callCount(), 1);
+  assert.deepStrictEqual(readFile.mock.calls[0].arguments, [
+    '../../../../.changeset/some-happy-path.md',
+    'utf-8',
+  ]);
+});
+
+test('ignores .changeset/README.md', async () => {
+  const event = {
+    pull_request: {
+      labels: [],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/README.md',
+  };
+
+  const readFile = mock.fn(() => {});
+
+  await verifyChangesets(event, env, readFile);
+
+  assert.strictEqual(readFile.mock.callCount(), 0);
+});
+
+test('invalid file - not a .changeset file', async () => {
+  const event = {
+    pull_request: {
+      labels: [],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/not-a-changeset-file.txt',
+  };
+
+  const readFile = mock.fn(() => {});
+
+  await assert.rejects(
+    () => verifyChangesets(event, env, readFile),
+    Object.assign(new Error('Invalid file - not a .changeset file'), {
+      path: '.changeset/not-a-changeset-file.txt',
+    }),
+  );
+
+  assert.strictEqual(readFile.mock.callCount(), 0);
+});
+
+test('invalid .changeset file - no frontmatter', async () => {
+  const event = {
+    pull_request: {
+      labels: [],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/invalid-changeset-file.md',
+  };
+
+  const readFile = mock.fn(async path => {
+    return 'frontmatter missing';
+  });
+  await assert.rejects(
+    () => verifyChangesets(event, env, readFile),
+    Object.assign(new Error('Invalid .changeset file - no frontmatter found'), {
+      path: '.changeset/invalid-changeset-file.md',
+      content: 'frontmatter missing',
+    }),
+  );
+  assert.strictEqual(readFile.mock.callCount(), 1);
+  assert.deepStrictEqual(readFile.mock.calls[0].arguments, [
+    '../../../../.changeset/invalid-changeset-file.md',
+    'utf-8',
+  ]);
+});
+
+test('minor update', async () => {
+  const event = {
+    pull_request: {
+      labels: [],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/patch-update.md .changeset/minor-update.md',
+  };
+
+  const readFile = mock.fn(async path => {
+    if (path.endsWith('patch-update.md')) {
+      return `---\nai: patch\n---\n## Test changeset`;
+    }
+
+    return `---\n@ai-sdk/provider: minor\n---\n## Test changeset`;
+  });
+
+  await assert.rejects(
+    () => verifyChangesets(event, env, readFile),
+    Object.assign(
+      new Error(
+        `Invalid .changeset file - invalid version bump (only "patch" is allowed, see https://sdk.vercel.ai/docs/migration-guides/versioning). To bypass, add one of the following labels: minor, major`,
+      ),
+      {
+        path: '.changeset/minor-update.md',
+        content: '---\n@ai-sdk/provider: minor\n---\n## Test changeset',
+      },
+    ),
+  );
+
+  assert.strictEqual(readFile.mock.callCount(), 2);
+  assert.deepStrictEqual(readFile.mock.calls[0].arguments, [
+    '../../../../.changeset/patch-update.md',
+    'utf-8',
+  ]);
+  assert.deepStrictEqual(readFile.mock.calls[1].arguments, [
+    '../../../../.changeset/minor-update.md',
+    'utf-8',
+  ]);
+});
+
+test('minor update - with "minor" label', async () => {
+  const event = {
+    pull_request: {
+      labels: [
+        {
+          name: 'minor',
+        },
+      ],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/patch-update.md .changeset/minor-update.md',
+  };
+
+  const readFile = mock.fn(async path => {
+    if (path.endsWith('patch-update.md')) {
+      return `---\nai: patch\n---\n## Test changeset`;
+    }
+
+    return `---\n@ai-sdk/provider: minor\n---\n## Test changeset`;
+  });
+
+  const message = await verifyChangesets(event, env, readFile);
+  assert.strictEqual(
+    message,
+    'Skipping changeset verification - "minor" label found',
+  );
+});
+
+test('major update - with "major" label', async () => {
+  const event = {
+    pull_request: {
+      labels: [
+        {
+          name: 'major',
+        },
+      ],
+    },
+  };
+  const env = {
+    CHANGED_FILES: '.changeset/patch-update.md .changeset/major-update.md',
+  };
+
+  const readFile = mock.fn(async path => {
+    if (path.endsWith('patch-update.md')) {
+      return `---\nai: patch\n---\n## Test changeset`;
+    }
+
+    return `---\n@ai-sdk/provider: major\n---\n## Test changeset`;
+  });
+
+  const message = await verifyChangesets(event, env, readFile);
+  assert.strictEqual(
+    message,
+    'Skipping changeset verification - "major" label found',
+  );
+});

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -1,0 +1,38 @@
+# vercel/ai uses https://github.com/changesets/changesets for versioning and changelogs,
+# but is not following semantic versioning. Instead, it uses `patch` for both fixes
+# and features. It uses `minor` for "marketing releases", accompanied by a blog post and migration guide.
+# This workflow verifies that all `.changeset/*.md` files use `patch` unless a `minor-release` label is present.
+name: Verify Changesets
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+    paths:
+      - '.changeset/*.md'
+
+jobs:
+  verify-changesets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - name: get all changed files from .changeset/*.md
+        id: changeset-files
+        run: |
+          echo "changed-files=$(git diff --diff-filter=dr --name-only $BASE_SHA -- '.changeset/*.md' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      - name: Verify changesets
+        working-directory: .github/workflows/actions/verify-changesets
+        run: |
+          node index.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGED_FILES: ${{ steps.changeset-files.outputs.changed-files }}

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'


### PR DESCRIPTION
follow up to #5916. The problem was that the workflow tried to checkout a branch form `origin` but the pull request came from a fork.

I fixed it by removing the `ref` input from the `actions/checkout` step. I verified that the `ref` input is not necessary for `actions/checkout` handling `pull_request` events via

1. https://github.com/gr2m/sandbox/actions/runs/14623027033?pr=295
2. https://github.com/gr2m/sandbox/actions/runs/14623009490?pr=295

I also verified for pull requests from forks

1. https://github.com/gr2m/sandbox/actions/runs/14623280171?pr=297
2. https://github.com/gr2m/sandbox/actions/runs/14623331253?pr=297

closes #5859