### PR TITLE
chore (automation): skip changeset validation if no `.changeset/*.md` files were added or updated

### DIFF
--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
       - name: Verify changesets
+        if: steps.changeset-files.outputs.changed-files != ''
         working-directory: .github/workflows/actions/verify-changesets
         run: |
           node index.js


### PR DESCRIPTION
closes #5859

- reproduced the problem via https://github.com/gr2m/sandbox/actions/runs/14626462613?pr=299
- confirmed fix via https://github.com/gr2m/sandbox/actions/runs/14626508878/job/41039164245?pr=299 (change: https://github.com/gr2m/sandbox/pull/299/commits/b76b2a695a467d5833a26bf0d6706552fc44a780)