### PR TITLE
feat: deprecate `ProviderV2#image` across all providers

### DIFF
--- a/content/cookbook/01-next/12-generate-image-with-chat-prompt.mdx
+++ b/content/cookbook/01-next/12-generate-image-with-chat-prompt.mdx
@@ -43,7 +43,7 @@ export async function POST(request: Request) {
         }),
         execute: async ({ prompt }) => {
           const { image } = await experimental_generateImage({
-            model: openai.image('dall-e-3'),
+            model: openai.imageModel('dall-e-3'),
             prompt,
           });
           // in production, save this image to blob storage and return a URL

--- a/content/docs/03-ai-sdk-core/35-image-generation.mdx
+++ b/content/docs/03-ai-sdk-core/35-image-generation.mdx
@@ -15,7 +15,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const { image } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   prompt: 'Santa Claus driving a Cadillac',
 });
 ```
@@ -43,7 +43,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const { image } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   prompt: 'Santa Claus driving a Cadillac',
   size: '1024x1024',
 });
@@ -59,7 +59,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import { vertex } from '@ai-sdk/google-vertex';
 
 const { image } = await generateImage({
-  model: vertex.image('imagen-3.0-generate-002'),
+  model: vertex.imageModel('imagen-3.0-generate-002'),
   prompt: 'Santa Claus driving a Cadillac',
   aspectRatio: '16:9',
 });
@@ -74,7 +74,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const { images } = await generateImage({
-  model: openai.image('dall-e-2'),
+  model: openai.imageModel('dall-e-2'),
   prompt: 'Santa Claus driving a Cadillac',
   n: 4, // number of images to generate
 });
@@ -90,7 +90,7 @@ Each image model has an internal limit on how many images it can generate in a s
 If needed, you can override this behavior using the `maxImagesPerCall` setting when configuring your model. This is particularly useful when working with new or custom models where the default batch size might not be optimal:
 
 ```tsx
-const model = openai.image('dall-e-2', {
+const model = openai.imageModel('dall-e-2', {
   maxImagesPerCall: 5, // Override the default batch size
 });
 
@@ -111,7 +111,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const { image } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   prompt: 'Santa Claus driving a Cadillac',
   seed: 1234567890,
 });
@@ -129,7 +129,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const { image } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   prompt: 'Santa Claus driving a Cadillac',
   size: '1024x1024',
   providerOptions: {
@@ -149,7 +149,7 @@ import { openai } from '@ai-sdk/openai';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   prompt: 'Santa Claus driving a Cadillac',
   abortSignal: AbortSignal.timeout(1000), // Abort after 1 second
 });
@@ -165,7 +165,7 @@ import { openai } from '@ai-sdk/openai';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   value: 'sunny day at the beach',
   headers: { 'X-Custom-Header': 'custom-value' },
 });
@@ -177,7 +177,7 @@ If the model returns warnings, e.g. for unsupported parameters, they will be ava
 
 ```tsx
 const { image, warnings } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   prompt: 'Santa Claus driving a Cadillac',
 });
 ```
@@ -190,7 +190,7 @@ Some providers expose additional meta data for the result overall or per image.
 const prompt = 'Santa Claus driving a Cadillac';
 
 const { image, providerMetaData } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   prompt,
 });
 

--- a/content/docs/07-reference/01-ai-sdk-core/10-generate-image.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/10-generate-image.mdx
@@ -16,7 +16,7 @@ such as creating visual content or generating images for data augmentation.
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { images } = await generateImage({
-  model: openai.image('dall-e-3'),
+  model: openai.imageModel('dall-e-3'),
   prompt: 'A futuristic cityscape at sunset',
   n: 3,
   size: '1024x1024',

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -169,7 +169,7 @@ import { xai } from '@ai-sdk/xai';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: xai.image('grok-2-image'),
+  model: xai.imageModel('grok-2-image'),
   prompt: 'A futuristic cityscape at sunset',
 });
 ```
@@ -188,7 +188,7 @@ import { xai } from '@ai-sdk/xai';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { images } = await generateImage({
-  model: xai.image('grok-2-image', {
+  model: xai.imageModel('grok-2-image', {
     maxImagesPerCall: 5, // Default is 10
   }),
   prompt: 'A futuristic cityscape at sunset',

--- a/content/providers/01-ai-sdk-providers/02-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/02-openai.mdx
@@ -913,10 +913,10 @@ The following optional provider options are available for OpenAI embedding model
 ## Image Models
 
 You can create models that call the [OpenAI image generation API](https://platform.openai.com/docs/api-reference/images)
-using the `.image()` factory method.
+using the `.imageModel()` factory method.
 
 ```ts
