### PR TITLE
chore (provider): remove unused `AISDKError` import

### DIFF
--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -1,4 +1,4 @@
-import { AISDKError, ImageModelV2, JSONValue } from '@ai-sdk/provider';
+import { ImageModelV2, JSONValue } from '@ai-sdk/provider';
 import { NoImageGeneratedError } from '../../errors/no-image-generated-error';
 import {
   DefaultGeneratedFile,


### PR DESCRIPTION
Removes unused `AISDKError` import from `packages/ai/core/generate-image/generate-image.ts`.
