### PR TITLE
feat (providers/openai): add gpt-image-1 model id to image settings (#5970)

### DIFF
--- a/.changeset/famous-ties-train.md
+++ b/.changeset/famous-ties-train.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat (providers/openai): add gpt-image-1 model id to image settings

--- a/packages/openai/src/openai-image-settings.ts
+++ b/packages/openai/src/openai-image-settings.ts
@@ -1,4 +1,8 @@
-export type OpenAIImageModelId = 'dall-e-3' | 'dall-e-2' | (string & {});
+export type OpenAIImageModelId =
+  | 'gpt-image-1'
+  | 'dall-e-3'
+  | 'dall-e-2'
+  | (string & {});
 
 // https://platform.openai.com/docs/guides/images
 export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {


### PR DESCRIPTION
## Background

OpenAI launched the `gpt-image-1` model yesterday. We shipped initial support. The model id should be included in the autocomplete model id sets.

## Summary

Added the new model id to image model settings id list.

## Related Issues

Continued from #5969 and follow up to #5951