### PR TITLE
docs: update image detail terminology and fix broken documentation link (#5941)

### DIFF
--- a/content/providers/01-ai-sdk-providers/02-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/02-openai.mdx
@@ -384,7 +384,7 @@ const rejectedPredictionTokens = openaiMetadata?.rejectedPredictionTokens;
 
 #### Image Detail
 
-You can use the `openai` provider option to set the [image generation detail](https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding) to `high`, `low`, or `auto`:
+You can use the `openai` provider option to set the [image input detail](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#specify-image-input-detail-level) to `high`, `low`, or `auto`:
 
 ```ts highlight="13-16"
 const result = await generateText({


### PR DESCRIPTION

## Background

The documentation previously referenced the term **"image generation detail"**, which is misleading. The feature actually refers to how the model **processes image input**, not generation. Additionally, the old documentation URL was no longer valid and resulted in a broken link.

## Summary

- Replaced the term **"image generation detail"** with **"image input detail"** for clarity and accuracy.
- Updated the broken OpenAI documentation URL to a valid one:
- **Old URL:** `https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding`
- **New URL:** `https://platform.openai.com/docs/guides/images-vision#specify-image-input-detail-level`

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this necessary? -->

## Summary

<!-- What did you change? -->

## Tasks

<!-- Please check if the PR fulfills the following requirements: -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If required, a _patch_ changeset for relevant packages has been added
- [ ] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

<!-- Feel free to mention things not covered by this PR that can be done in future PRs -->
