### PR TITLE
fix (docs): update formatting in useChat reference docs 

### DIFF
--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -396,7 +396,7 @@ const streamContext = createResumableStreamContext({
   waitUntil: after,
 });
 
-export async function GET() {
+export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const chatId = searchParams.get('chatId');
 

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -597,7 +597,7 @@ Allows you to easily create a conversational user interface for your chatbot app
       name: 'experimental_resume',
       type: '() => void',
       description: 'Function to resume an ongoing chat generation stream.',
-    }
+    },
     {
       name: 'setMessages',
       type: '(messages: Message[] | ((messages: Message[]) => Message[]) => void',


### PR DESCRIPTION
## Background
This pull request fixes a docs formatting issue due to a missing comma in useChat reference docs.

## Summary

Fixed formatting in useChat reference docs by adding a comma.

## Tasks
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues
#6053