### PR TITLE
feat (ai): add filename to file ui parts

### DIFF
--- a/.changeset/real-apes-lick.md
+++ b/.changeset/real-apes-lick.md
@@ -1,0 +1,5 @@
+---
+'ai': minor
+---
+
+feat (ai): add filename to file ui parts

--- a/examples/next-openai/app/use-chat-attachments-append/page.tsx
+++ b/examples/next-openai/app/use-chat-attachments-append/page.tsx
@@ -31,7 +31,11 @@ export default function Page() {
                 ) {
                   return (
                     <div key={index}>
-                      <img className="rounded-md w-60" src={part.url} />
+                      <img
+                        className="rounded-md w-60"
+                        src={part.url}
+                        alt={part.filename}
+                      />
                     </div>
                   );
                 }
@@ -79,16 +83,6 @@ export default function Page() {
                       <span className="text-sm text-zinc-500">
                         {attachment.name}
                       </span>
-                    </div>
-                  );
-                } else if (type.startsWith('text/')) {
-                  return (
-                    <div
-                      key={attachment.name}
-                      className="flex flex-col flex-shrink-0 w-24 gap-1 text-sm text-zinc-500"
-                    >
-                      <div className="w-16 h-20 rounded-md bg-zinc-100" />
-                      {attachment.name}
                     </div>
                   );
                 }

--- a/examples/next-openai/app/use-chat-attachments-url/page.tsx
+++ b/examples/next-openai/app/use-chat-attachments-url/page.tsx
@@ -22,17 +22,27 @@ export default function Page() {
           <div key={message.id} className="flex flex-row gap-2">
             <div className="flex-shrink-0 w-24 text-zinc-500">{`${message.role}: `}</div>
 
-            {message.parts.map((part, index) => {
-              if (part.type === 'text') {
-                return <div key={index}>{part.text}</div>;
-              }
-              if (
-                part.type === 'file' &&
-                part.mediaType?.startsWith('image/')
-              ) {
-                return <img key={index} src={part.url} />;
-              }
-            })}
+            <div className="flex flex-col gap-2">
+              {message.parts.map((part, index) => {
+                if (part.type === 'text') {
+                  return <div key={index}>{part.text}</div>;
+                }
+                if (
+                  part.type === 'file' &&
+                  part.mediaType?.startsWith('image/')
+                ) {
+                  return (
+                    <div key={index}>
+                      <img
+                        className="rounded-md w-60"
+                        src={part.url}
+                        alt={part.filename}
+                      />
+                    </div>
+                  );
+                }
+              })}
+            </div>
           </div>
         ))}
       </div>
@@ -62,11 +72,9 @@ export default function Page() {
                 <img
                   className="w-24 rounded-md"
                   src={file.url}
-                  // alt={file.name} TODO filename support
+                  alt={file.filename}
                 />
-                <span className="text-sm text-zinc-500">
-                  {'name' /* TODO file.name*/}
-                </span>
+                <span className="text-sm text-zinc-500">{file.filename}</span>
               </div>
             ))}
         </div>
