### PR TITLE
feat (provider/google): add new gemini models (#6023)

### DIFF
--- a/.changeset/chilly-tips-know.md
+++ b/.changeset/chilly-tips-know.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat (provider/google): add new gemini models

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -509,16 +509,17 @@ The following Zod features are known to not work with Google Generative AI:
 
 ### Model Capabilities
 
-| Model                        | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
-| ---------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `gemini-2.5-pro-exp-03-25`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-2.0-flash-001`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-pro`             | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-pro-latest`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-flash`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-flash-latest`    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-flash-8b`        | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-flash-8b-latest` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| Model                            | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
+| -------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gemini-2.5-flash-preview-04-17` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-2.5-pro-exp-03-25`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-2.0-flash`               | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-pro`                 | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-pro-latest`          | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-flash`               | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-flash-latest`        | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-flash-8b`            | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-flash-8b-latest`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   The table above lists popular models. Please see the [Google Generative AI

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 export type GoogleGenerativeAIModelId =
   // Stable models
   // https://ai.google.dev/gemini-api/docs/models/gemini
-  | 'gemini-2.0-flash-001'
   | 'gemini-1.5-flash'
   | 'gemini-1.5-flash-latest'
   | 'gemini-1.5-flash-001'
@@ -15,13 +14,17 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-1.5-pro-latest'
   | 'gemini-1.5-pro-001'
   | 'gemini-1.5-pro-002'
-  // Experimental models
-  // https://ai.google.dev/gemini-api/docs/models/experimental-models
-  | 'gemini-2.5-pro-exp-03-25'
-  | 'gemini-2.0-flash-lite-preview-02-05'
+  | 'gemini-2.0-flash'
+  | 'gemini-2.0-flash-001'
+  | 'gemini-2.0-flash-live-001'
+  | 'gemini-2.0-flash-lite'
   | 'gemini-2.0-pro-exp-02-05'
   | 'gemini-2.0-flash-thinking-exp-01-21'
   | 'gemini-2.0-flash-exp'
+  // Experimental models
+  // https://ai.google.dev/gemini-api/docs/models/experimental-models
+  | 'gemini-2.5-pro-exp-03-25'
+  | 'gemini-2.5-flash-preview-04-17'
   | 'gemini-exp-1206'
   | 'gemma-3-27b-it'
   | 'learnlm-1.5-pro-experimental'


### PR DESCRIPTION
## Summary
This adds the new gemini models as listed on
https://developers.googleblog.com/en/start-building-with-gemini-25-flash/