### PR TITLE
feat (ai): replace maxSteps with continueUntil (generateText)

### DIFF
--- a/.changeset/thick-parents-grab.md
+++ b/.changeset/thick-parents-grab.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+feat (ai): replace maxSteps with continueUntil (generateText)

--- a/examples/ai-core/src/complex/math-agent/agent-required-tool-choice.ts
+++ b/examples/ai-core/src/complex/math-agent/agent-required-tool-choice.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool } from 'ai';
+import { generateText, maxSteps, tool } from 'ai';
 import 'dotenv/config';
 import * as mathjs from 'mathjs';
 import { z } from 'zod';
@@ -31,7 +31,7 @@ async function main() {
       }),
     },
     toolChoice: 'required',
-    maxSteps: 10,
+    continueUntil: maxSteps(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/ai-core/src/complex/math-agent/agent.ts
+++ b/examples/ai-core/src/complex/math-agent/agent.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool } from 'ai';
+import { generateText, maxSteps, tool } from 'ai';
 import 'dotenv/config';
 import * as mathjs from 'mathjs';
 import { z } from 'zod';
@@ -16,7 +16,7 @@ async function main() {
         execute: async ({ expression }) => mathjs.evaluate(expression),
       }),
     },
-    maxSteps: 10,
+    continueUntil: maxSteps(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/ai-core/src/e2e/feature-test-suite.ts
+++ b/examples/ai-core/src/e2e/feature-test-suite.ts
@@ -11,6 +11,7 @@ import {
   experimental_generateImage as generateImage,
   generateObject,
   generateText,
+  maxSteps,
   streamObject,
   streamText,
 } from 'ai';
@@ -707,7 +708,7 @@ export function createFeatureTestSuite({
                       },
                     },
                   },
-                  maxSteps: 10,
+                  continueUntil: maxSteps(10),
                 });
 
                 expect(weatherCalls).toBe(1);

--- a/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
+++ b/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
@@ -8,7 +8,7 @@ import {
   vertexAnthropic as vertexAnthropicEdge,
 } from '@ai-sdk/google-vertex/anthropic/edge';
 import { LanguageModelV2 } from '@ai-sdk/provider';
-import { APICallError, generateText } from 'ai';
+import { APICallError, generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 import fs from 'fs';
 import { describe, expect, it } from 'vitest';
@@ -153,7 +153,7 @@ const toolTests = (model: LanguageModelV2) => {
         },
         prompt:
           'How can I switch to dark mode? Take a look at the screen and tell me.',
-        maxSteps: 5,
+        continueUntil: maxSteps(5),
       });
 
       console.log(result.text);
@@ -185,7 +185,7 @@ README.md     build         data          node_modules  package.json  src       
           }),
         },
         prompt: 'List the files in my directory.',
-        maxSteps: 2,
+        continueUntil: maxSteps(2),
       });
 
       expect(result.text).toBeTruthy();
@@ -227,7 +227,7 @@ README.md     build         data          node_modules  package.json  src       
           }),
         },
         prompt: 'Update my README file to talk about AI.',
-        maxSteps: 5,
+        continueUntil: maxSteps(5),
       });
 
       expect(result.text).toBeTruthy();

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { ModelMessage, generateText } from 'ai';
+import { ModelMessage, generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { weatherTool } from '../tools/weather-tool';
@@ -21,7 +21,7 @@ async function main() {
       tools: { weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
       messages,
-      maxSteps: 5,
+      continueUntil: maxSteps(5),
       providerOptions: {
         bedrock: {
           reasoningConfig: { type: 'enabled', budgetTokens: 2048 },

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -13,7 +13,7 @@ async function main() {
       },
     },
     maxRetries: 0,
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log('Reasoning:');

--- a/examples/ai-core/src/generate-text/amazon-bedrock-tool-call-image-result.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-tool-call-image-result.ts
@@ -1,7 +1,7 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText, tool } from 'ai';
-import { z } from 'zod';
+import { generateText, maxSteps, tool } from 'ai';
 import 'dotenv/config';
+import { z } from 'zod';
 
 async function main() {
   const result = await generateText({
@@ -40,7 +40,7 @@ async function main() {
         },
       }),
     },
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-bash.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-bash.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -22,7 +22,7 @@ async function main() {
       }),
     },
     prompt: 'List the files in my home directory.',
-    maxSteps: 2,
+    continueUntil: maxSteps(2),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-computer.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-computer.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 import fs from 'node:fs';
 
@@ -42,7 +42,7 @@ async function main() {
     },
     prompt:
       'How can I switch to dark mode? Take a look at the screen and tell me.',
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-editor-cache-control.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-editor-cache-control.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -45,7 +45,7 @@ This is a test file.
         },
       },
     ],
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-editor.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-editor.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -35,7 +35,7 @@ This is a test file.
       }),
     },
     prompt: 'Update my README file to talk about AI.',
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-core/src/generate-text/anthropic-reasoning-chatbot.ts
+++ b/examples/ai-core/src/generate-text/anthropic-reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { createAnthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { ModelMessage, generateText } from 'ai';
+import { ModelMessage, generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { weatherTool } from '../tools/weather-tool';
@@ -33,7 +33,7 @@ async function main() {
       tools: { weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
       messages,
-      maxSteps: 5,
+      continueUntil: maxSteps(5),
       providerOptions: {
         anthropic: {
           thinking: { type: 'enabled', budgetTokens: 12000 },

--- a/examples/ai-core/src/generate-text/google-multi-step.ts
+++ b/examples/ai-core/src/generate-text/google-multi-step.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, tool } from 'ai';
+import { generateText, maxSteps, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -28,7 +28,7 @@ async function main() {
         }),
       }),
     },
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
     // prompt: 'What is the weather in my current location?',
     prompt: 'What is the weather in Paris?',
   });

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-bash.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-bash.ts
@@ -1,6 +1,6 @@
-import 'dotenv/config';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
+import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
@@ -22,7 +22,7 @@ async function main() {
       }),
     },
     prompt: 'List the files in my home directory.',
