### PR TITLE
chore (ai): rename reasoning UI parts 'reasoning' property to 'text'

### DIFF
--- a/.changeset/tough-mugs-fail.md
+++ b/.changeset/tough-mugs-fail.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): rename reasoning UI parts 'reasoning' property to 'text'

--- a/examples/next-openai/app/use-chat-reasoning-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-reasoning-tools/page.tsx
@@ -48,7 +48,7 @@ export default function Chat() {
                   key={index}
                   className="max-w-full mb-4 overflow-x-auto italic text-gray-500 break-words whitespace-pre-wrap"
                 >
-                  {part.reasoning}
+                  {part.text}
                 </pre>
               );
             }

--- a/examples/next-openai/app/use-chat-reasoning/page.tsx
+++ b/examples/next-openai/app/use-chat-reasoning/page.tsx
@@ -45,7 +45,7 @@ export default function Chat() {
                     key={index}
                     className="max-w-full mb-4 overflow-x-auto italic text-gray-500 break-words whitespace-pre-wrap"
                   >
-                    {part.reasoning}
+                    {part.text}
                   </pre>
                 );
               }

--- a/packages/ai/core/prompt/__snapshots__/append-response-messages.test.ts.snap
+++ b/packages/ai/core/prompt/__snapshots__/append-response-messages.test.ts.snap
@@ -185,7 +185,7 @@ exports[`appendResponseMessages > after assistant message > appends assistant me
             "signature": "sig-1",
           },
         },
-        "reasoning": "reasoning part",
+        "text": "reasoning part",
         "type": "reasoning",
       },
       {
@@ -198,7 +198,7 @@ exports[`appendResponseMessages > after assistant message > appends assistant me
             "signature": "sig-2",
           },
         },
-        "reasoning": "reasoning part 2",
+        "text": "reasoning part 2",
         "type": "reasoning",
       },
       {
@@ -340,7 +340,7 @@ exports[`appendResponseMessages > after user message > appends assistant message
             "isRedacted": true,
           },
         },
-        "reasoning": "reasoning partredacted part",
+        "text": "reasoning partredacted part",
         "type": "reasoning",
       },
       {
@@ -353,7 +353,7 @@ exports[`appendResponseMessages > after user message > appends assistant message
             "signature": "sig-2",
           },
         },
-        "reasoning": "reasoning part 2",
+        "text": "reasoning part 2",
         "type": "reasoning",
       },
       {

--- a/packages/ai/core/prompt/append-response-messages.ts
+++ b/packages/ai/core/prompt/append-response-messages.ts
@@ -94,13 +94,13 @@ Internal. For test use only. May change without notice.
                 if (reasoningPart == null) {
                   reasoningPart = {
                     type: 'reasoning' as const,
-                    reasoning: '',
+                    text: '',
                   };
                   parts.push(reasoningPart);
                 }
 
                 reasoningTextContent = (reasoningTextContent ?? '') + part.text;
-                reasoningPart.reasoning += part.text;
+                reasoningPart.text += part.text;
                 reasoningPart.providerMetadata = part.providerOptions;
                 break;
               }

