### PR TITLE
chore (ai): improve consistency of generate text result, stream text result, and step result

### DIFF
--- a/.changeset/good-swans-heal.md
+++ b/.changeset/good-swans-heal.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): improve consistency of generate text result, stream text result, and step result

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should be called for each step 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "args": {
@@ -22,11 +22,8 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
         "type": "tool-result",
       },
     ],
-    "files": [],
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -63,29 +60,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "",
-    "toolCalls": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-call",
-      },
-    ],
-    "toolResults": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "result": "result1",
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-result",
-      },
-    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 10,
@@ -95,18 +69,15 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
     },
     "warnings": [],
   },
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "Hello, world!",
         "type": "text",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -155,10 +126,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
-    "sources": [],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -214,7 +181,7 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.response.mess
 
 exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should contain all steps 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "args": {
@@ -234,11 +201,8 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
         "type": "tool-result",
       },
     ],
-    "files": [],
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -275,29 +239,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "",
-    "toolCalls": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-call",
-      },
-    ],
-    "toolResults": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "result": "result1",
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-result",
-      },
-    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 10,
@@ -307,18 +248,15 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
     },
     "warnings": [],
   },
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "Hello, world!",
         "type": "text",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -367,10 +305,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
-    "sources": [],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -385,7 +319,7 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
 
 exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > onStepFinish should be called for each step 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "args": {
@@ -405,11 +339,8 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > onS
         "type": "tool-result",
       },
     ],
-    "files": [],
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -446,29 +377,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > onS
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "",
-    "toolCalls": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-call",
-      },
-    ],
-    "toolResults": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "result": "result1",
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-result",
-      },
-    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 10,
@@ -478,18 +386,15 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > onS
     },
     "warnings": [],
   },
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "Hello, world!",
         "type": "text",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -538,10 +443,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > onS
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
-    "sources": [],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -597,7 +498,7 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > res
 
 exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > result.steps should contain all steps 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "args": {
@@ -617,11 +518,8 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > res
         "type": "tool-result",
       },
     ],
