### PR TITLE
fix(provider-utils): fix SSE parser bug (CRLF) (#6197)

### DIFF
--- a/.changeset/shaggy-singers-promise.md
+++ b/.changeset/shaggy-singers-promise.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): fix SSE parser bug (CRLF)

--- a/packages/provider-utils/src/event-source-parser-stream.test.ts
+++ b/packages/provider-utils/src/event-source-parser-stream.test.ts
@@ -43,6 +43,12 @@ describe('EventSourceParserStream', () => {
     ]);
   });
 
+  it('should handle CRLF lines correctly', async () => {
+    expect(await parseStream(['data: sup?\r\nevent: hey\n\n'])).toEqual([
+      { data: 'sup?', event: 'hey' },
+    ]);
+  });
+
   it('should handle CRLF line endings', async () => {
     expect(await parseStream(['data: hello\r\n\r\n'])).toEqual([
       { data: 'hello' },

--- a/packages/provider-utils/src/event-source-parser-stream.ts
+++ b/packages/provider-utils/src/event-source-parser-stream.ts
@@ -120,8 +120,7 @@ function splitLines(buffer: string, chunk: string) {
     } else if (char === '\r') {
       lines.push(currentLine);
       currentLine = '';
-
-      if (chunk[i + 1] === '\n') {
+      if (chunk[i] === '\n') {
         i++; // CRLF case: Skip the LF character
       }
     } else {


### PR DESCRIPTION
## Background

The below MCP SSE message will make the stream reader timeout.  
```
data: /message?sessionId=123\r\nevent: endpoint
```

## Summary

Fix the `splitLines` parser issue. The CRLF pointer was incorrectly implemented.