### PR TITLE
fix(provider-utils): fix SSE parser bug (CRLF)

### DIFF
--- a/.changeset/shaggy-singers-promise.md
+++ b/.changeset/shaggy-singers-promise.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': major
+---
+
+SSE parser bug (CRLF should be handled correctly)

--- a/.changeset/shaggy-singers-promise.md
+++ b/.changeset/shaggy-singers-promise.md
@@ -1,5 +1,5 @@
 ---
-'@ai-sdk/provider-utils': major
+'@ai-sdk/provider-utils': patch
 ---
 
-SSE parser bug (CRLF should be handled correctly)
+fix(provider-utils): fix SSE parser bug (CRLF)

--- a/packages/provider-utils/src/event-source-parser-stream.test.ts
+++ b/packages/provider-utils/src/event-source-parser-stream.test.ts
@@ -43,6 +43,12 @@ describe('EventSourceParserStream', () => {
     ]);
   });
 
+  it('should handle CRLF lines correctly', async () => {
+    expect(await parseStream(['data: sup?\r\nevent: hey\n\n'])).toEqual([
+      { data: 'sup?', event: 'hey' },
+    ]);
+  });
+
   it('should handle CRLF line endings', async () => {
     expect(await parseStream(['data: hello\r\n\r\n'])).toEqual([
       { data: 'hello' },

--- a/packages/provider-utils/src/event-source-parser-stream.ts
+++ b/packages/provider-utils/src/event-source-parser-stream.ts
@@ -120,8 +120,7 @@ function splitLines(buffer: string, chunk: string) {
     } else if (char === '\r') {
       lines.push(currentLine);
       currentLine = '';
-
-      if (chunk[i + 1] === '\n') {
+      if (chunk[i] === '\n') {
         i++; // CRLF case: Skip the LF character
       }
     } else {


### PR DESCRIPTION
CRLF pointer was incorrectly implemented in event-source-parser-stream

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The below MCP SSE message will make the stream reader timeout.  
```
data: /message?sessionId=123\r\nevent: endpoint
```

<!-- Why was this change necessary? -->

## Summary

Fix the `splitLines` parser issue. The CRLF pointer was incorrectly implemented.
<!-- What did you change? -->

## Verification

`pnpm test`

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

