### PR TITLE
fix "Use the re-ask strategy for repair" docs - parse tool call args

### DIFF
--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -533,7 +533,7 @@ const result = await generateText({
               type: 'tool-call',
               toolCallId: toolCall.toolCallId,
               toolName: toolCall.toolName,
-              args: toolCall.args,
+              args: JSON.parse(toolCall.args),
             },
           ],
         },


### PR DESCRIPTION
## Background

We're using `experimental_repairToolCall` with retry strategy to repair wrong tool calls and we hit a 400 error in the generateText inside this repair function.

After some (pretty long) investigation, I found out that there is a bug in docs (which we used as based our implementation):
- repairToolCall accepts toolCall of type LanguageModelV1FunctionToolCall which has args as a string [source](https://github.com/vercel/ai/blob/845080d80b8538bb9c7e527d2213acb5f33ac9c2/packages/provider/src/language-model/v1/language-model-v1-function-tool-call.ts#L10)
- experimental_repairToolCall is calling generateText and passing 'tool-call' message which expects object in args, but a string is passed
- this causes 400 error response from LLMs (at least Anthropic in my case) 

## Summary

I've added a json parsing before passing args to generateText. If JSON parse is unsuccessful, fixing is skipped

