### PR TITLE
chore (ai): move maxSteps into UseChatOptions

### DIFF
--- a/.changeset/great-mangos-scream.md
+++ b/.changeset/great-mangos-scream.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore (ai): move maxSteps into UseChatOptions

--- a/packages/ai/core/types/ui-messages.ts
+++ b/packages/ai/core/types/ui-messages.ts
@@ -339,6 +339,16 @@ Custom fetch implementation. You can use it as a middleware to intercept request
 or to provide a custom fetch implementation for e.g. testing.
     */
   fetch?: FetchFunction;
+
+  /**
+Maximum number of sequential LLM calls (steps), e.g. when you use tool calls.
+Must be at least 1.
+
+A maximum number is required to prevent infinite loops in the case of misconfigured tools.
+
+By default, it's set to 1, which means that only a single LLM call is made.
+ */
+  maxSteps?: number;
 };
 
 export type UseCompletionOptions = {

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -170,16 +170,6 @@ Default is undefined, which disables throttling.
    */
   experimental_throttle?: number;
 
-  /**
-Maximum number of sequential LLM calls (steps), e.g. when you use tool calls.
-Must be at least 1.
-
-A maximum number is required to prevent infinite loops in the case of misconfigured tools.
-
-By default, it's set to 1, which means that only a single LLM call is made.
- */
-  maxSteps?: number;
-
   '~internal'?: {
     currentDate?: () => Date;
   };

--- a/packages/svelte/src/chat.svelte.ts
+++ b/packages/svelte/src/chat.svelte.ts
@@ -24,15 +24,6 @@ import {
 
 export type ChatOptions = Readonly<
   Omit<UseChatOptions, 'keepLastMessageOnError'> & {
-    /**
-     * Maximum number of sequential LLM calls (steps), e.g. when you use tool calls.
-     * Must be at least 1.
-     * A maximum number is required to prevent infinite loops in the case of misconfigured tools.
-     * By default, it's set to 1, which means that only a single LLM call is made.
-     * @default 1
-     */
-    maxSteps?: number;
-
     '~internal'?: {
       currentDate?: () => Date;
     };

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -131,13 +131,6 @@ export function useChat(
     ...options
   }: UseChatOptions & {
     /**
-     * Maximum number of sequential LLM calls (steps), e.g. when you use tool calls. Must be at least 1.
-     * A maximum number is required to prevent infinite loops in the case of misconfigured tools.
-     * By default, it's set to 1, which means that only a single LLM call is made.
-     */
-    maxSteps?: number;
-
-    /**
      * Experimental (Vue only). When a function is provided, it will be used
      * to prepare the request body for the chat API. This can be useful for
      * customizing the request body based on the messages and data in the chat.


### PR DESCRIPTION
## Background

`maxSteps` is available in all `useChat` implementations.

## Summary

Add `maxSteps` to `UseChatOptions`.