-const model = openai.image('dall-e-3');
+const model = openai.imageModel('dall-e-3');
 ```
 
 <Note>
@@ -936,7 +936,7 @@ You can pass optional `providerOptions` to the image model. These are prone to c
 
 ```ts
 const { image, providerMetadata } = await generateImage({
-  model: openai.image('gpt-image-1'),
+  model: openai.imageModel('gpt-image-1'),
   prompt: 'A salamander at sunrise in a forest pond in the Seychelles.',
   providerOptions: {
     openai: { quality: 'high' },

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -476,7 +476,7 @@ The following optional provider options are available for Bedrock Titan embeddin
 ## Image Models
 
 You can create models that call the Bedrock API [Bedrock API](https://docs.aws.amazon.com/nova/latest/userguide/image-generation.html)
-using the `.image()` factory method.
+using the `.imageModel()` factory method.
 
 For more on the Amazon Nova Canvas image model, see the [Nova Canvas
 Overview](https://docs.aws.amazon.com/ai/responsible-ai/nova-canvas/overview.html).
@@ -486,7 +486,7 @@ Overview](https://docs.aws.amazon.com/ai/responsible-ai/nova-canvas/overview.htm
 </Note>
 
 ```ts
-const model = bedrock.image('amazon.nova-canvas-v1:0');
+const model = bedrock.imageModel('amazon.nova-canvas-v1:0');
 ```
 
 You can then generate images with the `experimental_generateImage` function:

--- a/content/providers/01-ai-sdk-providers/10-fal.mdx
+++ b/content/providers/01-ai-sdk-providers/10-fal.mdx
@@ -69,7 +69,7 @@ You can use the following optional settings to customize the Fal provider instan
 
 ## Image Models
 
-You can create Fal image models using the `.image()` factory method.
+You can create Fal image models using the `.imageModel()` factory method.
 For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ### Basic Usage
@@ -80,7 +80,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import fs from 'fs';
 
 const { image } = await generateImage({
-  model: fal.image('fal-ai/fast-sdxl'),
+  model: fal.imageModel('fal-ai/fast-sdxl'),
   prompt: 'A serene mountain landscape at sunset',
 });
 

--- a/content/providers/01-ai-sdk-providers/11-deepinfra.mdx
+++ b/content/providers/01-ai-sdk-providers/11-deepinfra.mdx
@@ -117,7 +117,7 @@ DeepInfra language models can also be used in the `streamText` function (see [AI
 
 ## Image Models
 
-You can create DeepInfra image models using the `.image()` factory method.
+You can create DeepInfra image models using the `.imageModel()` factory method.
 For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ```ts
@@ -125,7 +125,7 @@ import { deepinfra } from '@ai-sdk/deepinfra';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: deepinfra.image('stabilityai/sd3.5'),
+  model: deepinfra.imageModel('stabilityai/sd3.5'),
   prompt: 'A futuristic cityscape at sunset',
   aspectRatio: '16:9',
 });
@@ -147,7 +147,7 @@ import { deepinfra } from '@ai-sdk/deepinfra';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: deepinfra.image('stabilityai/sd3.5'),
+  model: deepinfra.imageModel('stabilityai/sd3.5'),
   prompt: 'A futuristic cityscape at sunset',
   aspectRatio: '16:9',
   providerOptions: {

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -613,14 +613,14 @@ The following optional provider options are available for Google Vertex AI embed
 ### Image Models
 
 You can create [Imagen](https://cloud.google.com/vertex-ai/generative-ai/docs/image/overview) models that call the [Imagen on Vertex AI API](https://cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images)
-using the `.image()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
+using the `.imageModel()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ```ts
 import { vertex } from '@ai-sdk/google-vertex';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: vertex.image('imagen-3.0-generate-002'),
+  model: vertex.imageModel('imagen-3.0-generate-002'),
   prompt: 'A futuristic cityscape at sunset',
   aspectRatio: '16:9',
 });
@@ -634,7 +634,7 @@ import { GoogleVertexImageProviderOptions } from '@ai-sdk/google-vertex';
 import { generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: vertex.image('imagen-3.0-generate-002'),
+  model: vertex.imageModel('imagen-3.0-generate-002'),
   providerOptions: {
     vertex: {
       negativePrompt: 'pixelated, blurry, low-quality',

--- a/content/providers/01-ai-sdk-providers/24-togetherai.mdx
+++ b/content/providers/01-ai-sdk-providers/24-togetherai.mdx
@@ -132,7 +132,7 @@ The Together.ai provider also supports [completion models](https://docs.together
 
 ## Image Models
 
-You can create Together.ai image models using the `.image()` factory method.
+You can create Together.ai image models using the `.imageModel()` factory method.
 For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ```ts
@@ -140,7 +140,7 @@ import { togetherai } from '@ai-sdk/togetherai';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { images } = await generateImage({
-  model: togetherai.image('black-forest-labs/FLUX.1-dev'),
+  model: togetherai.imageModel('black-forest-labs/FLUX.1-dev'),
   prompt: 'A delighted resplendent quetzal mid flight amidst raindrops',
 });
 ```
@@ -152,7 +152,7 @@ import { togetherai } from '@ai-sdk/togetherai';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { images } = await generateImage({
-  model: togetherai.image('black-forest-labs/FLUX.1-dev'),
+  model: togetherai.imageModel('black-forest-labs/FLUX.1-dev'),
   prompt: 'A delighted resplendent quetzal mid flight amidst raindrops',
   size: '512x512',
   // Optional additional provider-specific request parameters

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -146,7 +146,7 @@ const model = fireworks.textEmbeddingModel(
 
 ## Image Models
 
-You can create Fireworks image models using the `.image()` factory method.
+You can create Fireworks image models using the `.imageModel()` factory method.
 For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ```ts
@@ -154,7 +154,7 @@ import { fireworks } from '@ai-sdk/fireworks';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: fireworks.image('accounts/fireworks/models/flux-1-dev-fp8'),
+  model: fireworks.imageModel('accounts/fireworks/models/flux-1-dev-fp8'),
   prompt: 'A futuristic cityscape at sunset',
   aspectRatio: '16:9',
 });

--- a/content/providers/01-ai-sdk-providers/60-replicate.mdx
+++ b/content/providers/01-ai-sdk-providers/60-replicate.mdx
@@ -65,7 +65,7 @@ You can use the following optional settings to customize the Replicate provider 
 
 ## Image Models
 
-You can create Replicate image models using the `.image()` factory method.
+You can create Replicate image models using the `.imageModel()` factory method.
 For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 <Note>
@@ -106,7 +106,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import { writeFile } from 'node:fs/promises';
 
 const { image } = await generateImage({
-  model: replicate.image('black-forest-labs/flux-schnell'),
+  model: replicate.imageModel('black-forest-labs/flux-schnell'),
   prompt: 'The Loch Ness Monster getting a manicure',
   aspectRatio: '16:9',
 });
@@ -123,7 +123,7 @@ import { replicate } from '@ai-sdk/replicate';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: replicate.image('recraft-ai/recraft-v3'),
+  model: replicate.imageModel('recraft-ai/recraft-v3'),
   prompt: 'The Loch Ness Monster getting a manicure',
   size: '1365x1024',
   providerOptions: {
@@ -141,7 +141,7 @@ import { replicate } from '@ai-sdk/replicate';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: replicate.image(
+  model: replicate.imageModel(
     'bytedance/sdxl-lightning-4step:5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637',
   ),
   prompt: 'The Loch Ness Monster getting a manicure',

--- a/content/providers/01-ai-sdk-providers/80-luma.mdx
+++ b/content/providers/01-ai-sdk-providers/80-luma.mdx
@@ -69,7 +69,7 @@ You can use the following optional settings to customize the Luma provider insta
 
 ## Image Models
 
-You can create Luma image models using the `.image()` factory method.
+You can create Luma image models using the `.imageModel()` factory method.
 For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ### Basic Usage
@@ -80,7 +80,7 @@ import { experimental_generateImage as generateImage } from 'ai';
 import fs from 'fs';
 
 const { image } = await generateImage({
-  model: luma.image('photon-1'),
+  model: luma.imageModel('photon-1'),
   prompt: 'A serene mountain landscape at sunset',
   aspectRatio: '16:9',
 });
@@ -95,7 +95,7 @@ console.log(`Image saved to ${filename}`);
 When creating an image model, you can customize the generation behavior with optional settings:
 
 ```ts
-const model = luma.image('photon-1', {
+const model = luma.imageModel('photon-1', {
   maxImagesPerCall: 1, // Maximum number of images to generate per API call
   pollIntervalMillis: 5000, // How often to check for completed images (in ms)
   maxPollAttempts: 10, // Maximum number of polling attempts before timeout
@@ -158,7 +158,7 @@ Use up to 4 reference images to guide your generation. Useful for creating varia
 ```ts
 // Example: Generate a salamander with reference
 await generateImage({
-  model: luma.image('photon-1'),
+  model: luma.imageModel('photon-1'),
   prompt: 'A salamander at dusk in a forest pond, in the style of ukiyo-e',
   providerOptions: {
     luma: {
@@ -180,7 +180,7 @@ Apply specific visual styles to your generations using reference images. Control
 ```ts
 // Example: Generate with style reference
 await generateImage({
-  model: luma.image('photon-1'),
+  model: luma.imageModel('photon-1'),
   prompt: 'A blue cream Persian cat launching its website on Vercel',
   providerOptions: {
     luma: {
@@ -202,7 +202,7 @@ Create consistent and personalized characters using up to 4 reference images of 
 ```ts
 // Example: Generate character-based image
 await generateImage({
-  model: luma.image('photon-1'),
+  model: luma.imageModel('photon-1'),
   prompt: 'A woman with a cat riding a broomstick in a forest',
   providerOptions: {
     luma: {
@@ -227,7 +227,7 @@ Transform existing images using text prompts. Use the `weight` parameter to cont
 ```ts
 // Example: Modify existing image
 await generateImage({
-  model: luma.image('photon-1'),
+  model: luma.imageModel('photon-1'),
   prompt: 'transform the bike to a boat',
   providerOptions: {
     luma: {

--- a/content/providers/03-community-providers/94-langdb.mdx
+++ b/content/providers/03-community-providers/94-langdb.mdx
@@ -89,7 +89,7 @@ const langdb = createLangDB({
 
 export async function generateImageExample() {
   const { images } = await generateImage({
-    model: langdb.image('openai/dall-e-3'),
+    model: langdb.imageModel('openai/dall-e-3'),
     prompt: 'A delighted resplendent quetzal mid-flight amidst raindrops',
   });
 

--- a/examples/ai-core/src/e2e/fireworks.test.ts
+++ b/examples/ai-core/src/e2e/fireworks.test.ts
@@ -38,7 +38,7 @@ createFeatureTestSuite({
     ],
     imageModels: [
       createImageModelWithCapabilities(
-        provider.image('accounts/fireworks/models/flux-1-dev-fp8'),
+        provider.imageModel('accounts/fireworks/models/flux-1-dev-fp8'),
       ),
     ],
   },

--- a/examples/ai-core/src/e2e/google-vertex.test.ts
+++ b/examples/ai-core/src/e2e/google-vertex.test.ts
@@ -66,7 +66,7 @@ const createImageModel = (
   modelId: string,
   additionalTests: ((model: ImageModelV2) => void)[] = [],
 ): ModelWithCapabilities<ImageModelV2> => {
-  const model = vertex.image(modelId);
+  const model = vertex.imageModel(modelId);
 
   if (additionalTests.length > 0) {
     describe.each([createModelObject(model)])(
@@ -83,9 +83,9 @@ const createModelVariants = (
   vertex: typeof vertexNode | typeof vertexEdge,
   modelId: string,
 ): ModelWithCapabilities<LanguageModelV2>[] => [
-  createBaseModel(vertex, modelId),
-  createSearchGroundedModel(vertex, modelId),
-];
+    createBaseModel(vertex, modelId),
+    createSearchGroundedModel(vertex, modelId),
+  ];
 
 const createModelsForRuntime = (
   vertex: typeof vertexNode | typeof vertexEdge,

--- a/examples/ai-core/src/e2e/google-vertex.test.ts
+++ b/examples/ai-core/src/e2e/google-vertex.test.ts
@@ -83,9 +83,9 @@ const createModelVariants = (
   vertex: typeof vertexNode | typeof vertexEdge,
   modelId: string,
 ): ModelWithCapabilities<LanguageModelV2>[] => [
-    createBaseModel(vertex, modelId),
-    createSearchGroundedModel(vertex, modelId),
-  ];
+  createBaseModel(vertex, modelId),
+  createSearchGroundedModel(vertex, modelId),
+];
 
 const createModelsForRuntime = (
   vertex: typeof vertexNode | typeof vertexEdge,

--- a/examples/ai-core/src/e2e/luma.test.ts
+++ b/examples/ai-core/src/e2e/luma.test.ts
@@ -10,10 +10,10 @@ import 'dotenv/config';
 createFeatureTestSuite({
   name: 'Luma',
   models: {
-    invalidImageModel: provider.image('no-such-model'),
+    invalidImageModel: provider.imageModel('no-such-model'),
     imageModels: [
-      createImageModelWithCapabilities(provider.image('photon-flash-1')),
-      createImageModelWithCapabilities(provider.image('photon-1')),
+      createImageModelWithCapabilities(provider.imageModel('photon-flash-1')),
+      createImageModelWithCapabilities(provider.imageModel('photon-1')),
     ],
   },
   timeout: 30000,

--- a/packages/amazon-bedrock/src/bedrock-image-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.test.ts
@@ -118,15 +118,15 @@ describe('doGenerate', () => {
   });
 
   it('should respect maxImagesPerCall setting', async () => {
-    const customModel = provider.image('amazon.nova-canvas-v1:0', {
+    const customModel = provider.imageModel('amazon.nova-canvas-v1:0', {
       maxImagesPerCall: 2,
     });
     expect(customModel.maxImagesPerCall).toBe(2);
 
-    const defaultModel = provider.image('amazon.nova-canvas-v1:0');
+    const defaultModel = provider.imageModel('amazon.nova-canvas-v1:0');
     expect(defaultModel.maxImagesPerCall).toBe(5); // 'amazon.nova-canvas-v1:0','s default from settings
 
-    const unknownModel = provider.image('unknown-model' as any);
+    const unknownModel = provider.imageModel('unknown-model' as any);
     expect(unknownModel.maxImagesPerCall).toBe(1); // fallback for unknown models
   });
 

--- a/packages/amazon-bedrock/src/bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.test.ts
@@ -140,7 +140,7 @@ describe('AmazonBedrockProvider', () => {
       const provider = createAmazonBedrock();
       const modelId = 'amazon.titan-image-generator';
 
-      const model = provider.image(modelId, {
+      const model = provider.imageModel(modelId, {
         maxImagesPerCall: 5,
       });
 

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -63,7 +63,7 @@ Custom headers to include in the requests.
   /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
-*/
+   */
   fetch?: FetchFunction;
 
   /**
@@ -85,11 +85,18 @@ export interface AmazonBedrockProvider extends ProviderV2 {
 
   embedding(modelId: BedrockEmbeddingModelId): EmbeddingModelV2<string>;
 
+  /**
+Creates a model for image generation.
+@deprecated Use `imageModel` instead.
+   */
   image(
     modelId: BedrockImageModelId,
     settings?: BedrockImageSettings,
   ): ImageModelV2;
 
+  /**
+Creates a model for image generation.
+   */
   imageModel(
     modelId: BedrockImageModelId,
     settings?: BedrockImageSettings,

--- a/packages/deepinfra/src/deepinfra-provider.test.ts
+++ b/packages/deepinfra/src/deepinfra-provider.test.ts
@@ -138,7 +138,7 @@ describe('DeepInfraProvider', () => {
       const modelId = 'deepinfra-image-model';
       const settings = { maxImagesPerCall: 2 };
 
-      const model = provider.image(modelId, settings);
+      const model = provider.imageModel(modelId, settings);
 
       expect(model).toBeInstanceOf(DeepInfraImageModel);
       expect(DeepInfraImageModel).toHaveBeenCalledWith(
@@ -155,7 +155,7 @@ describe('DeepInfraProvider', () => {
       const provider = createDeepInfra();
       const modelId = 'deepinfra-image-model';
 
-      const model = provider.image(modelId);
+      const model = provider.imageModel(modelId);
 
       expect(model).toBeInstanceOf(DeepInfraImageModel);
       expect(DeepInfraImageModel).toHaveBeenCalledWith(
@@ -170,7 +170,7 @@ describe('DeepInfraProvider', () => {
       const provider = createDeepInfra({ baseURL: customBaseURL });
       const modelId = 'deepinfra-image-model';
 
-      const model = provider.image(modelId);
+      const model = provider.imageModel(modelId);
 
       expect(DeepInfraImageModel).toHaveBeenCalledWith(
         modelId,

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -56,7 +56,8 @@ Creates a chat model for text generation.
 
   /**
 Creates a model for image generation.
-  */
+@deprecated Use `imageModel` instead.
+*/
   image(
     modelId: DeepInfraImageModelId,
     settings?: DeepInfraImageSettings,
@@ -64,7 +65,7 @@ Creates a model for image generation.
 
   /**
 Creates a model for image generation.
-  */
+*/
   imageModel(
     modelId: DeepInfraImageModelId,
     settings?: DeepInfraImageSettings,

--- a/packages/fal/src/fal-provider.test.ts
+++ b/packages/fal/src/fal-provider.test.ts
@@ -16,7 +16,7 @@ describe('createFal', () => {
       const provider = createFal();
       const modelId = 'fal-ai/flux/dev';
 
-      const model = provider.image(modelId);
+      const model = provider.imageModel(modelId);
 
       expect(model).toBeInstanceOf(FalImageModel);
       expect(FalImageModel).toHaveBeenCalledWith(
@@ -34,7 +34,7 @@ describe('createFal', () => {
       const modelId = 'fal-ai/flux/dev';
       const settings = { maxImagesPerCall: 3 };
 
-      const model = provider.image(modelId, settings);
+      const model = provider.imageModel(modelId, settings);
 
       expect(model).toBeInstanceOf(FalImageModel);
       expect(FalImageModel).toHaveBeenCalledWith(
@@ -60,7 +60,7 @@ describe('createFal', () => {
       });
       const modelId = 'fal-ai/flux/dev';
 
-      provider.image(modelId);
+      provider.imageModel(modelId);
 
       expect(FalImageModel).toHaveBeenCalledWith(
         modelId,

--- a/packages/fal/src/fal-provider.ts
+++ b/packages/fal/src/fal-provider.ts
@@ -15,7 +15,7 @@ export interface FalProviderSettings {
   /**
 fal.ai API key. Default value is taken from the `FAL_API_KEY` environment
 variable, falling back to `FAL_KEY`.
-  */
+   */
   apiKey?: string;
 
   /**
@@ -39,6 +39,7 @@ requests, or to provide a custom fetch implementation for e.g. testing.
 export interface FalProvider extends ProviderV2 {
   /**
 Creates a model for image generation.
+@deprecated Use `imageModel` instead.
    */
   image(modelId: FalImageModelId, settings?: FalImageSettings): ImageModelV2;
 

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -132,7 +132,7 @@ describe('FireworksProvider', () => {
       const modelId = 'accounts/fireworks/models/flux-1-dev-fp8';
       const settings = { maxImagesPerCall: 2 };
 
-      const model = provider.image(modelId, settings);
+      const model = provider.imageModel(modelId, settings);
 
       expect(model).toBeInstanceOf(FireworksImageModel);
       expect(FireworksImageModel).toHaveBeenCalledWith(
@@ -149,7 +149,7 @@ describe('FireworksProvider', () => {
       const provider = createFireworks();
       const modelId = 'accounts/fireworks/models/flux-1-dev-fp8';
 
-      const model = provider.image(modelId);
+      const model = provider.imageModel(modelId);
 
       expect(model).toBeInstanceOf(FireworksImageModel);
       expect(FireworksImageModel).toHaveBeenCalledWith(
@@ -164,7 +164,7 @@ describe('FireworksProvider', () => {
       const provider = createFireworks({ baseURL: customBaseURL });
       const modelId = 'accounts/fireworks/models/flux-1-dev-fp8';
 
-      const model = provider.image(modelId);
+      const model = provider.imageModel(modelId);
 
       expect(FireworksImageModel).toHaveBeenCalledWith(
         modelId,

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -87,6 +87,7 @@ Creates a text embedding model for text generation.
 
   /**
 Creates a model for image generation.
+@deprecated Use `imageModel` instead.
 */
   image(
     modelId: FireworksImageModelId,

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -142,7 +142,7 @@ describe('google-vertex-provider', () => {
       project: 'test-project',
       location: 'test-location',
     });
-    provider.image('imagen-3.0-generate-002');
+    provider.imageModel('imagen-3.0-generate-002');
 
     expect(GoogleVertexImageModel).toHaveBeenCalledWith(
       'imagen-3.0-generate-002',
@@ -164,7 +164,7 @@ describe('google-vertex-provider', () => {
     const imageSettings = {
       maxImagesPerCall: 4,
     };
-    provider.image('imagen-3.0-generate-002', imageSettings);
+    provider.imageModel('imagen-3.0-generate-002', imageSettings);
 
     expect(GoogleVertexImageModel).toHaveBeenCalledWith(
       'imagen-3.0-generate-002',

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -26,7 +26,8 @@ Creates a model for text generation.
   languageModel: (modelId: GoogleVertexModelId) => LanguageModelV2;
 
   /**
-   * Creates a model for image generation.
+Creates a model for image generation.
+@deprecated Use `imageModel` instead.
    */
   image(
     modelId: GoogleVertexImageModelId,

--- a/packages/luma/src/luma-provider.test.ts
+++ b/packages/luma/src/luma-provider.test.ts
@@ -16,7 +16,7 @@ describe('createLuma', () => {
       const provider = createLuma();
       const modelId = 'luma-v1';
 
-      const model = provider.image(modelId);
+      const model = provider.imageModel(modelId);
 
       expect(model).toBeInstanceOf(LumaImageModel);
       expect(LumaImageModel).toHaveBeenCalledWith(
@@ -34,7 +34,7 @@ describe('createLuma', () => {
       const modelId = 'luma-v1';
       const settings = { maxImagesPerCall: 2 };
 
-      const model = provider.image(modelId, settings);
+      const model = provider.imageModel(modelId, settings);
 
       expect(model).toBeInstanceOf(LumaImageModel);
       expect(LumaImageModel).toHaveBeenCalledWith(
@@ -60,7 +60,7 @@ describe('createLuma', () => {
       });
       const modelId = 'luma-v1';
 
-      provider.image(modelId);
+      provider.imageModel(modelId);
 
       expect(LumaImageModel).toHaveBeenCalledWith(
         modelId,

--- a/packages/luma/src/luma-provider.ts
+++ b/packages/luma/src/luma-provider.ts
@@ -31,7 +31,8 @@ or to provide a custom fetch implementation for e.g. testing.
 export interface LumaProvider extends ProviderV2 {
   /**
 Creates a model for image generation.
-  */
+@deprecated Use `imageModel` instead.
+   */
   image(modelId: LumaImageModelId, settings?: LumaImageSettings): ImageModelV2;
 
   /**

--- a/packages/openai/src/openai-image-model.test.ts
+++ b/packages/openai/src/openai-image-model.test.ts
@@ -136,7 +136,9 @@ describe('doGenerate', () => {
   it('should respect maxImagesPerCall setting', async () => {
     prepareJsonResponse();
 
-    const customModel = provider.imageModel('dall-e-2', { maxImagesPerCall: 5 });
+    const customModel = provider.imageModel('dall-e-2', {
+      maxImagesPerCall: 5,
+    });
     expect(customModel.maxImagesPerCall).toBe(5);
 
     const defaultModel = provider.imageModel('dall-e-2');

--- a/packages/openai/src/openai-image-model.test.ts
+++ b/packages/openai/src/openai-image-model.test.ts
@@ -5,7 +5,7 @@ import { createOpenAI } from './openai-provider';
 const prompt = 'A cute baby sea otter';
 
 const provider = createOpenAI({ apiKey: 'test-api-key' });
-const model = provider.image('dall-e-3', { maxImagesPerCall: 2 });
+const model = provider.imageModel('dall-e-3', { maxImagesPerCall: 2 });
 
 const server = createTestServer({
   'https://api.openai.com/v1/images/generations': {},
@@ -70,7 +70,7 @@ describe('doGenerate', () => {
       },
     });
 
-    await provider.image('dall-e-3').doGenerate({
+    await provider.imageModel('dall-e-3').doGenerate({
       prompt,
       n: 1,
       size: '1024x1024',
@@ -136,13 +136,13 @@ describe('doGenerate', () => {
   it('should respect maxImagesPerCall setting', async () => {
     prepareJsonResponse();
 
-    const customModel = provider.image('dall-e-2', { maxImagesPerCall: 5 });
+    const customModel = provider.imageModel('dall-e-2', { maxImagesPerCall: 5 });
     expect(customModel.maxImagesPerCall).toBe(5);
 
-    const defaultModel = provider.image('dall-e-2');
+    const defaultModel = provider.imageModel('dall-e-2');
     expect(defaultModel.maxImagesPerCall).toBe(10); // dall-e-2's default from settings
 
-    const unknownModel = provider.image('unknown-model' as any);
+    const unknownModel = provider.imageModel('unknown-model' as any);
     expect(unknownModel.maxImagesPerCall).toBe(1); // fallback for unknown models
   });
 
@@ -217,7 +217,7 @@ describe('doGenerate', () => {
   it('should not include response_format for gpt-image-1', async () => {
     prepareJsonResponse();
 
-    const gptImageModel = provider.image('gpt-image-1');
+    const gptImageModel = provider.imageModel('gpt-image-1');
     await gptImageModel.doGenerate({
       prompt,
       n: 1,

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -76,6 +76,7 @@ Creates a model for text embeddings.
 
   /**
 Creates a model for image generation.
+@deprecated Use `imageModel` instead.
    */
   image(
     modelId: OpenAIImageModelId,
@@ -109,27 +110,27 @@ OpenAI-specific tools.
 export interface OpenAIProviderSettings {
   /**
 Base URL for the OpenAI API calls.
-     */
+   */
   baseURL?: string;
 
   /**
 API key for authenticating requests.
-     */
+   */
   apiKey?: string;
 
   /**
 OpenAI Organization.
-     */
+   */
   organization?: string;
 
   /**
 OpenAI project.
-     */
+   */
   project?: string;
 
   /**
 Custom headers to include in the requests.
-     */
+   */
   headers?: Record<string, string>;
 
   /**
@@ -147,7 +148,7 @@ Provider name. Overrides the `openai` default name for 3rd party providers.
   /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
-    */
+   */
   fetch?: FetchFunction;
 }
 

--- a/packages/replicate/src/replicate-image-model.test.ts
+++ b/packages/replicate/src/replicate-image-model.test.ts
@@ -5,7 +5,7 @@ import { ReplicateImageModel } from './replicate-image-model';
 const prompt = 'The Loch Ness monster getting a manicure';
 
 const provider = createReplicate({ apiToken: 'test-api-token' });
-const model = provider.image('black-forest-labs/flux-schnell');
+const model = provider.imageModel('black-forest-labs/flux-schnell');
 
 describe('doGenerate', () => {
   const testDate = new Date(2024, 0, 1);
@@ -108,7 +108,7 @@ describe('doGenerate', () => {
       },
     });
 
-    await provider.image('black-forest-labs/flux-schnell').doGenerate({
+    await provider.imageModel('black-forest-labs/flux-schnell').doGenerate({
       prompt,
       n: 1,
       size: undefined,
@@ -271,7 +271,7 @@ describe('doGenerate', () => {
   it('should set version in request body for versioned models', async () => {
     prepareResponse();
 
-    const versionedModel = provider.image(
+    const versionedModel = provider.imageModel(
       'bytedance/sdxl-lightning-4step:5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637',
     );
 

--- a/packages/replicate/src/replicate-provider.test.ts
+++ b/packages/replicate/src/replicate-provider.test.ts
@@ -18,7 +18,7 @@ describe('createReplicate', () => {
 
   it('creates an image model instance', () => {
     const provider = createReplicate({ apiToken: 'test-token' });
-    const model = provider.image('black-forest-labs/flux-schnell');
+    const model = provider.imageModel('black-forest-labs/flux-schnell');
     expect(model).toBeInstanceOf(ReplicateImageModel);
   });
 });

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -22,19 +22,20 @@ The default prefix is `https://api.replicate.com/v1`.
 
   /**
 Custom headers to include in the requests.
-     */
+   */
   headers?: Record<string, string>;
 
   /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
-    */
+   */
   fetch?: FetchFunction;
 }
 
 export interface ReplicateProvider extends ProviderV2 {
   /**
-   * Creates a Replicate image generation model.
+Creates a model for image generation.
+@deprecated Use `imageModel` instead.
    */
   image(
     modelId: ReplicateImageModelId,

--- a/packages/togetherai/src/togetherai-provider.test.ts
+++ b/packages/togetherai/src/togetherai-provider.test.ts
@@ -133,7 +133,7 @@ describe('TogetherAIProvider', () => {
       const modelId = 'stabilityai/stable-diffusion-xl';
       const settings = { maxImagesPerCall: 4 };
 
-      const model = provider.image(modelId, settings);
+      const model = provider.imageModel(modelId, settings);
 
       expect(TogetherAIImageModel).toHaveBeenCalledWith(
         modelId,
@@ -152,7 +152,7 @@ describe('TogetherAIProvider', () => {
       });
       const modelId = 'stabilityai/stable-diffusion-xl';
 
-      provider.image(modelId);
+      provider.imageModel(modelId);
 
       expect(TogetherAIImageModel).toHaveBeenCalledWith(
         modelId,

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -83,7 +83,10 @@ Creates a model for image generation.
   /**
   Creates a model for image generation.
 */
-  imageModel(modelId: TogetherAIImageModelId): ImageModelV2;
+  imageModel(
+    modelId: TogetherAIImageModelId,
+    settings?: TogetherAIImageSettings,
+  ): ImageModelV2;
 }
 
 export function createTogetherAI(

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -72,8 +72,9 @@ Creates a text embedding model for text generation.
   ): EmbeddingModelV2<string>;
 
   /**
-  Creates a model for image generation.
-   */
+Creates a model for image generation.
+@deprecated Use `imageModel` instead.
+*/
   image(
     modelId: TogetherAIImageModelId,
     settings?: TogetherAIImageSettings,
@@ -81,7 +82,7 @@ Creates a text embedding model for text generation.
 
   /**
   Creates a model for image generation.
-   */
+*/
   imageModel(modelId: TogetherAIImageModelId): ImageModelV2;
 }
 

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -40,7 +40,8 @@ Creates an Xai chat model for text generation.
   chat: (modelId: XaiChatModelId) => LanguageModelV2;
 
   /**
-Creates an Xai image model for image generation.
+Creates a model for image generation.
+@deprecated Use `imageModel` instead.
    */
   image(modelId: XaiImageModelId, settings?: XaiImageSettings): ImageModelV2;
 
@@ -56,7 +57,7 @@ Creates an Xai image model for image generation.
 export interface XaiProviderSettings {
   /**
 Base URL for the xAI API calls.
-     */
+   */
   baseURL?: string;
 
   /**
@@ -72,7 +73,7 @@ Custom headers to include in the requests.
   /**
 Custom fetch implementation. You can use it as a middleware to intercept requests,
 or to provide a custom fetch implementation for e.g. testing.
-  */
+   */
   fetch?: FetchFunction;
 }
 


### PR DESCRIPTION
## Background

The `image()` method is deprecated in some implementations of `ProviderV2`, but not all.

## Summary

This pull request deprecates the `image()` method in all implementations of `ProviderV2` to ensure consistency across the codebase.

## Verification

In VS Code, the `image()` method is now formatted as deprecated in all implementations of `ProviderV2`.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

If we want to remove the `image()` method as part of v5, I can create another PR. 

If we want to keep `image()` method for now, I suggest we add a `deprecations.test.ts` file where we add tests for all deprecated APIs. It helps prevent regressions in deprecated APIs and also helps to keep track of existing deprecations in our code base ([example](https://github.com/octokit/app.js/blob/5be12101078e02a1c317b1651dc063aba449f499/test/deprecations.test.ts#L4))

## Related Issues

Follow up to https://github.com/vercel/ai/pull/6083/files#diff-b6c7730de57320bd7464c529d9c667570fd5783648eabdd1559b55fec730ea50R85
