### PR TITLE
fix (ai-sdk/vue): status reactivity

### DIFF
--- a/.changeset/heavy-ligers-lay.md
+++ b/.changeset/heavy-ligers-lay.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/vue': patch
+---
+
+fix (ai-sdk/vue): fix status reactivity

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -106,6 +106,10 @@ export type UseChatHelpers = {
 // @ts-expect-error - some issues with the default export of useSWRV
 const useSWRV = (swrv.default as (typeof import('swrv'))['default']) || swrv;
 const store: Record<string, UIMessage[] | undefined> = {};
+const statusStore: Record<
+  string,
+  Ref<'submitted' | 'streaming' | 'ready' | 'error'>
+> = {};
 
 export function useChat(
   {
@@ -164,7 +168,11 @@ export function useChat(
     () => store[key] ?? fillMessageParts(initialMessages),
   );
 
-  const status = ref<'submitted' | 'streaming' | 'ready' | 'error'>('ready');
+  const status =
+    statusStore[chatId] ??
+    (statusStore[chatId] = ref<'submitted' | 'streaming' | 'ready' | 'error'>(
+      'ready',
+    ));
 
   // Force the `data` to be `initialMessages` if it's `undefined`.
   messagesData.value ??= fillMessageParts(initialMessages);

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -174,6 +174,47 @@ describe('data protocol stream', () => {
       });
     });
 
+    it('gets stuck when the stream finishes while the tab is hidden', async () => {
+      const controller = new TestResponseController();
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      const originalVisibilityState = document.visibilityState;
+
+      try {
+        await userEvent.click(screen.getByTestId('do-append'));
+        await waitFor(() =>
+          expect(screen.getByTestId('status')).toHaveTextContent('submitted'),
+        );
+
+        controller.write('0:"Hello"\n');
+        await waitFor(() =>
+          expect(screen.getByTestId('status')).toHaveTextContent('streaming'),
+        );
+
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          get: () => 'hidden',
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        controller.write('0:", world."\n');
+        controller.close();
+
+        await waitFor(() =>
+          expect(screen.getByTestId('status')).toHaveTextContent('ready'),
+        );
+      } finally {
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          get: () => originalVisibilityState,
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      }
+    });
+
     it('should set status to error when there is a server error', async () => {
       server.urls['/api/chat'].response = {
         type: 'error',

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -174,7 +174,7 @@ describe('data protocol stream', () => {
       });
     });
 
-    it('gets stuck when the stream finishes while the tab is hidden', async () => {
+    it('should update status when the tab is hidden', async () => {
       const controller = new TestResponseController();
       server.urls['/api/chat'].response = {
         type: 'controlled-stream',


### PR DESCRIPTION
## Background

Bug with Vue that led to status not updating when tab was changed.

## Summary

Changes status from using SWR to using Vue ref.

## Verification
Tested locally.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)

## Related Issues

Fixes  #6110.