### PR TITLE
chore (ci): add build examples ci target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,30 @@ on:
     branches: [main, v5]
 
 jobs:
+  build-examples:
+    name: 'Build Examples'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Examples
+        run: pnpm run build:examples
+
   prettier:
     name: 'Prettier'
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "name": "ai-repo",
   "scripts": {
-    "build": "turbo build",
+    "build": "turbo build --concurrency 16",
+    "build:examples": "turbo build --filter=@example/*",
     "changeset": "changeset",
     "clean": "turbo clean",
     "dev": "turbo dev --no-cache --concurrency 16 --continue",


### PR DESCRIPTION
## Background

Building the examples surfaces errors that our typescript type checker does not find. We need to build the examples to make sure there are no unforeseen breakages.

## Summary

Add CI job that builds the examples.