### PR TITLE
feat (ai): add content to generateText result

### DIFF
--- a/.changeset/fuzzy-comics-listen.md
+++ b/.changeset/fuzzy-comics-listen.md
@@ -1,0 +1,5 @@
+---
+'ai': minor
+---
+
+feat (ai): add content to generateText result

--- a/examples/ai-core/src/generate-text/deepseek-reasoning.ts
+++ b/examples/ai-core/src/generate-text/deepseek-reasoning.ts
@@ -8,13 +8,7 @@ async function main() {
     prompt: 'How many "r"s are in the word "strawberry"?',
   });
 
-  console.log('Reasoning:');
-  console.log(result.reasoningText);
-  console.log();
-
-  console.log('Text:');
-  console.log(result.text);
-  console.log();
+  console.log(result.content);
 
   console.log('Token usage:', result.usage);
   console.log('Finish reason:', result.finishReason);

--- a/examples/ai-core/src/generate-text/google-image.ts
+++ b/examples/ai-core/src/generate-text/google-image.ts
@@ -22,7 +22,7 @@ async function main() {
     },
   });
 
-  console.log(result.text);
+  console.log(result.content);
 }
 
 main().catch(console.error);

--- a/packages/ai/core/generate-text/content-part.ts
+++ b/packages/ai/core/generate-text/content-part.ts
@@ -1,0 +1,16 @@
+import { ProviderMetadata } from '../types';
+import { Source } from '../types/language-model';
+import { GeneratedFile } from './generated-file';
+import { ToolCallUnion } from './tool-call';
+import { ToolResultUnion } from './tool-result';
+import { ToolSet } from './tool-set';
+
+export type ContentPart<TOOLS extends ToolSet> =
+  | { type: 'text'; text: string }
+  | { type: 'reasoning'; text: string; providerMetadata?: ProviderMetadata }
+  | ({ type: 'source' } & Source)
+  | { type: 'file'; file: GeneratedFile } // different because of GeneratedFile object
+  | ({ type: 'tool-call' } & ToolCallUnion<TOOLS>)
+  | ({
+      type: 'tool-result';
+    } & ToolResultUnion<TOOLS>);

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -4,6 +4,7 @@ import { Source } from '../types/language-model';
 import { LanguageModelRequestMetadata } from '../types/language-model-request-metadata';
 import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
 import { LanguageModelUsage } from '../types/usage';
+import { ContentPart } from './content-part';
 import { GeneratedFile } from './generated-file';
 import { ResponseMessage, StepResult } from './step-result';
 import { ToolCallArray } from './tool-call';