@@ -86,7 +94,7 @@ export default function Page() {
                   ...prevFiles,
                   {
                     type: 'file' as const,
-                    // name: file.name, TODO filename support
+                    filename: file.name,
                     mediaType: blob.contentType ?? '*/*',
                     url: blob.url,
                   },

--- a/examples/next-openai/app/use-chat-attachments/page.tsx
+++ b/examples/next-openai/app/use-chat-attachments/page.tsx
@@ -30,7 +30,14 @@ export default function Page() {
                 ) {
                   return (
                     <div key={index}>
-                      <img className="rounded-md w-60" src={part.url} />
+                      <img
+                        className="rounded-md w-60"
+                        src={part.url}
+                        alt={part.filename}
+                      />
+                      <span className="text-sm text-zinc-500">
+                        {part.filename}
+                      </span>
                     </div>
                   );
                 }

--- a/packages/ai/core/prompt/convert-to-core-messages.ts
+++ b/packages/ai/core/prompt/convert-to-core-messages.ts
@@ -48,6 +48,7 @@ export function convertToCoreMessages<TOOLS extends ToolSet = never>(
                 ? {
                     type: 'file' as const,
                     mediaType: part.mediaType,
+                    filename: part.filename,
                     data: part.url,
                   }
                 : part,

--- a/packages/ai/core/types/ui-messages.ts
+++ b/packages/ai/core/types/ui-messages.ts
@@ -142,6 +142,11 @@ export type FileUIPart = {
   mediaType: string;
 
   /**
+   * Optional filename of the file.
+   */
+  filename?: string;
+
+  /**
    * The URL of the file.
    * It can either be a URL to a hosted file or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
    */

--- a/packages/ai/core/util/convert-file-list-to-file-ui-parts.ts
+++ b/packages/ai/core/util/convert-file-list-to-file-ui-parts.ts
@@ -13,9 +13,8 @@ export async function convertFileListToFileUIParts(
   }
 
   return Promise.all(
-    Array.from(files).map(async attachment => {
-      // TODO add filename once supported by file ui parts
-      const { name, type } = attachment;
+    Array.from(files).map(async file => {
+      const { name, type } = file;
 
       const dataUrl = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
@@ -23,12 +22,13 @@ export async function convertFileListToFileUIParts(
           resolve(readerEvent.target?.result as string);
         };
         reader.onerror = error => reject(error);
-        reader.readAsDataURL(attachment);
+        reader.readAsDataURL(file);
       });
 
       return {
         type: 'file',
         mediaType: type,
+        filename: name,
         url: dataUrl,
       };
     }),

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1603,7 +1603,7 @@ describe('attachments with empty submit', () => {
               files: [
                 {
                   type: 'file',
-                  // name: 'test.png', TODO enable file name
+                  filename: 'test.png',
                   mediaType: 'image/png',
                   url: 'https://example.com/image.png',
                 },

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1338,6 +1338,7 @@ describe('file attachments with data url', () => {
             {
               type: 'file',
               mediaType: 'text/plain',
+              filename: 'test.txt',
               url: 'data:text/plain;base64,dGVzdCBmaWxlIGNvbnRlbnQ=',
             },
             {
@@ -1370,6 +1371,7 @@ describe('file attachments with data url', () => {
             "content": "Message with text attachment",
             "parts": [
               {
+                "filename": "test.txt",
                 "mediaType": "text/plain",
                 "type": "file",
                 "url": "data:text/plain;base64,dGVzdCBmaWxlIGNvbnRlbnQ=",
@@ -1418,6 +1420,7 @@ describe('file attachments with data url', () => {
             {
               type: 'file',
               mediaType: 'image/png',
+              filename: 'test.png',
               url: 'data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50',
             },
             {
@@ -1450,6 +1453,7 @@ describe('file attachments with data url', () => {
             "content": "Message with image attachment",
             "parts": [
               {
+                "filename": "test.png",
                 "mediaType": "image/png",
                 "type": "file",
                 "url": "data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50",
@@ -1642,6 +1646,7 @@ describe('attachments with empty submit', () => {
             {
               type: 'file',
               mediaType: 'image/png',
+              filename: 'test.png',
               url: 'https://example.com/image.png',
             },
             {
@@ -1674,6 +1679,7 @@ describe('attachments with empty submit', () => {
             "content": "",
             "parts": [
               {
+                "filename": "test.png",
                 "mediaType": "image/png",
                 "type": "file",
                 "url": "https://example.com/image.png",

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -1055,6 +1055,7 @@ describe('file attachments with data url', () => {
           "id": "id-1",
           "parts": [
             {
+              "filename": "test.txt",
               "mediaType": "text/plain",
               "type": "file",
               "url": "data:text/plain;base64,dGVzdCBmaWxlIGNvbnRlbnQ=",
@@ -1090,6 +1091,7 @@ describe('file attachments with data url', () => {
             "content": "Message with text attachment",
             "parts": [
               {
+                "filename": "test.txt",
                 "mediaType": "text/plain",
                 "type": "file",
                 "url": "data:text/plain;base64,dGVzdCBmaWxlIGNvbnRlbnQ=",
@@ -1130,6 +1132,7 @@ describe('file attachments with data url', () => {
           "id": "id-1",
           "parts": [
             {
+              "filename": "test.png",
               "mediaType": "image/png",
               "type": "file",
               "url": "data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50",
@@ -1165,6 +1168,7 @@ describe('file attachments with data url', () => {
             "content": "Message with image attachment",
             "parts": [
               {
+                "filename": "test.png",
                 "mediaType": "image/png",
                 "type": "file",
                 "url": "data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50",
@@ -1218,6 +1222,7 @@ describe('file attachments with url', () => {
           "id": "id-1",
           "parts": [
             {
+              "filename": "test.png",
               "mediaType": "image/png",
               "type": "file",
               "url": "data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50",
@@ -1253,6 +1258,7 @@ describe('file attachments with url', () => {
             "content": "Message with image attachment",
             "parts": [
               {
+                "filename": "test.png",
                 "mediaType": "image/png",
                 "type": "file",
                 "url": "data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50",
@@ -1305,6 +1311,7 @@ describe('file attachments with empty text content', () => {
           "id": "id-1",
           "parts": [
             {
+              "filename": "test.png",
               "mediaType": "image/png",
               "type": "file",
               "url": "data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50",
@@ -1340,6 +1347,7 @@ describe('file attachments with empty text content', () => {
             "content": "",
             "parts": [
               {
+                "filename": "test.png",
                 "mediaType": "image/png",
                 "type": "file",
                 "url": "data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50",

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -783,6 +783,7 @@ describe('file attachments with data url', () => {
             {
               type: 'file',
               mediaType: 'text/plain',
+              filename: 'test.txt',
               url: 'data:text/plain;base64,dGVzdCBmaWxlIGNvbnRlbnQ=',
             },
             {
@@ -840,6 +841,7 @@ describe('file attachments with data url', () => {
             {
               type: 'file',
               mediaType: 'image/png',
+              filename: 'test.png',
               url: 'data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50',
             },
             {
@@ -952,6 +954,7 @@ describe('attachments with empty submit', () => {
             {
               type: 'file',
               mediaType: 'image/png',
+              filename: 'test.png',
               url: 'data:image/png;base64,dGVzdCBpbWFnZSBjb250ZW50',
             },
             {


### PR DESCRIPTION
## Background

Attachments were moved to file ui parts in a previous pull request. File UI parts do not have filenames (file content parts do).

## Summary

Add filenames to file ui parts.

## Verification

Tested with `examples/next-openai` attachment uploads.