-    "files": [],
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -658,29 +556,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > res
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "",
-    "toolCalls": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-call",
-      },
-    ],
-    "toolResults": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "result": "result1",
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-result",
-      },
-    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 10,
@@ -690,18 +565,15 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > res
     },
     "warnings": [],
   },
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "Hello, world!",
         "type": "text",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -750,10 +622,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > res
       "modelId": "test-response-model-id",
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
-    "sources": [],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -947,7 +815,7 @@ exports[`result.sources > should contain sources 1`] = `
 
 exports[`result.steps > should add the reasoning from the model response to the step result 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "providerMetadata": {
@@ -972,30 +840,8 @@ exports[`result.steps > should add the reasoning from the model response to the 
         "type": "text",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [
-      {
-        "providerMetadata": {
-          "testProvider": {
-            "signature": "signature",
-          },
-        },
-        "text": "I will open the conversation with witty banter.",
-        "type": "reasoning",
-      },
-      {
-        "providerMetadata": {
-          "testProvider": {
-            "redactedData": "redacted-reasoning-data",
-          },
-        },
-        "text": "",
-        "type": "reasoning",
-      },
-    ],
-    "reasoningText": "I will open the conversation with witty banter.",
     "request": {},
     "response": {
       "body": undefined,
@@ -1034,10 +880,6 @@ exports[`result.steps > should add the reasoning from the model response to the 
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -1052,7 +894,7 @@ exports[`result.steps > should add the reasoning from the model response to the 
 
 exports[`result.steps > should contain files 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "Hello, world!",
@@ -1079,26 +921,8 @@ exports[`result.steps > should contain files 1`] = `
         "type": "file",
       },
     ],
-    "files": [
-      DefaultGeneratedFile {
-        "base64Data": "AQID",
-        "mediaType": "image/png",
-        "uint8ArrayData": Uint8Array [
-          1,
-          2,
-          3,
-        ],
-      },
-      DefaultGeneratedFile {
-        "base64Data": "QkFVRw==",
-        "mediaType": "image/jpeg",
-        "uint8ArrayData": undefined,
-      },
-    ],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -1129,10 +953,6 @@ exports[`result.steps > should contain files 1`] = `
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -1147,7 +967,7 @@ exports[`result.steps > should contain files 1`] = `
 
 exports[`result.steps > should contain sources 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "Hello, world!",
@@ -1178,11 +998,8 @@ exports[`result.steps > should contain sources 1`] = `
         "url": "https://example.com/2",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "body": undefined,
@@ -1203,35 +1020,6 @@ exports[`result.steps > should contain sources 1`] = `
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [
-      {
-        "id": "123",
-        "providerMetadata": {
-          "provider": {
-            "custom": "value",
-          },
-        },
-        "sourceType": "url",
-        "title": "Example",
-        "type": "source",
-        "url": "https://example.com",
-      },
-      {
-        "id": "456",
-        "providerMetadata": {
-          "provider": {
-            "custom": "value2",
-          },
-        },
-        "sourceType": "url",
-        "title": "Example 2",
-        "type": "source",
-        "url": "https://example.com/2",
-      },
-    ],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -777,7 +777,7 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > res
 exports[`result.files > should contain files 1`] = `
 [
   DefaultGeneratedFile {
-    "base64Data": undefined,
+    "base64Data": "AQID",
     "mediaType": "image/png",
     "uint8ArrayData": Uint8Array [
       1,

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -64,7 +64,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "",
     "toolCalls": [
       {
@@ -157,7 +156,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > onStepFinish should 
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
     "sources": [],
-    "stepType": "tool-result",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],
@@ -278,7 +276,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "",
     "toolCalls": [
       {
@@ -371,7 +368,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result > result.steps should 
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
     "sources": [],
-    "stepType": "tool-result",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],
@@ -451,7 +447,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > onS
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "",
     "toolCalls": [
       {
@@ -544,7 +539,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > onS
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
     "sources": [],
-    "stepType": "tool-result",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],
@@ -665,7 +659,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > res
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "",
     "toolCalls": [
       {
@@ -758,7 +751,6 @@ exports[`options.maxSteps > 2 steps: initial, tool-result with prepareStep > res
       "timestamp": 1970-01-01T00:00:10.000Z,
     },
     "sources": [],
-    "stepType": "tool-result",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],
@@ -1043,7 +1035,6 @@ exports[`result.steps > should add the reasoning from the model response to the 
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],
@@ -1139,7 +1130,6 @@ exports[`result.steps > should contain files 1`] = `
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],
@@ -1239,7 +1229,6 @@ exports[`result.steps > should contain sources 1`] = `
         "url": "https://example.com/2",
       },
     ],
-    "stepType": "initial",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -182,7 +182,7 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
   },
   "sources": [],
   "steps": [
-    {
+    DefaultStepResult {
       "content": [
         {
           "providerMetadata": undefined,
@@ -207,17 +207,8 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
           "type": "tool-result",
         },
       ],
-      "files": [],
       "finishReason": "tool-calls",
       "providerMetadata": undefined,
-      "reasoning": [
-        {
-          "providerMetadata": undefined,
-          "text": "thinking",
-          "type": "reasoning",
-        },
-      ],
-      "reasoningText": "thinking",
       "request": {},
       "response": {
         "headers": {
@@ -260,29 +251,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
-      "sources": [],
-      "text": "",
-      "toolCalls": [
-        {
-          "args": {
-            "value": "value",
-          },
-          "toolCallId": "call-1",
-          "toolName": "tool1",
-          "type": "tool-call",
-        },
-      ],
-      "toolResults": [
-        {
-          "args": {
-            "value": "value",
-          },
-          "result": "result1",
-          "toolCallId": "call-1",
-          "toolName": "tool1",
-          "type": "tool-result",
-        },
-      ],
       "usage": {
         "cachedInputTokens": undefined,
         "inputTokens": 3,
@@ -292,18 +260,15 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
       },
       "warnings": undefined,
     },
-    {
+    DefaultStepResult {
       "content": [
         {
           "text": "Hello, world!",
           "type": "text",
         },
       ],
-      "files": [],
       "finishReason": "stop",
       "providerMetadata": undefined,
-      "reasoning": [],
-      "reasoningText": undefined,
       "request": {},
       "response": {
         "headers": {
@@ -356,10 +321,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
-      "sources": [],
-      "text": "Hello, world!",
-      "toolCalls": [],
-      "toolResults": [],
       "usage": {
         "cachedInputTokens": 3,
         "inputTokens": 3,
@@ -386,7 +347,7 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
 
 exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbacks > onStepFinish should send correct information 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "providerMetadata": undefined,
@@ -411,17 +372,8 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
         "type": "tool-result",
       },
     ],
-    "files": [],
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
-    "reasoning": [
-      {
-        "providerMetadata": undefined,
-        "text": "thinking",
-        "type": "reasoning",
-      },
-    ],
-    "reasoningText": "thinking",
     "request": {},
     "response": {
       "headers": {
@@ -464,29 +416,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "",
-    "toolCalls": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-call",
-      },
-    ],
-    "toolResults": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "result": "result1",
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-result",
-      },
-    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -496,18 +425,15 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
     },
     "warnings": undefined,
   },
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "Hello, world!",
         "type": "text",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "headers": {
@@ -560,10 +486,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
-    "sources": [],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": 3,
       "inputTokens": 3,
@@ -871,7 +793,7 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > value p
 
 exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > value promises > result.steps should contain all steps 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "providerMetadata": undefined,
@@ -896,17 +818,8 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > value p
         "type": "tool-result",
       },
     ],
-    "files": [],
     "finishReason": "tool-calls",
     "providerMetadata": undefined,
-    "reasoning": [
-      {
-        "providerMetadata": undefined,
-        "text": "thinking",
-        "type": "reasoning",
-      },
-    ],
-    "reasoningText": "thinking",
     "request": {},
     "response": {
       "headers": {
@@ -949,29 +862,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > value p
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "",
-    "toolCalls": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-call",
-      },
-    ],
-    "toolResults": [
-      {
-        "args": {
-          "value": "value",
-        },
-        "result": "result1",
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-result",
-      },
-    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -981,18 +871,15 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > value p
     },
     "warnings": undefined,
   },
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "Hello, world!",
         "type": "text",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "headers": {
@@ -1045,10 +932,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > value p
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
-    "sources": [],
-    "text": "Hello, world!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": 3,
       "inputTokens": 3,
@@ -1216,7 +1099,7 @@ exports[`streamText > options.onFinish > should send correct information 1`] = `
   },
   "sources": [],
   "steps": [
-    {
+    DefaultStepResult {
       "content": [
         {
           "text": "Hello, ",
@@ -1244,15 +1127,12 @@ exports[`streamText > options.onFinish > should send correct information 1`] = `
           "type": "text",
         },
       ],
-      "files": [],
       "finishReason": "stop",
       "providerMetadata": {
         "testProvider": {
           "testKey": "testValue",
         },
       },
-      "reasoning": [],
-      "reasoningText": undefined,
       "request": {},
       "response": {
         "headers": {
@@ -1298,29 +1178,6 @@ exports[`streamText > options.onFinish > should send correct information 1`] = `
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
-      "sources": [],
-      "text": "Hello, world!",
-      "toolCalls": [
-        {
-          "args": {
-            "value": "value",
-          },
-          "toolCallId": "call-1",
-          "toolName": "tool1",
-          "type": "tool-call",
-        },
-      ],
-      "toolResults": [
-        {
-          "args": {
-            "value": "value",
-          },
-          "result": "value-result",
-          "toolCallId": "call-1",
-          "toolName": "tool1",
-          "type": "tool-result",
-        },
-      ],
       "usage": {
         "cachedInputTokens": undefined,
         "inputTokens": 3,
@@ -1439,7 +1296,7 @@ exports[`streamText > options.onFinish > should send files 1`] = `
   },
   "sources": [],
   "steps": [
-    {
+    DefaultStepResult {
       "content": [
         {
           "file": DefaultGeneratedFileWithType {
@@ -1464,24 +1321,8 @@ exports[`streamText > options.onFinish > should send files 1`] = `
           "type": "file",
         },
       ],
-      "files": [
-        DefaultGeneratedFileWithType {
-          "base64Data": "Hello World",
-          "mediaType": "text/plain",
-          "type": "file",
-          "uint8ArrayData": undefined,
-        },
-        DefaultGeneratedFileWithType {
-          "base64Data": "QkFVRw==",
-          "mediaType": "image/jpeg",
-          "type": "file",
-          "uint8ArrayData": undefined,
-        },
-      ],
       "finishReason": "stop",
       "providerMetadata": undefined,
-      "reasoning": [],
-      "reasoningText": undefined,
       "request": {},
       "response": {
         "headers": undefined,
@@ -1511,10 +1352,6 @@ exports[`streamText > options.onFinish > should send files 1`] = `
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
-      "sources": [],
-      "text": "Hello!",
-      "toolCalls": [],
-      "toolResults": [],
       "usage": {
         "cachedInputTokens": undefined,
         "inputTokens": 3,
@@ -1622,7 +1459,7 @@ exports[`streamText > options.onFinish > should send sources 1`] = `
     },
   ],
   "steps": [
-    {
+    DefaultStepResult {
       "content": [
         {
           "id": "123",
@@ -1653,11 +1490,8 @@ exports[`streamText > options.onFinish > should send sources 1`] = `
           "url": "https://example.com/2",
         },
       ],
-      "files": [],
       "finishReason": "stop",
       "providerMetadata": undefined,
-      "reasoning": [],
-      "reasoningText": undefined,
       "request": {},
       "response": {
         "headers": undefined,
@@ -1677,35 +1511,6 @@ exports[`streamText > options.onFinish > should send sources 1`] = `
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
-      "sources": [
-        {
-          "id": "123",
-          "providerMetadata": {
-            "provider": {
-              "custom": "value",
-            },
-          },
-          "sourceType": "url",
-          "title": "Example",
-          "type": "source",
-          "url": "https://example.com",
-        },
-        {
-          "id": "456",
-          "providerMetadata": {
-            "provider": {
-              "custom": "value2",
-            },
-          },
-          "sourceType": "url",
-          "title": "Example 2",
-          "type": "source",
-          "url": "https://example.com/2",
-        },
-      ],
-      "text": "Hello!",
-      "toolCalls": [],
-      "toolResults": [],
       "usage": {
         "cachedInputTokens": undefined,
         "inputTokens": 3,
@@ -1764,18 +1569,15 @@ exports[`streamText > options.output > object output > should call onFinish with
   },
   "sources": [],
   "steps": [
-    {
+    DefaultStepResult {
       "content": [
         {
           "text": "{ "value": "Hello, world!" }",
           "type": "text",
         },
       ],
-      "files": [],
       "finishReason": "stop",
       "providerMetadata": undefined,
-      "reasoning": [],
-      "reasoningText": undefined,
       "request": {},
       "response": {
         "headers": undefined,
@@ -1795,10 +1597,6 @@ exports[`streamText > options.output > object output > should call onFinish with
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
-      "sources": [],
-      "text": "{ "value": "Hello, world!" }",
-      "toolCalls": [],
-      "toolResults": [],
       "usage": {
         "cachedInputTokens": undefined,
         "inputTokens": 3,
@@ -1908,7 +1706,7 @@ exports[`streamText > options.transform > with base transformation > options.onF
   },
   "sources": [],
   "steps": [
-    {
+    DefaultStepResult {
       "content": [
         {
           "text": "HELLO, ",
@@ -1936,15 +1734,12 @@ exports[`streamText > options.transform > with base transformation > options.onF
           "type": "text",
         },
       ],
-      "files": [],
       "finishReason": "stop",
       "providerMetadata": {
         "testProvider": {
           "testKey": "TEST VALUE",
         },
       },
-      "reasoning": [],
-      "reasoningText": undefined,
       "request": {},
       "response": {
         "headers": {
@@ -1990,29 +1785,6 @@ exports[`streamText > options.transform > with base transformation > options.onF
         "modelId": "mock-model-id",
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
-      "sources": [],
-      "text": "HELLO, WORLD!",
-      "toolCalls": [
-        {
-          "args": {
-            "value": "VALUE",
-          },
-          "toolCallId": "call-1",
-          "toolName": "tool1",
-          "type": "tool-call",
-        },
-      ],
-      "toolResults": [
-        {
-          "args": {
-            "value": "VALUE",
-          },
-          "result": "VALUE-RESULT",
-          "toolCallId": "call-1",
-          "toolName": "tool1",
-          "type": "tool-result",
-        },
-      ],
       "usage": {
         "cachedInputTokens": undefined,
         "inputTokens": 3,
@@ -2057,7 +1829,7 @@ exports[`streamText > options.transform > with base transformation > options.onF
 `;
 
 exports[`streamText > options.transform > with base transformation > options.onStepFinish should receive transformed data 1`] = `
-{
+DefaultStepResult {
   "content": [
     {
       "text": "HELLO, ",
@@ -2085,15 +1857,12 @@ exports[`streamText > options.transform > with base transformation > options.onS
       "type": "text",
     },
   ],
-  "files": [],
   "finishReason": "stop",
   "providerMetadata": {
     "testProvider": {
       "testKey": "TEST VALUE",
     },
   },
-  "reasoning": [],
-  "reasoningText": undefined,
   "request": {},
   "response": {
     "headers": {
@@ -2139,29 +1908,6 @@ exports[`streamText > options.transform > with base transformation > options.onS
     "modelId": "mock-model-id",
     "timestamp": 1970-01-01T00:00:00.000Z,
   },
-  "sources": [],
-  "text": "HELLO, WORLD!",
-  "toolCalls": [
-    {
-      "args": {
-        "value": "VALUE",
-      },
-      "toolCallId": "call-1",
-      "toolName": "tool1",
-      "type": "tool-call",
-    },
-  ],
-  "toolResults": [
-    {
-      "args": {
-        "value": "VALUE",
-      },
-      "result": "VALUE-RESULT",
-      "toolCallId": "call-1",
-      "toolName": "tool1",
-      "type": "tool-result",
-    },
-  ],
   "usage": {
     "cachedInputTokens": undefined,
     "inputTokens": 3,
@@ -2175,7 +1921,7 @@ exports[`streamText > options.transform > with base transformation > options.onS
 
 exports[`streamText > options.transform > with base transformation > result.steps should be transformed 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "text": "HELLO, WORLD!",
@@ -2199,11 +1945,8 @@ exports[`streamText > options.transform > with base transformation > result.step
         "type": "tool-result",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "headers": undefined,
@@ -2243,29 +1986,6 @@ exports[`streamText > options.transform > with base transformation > result.step
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "HELLO, WORLD!",
-    "toolCalls": [
-      {
-        "args": {
-          "value": "VALUE",
-        },
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-call",
-      },
-    ],
-    "toolResults": [
-      {
-        "args": {
-          "value": "VALUE",
-        },
-        "result": "RESULT1",
-        "toolCallId": "call-1",
-        "toolName": "tool1",
-        "type": "tool-result",
-      },
-    ],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -2363,18 +2083,15 @@ exports[`streamText > options.transform > with base transformation > telemetry s
 `;
 
 exports[`streamText > options.transform > with transformation that aborts stream > options.onStepFinish should be called 1`] = `
-{
+DefaultStepResult {
   "content": [
     {
       "text": "Hello, ",
       "type": "text",
     },
   ],
-  "files": [],
   "finishReason": "stop",
   "providerMetadata": undefined,
-  "reasoning": [],
-  "reasoningText": undefined,
   "request": {},
   "response": {
     "id": "response-id",
@@ -2393,10 +2110,6 @@ exports[`streamText > options.transform > with transformation that aborts stream
     "modelId": "mock-model-id",
     "timestamp": 1970-01-01T00:00:00.000Z,
   },
-  "sources": [],
-  "text": "Hello, ",
-  "toolCalls": [],
-  "toolResults": [],
   "usage": {
     "cachedInputTokens": undefined,
     "inputTokens": undefined,
@@ -3441,7 +3154,7 @@ exports[`streamText > result.sources > should contain sources 1`] = `
 
 exports[`streamText > result.steps > should add the files from the model response to the step result 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "file": DefaultGeneratedFileWithType {
@@ -3466,24 +3179,8 @@ exports[`streamText > result.steps > should add the files from the model respons
         "type": "file",
       },
     ],
-    "files": [
-      DefaultGeneratedFileWithType {
-        "base64Data": "Hello World",
-        "mediaType": "text/plain",
-        "type": "file",
-        "uint8ArrayData": undefined,
-      },
-      DefaultGeneratedFileWithType {
-        "base64Data": "QkFVRw==",
-        "mediaType": "image/jpeg",
-        "type": "file",
-        "uint8ArrayData": undefined,
-      },
-    ],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "headers": undefined,
@@ -3513,10 +3210,6 @@ exports[`streamText > result.steps > should add the files from the model respons
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "Hello!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -3531,7 +3224,7 @@ exports[`streamText > result.steps > should add the files from the model respons
 
 exports[`streamText > result.steps > should add the reasoning from the model response to the step result 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "providerMetadata": {
@@ -3565,39 +3258,8 @@ exports[`streamText > result.steps > should add the reasoning from the model res
         "type": "text",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [
-      {
-        "providerMetadata": {
-          "testProvider": {
-            "signature": "1234567890",
-          },
-        },
-        "text": "I will open the conversation with witty banter. ",
-        "type": "reasoning",
-      },
-      {
-        "providerMetadata": {
-          "testProvider": {
-            "redactedData": "redacted-reasoning-data",
-          },
-        },
-        "text": "",
-        "type": "reasoning",
-      },
-      {
-        "providerMetadata": {
-          "testProvider": {
-            "signature": "1234567890",
-          },
-        },
-        "text": "Once the user has relaxed, I will pry for valuable information.",
-        "type": "reasoning",
-      },
-    ],
-    "reasoningText": "I will open the conversation with witty banter. Once the user has relaxed, I will pry for valuable information.",
     "request": {},
     "response": {
       "headers": undefined,
@@ -3644,10 +3306,6 @@ exports[`streamText > result.steps > should add the reasoning from the model res
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [],
-    "text": "Hi there!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,
@@ -3662,7 +3320,7 @@ exports[`streamText > result.steps > should add the reasoning from the model res
 
 exports[`streamText > result.steps > should add the sources from the model response to the step result 1`] = `
 [
-  {
+  DefaultStepResult {
     "content": [
       {
         "id": "123",
@@ -3693,11 +3351,8 @@ exports[`streamText > result.steps > should add the sources from the model respo
         "url": "https://example.com/2",
       },
     ],
-    "files": [],
     "finishReason": "stop",
     "providerMetadata": undefined,
-    "reasoning": [],
-    "reasoningText": undefined,
     "request": {},
     "response": {
       "headers": undefined,
@@ -3717,35 +3372,6 @@ exports[`streamText > result.steps > should add the sources from the model respo
       "modelId": "mock-model-id",
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
-    "sources": [
-      {
-        "id": "123",
-        "providerMetadata": {
-          "provider": {
-            "custom": "value",
-          },
-        },
-        "sourceType": "url",
-        "title": "Example",
-        "type": "source",
-        "url": "https://example.com",
-      },
-      {
-        "id": "456",
-        "providerMetadata": {
-          "provider": {
-            "custom": "value2",
-          },
-        },
-        "sourceType": "url",
-        "title": "Example 2",
-        "type": "source",
-        "url": "https://example.com/2",
-      },
-    ],
-    "text": "Hello!",
-    "toolCalls": [],
-    "toolResults": [],
     "usage": {
       "cachedInputTokens": undefined,
       "inputTokens": 3,

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -261,7 +261,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
       "sources": [],
-      "stepType": "initial",
       "text": "",
       "toolCalls": [
         {
@@ -358,7 +357,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
         "timestamp": 1970-01-01T00:00:01.000Z,
       },
       "sources": [],
-      "stepType": "tool-result",
       "text": "Hello, world!",
       "toolCalls": [],
       "toolResults": [],
@@ -467,7 +465,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "",
     "toolCalls": [
       {
@@ -564,7 +561,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > callbac
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
     "sources": [],
-    "stepType": "tool-result",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],
@@ -954,7 +950,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > value p
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "",
     "toolCalls": [
       {
@@ -1051,7 +1046,6 @@ exports[`streamText > options.maxSteps > 2 steps: initial, tool-result > value p
       "timestamp": 1970-01-01T00:00:01.000Z,
     },
     "sources": [],
-    "stepType": "tool-result",
     "text": "Hello, world!",
     "toolCalls": [],
     "toolResults": [],
@@ -1305,7 +1299,6 @@ exports[`streamText > options.onFinish > should send correct information 1`] = `
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
       "sources": [],
-      "stepType": "initial",
       "text": "Hello, world!",
       "toolCalls": [
         {
@@ -1519,7 +1512,6 @@ exports[`streamText > options.onFinish > should send files 1`] = `
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
       "sources": [],
-      "stepType": "initial",
       "text": "Hello!",
       "toolCalls": [],
       "toolResults": [],
@@ -1711,7 +1703,6 @@ exports[`streamText > options.onFinish > should send sources 1`] = `
           "url": "https://example.com/2",
         },
       ],
-      "stepType": "initial",
       "text": "Hello!",
       "toolCalls": [],
       "toolResults": [],
@@ -1805,7 +1796,6 @@ exports[`streamText > options.output > object output > should call onFinish with
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
       "sources": [],
-      "stepType": "initial",
       "text": "{ "value": "Hello, world!" }",
       "toolCalls": [],
       "toolResults": [],
@@ -2001,7 +1991,6 @@ exports[`streamText > options.transform > with base transformation > options.onF
         "timestamp": 1970-01-01T00:00:00.000Z,
       },
       "sources": [],
-      "stepType": "initial",
       "text": "HELLO, WORLD!",
       "toolCalls": [
         {
@@ -2151,7 +2140,6 @@ exports[`streamText > options.transform > with base transformation > options.onS
     "timestamp": 1970-01-01T00:00:00.000Z,
   },
   "sources": [],
-  "stepType": "initial",
   "text": "HELLO, WORLD!",
   "toolCalls": [
     {
@@ -2256,7 +2244,6 @@ exports[`streamText > options.transform > with base transformation > result.step
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "HELLO, WORLD!",
     "toolCalls": [
       {
@@ -2407,7 +2394,6 @@ exports[`streamText > options.transform > with transformation that aborts stream
     "timestamp": 1970-01-01T00:00:00.000Z,
   },
   "sources": [],
-  "stepType": "initial",
   "text": "Hello, ",
   "toolCalls": [],
   "toolResults": [],
@@ -3528,7 +3514,6 @@ exports[`streamText > result.steps > should add the files from the model respons
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "Hello!",
     "toolCalls": [],
     "toolResults": [],
@@ -3660,7 +3645,6 @@ exports[`streamText > result.steps > should add the reasoning from the model res
       "timestamp": 1970-01-01T00:00:00.000Z,
     },
     "sources": [],
-    "stepType": "initial",
     "text": "Hi there!",
     "toolCalls": [],
     "toolResults": [],
@@ -3759,7 +3743,6 @@ exports[`streamText > result.steps > should add the sources from the model respo
         "url": "https://example.com/2",
       },
     ],
-    "stepType": "initial",
     "text": "Hello!",
     "toolCalls": [],
     "toolResults": [],

--- a/packages/ai/core/generate-text/as-content.ts
+++ b/packages/ai/core/generate-text/as-content.ts
@@ -1,6 +1,6 @@
 import { LanguageModelV2Content } from '@ai-sdk/provider';
 import { ContentPart } from './content-part';
-import { DefaultGeneratedFile, GeneratedFile } from './generated-file';
+import { DefaultGeneratedFile } from './generated-file';
 import { ToolCallArray } from './tool-call';
 import { ToolResultArray } from './tool-result';
 import { ToolSet } from './tool-set';
@@ -38,22 +38,4 @@ export function asContent<TOOLS extends ToolSet>({
     }),
     ...toolResults,
   ];
-}
-
-export function extractFiles(
-  content: Array<ContentPart<ToolSet>>,
-): Array<GeneratedFile> {
-  return content.filter(part => part.type === 'file').map(part => part.file);
-}
-
-export function extractReasoning(
-  content: Array<ContentPart<ToolSet>>,
-): Array<ContentPart<ToolSet> & { type: 'reasoning' }> {
-  return content.filter(part => part.type === 'reasoning');
-}
-
-export function extractSources(
-  content: Array<ContentPart<ToolSet>>,
-): Array<ContentPart<ToolSet> & { type: 'source' }> {
-  return content.filter(part => part.type === 'source');
 }

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -23,17 +23,17 @@ The content that was generated in the last step.
   readonly content: Array<ContentPart<TOOLS>>;
 
   /**
-The generated text. If you are using continue steps, this can include text from all steps.
+The text that was generated in the last step.
      */
   readonly text: string;
 
   /**
-The full reasoning that the model has generated.
+The full reasoning that the model has generated in the last step.
    */
   readonly reasoning: Array<ReasoningPart>;
 
   /**
-The reasoning text that the model has generated. Can be undefined if the model
+The reasoning text that the model has generated in the last step. Can be undefined if the model
 has only generated text.
    */
   readonly reasoningText: string | undefined;
@@ -45,33 +45,32 @@ Empty array if no files were generated.
   readonly files: Array<GeneratedFile>;
 
   /**
-Sources that have been used as input to generate the response.
-For multi-step generation, the sources are accumulated from all steps.
+Sources that have been used as references in the last step.
    */
   readonly sources: Array<Source>;
 
   /**
-  The tool calls that were made during the generation.
+The tool calls that were made in the last step.
    */
   readonly toolCalls: ToolCallArray<TOOLS>;
 
   /**
-  The results of the tool calls.
+The results of the tool calls from the last step.
    */
   readonly toolResults: ToolResultArray<TOOLS>;
 
   /**
-  The reason why the generation finished.
+The reason why the generation finished.
    */
   readonly finishReason: FinishReason;
 
   /**
-  The token usage of the generated text.
+The overall token usage of all steps.
    */
   readonly usage: LanguageModelUsage;
 
   /**
-  Warnings from the model provider (e.g. unsupported settings)
+Warnings from the model provider (e.g. unsupported settings)
    */
   readonly warnings: CallWarning[] | undefined;
 

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -163,7 +163,7 @@ describe('result.content', () => {
         },
         {
           "file": DefaultGeneratedFile {
-            "base64Data": undefined,
+            "base64Data": "AQID",
             "mediaType": "image/png",
             "uint8ArrayData": Uint8Array [
               1,

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -496,7 +496,6 @@ A function that attempts to repair a tool call that failed to parse.
 
         // Add step information (after response messages are updated):
         const currentStepResult: StepResult<TOOLS> = {
-          stepType,
           content: stepContent,
           text: stepText,
           reasoningText: asReasoningText(extractReasoning(stepContent)),

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -662,60 +662,60 @@ class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
     this.resolvedOutput = options.resolvedOutput;
   }
 
-  private get currentStep() {
+  private get lastStep() {
     return this.steps[this.steps.length - 1];
   }
 
   get content() {
-    return this.currentStep.content;
+    return this.lastStep.content;
   }
 
   get text() {
-    return this.currentStep.text;
+    return this.lastStep.text;
   }
 
   get files() {
-    return this.currentStep.files;
+    return this.lastStep.files;
   }
 
   get reasoningText() {
-    return this.currentStep.reasoningText;
+    return this.lastStep.reasoningText;
   }
 
   get reasoning() {
-    return this.currentStep.reasoning;
+    return this.lastStep.reasoning;
   }
 
   get toolCalls() {
-    return this.currentStep.toolCalls;
+    return this.lastStep.toolCalls;
   }
 
   get toolResults() {
-    return this.currentStep.toolResults;
+    return this.lastStep.toolResults;
   }
 
   get sources() {
-    return this.currentStep.sources;
+    return this.lastStep.sources;
   }
 
   get finishReason() {
-    return this.currentStep.finishReason;
+    return this.lastStep.finishReason;
   }
 
   get warnings() {
-    return this.currentStep.warnings;
+    return this.lastStep.warnings;
   }
 
   get providerMetadata() {
-    return this.currentStep.providerMetadata;
+    return this.lastStep.providerMetadata;
   }
 
   get response() {
-    return this.currentStep.response;
+    return this.lastStep.response;
   }
 
   get request() {
-    return this.currentStep.request;
+    return this.lastStep.request;
   }
 
   get usage() {

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -23,17 +23,11 @@ import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attribu
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { LanguageModel, ProviderOptions, ToolChoice } from '../types';
 import { addLanguageModelUsage, LanguageModelUsage } from '../types/usage';
-import {
-  asContent,
-  extractFiles,
-  extractReasoning,
-  extractSources,
-} from './as-content';
+import { asContent } from './as-content';
 import { extractContentText } from './extract-content-text';
 import { GenerateTextResult } from './generate-text-result';
 import { Output } from './output';
 import { parseToolCall } from './parse-tool-call';
-import { asReasoningText } from './reasoning';
 import { ResponseMessage } from './response-message';
 import { DefaultStepResult, StepResult } from './step-result';
 import { toResponseMessages } from './to-response-messages';

--- a/packages/ai/core/generate-text/step-result.ts
+++ b/packages/ai/core/generate-text/step-result.ts
@@ -102,11 +102,4 @@ from the provider to the AI SDK and enable provider-specific
 results that can be fully encapsulated in the provider.
    */
   readonly providerMetadata: ProviderMetadata | undefined;
-
-  /**
-The type of step that this result is for. The first step is always
-an "initial" step, and subsequent steps are either "continue" steps
-or "tool-result" steps.
-   */
-  readonly stepType: 'initial' | 'tool-result';
 };

--- a/packages/ai/core/generate-text/step-result.ts
+++ b/packages/ai/core/generate-text/step-result.ts
@@ -103,3 +103,76 @@ results that can be fully encapsulated in the provider.
    */
   readonly providerMetadata: ProviderMetadata | undefined;
 };
+
+export class DefaultStepResult<TOOLS extends ToolSet>
+  implements StepResult<TOOLS>
+{
+  readonly content: StepResult<TOOLS>['content'];
+  readonly finishReason: StepResult<TOOLS>['finishReason'];
+  readonly usage: StepResult<TOOLS>['usage'];
+  readonly warnings: StepResult<TOOLS>['warnings'];
+  readonly request: StepResult<TOOLS>['request'];
+  readonly response: StepResult<TOOLS>['response'];
+  readonly providerMetadata: StepResult<TOOLS>['providerMetadata'];
+
+  constructor({
+    content,
+    finishReason,
+    usage,
+    warnings,
+    request,
+    response,
+    providerMetadata,
+  }: {
+    content: StepResult<TOOLS>['content'];
+    finishReason: StepResult<TOOLS>['finishReason'];
+    usage: StepResult<TOOLS>['usage'];
+    warnings: StepResult<TOOLS>['warnings'];
+    request: StepResult<TOOLS>['request'];
+    response: StepResult<TOOLS>['response'];
+    providerMetadata: StepResult<TOOLS>['providerMetadata'];
+  }) {
+    this.content = content;
+    this.finishReason = finishReason;
+    this.usage = usage;
+    this.warnings = warnings;
+    this.request = request;
+    this.response = response;
+    this.providerMetadata = providerMetadata;
+  }
+
+  get text() {
+    return this.content
+      .filter(part => part.type === 'text')
+      .map(part => part.text)
+      .join('');
+  }
+
+  get reasoning() {
+    return this.content.filter(part => part.type === 'reasoning');
+  }
+
+  get reasoningText() {
+    return this.reasoning.length === 0
+      ? undefined
+      : this.reasoning.map(part => part.text).join('');
+  }
+
+  get files() {
+    return this.content
+      .filter(part => part.type === 'file')
+      .map(part => part.file);
+  }
+
+  get sources() {
+    return this.content.filter(part => part.type === 'source');
+  }
+
+  get toolCalls() {
+    return this.content.filter(part => part.type === 'tool-call');
+  }
+
+  get toolResults() {
+    return this.content.filter(part => part.type === 'tool-result');
+  }
+}

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -112,8 +112,7 @@ Resolved when the response is finished.
   readonly files: Promise<GeneratedFile[]>;
 
   /**
-Sources that have been used as input to generate the response.
-For multi-step generation, the sources are accumulated from all steps.
+Sources that have been used as references in the last step.
 
 Resolved when the response is finished.
    */

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -699,7 +699,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
 
           // Add step information (after response messages are updated):
           const currentStepResult: StepResult<TOOLS> = {
-            stepType,
             content: recordedContent,
             text: recordedStepText,
             reasoningText: asReasoningText(extractReasoning(recordedContent)),

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -447,50 +447,14 @@ function createOutputTransformStream<
 class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
   implements StreamTextResult<TOOLS, PARTIAL_OUTPUT>
 {
-  private readonly warningsPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['warnings']>
-  >();
   private readonly usagePromise = new DelayedPromise<
     Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['usage']>
   >();
   private readonly finishReasonPromise = new DelayedPromise<
     Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['finishReason']>
   >();
-  private readonly providerMetadataPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['providerMetadata']>
-  >();
-  private readonly textPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['text']>
-  >();
-  private readonly reasoningPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['reasoningText']>
-  >();
-  private readonly reasoningDetailsPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['reasoning']>
-  >();
-  private readonly sourcesPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['sources']>
-  >();
-  private readonly filesPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['files']>
-  >();
-  private readonly toolCallsPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['toolCalls']>
-  >();
-  private readonly toolResultsPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['toolResults']>
-  >();
-  private readonly requestPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['request']>
-  >();
-  private readonly responsePromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['response']>
-  >();
   private readonly stepsPromise = new DelayedPromise<
     Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['steps']>
-  >();
-  private readonly contentPromise = new DelayedPromise<
-    Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['content']>
   >();
 
   private readonly addStream: (
@@ -709,22 +673,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
             return; // no steps recorded (e.g. in error scenario)
           }
 
-          // from last step (when there are errors there may be no last step)
-          const lastStep = recordedSteps[recordedSteps.length - 1];
-
-          self.contentPromise.resolve(lastStep.content);
-          self.warningsPromise.resolve(lastStep.warnings);
-          self.requestPromise.resolve(lastStep.request);
-          self.responsePromise.resolve(lastStep.response);
-          self.toolCallsPromise.resolve(lastStep.toolCalls);
-          self.toolResultsPromise.resolve(lastStep.toolResults);
-          self.providerMetadataPromise.resolve(lastStep.providerMetadata);
-          self.reasoningPromise.resolve(lastStep.reasoningText);
-          self.reasoningDetailsPromise.resolve(lastStep.reasoning);
-          self.textPromise.resolve(lastStep.text);
-          self.sourcesPromise.resolve(lastStep.sources);
-          self.filesPromise.resolve(lastStep.files);
-
           // derived:
           const finishReason = recordedFinishReason ?? 'unknown';
           const usage = recordedUsage ?? {
@@ -741,6 +689,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
           self.stepsPromise.resolve(recordedSteps);
 
           // call onFinish callback:
+          const lastStep = recordedSteps[recordedSteps.length - 1];
           await onFinish?.({
             finishReason,
             usage,
@@ -1277,12 +1226,60 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
     });
   }
 
+  get steps() {
+    return this.stepsPromise.value;
+  }
+
+  private get lastStep() {
+    return this.steps.then(steps => steps[steps.length - 1]);
+  }
+
   get content() {
-    return this.contentPromise.value;
+    return this.lastStep.then(step => step.content);
   }
 
   get warnings() {
-    return this.warningsPromise.value;
+    return this.lastStep.then(step => step.warnings);
+  }
+
+  get providerMetadata() {
+    return this.lastStep.then(step => step.providerMetadata);
+  }
+
+  get text() {
+    return this.lastStep.then(step => step.text);
+  }
+
+  get reasoningText() {
+    return this.lastStep.then(step => step.reasoningText);
+  }
+
+  get reasoning() {
+    return this.lastStep.then(step => step.reasoning);
+  }
+
+  get sources() {
+    return this.lastStep.then(step => step.sources);
+  }
+
+  get files() {
+    return this.lastStep.then(step => step.files);
+  }
+
+  get toolCalls() {
+    return this.lastStep.then(step => step.toolCalls);
+  }
+
+  get toolResults() {
+    return this.lastStep.then(step => step.toolResults);
+  }
+
+  get request() {
+    return this.lastStep.then(step => step.request);
+  }
+
+  get response() {
+    return this.lastStep.then(step => step.response);
   }
 
   get usage() {
@@ -1291,50 +1288,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
 
   get finishReason() {
     return this.finishReasonPromise.value;
-  }
-
-  get providerMetadata() {
-    return this.providerMetadataPromise.value;
-  }
-
-  get text() {
-    return this.textPromise.value;
-  }
-
-  get reasoningText() {
-    return this.reasoningPromise.value;
-  }
-
-  get reasoning() {
-    return this.reasoningDetailsPromise.value;
-  }
-
-  get sources() {
-    return this.sourcesPromise.value;
-  }
-
-  get files() {
-    return this.filesPromise.value;
-  }
-
-  get toolCalls() {
-    return this.toolCallsPromise.value;
-  }
-
-  get toolResults() {
-    return this.toolResultsPromise.value;
-  }
-
-  get request() {
-    return this.requestPromise.value;
-  }
-
-  get response() {
-    return this.responsePromise.value;
-  }
-
-  get steps() {
-    return this.stepsPromise.value;
   }
 
   /**

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -598,7 +598,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
     let recordedToolResults: ToolResultUnion<TOOLS>[] = [];
     let recordedFinishReason: FinishReason | undefined = undefined;
     let recordedUsage: LanguageModelUsage | undefined = undefined;
-    let stepType: 'initial' | 'tool-result' = 'initial';
     const recordedSteps: StepResult<TOOLS>[] = [];
     let rootSpan!: Span;
 
@@ -719,16 +718,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
           recordedToolResults = [];
           recordedStepText = '';
           activeReasoningPart = undefined;
-
-          if (
-            currentStep + 1 < maxSteps &&
-            // there are tool calls:
-            recordedToolCalls.length > 0 &&
-            // all current tool calls have results:
-            recordedToolResults.length === recordedToolCalls.length
-          ) {
-            stepType = 'tool-result';
-          }
 
           recordedResponse.messages.push(...stepMessages);
         }

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1,7 +1,4 @@
-import {
-  LanguageModelV2CallWarning,
-  LanguageModelV2Source,
-} from '@ai-sdk/provider';
+import { LanguageModelV2CallWarning } from '@ai-sdk/provider';
 import { createIdGenerator, IdGenerator } from '@ai-sdk/provider-utils';
 import { Span } from '@opentelemetry/api';
 import { ServerResponse } from 'node:http';
@@ -42,10 +39,8 @@ import {
 import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
 import { ProviderMetadata, ProviderOptions } from '../types/provider-metadata';
 import { addLanguageModelUsage, LanguageModelUsage } from '../types/usage';
-import { extractFiles, extractReasoning, extractSources } from './as-content';
 import { ContentPart } from './content-part';
 import { Output } from './output';
-import { asReasoningText } from './reasoning';
 import { ResponseMessage } from './response-message';
 import {
   runToolsTransformation,


### PR DESCRIPTION
## Background

The return interfaces of stream text, generate text, and step result are somewhat inconsistent.

## Summary

* `GenerateTextResult` tool calls, sources, files, etc are all from the last step
* remove `StepResult.stepType`
* introduce DefaultStepResult and increase code reuse