### PR TITLE
feat (ai): streamText/generateText: totalUsage contains usage for all steps. usage is for a single step

### DIFF
--- a/.changeset/red-frogs-cheer.md
+++ b/.changeset/red-frogs-cheer.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+feat (ai): streamText/generateText: totalUsage contains usage for all steps. usage is for a single step.

--- a/packages/ai/core/generate-text/generate-text-result.ts
+++ b/packages/ai/core/generate-text/generate-text-result.ts
@@ -65,9 +65,15 @@ The reason why the generation finished.
   readonly finishReason: FinishReason;
 
   /**
-The overall token usage of all steps.
+The token usage of the last step.
    */
   readonly usage: LanguageModelUsage;
+
+  /**
+The total token usage of all steps.
+When there are multiple steps, the usage is the sum of all step usages.
+   */
+  readonly totalUsage: LanguageModelUsage;
 
   /**
 Warnings from the model provider (e.g. unsupported settings)

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -768,14 +768,26 @@ describe('options.maxSteps', () => {
       expect(result.response.messages).toMatchSnapshot();
     });
 
-    it('result.usage should sum token usage', () => {
-      expect(result.usage).toMatchInlineSnapshot(`
+    it('result.totalUsage should sum token usage', () => {
+      expect(result.totalUsage).toMatchInlineSnapshot(`
         {
           "cachedInputTokens": undefined,
           "inputTokens": 13,
           "outputTokens": 15,
           "reasoningTokens": undefined,
           "totalTokens": 28,
+        }
+      `);
+    });
+
+    it('result.usage should contain token usage from final step', async () => {
+      expect(result.usage).toMatchInlineSnapshot(`
+        {
+          "cachedInputTokens": undefined,
+          "inputTokens": 3,
+          "outputTokens": 10,
+          "reasoningTokens": undefined,
+          "totalTokens": 13,
         }
       `);
     });
@@ -977,14 +989,26 @@ describe('options.maxSteps', () => {
       expect(result.response.messages).toMatchSnapshot();
     });
 
-    it('result.usage should sum token usage', () => {
-      expect(result.usage).toMatchInlineSnapshot(`
+    it('result.totalUsage should sum token usage', () => {
+      expect(result.totalUsage).toMatchInlineSnapshot(`
         {
           "cachedInputTokens": undefined,
           "inputTokens": 13,
           "outputTokens": 15,
           "reasoningTokens": undefined,
           "totalTokens": 28,
+        }
+      `);
+    });
+
+    it('result.usage should contain token usage from final step', async () => {
+      expect(result.usage).toMatchInlineSnapshot(`
+        {
+          "cachedInputTokens": undefined,
+          "inputTokens": 3,
+          "outputTokens": 10,
+          "reasoningTokens": undefined,
+          "totalTokens": 13,
         }
       `);
     });

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -646,63 +646,67 @@ class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
     this.resolvedOutput = options.resolvedOutput;
   }
 
-  private get lastStep() {
+  private get finalStep() {
     return this.steps[this.steps.length - 1];
   }
 
   get content() {
-    return this.lastStep.content;
+    return this.finalStep.content;
   }
 
   get text() {
-    return this.lastStep.text;
+    return this.finalStep.text;
   }
 
   get files() {
-    return this.lastStep.files;
+    return this.finalStep.files;
   }
 
   get reasoningText() {
-    return this.lastStep.reasoningText;
+    return this.finalStep.reasoningText;
   }
 
   get reasoning() {
-    return this.lastStep.reasoning;
+    return this.finalStep.reasoning;
   }
 
   get toolCalls() {
-    return this.lastStep.toolCalls;
+    return this.finalStep.toolCalls;
   }
 
   get toolResults() {
-    return this.lastStep.toolResults;
+    return this.finalStep.toolResults;
   }
 
   get sources() {
-    return this.lastStep.sources;
+    return this.finalStep.sources;
   }
 
   get finishReason() {
-    return this.lastStep.finishReason;
+    return this.finalStep.finishReason;
   }
 
   get warnings() {
-    return this.lastStep.warnings;
+    return this.finalStep.warnings;
   }
 
   get providerMetadata() {
-    return this.lastStep.providerMetadata;
+    return this.finalStep.providerMetadata;
   }
 
   get response() {
-    return this.lastStep.response;
+    return this.finalStep.response;
   }
 
   get request() {
-    return this.lastStep.request;
+    return this.finalStep.request;
   }
 
   get usage() {
+    return this.finalStep.usage;
+  }
+
+  get totalUsage() {
     return this.steps.reduce(
       (totalUsage, step) => {
         return addLanguageModelUsage(totalUsage, step.usage);

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -140,12 +140,19 @@ Resolved when the response is finished.
   readonly finishReason: Promise<FinishReason>;
 
   /**
+The token usage of the last step.
+
+Resolved when the response is finished.
+   */
+  readonly usage: Promise<LanguageModelUsage>;
+
+  /**
 The total token usage of the generated response.
 When there are multiple steps, the usage is the sum of all step usages.
 
 Resolved when the response is finished.
      */
