### PR TITLE
fix (release): update changeset

### DIFF
--- a/.changeset/large-ties-own.md
+++ b/.changeset/large-ties-own.md
@@ -1,5 +1,5 @@
 ---
-'@ai-sdk/ui-utils': patch
+'ai': patch
 ---
 
 fix(react-native): support experimental_attachments without FileList global


### PR DESCRIPTION
## Background

The `v5` branch github release action was broken due to an invalid changeset.

## Summary

Change package in changeset.