### PR TITLE
fix(react-native): support experimental_attachments without FileList global (#6045)

### DIFF
--- a/.changeset/large-ties-own.md
+++ b/.changeset/large-ties-own.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/ui-utils': patch
+---
+
+fix(react-native): support experimental_attachments without FileList global

--- a/packages/ai/core/util/prepare-attachments-for-request.ts
+++ b/packages/ai/core/util/prepare-attachments-for-request.ts
@@ -7,7 +7,13 @@ export async function prepareAttachmentsForRequest(
     return [];
   }
 
-  if (attachmentsFromOptions instanceof FileList) {
+  // https://github.com/vercel/ai/pull/6045
+  // React-native doesn't have a FileList
+  // global variable, so we need to check for it
+  if (
+    globalThis.FileList &&
+    attachmentsFromOptions instanceof globalThis.FileList
+  ) {
     return Promise.all(
       Array.from(attachmentsFromOptions).map(async attachment => {
         const { name, type } = attachment;


### PR DESCRIPTION
## Background

As brought up in
https://github.com/vercel/ai/issues/4908#issuecomment-2769490659, react-native doesn't have the FileList global

## Summary

Conditionally check for it