### PR TITLE
chore: remove misplaced changeset

### DIFF
--- a/packages/ai/.changeset/quick-toys-study.md
+++ b/packages/ai/.changeset/quick-toys-study.md
@@ -1,5 +1,0 @@
----
-'ai': patch
----
-
-fix (ai/mcp-stdio): make `createChildProcess` synchronous to prevent spawn race condition


### PR DESCRIPTION
## Background

Old changeset was in invalid location.

## Summary

Remove changeset.