### PR TITLE
docs: Add Next.js v14 configuration requirements to LangSmith docs (#5974)

### DIFF
--- a/content/providers/05-observability/langsmith.mdx
+++ b/content/providers/05-observability/langsmith.mdx
@@ -69,6 +69,18 @@ export function register() {
 
 You can learn more how to [setup OpenTelemetry instrumentation within your Next.js app here](https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation).
 
+If you are using Next.js version 14, you need to add the following configuration to your `next.config.js`:
+
+```js
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+};
+```
+
+For more information, see the [Next.js documentation on instrumentationHook](https://nextjs.org/docs/14/pages/api-reference/next-config-js/instrumentationHook).
+
 Afterwards, add the `experimental_telemetry` argument to your AI SDK calls that you want to trace. For convenience, we've included the `AISDKExporter.getSettings()` method which appends additional metadata for LangSmith.
 
 ```ts highlight="8"


### PR DESCRIPTION
## Background

To get LangSmith tracing to work correctly in Next.js v14, it seems that enabling the instrumentation hook via next.config.js is necessary. This might be a helpful addition to the docs.

## Summary

Added a section to the LangSmith observability documentation explaining the required `next.config.js` configuration for Next.js v14 users, including:
- Code example showing how to enable the instrumentation hook
- Link to the official Next.js documentation for further reference