### PR TITLE
docs(providers): fix minor errors in Azure and Bedrock docs (#5943)

### DIFF
--- a/content/providers/01-ai-sdk-providers/03-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/03-azure.mdx
@@ -451,7 +451,7 @@ using the `.embedding()` factory method.
 const model = azure.embedding('your-embedding-deployment');
 ```
 
-Azure OpenAI embedding models support several aditional settings.
+Azure OpenAI embedding models support several additional settings.
 You can pass them as an options argument:
 
 ```ts

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -440,7 +440,7 @@ using the `.embedding()` factory method.
 const model = bedrock.embedding('amazon.titan-embed-text-v1');
 ```
 
-Bedrock Titan embedding model amazon.titan-embed-text-v2:0 supports several aditional settings.
+Bedrock Titan embedding model amazon.titan-embed-text-v2:0 supports several additional settings.
 You can pass them as an options argument:
 
 ```ts


### PR DESCRIPTION
## Background

To improve the clarity and accuracy of the provider documentation.

## Summary

Corrected minor spelling (`aditional` -> `additional`) errors in the Azure and Bedrock provider documentation files
(`content/providers/...`).
