### PR TITLE
chore (ai): remove "data" UIMessage role

### DIFF
--- a/.changeset/curvy-lobsters-share.md
+++ b/.changeset/curvy-lobsters-share.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): remove "data" UIMessage role

--- a/packages/ai/core/prompt/convert-to-core-messages.ts
+++ b/packages/ai/core/prompt/convert-to-core-messages.ts
@@ -213,11 +213,6 @@ export function convertToCoreMessages<TOOLS extends ToolSet = never>(
         break;
       }
 
-      case 'data': {
-        // ignore
-        break;
-      }
-
       default: {
         const _exhaustiveCheck: never = role;
         throw new MessageConversionError({

--- a/packages/ai/core/prompt/detect-prompt-type.test.ts
+++ b/packages/ai/core/prompt/detect-prompt-type.test.ts
@@ -12,17 +12,6 @@ it('should return "messages" for empty arrays', () => {
   expect(detectPromptType([])).toBe('messages');
 });
 
-it('should detect UI messages with data role', () => {
-  const messages: Omit<UIMessage, 'id'>[] = [
-    {
-      role: 'data',
-      content: 'some data',
-      parts: [{ text: 'some data', type: 'text' }],
-    },
-  ];
-  expect(detectPromptType(messages)).toBe('ui-messages');
-});
-
 it('should detect UI messages with experimental_attachments', () => {
   const messages: Omit<UIMessage, 'id'>[] = [
     {

--- a/packages/ai/core/types/ui-messages.ts
+++ b/packages/ai/core/types/ui-messages.ts
@@ -64,27 +64,27 @@ Text content of the message. Use parts when possible.
   content: string;
 
   /**
-   * Additional attachments to be sent along with the message.
+Additional attachments to be sent along with the message.
    */
   // TODO replace with FileUIParts in user messages
   experimental_attachments?: Attachment[];
 
   /**
-The 'data' role is deprecated.
+The role of the message.
    */
-  role: 'system' | 'user' | 'assistant' | 'data';
+  role: 'system' | 'user' | 'assistant';
 
   /**
-   * Additional message-specific information added on the server via StreamData
+Additional message-specific information added on the server via StreamData
    */
   // TODO replace with special part
   annotations?: JSONValue[] | undefined;
 
   /**
-   * The parts of the message. Use this for rendering the message in the UI.
-   *
-   * Assistant messages can have text, reasoning and tool invocation parts.
-   * User messages can have text parts.
+The parts of the message. Use this for rendering the message in the UI.
+
+Assistant messages can have text, reasoning and tool invocation parts.
+User messages can have text parts.
    */
   parts: Array<UIMessagePart>;
 }


### PR DESCRIPTION
## Background

The `data` role was intended for `useAssistant` which has been removed.

## Summary

Remove the `data` message role from `UIMessage`.