### PR TITLE
chore (ai): restructure index files and entry point

### DIFF
--- a/packages/ai/core/generate-text/output.ts
+++ b/packages/ai/core/generate-text/output.ts
@@ -1,8 +1,14 @@
 import { LanguageModelV2CallOptions } from '@ai-sdk/provider';
-import { safeParseJSON, safeValidateTypes } from '@ai-sdk/provider-utils';
+import {
+  asSchema,
+  safeParseJSON,
+  safeValidateTypes,
+  Schema,
+} from '@ai-sdk/provider-utils';
 import { z } from 'zod';
-import { asSchema, DeepPartial, parsePartialJson, Schema } from '../../core';
 import { NoObjectGeneratedError } from '../../src/error/no-object-generated-error';
+import { DeepPartial } from '../../src/util/deep-partial';
+import { parsePartialJson } from '../../src/util/parse-partial-json';
 import { FinishReason } from '../types/language-model';
 import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
 import { LanguageModelUsage } from '../types/usage';

--- a/packages/ai/core/index.ts
+++ b/packages/ai/core/index.ts
@@ -1,13 +1,3 @@
-// re-exports:
-export {
-  asSchema,
-  createIdGenerator,
-  generateId,
-  jsonSchema,
-  type Schema,
-} from '@ai-sdk/provider-utils';
-export type { IdGenerator } from '@ai-sdk/provider-utils';
-
 // directory exports:
 export * from './embed';
 export * from './generate-image';
@@ -23,6 +13,3 @@ export * from './types';
 
 // telemetry types:
 export type { TelemetrySettings } from './telemetry/telemetry-settings';
-
-// directory exports from /src
-export * from '../src/';

--- a/packages/ai/index.ts
+++ b/packages/ai/index.ts
@@ -1,0 +1,2 @@
+// TODO remove once we can set the source folder in tsconfig.json to src/
+export * from './src';

--- a/packages/ai/index.ts
+++ b/packages/ai/index.ts
@@ -1,1 +1,0 @@
-export * from './streams';

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,6 +1,19 @@
+// re-exports:
+export {
+  asSchema,
+  createIdGenerator,
+  generateId,
+  jsonSchema,
+  type Schema,
+  type IdGenerator,
+} from '@ai-sdk/provider-utils';
+
 // directory exports
 export * from './data-stream';
 export * from './error';
 export * from './text-stream';
 export * from './ui';
 export * from './util';
+
+// directory exports from /core
+export * from '../core/';

--- a/packages/ai/streams/index.ts
+++ b/packages/ai/streams/index.ts
@@ -1,1 +1,0 @@
-export * from '../core/index';

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig([
   // Universal APIs
   {
-    entry: ['index.ts'],
+    entry: ['src/index.ts'],
     format: ['cjs', 'esm'],
     external: ['react', 'svelte', 'vue'],
     dts: true,


### PR DESCRIPTION
## Background

The build structure of the `ai` package was convoluted.

## Summary

The build uses `src/index.ts` as entry point.