### PR TITLE
feat (ai): add experimental prepareStep callback to generateText

### DIFF
--- a/.changeset/ten-students-yell.md
+++ b/.changeset/ten-students-yell.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): add experimental prepareStep callback to generateText

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -142,6 +142,40 @@ const result = await generateText({
 });
 ```
 
+### `experimental_prepareStep` callback
+
+<Note type="warning">
+  The `experimental_prepareStep` callback is experimental and may change in the
+  future.
+</Note>
+
+The `experimental_prepareStep` callback is called before a step is started.
+It is called with the current model, the step number, and the steps that have been executed so far.
+
+You can use it to provide different settings for a step.
+
+```tsx highlight="5-7"
+import { generateText } from 'ai';
+
+const result = await generateText({
+  // ...
+  experimental_prepareStep: async ({ model, stepNumber, steps }) => {
+    if (stepNumber === 0) {
+      return {
+        // use a different model for this step:
+        model: modelForThisParticularStep,
+        // force a tool choice for this step:
+        toolChoice: { type: 'tool', toolName: 'tool1' },
+        // limit the tools that are available for this step:
+        experimental_activeTools: ['tool1'],
+      };
+    }
+
+    // when nothing is returned, the default settings are used
+  },
+});
+```
+
 ## Response Messages
 
 Adding the generated assistant and tool messages to your conversation history is a common task,

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -146,11 +146,17 @@ const result = await generateText({
 
 <Note type="warning">
   The `experimental_prepareStep` callback is experimental and may change in the
-  future.
+  future. It is only available in the `generateText` function.
 </Note>
 
 The `experimental_prepareStep` callback is called before a step is started.
-It is called with the current model, the step number, and the steps that have been executed so far.
+
+It is called with the following parameters:
+
+- `model`: The model that was passed into `generateText`.
+- `maxSteps`: The maximum number of steps that was passed into `generateText`.
+- `stepNumber`: The number of the step that is being executed.
+- `steps`: The steps that have been executed so far.
 
 You can use it to provide different settings for a step.
 

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -159,7 +159,7 @@ import { generateText } from 'ai';
 
 const result = await generateText({
   // ...
-  experimental_prepareStep: async ({ model, stepNumber, steps }) => {
+  experimental_prepareStep: async ({ model, stepNumber, maxSteps, steps }) => {
     if (stepNumber === 0) {
       return {
         // use a different model for this step:

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -341,6 +341,347 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
 ]
 `;
 
+exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > onStepFinish should be called for each step 1`] = `
+[
+  {
+    "experimental_providerMetadata": undefined,
+    "files": [],
+    "finishReason": "tool-calls",
+    "isContinued": false,
+    "logprobs": undefined,
+    "providerMetadata": undefined,
+    "reasoning": undefined,
+    "reasoningDetails": [],
+    "request": {},
+    "response": {
+      "body": undefined,
+      "headers": undefined,
+      "id": "test-id-1-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "id": "msg-1",
+          "role": "tool",
+        },
+      ],
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "sources": [],
+    "stepType": "initial",
+    "text": "",
+    "toolCalls": [
+      {
+        "args": {
+          "value": "value",
+        },
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "toolResults": [
+      {
+        "args": {
+          "value": "value",
+        },
+        "result": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "usage": {
+      "completionTokens": 5,
+      "promptTokens": 10,
+      "totalTokens": 15,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "files": [],
+    "finishReason": "stop",
+    "isContinued": false,
+    "logprobs": undefined,
+    "providerMetadata": undefined,
+    "reasoning": undefined,
+    "reasoningDetails": [],
+    "request": {},
+    "response": {
+      "body": undefined,
+      "headers": {
+        "custom-response-header": "response-header-value",
+      },
+      "id": "test-id-2-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "id": "msg-1",
+          "role": "tool",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello, world!",
+              "type": "text",
+            },
+          ],
+          "id": "msg-2",
+          "role": "assistant",
+        },
+      ],
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:10.000Z,
+    },
+    "sources": [],
+    "stepType": "tool-result",
+    "text": "Hello, world!",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 20,
+      "promptTokens": 10,
+      "totalTokens": 30,
+    },
+    "warnings": undefined,
+  },
+]
+`;
+
+exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > result.response.messages should contain response messages from all steps 1`] = `
+[
+  {
+    "content": [
+      {
+        "args": {
+          "value": "value",
+        },
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "id": "msg-0",
+    "role": "assistant",
+  },
+  {
+    "content": [
+      {
+        "result": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "id": "msg-1",
+    "role": "tool",
+  },
+  {
+    "content": [
+      {
+        "text": "Hello, world!",
+        "type": "text",
+      },
+    ],
+    "id": "msg-2",
+    "role": "assistant",
+  },
+]
+`;
+
+exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > result.steps should contain all steps 1`] = `
+[
+  {
+    "experimental_providerMetadata": undefined,
+    "files": [],
+    "finishReason": "tool-calls",
+    "isContinued": false,
+    "logprobs": undefined,
+    "providerMetadata": undefined,
+    "reasoning": undefined,
+    "reasoningDetails": [],
+    "request": {},
+    "response": {
+      "body": undefined,
+      "headers": undefined,
+      "id": "test-id-1-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "id": "msg-1",
+          "role": "tool",
+        },
+      ],
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:00.000Z,
+    },
+    "sources": [],
+    "stepType": "initial",
+    "text": "",
+    "toolCalls": [
+      {
+        "args": {
+          "value": "value",
+        },
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-call",
+      },
+    ],
+    "toolResults": [
+      {
+        "args": {
+          "value": "value",
+        },
+        "result": "result1",
+        "toolCallId": "call-1",
+        "toolName": "tool1",
+        "type": "tool-result",
+      },
+    ],
+    "usage": {
+      "completionTokens": 5,
+      "promptTokens": 10,
+      "totalTokens": 15,
+    },
+    "warnings": undefined,
+  },
+  {
+    "experimental_providerMetadata": undefined,
+    "files": [],
+    "finishReason": "stop",
+    "isContinued": false,
+    "logprobs": undefined,
+    "providerMetadata": undefined,
+    "reasoning": undefined,
+    "reasoningDetails": [],
+    "request": {},
+    "response": {
+      "body": undefined,
+      "headers": {
+        "custom-response-header": "response-header-value",
+      },
+      "id": "test-id-2-from-model",
+      "messages": [
+        {
+          "content": [
+            {
+              "args": {
+                "value": "value",
+              },
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "id": "msg-0",
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "result": "result1",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
+          "id": "msg-1",
+          "role": "tool",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello, world!",
+              "type": "text",
+            },
+          ],
+          "id": "msg-2",
+          "role": "assistant",
+        },
+      ],
+      "modelId": "test-response-model-id",
+      "timestamp": 1970-01-01T00:00:10.000Z,
+    },
+    "sources": [],
+    "stepType": "tool-result",
+    "text": "Hello, world!",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completionTokens": 20,
+      "promptTokens": 10,
+      "totalTokens": 30,
+    },
+    "warnings": undefined,
+  },
+]
+`;
+
 exports[`options.maxSteps > 4 steps: initial, continue, continue, continue > onStepFinish should be called for each step 1`] = `
 [
   {

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -690,6 +690,209 @@ describe('options.maxSteps', () => {
     });
   });
 
