### PR TITLE
docs: add Browserless.io documentation link to tools list (#5830)

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -93,6 +93,7 @@ There are several providers that offer pre-built tools as **toolkits** that you 
 
 - **[agentic](https://github.com/transitive-bullshit/agentic)** - A collection of 20+ tools. Most tools connect to access external APIs such as [Exa](https://exa.ai/) or [E2B](https://e2b.dev/).
 - **[browserbase](https://docs.browserbase.com/integrations/vercel-ai/introduction)** - Browser tool that runs a headless browser
+- **[browserless](https://docs.browserless.io/ai-integrations/vercel-ai-sdk)** - Browser automation service with AI integration - self hosted or cloud based
 - **[Stripe agent tools](https://docs.stripe.com/agents)** - Tools for interacting with Stripe.
 - **[StackOne ToolSet](https://docs.stackone.com/agents)** - Agentic integrations for hundreds of [enterprise SaaS](https://www.stackone.com/integrations)
 - **[Toolhouse](https://docs.toolhouse.ai/toolhouse/using-vercel-ai)** - AI function-calling in 3 lines of code for over 25 different actions.


### PR DESCRIPTION
## Background

The AI SDK documentation currently lists various toolkits and integrations, including browser-related tools. Browserless.io provides a robust browser automation service with AI integration capabilities, and its documentation should be included alongside other similar tools to help developers discover and utilize this resource.

## Summary

This PR adds the Browserless.io documentation link to the tools list in `content/docs/02-foundations/04-tools.mdx`. The addition:
- Maintains consistent formatting with existing entries
- Places the entry logically after Browserbase (another browser-related tool)
- Provides a clear, concise description of Browserless.io's capabilities

## Future Work

- Consider adding more detailed examples of Browserless.io integration with the AI SDK
- Explore potential collaboration on additional documentation or examples
- Investigate opportunities for deeper integration between Browserless.io and the AI SDK