### PR TITLE
fix (docs): clarify reasoningSummary support and update examples

### DIFF
--- a/content/providers/01-ai-sdk-providers/02-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/02-openai.mdx
@@ -635,14 +635,14 @@ const sources = result.sources;
 
 #### Reasoning Summaries
 
-For reasoning models like `o3-mini`, `o3`, and `o4-mini`, you can enable reasoning summaries to see the model's thought process:
+For reasoning models like `o3-mini`, `o3`, and `o4-mini`, you can enable reasoning summaries to see the model's thought process. Different models support different summarizers—for example, `o4-mini` supports detailed summaries. Set `reasoningSummary: "auto"` to automatically receive the richest level available.
 
 ```ts highlight="8-9,16"
 import { openai } from '@ai-sdk/openai';
 import { streamText } from 'ai';
 
 const result = streamText({
-  model: openai.responses('o3-mini'),
+  model: openai.responses('o4-mini'),
   prompt: 'Tell me about the Mission burrito debate in San Francisco.',
   providerOptions: {
     openai: {
@@ -671,7 +671,7 @@ const result = await generateText({
   prompt: 'Tell me about the Mission burrito debate in San Francisco.',
   providerOptions: {
     openai: {
-      reasoningSummary: 'detailed',
+      reasoningSummary: 'auto',
     },
   },
 });

--- a/examples/ai-core/src/generate-text/openai-responses-reasoning-summary.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-reasoning-summary.ts
@@ -11,7 +11,7 @@ async function main() {
     providerOptions: {
       openai: {
         // https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries
-        reasoningSummary: 'auto', // 'detailed'
+        reasoningSummary: 'auto', // auto gives you the best available summary (detailed > auto > None)
       } satisfies OpenAIResponsesProviderOptions,
     },
   });

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts
@@ -13,7 +13,7 @@ async function main() {
       openai: {
         // https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries
         // reasoningSummary: 'auto', // 'detailed'
-        reasoningSummary: 'detailed',
+        reasoningSummary: 'auto',
       },
     },
   });


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Only `o4-mini` currently returns a **detailed** reasoning summary, [this is consistent with the description in the official documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries:~:text=while%20o4%2Dmini,detailed).
Local testing shows that specifying `reasoningSummary: "detailed"` with `o3` or `o3-mini` yields no reasoning summary at all, even though the request succeeds.  
Our docs and sample code suggested that `o3-mini` supports `detailed`, which can mislead users.


## Summary

- Replace `o3-mini` → `o4-mini` in code snippets.
- Recommend `"auto"` as the safest cross-model option.

## Verification

1. **o3-mini + "detailed"** → no summary available.  
2. **o3-mini + "auto"**      → returns concise summary & text stream.  
3. **o4-mini  + "detailed"** → returns detailed reasoning stream.  

All examples in the rendered MDX now execute without runtime errors.

## Tasks

- [ ] Tests have been added / updated (N/A — docs-only)
- [x] Documentation has been added / updated
- [ ] A _patch_ changeset has been added (N/A — docs-only)
- [x] Formatting issues have been fixed (`pnpm prettier-fix`)

## Future Work

If OpenAI later enables detailed summaries on `o3` / `o3-mini`, we can re-introduce “detailed” in examples; the `"auto"` setting will already surface the upgrade automatically.

## Related Issues

n/a
