### PR TITLE
chore (provider): change getSupportedUrls to supportedUrls (language model v2)

### DIFF
--- a/.changeset/green-pots-collect.md
+++ b/.changeset/green-pots-collect.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+chore (provider): change getSupportedUrls to supportedUrls (language model v2)

--- a/packages/ai/core/generate-object/generate-object.test.ts
+++ b/packages/ai/core/generate-object/generate-object.test.ts
@@ -1012,13 +1012,13 @@ describe('options.messages', () => {
     `);
   });
 
-  it('should support models that use "this" context in getSupportedUrls', async () => {
-    let getSupportedUrlsCalled = false;
+  it('should support models that use "this" context in supportedUrls', async () => {
+    let supportedUrlsCalled = false;
     class MockLanguageModelWithImageSupport extends MockLanguageModelV2 {
       constructor() {
         super({
-          async getSupportedUrls() {
-            getSupportedUrlsCalled = true;
+          supportedUrls: () => {
+            supportedUrlsCalled = true;
             // Reference 'this' to verify context
             return this.modelId === 'mock-model-id'
               ? ({ 'image/*': [/^https:\/\/.*$/] } as Record<string, RegExp[]>)
@@ -1046,6 +1046,6 @@ describe('options.messages', () => {
     });
 
     expect(result.object).toStrictEqual({ content: 'Hello, world!' });
-    expect(getSupportedUrlsCalled).toBe(true);
+    expect(supportedUrlsCalled).toBe(true);
   });
 });

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -248,7 +248,7 @@ Default and recommended: 'auto' (best mode for the model).
 
       const promptMessages = await convertToLanguageModelPrompt({
         prompt: standardizedPrompt,
-        supportedUrls: await model.getSupportedUrls(),
+        supportedUrls: await model.supportedUrls,
       });
 
       const generateResult = await retry(() =>

--- a/packages/ai/core/generate-object/stream-object.test.ts
+++ b/packages/ai/core/generate-object/stream-object.test.ts
@@ -1461,13 +1461,13 @@ describe('streamObject', () => {
       `);
     });
 