--- a/packages/ai/core/prompt/convert-to-core-messages.test.ts
+++ b/packages/ai/core/prompt/convert-to-core-messages.test.ts
@@ -258,7 +258,7 @@ describe('convertToCoreMessages', () => {
           parts: [
             {
               type: 'reasoning',
-              reasoning: 'Thinking...',
+              text: 'Thinking...',
               providerMetadata: {
                 testProvider: {
                   signature: '1234567890',
@@ -267,7 +267,7 @@ describe('convertToCoreMessages', () => {
             },
             {
               type: 'reasoning',
-              reasoning: 'redacted-data',
+              text: 'redacted-data',
               providerMetadata: {
                 testProvider: { isRedacted: true },
               },

--- a/packages/ai/core/prompt/convert-to-core-messages.ts
+++ b/packages/ai/core/prompt/convert-to-core-messages.ts
@@ -93,7 +93,7 @@ export function convertToCoreMessages<TOOLS extends ToolSet = never>(
                 case 'reasoning': {
                   content.push({
                     type: 'reasoning' as const,
-                    text: part.reasoning,
+                    text: part.text,
                     providerOptions: part.providerMetadata,
                   });
                   break;

--- a/packages/ai/core/types/ui-messages.ts
+++ b/packages/ai/core/types/ui-messages.ts
@@ -118,8 +118,7 @@ export type ReasoningUIPart = {
   /**
    * The reasoning text.
    */
-  // TODO: v5 rename to `text`
-  reasoning: string;
+  text: string;
 
   /**
    * The provider metadata.

--- a/packages/ai/core/util/__snapshots__/process-chat-response.test.ts.snap
+++ b/packages/ai/core/util/__snapshots__/process-chat-response.test.ts.snap
@@ -581,7 +581,7 @@ exports[`scenario: server provides reasoning > should call the onFinish function
               "signature": "abc123",
             },
           },
-          "reasoning": "I will open the conversation with witty banter. redacted-dataOnce the user has relaxed, I will pry for valuable information.",
+          "text": "I will open the conversation with witty banter. redacted-dataOnce the user has relaxed, I will pry for valuable information.",
           "type": "reasoning",
         },
         {
@@ -630,7 +630,7 @@ exports[`scenario: server provides reasoning > should call the update function w
         },
         {
           "providerMetadata": undefined,
-          "reasoning": "I will open the conversation",
+          "text": "I will open the conversation",
           "type": "reasoning",
         },
       ],
@@ -655,7 +655,7 @@ exports[`scenario: server provides reasoning > should call the update function w
               "signature": "1234567890",
             },
           },
-          "reasoning": "I will open the conversation with witty banter. ",
+          "text": "I will open the conversation with witty banter. ",
           "type": "reasoning",
         },
       ],
@@ -680,7 +680,7 @@ exports[`scenario: server provides reasoning > should call the update function w
               "isRedacted": true,
             },
           },
-          "reasoning": "I will open the conversation with witty banter. redacted-data",
+          "text": "I will open the conversation with witty banter. redacted-data",
           "type": "reasoning",
         },
       ],
@@ -701,7 +701,7 @@ exports[`scenario: server provides reasoning > should call the update function w
         },
         {
           "providerMetadata": undefined,
-          "reasoning": "I will open the conversation with witty banter. redacted-dataOnce the user has relaxed,",
+          "text": "I will open the conversation with witty banter. redacted-dataOnce the user has relaxed,",
           "type": "reasoning",
         },
       ],
@@ -726,7 +726,7 @@ exports[`scenario: server provides reasoning > should call the update function w
               "signature": "abc123",
             },
           },
-          "reasoning": "I will open the conversation with witty banter. redacted-dataOnce the user has relaxed, I will pry for valuable information.",
+          "text": "I will open the conversation with witty banter. redacted-dataOnce the user has relaxed, I will pry for valuable information.",
           "type": "reasoning",
         },
       ],
@@ -751,7 +751,7 @@ exports[`scenario: server provides reasoning > should call the update function w
               "signature": "abc123",
             },
           },
-          "reasoning": "I will open the conversation with witty banter. redacted-dataOnce the user has relaxed, I will pry for valuable information.",
+          "text": "I will open the conversation with witty banter. redacted-dataOnce the user has relaxed, I will pry for valuable information.",
           "type": "reasoning",
         },
         {
@@ -1283,7 +1283,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "1234567890",
             },
           },
-          "reasoning": "I will use a tool to get the weather in London.",
+          "text": "I will use a tool to get the weather in London.",
           "type": "reasoning",
         },
         {
@@ -1307,7 +1307,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "abc123",
             },
           },
-          "reasoning": "I know know the weather in London.",
+          "text": "I know know the weather in London.",
           "type": "reasoning",
         },
         {
@@ -1337,7 +1337,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
       "parts": [
         {
           "providerMetadata": undefined,
-          "reasoning": "I will ",
+          "text": "I will ",
           "type": "reasoning",
         },
       ],
@@ -1359,7 +1359,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "1234567890",
             },
           },
-          "reasoning": "I will use a tool to get the weather in London.",
+          "text": "I will use a tool to get the weather in London.",
           "type": "reasoning",
         },
       ],
@@ -1381,7 +1381,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "1234567890",
             },
           },
-          "reasoning": "I will use a tool to get the weather in London.",
+          "text": "I will use a tool to get the weather in London.",
           "type": "reasoning",
         },
         {
@@ -1415,7 +1415,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "1234567890",
             },
           },
-          "reasoning": "I will use a tool to get the weather in London.",
+          "text": "I will use a tool to get the weather in London.",
           "type": "reasoning",
         },
         {
@@ -1452,7 +1452,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "1234567890",
             },
           },
-          "reasoning": "I will use a tool to get the weather in London.",
+          "text": "I will use a tool to get the weather in London.",
           "type": "reasoning",
         },
         {
@@ -1476,7 +1476,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "abc123",
             },
           },
-          "reasoning": "I know know the weather in London.",
+          "text": "I know know the weather in London.",
           "type": "reasoning",
         },
       ],
@@ -1498,7 +1498,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "1234567890",
             },
           },
-          "reasoning": "I will use a tool to get the weather in London.",
+          "text": "I will use a tool to get the weather in London.",
           "type": "reasoning",
         },
         {
@@ -1522,7 +1522,7 @@ exports[`scenario: server-side tool roundtrip with multiple assistant reasoning 
               "signature": "abc123",
             },
           },
-          "reasoning": "I know know the weather in London.",
+          "text": "I know know the weather in London.",
           "type": "reasoning",
         },
         {

--- a/packages/ai/core/util/process-chat-response.ts
+++ b/packages/ai/core/util/process-chat-response.ts
@@ -150,12 +150,12 @@ export async function processChatResponse({
       if (currentReasoningPart == null) {
         currentReasoningPart = {
           type: 'reasoning',
-          reasoning: value.text,
+          text: value.text,
           providerMetadata: value.providerMetadata,
         };
         message.parts.push(currentReasoningPart);
       } else {
-        currentReasoningPart.reasoning += value.text;
+        currentReasoningPart.text += value.text;
         currentReasoningPart.providerMetadata = value.providerMetadata;
       }
 


### PR DESCRIPTION
## Background

The reasoning parts in the core/model messages use `text`, but the reasoning ui parts use `reasoning` as property names. Aligning the property names will reduce inconsistency.

## Summary

Rename `ReasoningUIPart` `reasoning` property to `text`.