### PR TITLE
feat (providers/openai): add gpt-image-1 model id to image settings

### DIFF
--- a/.changeset/famous-ties-train.md
+++ b/.changeset/famous-ties-train.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat (providers/openai): add gpt-image-1 model id to image settings

--- a/content/providers/01-ai-sdk-providers/02-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/02-openai.mdx
@@ -905,17 +905,21 @@ const model = openai.image('dall-e-3');
 | `dall-e-3`    | 1024x1024, 1792x1024, 1024x1792 |
 | `dall-e-2`    | 256x256, 512x512, 1024x1024     |
 
-You can pass optional `providerOptions` to the image model. These are prone to change by OpenAI and aremodel dependent. For example, the `gpt-image-1` model supports the `quality` option:
+You can pass optional `providerOptions` to the image model. These are prone to change by OpenAI and are model dependent. For example, the `gpt-image-1` model supports the `quality` option:
 
 ```ts
-const model = openai.image('gpt-image-1', {
+const { image } = await generateImage({
+  model: openai.image('gpt-image-1'),
+  prompt: 'A salamander at sunrise in a forest pond in the Seychelles.',
   providerOptions: {
     openai: { quality: 'high' },
   },
 });
 ```
 
-For more information on the available options, see the [OpenAI API reference](https://platform.openai.com/docs/api-reference/images/create).
+For more on `generateImage()` see [Image Generation](/docs/ai-sdk-core/image-generation).
+
+For more information on the available OpenAI image model options, see the [OpenAI API reference](https://platform.openai.com/docs/api-reference/images/create).
 
 ## Transcription Models
 

--- a/packages/openai/src/openai-image-settings.ts
+++ b/packages/openai/src/openai-image-settings.ts
@@ -1,4 +1,8 @@
-export type OpenAIImageModelId = 'gpt-image-1' | 'dall-e-3' | 'dall-e-2' | (string & {});
+export type OpenAIImageModelId =
+  | 'gpt-image-1'
+  | 'dall-e-3'
+  | 'dall-e-2'
+  | (string & {});
 
 // https://platform.openai.com/docs/guides/images
 export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {

--- a/packages/openai/src/openai-image-settings.ts
+++ b/packages/openai/src/openai-image-settings.ts
@@ -1,4 +1,4 @@
-export type OpenAIImageModelId = 'dall-e-3' | 'dall-e-2' | (string & {});
+export type OpenAIImageModelId = 'gpt-image-1' | 'dall-e-3' | 'dall-e-2' | (string & {});
 
 // https://platform.openai.com/docs/guides/images
 export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {


### PR DESCRIPTION
## Background

OpenAI launched the `gpt-image-1` model yesterday. We shipped initial support. The model id should be included in the autocomplete model id sets.

## Summary

Added the new model id to image model settings id list.

## Related Issues

Continued from #5969 and follow up to #5951
