### PR TITLE
chore (ai): remove deprecated useChat isLoading helper

### DIFF
--- a/.changeset/twelve-waves-stare.md
+++ b/.changeset/twelve-waves-stare.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): remove deprecated useChat isLoading helper

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -88,13 +88,6 @@ export type UseChatHelpers<MESSAGE_METADATA = unknown> = {
   metadata?: Object;
 
   /**
-   * Whether the API request is in progress
-   *
-   * @deprecated use `status` instead
-   */
-  isLoading: boolean;
-
-  /**
    * Hook status:
    *
    * - `submitted`: The message has been sent to the API and we're awaiting the start of the response stream.
@@ -509,7 +502,6 @@ Default is undefined, which disables throttling.
     setInput,
     handleInputChange,
     handleSubmit,
-    isLoading: status === 'submitted' || status === 'streaming',
     status,
     addToolResult,
   };

--- a/packages/vue/src/use-chat.ts
+++ b/packages/vue/src/use-chat.ts
@@ -70,13 +70,6 @@ export type UseChatHelpers<MESSAGE_METADATA> = {
   ) => void;
 
   /**
-   * Whether the API request is in progress
-   *
-   * @deprecated use `status` instead
-   */
-  isLoading: Ref<boolean>;
-
-  /**
    * Hook status:
    *
    * - `submitted`: The message has been sent to the API and we're awaiting the start of the response stream.
@@ -402,9 +395,6 @@ export function useChat<MESSAGE_METADATA = unknown>(
     setMessages,
     input,
     handleSubmit,
-    isLoading: computed(
-      () => status.value === 'submitted' || status.value === 'streaming',
-    ),
     status: status as Ref<'submitted' | 'streaming' | 'ready' | 'error'>,
     addToolResult,
   };


### PR DESCRIPTION
## Background

`isLoading` in `useChat` has been replaced by `state`, which allows for more fine-grained ui state management.

## Summary

Remove deprecated `isLoading` helper from `useChat`.