### PR TITLE
feat(provider/openai): add o3 & o4-mini with developer systemMessageMode (#5932)

### DIFF
--- a/.changeset/spicy-shoes-matter.md
+++ b/.changeset/spicy-shoes-matter.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add o3 & o4-mini with developer systemMessageMode

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -718,10 +718,22 @@ const reasoningModels = {
   'o1-preview-2024-09-12': {
     systemMessageMode: 'remove',
   },
+  o3: {
+    systemMessageMode: 'developer',
+  },
+  'o3-2025-04-16': {
+    systemMessageMode: 'developer',
+  },
   'o3-mini': {
     systemMessageMode: 'developer',
   },
   'o3-mini-2025-01-31': {
+    systemMessageMode: 'developer',
+  },
+  'o4-mini': {
+    systemMessageMode: 'developer',
+  },
+  'o4-mini-2025-04-16': {
     systemMessageMode: 'developer',
   },
 } as const;


### PR DESCRIPTION
## Background

The addition of the `o4-mini` model was necessary to expand the set of available reasoning models. This new model follows the same structure as the existing `o3-mini`, with a `systemMessageMode` set to `"developer"`, ensuring consistency in the reasoning logic and providing more options for future functionality.

## Summary

Added the `o4-mini` model to the `reasoningModels` constant with a `systemMessageMode` set to `"developer"`. This allows for new reasoning configurations with the same structure as other models, such as `o3-mini`.
