### PR TITLE
chore (ai): remove IdGenerator duplication

### DIFF
--- a/packages/ai/core/types/ui-messages.ts
+++ b/packages/ai/core/types/ui-messages.ts
@@ -3,10 +3,13 @@ import {
   LanguageModelV2FinishReason,
   LanguageModelV2Source,
 } from '@ai-sdk/provider';
-import { FetchFunction, ToolCall, ToolResult } from '@ai-sdk/provider-utils';
+import {
+  FetchFunction,
+  IdGenerator,
+  ToolCall,
+  ToolResult,
+} from '@ai-sdk/provider-utils';
 import { LanguageModelUsage } from './usage';
-
-export type IdGenerator = () => string;
 
 /**
 Tool invocations are either tool calls or tool results. For each assistant tool call,

--- a/packages/ai/core/util/call-chat-api.ts
+++ b/packages/ai/core/util/call-chat-api.ts
@@ -1,7 +1,8 @@
 import { JSONValue } from '@ai-sdk/provider';
-import { IdGenerator, UIMessage, UseChatOptions } from '../types';
+import { UIMessage, UseChatOptions } from '../types';
 import { processChatResponse } from './process-chat-response';
 import { processChatTextResponse } from './process-chat-text-response';
+import { IdGenerator } from '@ai-sdk/provider-utils';
 
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => fetch;


### PR DESCRIPTION
## Background

The `IdGenerator` definition was duplicated in `ui-messages.ts`.

## Summary

Remove the duplicate `IdGenerator` definition.