### PR TITLE
chore (ai): remove redundant `mimeType` property

### DIFF
--- a/.changeset/nasty-lobsters-shave.md
+++ b/.changeset/nasty-lobsters-shave.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): remove redundant `mimeType` property

--- a/packages/ai/core/generate-speech/generated-audio-file.ts
+++ b/packages/ai/core/generate-speech/generated-audio-file.ts
@@ -29,21 +29,22 @@ export class DefaultGeneratedAudioFile
     super({ data, mediaType });
     let format = 'mp3';
 
-    // If format is not provided, try to determine it from the mimeType
+    // If format is not provided, try to determine it from the media type
     if (mediaType) {
-      const mimeTypeParts = mediaType.split('/');
+      const mediaTypeParts = mediaType.split('/');
 
-      if (mimeTypeParts.length === 2) {
+      if (mediaTypeParts.length === 2) {
         // Handle special cases for audio formats
         if (mediaType !== 'audio/mpeg') {
-          format = mimeTypeParts[1];
+          format = mediaTypeParts[1];
         }
       }
     }
 
     if (!format) {
+      // TODO this should be an AI SDK error
       throw new Error(
-        'Audio format must be provided or determinable from mimeType',
+        'Audio format must be provided or determinable from media type',
       );
     }
 

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -4028,11 +4028,11 @@ exports[`streamText > result.pipeDataStreamToResponse > should write file conten
 [
   "f:{"messageId":"msg-0"}
 ",
-  "k:{"mimeType":"text/plain","url":"data:text/plain;base64,Hello World"}
+  "k:{"mediaType":"text/plain","url":"data:text/plain;base64,Hello World"}
 ",
   "0:"Hello!"
 ",
-  "k:{"mimeType":"image/jpeg","url":"data:image/jpeg;base64,QkFVRw=="}
+  "k:{"mediaType":"image/jpeg","url":"data:image/jpeg;base64,QkFVRw=="}
 ",
   "e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10},"isContinued":false}
 ",
@@ -4525,11 +4525,11 @@ exports[`streamText > result.toDataStream > should send file content 1`] = `
 [
   "f:{"messageId":"msg-0"}
 ",
-  "k:{"mimeType":"text/plain","url":"data:text/plain;base64,Hello World"}
+  "k:{"mediaType":"text/plain","url":"data:text/plain;base64,Hello World"}
 ",
   "0:"Hello!"
 ",
-  "k:{"mimeType":"image/jpeg","url":"data:image/jpeg;base64,QkFVRw=="}
+  "k:{"mediaType":"image/jpeg","url":"data:image/jpeg;base64,QkFVRw=="}
 ",
   "e:{"finishReason":"stop","usage":{"promptTokens":3,"completionTokens":10},"isContinued":false}
 ",

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1612,7 +1612,7 @@ However, the LLM results are expected to be small enough to not cause issues.
               controller.enqueue(
                 // TODO update protocol to v2 or replace with event stream
                 formatDataStreamPart('file', {
-                  mimeType: chunk.file.mediaType, // TODO mediaType
+                  mediaType: chunk.file.mediaType,
                   url: `data:${chunk.file.mediaType};base64,${chunk.file.base64}`,
                 }),
               );

--- a/packages/ai/core/prompt/append-response-messages.ts
+++ b/packages/ai/core/prompt/append-response-messages.ts
@@ -115,8 +115,8 @@ Internal. For test use only. May change without notice.
                 }
                 parts.push({
                   type: 'file' as const,
-                  mediaType: part.mediaType ?? part.mimeType,
-                  url: `data:${part.mediaType ?? part.mimeType};base64,${convertDataContentToBase64String(part.data)}`,
+                  mediaType: part.mediaType,
+                  url: `data:${part.mediaType};base64,${convertDataContentToBase64String(part.data)}`,
                 });
                 break;
             }

--- a/packages/ai/core/prompt/content-part.ts
+++ b/packages/ai/core/prompt/content-part.ts
@@ -59,11 +59,6 @@ Optional IANA media type of the image.
   mediaType?: string;
 
   /**
-@deprecated Use `mediaType` instead.
-   */
-  mimeType?: string;
-
-  /**
 Additional provider-specific metadata. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
@@ -78,7 +73,6 @@ export const imagePartSchema: z.ZodType<ImagePart> = z.object({
   type: z.literal('image'),
   image: z.union([dataContentSchema, z.instanceof(URL)]),
   mediaType: z.string().optional(),
-  mimeType: z.string().optional(),
   providerOptions: providerMetadataSchema.optional(),
 });
 
@@ -109,11 +103,6 @@ IANA media type of the file.
   mediaType: string;
 
   /**
-@deprecated Use `mediaType` instead.
-   */
-  mimeType?: string;
-
-  /**
 Additional provider-specific metadata. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
@@ -129,7 +118,6 @@ export const filePartSchema: z.ZodType<FilePart> = z.object({
   data: z.union([dataContentSchema, z.instanceof(URL)]),
   filename: z.string().optional(),
   mediaType: z.string(),
-  mimeType: z.string().optional(),
   providerOptions: providerMetadataSchema.optional(),
 });
 

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -115,7 +115,7 @@ export function convertToLanguageModelMessage(
                   type: 'file',
                   data,
                   filename: part.filename,
-                  mediaType: mediaType ?? part.mediaType ?? part.mimeType,
+                  mediaType: mediaType ?? part.mediaType,
                   providerOptions,
                 };
               }
@@ -194,9 +194,7 @@ async function downloadAssets(
     )
     .map(part => {
       const mediaType =
-        part.mediaType ??
-        part.mimeType ??
-        (part.type === 'image' ? 'image/*' : undefined);
+        part.mediaType ?? (part.type === 'image' ? 'image/*' : undefined);
 
       let data = part.type === 'image' ? part.image : part.data;
       if (typeof data === 'string') {
@@ -275,8 +273,7 @@ function convertPartToLanguageModelPart(
   const { data: convertedData, mediaType: convertedMediaType } =
     convertToLanguageModelV2DataContent(originalData);
 
-  let mediaType: string | undefined =
-    convertedMediaType ?? part.mediaType ?? part.mimeType;
+  let mediaType: string | undefined = convertedMediaType ?? part.mediaType;
   let data: Uint8Array | string | URL = convertedData; // binary | base64 | url
 
   // If the content is a URL, we check if it was downloaded:

--- a/packages/ai/core/util/data-stream-parts.test.ts
+++ b/packages/ai/core/util/data-stream-parts.test.ts
@@ -363,7 +363,7 @@ describe('data-stream-parts', () => {
     it('should format a file stream part', () => {
       const file = {
         url: 'data:text/plain;base64,SGVsbG8gV29ybGQ=',
-        mimeType: 'text/plain',
+        mediaType: 'text/plain',
       };
 
       expect(formatDataStreamPart('file', file)).toEqual(
@@ -374,7 +374,7 @@ describe('data-stream-parts', () => {
     it('should parse a file stream part', () => {
       const file = {
         url: 'data:text/plain;base64,SGVsbG8gV29ybGQ=',
-        mimeType: 'text/plain',
+        mediaType: 'text/plain',
       };
 
       const input = `k:${JSON.stringify(file)}`;
@@ -387,7 +387,7 @@ describe('data-stream-parts', () => {
     it('should throw an error if the file value is not an object', () => {
       const input = 'k:"not an object"';
       expect(() => parseDataStreamPart(input)).toThrow(
-        '"file" parts expect an object with a "url" and "mimeType" property.',
+        '"file" parts expect an object with a "url" and "mediaType" property.',
       );
     });
 
@@ -395,7 +395,7 @@ describe('data-stream-parts', () => {
       const invalidFile = { name: 'test.txt' };
       const input = `k:${JSON.stringify(invalidFile)}`;
       expect(() => parseDataStreamPart(input)).toThrow(
-        '"file" parts expect an object with a "url" and "mimeType" property.',
+        '"file" parts expect an object with a "url" and "mediaType" property.',
       );
     });
   });

--- a/packages/ai/core/util/data-stream-parts.ts
+++ b/packages/ai/core/util/data-stream-parts.ts
@@ -402,7 +402,7 @@ const fileStreamPart: DataStreamPart<
   'file',
   {
     url: string;
-    mimeType: string; // TODO mediaType
+    mediaType: string;
   }
 > = {
   code: 'k',
@@ -413,14 +413,14 @@ const fileStreamPart: DataStreamPart<
       typeof value !== 'object' ||
       !('url' in value) ||
       typeof value.url !== 'string' ||
-      !('mimeType' in value) ||
-      typeof value.mimeType !== 'string'
+      !('mediaType' in value) ||
+      typeof value.mediaType !== 'string'
     ) {
       throw new Error(
-        '"file" parts expect an object with a "url" and "mimeType" property.',
+        '"file" parts expect an object with a "url" and "mediaType" property.',
       );
     }
-    return { type: 'file', value: value as { url: string; mimeType: string } };
+    return { type: 'file', value: value as { url: string; mediaType: string } };
   },
 };
 
@@ -533,7 +533,7 @@ export const parseDataStreamPart = (line: string): DataStreamPartType => {
 };
 
 /**
-Prepends a string with a prefix from the `StreamChunkPrefixes`, JSON-ifies it,
+Prepends a string with a prefix from the `StreamChunkPrefixes`, converts it to JSON,
 and appends a new line.
 
 It ensures type-safety for the part type and value.

--- a/packages/ai/core/util/process-chat-response.test.ts
+++ b/packages/ai/core/util/process-chat-response.test.ts
@@ -713,12 +713,12 @@ describe('scenario: server provides file parts', () => {
       formatDataStreamPart('text', 'Here is a file:'),
       formatDataStreamPart('file', {
         url: 'data:text/plain;base64,SGVsbG8gV29ybGQ=',
-        mimeType: 'text/plain',
+        mediaType: 'text/plain',
       }),
       formatDataStreamPart('text', 'And another one:'),
       formatDataStreamPart('file', {
         url: 'data:application/json;base64,eyJrZXkiOiJ2YWx1ZSJ9',
-        mimeType: 'application/json',
+        mediaType: 'application/json',
       }),
       formatDataStreamPart('finish_step', {
         finishReason: 'stop',

--- a/packages/ai/core/util/process-chat-response.ts
+++ b/packages/ai/core/util/process-chat-response.ts
@@ -169,7 +169,7 @@ export async function processChatResponse({
     onFilePart(value) {
       message.parts.push({
         type: 'file',
-        mediaType: value.mimeType,
+        mediaType: value.mediaType,
         url: value.url,
       });
 


### PR DESCRIPTION
## Background

The `mimeType` property was still used on messages which should be migrated.

## Summary

Remove `mimeType` property since we are using `mediaType`.