### PR TITLE
chore (ui): inline/remove ChatRequest type

### DIFF
--- a/.changeset/fair-bikes-hear.md
+++ b/.changeset/fair-bikes-hear.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/svelte': major
+'@ai-sdk/react': major
+'ai': major
+---
+
+chore (ui): inline/remove ChatRequest type

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -16,5 +16,8 @@ export {
 } from './should-resubmit-messages';
 export * from './ui-messages';
 export { updateToolCallResult } from './update-tool-call-result';
-export * from './use-chat';
-export * from './use-completion';
+export { type UseChatOptions, type ChatRequestOptions } from './use-chat';
+export {
+  type UseCompletionOptions,
+  type CompletionRequestOptions,
+} from './use-completion';

--- a/packages/ai/src/ui/use-chat.ts
+++ b/packages/ai/src/ui/use-chat.ts
@@ -3,28 +3,6 @@ import { FetchFunction, IdGenerator, ToolCall } from '@ai-sdk/provider-utils';
 import { LanguageModelUsage } from '../../core/types/usage';
 import { UIMessage } from './ui-messages';
 
-export type ChatRequest = {
-  /**
-  An optional object of headers to be passed to the API endpoint.
-   */
-  headers?: Record<string, string> | Headers;
-
-  /**
-  An optional object to be passed to the API endpoint.
-  */
-  body?: object;
-
-  /**
-  The messages of the chat.
-     */
-  messages: UIMessage[];
-
-  /**
-  Additional data to be sent to the server.
-     */
-  data?: JSONValue;
-};
-
 export type ChatRequestOptions = {
   /**
   Additional headers that should be to be passed to the API endpoint.

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -1,5 +1,4 @@
 import type {
-  ChatRequest,
   ChatRequestOptions,
   CreateUIMessage,
   FileUIPart,
@@ -242,7 +241,12 @@ Default is undefined, which disables throttling.
 
   const triggerRequest = useCallback(
     async (
-      chatRequest: ChatRequest,
+      chatRequest: {
+        headers?: Record<string, string> | Headers;
+        body?: object;
+        messages: UIMessage[];
+        data?: JSONValue;
+      },
       requestType: 'generate' | 'resume' = 'generate',
     ) => {
       mutateStatus('submitted');

--- a/packages/svelte/src/chat.svelte.ts
+++ b/packages/svelte/src/chat.svelte.ts
@@ -8,7 +8,6 @@ import {
   isAssistantMessageWithCompletedToolCalls,
   shouldResubmitMessages,
   updateToolCallResult,
-  type ChatRequest,
   type ChatRequestOptions,
   type CreateUIMessage,
   type JSONValue,
@@ -183,7 +182,12 @@ export class Chat {
       parts: [...fileParts, { type: 'text', text: this.input }],
     });
 
-    const chatRequest: ChatRequest = {
+    const chatRequest: {
+      headers?: Record<string, string> | Headers;
+      body?: object;
+      messages: UIMessage[];
+      data?: JSONValue;
+    } = {
       messages,
       headers: options.headers,
       body: options.body,
@@ -222,7 +226,12 @@ export class Chat {
     }
   };
 
-  #triggerRequest = async (chatRequest: ChatRequest) => {
+  #triggerRequest = async (chatRequest: {
+    headers?: Record<string, string> | Headers;
+    body?: object;
+    messages: UIMessage[];
+    data?: JSONValue;
+  }) => {
     this.#store.status = 'submitted';
     this.#store.error = undefined;
 


### PR DESCRIPTION
## Background

The `ChatRequest` types is not used in any end-user facing interfaces.

## Summary

* inline/remove ChatRequest type