### PR TITLE
chore (ai): make ui stream parts value optional when it's not required

### DIFF
--- a/.changeset/fresh-otters-chew.md
+++ b/.changeset/fresh-otters-chew.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore (ai): make ui stream parts value optional when it's not required

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -5,9 +5,7 @@ exports[`streamText > multiple stream consumption > should support text stream, 
   "dataStream": [
     {
       "type": "start-step",
-      "value": {
-        "metadata": undefined,
-      },
+      "value": undefined,
     },
     {
       "type": "text",
@@ -23,15 +21,11 @@ exports[`streamText > multiple stream consumption > should support text stream, 
     },
     {
       "type": "finish-step",
-      "value": {
-        "metadata": undefined,
-      },
+      "value": undefined,
     },
     {
       "type": "finish",
-      "value": {
-        "metadata": undefined,
-      },
+      "value": undefined,
     },
   ],
   "fullStream": [
@@ -2780,16 +2774,16 @@ exports[`streamText > result.fullStream > should use fallback response metadata 
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error messages by default 1`] = `
 [
-  "data: {"type":"start-step","value":{}}
+  "data: {"type":"start-step"}
 
 ",
   "data: {"type":"error","value":"An error occurred."}
 
 ",
-  "data: {"type":"finish-step","value":{}}
+  "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish","value":{}}
+  "data: {"type":"finish"}
 
 ",
   "data: [DONE]
@@ -2800,13 +2794,16 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error m
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should omit message finish event (d:) when sendFinish is false 1`] = `
 [
-  "data: {"type":"start-step","value":{}}
+  "data: {"type":"start-step"}
 
 ",
   "data: {"type":"text","value":"Hello, World!"}
 
 ",
-  "data: {"type":"finish-step","value":{}}
+  "data: {"type":"finish-step"}
+
+",
+  "data: {"type":"finish"}
 
 ",
   "data: [DONE]
@@ -2817,16 +2814,16 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should omit message
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should support custom error messages 1`] = `
 [
-  "data: {"type":"start-step","value":{}}
+  "data: {"type":"start-step"}
 
 ",
   "data: {"type":"error","value":"custom error message: error"}
 
 ",
-  "data: {"type":"finish-step","value":{}}
+  "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish","value":{}}
+  "data: {"type":"finish"}
 
 ",
   "data: [DONE]
@@ -3219,16 +3216,11 @@ exports[`streamText > result.toUIMessageStream > should create a data stream 1`]
 [
   {
     "type": "start",
-    "value": {
-      "messageId": undefined,
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "text",
@@ -3244,15 +3236,11 @@ exports[`streamText > result.toUIMessageStream > should create a data stream 1`]
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "finish",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
 ]
 `;
