### PR TITLE
fix (docs): mcpClient.tools() need to await (#6186)

### DIFF
--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -757,9 +757,11 @@ const mcpClient = await experimental_createMCPClient({
   // ...
 });
 
+const tools = await mcpClient.tools();
+
 const result = await streamText({
   model: openai('gpt-4o'),
-  tools: mcpClient.tools(),
+  tools,
   prompt: 'What is the weather in Brooklyn, New York?',
   onFinish: async () => {
     await mcpClient.close();


### PR DESCRIPTION
## Background

In mcp doc, `mcpClient.tools()` need to await


## Verification

Just fix doc problem