### PR TITLE
refactor (provider): use `SharedV2ProviderOptions` in `ImageModelV2`

### DIFF
--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -12,6 +12,7 @@ import {
   detectMediaType,
   imageMediaTypeSignatures,
 } from '../util/detect-media-type';
+import { ProviderOptions } from '../types/provider-metadata';
 
 /**
 Generates images using an image model.
@@ -86,7 +87,7 @@ record is keyed by the provider-specific metadata key.
 }
 ```
      */
-  providerOptions?: Record<string, Record<string, JSONValue>>;
+  providerOptions?: ProviderOptions;
 
   /**
 Maximum number of retries per embedding model call. Set to 0 to disable retries.

--- a/packages/provider/src/image-model/v2/image-model-v2-call-options.ts
+++ b/packages/provider/src/image-model/v2/image-model-v2-call-options.ts
@@ -1,4 +1,4 @@
-import { JSONValue } from '../../json-value/json-value';
+import { SharedV2ProviderOptions } from '../../shared';
 
 export type ImageModelV2CallOptions = {
   /**
@@ -45,7 +45,7 @@ record is keyed by the provider-specific metadata key.
 }
 ```
  */
-  providerOptions: Record<string, Record<string, JSONValue>>;
+  providerOptions: SharedV2ProviderOptions;
 
   /**
 Abort signal for cancelling the operation.


### PR DESCRIPTION
Built on #5975, merge it first.

## Background

Remove code duplication by using shared type.

## Summary

```diff
export type ImageModelV2CallOptions = {
  …
-  providerOptions: Record<string, Record<string, JSONValue>>;
+  providerOptions: SharedV2ProviderOptions;
```