@@ -3261,9 +3249,7 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
 [
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "error",
@@ -3271,15 +3257,11 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "finish",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
 ]
 `;
@@ -3288,9 +3270,7 @@ exports[`streamText > result.toUIMessageStream > should omit message finish even
 [
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "text",
@@ -3298,9 +3278,11 @@ exports[`streamText > result.toUIMessageStream > should omit message finish even
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
+  },
+  {
+    "type": "finish",
+    "value": undefined,
   },
 ]
 `;
@@ -3309,9 +3291,7 @@ exports[`streamText > result.toUIMessageStream > should send file content 1`] = 
 [
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "file",
@@ -3333,15 +3313,11 @@ exports[`streamText > result.toUIMessageStream > should send file content 1`] = 
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "finish",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
 ]
 `;
@@ -3350,9 +3326,7 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
 [
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "reasoning",
@@ -3382,7 +3356,6 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
   },
   {
     "type": "reasoning-part-finish",
-    "value": null,
   },
   {
     "type": "reasoning",
@@ -3398,7 +3371,6 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
   },
   {
     "type": "reasoning-part-finish",
-    "value": null,
   },
   {
     "type": "reasoning",
@@ -3428,7 +3400,6 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
   },
   {
     "type": "reasoning-part-finish",
-    "value": null,
   },
   {
     "type": "text",
@@ -3440,15 +3411,11 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "finish",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
 ]
 `;
@@ -3457,9 +3424,7 @@ exports[`streamText > result.toUIMessageStream > should send source content when
 [
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "source",
@@ -3497,15 +3462,11 @@ exports[`streamText > result.toUIMessageStream > should send source content when
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "finish",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
 ]
 `;
@@ -3514,9 +3475,7 @@ exports[`streamText > result.toUIMessageStream > should send tool call and tool 
 [
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "tool-call",
@@ -3537,15 +3496,11 @@ exports[`streamText > result.toUIMessageStream > should send tool call and tool 
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "finish",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
 ]
 `;
@@ -3554,9 +3509,7 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
 [
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "tool-call-streaming-start",
@@ -3598,15 +3551,11 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "finish",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
 ]
 `;
@@ -3615,9 +3564,7 @@ exports[`streamText > result.toUIMessageStream > should support custom error mes
 [
   {
     "type": "start-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "error",
@@ -3625,31 +3572,27 @@ exports[`streamText > result.toUIMessageStream > should support custom error mes
   },
   {
     "type": "finish-step",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
   {
     "type": "finish",
-    "value": {
-      "metadata": undefined,
-    },
+    "value": undefined,
   },
 ]
 `;
 
 exports[`streamText > result.toUIMessageStreamResponse > should mask error messages by default 1`] = `
 [
-  "data: {"type":"start-step","value":{}}
+  "data: {"type":"start-step"}
 
 ",
   "data: {"type":"error","value":"An error occurred."}
 
 ",
-  "data: {"type":"finish-step","value":{}}
+  "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish","value":{}}
+  "data: {"type":"finish"}
 
 ",
   "data: [DONE]
@@ -3660,16 +3603,16 @@ exports[`streamText > result.toUIMessageStreamResponse > should mask error messa
 
 exports[`streamText > result.toUIMessageStreamResponse > should support custom error messages 1`] = `
 [
-  "data: {"type":"start-step","value":{}}
+  "data: {"type":"start-step"}
 
 ",
   "data: {"type":"error","value":"custom error message: error"}
 
 ",
-  "data: {"type":"finish-step","value":{}}
+  "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish","value":{}}
+  "data: {"type":"finish"}
 
 ",
   "data: [DONE]

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -834,10 +834,10 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start","value":{}}
+          "data: {"type":"start"}
 
         ",
-          "data: {"type":"start-step","value":{}}
+          "data: {"type":"start-step"}
 
         ",
           "data: {"type":"text","value":"Hello"}
@@ -849,10 +849,10 @@ describe('streamText', () => {
           "data: {"type":"text","value":"world!"}
 
         ",
-          "data: {"type":"finish-step","value":{}}
+          "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","value":{}}
+          "data: {"type":"finish"}
 
         ",
           "data: [DONE]
@@ -896,10 +896,10 @@ describe('streamText', () => {
 
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start","value":{}}
+          "data: {"type":"start"}
 
         ",
-          "data: {"type":"start-step","value":{}}
+          "data: {"type":"start-step"}
 
         ",
           "data: {"type":"text","value":"Hello"}
@@ -911,10 +911,10 @@ describe('streamText', () => {
           "data: {"type":"text","value":"world!"}
 
         ",
-          "data: {"type":"finish-step","value":{}}
+          "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","value":{}}
+          "data: {"type":"finish"}
 
         ",
           "data: [DONE]
@@ -1016,7 +1016,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start-step","value":{}}
+          "data: {"type":"start-step"}
 
         ",
           "data: {"type":"reasoning","value":{"type":"reasoning","text":"I will open the conversation"}}
@@ -1028,13 +1028,13 @@ describe('streamText', () => {
           "data: {"type":"reasoning","value":{"type":"reasoning","text":"","providerMetadata":{"testProvider":{"signature":"1234567890"}}}}
 
         ",
-          "data: {"type":"reasoning-part-finish","value":null}
+          "data: {"type":"reasoning-part-finish"}
 
         ",
           "data: {"type":"reasoning","value":{"type":"reasoning","text":"","providerMetadata":{"testProvider":{"redactedData":"redacted-reasoning-data"}}}}
 
         ",
-          "data: {"type":"reasoning-part-finish","value":null}
+          "data: {"type":"reasoning-part-finish"}
 
         ",
           "data: {"type":"reasoning","value":{"type":"reasoning","text":"Once the user has relaxed,"}}
@@ -1046,7 +1046,7 @@ describe('streamText', () => {
           "data: {"type":"reasoning","value":{"type":"reasoning","text":"","providerMetadata":{"testProvider":{"signature":"1234567890"}}}}
 
         ",
-          "data: {"type":"reasoning-part-finish","value":null}
+          "data: {"type":"reasoning-part-finish"}
 
         ",
           "data: {"type":"text","value":"Hi"}
@@ -1055,10 +1055,10 @@ describe('streamText', () => {
           "data: {"type":"text","value":" there!"}
 
         ",
-          "data: {"type":"finish-step","value":{}}
+          "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","value":{}}
+          "data: {"type":"finish"}
 
         ",
           "data: [DONE]
@@ -1094,7 +1094,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start-step","value":{}}
+          "data: {"type":"start-step"}
 
         ",
           "data: {"type":"source","value":{"type":"source","sourceType":"url","id":"123","url":"https://example.com","title":"Example","providerMetadata":{"provider":{"custom":"value"}}}}
@@ -1106,10 +1106,10 @@ describe('streamText', () => {
           "data: {"type":"source","value":{"type":"source","sourceType":"url","id":"456","url":"https://example.com/2","title":"Example 2","providerMetadata":{"provider":{"custom":"value2"}}}}
 
         ",
-          "data: {"type":"finish-step","value":{}}
+          "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","value":{}}
+          "data: {"type":"finish"}
 
         ",
           "data: [DONE]
@@ -1143,7 +1143,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start-step","value":{}}
+          "data: {"type":"start-step"}
 
         ",
           "data: {"type":"file","value":{"mediaType":"text/plain","url":"data:text/plain;base64,Hello World"}}
@@ -1155,10 +1155,10 @@ describe('streamText', () => {
           "data: {"type":"file","value":{"mediaType":"image/jpeg","url":"data:image/jpeg;base64,QkFVRw=="}}
 
         ",
-          "data: {"type":"finish-step","value":{}}
+          "data: {"type":"finish-step"}
 
         ",
-          "data: {"type":"finish","value":{}}
+          "data: {"type":"finish"}
 
         ",
           "data: [DONE]
@@ -1486,10 +1486,10 @@ describe('streamText', () => {
       expect(await convertResponseStreamToArray(response))
         .toMatchInlineSnapshot(`
           [
-            "data: {"type":"start","value":{}}
+            "data: {"type":"start"}
 
           ",
-            "data: {"type":"start-step","value":{}}
+            "data: {"type":"start-step"}
 
           ",
             "data: {"type":"text","value":"Hello"}
@@ -1501,10 +1501,10 @@ describe('streamText', () => {
             "data: {"type":"text","value":"world!"}
 
           ",
-            "data: {"type":"finish-step","value":{}}
+            "data: {"type":"finish-step"}
 
           ",
-            "data: {"type":"finish","value":{}}
+            "data: {"type":"finish"}
 
           ",
             "data: [DONE]
@@ -1544,10 +1544,10 @@ describe('streamText', () => {
       expect(await convertResponseStreamToArray(response))
         .toMatchInlineSnapshot(`
           [
-            "data: {"type":"start","value":{}}
+            "data: {"type":"start"}
 
           ",
-            "data: {"type":"start-step","value":{}}
+            "data: {"type":"start-step"}
 
           ",
             "data: {"type":"text","value":"Hello"}
@@ -1559,10 +1559,10 @@ describe('streamText', () => {
             "data: {"type":"text","value":"world!"}
 
           ",
-            "data: {"type":"finish-step","value":{}}
+            "data: {"type":"finish-step"}
 
           ",
-            "data: {"type":"finish","value":{}}
+            "data: {"type":"finish"}
 
           ",
             "data: [DONE]

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1382,10 +1382,7 @@ However, the LLM results are expected to be small enough to not cause issues.
 
             case 'reasoning-part-finish': {
               if (sendReasoning) {
-                controller.enqueue({
-                  type: 'reasoning-part-finish',
-                  value: null,
-                });
+                controller.enqueue({ type: 'reasoning-part-finish' });
               }
               break;
             }
@@ -1462,47 +1459,42 @@ However, the LLM results are expected to be small enough to not cause issues.
             }
 
             case 'start-step': {
+              const metadata = messageMetadata?.({ part });
               controller.enqueue({
                 type: 'start-step',
-                value: {
-                  metadata: messageMetadata?.({ part }),
-                },
+                value: metadata != null ? { metadata } : undefined,
               });
               break;
             }
 
             case 'finish-step': {
+              const metadata = messageMetadata?.({ part });
               controller.enqueue({
                 type: 'finish-step',
-                value: {
-                  metadata: messageMetadata?.({ part }),
-                },
+                value: metadata != null ? { metadata } : undefined,
               });
+
               break;
             }
 
             case 'start': {
-              if (experimental_sendStart) {
-                controller.enqueue({
-                  type: 'start',
-                  value: {
-                    messageId,
-                    metadata: messageMetadata?.({ part }),
-                  },
-                });
-              }
+              const metadata = messageMetadata?.({ part });
+              controller.enqueue({
+                type: 'start',
+                value:
+                  messageId != null || metadata != null
+                    ? { messageId, metadata }
+                    : undefined,
+              });
               break;
             }
 
             case 'finish': {
-              if (experimental_sendFinish) {
-                controller.enqueue({
-                  type: 'finish',
-                  value: {
-                    metadata: messageMetadata?.({ part }),
-                  },
-                });
-              }
+              const metadata = messageMetadata?.({ part });
+              controller.enqueue({
+                type: 'finish',
+                value: metadata != null ? { metadata } : undefined,
+              });
               break;
             }
 

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -66,38 +66,32 @@ export const uiMessageStreamPartSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('metadata'),
-    value: z.object({
-      metadata: z.unknown(),
-    }),
+    value: z.object({ metadata: z.unknown() }),
   }),
   z.object({
     type: z.literal('start-step'),
-    value: z.object({
-      metadata: z.unknown(),
-    }),
+    value: z.object({ metadata: z.unknown() }).optional(),
   }),
   z.object({
     type: z.literal('finish-step'),
-    value: z.object({
-      metadata: z.unknown(),
-    }),
+    value: z.object({ metadata: z.unknown() }).optional(),
   }),
   z.object({
     type: z.literal('start'),
-    value: z.object({
-      messageId: z.string().optional(),
-      metadata: z.unknown(),
-    }),
+    value: z
+      .object({
+        messageId: z.string().optional(),
+        metadata: z.unknown(),
+      })
+      .optional(),
   }),
   z.object({
     type: z.literal('finish'),
-    value: z.object({
-      metadata: z.unknown(),
-    }),
+    value: z.object({ metadata: z.unknown() }).optional(),
   }),
   z.object({
     type: z.literal('reasoning-part-finish'),
-    value: z.null(),
+    value: z.null().optional(),
   }),
 ]);
 

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -44,11 +44,11 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         { type: 'text', value: 'Hello, ' },
         { type: 'text', value: 'world!' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -144,7 +144,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         {
           type: 'tool-call',
           value: {
@@ -160,11 +160,11 @@ describe('processUIMessageStream', () => {
             result: { weather: 'sunny' },
           },
         },
-        { type: 'finish-step', value: {} },
-        { type: 'start-step', value: {} },
+        { type: 'finish-step' },
+        { type: 'start-step' },
         { type: 'text', value: 'The weather in London is sunny.' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -361,7 +361,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         {
           type: 'tool-call',
           value: {
@@ -377,11 +377,11 @@ describe('processUIMessageStream', () => {
             result: { weather: 'sunny' },
           },
         },
-        { type: 'finish-step', value: {} },
-        { type: 'start-step', value: {} },
+        { type: 'finish-step' },
+        { type: 'start-step' },
         { type: 'text', value: 'The weather in London is sunny.' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -689,7 +689,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         { type: 'text', value: 'I will ' },
         { type: 'text', value: 'use a tool to get the weather in London.' },
         {
@@ -707,12 +707,12 @@ describe('processUIMessageStream', () => {
             result: { weather: 'sunny' },
           },
         },
-        { type: 'finish-step', value: {} },
-        { type: 'start-step', value: {} },
+        { type: 'finish-step' },
+        { type: 'start-step' },
         { type: 'text', value: 'The weather in London ' },
         { type: 'text', value: 'is sunny.' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -999,7 +999,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         { type: 'reasoning', value: { text: 'I will ' } },
         {
           type: 'reasoning',
@@ -1010,7 +1010,7 @@ describe('processUIMessageStream', () => {
             },
           },
         },
-        { type: 'reasoning-part-finish', value: null },
+        { type: 'reasoning-part-finish' },
         {
           type: 'tool-call',
           value: {
@@ -1026,8 +1026,8 @@ describe('processUIMessageStream', () => {
             result: { weather: 'sunny' },
           },
         },
-        { type: 'finish-step', value: {} },
-        { type: 'start-step', value: {} },
+        { type: 'finish-step' },
+        { type: 'start-step' },
         {
           type: 'reasoning',
           value: {
@@ -1037,10 +1037,10 @@ describe('processUIMessageStream', () => {
             },
           },
         },
-        { type: 'reasoning-part-finish', value: null },
+        { type: 'reasoning-part-finish' },
         { type: 'text', value: 'The weather in London is sunny.' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -1673,10 +1673,10 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         { type: 'text', value: 't1' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
         {
           type: 'metadata',
           value: {
@@ -1794,8 +1794,8 @@ describe('processUIMessageStream', () => {
           },
         },
         { type: 'text', value: 't1' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState({
@@ -1900,7 +1900,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         {
           type: 'tool-call-streaming-start',
           value: {
@@ -1937,8 +1937,8 @@ describe('processUIMessageStream', () => {
             result: 'test-result',
           },
         },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -2130,11 +2130,11 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         { type: 'text', value: 'Hello, ' },
         { type: 'text', value: 'world!' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -2230,7 +2230,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         {
           type: 'reasoning',
           value: {
@@ -2270,10 +2270,10 @@ describe('processUIMessageStream', () => {
             },
           },
         },
-        { type: 'reasoning-part-finish', value: null },
+        { type: 'reasoning-part-finish' },
         { type: 'text', value: 'Hi there!' },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -2468,7 +2468,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         {
           type: 'tool-call',
           value: {
@@ -2477,8 +2477,8 @@ describe('processUIMessageStream', () => {
             args: { city: 'London' },
           },
         },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -2601,7 +2601,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         { type: 'text', value: 'The weather in London is sunny.' },
         {
           type: 'source',
@@ -2613,8 +2613,8 @@ describe('processUIMessageStream', () => {
             title: 'Example',
           },
         },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();
@@ -2730,7 +2730,7 @@ describe('processUIMessageStream', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         { type: 'start', value: { messageId: 'msg-123' } },
-        { type: 'start-step', value: {} },
+        { type: 'start-step' },
         { type: 'text', value: 'Here is a file:' },
         {
           type: 'file',
@@ -2747,8 +2747,8 @@ describe('processUIMessageStream', () => {
             mediaType: 'application/json',
           },
         },
-        { type: 'finish-step', value: {} },
-        { type: 'finish', value: {} },
+        { type: 'finish-step' },
+        { type: 'finish' },
       ]);
 
       state = createStreamingUIMessageState();

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -289,7 +289,7 @@ export function processUIMessageStream<MESSAGE_METADATA = unknown>({
               // add a step boundary part to the message
               state.message.parts.push({ type: 'step-start' });
 
-              await updateMessageMetadata(value.metadata);
+              await updateMessageMetadata(value?.metadata);
               write();
               break;
             }
@@ -301,29 +301,29 @@ export function processUIMessageStream<MESSAGE_METADATA = unknown>({
               state.activeTextPart = undefined;
               state.activeReasoningPart = undefined;
 
-              await updateMessageMetadata(value.metadata);
-              if (value.metadata != null) {
+              await updateMessageMetadata(value?.metadata);
+              if (value?.metadata != null) {
                 write();
               }
               break;
             }
 
             case 'start': {
-              if (value.messageId != null) {
+              if (value?.messageId != null) {
                 state.message.id = value.messageId;
               }
 
-              await updateMessageMetadata(value.metadata);
+              await updateMessageMetadata(value?.metadata);
 
-              if (value.messageId != null || value.metadata != null) {
+              if (value?.messageId != null || value?.metadata != null) {
                 write();
               }
               break;
             }
 
             case 'finish': {
-              await updateMessageMetadata(value.metadata);
-              if (value.metadata != null) {
+              await updateMessageMetadata(value?.metadata);
+              if (value?.metadata != null) {
                 write();
               }
               break;

--- a/packages/ai/src/ui/transform-text-to-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/transform-text-to-ui-message-stream.test.ts
@@ -12,37 +12,33 @@ describe('transformTextToUiMessageStream', () => {
 
     expect(await convertReadableStreamToArray(transformedStream))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "type": "start",
-          "value": {},
-        },
-        {
-          "type": "start-step",
-          "value": {},
-        },
-        {
-          "type": "text",
-          "value": "Hello",
-        },
-        {
-          "type": "text",
-          "value": " ",
-        },
-        {
-          "type": "text",
-          "value": "World",
-        },
-        {
-          "type": "finish-step",
-          "value": {},
-        },
-        {
-          "type": "finish",
-          "value": {},
-        },
-      ]
-    `);
+        [
+          {
+            "type": "start",
+          },
+          {
+            "type": "start-step",
+          },
+          {
+            "type": "text",
+            "value": "Hello",
+          },
+          {
+            "type": "text",
+            "value": " ",
+          },
+          {
+            "type": "text",
+            "value": "World",
+          },
+          {
+            "type": "finish-step",
+          },
+          {
+            "type": "finish",
+          },
+        ]
+      `);
   });
 
   it('should handle empty streams correctly', async () => {
@@ -52,25 +48,21 @@ describe('transformTextToUiMessageStream', () => {
 
     expect(await convertReadableStreamToArray(transformedStream))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "type": "start",
-          "value": {},
-        },
-        {
-          "type": "start-step",
-          "value": {},
-        },
-        {
-          "type": "finish-step",
-          "value": {},
-        },
-        {
-          "type": "finish",
-          "value": {},
-        },
-      ]
-    `);
+        [
+          {
+            "type": "start",
+          },
+          {
+            "type": "start-step",
+          },
+          {
+            "type": "finish-step",
+          },
+          {
+            "type": "finish",
+          },
+        ]
+      `);
   });
 
   it('should handle single chunk streams', async () => {
@@ -80,28 +72,24 @@ describe('transformTextToUiMessageStream', () => {
 
     expect(await convertReadableStreamToArray(transformedStream))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "type": "start",
-          "value": {},
-        },
-        {
-          "type": "start-step",
-          "value": {},
-        },
-        {
-          "type": "text",
-          "value": "Complete message",
-        },
-        {
-          "type": "finish-step",
-          "value": {},
-        },
-        {
-          "type": "finish",
-          "value": {},
-        },
-      ]
-    `);
+        [
+          {
+            "type": "start",
+          },
+          {
+            "type": "start-step",
+          },
+          {
+            "type": "text",
+            "value": "Complete message",
+          },
+          {
+            "type": "finish-step",
+          },
+          {
+            "type": "finish",
+          },
+        ]
+      `);
   });
 });

--- a/packages/ai/src/ui/transform-text-to-ui-message-stream.ts
+++ b/packages/ai/src/ui/transform-text-to-ui-message-stream.ts
@@ -8,8 +8,8 @@ export function transformTextToUiMessageStream({
   return stream.pipeThrough(
     new TransformStream<string, UIMessageStreamPart>({
       start(controller) {
-        controller.enqueue({ type: 'start', value: {} });
-        controller.enqueue({ type: 'start-step', value: {} });
+        controller.enqueue({ type: 'start' });
+        controller.enqueue({ type: 'start-step' });
       },
 
       async transform(part, controller) {
@@ -17,8 +17,8 @@ export function transformTextToUiMessageStream({
       },
 
       async flush(controller) {
-        controller.enqueue({ type: 'finish-step', value: {} });
-        controller.enqueue({ type: 'finish', value: {} });
+        controller.enqueue({ type: 'finish-step' });
+        controller.enqueue({ type: 'finish' });
       },
     }),
   );

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -912,8 +912,8 @@ describe('tool invocations', () => {
 
     await userEvent.click(screen.getByTestId('do-append'));
 
-    controller.write(formatStreamPart({ type: 'start', value: {} }));
-    controller.write(formatStreamPart({ type: 'start-step', value: {} }));
+    controller.write(formatStreamPart({ type: 'start' }));
+    controller.write(formatStreamPart({ type: 'start-step' }));
     controller.write(
       formatStreamPart({
         type: 'tool-call',
@@ -1004,8 +1004,8 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-append'));
 
     // start stream
-    controller1.write(formatStreamPart({ type: 'start', value: {} }));
-    controller1.write(formatStreamPart({ type: 'start-step', value: {} }));
+    controller1.write(formatStreamPart({ type: 'start' }));
+    controller1.write(formatStreamPart({ type: 'start-step' }));
 
     // tool call
     controller1.write(
@@ -1039,8 +1039,8 @@ describe('tool invocations', () => {
     expect(server.calls.length).toBe(1);
 
     // finish stream
-    controller1.write(formatStreamPart({ type: 'finish-step', value: {} }));
-    controller1.write(formatStreamPart({ type: 'finish', value: {} }));
+    controller1.write(formatStreamPart({ type: 'finish-step' }));
+    controller1.write(formatStreamPart({ type: 'finish' }));
 
     await controller1.close();
 

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -817,8 +817,8 @@ describe('tool invocations', () => {
     });
 
     // start stream
-    controller1.write(formatStreamPart({ type: 'start', value: {} }));
-    controller1.write(formatStreamPart({ type: 'start-step', value: {} }));
+    controller1.write(formatStreamPart({ type: 'start' }));
+    controller1.write(formatStreamPart({ type: 'start-step' }));
 
     // tool call
     controller1.write(
@@ -872,8 +872,8 @@ describe('tool invocations', () => {
     expect(server.calls.length).toBe(1);
 
     // finish stream
-    controller1.write(formatStreamPart({ type: 'finish-step', value: {} }));
-    controller1.write(formatStreamPart({ type: 'finish', value: {} }));
+    controller1.write(formatStreamPart({ type: 'finish-step' }));
+    controller1.write(formatStreamPart({ type: 'finish' }));
 
     await controller1.close();
 

--- a/packages/vue/src/use-chat.ui.test.tsx
+++ b/packages/vue/src/use-chat.ui.test.tsx
@@ -209,7 +209,7 @@ describe('data protocol stream', () => {
         formatStreamPart({ type: 'text', value: ',' }),
         formatStreamPart({ type: 'text', value: ' world' }),
         formatStreamPart({ type: 'text', value: '.' }),
-        formatStreamPart({ type: 'finish', value: {} }),
+        formatStreamPart({ type: 'finish' }),
       ],
     };
 
@@ -700,8 +700,8 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-append'));
 
     // start stream
-    controller1.write(formatStreamPart({ type: 'start', value: {} }));
-    controller1.write(formatStreamPart({ type: 'start-step', value: {} }));
+    controller1.write(formatStreamPart({ type: 'start' }));
+    controller1.write(formatStreamPart({ type: 'start-step' }));
 
     // tool call
     controller1.write(
@@ -735,8 +735,8 @@ describe('tool invocations', () => {
     expect(server.calls.length).toBe(1);
 
     // finish stream
-    controller1.write(formatStreamPart({ type: 'finish-step', value: {} }));
-    controller1.write(formatStreamPart({ type: 'finish', value: {} }));
+    controller1.write(formatStreamPart({ type: 'finish-step' }));
+    controller1.write(formatStreamPart({ type: 'finish' }));
 
     await controller1.close();
 


### PR DESCRIPTION
## Background
We send `value: {}` in UI message parts even when it could be optional and contains no data.

## Summary

Make `value` optional when it can be ommited.

## Verification

Check with `examples/next-openai` in Chrome dev tools EventStream tab.
