### PR TITLE
fix (react): integrate addToolResult into UseChatHelpers type without intersection

### DIFF
--- a/.changeset/hungry-trains-compete.md
+++ b/.changeset/hungry-trains-compete.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix (react): integrate addToolResult into UseChatHelpers type without intersection

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -106,6 +106,14 @@ export type UseChatHelpers = {
       | ((data: JSONValue[] | undefined) => JSONValue[] | undefined),
   ) => void;
 
+  addToolResult: ({
+    toolCallId,
+    result,
+  }: {
+    toolCallId: string;
+    result: any;
+  }) => void;
+
   /** The id of the chat */
   id: string;
 };
@@ -164,15 +172,7 @@ A maximum number is required to prevent infinite loops in the case of misconfigu
 By default, it's set to 1, which means that only a single LLM call is made.
  */
   maxSteps?: number;
-} = {}): UseChatHelpers & {
-  addToolResult: ({
-    toolCallId,
-    result,
-  }: {
-    toolCallId: string;
-    result: any;
-  }) => void;
-} {
+} = {}): UseChatHelpers {
   // Generate ID once, store in state for stability across re-renders
   const [hookId] = useState(generateId);
 


### PR DESCRIPTION
## Background
Unnecessary type intersection used for addToolResult in React's useChat implementation.

## Summary
Integrated addToolResult directly into UseChatHelpers type for cleaner type definition.

## Verification
Type checking works as expected with no functional changes.

## Tasks
- [x] A _patch_ changeset for relevant packages has been added
- [x] Formatting issues have been fixed

This PR replaces #6055 which was originally targeted at the main branch.
I've closed the original PR and created this new one targeting the v5 branch.