+  describe('2 steps: initial, tool-result with prepareStep', () => {
+    let result: GenerateTextResult<any, any>;
+    let onStepFinishResults: StepResult<any>[];
+
+    beforeEach(async () => {
+      onStepFinishResults = [];
+
+      let responseCount = 0;
+
+      const trueModel = new MockLanguageModelV1({
+        doGenerate: async ({ prompt, mode }) => {
+          switch (responseCount++) {
+            case 0:
+              expect(mode).toStrictEqual({
+                type: 'regular',
+                toolChoice: { type: 'tool', toolName: 'tool1' },
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'tool1',
+                    description: undefined,
+                    parameters: {
+                      $schema: 'http://json-schema.org/draft-07/schema#',
+                      additionalProperties: false,
+                      properties: { value: { type: 'string' } },
+                      required: ['value'],
+                      type: 'object',
+                    },
+                  },
+                ],
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'test-input' }],
+                  providerMetadata: undefined,
+                },
+              ]);
+
+              return {
+                ...dummyResponseValues,
+                toolCalls: [
+                  {
+                    toolCallType: 'function',
+                    toolCallId: 'call-1',
+                    toolName: 'tool1',
+                    args: `{ "value": "value" }`,
+                  },
+                ],
+                toolResults: [
+                  {
+                    toolCallId: 'call-1',
+                    toolName: 'tool1',
+                    args: { value: 'value' },
+                    result: 'result1',
+                  },
+                ],
+                finishReason: 'tool-calls',
+                usage: { completionTokens: 5, promptTokens: 10 },
+                response: {
+                  id: 'test-id-1-from-model',
+                  timestamp: new Date(0),
+                  modelId: 'test-response-model-id',
+                },
+              };
+            case 1:
+              expect(mode).toStrictEqual({
+                type: 'regular',
+                toolChoice: { type: 'auto' },
+                tools: [],
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'test-input' }],
+                  providerMetadata: undefined,
+                },
+                {
+                  role: 'assistant',
+                  content: [
+                    {
+                      type: 'tool-call',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      args: { value: 'value' },
+                      providerMetadata: undefined,
+                    },
+                  ],
+                  providerMetadata: undefined,
+                },
+                {
+                  role: 'tool',
+                  content: [
+                    {
+                      type: 'tool-result',
+                      toolCallId: 'call-1',
+                      toolName: 'tool1',
+                      result: 'result1',
+                      content: undefined,
+                      isError: undefined,
+                      providerMetadata: undefined,
+                    },
+                  ],
+                  providerMetadata: undefined,
+                },
+              ]);
+              return {
+                ...dummyResponseValues,
+                text: 'Hello, world!',
+                response: {
+                  id: 'test-id-2-from-model',
+                  timestamp: new Date(10000),
+                  modelId: 'test-response-model-id',
+                },
+                rawResponse: {
+                  headers: {
+                    'custom-response-header': 'response-header-value',
+                  },
+                },
+              };
+            default:
+              throw new Error(`Unexpected response count: ${responseCount}`);
+          }
+        },
+      });
+
+      result = await generateText({
+        model: modelWithFiles,
+        tools: {
+          tool1: tool({
+            parameters: z.object({ value: z.string() }),
+            execute: async (args, options) => {
+              expect(args).toStrictEqual({ value: 'value' });
+              expect(options.messages).toStrictEqual([
+                { role: 'user', content: 'test-input' },
+              ]);
+              return 'result1';
+            },
+          }),
+        },
+        prompt: 'test-input',
+        maxSteps: 3,
+        onStepFinish: async event => {
+          onStepFinishResults.push(event);
+        },
+        experimental_prepareStep: async ({ model, stepNumber, steps }) => {
+          expect(model).toStrictEqual(modelWithFiles);
+
+          if (stepNumber === 0) {
+            expect(steps).toStrictEqual([]);
+            return {
+              model: trueModel,
+              toolChoice: {
+                type: 'tool',
+                toolName: 'tool1' as const,
+              },
+            };
+          }
+
+          if (stepNumber === 1) {
+            expect(steps.length).toStrictEqual(1);
+            return { model: trueModel, experimental_activeTools: [] };
+          }
+        },
+        experimental_generateMessageId: mockId({ prefix: 'msg' }),
+      });
+    });
+
+    it('result.text should return text from last step', async () => {
+      assert.deepStrictEqual(result.text, 'Hello, world!');
+    });
+
+    it('result.toolCalls should return empty tool calls from last step', async () => {
+      assert.deepStrictEqual(result.toolCalls, []);
+    });
+
+    it('result.toolResults should return empty tool results from last step', async () => {
+      assert.deepStrictEqual(result.toolResults, []);
+    });
+
+    it('result.response.messages should contain response messages from all steps', () => {
+      expect(result.response.messages).toMatchSnapshot();
+    });
+
+    it('result.usage should sum token usage', () => {
+      assert.deepStrictEqual(result.usage, {
+        completionTokens: 25,
+        promptTokens: 20,
+        totalTokens: 45,
+      });
+    });
+
+    it('result.steps should contain all steps', () => {
+      expect(result.steps).toMatchSnapshot();
+    });
+
+    it('onStepFinish should be called for each step', () => {
+      expect(onStepFinishResults).toMatchSnapshot();
+    });
+  });
+
   describe('4 steps: initial, continue, continue, continue', () => {
     let result: GenerateTextResult<any, any>;
     let onStepFinishResults: StepResult<any>[];

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -205,6 +205,7 @@ Optional function that you can use to provide different settings for a step.
 @param options - The options for the step.
 @param options.steps - The steps that have been executed so far.
 @param options.stepNumber - The number of the step that is being executed.
+@param options.maxSteps - The maximum number of steps.
 @param options.model - The model that is being used.
 
 @returns An object that contains the settings for the step.
@@ -213,6 +214,7 @@ If you return undefined (or for undefined settings), the settings from the outer
     experimental_prepareStep?: (options: {
       steps: Array<StepResult<TOOLS>>;
       stepNumber: number;
+      maxSteps: number;
       model: LanguageModel;
     }) => PromiseLike<
       | {
@@ -324,6 +326,7 @@ A function that attempts to repair a tool call that failed to parse.
         const prepareStepResult = await prepareStep?.({
           model,
           steps,
+          maxSteps,
           stepNumber: stepCount,
         });
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -199,17 +199,26 @@ Optional specification for parsing structured outputs from the LLM response.
      */
     experimental_output?: Output<OUTPUT, OUTPUT_PARTIAL>;
 
+    /**
+Optional function that you can use to provide different settings for a step.
+
+@param options - The options for the step.
+@param options.steps - The steps that have been executed so far.
+@param options.stepNumber - The number of the step that is being executed.
+@param options.model - The model that is being used.
+
+@returns An object that contains the settings for the step.
+If you return undefined (or for undefined settings), the settings from the outer level will be used.
+    */
     experimental_prepareStep?: (options: {
       steps: Array<StepResult<TOOLS>>;
       stepNumber: number;
       model: LanguageModel;
-      // TODO default settings, messages, system
     }) => PromiseLike<
       | {
           model?: LanguageModel;
           toolChoice?: ToolChoice<TOOLS>;
           experimental_activeTools?: Array<keyof TOOLS>;
-          // TODO settings, messages
         }
       | undefined
     >;


### PR DESCRIPTION
## Background

For many agentic use cases, it is helpful to be able to control the different settings at each step.

## Summary

Add `experimental_prepareStep` option to `generateText` that allows modifying `model`, `toolChoice`, and `experimental_activeTools` for each step.

## Tasks

- [x] implementation
- [x] tests
- [x] documentation
- [x] changeset

## Future Work

Add to `streamText`. Add more inputs and outputs to `experimental_prepareStep`.

## Related Issues
#4954 #3944 #5478 