### PR TITLE
chore (ai): remove useChat keepLastMessageOnError

### DIFF
--- a/.changeset/funny-mayflies-yawn.md
+++ b/.changeset/funny-mayflies-yawn.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): remove useChat keepLastMessageOnError

--- a/packages/ai/core/types/ui-messages.ts
+++ b/packages/ai/core/types/ui-messages.ts
@@ -223,13 +223,6 @@ Additional data to be sent to the API endpoint.
 
 export type UseChatOptions = {
   /**
-Keeps the last message when an error happens. Defaults to `true`.
-
-@deprecated This option will be removed in the next major release.
-   */
-  keepLastMessageOnError?: boolean;
-
-  /**
    * The API endpoint that accepts a `{ messages: Message[] }` object and returns
    * a stream of tokens of the AI chat response. Defaults to `/api/chat`.
    */

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -142,7 +142,6 @@ export function useChat({
   body,
   generateId = generateIdFunc,
   fetch,
-  keepLastMessageOnError = true,
   experimental_throttle: throttleWaitMs,
   ...options
 }: UseChatOptions & {
@@ -313,11 +312,6 @@ By default, it's set to 1, which means that only a single LLM call is made.
             ...chatRequest.headers,
           },
           abortController: () => abortControllerRef.current,
-          restoreMessagesOnFailure() {
-            if (!keepLastMessageOnError) {
-              throttledMutate(previousMessages, false);
-            }
-          },
           onResponse,
           onUpdate({ message, data, replaceLastMessage }) {
             mutateStatus('streaming');
@@ -401,7 +395,6 @@ By default, it's set to 1, which means that only a single LLM call is made.
       abortControllerRef,
       generateId,
       fetch,
-      keepLastMessageOnError,
       throttleWaitMs,
       chatId,
       getCurrentDate,

--- a/packages/svelte/src/chat.svelte.ts
+++ b/packages/svelte/src/chat.svelte.ts
@@ -23,7 +23,7 @@ import {
 } from './chat-context.svelte.js';
 
 export type ChatOptions = Readonly<
-  Omit<UseChatOptions, 'keepLastMessageOnError'> & {
+  UseChatOptions & {
     /**
      * Maximum number of sequential LLM calls (steps), e.g. when you use tool calls.
      * Must be at least 1.
@@ -275,7 +275,6 @@ export class Chat {
           ...chatRequest.headers,
         },
         abortController: () => abortController,
-        restoreMessagesOnFailure: () => {},
         onResponse: this.#options.onResponse,
         onUpdate: ({ message, data, replaceLastMessage }) => {
           this.#store.status = 'streaming';

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -125,7 +125,6 @@ export function useChat(
     generateId = generateIdFunc,
     onToolCall,
     fetch,
-    keepLastMessageOnError = true,
     maxSteps = 1,
     experimental_prepareRequestBody,
     ...options
@@ -266,12 +265,6 @@ export function useChat(
           }
         },
         onFinish,
-        restoreMessagesOnFailure() {
-          // Restore the previous messages if the request fails.
-          if (!keepLastMessageOnError) {
-            mutate(previousMessages);
-          }
-        },
         generateId,
         onToolCall,
         fetch,


### PR DESCRIPTION
## Background

`keepLastMessageOnError` is deprecated and should be removed in AI SDK 5.

## Summary

Remove `keepLastMessageOnError` and simplify adjacent code.