### PR TITLE
fix (ai): move image model settings to `generateImage({providerRequestOptions})`

### DIFF
--- a/packages/ai/core/generate-image/generate-image.test.ts
+++ b/packages/ai/core/generate-image/generate-image.test.ts
@@ -77,6 +77,7 @@ describe('generateImage', () => {
       aspectRatio: '16:9',
       seed: 12345,
       providerOptions: { 'mock-provider': { style: 'vivid' } },
+      providerRequestOptions: {},
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
     });
@@ -218,6 +219,7 @@ describe('generateImage', () => {
                   providerOptions: {
                     'mock-provider': { style: 'vivid' },
                   },
+                  providerRequestOptions: {},
                   headers: { 'custom-request-header': 'request-header-value' },
                   abortSignal: undefined,
                 });
@@ -232,6 +234,7 @@ describe('generateImage', () => {
                   size: '1024x1024',
                   aspectRatio: '16:9',
                   providerOptions: { 'mock-provider': { style: 'vivid' } },
+                  providerRequestOptions: {},
                   headers: { 'custom-request-header': 'request-header-value' },
                   abortSignal: undefined,
                 });
@@ -275,6 +278,7 @@ describe('generateImage', () => {
                   size: '1024x1024',
                   aspectRatio: '16:9',
                   providerOptions: { 'mock-provider': { style: 'vivid' } },
+                  providerRequestOptions: {},
                   headers: { 'custom-request-header': 'request-header-value' },
                   abortSignal: undefined,
                 });
@@ -290,6 +294,7 @@ describe('generateImage', () => {
                   size: '1024x1024',
                   aspectRatio: '16:9',
                   providerOptions: { 'mock-provider': { style: 'vivid' } },
+                  providerRequestOptions: {},
                   headers: { 'custom-request-header': 'request-header-value' },
                   abortSignal: undefined,
                 });

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -13,7 +13,7 @@ import {
   detectMediaType,
   imageMediaTypeSignatures,
 } from '../util/detect-media-type';
-import { ProviderOptions } from '../types/provider-metadata';
+import { ProviderOptions, ProviderRequestOptions } from '../types/provider-metadata';
 
 /**
 Generates images using an image model.
@@ -89,6 +89,22 @@ record is keyed by the provider-specific metadata key.
 ```
      */
   providerOptions?: ProviderOptions;
+
+  /**
+Additional provider-specific options that are passed through to the provider
+as body parameters.
+
+The outer record is keyed by the provider name, and the inner
+record is keyed by the provider-specific metadata key.
+```ts
+{
+  "openai": {
+    "style": "vivid"
+  }
+}
+```
+     */
+providerRequestOptions?: ProviderRequestOptions;
 
   /**
 Maximum number of retries per embedding model call. Set to 0 to disable retries.

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -162,6 +162,7 @@ Only applicable for HTTP-based providers.
           aspectRatio,
           seed,
           providerOptions: providerOptions ?? {},
+          providerRequestOptions: providerRequestOptions ?? {},
         }),
       ),
     ),

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -13,7 +13,10 @@ import {
   detectMediaType,
   imageMediaTypeSignatures,
 } from '../util/detect-media-type';
-import { ProviderOptions, ProviderRequestOptions } from '../types/provider-metadata';
+import {
+  ProviderOptions,
+  ProviderRequestOptions,
+} from '../types/provider-metadata';
 
 /**
 Generates images using an image model.
@@ -128,13 +131,14 @@ Only applicable for HTTP-based providers.
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
   // extract maxImagesPerCall from providerRequestOptions
-  const [
-    { maxImagesPerCall } = {}
-  ] = Object.values(providerOptions ?? {});
+  const [{ maxImagesPerCall } = {}] = Object.values(
+    providerRequestOptions ?? {},
+  );
 
   // default to 1 if the model has not specified limits on
   // how many images can be generated in a single call
-  const maxImagesPerCallWithDefault = (maxImagesPerCall as number) ?? model.maxImagesPerCall ?? 1;
+  const maxImagesPerCallWithDefault =
+    (maxImagesPerCall as number) ?? model.maxImagesPerCall ?? 1;
 
   // parallelize calls to the model:
   const callCount = Math.ceil(n / maxImagesPerCallWithDefault);

--- a/packages/ai/core/generate-speech/generate-speech.test.ts
+++ b/packages/ai/core/generate-speech/generate-speech.test.ts
@@ -65,6 +65,7 @@ describe('generateSpeech', () => {
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
       providerOptions: {},
+      providerRequestOptions: {},
       outputFormat: undefined,
       instructions: undefined,
       speed: undefined,

--- a/packages/ai/core/generate-speech/generate-speech.test.ts
+++ b/packages/ai/core/generate-speech/generate-speech.test.ts
@@ -65,7 +65,6 @@ describe('generateSpeech', () => {
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
       providerOptions: {},
-      providerRequestOptions: {},
       outputFormat: undefined,
       instructions: undefined,
       speed: undefined,

--- a/packages/ai/core/transcribe/transcribe.test.ts
+++ b/packages/ai/core/transcribe/transcribe.test.ts
@@ -82,7 +82,6 @@ describe('transcribe', () => {
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
       providerOptions: {},
-      providerRequestOptions: {},
     });
   });
 

--- a/packages/ai/core/transcribe/transcribe.test.ts
+++ b/packages/ai/core/transcribe/transcribe.test.ts
@@ -82,6 +82,7 @@ describe('transcribe', () => {
       headers: { 'custom-request-header': 'request-header-value' },
       abortSignal,
       providerOptions: {},
+      providerRequestOptions: {},
     });
   });
 

--- a/packages/ai/core/types/provider-metadata.ts
+++ b/packages/ai/core/types/provider-metadata.ts
@@ -21,6 +21,14 @@ provider-specific functionality that can be fully encapsulated in the provider.
  */
 export type ProviderOptions = SharedV2ProviderOptions;
 
+/**
+Additional provider-specific request options.
+
+They are NOT passed through to the provider from the AI SDK, they are used to
+change how requests are sent, e.g. how many requests and at what intervval.
+ */
+export type ProviderRequestOptions = SharedV2ProviderOptions;
+
 export const providerMetadataSchema: z.ZodType<ProviderMetadata> = z.record(
   z.string(),
   z.record(z.string(), jsonValueSchema),

--- a/packages/amazon-bedrock/src/bedrock-image-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.test.ts
@@ -34,15 +34,11 @@ describe('doGenerate', () => {
     },
   });
 
