### PR TITLE
chore (build): fix typecheck setup

### DIFF
--- a/contributing/packages.mdx
+++ b/contributing/packages.mdx
@@ -1,0 +1,3 @@
+# Packages
+
+When adding new packages under `packages`, please ensure they are added to `/tsconfig.json`.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,107 +1,43 @@
 {
   "references": [
-    {
-      "path": "packages/ai"
-    },
-    {
-      "path": "packages/rsc"
-    },
-    {
-      "path": "packages/amazon-bedrock"
-    },
-    {
-      "path": "packages/anthropic"
-    },
-    {
-      "path": "packages/azure"
-    },
-    {
-      "path": "packages/cerebras"
-    },
-    {
-      "path": "packages/codemod"
-    },
-    {
-      "path": "packages/cohere"
-    },
-    {
-      "path": "packages/deepinfra"
-    },
-    {
-      "path": "packages/deepseek"
-    },
-    {
-      "path": "packages/fal"
-    },
-    {
-      "path": "packages/fireworks"
-    },
-    {
-      "path": "packages/google-vertex"
-    },
-    {
-      "path": "packages/assemblyai"
-    },
-    {
-      "path": "packages/google"
-    },
-    {
-      "path": "packages/groq"
-    },
-    {
-      "path": "packages/luma"
-    },
-    {
-      "path": "packages/mistral"
-    },
-    {
-      "path": "packages/openai-compatible"
-    },
-    {
-      "path": "packages/openai"
-    },
-    {
-      "path": "packages/perplexity"
-    },
-    {
-      "path": "packages/provider-utils"
-    },
-    {
-      "path": "packages/provider"
-    },
-    {
-      "path": "packages/react"
-    },
-    {
-      "path": "packages/replicate"
-    },
-    {
-      "path": "packages/svelte"
-    },
-    {
-      "path": "packages/togetherai"
-    },
-    {
-      "path": "packages/revai"
-    },
-    {
-      "path": "packages/valibot"
-    },
-    {
-      "path": "packages/hume"
-    },
-    {
-      "path": "packages/vue"
-    },
-    {
-      "path": "packages/deepgram"
-    },
-    {
-      "path": "packages/xai"
-    },
-    {
-      "path": "packages/lmnt"
-    }
+    { "path": "packages/ai" },
+    { "path": "packages/amazon-bedrock" },
+    { "path": "packages/anthropic" },
+    { "path": "packages/assemblyai" },
+    { "path": "packages/azure" },
+    { "path": "packages/cerebras" },
+    { "path": "packages/codemod" },
+    { "path": "packages/cohere" },
+    { "path": "packages/deepgram" },
+    { "path": "packages/deepinfra" },
+    { "path": "packages/deepseek" },
+    { "path": "packages/elevenlabs" },
+    { "path": "packages/fal" },
+    { "path": "packages/fireworks" },
+    { "path": "packages/gladia" },
+    { "path": "packages/google" },
+    { "path": "packages/google-vertex" },
+    { "path": "packages/groq" },
+    { "path": "packages/hume" },
+    { "path": "packages/langchain" },
+    { "path": "packages/llamaindex" },
+    { "path": "packages/lmnt" },
+    { "path": "packages/luma" },
+    { "path": "packages/mistral" },
+    { "path": "packages/openai" },
+    { "path": "packages/openai-compatible" },
+    { "path": "packages/perplexity" },
+    { "path": "packages/provider" },
+    { "path": "packages/provider-utils" },
+    { "path": "packages/react" },
+    { "path": "packages/replicate" },
+    { "path": "packages/revai" },
+    { "path": "packages/rsc" },
+    { "path": "packages/svelte" },
+    { "path": "packages/togetherai" },
+    { "path": "packages/valibot" },
+    { "path": "packages/vue" },
+    { "path": "packages/xai" }
   ],
   "include": []
 }


### PR DESCRIPTION
## Background

Our typecheck setup was missing several packages.

## Summary

Reformat, sort alphabetically, add missing packages.