### PR TITLE
feat (ai): support model message array in prompt

### DIFF
--- a/.changeset/two-otters-whisper.md
+++ b/.changeset/two-otters-whisper.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+feat (ai): support model message array in prompt

--- a/packages/ai/core/prompt/prompt.ts
+++ b/packages/ai/core/prompt/prompt.ts
@@ -11,12 +11,16 @@ System message to include in the prompt. Can be used with `prompt` or `messages`
   system?: string;
 
   /**
-A simple text prompt. You can either use `prompt` or `messages` but not both.
- */
-  prompt?: string;
+A prompt. It can be either a text prompt or a list of messages.
+
+You can either use `prompt` or `messages` but not both.
+*/
+  prompt?: string | Array<ModelMessage>;
 
   /**
-A list of messages. You can either use `prompt` or `messages` but not both.
+A list of messages.
+
+You can either use `prompt` or `messages` but not both.
    */
   messages?: Array<ModelMessage>;
 };


### PR DESCRIPTION
## Background

Limiting the `prompt` property to `string` inputs makes it harder to change from text prompts to message prompts. There is no reason why `prompt` cannot accept `ModelMessage[]` inputs as well.

## Summary

Allow `ModelMessage[]` inputs on `prompt`.