### PR TITLE
fix(providers): always use optional instead of mix of nullish for providerOptions

### DIFF
--- a/.changeset/weak-moles-nail.md
+++ b/.changeset/weak-moles-nail.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/groq': patch
+---
+
+fix(providers): always use optional instead of mix of nullish for providerOptions

--- a/packages/amazon-bedrock/src/bedrock-chat-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.ts
@@ -44,10 +44,10 @@ export const bedrockProviderOptions = z.object({
   additionalModelRequestFields: z.record(z.any()).optional(),
   reasoningConfig: z
     .object({
-      type: z.union([z.literal('enabled'), z.literal('disabled')]).nullish(),
-      budgetTokens: z.number().nullish(),
+      type: z.union([z.literal('enabled'), z.literal('disabled')]).optional(),
+      budgetTokens: z.number().optional(),
     })
-    .nullish(),
+    .optional(),
 });
 
 export type BedrockProviderOptions = z.infer<typeof bedrockProviderOptions>;

--- a/packages/cohere/src/cohere-embedding-options.ts
+++ b/packages/cohere/src/cohere-embedding-options.ts
@@ -21,7 +21,7 @@ export const cohereEmbeddingOptions = z.object({
    */
   inputType: z
     .enum(['search_document', 'search_query', 'classification', 'clustering'])
-    .nullish(),
+    .optional(),
 
   /**
    * Specifies how the API will handle inputs longer than the maximum token length.
@@ -31,7 +31,7 @@ export const cohereEmbeddingOptions = z.object({
    * - "START": Will discard the start of the input until the remaining input is exactly the maximum input token length for the model.
    * - "END": Will discard the end of the input until the remaining input is exactly the maximum input token length for the model.
    */
-  truncate: z.enum(['NONE', 'START', 'END']).nullish(),
+  truncate: z.enum(['NONE', 'START', 'END']).optional(),
 });
 
 export type CohereEmbeddingOptions = z.infer<typeof cohereEmbeddingOptions>;

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -20,18 +20,18 @@ export type GroqChatModelId =
   | (string & {});
 
 export const groqProviderOptions = z.object({
-  reasoningFormat: z.enum(['parsed', 'raw', 'hidden']).nullish(),
+  reasoningFormat: z.enum(['parsed', 'raw', 'hidden']).optional(),
 
   /**
    * Whether to enable parallel function calling during tool use. Default to true.
    */
-  parallelToolCalls: z.boolean().nullish(),
+  parallelToolCalls: z.boolean().optional(),
 
   /**
    * A unique identifier representing your end-user, which can help OpenAI to
    * monitor and detect abuse. Learn more.
    */
-  user: z.string().nullish(),
+  user: z.string().optional(),
 });
 
 export type GroqProviderOptions = z.infer<typeof groqProviderOptions>;

--- a/packages/mistral/src/mistral-chat-options.ts
+++ b/packages/mistral/src/mistral-chat-options.ts
@@ -22,10 +22,10 @@ Whether to inject a safety prompt before all conversations.
 
 Defaults to `false`.
    */
-  safePrompt: z.boolean().nullish(),
+  safePrompt: z.boolean().optional(),
 
-  documentImageLimit: z.number().nullish(),
-  documentPageLimit: z.number().nullish(),
+  documentImageLimit: z.number().optional(),
+  documentPageLimit: z.number().optional(),
 });
 
 export type MistralProviderOptions = z.infer<typeof mistralProviderOptions>;

--- a/packages/openai/src/openai-transcription-options.ts
+++ b/packages/openai/src/openai-transcription-options.ts
@@ -12,23 +12,23 @@ export const openAITranscriptionProviderOptions = z.object({
    * Additional information to include in the transcription response.
    */
 
-  include: z.array(z.string()).nullish(),
+  include: z.array(z.string()).optional(),
 
   /**
    * The language of the input audio in ISO-639-1 format.
    */
-  language: z.string().nullish(),
+  language: z.string().optional(),
 
   /**
    * An optional text to guide the model's style or continue a previous audio segment.
    */
-  prompt: z.string().nullish(),
+  prompt: z.string().optional(),
 
   /**
    * The sampling temperature, between 0 and 1.
    * @default 0
    */
-  temperature: z.number().min(0).max(1).default(0).nullish(),
+  temperature: z.number().min(0).max(1).default(0).optional(),
 
   /**
    * The timestamp granularities to populate for this transcription.
@@ -37,7 +37,7 @@ export const openAITranscriptionProviderOptions = z.object({
   timestampGranularities: z
     .array(z.enum(['word', 'segment']))
     .default(['segment'])
-    .nullish(),
+    .optional(),
 });
 
 export type OpenAITranscriptionProviderOptions = z.infer<


### PR DESCRIPTION

## Background

We were using nullish in some places (due to AI autocompletion)

## Summary

Now it's unified to use `.optional()` everywhere

## Verification

Checked JSDoc to make sure we're not breaking anything

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
