### PR TITLE
fix(append): support Message.experimental_attachments

### DIFF
--- a/.changeset/great-carrots-sing.md
+++ b/.changeset/great-carrots-sing.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/react': patch
+'@ai-sdk/solid': patch
+'@ai-sdk/vue': patch
+---
+
+fix(append): support Message.experimental_attachments alongside ChatRequestOptions

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -407,7 +407,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
         data,
         headers,
         body,
-        experimental_attachments,
+        experimental_attachments = message.experimental_attachments,
       }: ChatRequestOptions = {},
     ) => {
       const attachmentsForRequest = await prepareAttachmentsForRequest(

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1504,37 +1504,35 @@ describe('attachments with empty submit', () => {
   });
 });
 
-describe('should append message with attachments', () => {
-  setupTestComponent(() => {
-    const { messages, append } = useChat();
+describe('append', () => {
+  describe('should append message with Message.experimental_attachments', () => {
+    setupTestComponent(() => {
+      const { messages, append } = useChat();
 
-    return (
-      <div>
-        {messages.map((m, idx) => (
-          <div data-testid={`message-${idx}`} key={m.id}>
-            {m.role === 'user' ? 'User: ' : 'AI: '}
-            {m.content}
-            {m.experimental_attachments?.map(attachment => (
-              <img
-                key={attachment.name}
-                src={attachment.url}
-                alt={attachment.name}
-                data-testid={`attachment-${idx}`}
-              />
-            ))}
-          </div>
-        ))}
+      return (
+        <div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.content}
+              {m.experimental_attachments?.map(attachment => (
+                <img
+                  key={attachment.name}
+                  src={attachment.url}
+                  alt={attachment.name}
+                  data-testid={`attachment-${idx}`}
+                />
+              ))}
+            </div>
+          ))}
 
-        <form
-          onSubmit={event => {
-            event.preventDefault();
+          <form
+            onSubmit={event => {
+              event.preventDefault();
 
-            append(
-              {
+              append({
                 role: 'user',
                 content: 'Message with image attachment',
-              },
-              {
                 experimental_attachments: [
                   {
                     name: 'test.png',
@@ -1542,58 +1540,151 @@ describe('should append message with attachments', () => {
                     url: 'https://example.com/image.png',
                   },
                 ],
+              });
+            }}
+            data-testid="chat-form"
+          >
+            <button type="submit" data-testid="submit-button">
+              Send
+            </button>
+          </form>
+        </div>
+      );
+    });
+
+    it('should handle image file attachment and submission', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: ['0:"Response to message with image attachment"\n'],
+      };
+
+      const submitButton = screen.getByTestId('submit-button');
+      await userEvent.click(submitButton);
+
+      await screen.findByTestId('message-0');
+      expect(screen.getByTestId('message-0')).toHaveTextContent(
+        'User: Message with image attachment',
+      );
+
+      await screen.findByTestId('attachment-0');
+      expect(screen.getByTestId('attachment-0')).toHaveAttribute(
+        'src',
+        expect.stringContaining('https://example.com/image.png'),
+      );
+
+      await screen.findByTestId('message-1');
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
+
+      expect(await server.calls[0].requestBody).toStrictEqual({
+        id: expect.any(String),
+        messages: [
+          {
+            role: 'user',
+            content: 'Message with image attachment',
+            experimental_attachments: [
+              {
+                name: 'test.png',
+                contentType: 'image/png',
+                url: 'https://example.com/image.png',
               },
-            );
-          }}
-          data-testid="chat-form"
-        >
-          <button type="submit" data-testid="submit-button">
-            Send
-          </button>
-        </form>
-      </div>
-    );
+            ],
+            parts: [{ text: 'Message with image attachment', type: 'text' }],
+          },
+        ],
+      });
+    });
   });
+  describe('should append message with ChatRequestOptions.experimental_attachments', () => {
+    setupTestComponent(() => {
+      const { messages, append } = useChat();
 
-  it('should handle image file attachment and submission', async () => {
-    server.urls['/api/chat'].response = {
-      type: 'stream-chunks',
-      chunks: ['0:"Response to message with image attachment"\n'],
-    };
+      return (
+        <div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.content}
+              {m.experimental_attachments?.map(attachment => (
+                <img
+                  key={attachment.name}
+                  src={attachment.url}
+                  alt={attachment.name}
+                  data-testid={`attachment-${idx}`}
+                />
+              ))}
+            </div>
+          ))}
 
-    const submitButton = screen.getByTestId('submit-button');
-    await userEvent.click(submitButton);
+          <form
+            onSubmit={event => {
+              event.preventDefault();
 
-    await screen.findByTestId('message-0');
-    expect(screen.getByTestId('message-0')).toHaveTextContent(
-      'User: Message with image attachment',
-    );
+              append(
+                {
+                  role: 'user',
+                  content: 'Message with image attachment',
+                },
+                {
+                  experimental_attachments: [
+                    {
+                      name: 'test.png',
+                      contentType: 'image/png',
+                      url: 'https://example.com/image.png',
+                    },
+                  ],
+                },
+              );
+            }}
+            data-testid="chat-form"
+          >
+            <button type="submit" data-testid="submit-button">
+              Send
+            </button>
+          </form>
+        </div>
+      );
+    });
 
-    await screen.findByTestId('attachment-0');
-    expect(screen.getByTestId('attachment-0')).toHaveAttribute(
-      'src',
-      expect.stringContaining('https://example.com/image.png'),
-    );
+    it('should handle image file attachment and submission', async () => {
+      server.urls['/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: ['0:"Response to message with image attachment"\n'],
+      };
 
-    await screen.findByTestId('message-1');
-    expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
+      const submitButton = screen.getByTestId('submit-button');
+      await userEvent.click(submitButton);
 
-    expect(await server.calls[0].requestBody).toStrictEqual({
-      id: expect.any(String),
-      messages: [
-        {
-          role: 'user',
-          content: 'Message with image attachment',
-          experimental_attachments: [
-            {
-              name: 'test.png',
-              contentType: 'image/png',
-              url: 'https://example.com/image.png',
-            },
-          ],
-          parts: [{ text: 'Message with image attachment', type: 'text' }],
-        },
-      ],
+      await screen.findByTestId('message-0');
+      expect(screen.getByTestId('message-0')).toHaveTextContent(
+        'User: Message with image attachment',
+      );
+
+      await screen.findByTestId('attachment-0');
+      expect(screen.getByTestId('attachment-0')).toHaveAttribute(
+        'src',
+        expect.stringContaining('https://example.com/image.png'),
+      );
+
+      await screen.findByTestId('message-1');
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI:');
+
+      expect(await server.calls[0].requestBody).toStrictEqual({
+        id: expect.any(String),
+        messages: [
+          {
+            role: 'user',
+            content: 'Message with image attachment',
+            experimental_attachments: [
+              {
+                name: 'test.png',
+                contentType: 'image/png',
+                url: 'https://example.com/image.png',
+              },
+            ],
+            parts: [{ text: 'Message with image attachment', type: 'text' }],
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/solid/src/use-chat.ts
+++ b/packages/solid/src/use-chat.ts
@@ -375,7 +375,12 @@ export function useChat(
 
   const append: UseChatHelpers['append'] = async (
     message,
-    { data, headers, body, experimental_attachments } = {},
+    {
+      data,
+      headers,
+      body,
+      experimental_attachments = message.experimental_attachments,
+    } = {},
   ) => {
     const attachmentsForRequest = await prepareAttachmentsForRequest(
       experimental_attachments,

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -317,7 +317,7 @@ export function useChat(
 
   const append: UseChatHelpers['append'] = async (message, options) => {
     const attachmentsForRequest = await prepareAttachmentsForRequest(
-      options?.experimental_attachments,
+      options?.experimental_attachments ?? message.experimental_attachments,
     );
 
     return triggerRequest(


### PR DESCRIPTION
## Background

We didn't support `Message.experimental_attachments` which is confusing since you have to pass it in a second argument

fixes #4908

## Summary

Added support for `Message.experimental_attachments`

## Verification

E2E test

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
