### PR TITLE
fix (ui/react): update messages immediately with the submitted user message

### DIFF
--- a/.changeset/happy-countries-dream.md
+++ b/.changeset/happy-countries-dream.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ui/react): update messages immediately with the submitted user message

--- a/packages/ai/src/ui/chat-store.ts
+++ b/packages/ai/src/ui/chat-store.ts
@@ -189,19 +189,6 @@ export class ChatStore<MESSAGE_METADATA> {
     this.emit({ type: 'chat-messages-changed', chatId: id });
   }
 
-  appendMessage({
-    id,
-    message,
-  }: {
-    id: string;
-    message: UIMessage<MESSAGE_METADATA>;
-  }) {
-    const chat = this.getChat(id);
-
-    chat.messages = [...chat.messages, { ...message }];
-    this.emit({ type: 'chat-messages-changed', chatId: id });
-  }
-
   removeAssistantResponse(id: string) {
     const chat = this.getChat(id);
 
@@ -386,6 +373,9 @@ export class ChatStore<MESSAGE_METADATA> {
   }) {
     const self = this;
     const chat = this.getChat(chatId);
+
+    // update the messages array with the new message:
+    this.setMessages({ id: chatId, messages: chatMessages });
 
     this.setStatus({ id: chatId, status: 'submitted', error: undefined });
 

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -122,6 +122,33 @@ describe('data protocol stream', () => {
     });
   });
 
+  it('should show user message immediately', async () => {
+    const controller = new TestResponseController();
+    server.urls['/api/chat'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    await userEvent.click(screen.getByTestId('do-append'));
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+      ).toStrictEqual([
+        {
+          role: 'user',
+          parts: [
+            {
+              text: 'hi',
+              type: 'text',
+            },
+          ],
+          id: 'id-1',
+        },
+      ]);
+    });
+  });
+
   it('should show error response when there is a server error', async () => {
     server.urls['/api/chat'].response = {
       type: 'error',


### PR DESCRIPTION
## Background

With the new `ChatStore`, showing the user message immediately was broken.

## Summary

Update the chat store with the new messages before sending the request to the transport.