### PR TITLE
fix (ai): fix experimental sendStart/sendFinish options in streamText

### DIFF
--- a/.changeset/seven-beans-push.md
+++ b/.changeset/seven-beans-push.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): fix experimental sendStart/sendFinish options in streamText

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -2803,9 +2803,6 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should omit message
   "data: {"type":"finish-step"}
 
 ",
-  "data: {"type":"finish"}
-
-",
   "data: [DONE]
 
 ",
@@ -3266,7 +3263,28 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
 ]
 `;
 
-exports[`streamText > result.toUIMessageStream > should omit message finish event (d:) when sendFinish is false 1`] = `
+exports[`streamText > result.toUIMessageStream > should omit message finish event when sendFinish is false 1`] = `
+[
+  {
+    "type": "start",
+    "value": undefined,
+  },
+  {
+    "type": "start-step",
+    "value": undefined,
+  },
+  {
+    "type": "text",
+    "value": "Hello, World!",
+  },
+  {
+    "type": "finish-step",
+    "value": undefined,
+  },
+]
+`;
+
+exports[`streamText > result.toUIMessageStream > should omit message start event when sendStart is false 1`] = `
 [
   {
     "type": "start-step",

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1406,10 +1406,11 @@ describe('streamText', () => {
       expect(await convertReadableStreamToArray(dataStream)).toMatchSnapshot();
     });
 
-    it('should omit message finish event (d:) when sendFinish is false', async () => {
+    it('should omit message finish event when sendFinish is false', async () => {
       const result = streamText({
         model: createTestModel({
           stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
             { type: 'text', text: 'Hello, World!' },
             {
               type: 'finish',
@@ -1423,6 +1424,29 @@ describe('streamText', () => {
 
       const dataStream = result.toUIMessageStream({
         experimental_sendFinish: false,
+      });
+
+      expect(await convertReadableStreamToArray(dataStream)).toMatchSnapshot();
+    });
+
+    it('should omit message start event when sendStart is false', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'text', text: 'Hello, World!' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: testUsage,
+            },
+          ]),
+        }),
+        ...defaultSettings(),
+      });
+
+      const dataStream = result.toUIMessageStream({
+        experimental_sendStart: false,
       });
 
       expect(await convertReadableStreamToArray(dataStream)).toMatchSnapshot();

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1478,23 +1478,27 @@ However, the LLM results are expected to be small enough to not cause issues.
             }
 
             case 'start': {
-              const metadata = messageMetadata?.({ part });
-              controller.enqueue({
-                type: 'start',
-                value:
-                  messageId != null || metadata != null
-                    ? { messageId, metadata }
-                    : undefined,
-              });
+              if (experimental_sendStart) {
+                const metadata = messageMetadata?.({ part });
+                controller.enqueue({
+                  type: 'start',
+                  value:
+                    messageId != null || metadata != null
+                      ? { messageId, metadata }
+                      : undefined,
+                });
+              }
               break;
             }
 
             case 'finish': {
-              const metadata = messageMetadata?.({ part });
-              controller.enqueue({
-                type: 'finish',
-                value: metadata != null ? { metadata } : undefined,
-              });
+              if (experimental_sendFinish) {
+                const metadata = messageMetadata?.({ part });
+                controller.enqueue({
+                  type: 'finish',
+                  value: metadata != null ? { metadata } : undefined,
+                });
+              }
               break;
             }
 


### PR DESCRIPTION
## Background

The experimental `sendStart` and `sendFinish` options were broken.

## Summary

Fix experimental sendStart/sendFinish options in streamText.
