### PR TITLE
fix(providers/openai): logprobs for stream alongside completion model

### DIFF
--- a/.changeset/swift-geckos-joke.md
+++ b/.changeset/swift-geckos-joke.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(providers/openai): logprobs for stream alongside completion model

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -1444,7 +1444,100 @@ describe('doStream', () => {
         {
           "finishReason": "stop",
           "providerMetadata": {
-            "openai": {},
+            "openai": {
+              "logprobs": [
+                {
+                  "logprob": -0.0009994634,
+                  "token": "Hello",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.0009994634,
+                      "token": "Hello",
+                    },
+                  ],
+                },
+                {
+                  "logprob": -0.13410144,
+                  "token": "!",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.13410144,
+                      "token": "!",
+                    },
+                  ],
+                },
+                {
+                  "logprob": -0.0009250381,
+                  "token": " How",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.0009250381,
+                      "token": " How",
+                    },
+                  ],
+                },
+                {
+                  "logprob": -0.047709424,
+                  "token": " can",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.047709424,
+                      "token": " can",
+                    },
+                  ],
+                },
+                {
+                  "logprob": -0.000009014684,
+                  "token": " I",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.000009014684,
+                      "token": " I",
+                    },
+                  ],
+                },
+                {
+                  "logprob": -0.009125131,
+                  "token": " assist",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.009125131,
+                      "token": " assist",
+                    },
+                  ],
+                },
+                {
+                  "logprob": -0.0000066306106,
+                  "token": " you",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.0000066306106,
+                      "token": " you",
+                    },
+                  ],
+                },
+                {
+                  "logprob": -0.00011093382,
+                  "token": " today",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.00011093382,
+                      "token": " today",
+                    },
+                  ],
+                },
+                {
+                  "logprob": -0.00004596782,
+                  "token": "?",
+                  "top_logprobs": [
+                    {
+                      "logprob": -0.00004596782,
+                      "token": "?",
+                    },
+                  ],
+                },
+              ],
+            },
           },
           "type": "finish",
           "usage": {

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -487,6 +487,10 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
               finishReason = mapOpenAIFinishReason(choice.finish_reason);
             }
 
+            if (choice?.logprobs != null) {
+              providerMetadata.openai.logprobs = choice.logprobs.content;
+            }
+
             if (choice?.delta == null) {
               return;
             }
@@ -721,6 +725,24 @@ const openaiChatChunkSchema = z.union([
                 }),
               )
               .nullish(),
+          })
+          .nullish(),
+        logprobs: z
+          .object({
+            content: z
+              .array(
+                z.object({
+                  token: z.string(),
+                  logprob: z.number(),
+                  top_logprobs: z.array(
+                    z.object({
+                      token: z.string(),
+                      logprob: z.number(),
+                    }),
+                  ),
+                }),
+              )
+              .nullable(),
           })
           .nullish(),
         finish_reason: z.string().nullish(),

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -742,7 +742,7 @@ const openaiChatChunkSchema = z.union([
                   ),
                 }),
               )
-              .nullable(),
+              .nullish(),
           })
           .nullish(),
         finish_reason: z.string().nullish(),

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -487,7 +487,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
               finishReason = mapOpenAIFinishReason(choice.finish_reason);
             }
 
-            if (choice?.logprobs != null) {
+            if (choice?.logprobs?.content != null) {
               providerMetadata.openai.logprobs = choice.logprobs.content;
             }
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Followup to https://github.com/vercel/ai/pull/6049, we were missing streaming logprobs it was commented for the completion model but accidentally missed this one

## Summary

<!-- What did you change? -->

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
