### PR TITLE
fix (docs): Laminar observability - add note on next.config

### DIFF
--- a/content/providers/05-observability/laminar.mdx
+++ b/content/providers/05-observability/laminar.mdx
@@ -74,7 +74,7 @@ In your `next.config.js` (`.ts` / `.mjs`), add the following lines:
 
 ```javascript
 const nextConfig = {
-  serverExternalPackages: ["@lmnr-ai/lmnr"],
+  serverExternalPackages: ['@lmnr-ai/lmnr'],
 };
 
 export default nextConfig;

--- a/content/providers/05-observability/laminar.mdx
+++ b/content/providers/05-observability/laminar.mdx
@@ -68,6 +68,20 @@ export async function register() {
 }
 ```
 
+### Add @lmnr-ai/lmnr to your next.config
+
+In your `next.config.js` (`.ts` / `.mjs`), add the following lines:
+
+```javascript
+const nextConfig = {
+  serverExternalPackages: ["@lmnr-ai/lmnr"],
+};
+
+export default nextConfig;
+```
+
+This is because Laminar depends on OpenTelemetry, which uses some Node.js-specific functionality, and we need to inform Next.js about it. Learn more in the [Next.js docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages).
+
 ### Tracing AI SDK calls
 
 Then, when you call AI SDK functions in any of your API routes, add the Laminar tracer to the `experimental_telemetry` option.


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Like many other OpenTelemetry instrumentations, Laminar depends on `@opentelemetry/instrumentation`, which, in turn, depends on `require-in-the-middle` and `import-in-the-middle`. Importing and initializing Laminar inside Next.js `instrumentation.ts` file causes Next.js to try resolving these two packages, but fails, and results in:

- Laminar not being able to send traces. This is because unlike many other instrumentation libraries, Laminar is not intrusive and does not set its tracer provider globally (so that others, e.g. `@vercel/otel` can set theirs).
- Error messages (see below)

We have tried many different things to debug, including bundling Laminar differently, shipping those two packages within Laminar as `noExternal`, adding a separate entrypoint in our package for Next.js, but nothing seems to have worked.

The only thing that's worked was adding `@lmnr-ai/lmnr` in `serverExternalPackages` in [next.config](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages).

Example error message without turbopack:
```
 ⚠ ./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/index.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/index.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/index.js
./node_modules/.pnpm/@lmnr-ai+lmnr@file+..+..+ts-sdk/node_modules/@lmnr-ai/lmnr/dist/index.js

./node_modules/.pnpm/require-in-the-middle@7.5.2/node_modules/require-in-the-middle/index.js
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

Import trace for requested module:
./node_modules/.pnpm/require-in-the-middle@7.5.2/node_modules/require-in-the-middle/index.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/index.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/index.js
./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/index.js
./node_modules/.pnpm/@lmnr-ai+lmnr@file+..+..+ts-sdk/node_modules/@lmnr-ai/lmnr/dist/index.js
```

Example error message with Turbopack

```
 ⚠ ./node_modules/.pnpm/@opentelemetry+instrumentation@0.57.2_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node
Package import-in-the-middle can't be external
The request import-in-the-middle matches serverExternalPackages (or the default list).
The request could not be resolved by Node.js from the project directory.
Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.
Try to install it into the project directory by running npm install import-in-the-middle from the project directory.


 ⚠ ./node_modules/.pnpm/@opentelemetry+instrumentation@0.56.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node
Package require-in-the-middle can't be external
The request require-in-the-middle matches serverExternalPackages (or the default list).
The request could not be resolved by Node.js from the project directory.
Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.
Try to install it into the project directory by running npm install require-in-the-middle from the project directory.
```

## Summary

<!-- What did you change? -->

Add a subsection within the Next.js section that describes

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

Syntax highlighter for MDX

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
