### PR TITLE
fix(providers/google): accept nullish in safetyRatings

### DIFF
--- a/.changeset/odd-tables-cross.md
+++ b/.changeset/odd-tables-cross.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(providers/google): accept nullish in safetyRatings

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -271,7 +271,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       providerMetadata: {
         google: {
           groundingMetadata: candidate.groundingMetadata ?? null,
-          safetyRatings: candidate.safetyRatings?.map((rating) => rating ?? null) ?? null,
+          safetyRatings: candidate.safetyRatings ?? null,
         },
       },
       sources: extractSources({
@@ -418,7 +418,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
               providerMetadata = {
                 google: {
                   groundingMetadata: candidate.groundingMetadata ?? null,
-                  safetyRatings: candidate.safetyRatings?.map((rating) => rating ?? null) ?? null,
+                  safetyRatings: candidate.safetyRatings ?? null,
                 },
               };
             }
@@ -575,8 +575,8 @@ export const groundingMetadataSchema = z.object({
 
 // https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters
 export const safetyRatingSchema = z.object({
-  category: z.string(),
-  probability: z.string(),
+  category: z.string().nullish(),
+  probability: z.string().nullish(),
   probabilityScore: z.number().nullish(),
   severity: z.string().nullish(),
   severityScore: z.number().nullish(),
@@ -588,7 +588,7 @@ const responseSchema = z.object({
     z.object({
       content: contentSchema.nullish().or(z.object({}).strict()),
       finishReason: z.string().nullish(),
-      safetyRatings: z.array(safetyRatingSchema.nullish()).nullish(),
+      safetyRatings: z.array(safetyRatingSchema).nullish(),
       groundingMetadata: groundingMetadataSchema.nullish(),
     }),
   ),
@@ -609,7 +609,7 @@ const chunkSchema = z.object({
       z.object({
         content: contentSchema.nullish(),
         finishReason: z.string().nullish(),
-        safetyRatings: z.array(safetyRatingSchema.nullish()).nullish(),
+        safetyRatings: z.array(safetyRatingSchema).nullish(),
         groundingMetadata: groundingMetadataSchema.nullish(),
       }),
     )

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -271,7 +271,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       providerMetadata: {
         google: {
           groundingMetadata: candidate.groundingMetadata ?? null,
-          safetyRatings: candidate.safetyRatings ?? null,
+          safetyRatings: candidate.safetyRatings?.map((rating) => rating ?? null) ?? null,
         },
       },
       sources: extractSources({
@@ -418,7 +418,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
               providerMetadata = {
                 google: {
                   groundingMetadata: candidate.groundingMetadata ?? null,
-                  safetyRatings: candidate.safetyRatings ?? null,
+                  safetyRatings: candidate.safetyRatings?.map((rating) => rating ?? null) ?? null,
                 },
               };
             }
@@ -588,7 +588,7 @@ const responseSchema = z.object({
     z.object({
       content: contentSchema.nullish().or(z.object({}).strict()),
       finishReason: z.string().nullish(),
-      safetyRatings: z.array(safetyRatingSchema).nullish(),
+      safetyRatings: z.array(safetyRatingSchema.nullish()).nullish(),
       groundingMetadata: groundingMetadataSchema.nullish(),
     }),
   ),
@@ -609,7 +609,7 @@ const chunkSchema = z.object({
       z.object({
         content: contentSchema.nullish(),
         finishReason: z.string().nullish(),
-        safetyRatings: z.array(safetyRatingSchema).nullish(),
+        safetyRatings: z.array(safetyRatingSchema.nullish()).nullish(),
         groundingMetadata: groundingMetadataSchema.nullish(),
       }),
     )


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The safetyRating was an empty object for some reason

## Summary

Fixes https://github.com/vercel/ai/issues/6109

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
