### PR TITLE
chore (ai/mcp): add `assertCapability` method to experimental MCP client (#6047)

### DIFF
--- a/.changeset/sour-mails-cheer.md
+++ b/.changeset/sour-mails-cheer.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore (ai/mcp): add `assertCapability` method to experimental MCP client

--- a/packages/ai/core/tool/mcp/mock-mcp-transport.ts
+++ b/packages/ai/core/tool/mcp/mock-mcp-transport.ts
@@ -82,6 +82,17 @@ export class MockMCPTransport implements MCPTransport {
 
       if (message.method === 'tools/list') {
         await delay(10);
+        if (this.tools.length === 0) {
+          this.onmessage?.({
+            jsonrpc: '2.0',
+            id: message.id,
+            error: {
+              code: -32000,
+              message: 'Method not supported',
+            },
+          });
+          return;
+        }
         this.onmessage?.({
           jsonrpc: '2.0',
           id: message.id,


### PR DESCRIPTION
## Background

Splits up https://github.com/vercel/ai/pull/5972 into package changes and updates to examples.

## Summary

Moves capabilities validation downstream to the request level instead of the method level.

This PR adds a new private `assertCapability` method called at the request level. This means our custom, lightweight client defaults strict mode to true for tool listing and tool calling.
