### PR TITLE
feat(provider/anthropic): start adding support for Anthropic's Web Search

### DIFF
--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -26,6 +26,7 @@ export interface AnthropicAssistantMessage {
     | AnthropicThinkingContent
     | AnthropicRedactedThinkingContent
     | AnthropicToolCallContent
+    | AnthropicWebSearchContent
   >;
 }
 
@@ -40,6 +41,14 @@ export interface AnthropicThinkingContent {
   thinking: string;
   signature: string;
   cache_control: AnthropicCacheControl | undefined;
+}
+
+export interface AnthropicWebSearchContent {
+  type: 'web_search_result';
+  url: string;
+  title: string;
+  encrypted_content: string;
+  page_age: string;
 }
 
 export interface AnthropicRedactedThinkingContent {
@@ -72,7 +81,7 @@ export interface AnthropicDocumentContent {
 }
 
 export interface AnthropicToolCallContent {
-  type: 'tool_use';
+  type: 'tool_use' | 'server_tool_use';
   id: string;
   name: string;
   input: unknown;
@@ -81,6 +90,14 @@ export interface AnthropicToolCallContent {
 
 export interface AnthropicToolResultContent {
   type: 'tool_result';
+  tool_use_id: string;
+  content: string | Array<AnthropicTextContent | AnthropicImageContent>;
+  is_error: boolean | undefined;
+  cache_control: AnthropicCacheControl | undefined;
+}
+
+export interface AnthropicWebSearchToolResultContent {
+  type: 'web_search_tool_result';
   tool_use_id: string;
   content: string | Array<AnthropicTextContent | AnthropicImageContent>;
   is_error: boolean | undefined;
@@ -107,6 +124,20 @@ export type AnthropicTool =
   | {
       name: string;
       type: 'bash_20250124' | 'bash_20241022';
+    }
+    | {
+      name: string;
+      type: 'web_search_20250305';
+      max_uses?: number;
+      allowed_domains?: string[];
+      blocked_domains?: string[];
+      user_location?: {
+        type: 'approximate',
+        city: string,
+        region: string,
+        country: string,
+        timezone: string
+      }
     };
 
 export type AnthropicToolChoice =

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -96,10 +96,16 @@ export interface AnthropicToolResultContent {
   cache_control: AnthropicCacheControl | undefined;
 }
 
+// New type for web search tool result errors
+export interface AnthropicWebSearchToolResultErrorContent {
+  type: 'web_search_tool_result_error';
+  error_code: string; // e.g., 'max_uses_exceeded', 'too_many_requests', etc.
+}
+
 export interface AnthropicWebSearchToolResultContent {
   type: 'web_search_tool_result';
   tool_use_id: string;
-  content: string | Array<AnthropicTextContent | AnthropicImageContent>;
+  content: Array<AnthropicWebSearchContent> | AnthropicWebSearchToolResultErrorContent; // Updated
   is_error: boolean | undefined;
   cache_control: AnthropicCacheControl | undefined;
 }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -396,6 +396,9 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
       | 'text'
       | 'thinking'
       | 'tool_use'
+      | 'server_tool_use'
+      | 'web_search_result'
+      | 'web_search_tool_result'
       | 'redacted_thinking'
       | undefined = undefined;
 
@@ -437,7 +440,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV1 {
                     return;
                   }
 
-                  case 'tool_use': {
+                  case 'tool_use': 
+                  case 'server_tool_use':
+                  case 'web_search_result':
+                  case 'web_search_tool_result':  {
                     toolCallContentBlocks[value.index] = {
                       toolCallId: value.content_block.id,
                       toolName: value.content_block.name,
@@ -620,6 +626,22 @@ const anthropicMessagesResponseSchema = z.object({
         name: z.string(),
         input: z.unknown(),
       }),
+      z.object({
+        type: z.literal('server_tool_use'),
+        id: z.string(),
+        name: z.string(),
+        input: z.unknown(),
+      }),
+      z.object({
+        type: z.literal('web_search_result'),
+        id: z.string(),
+        name: z.string(),
+      }),
+      z.object({
+        type: z.literal('web_search_tool_result'),
+        tool_use_id: z.string(),
+        content: z.unknown(),
+      }),
     ]),
   ),
   stop_reason: z.string().nullish(),
@@ -661,6 +683,21 @@ const anthropicMessagesChunkSchema = z.discriminatedUnion('type', [
       }),
       z.object({
         type: z.literal('tool_use'),
+        id: z.string(),
+        name: z.string(),
+      }),
+      z.object({
+        type: z.literal('server_tool_use'),
+        id: z.string(),
+        name: z.string(),
+      }),
+      z.object({
+        type: z.literal('web_search_result'),
+        id: z.string(),
+        name: z.string(),
+      }),
+      z.object({
+        type: z.literal('web_search_tool_result'),
         id: z.string(),
         name: z.string(),
       }),

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -88,6 +88,142 @@ it('should correctly prepare provider-defined tools', () => {
   expect(result.toolWarnings).toEqual([]);
 });
 
+it('should correctly prepare provider-defined web_search tool', () => {
+  // Test with basic web_search tool
+  let result = prepareTools({
+    type: 'regular',
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'anthropic.web_search_20250305',
+        name: 'web_search',
+        args: {},
+      },
+    ],
+  });
+  expect(result.tools).toEqual([
+    {
+      name: 'web_search',
+      type: 'web_search_20250305',
+    },
+  ]);
+  expect(result.toolWarnings).toEqual([]);
+  expect(result.betas.has('WEB_SEARCH_TOOL_20250305_SUPPORT')).toBe(true); // Assuming a beta flag might be set
+
+  // Test with max_uses
+  result = prepareTools({
+    type: 'regular',
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'anthropic.web_search_20250305',
+        name: 'web_search',
+        args: { max_uses: 3 },
+      },
+    ],
+  });
+  expect(result.tools).toEqual([
+    {
+      name: 'web_search',
+      type: 'web_search_20250305',
+      max_uses: 3,
+    },
+  ]);
+
+  // Test with allowed_domains
+  result = prepareTools({
+    type: 'regular',
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'anthropic.web_search_20250305',
+        name: 'web_search',
+        args: { allowed_domains: ['example.com'] },
+      },
+    ],
+  });
+  expect(result.tools).toEqual([
+    {
+      name: 'web_search',
+      type: 'web_search_20250305',
+      allowed_domains: ['example.com'],
+    },
+  ]);
+
+  // Test with blocked_domains
+  result = prepareTools({
+    type: 'regular',
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'anthropic.web_search_20250305',
+        name: 'web_search',
+        args: { blocked_domains: ['blocked.com'] },
+      },
+    ],
+  });
+  expect(result.tools).toEqual([
+    {
+      name: 'web_search',
+      type: 'web_search_20250305',
+      blocked_domains: ['blocked.com'],
+    },
+  ]);
+
+  // Test with user_location
+  const userLocation = {
+    type: 'approximate' as const,
+    city: 'San Francisco',
+    region: 'CA',
+    country: 'US',
+    timezone: 'America/Los_Angeles',
+  };
+  result = prepareTools({
+    type: 'regular',
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'anthropic.web_search_20250305',
+        name: 'web_search',
+        args: { user_location: userLocation },
+      },
+    ],
+  });
+  expect(result.tools).toEqual([
+    {
+      name: 'web_search',
+      type: 'web_search_20250305',
+      user_location: userLocation,
+    },
+  ]);
+
+  // Test with all parameters
+  result = prepareTools({
+    type: 'regular',
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'anthropic.web_search_20250305',
+        name: 'web_search',
+        args: {
+          max_uses: 5,
+          allowed_domains: ['example.com', 'another.org'],
+          user_location: userLocation,
+        },
+      },
+    ],
+  });
+  expect(result.tools).toEqual([
+    {
+      name: 'web_search',
+      type: 'web_search_20250305',
+      max_uses: 5,
+      allowed_domains: ['example.com', 'another.org'],
+      user_location: userLocation,
+    },
+  ]);
+});
+
 it('should add warnings for unsupported tools', () => {
   const result = prepareTools({
     type: 'regular',

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -86,6 +86,12 @@ export function prepareTools(
               type: 'bash_20241022',
             });
             break;
+          case 'anthropic.web_search_20250305':
+            anthropicTools.push({
+              name: tool.name,
+              type: 'web_search_20250305',
+            });
+            break;
           default:
             toolWarnings.push({ type: 'unsupported-tool', tool });
             break;

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -90,6 +90,18 @@ export function prepareTools(
             anthropicTools.push({
               name: tool.name,
               type: 'web_search_20250305',
+              ...((tool as any).args as {
+                max_uses?: number;
+                allowed_domains?: string[];
+                blocked_domains?: string[];
+                user_location?: {
+                  type: 'approximate',
+                  city: string,
+                  region: string,
+                  country: string,
+                  timezone: string
+                };
+              }),
             });
             break;
           default:

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -19,13 +19,6 @@ export type ToolResultContent = Array<
       data: string; // base64 encoded png image, e.g. screenshot
       mimeType?: string; // e.g. 'image/png';
     }
-  | {
-      type: 'web_search_result';
-      url: string;
-      title: string;
-      encrypted_content: string;
-      page_age: string;
-    }
 >;
 
 const Bash20241022Parameters = z.object({
@@ -552,7 +545,18 @@ function webSearchTool_20250305<RESULT>(options: {
 }): {
   type: 'provider-defined';
   id: 'anthropic.web_search_20250305';
-  args: {};
+  args: {
+    max_uses?: number;
+    allowed_domains?: string[];
+    blocked_domains?: string[];
+    user_location?: {
+      type: 'approximate',
+      city: string,
+      region: string,
+      country: string,
+      timezone: string
+    };
+  };
   parameters: typeof WebSearch20250305Parameters;
   execute: ExecuteFunction<z.infer<typeof WebSearch20250305Parameters>, RESULT>;
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
@@ -560,7 +564,12 @@ function webSearchTool_20250305<RESULT>(options: {
   return {
     type: 'provider-defined',
     id: 'anthropic.web_search_20250305',
-    args: {},
+    args: {
+      max_uses: options.max_uses,
+      allowed_domains: options.allowed_domains,
+      blocked_domains: options.blocked_domains,
+      user_location: options.user_location,
+    },
     parameters: WebSearch20250305Parameters,
     execute: options.execute,
     experimental_toToolResultContent: options.experimental_toToolResultContent,

--- a/packages/anthropic/src/map-anthropic-stop-reason.ts
+++ b/packages/anthropic/src/map-anthropic-stop-reason.ts
@@ -8,6 +8,7 @@ export function mapAnthropicStopReason(
     case 'stop_sequence':
       return 'stop';
     case 'tool_use':
+    case 'server_tool_use':
       return 'tool-calls';
     case 'max_tokens':
       return 'length';


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Anthropic just [announced the availability of web search in their API](https://www.anthropic.com/news/web-search-api?utm_source=it&utm_medium=email&utm_campaign=5-7-web-search-api). This feature is really exciting to me.

## Summary

Added support for what is presented in the [documentation](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool).

## Verification

I currently just got it to work:

```
const gen = await generateText({
	model,
	prompt,
	tools: {
		web_search: anthropic.tools.webSearch_20250305({
			max_uses: 2,
		}),
	},
	maxSteps: 3
})
```

## Tasks

- [X] Get the basic feature to work
- [ ] Make sure the output from the server is correctly mapped in the SDK response
- [ ] Check types and schema validations (some have been done very quickly to get it to work late at night)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

Note: I don't know how to write tests... yet. Happy to get help on that front

## Disclaimer

I've only contributed to documentation before, I hope this will help. And I'd also understand if it doesn't, I really don't mind if this gets closed for any reason.

Also, I'm on EU timezone, I'll pick up the work as soon as I can, but I'm 100% open to let anyone pick this up at any time