-    maxSteps: 2,
+    continueUntil: maxSteps(2),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-computer.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-computer.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
 import fs from 'node:fs';
 
 async function main() {
@@ -42,7 +42,7 @@ async function main() {
     },
     prompt:
       'How can I switch to dark mode? Take a look at the screen and tell me.',
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor-cache-control.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor-cache-control.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
 
 async function main() {
   let editorContent = `
@@ -45,7 +45,7 @@ This is a test file.
         },
       },
     ],
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText } from 'ai';
+import { generateText, maxSteps } from 'ai';
 
 async function main() {
   let editorContent = `
@@ -35,7 +35,7 @@ This is a test file.
       }),
     },
     prompt: 'Update my README file to talk about AI.',
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-core/src/generate-text/google-vertex-multi-step.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-multi-step.ts
@@ -1,5 +1,5 @@
 import { vertex } from '@ai-sdk/google-vertex';
-import { generateText, tool } from 'ai';
+import { generateText, maxSteps, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -28,7 +28,7 @@ async function main() {
         }),
       }),
     },
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
     // prompt: 'What is the weather in my current location?',
     prompt: 'What is the weather in Paris?',
   });

--- a/examples/ai-core/src/generate-text/google-vertex-tool-call.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-tool-call.ts
@@ -1,5 +1,5 @@
 import { vertex } from '@ai-sdk/google-vertex';
-import { generateText, tool } from 'ai';
+import { generateText, maxSteps, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -22,7 +22,7 @@ async function main() {
         },
       }),
     },
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
   });
 
   console.log(text);

--- a/examples/ai-core/src/generate-text/openai-active-tools.ts
+++ b/examples/ai-core/src/generate-text/openai-active-tools.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool } from 'ai';
+import { generateText, maxSteps, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { weatherTool } from '../tools/weather-tool';
@@ -14,7 +14,7 @@ async function main() {
       }),
     },
     experimental_activeTools: [], // disable all tools
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
     prompt:
       'What is the weather in San Francisco and what attractions should I visit?',
   });

--- a/examples/ai-core/src/generate-text/openai-multi-step.ts
+++ b/examples/ai-core/src/generate-text/openai-multi-step.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, tool } from 'ai';
+import { generateText, maxSteps, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -28,7 +28,7 @@ async function main() {
         }),
       }),
     },
-    maxSteps: 5,
+    continueUntil: maxSteps(5),
     prompt: 'What is the weather in my current location?',
 
     onStepFinish: step => {

--- a/examples/ai-core/src/generate-text/openai-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-output-object.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, Output, tool } from 'ai';
+import { generateText, maxSteps, Output, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -25,7 +25,7 @@ async function main() {
         temperature: z.number(),
       }),
     }),
-    maxSteps: 2,
+    continueUntil: maxSteps(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-core/src/generate-text/openai-responses-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-output-object.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, Output, tool } from 'ai';
+import { generateText, maxSteps, Output, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -25,7 +25,7 @@ async function main() {
         temperature: z.number(),
       }),
     }),
