### PR TITLE
feat (ai): add ui data parts

### DIFF
--- a/.changeset/slow-laws-end.md
+++ b/.changeset/slow-laws-end.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+feat (ai): add ui data parts

--- a/examples/next-openai/app/api/use-chat-custom-sources/route.ts
+++ b/examples/next-openai/app/api/use-chat-custom-sources/route.ts
@@ -15,7 +15,6 @@ export async function POST(req: Request) {
       writer.write({
         type: 'source',
         value: {
-          type: 'source',
           sourceType: 'url',
           id: 'source-1',
           url: 'https://example.com',

--- a/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
+++ b/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
@@ -1,0 +1,34 @@
+import { openai } from '@ai-sdk/openai';
+import {
+  convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  streamText,
+} from 'ai';
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const stream = createUIMessageStream({
+    execute: writer => {
+      // TODO: message start is a problem;
+      writer.write({
+        type: 'data-hello-world',
+        value: {
+          data: {
+            name: 'World',
+          },
+        },
+      });
+
+      const result = streamText({
+        model: openai('gpt-4o'),
+        messages: convertToModelMessages(messages),
+      });
+
+      writer.merge(result.toUIMessageStream());
+    },
+  });
+
+  return createUIMessageStreamResponse({ stream });
+}

--- a/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
+++ b/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
         model: openai('gpt-4o'),
         maxSteps: 2,
         tools: {
-          'weather-tool': {
+          weather: {
             description: 'Get the weather in a city',
             parameters: z.object({
               city: z.string(),

--- a/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
+++ b/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
@@ -26,10 +26,8 @@ export async function POST(req: Request) {
               // update display
               writer.write({
                 type: 'data-weather',
-                value: {
-                  id: toolCallId,
-                  data: { city, status: 'loading' },
-                },
+                id: toolCallId,
+                data: { city, status: 'loading' },
               });
 
               await delay(2000); // fake delay
@@ -38,10 +36,8 @@ export async function POST(req: Request) {
               // update display
               writer.write({
                 type: 'data-weather',
-                value: {
-                  id: toolCallId,
-                  data: { city, weather, status: 'success' },
-                },
+                id: toolCallId,
+                data: { city, weather, status: 'success' },
               });
 
               // for LLM roundtrip

--- a/examples/next-openai/app/page.tsx
+++ b/examples/next-openai/app/page.tsx
@@ -12,16 +12,48 @@ export default function Chat() {
     messages,
     reload,
     stop,
-  } = useChat();
+  } = useChat<
+    { metadataKey: string },
+    {
+      weather: {
+        city: string;
+        temperature: number;
+      };
+      activity: {
+        type: string;
+        description: string;
+      };
+    }
+  >();
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {messages.map(m => (
         <div key={m.id} className="whitespace-pre-wrap">
           {m.role === 'user' ? 'User: ' : 'AI: '}
-          {m.parts
-            .map(part => (part.type === 'text' ? part.text : ''))
-            .join('')}
+          {m.parts.map(part => {
+            switch (part.type) {
+              case 'text': {
+                return part.text;
+              }
+              case 'data-weather': {
+                return (
+                  <div>
+                    <div>{part.value.city}</div>
+                    <div>{part.value.temperature}</div>
+                  </div>
+                );
+              }
+              case 'data-activity': {
+                return (
+                  <div>
+                    <div>{part.value.type}</div>
+                    <div>{part.value.description}</div>
+                  </div>
+                );
+              }
+            }
+          })}
         </div>
       ))}
 

--- a/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
+++ b/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
@@ -16,8 +16,10 @@ export default function Chat() {
   } = useChat<
     unknown,
     {
-      'hello-world': {
-        name: string;
+      weather: {
+        city: string;
+        weather: string;
+        status: 'loading' | 'success';
       };
     }
   >({
@@ -32,21 +34,34 @@ export default function Chat() {
         <div key={message.id} className="whitespace-pre-wrap">
           {message.role === 'user' ? 'User: ' : 'AI: '}{' '}
           {message.parts
-            .filter(part => part.type === 'data-hello-world')
-            .map(part => (
+            .filter(part => part.type === 'data-weather')
+            .map((part, index) => (
               <span
-                key={part.type}
+                key={index}
                 style={{
                   border: '2px solid red',
                   padding: '2px',
                   borderRadius: '4px',
+                  display: 'inline-block',
+                  minWidth: '180px',
                 }}
               >
-                Hello, {part.value.name}!
+                {part.value.status === 'loading' ? (
+                  <>
+                    Getting weather for <b>{part.value.city}</b>...
+                  </>
+                ) : part.value.status === 'success' ? (
+                  <>
+                    Weather in <b>{part.value.city}</b>:{' '}
+                    <b>{part.value.weather}</b>
+                  </>
+                ) : (
+                  <>Unknown weather state</>
+                )}
               </span>
             ))}
           {message.parts
-            .filter(part => part.type !== 'data-hello-world')
+            .filter(part => part.type !== 'data-weather')
             .map((part, index) => {
               if (part.type === 'text') {
                 return <div key={index}>{part.text}</div>;

--- a/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
+++ b/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { defaultChatStore } from 'ai';
+
+export default function Chat() {
+  const {
+    error,
+    input,
+    status,
+    handleInputChange,
+    handleSubmit,
+    messages,
+    reload,
+    stop,
+  } = useChat<
+    unknown,
+    {
+      'hello-world': {
+        name: string;
+      };
+    }
+  >({
+    chatStore: defaultChatStore({
+      api: '/api/use-chat-data-ui-parts',
+    }),
+  });
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap">
+          {message.role === 'user' ? 'User: ' : 'AI: '}{' '}
+          {message.parts
+            .filter(part => part.type === 'data-hello-world')
+            .map(part => (
+              <span
+                key={part.type}
+                style={{
+                  border: '2px solid red',
+                  padding: '2px',
+                  borderRadius: '4px',
+                }}
+              >
+                Hello, {part.value.name}!
+              </span>
+            ))}
+          {message.parts
+            .filter(part => part.type !== 'data-hello-world')
+            .map((part, index) => {
+              if (part.type === 'text') {
+                return <div key={index}>{part.text}</div>;
+              }
+            })}
+        </div>
+      ))}
+
+      {(status === 'submitted' || status === 'streaming') && (
+        <div className="mt-4 text-gray-500">
+          {status === 'submitted' && <div>Loading...</div>}
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+            onClick={stop}
+          >
+            Stop
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4">
+          <div className="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
+            onClick={() => reload()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <input
+          className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          value={input}
+          placeholder="Say something..."
+          onChange={handleInputChange}
+          disabled={status !== 'ready'}
+        />
+      </form>
+    </div>
+  );
+}

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ProviderMetadata } from '../../core';
 
-export const uiMessageStreamPartSchema = z.discriminatedUnion('type', [
+export const uiMessageStreamPartSchema = z.union([
   z.object({
     type: z.literal('text'),
     value: z.string(),

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -44,7 +44,6 @@ export const uiMessageStreamPartSchema = z.union([
   z.object({
     type: z.literal('source'),
     value: z.object({
-      type: z.literal('source'),
       sourceType: z.literal('url'),
       id: z.string(),
       url: z.string(),
@@ -135,9 +134,9 @@ export type UIMessageStreamPart =
       };
     }
   | {
+      // TODO evaluate flattening sources similar to data ui parts
       type: 'source';
       value: {
-        type: 'source';
         sourceType: 'url';
         id: string;
         url: string;
@@ -155,6 +154,7 @@ export type UIMessageStreamPart =
   | {
       type: `data-${string}`;
       value: {
+        id?: string;
         data: unknown;
       };
     }

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -60,10 +60,8 @@ export const uiMessageStreamPartSchema = z.union([
   }),
   z.object({
     type: z.string().startsWith('data-'),
-    value: z.object({
-      id: z.string().optional(),
-      data: z.unknown(),
-    }),
+    id: z.string().optional(),
+    data: z.unknown(),
   }),
   z.object({
     type: z.literal('metadata'),
@@ -156,10 +154,8 @@ export type UIMessageStreamPart =
     }
   | {
       type: `data-${string}`;
-      value: {
-        id?: string;
-        data: unknown;
-      };
+      id?: string;
+      data: unknown;
     }
   | {
       type: 'metadata';
@@ -183,5 +179,4 @@ export type UIMessageStreamPart =
     }
   | {
       type: 'reasoning-part-finish';
-      value?: null;
     };

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -60,7 +60,10 @@ export const uiMessageStreamPartSchema = z.union([
   }),
   z.object({
     type: z.string().startsWith('data-'),
-    value: z.object({ data: z.unknown() }),
+    value: z.object({
+      id: z.string().optional(),
+      data: z.unknown(),
+    }),
   }),
   z.object({
     type: z.literal('metadata'),

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -1,26 +1,5 @@
 import { z } from 'zod';
 
-const toolCallSchema = z.object({
-  toolCallId: z.string(),
-  toolName: z.string(),
-  args: z.unknown(),
-});
-
-const toolResultValueSchema = z.object({
-  toolCallId: z.string(),
-  result: z.unknown(),
-  providerMetadata: z.any().optional(),
-});
-
-const sourceSchema = z.object({
-  type: z.literal('source'),
-  sourceType: z.literal('url'),
-  id: z.string(),
-  url: z.string(),
-  title: z.string().optional(),
-  providerMetadata: z.any().optional(), // Use z.any() for generic metadata
-});
-
 export const uiMessageStreamPartSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('text'),
@@ -32,11 +11,19 @@ export const uiMessageStreamPartSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('tool-call'),
-    value: toolCallSchema,
+    value: z.object({
+      toolCallId: z.string(),
+      toolName: z.string(),
+      args: z.unknown(),
+    }),
   }),
   z.object({
     type: z.literal('tool-result'),
-    value: toolResultValueSchema,
+    value: z.object({
+      toolCallId: z.string(),
+      result: z.unknown(),
+      providerMetadata: z.any().optional(),
+    }),
   }),
   z.object({
     type: z.literal('tool-call-streaming-start'),
@@ -55,7 +42,14 @@ export const uiMessageStreamPartSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('source'),
-    value: sourceSchema,
+    value: z.object({
+      type: z.literal('source'),
+      sourceType: z.literal('url'),
+      id: z.string(),
+      url: z.string(),
+      title: z.string().optional(),
+      providerMetadata: z.any().optional(), // Use z.any() for generic metadata
+    }),
   }),
   z.object({
     type: z.literal('file'),

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -61,7 +61,7 @@ export const uiMessageStreamPartSchema = z.union([
   }),
   z.object({
     type: z.string().startsWith('data-'),
-    value: z.object({ warnings: z.array(z.string()) }),
+    value: z.object({ data: z.unknown() }),
   }),
   z.object({
     type: z.literal('metadata'),
@@ -155,7 +155,7 @@ export type UIMessageStreamPart =
   | {
       type: `data-${string}`;
       value: {
-        warnings: string[];
+        data: unknown;
       };
     }
   | {

--- a/packages/ai/src/ui/call-completion-api.ts
+++ b/packages/ai/src/ui/call-completion-api.ts
@@ -102,13 +102,12 @@ export async function callCompletionApi({
                   throw part.error;
                 }
 
-                const { type, value } = part.value;
-
-                if (type === 'text') {
-                  result += value;
+                const streamPart = part.value;
+                if (streamPart.type === 'text') {
+                  result += streamPart.value;
                   setCompletion(result);
-                } else if (type === 'error') {
-                  throw new Error(value);
+                } else if (streamPart.type === 'error') {
+                  throw new Error(streamPart.value);
                 }
               },
             }),

--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -1,12 +1,15 @@
 import { FetchFunction } from '@ai-sdk/provider-utils';
 import { UIMessageStreamPart } from '../ui-message-stream';
 import { fetchUIMessageStream } from './call-chat-api';
-import { UIMessage } from './ui-messages';
+import { UIDataTypes, UIMessage } from './ui-messages';
 
-export interface ChatTransport<MESSAGE_METADATA> {
+export interface ChatTransport<
+  MESSAGE_METADATA,
+  DATA_TYPES extends UIDataTypes,
+> {
   submitMessages: (options: {
     chatId: string;
-    messages: UIMessage<MESSAGE_METADATA>[];
+    messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
     abortController: AbortController;
     body?: object;
     headers?: Record<string, string> | Headers;
@@ -14,8 +17,10 @@ export interface ChatTransport<MESSAGE_METADATA> {
   }) => Promise<ReadableStream<UIMessageStreamPart>>;
 }
 
-export class DefaultChatTransport<MESSAGE_METADATA>
-  implements ChatTransport<MESSAGE_METADATA>
+export class DefaultChatTransport<
+  MESSAGE_METADATA,
+  DATA_TYPES extends UIDataTypes,
+> implements ChatTransport<MESSAGE_METADATA, DATA_TYPES>
 {
   private api: string;
   private credentials?: RequestCredentials;
@@ -25,7 +30,7 @@ export class DefaultChatTransport<MESSAGE_METADATA>
   private fetch?: FetchFunction;
   private prepareRequestBody?: (options: {
     id: string;
-    messages: UIMessage<MESSAGE_METADATA>[];
+    messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
     requestBody?: object;
   }) => unknown;
 
@@ -88,7 +93,7 @@ export class DefaultChatTransport<MESSAGE_METADATA>
      */
     prepareRequestBody?: (options: {
       id: string;
-      messages: UIMessage<MESSAGE_METADATA>[];
+      messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
       requestBody?: object;
     }) => unknown;
   }) {
@@ -108,7 +113,9 @@ export class DefaultChatTransport<MESSAGE_METADATA>
     body,
     headers,
     requestType,
-  }: Parameters<ChatTransport<MESSAGE_METADATA>['submitMessages']>[0]) {
+  }: Parameters<
+    ChatTransport<MESSAGE_METADATA, DATA_TYPES>['submitMessages']
+  >[0]) {
     return fetchUIMessageStream({
       api: this.api,
       headers: {

--- a/packages/ai/src/ui/default-chat-store.ts
+++ b/packages/ai/src/ui/default-chat-store.ts
@@ -6,9 +6,12 @@ import {
 } from '@ai-sdk/provider-utils';
 import { ChatStore } from './chat-store';
 import { DefaultChatTransport } from './chat-transport';
-import { UIMessage } from './ui-messages';
+import { UIDataTypes, UIMessage } from './ui-messages';
 
-export function defaultChatStore<MESSAGE_METADATA>({
+export function defaultChatStore<
+  MESSAGE_METADATA = unknown,
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
+>({
   api,
   fetch,
   streamProtocol = 'ui-message',
@@ -97,18 +100,18 @@ export function defaultChatStore<MESSAGE_METADATA>({
    */
   prepareRequestBody?: (options: {
     id: string;
-    messages: UIMessage<MESSAGE_METADATA>[];
+    messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
     requestBody?: object;
   }) => unknown;
 
   chats?: {
     [id: string]: {
-      messages: UIMessage<MESSAGE_METADATA>[];
+      messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
     };
   };
-}): ChatStore<MESSAGE_METADATA> {
-  return new ChatStore<MESSAGE_METADATA>({
-    transport: new DefaultChatTransport<MESSAGE_METADATA>({
+}): ChatStore<MESSAGE_METADATA, DATA_TYPES> {
+  return new ChatStore<MESSAGE_METADATA, DATA_TYPES>({
+    transport: new DefaultChatTransport<MESSAGE_METADATA, DATA_TYPES>({
       api,
       fetch,
       streamProtocol,

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -2906,7 +2906,10 @@ describe('processUIMessageStream', () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
         { type: 'start-step' },
-        { type: 'data-test', value: { data: 'example-data-can-be-anything' } },
+        {
+          type: 'data-test',
+          data: 'example-data-can-be-anything',
+        },
         { type: 'finish-step' },
         { type: 'finish' },
       ]);
@@ -2993,17 +2996,13 @@ describe('processUIMessageStream', () => {
         { type: 'start-step' },
         {
           type: 'data-test',
-          value: {
-            id: 'data-part-id',
-            data: 'example-data-can-be-anything',
-          },
+          id: 'data-part-id',
+          data: 'example-data-can-be-anything',
         },
         {
           type: 'data-test',
-          value: {
-            id: 'data-part-id',
-            data: 'or-something-else',
-          },
+          id: 'data-part-id',
+          data: 'or-something-else',
         },
         { type: 'finish-step' },
         { type: 'finish' },

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -2901,4 +2901,87 @@ describe('processUIMessageStream', () => {
       `);
     });
   });
+
+  describe('data ui parts (single part)', () => {
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', value: { messageId: 'msg-123' } },
+        { type: 'start-step' },
+        { type: 'data-test', value: { data: 'example-data-can-be-anything' } },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState();
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+        }),
+      });
+    });
+
+    it('should call the update function with the correct arguments', async () => {
+      expect(writeCalls).toMatchInlineSnapshot(`
+        [
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": {},
+              "parts": [],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": {},
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": {},
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "type": "data-test",
+                  "value": "example-data-can-be-anything",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+        ]
+      `);
+    });
+
+    it('should have the correct final message state', async () => {
+      expect(state!.message).toMatchInlineSnapshot(`
+        {
+          "id": "msg-123",
+          "metadata": {},
+          "parts": [
+            {
+              "type": "step-start",
+            },
+            {
+              "type": "data-test",
+              "value": "example-data-can-be-anything",
+            },
+          ],
+          "role": "assistant",
+        }
+      `);
+    });
+  });
 });

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -40,7 +40,7 @@ describe('processUIMessageStream', () => {
     });
   };
 
-  describe('scenario: simple text response', () => {
+  describe('text', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -140,7 +140,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: server-side tool roundtrip', () => {
+  describe('server-side tool roundtrip', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -357,7 +357,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: server-side tool roundtrip with existing assistant message', () => {
+  describe('server-side tool roundtrip with existing assistant message', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -685,7 +685,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: server-side tool roundtrip with multiple assistant texts', () => {
+  describe('server-side tool roundtrip with multiple assistant texts', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -995,7 +995,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: server-side tool roundtrip with multiple assistant reasoning', () => {
+  describe('server-side tool roundtrip with multiple assistant reasoning', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -1382,7 +1382,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: message metadata', () => {
+  describe('message metadata', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         {
@@ -1669,7 +1669,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: delayed message metadata after finish', () => {
+  describe('message metadata delayed after finish', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -1780,7 +1780,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: message metadata with existing assistant lastMessage', () => {
+  describe('message metadata with existing assistant lastMessage', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -1896,7 +1896,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: tool call streaming', () => {
+  describe('tool call streaming', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -2126,7 +2126,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: server provides message ids', () => {
+  describe('start with message id', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -2226,7 +2226,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: server provides reasoning', () => {
+  describe('reasoning', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -2464,7 +2464,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: onToolCall is executed', () => {
+  describe('onToolCall is executed', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -2597,7 +2597,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: server provides sources', () => {
+  describe('sources', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
@@ -2726,7 +2726,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('scenario: server provides file parts', () => {
+  describe('file parts', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -9,12 +9,16 @@ import type {
   TextUIPart,
   ToolInvocation,
   ToolInvocationUIPart,
+  UIDataTypes,
   UIMessage,
 } from './ui-messages';
 import { UseChatOptions } from './use-chat';
 
-export type StreamingUIMessageState<MESSAGE_METADATA = unknown> = {
-  message: UIMessage<MESSAGE_METADATA>;
+export type StreamingUIMessageState<
+  MESSAGE_METADATA = unknown,
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
+> = {
+  message: UIMessage<MESSAGE_METADATA, DATA_TYPES>;
   activeTextPart: TextUIPart | undefined;
   activeReasoningPart: ReasoningUIPart | undefined;
   partialToolCalls: Record<
@@ -24,20 +28,23 @@ export type StreamingUIMessageState<MESSAGE_METADATA = unknown> = {
   step: number;
 };
 
-export function createStreamingUIMessageState<MESSAGE_METADATA = unknown>({
+export function createStreamingUIMessageState<
+  MESSAGE_METADATA = unknown,
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
+>({
   lastMessage,
   newMessageId = 'no-id',
 }: {
-  lastMessage?: UIMessage<MESSAGE_METADATA>;
+  lastMessage?: UIMessage<MESSAGE_METADATA, DATA_TYPES>;
   newMessageId?: string;
-} = {}): StreamingUIMessageState<MESSAGE_METADATA> {
+} = {}): StreamingUIMessageState<MESSAGE_METADATA, DATA_TYPES> {
   const isContinuation = lastMessage?.role === 'assistant';
 
   const step = isContinuation
     ? 1 + (extractMaxToolInvocationStep(getToolInvocations(lastMessage)) ?? 0)
     : 0;
 
-  const message: UIMessage<MESSAGE_METADATA> = isContinuation
+  const message: UIMessage<MESSAGE_METADATA, DATA_TYPES> = isContinuation
     ? structuredClone(lastMessage)
     : {
         id: newMessageId,
@@ -55,7 +62,10 @@ export function createStreamingUIMessageState<MESSAGE_METADATA = unknown>({
   };
 }
 
-export function processUIMessageStream<MESSAGE_METADATA = unknown>({
+export function processUIMessageStream<
+  MESSAGE_METADATA = unknown,
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
+>({
   stream,
   onToolCall,
   messageMetadataSchema,

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -348,7 +348,11 @@ export function processUIMessageStream<
 
             default: {
               if (type.startsWith('data-')) {
-                // TODO: handle data events
+                state.message.parts.push({
+                  type,
+                  value: value.data as unknown as DATA_TYPES[keyof DATA_TYPES],
+                });
+                write();
               }
             }
           }

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -362,7 +362,11 @@ export function processUIMessageStream<
                       )
                     : undefined;
 
+                console.log(JSON.stringify(state.message.parts, null, 2));
+
                 if (existingPart != null) {
+                  console.log('existingPart', existingPart);
+
                   // TODO improve type safety
                   (existingPart as any).value = mergeObjects(
                     (existingPart as any).data,

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -1,5 +1,6 @@
 import { LanguageModelV2Source } from '@ai-sdk/provider';
 import { ToolCall, ToolResult } from '@ai-sdk/provider-utils';
+import { ValueOf } from '../util/value-of';
 
 /**
 Tool invocations are either tool calls or tool results. For each assistant tool call,
@@ -18,7 +19,10 @@ export type ToolInvocation =
 /**
  * AI SDK UI Messages. They are used in the client and to communicate between the frontend and the API routes.
  */
-export interface UIMessage<METADATA = unknown> {
+export interface UIMessage<
+  METADATA = unknown,
+  DATA_PARTS extends Record<string, unknown> = Record<string, unknown>,
+> {
   /**
 A unique identifier for the message.
    */
@@ -44,16 +48,25 @@ User messages can have text parts and file parts.
 
 Assistant messages can have text, reasoning, tool invocation, and file parts.
    */
-  parts: Array<UIMessagePart>;
+  parts: Array<UIMessagePart<DATA_PARTS>>;
 }
 
-export type UIMessagePart =
+export type UIMessagePart<DATA_TYPES extends Record<string, unknown>> =
   | TextUIPart
   | ReasoningUIPart
   | ToolInvocationUIPart
   | SourceUIPart
   | FileUIPart
+  | DataUIPart<DATA_TYPES>
   | StepStartUIPart;
+
+export type DataUIPart<DATA_TYPES extends Record<string, unknown>> = ValueOf<{
+  [NAME in keyof DATA_TYPES & string]: {
+    type: `data-${NAME}`;
+    id: string;
+    value: DATA_TYPES[NAME];
+  };
+}>;
 
 /**
  * A text part of a message.

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -68,7 +68,6 @@ export type UIMessagePart<DATA_TYPES extends UIDataTypes> =
 export type DataUIPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
   [NAME in keyof DATA_TYPES & string]: {
     type: `data-${NAME}`;
-    id: string;
     value: DATA_TYPES[NAME];
   };
 }>;

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -17,11 +17,16 @@ export type ToolInvocation =
   | ({ state: 'result'; step?: number } & ToolResult<string, any, any>);
 
 /**
- * AI SDK UI Messages. They are used in the client and to communicate between the frontend and the API routes.
+The data types that can be used in the UI message for the UI message data parts.
+ */
+export type UIDataTypes = Record<string, unknown>;
+
+/**
+AI SDK UI Messages. They are used in the client and to communicate between the frontend and the API routes.
  */
 export interface UIMessage<
   METADATA = unknown,
-  DATA_PARTS extends Record<string, unknown> = Record<string, unknown>,
+  DATA_PARTS extends UIDataTypes = UIDataTypes,
 > {
   /**
 A unique identifier for the message.
@@ -51,7 +56,7 @@ Assistant messages can have text, reasoning, tool invocation, and file parts.
   parts: Array<UIMessagePart<DATA_PARTS>>;
 }
 
-export type UIMessagePart<DATA_TYPES extends Record<string, unknown>> =
+export type UIMessagePart<DATA_TYPES extends UIDataTypes> =
   | TextUIPart
   | ReasoningUIPart
   | ToolInvocationUIPart
@@ -60,7 +65,7 @@ export type UIMessagePart<DATA_TYPES extends Record<string, unknown>> =
   | DataUIPart<DATA_TYPES>
   | StepStartUIPart;
 
-export type DataUIPart<DATA_TYPES extends Record<string, unknown>> = ValueOf<{
+export type DataUIPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
   [NAME in keyof DATA_TYPES & string]: {
     type: `data-${NAME}`;
     id: string;
@@ -153,9 +158,9 @@ export type StepStartUIPart = {
   type: 'step-start';
 };
 
-export type CreateUIMessage<METADATA = unknown> = Omit<
-  UIMessage<METADATA>,
-  'id'
-> & {
-  id?: UIMessage<METADATA>['id'];
+export type CreateUIMessage<
+  METADATA = unknown,
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
+> = Omit<UIMessage<METADATA, DATA_TYPES>, 'id'> & {
+  id?: UIMessage<METADATA, DATA_TYPES>['id'];
 };

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -1,4 +1,3 @@
-import { LanguageModelV2Source } from '@ai-sdk/provider';
 import { ToolCall, ToolResult } from '@ai-sdk/provider-utils';
 import { ValueOf } from '../util/value-of';
 
@@ -68,6 +67,7 @@ export type UIMessagePart<DATA_TYPES extends UIDataTypes> =
 export type DataUIPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
   [NAME in keyof DATA_TYPES & string]: {
     type: `data-${NAME}`;
+    id?: string;
     value: DATA_TYPES[NAME];
   };
 }>;
@@ -122,7 +122,13 @@ export type SourceUIPart = {
   /**
    * The source.
    */
-  source: LanguageModelV2Source;
+  source: {
+    sourceType: 'url';
+    id: string;
+    url: string;
+    title?: string;
+    providerMetadata?: Record<string, any>;
+  };
 };
 
 /**

--- a/packages/ai/src/ui/use-chat.ts
+++ b/packages/ai/src/ui/use-chat.ts
@@ -4,8 +4,8 @@ import {
   Schema,
   ToolCall,
 } from '@ai-sdk/provider-utils';
-import { UIMessage } from './ui-messages';
 import { ChatStore } from './chat-store';
+import { UIDataTypes, UIMessage } from './ui-messages';
 
 export type ChatRequestOptions = {
   /**
@@ -19,7 +19,10 @@ export type ChatRequestOptions = {
   body?: object;
 };
 
-export type UseChatOptions<MESSAGE_METADATA = unknown> = {
+export type UseChatOptions<
+  MESSAGE_METADATA = unknown,
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
+> = {
   /**
    * A unique identifier for the chat. If not provided, a random one will be
    * generated. When provided, the `useChat` hook with the same `id` will
@@ -51,7 +54,7 @@ export type UseChatOptions<MESSAGE_METADATA = unknown> = {
    * @param message The message that was streamed.
    */
   onFinish?: (options: {
-    message: UIMessage<NoInfer<MESSAGE_METADATA>>;
+    message: UIMessage<MESSAGE_METADATA, DATA_TYPES>;
   }) => void;
 
   /**
@@ -68,7 +71,7 @@ export type UseChatOptions<MESSAGE_METADATA = unknown> = {
   /**
    * Optional chat store. Default is used when not provided.
    */
-  chatStore?: ChatStore<MESSAGE_METADATA>;
+  chatStore?: ChatStore<MESSAGE_METADATA, DATA_TYPES>;
 };
 
 export type OriginalUseChatOptions<MESSAGE_METADATA = unknown> = {

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -16,7 +16,10 @@ import { useCallback, useRef, useState, useSyncExternalStore } from 'react';
 
 export type { CreateUIMessage, UIMessage, UseChatOptions };
 
-export type UseChatHelpers<MESSAGE_METADATA = unknown> = {
+export type UseChatHelpers<
+  MESSAGE_METADATA = unknown,
+  DATA_TYPES extends Record<string, unknown> = Record<string, unknown>,
+> = {
   /**
    * The id of the chat.
    */
@@ -33,7 +36,7 @@ export type UseChatHelpers<MESSAGE_METADATA = unknown> = {
   readonly status: 'submitted' | 'streaming' | 'ready' | 'error';
 
   /** Current messages in the chat */
-  readonly messages: UIMessage<MESSAGE_METADATA>[];
+  readonly messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
 
   /** The error object of the API request */
   readonly error: undefined | Error;
@@ -76,10 +79,10 @@ export type UseChatHelpers<MESSAGE_METADATA = unknown> = {
    */
   setMessages: (
     messages:
-      | UIMessage<MESSAGE_METADATA>[]
+      | UIMessage<MESSAGE_METADATA, DATA_TYPES>[]
       | ((
-          messages: UIMessage<MESSAGE_METADATA>[],
-        ) => UIMessage<MESSAGE_METADATA>[]),
+          messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[],
+        ) => UIMessage<MESSAGE_METADATA, DATA_TYPES>[]),
   ) => void;
 
   /** The current value of the input */
@@ -112,7 +115,10 @@ export type UseChatHelpers<MESSAGE_METADATA = unknown> = {
   }) => void;
 };
 
-export function useChat<MESSAGE_METADATA>({
+export function useChat<
+  MESSAGE_METADATA = unknown,
+  DATA_TYPES extends Record<string, unknown> = Record<string, unknown>,
+>({
   id,
   initialInput = '',
   onToolCall,
@@ -127,7 +133,7 @@ Custom throttle wait in ms for the chat messages and data updates.
 Default is undefined, which disables throttling.
    */
   experimental_throttle?: number;
-} = {}): UseChatHelpers<MESSAGE_METADATA> {
+} = {}): UseChatHelpers<MESSAGE_METADATA, DATA_TYPES> {
   // Generate ID once, store in state for stability across re-renders
   const [hookId] = useState(generateId);
 

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -1,16 +1,15 @@
-import type {
-  ChatRequestOptions,
-  CreateUIMessage,
-  FileUIPart,
-  UIMessage,
-  UseChatOptions,
-} from 'ai';
 import {
   ChatStore,
   convertFileListToFileUIParts,
   defaultChatStore,
   generateId as generateIdFunc,
+  type ChatRequestOptions,
   type ChatStoreEvent,
+  type CreateUIMessage,
+  type FileUIPart,
+  type UIDataTypes,
+  type UIMessage,
+  type UseChatOptions,
 } from 'ai';
 import { useCallback, useRef, useState, useSyncExternalStore } from 'react';
 
@@ -18,7 +17,7 @@ export type { CreateUIMessage, UIMessage, UseChatOptions };
 
 export type UseChatHelpers<
   MESSAGE_METADATA = unknown,
-  DATA_TYPES extends Record<string, unknown> = Record<string, unknown>,
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
 > = {
   /**
    * The id of the chat.
@@ -49,7 +48,7 @@ export type UseChatHelpers<
    * @param options Additional options to pass to the API call
    */
   append: (
-    message: CreateUIMessage<MESSAGE_METADATA>,
+    message: CreateUIMessage<MESSAGE_METADATA, DATA_TYPES>,
     options?: ChatRequestOptions,
   ) => Promise<void>;
 
@@ -127,7 +126,7 @@ export function useChat<
   generateId = generateIdFunc,
   experimental_throttle: throttleWaitMs,
   chatStore: chatStoreArg,
-}: UseChatOptions<MESSAGE_METADATA> & {
+}: UseChatOptions<MESSAGE_METADATA, DATA_TYPES> & {
   /**
 Custom throttle wait in ms for the chat messages and data updates.
 Default is undefined, which disables throttling.
@@ -144,7 +143,7 @@ Default is undefined, which disables throttling.
   // TODO enable as arg
   const chatStore = useRef(
     chatStoreArg ??
-      defaultChatStore<MESSAGE_METADATA>({
+      defaultChatStore<MESSAGE_METADATA, DATA_TYPES>({
         api: '/api/chat',
         generateId,
       }),
@@ -179,7 +178,7 @@ Default is undefined, which disables throttling.
   const addToolResult = useCallback(
     (
       options: Omit<
-        Parameters<ChatStore<MESSAGE_METADATA>['addToolResult']>[0],
+        Parameters<ChatStore<MESSAGE_METADATA, DATA_TYPES>['addToolResult']>[0],
         'chatId'
       >,
     ) => chatStore.current.addToolResult({ chatId, ...options }),
@@ -223,7 +222,7 @@ Default is undefined, which disables throttling.
 
   const append = useCallback(
     (
-      message: CreateUIMessage<MESSAGE_METADATA>,
+      message: CreateUIMessage<MESSAGE_METADATA, DATA_TYPES>,
       { headers, body }: ChatRequestOptions = {},
     ) =>
       chatStore.current.submitMessage({
@@ -266,10 +265,10 @@ Default is undefined, which disables throttling.
   const setMessages = useCallback(
     (
       messagesParam:
-        | UIMessage<MESSAGE_METADATA>[]
+        | UIMessage<MESSAGE_METADATA, DATA_TYPES>[]
         | ((
-            messages: UIMessage<MESSAGE_METADATA>[],
-          ) => UIMessage<MESSAGE_METADATA>[]),
+            messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[],
+          ) => UIMessage<MESSAGE_METADATA, DATA_TYPES>[]),
     ) => {
       if (typeof messagesParam === 'function') {
         messagesParam = messagesParam(messages);
@@ -316,7 +315,7 @@ Default is undefined, which disables throttling.
 
       setInput('');
     },
-    [input, generateId, append, messages],
+    [input, generateId, append],
   );
 
   const handleInputChange = (e: any) => {

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -726,16 +726,30 @@ describe('onToolCall', () => {
     await userEvent.click(screen.getByTestId('do-append'));
 
     await screen.findByTestId('message-1');
-    expect(screen.getByTestId('message-1')).toHaveTextContent(
-      `{"state":"call","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool"}`,
-    );
+    expect(
+      JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+    ).toStrictEqual({
+      state: 'call',
+      step: 0,
+      args: { testArg: 'test-value' },
+      toolCallId: 'tool-call-0',
+      toolName: 'test-tool',
+    });
 
     resolve();
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        `{"state":"result","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool","result":"test-tool-response: test-tool tool-call-0 {\\"testArg\\":\\"test-value\\"}"}`,
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'result',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        result:
+          'test-tool-response: test-tool tool-call-0 {"testArg":"test-value"}',
+      });
     });
   });
 });
@@ -814,9 +828,14 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"partial-call","step":0,"toolCallId":"tool-call-0","toolName":"test-tool"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'partial-call',
+        step: 0,
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+      });
     });
 
     controller.write(
@@ -830,9 +849,15 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"partial-call","step":0,"toolCallId":"tool-call-0","toolName":"test-tool","args":{"testArg":"t"}}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'partial-call',
+        step: 0,
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        args: { testArg: 't' },
+      });
     });
 
     controller.write(
@@ -846,9 +871,15 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"partial-call","step":0,"toolCallId":"tool-call-0","toolName":"test-tool","args":{"testArg":"test-value"}}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'partial-call',
+        step: 0,
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        args: { testArg: 'test-value' },
+      });
     });
 
     controller.write(
@@ -863,9 +894,15 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"call","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'call',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+      });
     });
 
     controller.write(
@@ -880,9 +917,16 @@ describe('tool invocations', () => {
     controller.close();
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        `{"state":"result","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool","result":"test-result"}`,
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'result',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        result: 'test-result',
+      });
     });
   });
 
@@ -907,9 +951,15 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"call","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'call',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+      });
     });
 
     controller.write(
@@ -924,9 +974,16 @@ describe('tool invocations', () => {
     controller.close();
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"result","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool","result":"test-result"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'result',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        result: 'test-result',
+      });
     });
   });
 
@@ -953,17 +1010,30 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"call","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'call',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+      });
     });
 
     await userEvent.click(screen.getByTestId('add-result-0'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"result","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool","result":"test-result"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'result',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        result: 'test-result',
+      });
     });
 
     controller.write(
@@ -1047,9 +1117,15 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"call","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'call',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+      });
     });
 
     // user submits the tool result
@@ -1057,9 +1133,16 @@ describe('tool invocations', () => {
 
     // UI should show the tool result
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"result","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool","result":"test-result"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'result',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        result: 'test-result',
+      });
     });
 
     // should not have called the API yet

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -583,9 +583,15 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"call","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'call',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+      });
     });
 
     controller.write(
@@ -600,9 +606,16 @@ describe('tool invocations', () => {
     controller.close();
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"result","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool","result":"test-result"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'result',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        result: 'test-result',
+      });
     });
 
     // wait for final text to ensure test does not have side-effects
@@ -632,9 +645,15 @@ describe('tool invocations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-1')).toHaveTextContent(
-        '{"state":"call","step":0,"args":{"testArg":"test-value"},"toolCallId":"tool-call-0","toolName":"test-tool"}',
-      );
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'call',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+      });
     });
 
     controller.write(


### PR DESCRIPTION
## Background

The AI SDK needs to support message parts with custom user data.

## Summary

Add data ui parts and allows for data ui part updates.

## Verification

Add example to `examples/next-openai` and test it.

## Tasks

- [x] basic types exploration
- [x] sending parts using the ui message stream
   - [x] extend ui message part schema
   - [x] process in ui message part processor
- [x] updating parts: id / replacement support

## Future Work
- type inference from schemas
- Svelte support
- Vue support