### PR TITLE
chore(provider-utils): move ToolResultContent to provider-utils

### DIFF
--- a/.changeset/angry-crabs-develop.md
+++ b/.changeset/angry-crabs-develop.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+chore(provider-utils): move ToolResultContent to provider-utils

--- a/packages/ai/core/prompt/tool-result-content.ts
+++ b/packages/ai/core/prompt/tool-result-content.ts
@@ -1,21 +1,7 @@
+import { ToolResultContent } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 
-export type ToolResultContent = Array<
-  | {
-      type: 'text';
-      text: string;
-    }
-  | {
-      type: 'image';
-      data: string; // base64 encoded png image, e.g. screenshot
-      mediaType?: string; // e.g. 'image/png';
-
-      /**
-       * @deprecated Use `mediaType` instead.
-       */
-      mimeType?: string; // e.g. 'image/png';
-    }
->;
+export type { ToolResultContent };
 
 export const toolResultContentSchema: z.ZodType<ToolResultContent> = z.array(
   z.union([

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -1,25 +1,12 @@
+import { ToolResultContent } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 
-// Copied from ai package
 type ExecuteFunction<PARAMETERS, RESULT> =
   | undefined
   | ((
       args: PARAMETERS,
       options: { abortSignal?: AbortSignal },
     ) => Promise<RESULT>);
-
-// Copied from ai package
-export type ToolResultContent = Array<
-  | {
-      type: 'text';
-      text: string;
-    }
-  | {
-      type: 'image';
-      data: string; // base64 encoded png image, e.g. screenshot
-      mediaType?: string; // e.g. 'image/png';
-    }
->;
 
 const Bash20241022Parameters = z.object({
   command: z.string(),

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -30,4 +30,4 @@ export type { Schema } from './schema';
 export { zodSchema } from './zod-schema';
 
 export type { ToolCall } from './types/tool-call';
-export type { ToolResult } from './types/tool-result';
+export type { ToolResult, ToolResultContent } from './types/tool-result';

--- a/packages/provider-utils/src/types/tool-result.ts
+++ b/packages/provider-utils/src/types/tool-result.ts
@@ -23,3 +23,20 @@ Result of the tool call. This is the result of the tool's execution.
      */
   result: RESULT;
 }
+
+export type ToolResultContent = Array<
+  | {
+      type: 'text';
+      text: string;
+    }
+  | {
+      type: 'image';
+      data: string; // base64 encoded png image, e.g. screenshot
+      mediaType?: string; // e.g. 'image/png';
+
+      /**
+       * @deprecated Use `mediaType` instead.
+       */
+      mimeType?: string; // e.g. 'image/png';
+    }
+>;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

After a lot of cross-referencing, the only cleanup we need is to unify this interface into provider-utils

## Summary

Move ToolResultContent to provider-utils