### PR TITLE
chore (ai): remove getUIText()

### DIFF
--- a/.changeset/fresh-swans-march.md
+++ b/.changeset/fresh-swans-march.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): remove getUIText helper

--- a/examples/next-fastapi/app/(examples)/01-chat-text/page.tsx
+++ b/examples/next-fastapi/app/(examples)/01-chat-text/page.tsx
@@ -2,7 +2,6 @@
 
 import { Card } from '@/app/components';
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Page() {
   const { messages, input, handleSubmit, handleInputChange, status } = useChat({
@@ -17,7 +16,9 @@ export default function Page() {
           <div key={message.id} className="flex flex-row gap-2">
             <div className="flex-shrink-0 w-24 text-zinc-500">{`${message.role}: `}</div>
             <div className="flex flex-col gap-2">
-              {getUIText(message.parts)}
+              {message.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
             </div>
           </div>
         ))}

--- a/examples/next-langchain/app/api/chat/route.ts
+++ b/examples/next-langchain/app/api/chat/route.ts
@@ -1,7 +1,7 @@
 import { toDataStream } from '@ai-sdk/langchain';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
-import { createDataStreamResponse, getUIText, UIMessage } from 'ai';
+import { createDataStreamResponse, UIMessage } from 'ai';
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
@@ -21,8 +21,16 @@ export async function POST(req: Request) {
   const stream = await model.stream(
     messages.map(message =>
       message.role == 'user'
-        ? new HumanMessage(getUIText(message.parts))
-        : new AIMessage(getUIText(message.parts)),
+        ? new HumanMessage(
+            message.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join(''),
+          )
+        : new AIMessage(
+            message.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join(''),
+          ),
     ),
   );
 

--- a/examples/next-langchain/app/page.tsx
+++ b/examples/next-langchain/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit } = useChat();
@@ -12,7 +11,9 @@ export default function Chat() {
         ? messages.map(m => (
             <div key={m.id} className="whitespace-pre-wrap">
               {m.role === 'user' ? 'User: ' : 'AI: '}
-              {getUIText(m.parts)}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
             </div>
           ))
         : null}

--- a/examples/next-openai-kasada-bot-protection/app/page.tsx
+++ b/examples/next-openai-kasada-bot-protection/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 import { toast } from 'sonner';
 
 export default function Chat() {
@@ -17,7 +16,9 @@ export default function Chat() {
         ? messages.map(m => (
             <div key={m.id} className="whitespace-pre-wrap">
               {m.role === 'user' ? 'User: ' : 'AI: '}
-              {getUIText(m.parts)}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
             </div>
           ))
         : null}

--- a/examples/next-openai-pages/pages/chat/stream-chat-api-route/index.tsx
+++ b/examples/next-openai-pages/pages/chat/stream-chat-api-route/index.tsx
@@ -1,5 +1,4 @@
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit, status } = useChat({
@@ -12,7 +11,11 @@ export default function Chat() {
         {messages.map(message => (
           <div key={message.id} className="flex flex-row gap-2">
             <div className="w-24 text-zinc-500">{`${message.role}: `}</div>
-            <div className="w-full">{getUIText(message.parts)}</div>
+            <div className="w-full">
+              {message.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
           </div>
         ))}
       </div>

--- a/examples/next-openai-pages/pages/chat/stream-chat-edge/index.tsx
+++ b/examples/next-openai-pages/pages/chat/stream-chat-edge/index.tsx
@@ -1,5 +1,4 @@
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit, status } = useChat({
@@ -12,7 +11,11 @@ export default function Chat() {
         {messages.map(message => (
           <div key={message.id} className="flex flex-row gap-2">
             <div className="w-24 text-zinc-500">{`${message.role}: `}</div>
-            <div className="w-full">{getUIText(message.parts)}</div>
+            <div className="w-full">
+              {message.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
           </div>
         ))}
       </div>

--- a/examples/next-openai-pages/pages/chat/stream-chat/index.tsx
+++ b/examples/next-openai-pages/pages/chat/stream-chat/index.tsx
@@ -1,5 +1,4 @@
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Page() {
   const { messages, input, handleSubmit, handleInputChange, status } = useChat({
@@ -12,7 +11,11 @@ export default function Page() {
         {messages.map(message => (
           <div key={message.id} className="flex flex-row gap-2">
             <div className="w-24 text-zinc-500">{`${message.role}: `}</div>
-            <div className="w-full">{getUIText(message.parts)}</div>
+            <div className="w-full">
+              {message.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
           </div>
         ))}
       </div>

--- a/examples/next-openai-upstash-rate-limits/app/page.tsx
+++ b/examples/next-openai-upstash-rate-limits/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 import { toast } from 'sonner';
 
 export default function Chat() {
@@ -17,7 +16,9 @@ export default function Chat() {
         ? messages.map(m => (
             <div key={m.id} className="whitespace-pre-wrap">
               {m.role === 'user' ? 'User: ' : 'AI: '}
-              {getUIText(m.parts)}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
             </div>
           ))
         : null}

--- a/examples/next-openai/app/mcp/page.tsx
+++ b/examples/next-openai/app/mcp/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Chat() {
   const {
@@ -26,7 +25,9 @@ export default function Chat() {
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
         </div>
       ))}
 

--- a/examples/next-openai/app/page.tsx
+++ b/examples/next-openai/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Chat() {
   const {
@@ -25,7 +24,9 @@ export default function Chat() {
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
         </div>
       ))}
 

--- a/examples/next-openai/app/use-chat-continue/page.tsx
+++ b/examples/next-openai/app/use-chat-continue/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Chat() {
   const {
@@ -22,7 +21,9 @@ export default function Chat() {
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
         </div>
       ))}
 

--- a/examples/next-openai/app/use-chat-persistence-single-message/[id]/chat.tsx
+++ b/examples/next-openai/app/use-chat-persistence-single-message/[id]/chat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createIdGenerator, getUIText } from 'ai';
+import { createIdGenerator } from 'ai';
 import { UIMessage, useChat } from '@ai-sdk/react';
 
 export default function Chat({
@@ -24,7 +24,9 @@ export default function Chat({
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
         </div>
       ))}
 

--- a/examples/next-openai/app/use-chat-persistence/[id]/chat.tsx
+++ b/examples/next-openai/app/use-chat-persistence/[id]/chat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createIdGenerator, getUIText } from 'ai';
+import { createIdGenerator } from 'ai';
 import { UIMessage, useChat } from '@ai-sdk/react';
 
 export default function Chat({
@@ -19,7 +19,9 @@ export default function Chat({
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
         </div>
       ))}
 

--- a/examples/next-openai/app/use-chat-resilient-persistence/[id]/chat.tsx
+++ b/examples/next-openai/app/use-chat-resilient-persistence/[id]/chat.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { UIMessage, useChat } from '@ai-sdk/react';
-import { createIdGenerator, getUIText } from 'ai';
+import { createIdGenerator } from 'ai';
 
 export default function Chat({
   id,
@@ -20,7 +20,9 @@ export default function Chat({
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
         </div>
       ))}
 

--- a/examples/next-openai/app/use-chat-streamdata/page.tsx
+++ b/examples/next-openai/app/use-chat-streamdata/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { UIMessage, useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit, data, setData } =
@@ -26,7 +25,9 @@ export default function Chat() {
       {messages?.map((m: UIMessage) => (
         <div key={m.id} className="whitespace-pre-wrap">
           <strong>{`${m.role}: `}</strong>
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
           {m.annotations && (
             <pre className="p-4 text-sm bg-gray-100">
               {JSON.stringify(m.annotations, null, 2)}

--- a/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
+++ b/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getToolInvocations, getUIText, ToolInvocation, UIMessage } from 'ai';
+import { getToolInvocations, ToolInvocation, UIMessage } from 'ai';
 import { useChat } from '@ai-sdk/react';
 
 export default function Chat() {
@@ -29,7 +29,9 @@ export default function Chat() {
         return (
           <div key={m.id} className="whitespace-pre-wrap">
             {isNewRole && <strong>{`${m.role}: `}</strong>}
-            {getUIText(m.parts)}
+            {m.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join('')}
             {/** TODO switch to parts */}
             {getToolInvocations(m as UIMessage).map(
               (toolInvocation: ToolInvocation) => {

--- a/examples/next-openai/app/use-chat-throttle/page.tsx
+++ b/examples/next-openai/app/use-chat-throttle/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 import { useLayoutEffect, useRef } from 'react';
 
 export default function Chat() {
@@ -23,7 +22,9 @@ export default function Chat() {
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
         </div>
       ))}
       <form onSubmit={handleSubmit}>

--- a/examples/next-openai/app/use-chat-vision/page.tsx
+++ b/examples/next-openai/app/use-chat-vision/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { getUIText } from 'ai';
 
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit } = useChat({
@@ -12,7 +11,9 @@ export default function Chat() {
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {getUIText(m.parts)}
+          {m.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
         </div>
       ))}
 

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -2,7 +2,6 @@ import { ToolSet } from '../../core/generate-text/tool-set';
 import { ToolResultPart } from '../../core/prompt/content-part';
 import { AssistantContent, ModelMessage } from '../../core/prompt/message';
 import { MessageConversionError } from '../../core/prompt/message-conversion-error';
-import { getUIText } from './get-ui-text';
 import {
   FileUIPart,
   ReasoningUIPart,
@@ -27,7 +26,9 @@ export function convertToModelMessages<TOOLS extends ToolSet = never>(
       case 'system': {
         modelMessages.push({
           role: 'system',
-          content: getUIText(message.parts),
+          content: message.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join(''),
         });
         break;
       }

--- a/packages/ai/src/ui/get-ui-text.ts
+++ b/packages/ai/src/ui/get-ui-text.ts
@@ -1,5 +1,0 @@
-import { UIMessagePart } from './ui-messages';
-
-export function getUIText(parts: UIMessagePart[]): string {
-  return parts.map(part => (part.type === 'text' ? part.text : '')).join('');
-}

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -9,7 +9,6 @@ export {
 } from './convert-to-model-messages';
 export { extractMaxToolInvocationStep } from './extract-max-tool-invocation-step';
 export { getToolInvocations } from './get-tool-invocations';
-export { getUIText } from './get-ui-text';
 export { processTextStream } from './process-text-stream';
 export {
   isAssistantMessageWithCompletedToolCalls,

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -12,7 +12,6 @@ import {
   DataStreamPart,
   FinishReason,
   getToolInvocations,
-  getUIText,
   LanguageModelUsage,
   UIMessage,
 } from 'ai';
@@ -472,7 +471,9 @@ describe('text stream', () => {
               {m.role === 'user' ? 'User: ' : 'AI: '}
             </div>
             <div data-testid={`message-${idx}-content`}>
-              {getUIText(m.parts)}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
             </div>
           </div>
         ))}
@@ -584,7 +585,9 @@ describe('form actions', () => {
         {messages.map((m, idx) => (
           <div data-testid={`message-${idx}`} key={m.id}>
             {m.role === 'user' ? 'User: ' : 'AI: '}
-            {getUIText(m.parts)}
+            {m.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join('')}
           </div>
         ))}
 
@@ -642,7 +645,9 @@ describe('form actions (with options)', () => {
         {messages.map((m, idx) => (
           <div data-testid={`message-${idx}`} key={m.id}>
             {m.role === 'user' ? 'User: ' : 'AI: '}
-            {getUIText(m.parts)}
+            {m.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join('')}
           </div>
         ))}
 
@@ -739,7 +744,9 @@ describe('prepareRequestBody', () => {
         {messages.map((m, idx) => (
           <div data-testid={`message-${idx}`} key={m.id}>
             {m.role === 'user' ? 'User: ' : 'AI: '}
-            {getUIText(m.parts)}
+            {m.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join('')}
           </div>
         ))}
 
@@ -1215,7 +1222,9 @@ describe('maxSteps', () => {
         <div>
           {messages.map((m, idx) => (
             <div data-testid={`message-${idx}`} key={m.id}>
-              {getUIText(m.parts)}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
             </div>
           ))}
 
@@ -1939,7 +1948,9 @@ describe('reload', () => {
         {messages.map((m, idx) => (
           <div data-testid={`message-${idx}`} key={m.id}>
             {m.role === 'user' ? 'User: ' : 'AI: '}
-            {getUIText(m.parts)}
+            {m.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join('')}
           </div>
         ))}
 
@@ -2042,7 +2053,9 @@ describe('test sending additional fields during message submission', () => {
         {messages.map((m, idx) => (
           <div data-testid={`message-${idx}`} key={m.id}>
             {m.role === 'user' ? 'User: ' : 'AI: '}
-            {getUIText(m.parts)}
+            {m.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join('')}
           </div>
         ))}
 
@@ -2119,7 +2132,13 @@ describe('initialMessages', () => {
       });
 
       useEffect(() => {
-        setDerivedState(messages.map(m => getUIText(m.parts)));
+        setDerivedState(
+          messages.map(m =>
+            m.parts
+              .map(part => (part.type === 'text' ? part.text : ''))
+              .join(''),
+          ),
+        );
       }, [messages]);
 
       if (renderCount > 10) {
@@ -2132,7 +2151,9 @@ describe('initialMessages', () => {
           <div data-testid="derived-state">{derivedState.join(', ')}</div>
           {messages.map(m => (
             <div key={m.id} data-testid={`message-${m.role}`}>
-              {getUIText(m.parts)}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
             </div>
           ))}
         </div>
@@ -2183,7 +2204,13 @@ describe('initialMessages', () => {
       return (
         <div>
           <div data-testid="messages">
-            {messages.map(m => getUIText(m.parts)).join(', ')}
+            {messages
+              .map(m =>
+                m.parts
+                  .map(part => (part.type === 'text' ? part.text : ''))
+                  .join(''),
+              )
+              .join(', ')}
           </div>
 
           <button
@@ -2248,7 +2275,9 @@ describe('resume ongoing stream and return assistant message', () => {
           {messages.map((m, idx) => (
             <div data-testid={`message-${idx}`} key={m.id}>
               {m.role === 'user' ? 'User: ' : 'AI: '}
-              {getUIText(m.parts)}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
             </div>
           ))}
 

--- a/packages/vue/src/TestChatComponent.vue
+++ b/packages/vue/src/TestChatComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getUIText, LanguageModelUsage } from 'ai';
+import { LanguageModelUsage } from 'ai';
 import { reactive } from 'vue';
 import { UIMessage, useChat } from './use-chat';
 
@@ -29,7 +29,9 @@ const { messages, append, data, error, status, setData } = useChat({
       :data-testid="`message-${idx}`"
     >
       {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
-      {{ getUIText(m.parts) }}
+      {{
+        m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+      }}
     </div>
 
     <button

--- a/packages/vue/src/TestChatCustomMetadataComponent.vue
+++ b/packages/vue/src/TestChatCustomMetadataComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { generateId, getUIText } from 'ai';
+import { generateId } from 'ai';
 import { mockId, mockValues } from 'ai/test';
 import { useChat } from './use-chat';
 
@@ -28,7 +28,9 @@ const { messages, append } = useChat({
       :data-testid="`message-${idx}`"
     >
       {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
-      {{ getUIText(m.parts) }}
+      {{
+        m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+      }}
     </div>
 
     <button

--- a/packages/vue/src/TestChatFormComponent.vue
+++ b/packages/vue/src/TestChatFormComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getToolInvocations, getUIText } from 'ai';
+import { getToolInvocations } from 'ai';
 import { useChat } from './use-chat';
 
 const { messages, handleSubmit, input } = useChat({
@@ -21,7 +21,9 @@ const { messages, handleSubmit, input } = useChat({
       :data-testid="`message-${idx}`"
     >
       {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
-      {{ getUIText(m.parts) }}
+      {{
+        m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+      }}
 
       <div
         v-for="invocation in getToolInvocations(m)"

--- a/packages/vue/src/TestChatFormOptionsComponent.vue
+++ b/packages/vue/src/TestChatFormOptionsComponent.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { getUIText } from 'ai';
 import { useChat } from './use-chat';
 
 const { messages, handleSubmit, input } = useChat();
@@ -13,7 +12,9 @@ const { messages, handleSubmit, input } = useChat();
       :data-testid="`message-${idx}`"
     >
       {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
-      {{ getUIText(m.parts) }}
+      {{
+        m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+      }}
     </div>
 
     <form

--- a/packages/vue/src/TestChatPrepareRequestBodyComponent.vue
+++ b/packages/vue/src/TestChatPrepareRequestBodyComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getUIText, JSONValue } from 'ai';
+import { JSONValue } from 'ai';
 import { computed, ref } from 'vue';
 import { UIMessage, useChat } from './use-chat';
 
@@ -29,7 +29,9 @@ const isLoading = computed(() => status.value !== 'ready');
       :data-testid="`message-${idx}`"
     >
       {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
-      {{ getUIText(m.parts) }}
+      {{
+        m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+      }}
     </div>
 
     <button

--- a/packages/vue/src/TestChatReloadComponent.vue
+++ b/packages/vue/src/TestChatReloadComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { generateId, getUIText } from 'ai';
+import { generateId } from 'ai';
 import { mockId, mockValues } from 'ai/test';
 import { useChat } from './use-chat';
 
@@ -20,7 +20,9 @@ const { messages, append, reload } = useChat({
       :data-testid="`message-${idx}`"
     >
       {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
-      {{ getUIText(m.parts) }}
+      {{
+        m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+      }}
     </div>
 
     <button

--- a/packages/vue/src/TestChatTextStreamComponent.vue
+++ b/packages/vue/src/TestChatTextStreamComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getUIText, LanguageModelUsage } from 'ai';
+import { LanguageModelUsage } from 'ai';
 import { reactive } from 'vue';
 import { UIMessage, useChat } from './use-chat';
 
@@ -27,7 +27,9 @@ const { messages, append } = useChat({
       :data-testid="`message-${idx}`"
     >
       {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
-      {{ getUIText(m.parts) }}
+      {{
+        m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+      }}
     </div>
 
     <button

--- a/packages/vue/src/TestChatToolInvocationsComponent.vue
+++ b/packages/vue/src/TestChatToolInvocationsComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getToolInvocations, getUIText } from 'ai';
+import { getToolInvocations } from 'ai';
 import { useChat } from './use-chat';
 
 const { messages, append, addToolResult } = useChat({
@@ -31,7 +31,9 @@ const { messages, append, addToolResult } = useChat({
         />
       </div>
       <div :data-testid="`text-${idx}`">
-        {{ getUIText(m.parts) }}
+        {{
+          m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+        }}
       </div>
     </div>
 


### PR DESCRIPTION
## Background

`getUIText()` was introduced as a helper when `uiMessage.content` was removed. However, chatbots without special parts are increasingly uncommon, and the helper feels out of place.

## Summary

Remove the `getUIText()` function.