@@ -15,6 +16,11 @@ The result of a `generateText` call.
 It contains the generated text, the tool calls that were made during the generation, and the results of the tool calls.
  */
 export interface GenerateTextResult<TOOLS extends ToolSet, OUTPUT> {
+  /**
+The content that was generated.
+   */
+  readonly content: Array<ContentPart<TOOLS>>;
+
   /**
 The generated text.
      */

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -17,12 +17,12 @@ It contains the generated text, the tool calls that were made during the generat
  */
 export interface GenerateTextResult<TOOLS extends ToolSet, OUTPUT> {
   /**
-The content that was generated.
+The content that was generated in the last step.
    */
   readonly content: Array<ContentPart<TOOLS>>;
 
   /**
-The generated text.
+The generated text. If you are using continue steps, this can include text from all steps.
      */
   readonly text: string;
 
@@ -38,7 +38,8 @@ has only generated text.
   readonly reasoningText: string | undefined;
 
   /**
-The files that were generated. Empty array if no files were generated.
+The files that were generated in the last step.
+Empty array if no files were generated.
      */
   readonly files: Array<GeneratedFile>;
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -744,12 +744,7 @@ async function executeTools<TOOLS extends ToolSet>({
 class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
   implements GenerateTextResult<TOOLS, OUTPUT>
 {
-  readonly text: GenerateTextResult<TOOLS, OUTPUT>['text'];
-  readonly files: GenerateTextResult<TOOLS, OUTPUT>['files'];
-  readonly reasoningText: GenerateTextResult<TOOLS, OUTPUT>['reasoningText'];
-  readonly reasoning: GenerateTextResult<TOOLS, OUTPUT>['reasoning'];
-  readonly toolCalls: GenerateTextResult<TOOLS, OUTPUT>['toolCalls'];
-  readonly toolResults: GenerateTextResult<TOOLS, OUTPUT>['toolResults'];
+  readonly content: GenerateTextResult<TOOLS, OUTPUT>['content'];
   readonly finishReason: GenerateTextResult<TOOLS, OUTPUT>['finishReason'];
   readonly usage: GenerateTextResult<TOOLS, OUTPUT>['usage'];
   readonly warnings: GenerateTextResult<TOOLS, OUTPUT>['warnings'];
@@ -760,17 +755,11 @@ class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
   >['providerMetadata'];
   readonly response: GenerateTextResult<TOOLS, OUTPUT>['response'];
   readonly request: GenerateTextResult<TOOLS, OUTPUT>['request'];
-  readonly sources: GenerateTextResult<TOOLS, OUTPUT>['sources'];
 
   private readonly resolvedOutput: OUTPUT;
 
   constructor(options: {
-    text: GenerateTextResult<TOOLS, OUTPUT>['text'];
-    files: GenerateTextResult<TOOLS, OUTPUT>['files'];
-    reasoning: GenerateTextResult<TOOLS, OUTPUT>['reasoningText'];
-    reasoningDetails: GenerateTextResult<TOOLS, OUTPUT>['reasoning'];
-    toolCalls: GenerateTextResult<TOOLS, OUTPUT>['toolCalls'];
-    toolResults: GenerateTextResult<TOOLS, OUTPUT>['toolResults'];
+    content: GenerateTextResult<TOOLS, OUTPUT>['content'];
     finishReason: GenerateTextResult<TOOLS, OUTPUT>['finishReason'];
     usage: GenerateTextResult<TOOLS, OUTPUT>['usage'];
     warnings: GenerateTextResult<TOOLS, OUTPUT>['warnings'];
@@ -779,14 +768,8 @@ class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
     response: GenerateTextResult<TOOLS, OUTPUT>['response'];
     request: GenerateTextResult<TOOLS, OUTPUT>['request'];
     resolvedOutput: OUTPUT;
-    sources: GenerateTextResult<TOOLS, OUTPUT>['sources'];
   }) {
-    this.text = options.text;
-    this.files = options.files;
-    this.reasoningText = options.reasoning;
-    this.reasoning = options.reasoningDetails;
-    this.toolCalls = options.toolCalls;
-    this.toolResults = options.toolResults;
+    this.content = options.content;
     this.finishReason = options.finishReason;
     this.usage = options.usage;
     this.warnings = options.warnings;
@@ -795,7 +778,39 @@ class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
     this.steps = options.steps;
     this.providerMetadata = options.providerMetadata;
     this.resolvedOutput = options.resolvedOutput;
-    this.sources = options.sources;
+  }
+
+  get text() {
+    return this.content
+      .filter(part => part.type === 'text')
+      .map(part => part.text)
+      .join('');
+  }
+
+  get files() {
+    return this.content
+      .filter(part => part.type === 'file')
+      .map(part => part.file);
+  }
+
+  get reasoningText() {
+    return this.reasoning.map(part => part.text).join('');
+  }
+
+  get reasoning() {
+    return this.content.filter(part => part.type === 'reasoning');
+  }
+
+  get toolCalls() {
+    return this.content.filter(part => part.type === 'tool-call');
+  }
+
+  get toolResults() {
+    return this.content.filter(part => part.type === 'tool-result');
+  }
+
+  get sources() {
+    return this.content.filter(part => part.type === 'source');
   }
 
   get experimental_output() {

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -16,6 +16,7 @@ import { ResponseMessage, StepResult } from './step-result';
 import { ToolCallUnion } from './tool-call';
 import { ToolResultUnion } from './tool-result';
 import { ToolSet } from './tool-set';
+import { ContentPart } from './content-part';
 
 export type DataStreamOptions = {
   /**
@@ -272,12 +273,8 @@ If an error occurs, it is passed to the optional `onError` callback.
 }
 
 export type TextStreamPart<TOOLS extends ToolSet> =
-  | { type: 'text'; text: string }
-  | { type: 'reasoning'; text: string; providerMetadata?: ProviderMetadata }
+  | ContentPart<TOOLS>
   | { type: 'reasoning-part-finish' }
-  | ({ type: 'source' } & Source)
-  | { type: 'file'; file: GeneratedFile } // different because of GeneratedFile object
-  | ({ type: 'tool-call' } & ToolCallUnion<TOOLS>)
   | {
       type: 'tool-call-streaming-start';
       toolCallId: string;
@@ -289,9 +286,6 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       toolName: string;
       argsTextDelta: string;
     }
-  | ({
-      type: 'tool-result';
-    } & ToolResultUnion<TOOLS>)
   | {
       type: 'step-start';
       messageId: string;


### PR DESCRIPTION
## Background

LLMs generate different types of outputs such as text, reasoning, tool calls, images, audio, sources and more. Often the ordering can be important and needs to be preserved, e.g. reasoning before tool calls.

## Summary

Introduce an ordered `content` array of outputs on the `generateText` result.