-  readonly usage: Promise<LanguageModelUsage>;
+  readonly totalUsage: Promise<LanguageModelUsage>;
 
   /**
 Warnings from the model provider (e.g. unsupported settings) for the first step.

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -2636,8 +2636,8 @@ describe('streamText', () => {
           await result.consumeStream();
         });
 
-        it('result.usage should contain total token usage', async () => {
-          expect(await result.usage).toMatchInlineSnapshot(`
+        it('result.totalUsage should contain total token usage', async () => {
+          expect(await result.totalUsage).toMatchInlineSnapshot(`
             {
               "cachedInputTokens": 3,
               "inputTokens": 6,
@@ -2646,6 +2646,18 @@ describe('streamText', () => {
               "totalTokens": 36,
             }
           `);
+        });
+
+        it('result.usage should contain token usage from final step', async () => {
+          expect(await result.totalUsage).toMatchInlineSnapshot(`
+          {
+            "cachedInputTokens": 3,
+            "inputTokens": 6,
+            "outputTokens": 20,
+            "reasoningTokens": 10,
+            "totalTokens": 36,
+          }
+        `);
         });
 
         it('result.finishReason should contain finish reason from final step', async () => {
@@ -3252,7 +3264,7 @@ describe('streamText', () => {
         });
       });
 
-      it('result.usage should be transformed', async () => {
+      it('result.totalUsage should be transformed', async () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
@@ -3284,7 +3296,7 @@ describe('streamText', () => {
 
         await result.consumeStream();
 
-        expect(await result.usage).toStrictEqual({
+        expect(await result.totalUsage).toStrictEqual({
           inputTokens: 200,
           outputTokens: 300,
           totalTokens: undefined,

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -447,7 +447,7 @@ function createOutputTransformStream<
 class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
   implements StreamTextResult<TOOLS, PARTIAL_OUTPUT>
 {
-  private readonly usagePromise = new DelayedPromise<
+  private readonly totalUsagePromise = new DelayedPromise<
     Awaited<StreamTextResult<TOOLS, PARTIAL_OUTPUT>['usage']>
   >();
   private readonly finishReasonPromise = new DelayedPromise<
@@ -683,7 +683,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
 
           // from finish:
           self.finishReasonPromise.resolve(finishReason);
-          self.usagePromise.resolve(usage);
+          self.totalUsagePromise.resolve(usage);
 
           // aggregate results:
           self.stepsPromise.resolve(recordedSteps);
@@ -1230,60 +1230,64 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
     return this.stepsPromise.value;
   }
 
-  private get lastStep() {
+  private get finalStep() {
     return this.steps.then(steps => steps[steps.length - 1]);
   }
 
   get content() {
-    return this.lastStep.then(step => step.content);
+    return this.finalStep.then(step => step.content);
   }
 
   get warnings() {
-    return this.lastStep.then(step => step.warnings);
+    return this.finalStep.then(step => step.warnings);
   }
 
   get providerMetadata() {
-    return this.lastStep.then(step => step.providerMetadata);
+    return this.finalStep.then(step => step.providerMetadata);
   }
 
   get text() {
-    return this.lastStep.then(step => step.text);
+    return this.finalStep.then(step => step.text);
   }
 
   get reasoningText() {
-    return this.lastStep.then(step => step.reasoningText);
+    return this.finalStep.then(step => step.reasoningText);
   }
 
   get reasoning() {
-    return this.lastStep.then(step => step.reasoning);
+    return this.finalStep.then(step => step.reasoning);
   }
 
   get sources() {
-    return this.lastStep.then(step => step.sources);
+    return this.finalStep.then(step => step.sources);
   }
 
   get files() {
-    return this.lastStep.then(step => step.files);
+    return this.finalStep.then(step => step.files);
   }
 
   get toolCalls() {
-    return this.lastStep.then(step => step.toolCalls);
+    return this.finalStep.then(step => step.toolCalls);
   }
 
   get toolResults() {
-    return this.lastStep.then(step => step.toolResults);
-  }
-
-  get request() {
-    return this.lastStep.then(step => step.request);
-  }
-
-  get response() {
-    return this.lastStep.then(step => step.response);
+    return this.finalStep.then(step => step.toolResults);
   }
 
   get usage() {
-    return this.usagePromise.value;
+    return this.finalStep.then(step => step.usage);
+  }
+
+  get request() {
+    return this.finalStep.then(step => step.request);
+  }
+
+  get response() {
+    return this.finalStep.then(step => step.response);
+  }
+
+  get totalUsage() {
+    return this.totalUsagePromise.value;
   }
 
   get finishReason() {


### PR DESCRIPTION
## Background

Usage was different compared to other properties on generateText / streamText.

## Summary

Introduce `totalUsage` and align `usage` with other properties (value from last step).