### PR TITLE
chore (ai): use JSONValue definition from provider

### DIFF
--- a/.changeset/serious-numbers-teach.md
+++ b/.changeset/serious-numbers-teach.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore (ai): use JSONValue definition from provider

--- a/packages/ai/core/types/index.ts
+++ b/packages/ai/core/types/index.ts
@@ -4,6 +4,7 @@ export type {
   ImageGenerationWarning as ImageModelCallWarning,
 } from './image-model';
 export type { ImageModelResponseMetadata } from './image-model-response-metadata';
+export type { JSONValue } from './json-value';
 export type {
   CallWarning,
   FinishReason,
@@ -13,13 +14,13 @@ export type {
 export type { LanguageModelRequestMetadata } from './language-model-request-metadata';
 export type { LanguageModelResponseMetadata } from './language-model-response-metadata';
 export type { Provider } from './provider';
-export type { ProviderOptions, ProviderMetadata } from './provider-metadata';
-export type { EmbeddingModelUsage, LanguageModelUsage } from './usage';
-export * from './ui-messages';
+export type { ProviderMetadata, ProviderOptions } from './provider-metadata';
+export type { SpeechModel, SpeechWarning } from './speech-model';
+export type { SpeechModelResponseMetadata } from './speech-model-response-metadata';
 export type {
   TranscriptionModel,
   TranscriptionWarning,
 } from './transcription-model';
 export type { TranscriptionModelResponseMetadata } from './transcription-model-response-metadata';
-export type { SpeechModel, SpeechWarning } from './speech-model';
-export type { SpeechModelResponseMetadata } from './speech-model-response-metadata';
+export * from './ui-messages';
+export type { EmbeddingModelUsage, LanguageModelUsage } from './usage';

--- a/packages/ai/core/types/json-value.ts
+++ b/packages/ai/core/types/json-value.ts
@@ -1,4 +1,4 @@
-import { JSONValue } from '@ai-sdk/provider';
+import { JSONValue as OriginalJSONValue } from '@ai-sdk/provider';
 import { z } from 'zod';
 
 export const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
@@ -11,3 +11,5 @@ export const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
     z.array(jsonValueSchema),
   ]),
 );
+
+export type JSONValue = OriginalJSONValue;

--- a/packages/ai/core/types/ui-messages.ts
+++ b/packages/ai/core/types/ui-messages.ts
@@ -1,4 +1,5 @@
 import {
+  JSONValue,
   LanguageModelV2FinishReason,
   LanguageModelV2Source,
 } from '@ai-sdk/provider';
@@ -459,15 +460,3 @@ or to provide a custom fetch implementation for e.g. testing.
     */
   fetch?: FetchFunction;
 };
-
-/**
-A JSON value can be a string, number, boolean, object, array, or null.
-JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods.
- */
-export type JSONValue =
-  | null
-  | string
-  | number
-  | boolean
-  | { [value: string]: JSONValue }
-  | Array<JSONValue>;

--- a/packages/ai/core/util/call-chat-api.ts
+++ b/packages/ai/core/util/call-chat-api.ts
@@ -1,6 +1,7 @@
 import { processChatResponse } from './process-chat-response';
 import { processChatTextResponse } from './process-chat-text-response';
-import { IdGenerator, JSONValue, UIMessage, UseChatOptions } from '../types';
+import { IdGenerator, UIMessage, UseChatOptions } from '../types';
+import { JSONValue } from '@ai-sdk/provider';
 
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => fetch;

--- a/packages/ai/core/util/process-chat-response.ts
+++ b/packages/ai/core/util/process-chat-response.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV2FinishReason } from '@ai-sdk/provider';
+import { JSONValue, LanguageModelV2FinishReason } from '@ai-sdk/provider';
 import { generateId as generateIdFunction } from '@ai-sdk/provider-utils';
 import {
   calculateLanguageModelUsage,
@@ -7,7 +7,6 @@ import {
 import { parsePartialJson } from './parse-partial-json';
 import { processDataStream } from './process-data-stream';
 import type {
-  JSONValue,
   ReasoningUIPart,
   TextUIPart,
   ToolInvocation,

--- a/packages/provider/src/json-value/json-value.ts
+++ b/packages/provider/src/json-value/json-value.ts
@@ -1,3 +1,7 @@
+/**
+A JSON value can be a string, number, boolean, object, array, or null.
+JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods.
+ */
 export type JSONValue =
   | null
   | string


### PR DESCRIPTION
## Background

We had two (similar) definitions of `JSONValue`.

## Summary

Use only the `JSONValue` definition from `provider`.