### PR TITLE
Fix missing `gpt-image-1` type

### DIFF
--- a/packages/openai/src/openai-image-settings.ts
+++ b/packages/openai/src/openai-image-settings.ts
@@ -1,4 +1,4 @@
-export type OpenAIImageModelId = 'dall-e-3' | 'dall-e-2' | (string & {});
+export type OpenAIImageModelId = 'gpt-image-1' | 'dall-e-3' | 'dall-e-2' | (string & {});
 
 // https://platform.openai.com/docs/guides/images
 export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {


### PR DESCRIPTION
Sequel to https://github.com/vercel/ai/pull/5951