### PR TITLE
fix(react-native): support experimental_attachments without FileList global

### DIFF
--- a/.changeset/large-ties-own.md
+++ b/.changeset/large-ties-own.md
@@ -2,4 +2,4 @@
 '@ai-sdk/ui-utils': patch
 ---
 
-fix(react-native): don't use FileList global
+fix(react-native): support experimental_attachments without FileList global

--- a/.changeset/large-ties-own.md
+++ b/.changeset/large-ties-own.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/ui-utils': patch
+---
+
+fix(react-native): don't use FileList global

--- a/packages/ui-utils/src/prepare-attachments-for-request.ts
+++ b/packages/ui-utils/src/prepare-attachments-for-request.ts
@@ -7,7 +7,10 @@ export async function prepareAttachmentsForRequest(
     return [];
   }
 
-  if (attachmentsFromOptions instanceof FileList) {
+  if (
+    globalThis.FileList &&
+    attachmentsFromOptions instanceof globalThis.FileList
+  ) {
     return Promise.all(
       Array.from(attachmentsFromOptions).map(async attachment => {
         const { name, type } = attachment;

--- a/packages/ui-utils/src/prepare-attachments-for-request.ts
+++ b/packages/ui-utils/src/prepare-attachments-for-request.ts
@@ -7,6 +7,9 @@ export async function prepareAttachmentsForRequest(
     return [];
   }
 
+  // https://github.com/vercel/ai/pull/6045
+  // React-native doesn't have a FileList
+  // global variable, so we need to check for it
   if (
     globalThis.FileList &&
     attachmentsFromOptions instanceof globalThis.FileList


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

As brought up in https://github.com/vercel/ai/issues/4908#issuecomment-2769490659, react-native doesn't have the FileList global

## Summary

Conditionally check for it

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