-    it('should support models that use "this" context in getSupportedUrls', async () => {
-      let getSupportedUrlsCalled = false;
+    it('should support models that use "this" context in supportedUrls', async () => {
+      let supportedUrlsCalled = false;
       class MockLanguageModelWithImageSupport extends MockLanguageModelV2 {
         constructor() {
           super({
-            async getSupportedUrls() {
-              getSupportedUrlsCalled = true;
+            supportedUrls: () => {
+              supportedUrlsCalled = true;
               // Reference 'this' to verify context
               return this.modelId === 'mock-model-id'
                 ? ({ 'image/*': [/^https:\/\/.*$/] } as Record<
@@ -1508,7 +1508,7 @@ describe('streamObject', () => {
 
       const chunks = await convertAsyncIterableToArray(result.textStream);
       expect(chunks.join('')).toBe('{ "content": "Hello, world!" }');
-      expect(getSupportedUrlsCalled).toBe(true);
+      expect(supportedUrlsCalled).toBe(true);
     });
   });
 });

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -404,7 +404,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
           ...prepareCallSettings(settings),
           prompt: await convertToLanguageModelPrompt({
             prompt: standardizedPrompt,
-            supportedUrls: await model.getSupportedUrls(),
+            supportedUrls: await model.supportedUrls,
           }),
           providerOptions,
           abortSignal,

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -1544,13 +1544,13 @@ describe('options.messages', () => {
     expect(result.text).toStrictEqual('Hello, world!');
   });
 
-  it('should support models that use "this" context in getSupportedUrls', async () => {
-    let getSupportedUrlsCalled = false;
+  it('should support models that use "this" context in supportedUrls', async () => {
+    let supportedUrlsCalled = false;
     class MockLanguageModelWithImageSupport extends MockLanguageModelV2 {
       constructor() {
         super({
-          async getSupportedUrls() {
-            getSupportedUrlsCalled = true;
+          supportedUrls() {
+            supportedUrlsCalled = true;
             // Reference 'this' to verify context
             return this.modelId === 'mock-model-id'
               ? ({ 'image/*': [/^https:\/\/.*$/] } as Record<string, RegExp[]>)
@@ -1577,7 +1577,7 @@ describe('options.messages', () => {
     });
 
     expect(result.text).toStrictEqual('Hello, world!');
-    expect(getSupportedUrlsCalled).toBe(true);
+    expect(supportedUrlsCalled).toBe(true);
   });
 });
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -329,7 +329,7 @@ A function that attempts to repair a tool call that failed to parse.
             system: initialPrompt.system,
             messages: stepInputMessages,
           },
-          supportedUrls: await model.getSupportedUrls(),
+          supportedUrls: await model.supportedUrls,
         });
 
         const stepModel = prepareStepResult?.model ?? model;

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -3293,13 +3293,13 @@ describe('streamText', () => {
       ).toStrictEqual(['Hello']);
     });
 
-    it('should support models that use "this" context in getSupportedUrls', async () => {
-      let getSupportedUrlsCalled = false;
+    it('should support models that use "this" context in supportedUrls', async () => {
+      let supportedUrlsCalled = false;
       class MockLanguageModelWithImageSupport extends MockLanguageModelV2 {
         constructor() {
           super({
-            async getSupportedUrls() {
-              getSupportedUrlsCalled = true;
+            supportedUrls() {
+              supportedUrlsCalled = true;
               // Reference 'this' to verify context
               return this.modelId === 'mock-model-id'
                 ? ({ 'image/*': [/^https:\/\/.*$/] } as Record<
@@ -3332,7 +3332,7 @@ describe('streamText', () => {
 
       await result.consumeStream();
 
-      expect(getSupportedUrlsCalled).toBe(true);
+      expect(supportedUrlsCalled).toBe(true);
       expect(await result.text).toBe('Hello, world!');
     });
   });

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -942,7 +942,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
               system: initialPrompt.system,
               messages: stepInputMessages,
             },
-            supportedUrls: await model.getSupportedUrls(),
+            supportedUrls: await model.supportedUrls,
           });
 
           const toolsAndToolChoice = {

--- a/packages/ai/core/middleware/wrap-language-model.test.ts
+++ b/packages/ai/core/middleware/wrap-language-model.test.ts
@@ -158,23 +158,23 @@ describe('wrapLanguageModel', () => {
     });
   });
 
-  it('should pass through getSupportedUrls', async () => {
+  it('should pass through supportedUrls', async () => {
     const supportedUrls = {
       'image/*': [/^https:\/\/.*$/],
     };
 
     const wrappedModel = wrapLanguageModel({
-      model: new MockLanguageModelV2({ getSupportedUrls: supportedUrls }),
+      model: new MockLanguageModelV2({ supportedUrls }),
       middleware: {
         middlewareVersion: 'v2',
       },
     });
 
-    expect(await wrappedModel.getSupportedUrls()).toStrictEqual(supportedUrls);
+    expect(await wrappedModel.supportedUrls).toStrictEqual(supportedUrls);
   });
 
-  it('should support models that use "this" context in getSupportedUrls', async () => {
-    let getSupportedUrlsCalled = false;
+  it('should support models that use "this" context in supportedUrls', async () => {
+    let supportedUrlsCalled = false;
 
     class MockLanguageModelWithImageSupport implements LanguageModelV2 {
       readonly specificationVersion = 'v2';
@@ -188,8 +188,8 @@ describe('wrapLanguageModel', () => {
         'image/*': [/^https:\/\/.*$/],
       };
 
-      async getSupportedUrls() {
-        getSupportedUrlsCalled = true;
+      get supportedUrls() {
+        supportedUrlsCalled = true;
         // Reference 'this' to verify context
         return this.value;
       }
@@ -202,8 +202,8 @@ describe('wrapLanguageModel', () => {
       middleware: { middlewareVersion: 'v2' },
     });
 
-    expect(await wrappedModel.getSupportedUrls()).toStrictEqual(model.value);
-    expect(getSupportedUrlsCalled).toBe(true);
+    expect(await wrappedModel.supportedUrls).toStrictEqual(model.value);
+    expect(supportedUrlsCalled).toBe(true);
   });
 
   describe('wrapLanguageModel with multiple middlewares', () => {

--- a/packages/ai/core/middleware/wrap-language-model.ts
+++ b/packages/ai/core/middleware/wrap-language-model.ts
@@ -63,8 +63,8 @@ const doWrap = ({
     modelId: modelId ?? model.modelId,
 
     // TODO middleware should be able to modify the supported urls
-    async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-      return model.getSupportedUrls();
+    get supportedUrls(): LanguageModelV2['supportedUrls'] {
+      return model.supportedUrls;
     },
 
     async doGenerate(

--- a/packages/ai/core/test/mock-language-model-v2.ts
+++ b/packages/ai/core/test/mock-language-model-v2.ts
@@ -4,10 +4,11 @@ import { notImplemented } from './not-implemented';
 export class MockLanguageModelV2 implements LanguageModelV2 {
   readonly specificationVersion = 'v2';
 
+  private _supportedUrls: () => LanguageModelV2['supportedUrls'];
+
   readonly provider: LanguageModelV2['provider'];
   readonly modelId: LanguageModelV2['modelId'];
 
-  getSupportedUrls: LanguageModelV2['getSupportedUrls'];
   doGenerate: LanguageModelV2['doGenerate'];
   doStream: LanguageModelV2['doStream'];
 
@@ -17,15 +18,15 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
   constructor({
     provider = 'mock-provider',
     modelId = 'mock-model-id',
-    getSupportedUrls = {},
+    supportedUrls = {},
     doGenerate = notImplemented,
     doStream = notImplemented,
   }: {
     provider?: LanguageModelV2['provider'];
     modelId?: LanguageModelV2['modelId'];
-    getSupportedUrls?:
-      | LanguageModelV2['getSupportedUrls']
-      | Awaited<ReturnType<LanguageModelV2['getSupportedUrls']>>;
+    supportedUrls?:
+      | LanguageModelV2['supportedUrls']
+      | (() => LanguageModelV2['supportedUrls']);
     doGenerate?:
       | LanguageModelV2['doGenerate']
       | Awaited<ReturnType<LanguageModelV2['doGenerate']>>
@@ -59,9 +60,13 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
         return doStream;
       }
     };
-    this.getSupportedUrls =
-      typeof getSupportedUrls === 'function'
-        ? getSupportedUrls
-        : async () => getSupportedUrls;
+    this._supportedUrls =
+      typeof supportedUrls === 'function'
+        ? supportedUrls
+        : async () => supportedUrls;
+  }
+
+  get supportedUrls() {
+    return this._supportedUrls();
   }
 }

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -183,11 +183,9 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
     };
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return {
-      // no supported urls for bedrock
-    };
-  }
+  readonly supportedUrls: Record<string, RegExp[]> = {
+    // no supported urls for bedrock
+  };
 
   async doGenerate(
     options: Parameters<LanguageModelV2['doGenerate']>[0],

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -36,7 +36,7 @@ type AnthropicMessagesConfig = {
   fetch?: FetchFunction;
   buildRequestUrl?: (baseURL: string, isStreaming: boolean) => string;
   transformRequestBody?: (args: Record<string, any>) => Record<string, any>;
-  getSupportedUrls?: LanguageModelV2['getSupportedUrls'];
+  supportedUrls?: () => LanguageModelV2['supportedUrls'];
 };
 
 export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
@@ -62,8 +62,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
     return this.config.provider;
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return this.config.getSupportedUrls?.() ?? {};
+  get supportedUrls() {
+    return this.config.supportedUrls?.() ?? {};
   }
 
   private async getArgs({

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -91,7 +91,7 @@ export function createAnthropic(
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,
-      getSupportedUrls: async () => ({
+      supportedUrls: () => ({
         'image/*': [/^https?:\/\/.*$/],
       }),
     });

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -32,17 +32,15 @@ export class CohereChatLanguageModel implements LanguageModelV2 {
 
   readonly modelId: CohereChatModelId;
 
+  readonly supportedUrls = {
+    // No URLs are supported.
+  };
+
   private readonly config: CohereChatConfig;
 
   constructor(modelId: CohereChatModelId, config: CohereChatConfig) {
     this.modelId = modelId;
     this.config = config;
-  }
-
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return {
-      // No URLs are supported.
-    };
   }
 
   get provider(): string {

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -121,7 +121,7 @@ export function createVertex(
     return new GoogleGenerativeAILanguageModel(modelId, {
       ...createConfig('chat'),
       generateId: options.generateId ?? generateId,
-      getSupportedUrls: async () => ({
+      supportedUrls: () => ({
         '*': [
           // HTTP URLs:
           /^https?:\/\/.*$/,

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -755,7 +755,7 @@ describe('doGenerate', () => {
           'X-Common': 'config-value',
         }),
         generateId: () => 'test-id',
-        getSupportedUrls: async () => ({
+        supportedUrls: () => ({
           '*': [/^https?:\/\/.*$/],
         }),
       });

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -42,7 +42,7 @@ type GoogleGenerativeAIConfig = {
   /**
    * The supported URLs for the model.
    */
-  getSupportedUrls?: LanguageModelV2['getSupportedUrls'];
+  supportedUrls?: () => LanguageModelV2['supportedUrls'];
 };
 
 export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
@@ -64,8 +64,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
     return this.config.provider;
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return this.config.getSupportedUrls?.() ?? {};
+  get supportedUrls() {
+    return this.config.supportedUrls?.() ?? {};
   }
 
   private async getArgs({

--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -36,7 +36,7 @@ describe('google-provider', () => {
         baseURL: 'https://generativelanguage.googleapis.com/v1beta',
         headers: expect.any(Function),
         generateId: expect.any(Function),
-        getSupportedUrls: expect.any(Function),
+        supportedUrls: expect.any(Function),
       }),
     );
   });

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -101,7 +101,7 @@ export function createGoogleGenerativeAI(
       baseURL,
       headers: getHeaders,
       generateId: options.generateId ?? generateId,
-      getSupportedUrls: async () => ({
+      supportedUrls: () => ({
         '*': [
           // HTTP URLs:
           /^https?:\/\/.*$/,

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -39,6 +39,10 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
 
   readonly modelId: GroqChatModelId;
 
+  readonly supportedUrls = {
+    'image/*': [/^https?:\/\/.*$/],
+  };
+
   private readonly config: GroqChatConfig;
 
   constructor(modelId: GroqChatModelId, config: GroqChatConfig) {
@@ -48,12 +52,6 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
 
   get provider(): string {
     return this.config.provider;
-  }
-
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return {
-      'image/*': [/^https:\/\/.*$/],
-    };
   }
 
   private async getArgs({

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -49,11 +49,9 @@ export class MistralChatLanguageModel implements LanguageModelV2 {
     return this.config.provider;
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return {
-      'application/pdf': [/^https:\/\/.*$/],
-    };
-  }
+  readonly supportedUrls: Record<string, RegExp[]> = {
+    'application/pdf': [/^https:\/\/.*$/],
+  };
 
   private async getArgs({
     prompt,

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -53,7 +53,7 @@ export type OpenAICompatibleChatConfig = {
   /**
    * The supported URLs for the model.
    */
-  getSupportedUrls?: () => Promise<Record<string, RegExp[]>>;
+  supportedUrls?: () => LanguageModelV2['supportedUrls'];
 };
 
 export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
@@ -92,8 +92,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
     return this.config.provider.split('.')[0].trim();
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return this.config.getSupportedUrls?.() ?? {};
+  get supportedUrls() {
+    return this.config.supportedUrls?.() ?? {};
   }
 
   private async getArgs({

--- a/packages/openai-compatible/src/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-completion-language-model.ts
@@ -42,7 +42,7 @@ type OpenAICompatibleCompletionConfig = {
   /**
    * The supported URLs for the model.
    */
-  getSupportedUrls?: () => Promise<Record<string, RegExp[]>>;
+  supportedUrls?: () => LanguageModelV2['supportedUrls'];
 };
 
 export class OpenAICompatibleCompletionLanguageModel
@@ -79,8 +79,8 @@ export class OpenAICompatibleCompletionLanguageModel
     return this.config.provider.split('.')[0].trim();
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return this.config.getSupportedUrls?.() ?? {};
+  get supportedUrls() {
+    return this.config.supportedUrls?.() ?? {};
   }
 
   private async getArgs({

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -47,6 +47,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
 
   readonly modelId: OpenAIChatModelId;
 
+  readonly supportedUrls = {
+    'image/*': [/^https?:\/\/.*$/],
+  };
+
   private readonly config: OpenAIChatConfig;
 
   constructor(modelId: OpenAIChatModelId, config: OpenAIChatConfig) {
@@ -56,12 +60,6 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
 
   get provider(): string {
     return this.config.provider;
-  }
-
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return {
-      'image/*': [/^https?:\/\/.*$/],
-    };
   }
 
   private async getArgs({

--- a/packages/openai/src/openai-completion-language-model.ts
+++ b/packages/openai/src/openai-completion-language-model.ts
@@ -58,11 +58,9 @@ export class OpenAICompletionLanguageModel implements LanguageModelV2 {
     return this.config.provider;
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return {
-      // no supported urls for completion models
-    };
-  }
+  readonly supportedUrls: Record<string, RegExp[]> = {
+    // No URLs are supported for completion models.
+  };
 
   private async getArgs({
     prompt,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -35,11 +35,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
     this.config = config;
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return {
-      'image/*': [/^https?:\/\/.*$/],
-    };
-  }
+  readonly supportedUrls: Record<string, RegExp[]> = {
+    'image/*': [/^https?:\/\/.*$/],
+  };
 
   get provider(): string {
     return this.config.provider;

--- a/packages/perplexity/src/perplexity-language-model.ts
+++ b/packages/perplexity/src/perplexity-language-model.ts
@@ -43,11 +43,9 @@ export class PerplexityLanguageModel implements LanguageModelV2 {
     this.config = config;
   }
 
-  async getSupportedUrls(): Promise<Record<string, RegExp[]>> {
-    return {
-      // No URLs are supported.
-    };
-  }
+  readonly supportedUrls: Record<string, RegExp[]> = {
+    // No URLs are supported.
+  };
 
   private getArgs({
     prompt,

--- a/packages/provider/src/language-model/v2/language-model-v2.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2.ts
@@ -42,7 +42,9 @@ Provider-specific model ID for logging purposes.
    *
    * @returns A promise resolving to a map of supported URL patterns.
    */
-  getSupportedUrls(): PromiseLike<Record<string, RegExp[]>>;
+  supportedUrls:
+    | PromiseLike<Record<string, RegExp[]>>
+    | Record<string, RegExp[]>;
 
   /**
 Generates a language model output (non-streaming).

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -272,7 +272,7 @@ functionality that can be fully encapsulated in the provider.
       }),
       prompt: await convertToLanguageModelPrompt({
         prompt: validatedPrompt,
-        supportedUrls: await model.getSupportedUrls(),
+        supportedUrls: await model.supportedUrls,
       }),
       providerOptions,
       abortSignal,


### PR DESCRIPTION
## Background

To simplify language model v2 implementations.

## Summary

Changed `getSupportedUrls` to `supportedUrls`