### PR TITLE
feat (docs): add Dify community provider (#4084) (#6067)

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -72,6 +72,7 @@ The open-source community has created the following providers:
 - [Spark Provider](/providers/community-providers/spark) (`spark-ai-provider`)
 - [AnthropicVertex Provider](/providers/community-providers/anthropic-vertex-ai) (`anthropic-vertex-ai`)
 - [LangDB Provider](/providers/community-providers/langdb) (`@langdb/vercel-provider`)
+- [Dify Provider](/providers/community-providers/dify) (`dify-ai-provider`)
 - [Sarvam Provider](/providers/community-providers/sarvam) (`sarvam-ai-provider`)
 
 ## Self-Hosted Models

--- a/content/providers/03-community-providers/97-dify.mdx
+++ b/content/providers/03-community-providers/97-dify.mdx
@@ -1,0 +1,74 @@
+---
+title: Dify
+description: Learn how to use the Dify provider for the AI SDK.
+---
+
+# Dify Provider
+
+The **[Dify provider](https://github.com/warmwind/dify-ai-provider)** allows you to easily integrate Dify's application workflow with your applications using the AI SDK.
+
+## Setup
+
+The Dify provider is available in the `dify-ai-provider` module. You can install it with:
+
+```bash
+npm install dify-ai-provider
+
+# pnpm
+pnpm add dify-ai-provider
+
+# yarn
+yarn add dify-ai-provider
+```
+
+## Provider Instance
+
+You can import `difyProvider` from `dify-ai-provider` to create a provider instance:
+
+```ts
+import { difyProvider } from 'dify-ai-provider';
+```
+
+## Example
+
+### Use dify.ai
+
+```ts
+import { generateText } from 'ai';
+import { difyProvider } from 'dify-ai-provider';
+
+const dify = difyProvider('dify-application-id', {
+  responseMode: 'blocking',
+  apiKey: 'dify-api-key',
+});
+
+const { text, providerMetadata } = await generateText({
+  model: dify,
+  messages: [{ role: 'user', content: 'Hello, how are you today?' }],
+  headers: { 'user-id': 'test-user' },
+});
+
+const { conversationId, messageId } = providerMetadata.difyWorkflowData;
+console.log(text);
+console.log('conversationId', conversationId);
+console.log('messageId', messageId);
+```
+
+### Use self-hosted Dify
+
+```typescript
+import { createDifyProvider } from 'dify-ai-provider';
+
+const difyProvider = createDifyProvider({
+  baseURL: 'your-base-url',
+});
+
+const dify = difyProvider('dify-application-id', {
+  responseMode: 'blocking',
+  apiKey: 'dify-api-key',
+});
+```
+
+## Documentation
+
+Please refer to the **[Dify provider documentation](https://github.com/warmwind/dify-ai-provider)** for more detailed information.


### PR DESCRIPTION
## Background

The Dify provider allows developers to easily integrate Dify's application workflow with their applications using the Vercel AI SDK.

## Summary

This PR adds the Dify provider documentation to the AI SDK, enabling users to understand how to implement and use the Dify integration.

## Tasks

- [x] Documentation has been added for the Dify provider
- [x] Installation instructions are included
- [x] Usage examples for both cloud and self-hosted instances are provided

## Related Issues

[Support Dify Provider](https://github.com/vercel/ai/issues/4084)
