### PR TITLE
feat(providers/google): Add reasoning token output support

### DIFF
--- a/.changeset/twelve-baboons-sing.md
+++ b/.changeset/twelve-baboons-sing.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Add reasoning token output support for gemini models

--- a/.changeset/twelve-baboons-sing.md
+++ b/.changeset/twelve-baboons-sing.md
@@ -1,5 +1,5 @@
 ---
-'@ai-sdk/google': patch
+'@ai-sdk/google-vertex': patch
 ---
 
-Add reasoning token output support for gemini models
+Add reasoning token output support for gemini models via Vertex AI Provider

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -186,6 +186,11 @@ The following provider options are available:
     disables thinking. Budgets from 1 to 1024 tokens will be set to 1024.
     For more information see [Google Generative AI documentation](https://ai.google.dev/gemini-api/docs/thinking).
 
+  - **includeThoughts** _boolean_
+
+    Optional. When set to `true`, the model will include its "thought" process (reasoning steps) in the response. These are exposed as `reasoning` stream parts or
+    in the `reasoning` and `reasoningDetails` fields of the `generateText` result. Defaults to `false`
+
 You can use Google Generative AI language models to generate text with the `generateText` function:
 
 ```ts
@@ -237,6 +242,69 @@ const result = await generateText({
 </Note>
 
 See [File Parts](/docs/foundations/prompts#file-parts) for details on how to use files in prompts.
+
+### Reasoning (Thinking Tokens)
+
+Certain Google Gemini models support emitting "thinking" tokens, which represent the model's reasoning process before generating the final response. The AI SDK exposes these as reasoning information.
+
+To enable thinking tokens, set `includeThoughts: true` in the `thinkingConfig` provider option:
+
+```ts
+import { google } from '@ai-sdk/google';
+import { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google';
+import { generateText, streamText } from 'ai';
+
+// For generateText:
+const { text, reasoning, reasoningDetails } = await generateText({
+  model: google('gemini-2.5-flash-preview-04-17'), // Or other supported model
+  providerOptions: {
+    google: {
+      thinkingConfig: {
+        includeThoughts: true,
+        // thinkingBudget: 2048, // Optional
+      },
+    } satisfies GoogleGenerativeAIProviderOptions,
+  },
+  prompt: 'Explain quantum computing in simple terms.',
+});
+
+console.log('Reasoning:', reasoning);
+console.log('Reasoning Details:', reasoningDetails);
+console.log('Final Text:', text);
+
+// For streamText:
+const result = streamText({
+  model: google('gemini-2.5-flash-preview-04-17'), // Or other supported model
+  providerOptions: {
+    google: {
+      thinkingConfig: {
+        includeThoughts: true,
+        // thinkingBudget: 2048, // Optional
+      },
+    } satisfies GoogleGenerativeAIProviderOptions,
+  },
+  prompt: 'Explain quantum computing in simple terms.',
+});
+
+for await (const part of result.fullStream) {
+  if (part.type === 'reasoning') {
+    process.stdout.write(`THOUGHT: ${part.textDelta}\n`);
+  } else if (part.type === 'text-delta') {
+    process.stdout.write(part.textDelta);
+  }
+}
+```
+
+When `includeThoughts` is true, parts of the API response marked with `thought: true` will be processed as reasoning.
+
+- In `generateText`, these contribute to the `reasoning` (string) and `reasoningDetails` (array) fields.
+- In `streamText`, these are emitted as `reasoning` stream parts.
+
+<Note>
+  Refer to the [Google Generative AI
+  documentation](https://ai.google.dev/gemini-api/docs/thinking) for a list of
+  models that support thinking tokens and for more details on `thinkingBudget`.
+</Note>
 
 ### Cached Content
 

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -186,11 +186,6 @@ The following provider options are available:
     disables thinking. Budgets from 1 to 1024 tokens will be set to 1024.
     For more information see [Google Generative AI documentation](https://ai.google.dev/gemini-api/docs/thinking).
 
-  - **includeThoughts** _boolean_
-
-    Optional. When set to `true`, the model will include its "thought" process (reasoning steps) in the response. These are exposed as `reasoning` stream parts or
-    in the `reasoning` and `reasoningDetails` fields of the `generateText` result. Defaults to `false`
-
 You can use Google Generative AI language models to generate text with the `generateText` function:
 
 ```ts
@@ -242,69 +237,6 @@ const result = await generateText({
 </Note>
 
 See [File Parts](/docs/foundations/prompts#file-parts) for details on how to use files in prompts.
-
-### Reasoning (Thinking Tokens)
-
-Certain Google Gemini models support emitting "thinking" tokens, which represent the model's reasoning process before generating the final response. The AI SDK exposes these as reasoning information.
-
-To enable thinking tokens, set `includeThoughts: true` in the `thinkingConfig` provider option:
-
-```ts
-import { google } from '@ai-sdk/google';
-import { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google';
-import { generateText, streamText } from 'ai';
-
-// For generateText:
-const { text, reasoning, reasoningDetails } = await generateText({
-  model: google('gemini-2.5-flash-preview-04-17'), // Or other supported model
-  providerOptions: {
-    google: {
-      thinkingConfig: {
-        includeThoughts: true,
-        // thinkingBudget: 2048, // Optional
-      },
-    } satisfies GoogleGenerativeAIProviderOptions,
-  },
-  prompt: 'Explain quantum computing in simple terms.',
-});
-
-console.log('Reasoning:', reasoning);
-console.log('Reasoning Details:', reasoningDetails);
-console.log('Final Text:', text);
-
-// For streamText:
-const result = streamText({
-  model: google('gemini-2.5-flash-preview-04-17'), // Or other supported model
-  providerOptions: {
-    google: {
-      thinkingConfig: {
-        includeThoughts: true,
-        // thinkingBudget: 2048, // Optional
-      },
-    } satisfies GoogleGenerativeAIProviderOptions,
-  },
-  prompt: 'Explain quantum computing in simple terms.',
-});
-
-for await (const part of result.fullStream) {
-  if (part.type === 'reasoning') {
-    process.stdout.write(`THOUGHT: ${part.textDelta}\n`);
-  } else if (part.type === 'text-delta') {
-    process.stdout.write(part.textDelta);
-  }
-}
-```
-
-When `includeThoughts` is true, parts of the API response marked with `thought: true` will be processed as reasoning.
-
-- In `generateText`, these contribute to the `reasoning` (string) and `reasoningDetails` (array) fields.
-- In `streamText`, these are emitted as `reasoning` stream parts.
-
-<Note>
-  Refer to the [Google Generative AI
-  documentation](https://ai.google.dev/gemini-api/docs/thinking) for a list of
-  models that support thinking tokens and for more details on `thinkingBudget`.
-</Note>
 
 ### Cached Content
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -316,6 +316,71 @@ const { text } = await generateText({
 Google Vertex language models can also be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+#### Reasoning (Thinking Tokens)
+
+Google Vertex AI, through its support for Gemini models, can also emit "thinking" tokens, representing the model's reasoning process. The AI SDK exposes these as reasoning information.
+
+To enable thinking tokens for compatible Gemini models via Vertex, set `includeThoughts: true` in the `thinkingConfig` provider option. Since the Vertex provider uses the Google provider's underlying language model, these options are passed through `providerOptions.google`:
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google'; // Note: importing from @ai-sdk/google
+import { generateText, streamText } from 'ai';
+
+// For generateText:
+const { text, reasoning, reasoningDetails } = await generateText({
+  model: vertex('gemini-2.5-flash-preview-04-17'), // Or other supported model via Vertex
+  providerOptions: {
+    google: {
+      // Options are nested under 'google' for Vertex provider
+      thinkingConfig: {
+        includeThoughts: true,
+        // thinkingBudget: 2048, // Optional
+      },
+    } satisfies GoogleGenerativeAIProviderOptions,
+  },
+  prompt: 'Explain quantum computing in simple terms.',
+});
+
+console.log('Reasoning:', reasoning);
+console.log('Reasoning Details:', reasoningDetails);
+console.log('Final Text:', text);
+
+// For streamText:
+const result = streamText({
+  model: vertex('gemini-2.5-flash-preview-04-17'), // Or other supported model via Vertex
+  providerOptions: {
+    google: {
+      // Options are nested under 'google' for Vertex provider
+      thinkingConfig: {
+        includeThoughts: true,
+        // thinkingBudget: 2048, // Optional
+      },
+    } satisfies GoogleGenerativeAIProviderOptions,
+  },
+  prompt: 'Explain quantum computing in simple terms.',
+});
+
+for await (const part of result.fullStream) {
+  if (part.type === 'reasoning') {
+    process.stdout.write(`THOUGHT: ${part.textDelta}\n`);
+  } else if (part.type === 'text-delta') {
+    process.stdout.write(part.textDelta);
+  }
+}
+```
+
+When `includeThoughts` is true, parts of the API response marked with `thought: true` will be processed as reasoning.
+
+- In `generateText`, these contribute to the `reasoning` (string) and `reasoningDetails` (array) fields.
+- In `streamText`, these are emitted as `reasoning` stream parts.
+
+<Note>
+  Refer to the [Google Vertex AI documentation on
+  "thinking"](https://cloud.google.com/vertex-ai/generative-ai/docs/thinking)
+  for model compatibility and further details.
+</Note>
+
 #### File Inputs
 
 The Google Vertex provider supports file inputs, e.g. PDF files.

--- a/examples/ai-core/src/generate-text/google-vertex-reasoning-generate-text.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-reasoning-generate-text.ts
@@ -1,0 +1,29 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText } from 'ai';
+
+async function main() {
+  const result = await generateText({
+    model: vertex('gemini-2.5-flash-preview-04-17'),
+    prompt:
+      "Describe the most unusual or striking architectural feature you've ever seen in a building or structure.",
+    providerOptions: {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: 2048,
+          includeThoughts: true,
+        },
+      },
+    },
+  });
+
+  process.stdout.write('\x1b[34m' + result.reasoning + '\x1b[0m');
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+
+  console.log();
+  console.log('Warnings:', result.warnings);
+}
+
+main().catch(console.log);

--- a/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
@@ -4,12 +4,13 @@ import { streamText } from 'ai';
 async function main() {
   const result = streamText({
     model: vertex('gemini-2.5-flash-preview-04-17'),
-    prompt: 'Describe the most unusual or striking architectural feature you\'ve ever seen in a building or structure.',
+    prompt:
+      "Describe the most unusual or striking architectural feature you've ever seen in a building or structure.",
     providerOptions: {
       google: {
         thinkingConfig: {
           thinkingBudget: 2048,
-          includeThoughts: true
+          includeThoughts: true,
         },
       },
     },

--- a/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
@@ -1,0 +1,34 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { streamText } from 'ai';
+
+async function main() {
+  const result = streamText({
+    model: vertex('gemini-2.5-flash-preview-04-17'),
+    prompt: 'Describe the most unusual or striking architectural feature you\'ve ever seen in a building or structure.',
+    providerOptions: {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: 2048,
+          includeThoughts: true
+        },
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'reasoning') {
+      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.textDelta);
+    }
+  }
+
+  console.log();
+  console.log('Warnings:', await result.warnings);
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.log);

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -244,7 +244,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
         : candidate.content.parts;
 
     const toolCalls = getToolCallsFromParts({
-      parts,
+      parts: parts, // Use candidateParts
       generateId: this.config.generateId,
     });
 
@@ -252,6 +252,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
 
     return {
       text: getTextFromParts(parts),
+      reasoning: getReasoningDetailsFromParts(parts),
       files: getInlineDataParts(parts)?.map(part => ({
         data: part.inlineData.data,
         mimeType: part.inlineData.mimeType,
@@ -358,6 +359,18 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
                   type: 'text-delta',
                   textDelta: deltaText,
                 });
+              }
+
+              const reasoningDeltaText = getReasoningDetailsFromParts(
+                content.parts,
+              );
+              if (reasoningDeltaText != null) {
+                for (const part of reasoningDeltaText) {
+                  controller.enqueue({
+                    type: 'reasoning',
+                    textDelta: part.text,
+                  });
+                }
               }
 
               const inlineDataParts = getInlineDataParts(content.parts);
@@ -468,13 +481,27 @@ function getToolCallsFromParts({
 }
 
 function getTextFromParts(parts: z.infer<typeof contentSchema>['parts']) {
-  const textParts = parts?.filter(part => 'text' in part) as Array<
-    GoogleGenerativeAIContentPart & { text: string }
-  >;
+  const textParts = parts?.filter(
+    part => 'text' in part && (part as any).thought !== true, // Exclude thought parts
+  ) as Array<GoogleGenerativeAIContentPart & { text: string }>;
 
   return textParts == null || textParts.length === 0
     ? undefined
     : textParts.map(part => part.text).join('');
+}
+
+function getReasoningDetailsFromParts(
+  parts: z.infer<typeof contentSchema>['parts'],
+): Array<{ type: 'text'; text: string }> | undefined {
+  const reasoningParts = parts?.filter(
+    part => 'text' in part && (part as any).thought === true,
+  ) as Array<
+    GoogleGenerativeAIContentPart & { text: string; thought?: boolean }
+  >;
+
+  return reasoningParts == null || reasoningParts.length === 0
+    ? undefined
+    : reasoningParts.map(part => ({ type: 'text', text: part.text }));
 }
 
 function getInlineDataParts(parts: z.infer<typeof contentSchema>['parts']) {
@@ -517,6 +544,7 @@ const contentSchema = z.object({
       z.union([
         z.object({
           text: z.string(),
+          thought: z.boolean().nullish(),
         }),
         z.object({
           functionCall: z.object({
@@ -628,6 +656,7 @@ const googleGenerativeAIProviderOptionsSchema = z.object({
   thinkingConfig: z
     .object({
       thinkingBudget: z.number().nullish(),
+      includeThoughts: z.boolean().nullish(),
     })
     .nullish(),
 });

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -91,6 +91,20 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV1 {
       schema: googleGenerativeAIProviderOptionsSchema,
     });
 
+    // Add warning if includeThoughts is used with a non-Vertex Google provider
+    if (
+      googleOptions?.thinkingConfig?.includeThoughts === true &&
+      !this.config.provider.startsWith('google.vertex.')
+    ) {
+      warnings.push({
+        type: 'other',
+        message:
+          "The 'includeThoughts' option is only supported with the Google Vertex provider " +
+          'and might not be supported or could behave unexpectedly with the current Google provider ' +
+          `(${this.config.provider}).`,
+      });
+    }
+
     const generationConfig = {
       // standardized settings:
       maxOutputTokens: maxTokens,


### PR DESCRIPTION
## Background

[Vertex now supports extraction of thinking tokens in certain Gemini models](https://cloud.google.com/vertex-ai/generative-ai/docs/thinking).

When the configuration is passed via `providerOptions`, the sdk:
1. Did not extract reasoning tokens
2. Did not pass `include_thoughts` to the provider

## Summary

Added extraction logic to google-generative-ai package to parse reasoning tokens.

Added a `includeThoughts` switch to the `thinkingConfig` for vertex models.

## Verification

I verified it manually. Testable via examples/ai-core/src/stream-text/google-vertex-reasoning.ts. Easily copiable to google provider.

Tests have been added.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features) - c1264af
- [x] Examples have been updated
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues
Fixes #6259