-    maxSteps: 2,
+    continueUntil: maxSteps(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/mcp/src/http/client.ts
+++ b/examples/mcp/src/http/client.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { experimental_createMCPClient, generateText } from 'ai';
+import { experimental_createMCPClient, generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -18,7 +18,7 @@ async function main() {
     const { text: answer } = await generateText({
       model: openai('gpt-4o-mini'),
       tools,
-      maxSteps: 10,
+      continueUntil: maxSteps(10),
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },

--- a/examples/mcp/src/sse/client.ts
+++ b/examples/mcp/src/sse/client.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_createMCPClient, generateText } from 'ai';
+import { experimental_createMCPClient, generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -18,7 +18,7 @@ async function main() {
   const { text: answer } = await generateText({
     model: openai('gpt-4o-mini'),
     tools,
-    maxSteps: 10,
+    continueUntil: maxSteps(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/mcp/src/stdio/client.ts
+++ b/examples/mcp/src/stdio/client.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { experimental_createMCPClient, generateText } from 'ai';
+import { experimental_createMCPClient, generateText, maxSteps } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -31,7 +31,7 @@ async function main() {
           },
         },
       }),
-      maxSteps: 10,
+      continueUntil: maxSteps(10),
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },

--- a/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -1010,7 +1010,6 @@ exports[`telemetry > should not record telemetry inputs / outputs when disabled 
       "ai.operationId": "ai.generateText",
       "ai.response.finishReason": "stop",
       "ai.settings.maxRetries": 2,
-      "ai.settings.maxSteps": 1,
       "ai.usage.completionTokens": 10,
       "ai.usage.promptTokens": 3,
       "operation.name": "ai.generateText",
@@ -1068,7 +1067,6 @@ exports[`telemetry > should record successful tool call 1`] = `
       "ai.response.finishReason": "stop",
       "ai.response.toolCalls": "[{"toolCallType":"function","toolCallId":"call-1","toolName":"tool1","args":"{ \\"value\\": \\"value\\" }"}]",
       "ai.settings.maxRetries": 2,
-      "ai.settings.maxSteps": 1,
       "ai.usage.completionTokens": 10,
       "ai.usage.promptTokens": 3,
       "operation.name": "ai.generateText",
@@ -1137,7 +1135,6 @@ exports[`telemetry > should record telemetry data when enabled 1`] = `
       "ai.response.text": "Hello, world!",
       "ai.settings.frequencyPenalty": 0.3,
       "ai.settings.maxRetries": 2,
-      "ai.settings.maxSteps": 1,
       "ai.settings.presencePenalty": 0.4,
       "ai.settings.stopSequences": [
         "stop",

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -3,7 +3,7 @@ import { jsonSchema } from '@ai-sdk/provider-utils';
 import { mockId } from '@ai-sdk/provider-utils/test';
 import assert from 'node:assert';
 import { z } from 'zod';
-import { Output } from '.';
+import { maxSteps, Output } from '.';
 import { ToolExecutionError } from '../../src/error/tool-execution-error';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
 import { MockTracer } from '../test/mock-tracer';
@@ -735,7 +735,7 @@ describe('options.maxSteps', () => {
           }),
         },
         prompt: 'test-input',
-        maxSteps: 3,
+        continueUntil: maxSteps(3),
         onStepFinish: async event => {
           onStepFinishResults.push(event);
         },
@@ -936,7 +936,7 @@ describe('options.maxSteps', () => {
           }),
         },
         prompt: 'test-input',
-        maxSteps: 3,
+        continueUntil: maxSteps(3),
         onStepFinish: async event => {
           onStepFinishResults.push(event);
         },

--- a/packages/ai/core/generate-text/index.ts
+++ b/packages/ai/core/generate-text/index.ts
@@ -8,6 +8,7 @@ export type {
 export * as Output from './output';
 export { smoothStream, type ChunkDetector } from './smooth-stream';
 export type { StepResult } from './step-result';
+export { hasToolCall, maxSteps, type StopCondition } from './stop-condition';
 export { streamText } from './stream-text';
 export type {
   StreamTextOnChunkCallback,
@@ -17,9 +18,9 @@ export type {
   StreamTextTransform,
 } from './stream-text';
 export type {
-  UIMessageStreamOptions,
   StreamTextResult,
   TextStreamPart,
+  UIMessageStreamOptions,
 } from './stream-text-result';
 export type { ToolCall, ToolCallUnion } from './tool-call';
 export type { ToolCallRepairFunction } from './tool-call-repair';

--- a/packages/ai/core/generate-text/stop-condition.ts
+++ b/packages/ai/core/generate-text/stop-condition.ts
@@ -1,0 +1,17 @@
+import { StepResult } from './step-result';
+import { ToolSet } from './tool-set';
+
+export type StopCondition<TOOLS extends ToolSet> = (options: {
+  steps: Array<StepResult<TOOLS>>;
+}) => PromiseLike<boolean> | boolean;
+
+export function maxSteps(maxSteps: number): StopCondition<any> {
+  return ({ steps }) => steps.length >= maxSteps;
+}
+
+export function hasToolCall(toolName: string): StopCondition<any> {
+  return ({ steps }) =>
+    steps[steps.length - 1]?.toolCalls?.some(
+      toolCall => toolCall.toolName === toolName,
+    ) ?? false;
+}


### PR DESCRIPTION
## Background

The `maxSteps` parameter is not flexible enough for use cases that require more fine grained controlled over when the steps loop should end, e.g. when token consumption is exhausted or when a specific tool has been called.

## Summary

Replace `maxSteps` in `generateText` with `continueUntil`, which takes a more flexible `StopCondition`.

## Future Work

- Implement `continueUntil` for `streamText`
- Array support for `continueUntil`