-  const model = new BedrockImageModel(
-    'amazon.nova-canvas-v1:0',
-    {},
-    {
-      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
-      headers: mockConfigHeaders,
-      fetch: fakeFetchWithAuth,
-    },
-  );
+  const model = new BedrockImageModel('amazon.nova-canvas-v1:0', {
+    baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+    headers: mockConfigHeaders,
+    fetch: fakeFetchWithAuth,
+  });
 
   it('should pass the model and the settings', async () => {
     await model.doGenerate({
@@ -58,6 +54,7 @@ describe('doGenerate', () => {
           cfgScale: 1.2,
         },
       },
+      providerRequestOptions: {},
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -83,21 +80,17 @@ describe('doGenerate', () => {
       'shared-header': 'options-shared',
     };
 
-    const modelWithHeaders = new BedrockImageModel(
-      'amazon.nova-canvas-v1:0',
-      {},
-      {
-        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
-        headers: {
-          'model-header': 'model-value',
-          'shared-header': 'model-shared',
-        },
-        fetch: injectFetchHeaders({
-          'signed-header': 'signed-value',
-          authorization: 'AWS4-HMAC-SHA256...',
-        }),
+    const modelWithHeaders = new BedrockImageModel('amazon.nova-canvas-v1:0', {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: {
+        'model-header': 'model-value',
+        'shared-header': 'model-shared',
       },
-    );
+      fetch: injectFetchHeaders({
+        'signed-header': 'signed-value',
+        authorization: 'AWS4-HMAC-SHA256...',
+      }),
+    });
 
     await modelWithHeaders.doGenerate({
       prompt,
@@ -106,6 +99,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
       headers: optionsHeaders,
     });
 
@@ -118,11 +112,6 @@ describe('doGenerate', () => {
   });
 
   it('should respect maxImagesPerCall setting', async () => {
-    const customModel = provider.image('amazon.nova-canvas-v1:0', {
-      maxImagesPerCall: 2,
-    });
-    expect(customModel.maxImagesPerCall).toBe(2);
-
     const defaultModel = provider.image('amazon.nova-canvas-v1:0');
     expect(defaultModel.maxImagesPerCall).toBe(5); // 'amazon.nova-canvas-v1:0','s default from settings
 
@@ -138,6 +127,7 @@ describe('doGenerate', () => {
       aspectRatio: '1:1',
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.warnings).toStrictEqual([
@@ -158,6 +148,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
@@ -166,17 +157,13 @@ describe('doGenerate', () => {
   it('should include response data with timestamp, modelId and headers', async () => {
     const testDate = new Date('2024-03-15T12:00:00Z');
 
-    const customModel = new BedrockImageModel(
-      'amazon.nova-canvas-v1:0',
-      {},
-      {
-        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
-        headers: () => ({}),
-        _internal: {
-          currentDate: () => testDate,
-        },
+    const customModel = new BedrockImageModel('amazon.nova-canvas-v1:0', {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: () => ({}),
+      _internal: {
+        currentDate: () => testDate,
       },
-    );
+    });
 
     const result = await customModel.doGenerate({
       prompt,
@@ -185,6 +172,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.response).toStrictEqual({
@@ -207,6 +195,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: 1234,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     const afterDate = new Date();

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -30,9 +30,7 @@ export class BedrockImageModel implements ImageModelV2 {
   readonly provider = 'amazon-bedrock';
 
   get maxImagesPerCall(): number {
-    return (
-      this.settings.maxImagesPerCall ?? modelMaxImagesPerCall[this.modelId] ?? 1
-    );
+    return modelMaxImagesPerCall[this.modelId] ?? 1;
   }
 
   private getUrl(modelId: string): string {
@@ -42,7 +40,6 @@ export class BedrockImageModel implements ImageModelV2 {
 
   constructor(
     readonly modelId: BedrockImageModelId,
-    private readonly settings: BedrockImageSettings,
     private readonly config: BedrockImageModelConfig,
   ) {}
 

--- a/packages/amazon-bedrock/src/bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.test.ts
@@ -140,13 +140,10 @@ describe('AmazonBedrockProvider', () => {
       const provider = createAmazonBedrock();
       const modelId = 'amazon.titan-image-generator';
 
-      const model = provider.image(modelId, {
-        maxImagesPerCall: 5,
-      });
+      const model = provider.image(modelId);
 
       const constructorCall = BedrockImageModelMock.mock.calls[0];
       expect(constructorCall[0]).toBe(modelId);
-      expect(constructorCall[1]).toEqual({ maxImagesPerCall: 5 });
       expect(model).toBeInstanceOf(BedrockImageModel);
     });
 
@@ -154,13 +151,10 @@ describe('AmazonBedrockProvider', () => {
       const provider = createAmazonBedrock();
       const modelId = 'amazon.titan-image-generator';
 
-      const model = provider.imageModel(modelId, {
-        maxImagesPerCall: 5,
-      });
+      const model = provider.imageModel(modelId);
 
       const constructorCall = BedrockImageModelMock.mock.calls[0];
       expect(constructorCall[0]).toBe(modelId);
-      expect(constructorCall[1]).toEqual({ maxImagesPerCall: 5 });
       expect(model).toBeInstanceOf(BedrockImageModel);
     });
   });

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -167,11 +167,8 @@ export function createAmazonBedrock(
       fetch: sigv4Fetch,
     });
 
-  const createImageModel = (
-    modelId: BedrockImageModelId,
-    settings: BedrockImageSettings = {},
-  ) =>
-    new BedrockImageModel(modelId, settings, {
+  const createImageModel = (modelId: BedrockImageModelId) =>
+    new BedrockImageModel(modelId, {
       baseUrl: getBaseUrl,
       headers: options.headers ?? {},
       fetch: sigv4Fetch,

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -85,15 +85,9 @@ export interface AmazonBedrockProvider extends ProviderV2 {
 
   embedding(modelId: BedrockEmbeddingModelId): EmbeddingModelV2<string>;
 
-  image(
-    modelId: BedrockImageModelId,
-    settings?: BedrockImageSettings,
-  ): ImageModelV2;
+  image(modelId: BedrockImageModelId): ImageModelV2;
 
-  imageModel(
-    modelId: BedrockImageModelId,
-    settings?: BedrockImageSettings,
-  ): ImageModelV2;
+  imageModel(modelId: BedrockImageModelId): ImageModelV2;
 }
 
 /**

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -317,6 +317,7 @@ describe('image', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(
@@ -336,6 +337,7 @@ describe('image', () => {
           aspectRatio: undefined,
           seed: undefined,
           providerOptions: {},
+          providerRequestOptions: {},
         });
 
       expect(
@@ -361,6 +363,7 @@ describe('image', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         headers: {
           'Custom-Request-Header': 'request-header-value',
         },
@@ -389,6 +392,7 @@ describe('image', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(server.calls[0].requestUrl).toStrictEqual(
@@ -406,6 +410,7 @@ describe('image', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
@@ -421,6 +426,7 @@ describe('image', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: { openai: { style: 'natural' } },
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -53,10 +53,7 @@ Creates an Azure OpenAI completion model for text generation.
   /**
    * Creates an Azure OpenAI DALL-E model for image generation.
    */
-  imageModel(
-    deploymentId: string,
-    settings?: OpenAIImageSettings,
-  ): ImageModelV2;
+  imageModel(deploymentId: string): ImageModelV2;
 
   /**
 @deprecated Use `textEmbeddingModel` instead.

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -184,7 +184,7 @@ export function createAzure(
     modelId: string,
     settings: OpenAIImageSettings = {},
   ) =>
-    new OpenAIImageModel(modelId, settings, {
+    new OpenAIImageModel(modelId, {
       provider: 'azure.image',
       url,
       headers: getHeaders,

--- a/packages/deepinfra/src/deepinfra-image-model.test.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.test.ts
@@ -52,6 +52,7 @@ describe('DeepInfraImageModel', () => {
         aspectRatio: '16:9',
         seed: 42,
         providerOptions: { deepinfra: { additional_param: 'value' } },
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -73,6 +74,7 @@ describe('DeepInfraImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(server.calls[0].requestMethod).toStrictEqual('POST');
@@ -95,6 +97,7 @@ describe('DeepInfraImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         headers: {
           'Custom-Request-Header': 'request-header-value',
         },
@@ -127,6 +130,7 @@ describe('DeepInfraImageModel', () => {
           aspectRatio: undefined,
           seed: undefined,
           providerOptions: {},
+          providerRequestOptions: {},
         }),
       ).rejects.toThrow('Bad Request');
     });
@@ -141,6 +145,7 @@ describe('DeepInfraImageModel', () => {
         aspectRatio: undefined,
         seed: 42,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -163,6 +168,7 @@ describe('DeepInfraImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         abortSignal: controller.signal,
       });
 
@@ -186,6 +192,7 @@ describe('DeepInfraImageModel', () => {
           aspectRatio: undefined,
           seed: undefined,
           providerOptions: {},
+          providerRequestOptions: {},
         });
 
         expect(result.response).toStrictEqual({
@@ -214,6 +221,7 @@ describe('DeepInfraImageModel', () => {
           aspectRatio: undefined,
           seed: undefined,
           providerOptions: {},
+          providerRequestOptions: {},
         });
 
         expect(result.response.headers).toStrictEqual({

--- a/packages/deepinfra/src/deepinfra-image-model.test.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.test.ts
@@ -10,14 +10,12 @@ function createBasicModel({
   headers,
   fetch,
   currentDate,
-  settings,
 }: {
   headers?: () => Record<string, string>;
   fetch?: FetchFunction;
   currentDate?: () => Date;
-  settings?: DeepInfraImageSettings;
 } = {}) {
-  return new DeepInfraImageModel('stability-ai/sdxl', settings ?? {}, {
+  return new DeepInfraImageModel('stability-ai/sdxl', {
     provider: 'deepinfra',
     baseURL: 'https://api.example.com',
     headers: headers ?? (() => ({ 'api-key': 'test-key' })),
@@ -241,16 +239,6 @@ describe('DeepInfraImageModel', () => {
       expect(model.modelId).toBe('stability-ai/sdxl');
       expect(model.specificationVersion).toBe('v2');
       expect(model.maxImagesPerCall).toBe(1);
-    });
-
-    it('should use maxImagesPerCall from settings', () => {
-      const model = createBasicModel({
-        settings: {
-          maxImagesPerCall: 4,
-        },
-      });
-
-      expect(model.maxImagesPerCall).toBe(4);
     });
 
     it('should default maxImagesPerCall to 1 when not specified', () => {

--- a/packages/deepinfra/src/deepinfra-image-model.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.ts
@@ -32,7 +32,6 @@ export class DeepInfraImageModel implements ImageModelV2 {
 
   constructor(
     readonly modelId: DeepInfraImageModelId,
-    readonly settings: DeepInfraImageSettings,
     private config: DeepInfraImageModelConfig,
   ) {}
 

--- a/packages/deepinfra/src/deepinfra-image-model.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.ts
@@ -24,13 +24,10 @@ interface DeepInfraImageModelConfig {
 
 export class DeepInfraImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
+  readonly maxImagesPerCall = 1;
 
   get provider(): string {
     return this.config.provider;
-  }
-
-  get maxImagesPerCall(): number {
-    return this.settings.maxImagesPerCall ?? 1;
   }
 
   constructor(

--- a/packages/deepinfra/src/deepinfra-provider.test.ts
+++ b/packages/deepinfra/src/deepinfra-provider.test.ts
@@ -158,7 +158,6 @@ describe('DeepInfraProvider', () => {
       expect(model).toBeInstanceOf(DeepInfraImageModel);
       expect(DeepInfraImageModel).toHaveBeenCalledWith(
         modelId,
-        {},
         expect.any(Object),
       );
     });
@@ -172,7 +171,6 @@ describe('DeepInfraProvider', () => {
 
       expect(DeepInfraImageModel).toHaveBeenCalledWith(
         modelId,
-        expect.any(Object),
         expect.objectContaining({
           baseURL: `${customBaseURL}/inference`,
         }),

--- a/packages/deepinfra/src/deepinfra-provider.test.ts
+++ b/packages/deepinfra/src/deepinfra-provider.test.ts
@@ -136,14 +136,12 @@ describe('DeepInfraProvider', () => {
     it('should construct an image model with correct configuration', () => {
       const provider = createDeepInfra();
       const modelId = 'deepinfra-image-model';
-      const settings = { maxImagesPerCall: 2 };
 
-      const model = provider.image(modelId, settings);
+      const model = provider.image(modelId);
 
       expect(model).toBeInstanceOf(DeepInfraImageModel);
       expect(DeepInfraImageModel).toHaveBeenCalledWith(
         modelId,
-        settings,
         expect.objectContaining({
           provider: 'deepinfra.image',
           baseURL: 'https://api.deepinfra.com/v1/inference',

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -57,18 +57,12 @@ Creates a chat model for text generation.
   /**
 Creates a model for image generation.
   */
-  image(
-    modelId: DeepInfraImageModelId,
-    settings?: DeepInfraImageSettings,
-  ): ImageModelV2;
+  image(modelId: DeepInfraImageModelId): ImageModelV2;
 
   /**
 Creates a model for image generation.
   */
-  imageModel(
-    modelId: DeepInfraImageModelId,
-    settings?: DeepInfraImageSettings,
-  ): ImageModelV2;
+  imageModel(modelId: DeepInfraImageModelId): ImageModelV2;
 
   /**
 Creates a chat model for text generation.

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -130,11 +130,8 @@ export function createDeepInfra(
       getCommonModelConfig('embedding'),
     );
 
-  const createImageModel = (
-    modelId: DeepInfraImageModelId,
-    settings: DeepInfraImageSettings = {},
-  ) =>
-    new DeepInfraImageModel(modelId, settings, {
+  const createImageModel = (modelId: DeepInfraImageModelId) =>
+    new DeepInfraImageModel(modelId, {
       ...getCommonModelConfig('image'),
       baseURL: baseURL
         ? `${baseURL}/inference`

--- a/packages/fal/src/fal-image-model.test.ts
+++ b/packages/fal/src/fal-image-model.test.ts
@@ -16,7 +16,7 @@ function createBasicModel({
   currentDate?: () => Date;
   settings?: any;
 } = {}) {
-  return new FalImageModel('stable-diffusion-xl', settings ?? {}, {
+  return new FalImageModel('stable-diffusion-xl', {
     provider: 'fal',
     baseURL: 'https://api.example.com',
     headers: headers ?? { 'api-key': 'test-key' },
@@ -63,6 +63,7 @@ describe('FalImageModel', () => {
         aspectRatio: undefined,
         seed: 123,
         providerOptions: { fal: { additional_param: 'value' } },
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -84,6 +85,7 @@ describe('FalImageModel', () => {
         aspectRatio: '16:9',
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -104,6 +106,7 @@ describe('FalImageModel', () => {
         prompt,
         n: 1,
         providerOptions: {},
+        providerRequestOptions: {},
         headers: {
           'Custom-Request-Header': 'request-header-value',
         },
@@ -140,6 +143,7 @@ describe('FalImageModel', () => {
           prompt,
           n: 1,
           providerOptions: {},
+          providerRequestOptions: {},
           size: undefined,
           seed: undefined,
           aspectRatio: undefined,
@@ -162,6 +166,7 @@ describe('FalImageModel', () => {
           prompt,
           n: 1,
           providerOptions: {},
+          providerRequestOptions: {},
           size: undefined,
           seed: undefined,
           aspectRatio: undefined,
@@ -222,6 +227,7 @@ describe('FalImageModel', () => {
         prompt,
         n: 1,
         providerOptions: {},
+        providerRequestOptions: {},
         size: undefined,
         seed: undefined,
         aspectRatio: undefined,
@@ -257,6 +263,7 @@ describe('FalImageModel', () => {
         prompt,
         n: 2,
         providerOptions: {},
+        providerRequestOptions: {},
         size: undefined,
         seed: undefined,
         aspectRatio: undefined,

--- a/packages/fal/src/fal-image-model.test.ts
+++ b/packages/fal/src/fal-image-model.test.ts
@@ -190,22 +190,6 @@ describe('FalImageModel', () => {
       expect(model.specificationVersion).toBe('v2');
       expect(model.maxImagesPerCall).toBe(1);
     });
-
-    it('should use maxImagesPerCall from settings', () => {
-      const model = createBasicModel({
-        settings: {
-          maxImagesPerCall: 4,
-        },
-      });
-
-      expect(model.maxImagesPerCall).toBe(4);
-    });
-
-    it('should default maxImagesPerCall to 1 when not specified', () => {
-      const model = createBasicModel();
-
-      expect(model.maxImagesPerCall).toBe(1);
-    });
   });
 
   describe('response schema validation', () => {

--- a/packages/fal/src/fal-image-model.ts
+++ b/packages/fal/src/fal-image-model.ts
@@ -30,18 +30,14 @@ interface FalImageModelConfig {
 
 export class FalImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
+  readonly maxImagesPerCall = 1;
 
   get provider(): string {
     return this.config.provider;
   }
 
-  get maxImagesPerCall(): number {
-    return this.settings.maxImagesPerCall ?? 1;
-  }
-
   constructor(
     readonly modelId: FalImageModelId,
-    private readonly settings: FalImageSettings,
     private readonly config: FalImageModelConfig,
   ) {}
 

--- a/packages/fal/src/fal-provider.test.ts
+++ b/packages/fal/src/fal-provider.test.ts
@@ -21,7 +21,6 @@ describe('createFal', () => {
       expect(model).toBeInstanceOf(FalImageModel);
       expect(FalImageModel).toHaveBeenCalledWith(
         modelId,
-        {},
         expect.objectContaining({
           provider: 'fal.image',
           baseURL: 'https://fal.run',
@@ -39,7 +38,6 @@ describe('createFal', () => {
       expect(model).toBeInstanceOf(FalImageModel);
       expect(FalImageModel).toHaveBeenCalledWith(
         modelId,
-        settings,
         expect.objectContaining({
           provider: 'fal.image',
           baseURL: 'https://fal.run',
@@ -64,7 +62,6 @@ describe('createFal', () => {
 
       expect(FalImageModel).toHaveBeenCalledWith(
         modelId,
-        {},
         expect.objectContaining({
           baseURL: customBaseURL,
           headers: expect.any(Function),

--- a/packages/fal/src/fal-provider.ts
+++ b/packages/fal/src/fal-provider.ts
@@ -45,10 +45,7 @@ Creates a model for image generation.
   /**
 Creates a model for image generation.
    */
-  imageModel(
-    modelId: FalImageModelId,
-    settings?: FalImageSettings,
-  ): ImageModelV2;
+  imageModel(modelId: FalImageModelId): ImageModelV2;
 
   /**
 Creates a model for transcription.

--- a/packages/fal/src/fal-provider.ts
+++ b/packages/fal/src/fal-provider.ts
@@ -112,7 +112,7 @@ export function createFal(options: FalProviderSettings = {}): FalProvider {
     modelId: FalImageModelId,
     settings: FalImageSettings = {},
   ) =>
-    new FalImageModel(modelId, settings, {
+    new FalImageModel(modelId, {
       provider: 'fal.image',
       baseURL: baseURL ?? defaultBaseURL,
       headers: getHeaders,

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -10,32 +10,25 @@ function createBasicModel({
   headers,
   fetch,
   currentDate,
-  settings,
 }: {
   headers?: () => Record<string, string>;
   fetch?: FetchFunction;
   currentDate?: () => Date;
-  settings?: FireworksImageSettings;
 } = {}) {
-  return new FireworksImageModel(
-    'accounts/fireworks/models/flux-1-dev-fp8',
-    settings ?? {},
-    {
-      provider: 'fireworks',
-      baseURL: 'https://api.example.com',
-      headers: headers ?? (() => ({ 'api-key': 'test-key' })),
-      fetch,
-      _internal: {
-        currentDate,
-      },
+  return new FireworksImageModel('accounts/fireworks/models/flux-1-dev-fp8', {
+    provider: 'fireworks',
+    baseURL: 'https://api.example.com',
+    headers: headers ?? (() => ({ 'api-key': 'test-key' })),
+    fetch,
+    _internal: {
+      currentDate,
     },
-  );
+  });
 }
 
 function createSizeModel() {
   return new FireworksImageModel(
     'accounts/fireworks/models/playground-v2-5-1024px-aesthetic',
-    {},
     {
       provider: 'fireworks',
       baseURL: 'https://api.size-example.com',
@@ -376,16 +369,6 @@ describe('FireworksImageModel', () => {
       expect(model.modelId).toBe('accounts/fireworks/models/flux-1-dev-fp8');
       expect(model.specificationVersion).toBe('v2');
       expect(model.maxImagesPerCall).toBe(1);
-    });
-
-    it('should use maxImagesPerCall from settings', () => {
-      const model = createBasicModel({
-        settings: {
-          maxImagesPerCall: 4,
-        },
-      });
-
-      expect(model.maxImagesPerCall).toBe(4);
     });
 
     it('should default maxImagesPerCall to 1 when not specified', () => {

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -71,6 +71,7 @@ describe('FireworksImageModel', () => {
         aspectRatio: '16:9',
         seed: 42,
         providerOptions: { fireworks: { additional_param: 'value' } },
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -92,6 +93,7 @@ describe('FireworksImageModel', () => {
         aspectRatio: '16:9',
         seed: 42,
         providerOptions: { fireworks: { additional_param: 'value' } },
+        providerRequestOptions: {},
       });
 
       expect(server.calls[0].requestMethod).toStrictEqual('POST');
@@ -114,6 +116,7 @@ describe('FireworksImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         headers: {
           'Custom-Request-Header': 'request-header-value',
         },
@@ -140,6 +143,7 @@ describe('FireworksImageModel', () => {
           aspectRatio: undefined,
           seed: undefined,
           providerOptions: {},
+          providerRequestOptions: {},
         }),
       ).rejects.toMatchObject({
         message: 'Response body is empty',
@@ -167,6 +171,7 @@ describe('FireworksImageModel', () => {
           aspectRatio: undefined,
           seed: undefined,
           providerOptions: {},
+          providerRequestOptions: {},
         }),
       ).rejects.toMatchObject({
         message: 'Bad Request',
@@ -189,6 +194,7 @@ describe('FireworksImageModel', () => {
         aspectRatio: undefined,
         seed: 42,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -211,6 +217,7 @@ describe('FireworksImageModel', () => {
           aspectRatio: '1:1',
           seed: 123,
           providerOptions: {},
+          providerRequestOptions: {},
         });
 
         expect(result1.warnings).toContainEqual({
@@ -231,6 +238,7 @@ describe('FireworksImageModel', () => {
           aspectRatio: '1:1',
           seed: 123,
           providerOptions: {},
+          providerRequestOptions: {},
         });
 
         expect(result2.warnings).toContainEqual({
@@ -252,6 +260,7 @@ describe('FireworksImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         abortSignal: controller.signal,
       });
 
@@ -280,6 +289,7 @@ describe('FireworksImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(mockFetch).toHaveBeenCalled();
@@ -295,6 +305,7 @@ describe('FireworksImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toHaveProperty(
@@ -317,6 +328,7 @@ describe('FireworksImageModel', () => {
           aspectRatio: undefined,
           seed: undefined,
           providerOptions: {},
+          providerRequestOptions: {},
         });
 
         expect(result.response).toStrictEqual({
@@ -344,6 +356,7 @@ describe('FireworksImageModel', () => {
           aspectRatio: undefined,
           seed: undefined,
           providerOptions: {},
+          providerRequestOptions: {},
         });
 
         expect(result.response.headers).toStrictEqual({

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -72,13 +72,10 @@ interface FireworksImageModelConfig {
 
 export class FireworksImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
+  readonly maxImagesPerCall = 1;
 
   get provider(): string {
     return this.config.provider;
-  }
-
-  get maxImagesPerCall(): number {
-    return this.settings.maxImagesPerCall ?? 1;
   }
 
   constructor(

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -80,7 +80,6 @@ export class FireworksImageModel implements ImageModelV2 {
 
   constructor(
     readonly modelId: FireworksImageModelId,
-    readonly settings: FireworksImageSettings,
     private config: FireworksImageModelConfig,
   ) {}
 

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -132,7 +132,7 @@ describe('FireworksProvider', () => {
       const modelId = 'accounts/fireworks/models/flux-1-dev-fp8';
       const settings = { maxImagesPerCall: 2 };
 
-      const model = provider.image(modelId, settings);
+      const model = provider.image(modelId);
 
       expect(model).toBeInstanceOf(FireworksImageModel);
       expect(FireworksImageModel).toHaveBeenCalledWith(

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -127,24 +127,6 @@ describe('FireworksProvider', () => {
   });
 
   describe('image', () => {
-    it('should construct an image model with correct configuration', () => {
-      const provider = createFireworks();
-      const modelId = 'accounts/fireworks/models/flux-1-dev-fp8';
-      const settings = { maxImagesPerCall: 2 };
-
-      const model = provider.image(modelId);
-
-      expect(model).toBeInstanceOf(FireworksImageModel);
-      expect(FireworksImageModel).toHaveBeenCalledWith(
-        modelId,
-        settings,
-        expect.objectContaining({
-          provider: 'fireworks.image',
-          baseURL: 'https://api.fireworks.ai/inference/v1',
-        }),
-      );
-    });
-
     it('should use default settings when none provided', () => {
       const provider = createFireworks();
       const modelId = 'accounts/fireworks/models/flux-1-dev-fp8';
@@ -154,7 +136,6 @@ describe('FireworksProvider', () => {
       expect(model).toBeInstanceOf(FireworksImageModel);
       expect(FireworksImageModel).toHaveBeenCalledWith(
         modelId,
-        {},
         expect.any(Object),
       );
     });
@@ -164,11 +145,10 @@ describe('FireworksProvider', () => {
       const provider = createFireworks({ baseURL: customBaseURL });
       const modelId = 'accounts/fireworks/models/flux-1-dev-fp8';
 
-      const model = provider.image(modelId);
+      provider.image(modelId);
 
       expect(FireworksImageModel).toHaveBeenCalledWith(
         modelId,
-        expect.any(Object),
         expect.objectContaining({
           baseURL: customBaseURL,
         }),

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -144,11 +144,8 @@ export function createFireworks(
       errorStructure: fireworksErrorStructure,
     });
 
-  const createImageModel = (
-    modelId: FireworksImageModelId,
-    settings: FireworksImageSettings = {},
-  ) =>
-    new FireworksImageModel(modelId, settings, {
+  const createImageModel = (modelId: FireworksImageModelId) =>
+    new FireworksImageModel(modelId, {
       ...getCommonModelConfig('image'),
       baseURL: baseURL ?? defaultBaseURL,
     });

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -88,18 +88,12 @@ Creates a text embedding model for text generation.
   /**
 Creates a model for image generation.
 */
-  image(
-    modelId: FireworksImageModelId,
-    settings?: FireworksImageSettings,
-  ): ImageModelV2;
+  image(modelId: FireworksImageModelId): ImageModelV2;
 
   /**
 Creates a model for image generation.
 */
-  imageModel(
-    modelId: FireworksImageModelId,
-    settings?: FireworksImageSettings,
-  ): ImageModelV2;
+  imageModel(modelId: FireworksImageModelId): ImageModelV2;
 }
 
 const defaultBaseURL = 'https://api.fireworks.ai/inference/v1';

--- a/packages/google-vertex/src/google-vertex-image-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.test.ts
@@ -60,6 +60,7 @@ describe('GoogleVertexImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         headers: {
           'Custom-Request-Header': 'request-header-value',
         },
@@ -110,6 +111,7 @@ describe('GoogleVertexImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
@@ -125,6 +127,7 @@ describe('GoogleVertexImageModel', () => {
         aspectRatio: '16:9',
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -146,6 +149,7 @@ describe('GoogleVertexImageModel', () => {
         aspectRatio: '16:9',
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -167,6 +171,7 @@ describe('GoogleVertexImageModel', () => {
         aspectRatio: undefined,
         seed: 42,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -192,6 +197,7 @@ describe('GoogleVertexImageModel', () => {
             addWatermark: false,
           },
         },
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -215,6 +221,7 @@ describe('GoogleVertexImageModel', () => {
         aspectRatio: '1:1',
         seed: 123,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(result.warnings).toStrictEqual([
@@ -257,6 +264,7 @@ describe('GoogleVertexImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(result.response).toStrictEqual({
@@ -282,6 +290,7 @@ describe('GoogleVertexImageModel', () => {
         aspectRatio: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       const afterDate = new Date();
@@ -312,6 +321,7 @@ describe('GoogleVertexImageModel', () => {
             foo: 'bar',
           },
         },
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({

--- a/packages/google-vertex/src/google-vertex-image-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.test.ts
@@ -3,15 +3,11 @@ import { GoogleVertexImageModel } from './google-vertex-image-model';
 
 const prompt = 'A cute baby sea otter';
 
-const model = new GoogleVertexImageModel(
-  'imagen-3.0-generate-002',
-  {},
-  {
-    provider: 'google-vertex',
-    baseURL: 'https://api.example.com',
-    headers: { 'api-key': 'test-key' },
-  },
-);
+const model = new GoogleVertexImageModel('imagen-3.0-generate-002', {
+  provider: 'google-vertex',
+  baseURL: 'https://api.example.com',
+  headers: { 'api-key': 'test-key' },
+});
 
 const server = createTestServer({
   'https://api.example.com/models/imagen-3.0-generate-002:predict': {},
@@ -43,7 +39,6 @@ describe('GoogleVertexImageModel', () => {
 
       const modelWithHeaders = new GoogleVertexImageModel(
         'imagen-3.0-generate-002',
-        {},
         {
           provider: 'google-vertex',
           baseURL: 'https://api.example.com',
@@ -73,24 +68,9 @@ describe('GoogleVertexImageModel', () => {
       });
     });
 
-    it('should respect maxImagesPerCall setting', () => {
-      const customModel = new GoogleVertexImageModel(
-        'imagen-3.0-generate-002',
-        { maxImagesPerCall: 2 },
-        {
-          provider: 'google-vertex',
-          baseURL: 'https://api.example.com',
-          headers: { 'api-key': 'test-key' },
-        },
-      );
-
-      expect(customModel.maxImagesPerCall).toBe(2);
-    });
-
     it('should use default maxImagesPerCall when not specified', () => {
       const defaultModel = new GoogleVertexImageModel(
         'imagen-3.0-generate-002',
-        {},
         {
           provider: 'google-vertex',
           baseURL: 'https://api.example.com',
@@ -246,7 +226,6 @@ describe('GoogleVertexImageModel', () => {
 
       const customModel = new GoogleVertexImageModel(
         'imagen-3.0-generate-002',
-        {},
         {
           provider: 'google-vertex',
           baseURL: 'https://api.example.com',

--- a/packages/google-vertex/src/google-vertex-image-model.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.ts
@@ -27,14 +27,11 @@ interface GoogleVertexImageModelConfig {
 // https://cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images
 export class GoogleVertexImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
+  // https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api#parameter_list
+  readonly maxImagesPerCall = 4;
 
   get provider(): string {
     return this.config.provider;
-  }
-
-  get maxImagesPerCall(): number {
-    // https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api#parameter_list
-    return this.settings.maxImagesPerCall ?? 4;
   }
 
   constructor(

--- a/packages/google-vertex/src/google-vertex-image-model.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.ts
@@ -36,7 +36,6 @@ export class GoogleVertexImageModel implements ImageModelV2 {
 
   constructor(
     readonly modelId: GoogleVertexImageModelId,
-    readonly settings: GoogleVertexImageSettings,
     private config: GoogleVertexImageModelConfig,
   ) {}
 

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -161,14 +161,10 @@ describe('google-vertex-provider', () => {
       project: 'test-project',
       location: 'test-location',
     });
-    const imageSettings = {
-      maxImagesPerCall: 4,
-    };
-    provider.image('imagen-3.0-generate-002', imageSettings);
+    provider.image('imagen-3.0-generate-002');
 
     expect(GoogleVertexImageModel).toHaveBeenCalledWith(
       'imagen-3.0-generate-002',
-      imageSettings,
       expect.objectContaining({
         provider: 'google.vertex.image',
         headers: expect.any(Object),

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -146,7 +146,6 @@ describe('google-vertex-provider', () => {
 
     expect(GoogleVertexImageModel).toHaveBeenCalledWith(
       'imagen-3.0-generate-002',
-      {},
       expect.objectContaining({
         provider: 'google.vertex.image',
         baseURL:

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -129,10 +129,8 @@ export function createVertex(
   const createEmbeddingModel = (modelId: GoogleVertexEmbeddingModelId) =>
     new GoogleVertexEmbeddingModel(modelId, createConfig('embedding'));
 
-  const createImageModel = (
-    modelId: GoogleVertexImageModelId,
-    settings: GoogleVertexImageSettings = {},
-  ) => new GoogleVertexImageModel(modelId, settings, createConfig('image'));
+  const createImageModel = (modelId: GoogleVertexImageModelId) =>
+    new GoogleVertexImageModel(modelId, createConfig('image'));
 
   const provider = function (modelId: GoogleVertexModelId) {
     if (new.target) {

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -28,18 +28,12 @@ Creates a model for text generation.
   /**
    * Creates a model for image generation.
    */
-  image(
-    modelId: GoogleVertexImageModelId,
-    settings?: GoogleVertexImageSettings,
-  ): ImageModelV2;
+  image(modelId: GoogleVertexImageModelId): ImageModelV2;
 
   /**
 Creates a model for image generation.
    */
-  imageModel(
-    modelId: GoogleVertexImageModelId,
-    settings?: GoogleVertexImageSettings,
-  ): ImageModelV2;
+  imageModel(modelId: GoogleVertexImageModelId): ImageModelV2;
 }
 
 export interface GoogleVertexProviderSettings {

--- a/packages/luma/src/luma-image-model.test.ts
+++ b/packages/luma/src/luma-image-model.test.ts
@@ -17,7 +17,7 @@ function createBasicModel({
   currentDate?: () => Date;
   settings?: any;
 } = {}) {
-  return new LumaImageModel('test-model', settings ?? {}, {
+  return new LumaImageModel('test-model', {
     provider: 'luma',
     baseURL: 'https://api.example.com',
     headers: headers ?? (() => ({ 'api-key': 'test-key' })),
@@ -86,6 +86,7 @@ describe('LumaImageModel', () => {
         aspectRatio: '16:9',
         seed: undefined,
         providerOptions: { luma: { additional_param: 'value' } },
+        providerRequestOptions: {},
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -104,6 +105,7 @@ describe('LumaImageModel', () => {
         n: 1,
         aspectRatio: '16:9',
         providerOptions: {},
+        providerRequestOptions: {},
         size: undefined,
         seed: undefined,
       });
@@ -133,6 +135,7 @@ describe('LumaImageModel', () => {
         prompt,
         n: 1,
         providerOptions: {},
+        providerRequestOptions: {},
         headers: {
           'Custom-Request-Header': 'request-header-value',
         },
@@ -163,6 +166,7 @@ describe('LumaImageModel', () => {
           prompt,
           n: 1,
           providerOptions: {},
+          providerRequestOptions: {},
           size: undefined,
           seed: undefined,
           aspectRatio: undefined,
@@ -204,6 +208,7 @@ describe('LumaImageModel', () => {
           prompt,
           n: 1,
           providerOptions: {},
+          providerRequestOptions: {},
           size: undefined,
           seed: undefined,
           aspectRatio: undefined,
@@ -221,6 +226,7 @@ describe('LumaImageModel', () => {
           size: '1024x1024',
           seed: 123,
           providerOptions: {},
+          providerRequestOptions: {},
           aspectRatio: undefined,
         });
 
@@ -250,6 +256,7 @@ describe('LumaImageModel', () => {
           prompt,
           n: 1,
           providerOptions: {},
+          providerRequestOptions: {},
           size: undefined,
           seed: undefined,
           aspectRatio: undefined,
@@ -325,6 +332,7 @@ describe('LumaImageModel', () => {
         prompt,
         n: 1,
         providerOptions: {},
+        providerRequestOptions: {},
         size: undefined,
         seed: undefined,
         aspectRatio: undefined,
@@ -367,6 +375,7 @@ describe('LumaImageModel', () => {
         prompt,
         n: 1,
         providerOptions: {},
+        providerRequestOptions: {},
         size: undefined,
         seed: undefined,
         aspectRatio: undefined,
@@ -407,6 +416,7 @@ describe('LumaImageModel', () => {
         prompt,
         n: 1,
         providerOptions: {},
+        providerRequestOptions: {},
         size: undefined,
         seed: undefined,
         aspectRatio: undefined,
@@ -446,6 +456,7 @@ describe('LumaImageModel', () => {
         prompt,
         n: 1,
         providerOptions: {},
+        providerRequestOptions: {},
         size: undefined,
         seed: undefined,
         aspectRatio: undefined,
@@ -502,6 +513,7 @@ describe('LumaImageModel', () => {
         prompt,
         n: 1,
         providerOptions: {},
+        providerRequestOptions: {},
         size: undefined,
         seed: undefined,
         aspectRatio: undefined,

--- a/packages/luma/src/luma-image-model.test.ts
+++ b/packages/luma/src/luma-image-model.test.ts
@@ -10,7 +10,6 @@ function createBasicModel({
   headers,
   fetch,
   currentDate,
-  settings,
 }: {
   headers?: () => Record<string, string>;
   fetch?: FetchFunction;
@@ -278,22 +277,6 @@ describe('LumaImageModel', () => {
       expect(model.provider).toBe('luma');
       expect(model.modelId).toBe('test-model');
       expect(model.specificationVersion).toBe('v2');
-      expect(model.maxImagesPerCall).toBe(1);
-    });
-
-    it('should use maxImagesPerCall from settings', () => {
-      const model = createBasicModel({
-        settings: {
-          maxImagesPerCall: 4,
-        },
-      });
-
-      expect(model.maxImagesPerCall).toBe(4);
-    });
-
-    it('should default maxImagesPerCall to 1 when not specified', () => {
-      const model = createBasicModel();
-
       expect(model.maxImagesPerCall).toBe(1);
     });
   });

--- a/packages/luma/src/luma-image-model.ts
+++ b/packages/luma/src/luma-image-model.ts
@@ -32,6 +32,7 @@ interface LumaImageModelConfig {
 
 export class LumaImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
+  readonly maxImagesPerCall = 1;
 
   private readonly pollIntervalMillis: number;
   private readonly maxPollAttempts: number;
@@ -40,13 +41,8 @@ export class LumaImageModel implements ImageModelV2 {
     return this.config.provider;
   }
 
-  get maxImagesPerCall(): number {
-    return this.settings.maxImagesPerCall ?? 1;
-  }
-
   constructor(
     readonly modelId: string,
-    private readonly settings: LumaImageSettings,
     private readonly config: LumaImageModelConfig,
   ) {
     this.pollIntervalMillis =

--- a/packages/luma/src/luma-provider.test.ts
+++ b/packages/luma/src/luma-provider.test.ts
@@ -21,25 +21,6 @@ describe('createLuma', () => {
       expect(model).toBeInstanceOf(LumaImageModel);
       expect(LumaImageModel).toHaveBeenCalledWith(
         modelId,
-        {},
-        expect.objectContaining({
-          provider: 'luma.image',
-          baseURL: 'https://api.lumalabs.ai',
-        }),
-      );
-    });
-
-    it('should construct an image model with custom settings', () => {
-      const provider = createLuma();
-      const modelId = 'luma-v1';
-      const settings = { maxImagesPerCall: 2 };
-
-      const model = provider.image(modelId, settings);
-
-      expect(model).toBeInstanceOf(LumaImageModel);
-      expect(LumaImageModel).toHaveBeenCalledWith(
-        modelId,
-        settings,
         expect.objectContaining({
           provider: 'luma.image',
           baseURL: 'https://api.lumalabs.ai',
@@ -64,7 +45,6 @@ describe('createLuma', () => {
 
       expect(LumaImageModel).toHaveBeenCalledWith(
         modelId,
-        {},
         expect.objectContaining({
           baseURL: customBaseURL,
           headers: expect.any(Function),

--- a/packages/luma/src/luma-provider.ts
+++ b/packages/luma/src/luma-provider.ts
@@ -53,11 +53,8 @@ export function createLuma(options: LumaProviderSettings = {}): LumaProvider {
     ...options.headers,
   });
 
-  const createImageModel = (
-    modelId: LumaImageModelId,
-    settings: LumaImageSettings = {},
-  ) =>
-    new LumaImageModel(modelId, settings, {
+  const createImageModel = (modelId: LumaImageModelId) =>
+    new LumaImageModel(modelId, {
       provider: 'luma.image',
       baseURL: baseURL ?? defaultBaseURL,
       headers: getHeaders,

--- a/packages/luma/src/luma-provider.ts
+++ b/packages/luma/src/luma-provider.ts
@@ -37,10 +37,7 @@ Creates a model for image generation.
   /**
 Creates a model for image generation.
    */
-  imageModel(
-    modelId: LumaImageModelId,
-    settings?: LumaImageSettings,
-  ): ImageModelV2;
+  imageModel(modelId: LumaImageModelId): ImageModelV2;
 }
 
 const defaultBaseURL = 'https://api.lumalabs.ai';

--- a/packages/openai-compatible/src/openai-compatible-image-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-image-model.test.ts
@@ -20,7 +20,7 @@ function createBasicModel({
   settings?: any;
   errorStructure?: ProviderErrorStructure<any>;
 } = {}) {
-  return new OpenAICompatibleImageModel('dall-e-3', settings ?? {}, {
+  return new OpenAICompatibleImageModel('dall-e-3', {
     provider: 'openai-compatible',
     headers: headers ?? (() => ({ Authorization: 'Bearer test-key' })),
     url: ({ modelId, path }) => `https://api.example.com/${modelId}${path}`,
@@ -40,6 +40,7 @@ function createDefaultGenerateParams(overrides = {}): ImageModelV2CallOptions {
     aspectRatio: undefined,
     seed: undefined,
     providerOptions: {},
+    providerRequestOptions: {},
     headers: {},
     abortSignal: undefined,
     ...overrides,
@@ -259,16 +260,11 @@ describe('OpenAICompatibleImageModel', () => {
     it('should use real date when no custom date provider is specified', async () => {
       const beforeDate = new Date();
 
-      const model = new OpenAICompatibleImageModel(
-        'dall-e-3',
-        {},
-        {
-          provider: 'openai-compatible',
-          headers: () => ({ Authorization: 'Bearer test-key' }),
-          url: ({ modelId, path }) =>
-            `https://api.example.com/${modelId}${path}`,
-        },
-      );
+      const model = new OpenAICompatibleImageModel('dall-e-3', {
+        provider: 'openai-compatible',
+        headers: () => ({ Authorization: 'Bearer test-key' }),
+        url: ({ modelId, path }) => `https://api.example.com/${modelId}${path}`,
+      });
 
       const result = await model.doGenerate(createDefaultGenerateParams());
 

--- a/packages/openai-compatible/src/openai-compatible-image-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-image-model.test.ts
@@ -76,16 +76,6 @@ describe('OpenAICompatibleImageModel', () => {
       expect(model.maxImagesPerCall).toBe(10);
     });
 
-    it('should use maxImagesPerCall from settings', () => {
-      const model = createBasicModel({
-        settings: {
-          maxImagesPerCall: 5,
-        },
-      });
-
-      expect(model.maxImagesPerCall).toBe(5);
-    });
-
     it('should default maxImagesPerCall to 10 when not specified', () => {
       const model = createBasicModel();
 
@@ -280,13 +270,16 @@ describe('OpenAICompatibleImageModel', () => {
     });
 
     it('should pass the user setting in the request', async () => {
-      const model = createBasicModel({
-        settings: {
-          user: 'test-user-id',
-        },
-      });
-
-      await model.doGenerate(createDefaultGenerateParams());
+      const model = createBasicModel();
+      await model.doGenerate(
+        createDefaultGenerateParams({
+          providerRequestOptions: {
+            openai: {
+              user: 'test-user-id',
+            },
+          },
+        }),
+      );
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
         model: 'dall-e-3',
@@ -299,11 +292,16 @@ describe('OpenAICompatibleImageModel', () => {
     });
 
     it('should not include user field in request when setting is not provided', async () => {
-      const model = createBasicModel({
-        settings: {}, // explicitly empty settings
-      });
+      const model = createBasicModel();
 
-      await model.doGenerate(createDefaultGenerateParams());
+      await model.doGenerate(
+        createDefaultGenerateParams({
+          providerRequestOptions: {
+            // explicitly not setting user
+            openai: {},
+          },
+        }),
+      );
 
       const requestBody = await server.calls[0].requestBodyJson;
       expect(requestBody).toStrictEqual({

--- a/packages/openai-compatible/src/openai-compatible-image-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-image-model.ts
@@ -47,6 +47,7 @@ export class OpenAICompatibleImageModel implements ImageModelV2 {
     aspectRatio,
     seed,
     providerOptions,
+    providerRequestOptions,
     headers,
     abortSignal,
   }: Parameters<ImageModelV2['doGenerate']>[0]): Promise<
@@ -81,7 +82,9 @@ export class OpenAICompatibleImageModel implements ImageModelV2 {
         size,
         ...(providerOptions.openai ?? {}),
         response_format: 'b64_json',
-        ...(this.settings.user ? { user: this.settings.user } : {}),
+        ...(providerRequestOptions.openai?.user
+          ? { user: providerRequestOptions.openai.user }
+          : {}),
       },
       failedResponseHandler: createJsonErrorResponseHandler(
         this.config.errorStructure ?? defaultOpenAICompatibleErrorStructure,

--- a/packages/openai-compatible/src/openai-compatible-image-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-image-model.ts
@@ -29,10 +29,7 @@ export type OpenAICompatibleImageModelConfig = {
 
 export class OpenAICompatibleImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
-
-  get maxImagesPerCall(): number {
-    return this.settings.maxImagesPerCall ?? 10;
-  }
+  readonly maxImagesPerCall = 10;
 
   get provider(): string {
     return this.config.provider;
@@ -40,7 +37,6 @@ export class OpenAICompatibleImageModel implements ImageModelV2 {
 
   constructor(
     readonly modelId: OpenAICompatibleImageModelId,
-    private readonly settings: OpenAICompatibleImageSettings,
     private readonly config: OpenAICompatibleImageModelConfig,
   ) {}
 

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -130,15 +130,8 @@ export function createOpenAICompatible<
       ...getCommonModelConfig('embedding'),
     });
 
-  const createImageModel = (
-    modelId: IMAGE_MODEL_IDS,
-    settings: OpenAICompatibleImageSettings = {},
-  ) =>
-    new OpenAICompatibleImageModel(
-      modelId,
-      settings,
-      getCommonModelConfig('image'),
-    );
+  const createImageModel = (modelId: IMAGE_MODEL_IDS) =>
+    new OpenAICompatibleImageModel(modelId, getCommonModelConfig('image'));
 
   const provider = (modelId: CHAT_MODEL_IDS) => createLanguageModel(modelId);
 

--- a/packages/openai/src/openai-image-model.test.ts
+++ b/packages/openai/src/openai-image-model.test.ts
@@ -5,7 +5,7 @@ import { createOpenAI } from './openai-provider';
 const prompt = 'A cute baby sea otter';
 
 const provider = createOpenAI({ apiKey: 'test-api-key' });
-const model = provider.image('dall-e-3', { maxImagesPerCall: 2 });
+const model = provider.image('dall-e-3');
 
 const server = createTestServer({
   'https://api.openai.com/v1/images/generations': {},
@@ -46,6 +46,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: { openai: { style: 'vivid' } },
+      providerRequestOptions: {},
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -77,6 +78,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: { openai: { style: 'vivid' } },
+      providerRequestOptions: {},
       headers: {
         'Custom-Request-Header': 'request-header-value',
       },
@@ -102,6 +104,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.images).toStrictEqual(['base64-image-1', 'base64-image-2']);
@@ -117,6 +120,7 @@ describe('doGenerate', () => {
       aspectRatio: '1:1',
       seed: 123,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.warnings).toStrictEqual([
@@ -136,9 +140,6 @@ describe('doGenerate', () => {
   it('should respect maxImagesPerCall setting', async () => {
     prepareJsonResponse();
 
-    const customModel = provider.image('dall-e-2', { maxImagesPerCall: 5 });
-    expect(customModel.maxImagesPerCall).toBe(5);
-
     const defaultModel = provider.image('dall-e-2');
     expect(defaultModel.maxImagesPerCall).toBe(10); // dall-e-2's default from settings
 
@@ -156,18 +157,14 @@ describe('doGenerate', () => {
 
     const testDate = new Date('2024-03-15T12:00:00Z');
 
-    const customModel = new OpenAIImageModel(
-      'dall-e-3',
-      {},
-      {
-        provider: 'test-provider',
-        url: () => 'https://api.openai.com/v1/images/generations',
-        headers: () => ({}),
-        _internal: {
-          currentDate: () => testDate,
-        },
+    const customModel = new OpenAIImageModel('dall-e-3', {
+      provider: 'test-provider',
+      url: () => 'https://api.openai.com/v1/images/generations',
+      headers: () => ({}),
+      _internal: {
+        currentDate: () => testDate,
       },
-    );
+    });
 
     const result = await customModel.doGenerate({
       prompt,
@@ -176,6 +173,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.response).toStrictEqual({
@@ -201,6 +199,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     const afterDate = new Date();
@@ -225,6 +224,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     const requestBody =
@@ -249,6 +249,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     const requestBody =
@@ -266,6 +267,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: { openai: { style: 'vivid' } },
+      providerRequestOptions: {},
     });
 
     expect(result.providerMetadata).toStrictEqual({

--- a/packages/openai/src/openai-image-model.ts
+++ b/packages/openai/src/openai-image-model.ts
@@ -24,9 +24,7 @@ export class OpenAIImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
 
   get maxImagesPerCall(): number {
-    return (
-      this.settings.maxImagesPerCall ?? modelMaxImagesPerCall[this.modelId] ?? 1
-    );
+    return modelMaxImagesPerCall[this.modelId] ?? 1;
   }
 
   get provider(): string {
@@ -35,7 +33,6 @@ export class OpenAIImageModel implements ImageModelV2 {
 
   constructor(
     readonly modelId: OpenAIImageModelId,
-    private readonly settings: OpenAIImageSettings,
     private readonly config: OpenAIImageModelConfig,
   ) {}
 

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -77,18 +77,12 @@ Creates a model for text embeddings.
   /**
 Creates a model for image generation.
    */
-  image(
-    modelId: OpenAIImageModelId,
-    settings?: OpenAIImageSettings,
-  ): ImageModelV2;
+  image(modelId: OpenAIImageModelId): ImageModelV2;
 
   /**
 Creates a model for image generation.
    */
-  imageModel(
-    modelId: OpenAIImageModelId,
-    settings?: OpenAIImageSettings,
-  ): ImageModelV2;
+  imageModel(modelId: OpenAIImageModelId): ImageModelV2;
 
   /**
 Creates a model for transcription.

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -200,7 +200,7 @@ export function createOpenAI(
     modelId: OpenAIImageModelId,
     settings: OpenAIImageSettings = {},
   ) =>
-    new OpenAIImageModel(modelId, settings, {
+    new OpenAIImageModel(modelId, {
       provider: `${providerName}.image`,
       url: ({ path }) => `${baseURL}${path}`,
       headers: getHeaders,

--- a/packages/provider/src/image-model/v2/image-model-v2-call-options.ts
+++ b/packages/provider/src/image-model/v2/image-model-v2-call-options.ts
@@ -48,6 +48,23 @@ record is keyed by the provider-specific metadata key.
   providerOptions: SharedV2ProviderOptions;
 
   /**
+Additional provider-specific options that are NOT passed through to the provider
+as body parameters.
+
+The outer record is keyed by the provider name, and the inner
+record is keyed by the provider-specific metadata key.
+
+```ts
+{
+  "openai": {
+    "maxImagesPerCall": 3
+  }
+}
+```
+ */
+  providerRequestOptions: SharedV2ProviderOptions;
+
+  /**
 Abort signal for cancelling the operation.
  */
   abortSignal?: AbortSignal;

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -66,6 +66,7 @@ describe('doGenerate', () => {
           something: 'else',
         },
       },
+      providerRequestOptions: {},
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -90,6 +91,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(server.calls[0].requestMethod).toStrictEqual('POST');
@@ -115,6 +117,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
       headers: {
         'Custom-Request-Header': 'request-header-value',
       },
@@ -141,6 +144,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.images).toStrictEqual([
@@ -165,6 +169,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.images).toStrictEqual([
@@ -180,7 +185,6 @@ describe('doGenerate', () => {
   it('should return response metadata', async () => {
     const modelWithTimestamp = new ReplicateImageModel(
       'black-forest-labs/flux-schnell',
-      {},
       {
         provider: 'replicate',
         baseURL: 'https://api.replicate.com',
@@ -198,6 +202,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.response).toStrictEqual({
@@ -210,7 +215,6 @@ describe('doGenerate', () => {
   it('should include response headers in metadata', async () => {
     const modelWithTimestamp = new ReplicateImageModel(
       'black-forest-labs/flux-schnell',
-      {},
       {
         provider: 'replicate',
         baseURL: 'https://api.replicate.com',
@@ -255,6 +259,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(result.response).toStrictEqual({
@@ -282,6 +287,7 @@ describe('doGenerate', () => {
       aspectRatio: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
     });
 
     expect(server.calls[0].requestMethod).toStrictEqual('POST');

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -28,18 +28,14 @@ interface ReplicateImageModelConfig {
 
 export class ReplicateImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
+  readonly maxImagesPerCall = 1;
 
   get provider(): string {
     return this.config.provider;
   }
 
-  get maxImagesPerCall(): number {
-    return this.settings.maxImagesPerCall ?? 1;
-  }
-
   constructor(
     readonly modelId: ReplicateImageModelId,
-    private readonly settings: ReplicateImageSettings,
     private readonly config: ReplicateImageModelConfig,
   ) {}
 

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -51,7 +51,7 @@ export function createReplicate(
   options: ReplicateProviderSettings = {},
 ): ReplicateProvider {
   const createImageModel = (modelId: ReplicateImageModelId) =>
-    new ReplicateImageModel(modelId, settings ?? {}, {
+    new ReplicateImageModel(modelId, {
       provider: 'replicate',
       baseURL: options.baseURL ?? 'https://api.replicate.com/v1',
       headers: {

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -36,18 +36,12 @@ export interface ReplicateProvider extends ProviderV2 {
   /**
    * Creates a Replicate image generation model.
    */
-  image(
-    modelId: ReplicateImageModelId,
-    settings?: ReplicateImageSettings,
-  ): ReplicateImageModel;
+  image(modelId: ReplicateImageModelId): ReplicateImageModel;
 
   /**
    * Creates a Replicate image generation model.
    */
-  imageModel(
-    modelId: ReplicateImageModelId,
-    settings?: ReplicateImageSettings,
-  ): ReplicateImageModel;
+  imageModel(modelId: ReplicateImageModelId): ReplicateImageModel;
 }
 
 /**
@@ -56,10 +50,7 @@ export interface ReplicateProvider extends ProviderV2 {
 export function createReplicate(
   options: ReplicateProviderSettings = {},
 ): ReplicateProvider {
-  const createImageModel = (
-    modelId: ReplicateImageModelId,
-    settings?: ReplicateImageSettings,
-  ) =>
+  const createImageModel = (modelId: ReplicateImageModelId) =>
     new ReplicateImageModel(modelId, settings ?? {}, {
       provider: 'replicate',
       baseURL: options.baseURL ?? 'https://api.replicate.com/v1',

--- a/packages/togetherai/src/togetherai-image-model.test.ts
+++ b/packages/togetherai/src/togetherai-image-model.test.ts
@@ -56,6 +56,7 @@ describe('doGenerate', () => {
       size: '1024x1024',
       seed: 42,
       providerOptions: { togetherai: { additional_param: 'value' } },
+      providerRequestOptions: {},
       aspectRatio: undefined,
     });
 
@@ -80,6 +81,7 @@ describe('doGenerate', () => {
       size: '1024x1024',
       seed: 42,
       providerOptions: {},
+      providerRequestOptions: {},
       aspectRatio: undefined,
     });
 
@@ -102,6 +104,7 @@ describe('doGenerate', () => {
       size: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
       aspectRatio: undefined,
       headers: {
         'Custom-Request-Header': 'request-header-value',
@@ -134,6 +137,7 @@ describe('doGenerate', () => {
         size: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         aspectRatio: undefined,
       }),
     ).rejects.toMatchObject({
@@ -152,6 +156,7 @@ describe('doGenerate', () => {
         aspectRatio: '1:1',
         seed: 123,
         providerOptions: {},
+        providerRequestOptions: {},
       });
 
       expect(result.warnings).toContainEqual({
@@ -173,6 +178,7 @@ describe('doGenerate', () => {
       size: undefined,
       seed: undefined,
       providerOptions: {},
+      providerRequestOptions: {},
       aspectRatio: undefined,
       abortSignal: controller.signal,
     });
@@ -195,6 +201,7 @@ describe('doGenerate', () => {
         size: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         aspectRatio: undefined,
       });
 
@@ -227,6 +234,7 @@ describe('doGenerate', () => {
         size: undefined,
         seed: undefined,
         providerOptions: {},
+        providerRequestOptions: {},
         aspectRatio: undefined,
       });
 

--- a/packages/togetherai/src/togetherai-image-model.test.ts
+++ b/packages/togetherai/src/togetherai-image-model.test.ts
@@ -10,26 +10,20 @@ function createBasicModel({
   headers,
   fetch,
   currentDate,
-  settings,
 }: {
   headers?: () => Record<string, string>;
   fetch?: FetchFunction;
   currentDate?: () => Date;
-  settings?: TogetherAIImageSettings;
 } = {}) {
-  return new TogetherAIImageModel(
-    'stabilityai/stable-diffusion-xl',
-    settings ?? {},
-    {
-      provider: 'togetherai',
-      baseURL: 'https://api.example.com',
-      headers: headers ?? (() => ({ 'api-key': 'test-key' })),
-      fetch,
-      _internal: {
-        currentDate,
-      },
+  return new TogetherAIImageModel('stabilityai/stable-diffusion-xl', {
+    provider: 'togetherai',
+    baseURL: 'https://api.example.com',
+    headers: headers ?? (() => ({ 'api-key': 'test-key' })),
+    fetch,
+    _internal: {
+      currentDate,
     },
-  );
+  });
 }
 
 const server = createTestServer({
@@ -255,16 +249,6 @@ describe('constructor', () => {
     expect(model.modelId).toBe('stabilityai/stable-diffusion-xl');
     expect(model.specificationVersion).toBe('v2');
     expect(model.maxImagesPerCall).toBe(1);
-  });
-
-  it('should use maxImagesPerCall from settings', () => {
-    const model = createBasicModel({
-      settings: {
-        maxImagesPerCall: 4,
-      },
-    });
-
-    expect(model.maxImagesPerCall).toBe(4);
   });
 
   it('should default maxImagesPerCall to 1 when not specified', () => {

--- a/packages/togetherai/src/togetherai-image-model.ts
+++ b/packages/togetherai/src/togetherai-image-model.ts
@@ -24,13 +24,10 @@ interface TogetherAIImageModelConfig {
 
 export class TogetherAIImageModel implements ImageModelV2 {
   readonly specificationVersion = 'v2';
+  readonly maxImagesPerCall = 1;
 
   get provider(): string {
     return this.config.provider;
-  }
-
-  get maxImagesPerCall(): number {
-    return this.settings.maxImagesPerCall ?? 1;
   }
 
   constructor(

--- a/packages/togetherai/src/togetherai-image-model.ts
+++ b/packages/togetherai/src/togetherai-image-model.ts
@@ -32,7 +32,6 @@ export class TogetherAIImageModel implements ImageModelV2 {
 
   constructor(
     readonly modelId: TogetherAIImageModelId,
-    readonly settings: TogetherAIImageSettings,
     private config: TogetherAIImageModelConfig,
   ) {}
 

--- a/packages/togetherai/src/togetherai-provider.test.ts
+++ b/packages/togetherai/src/togetherai-provider.test.ts
@@ -154,7 +154,6 @@ describe('TogetherAIProvider', () => {
 
       expect(TogetherAIImageModel).toHaveBeenCalledWith(
         modelId,
-        expect.any(Object),
         expect.objectContaining({
           baseURL: 'https://custom.url/',
         }),

--- a/packages/togetherai/src/togetherai-provider.test.ts
+++ b/packages/togetherai/src/togetherai-provider.test.ts
@@ -131,13 +131,11 @@ describe('TogetherAIProvider', () => {
     it('should construct an image model with correct configuration', () => {
       const provider = createTogetherAI();
       const modelId = 'stabilityai/stable-diffusion-xl';
-      const settings = { maxImagesPerCall: 4 };
 
-      const model = provider.image(modelId, settings);
+      const model = provider.image(modelId);
 
       expect(TogetherAIImageModel).toHaveBeenCalledWith(
         modelId,
-        settings,
         expect.objectContaining({
           provider: 'togetherai.image',
           baseURL: 'https://api.together.xyz/v1/',

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -130,11 +130,8 @@ export function createTogetherAI(
       getCommonModelConfig('embedding'),
     );
 
-  const createImageModel = (
-    modelId: TogetherAIImageModelId,
-    settings: TogetherAIImageSettings = {},
-  ) =>
-    new TogetherAIImageModel(modelId, settings, {
+  const createImageModel = (modelId: TogetherAIImageModelId) =>
+    new TogetherAIImageModel(modelId, {
       ...getCommonModelConfig('image'),
       baseURL: baseURL ?? 'https://api.together.xyz/v1/',
     });

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -74,10 +74,7 @@ Creates a text embedding model for text generation.
   /**
   Creates a model for image generation.
    */
-  image(
-    modelId: TogetherAIImageModelId,
-    settings?: TogetherAIImageSettings,
-  ): ImageModelV2;
+  image(modelId: TogetherAIImageModelId): ImageModelV2;
 
   /**
   Creates a model for image generation.

--- a/packages/xai/src/xai-provider.test.ts
+++ b/packages/xai/src/xai-provider.test.ts
@@ -113,9 +113,9 @@ describe('xAIProvider', () => {
       expect(model).toBeInstanceOf(OpenAICompatibleImageModel);
 
       const constructorCall = OpenAICompatibleImageModelMock.mock.calls[0];
-      expect(constructorCall).toStrictEqual([modelId]);
+      expect(constructorCall[0]).toBe(modelId);
 
-      const config = constructorCall[2];
+      const config = constructorCall[1];
       expect(config.provider).toBe('xai.image');
       expect(config.url({ path: '/test-path' })).toBe(
         'https://api.x.ai/v1/test-path',
@@ -130,7 +130,7 @@ describe('xAIProvider', () => {
       provider.imageModel(modelId);
 
       const constructorCall = OpenAICompatibleImageModelMock.mock.calls[0];
-      const config = constructorCall[2];
+      const config = constructorCall[1];
       expect(config.url({ path: '/test-path' })).toBe(
         `${customBaseURL}/test-path`,
       );
@@ -143,7 +143,7 @@ describe('xAIProvider', () => {
       provider.imageModel('grok-2-image');
 
       const constructorCall = OpenAICompatibleImageModelMock.mock.calls[0];
-      const config = constructorCall[2];
+      const config = constructorCall[1];
       const headers = config.headers();
 
       expect(headers).toMatchObject({

--- a/packages/xai/src/xai-provider.test.ts
+++ b/packages/xai/src/xai-provider.test.ts
@@ -107,15 +107,13 @@ describe('xAIProvider', () => {
     it('should construct an image model with correct configuration', () => {
       const provider = createXai();
       const modelId = 'grok-2-image';
-      const settings = { maxImagesPerCall: 3 };
 
-      const model = provider.imageModel(modelId, settings);
+      const model = provider.imageModel(modelId);
 
       expect(model).toBeInstanceOf(OpenAICompatibleImageModel);
 
       const constructorCall = OpenAICompatibleImageModelMock.mock.calls[0];
-      expect(constructorCall[0]).toBe(modelId);
-      expect(constructorCall[1]).toEqual(settings);
+      expect(constructorCall).toStrictEqual([modelId]);
 
       const config = constructorCall[2];
       expect(config.provider).toBe('xai.image');

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -47,10 +47,7 @@ Creates an Xai image model for image generation.
   /**
 Creates an Xai image model for image generation.
    */
-  imageModel(
-    modelId: XaiImageModelId,
-    settings?: XaiImageSettings,
-  ): ImageModelV2;
+  imageModel(modelId: XaiImageModelId): ImageModelV2;
 }
 
 export interface XaiProviderSettings {

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -99,11 +99,8 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
     });
   };
 
-  const createImageModel = (
-    modelId: XaiImageModelId,
-    settings: XaiImageSettings = {},
-  ) => {
-    return new OpenAICompatibleImageModel(modelId, settings, {
+  const createImageModel = (modelId: XaiImageModelId) => {
+    return new OpenAICompatibleImageModel(modelId, {
       provider: 'xai.image',
       url: ({ path }) => `${baseURL}${path}`,
       headers: getHeaders,


### PR DESCRIPTION
## Background

Closes #6077

Alternative approach to #6083, based on https://github.com/vercel/ai/issues/6077#issuecomment-2848759225

## Summary

Before

```js
await generateImage({
  model: openai.image("dall-e-2", { maxImagesPerCall: 5 }),
  prompt,
  n: 10,
});
```

after

```js
await generateImage({
  model: openai.image("dall-e-2"),
  prompt,
  n: 10,
  providerRequestOptions: {
    openai: { maxImagesPerCall: 5 },
  },
});
```

## Verification

TBD

## Task

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

TBD
