### PR TITLE
fix (docs): Laminar observability - add note on next.config (#6248)

### DIFF
--- a/content/providers/05-observability/laminar.mdx
+++ b/content/providers/05-observability/laminar.mdx
@@ -68,6 +68,20 @@ export async function register() {
 }
 ```
 
+### Add @lmnr-ai/lmnr to your next.config
+
+In your `next.config.js` (`.ts` / `.mjs`), add the following lines:
+
+```javascript
+const nextConfig = {
+  serverExternalPackages: ['@lmnr-ai/lmnr'],
+};
+
+export default nextConfig;
+```
+
+This is because Laminar depends on OpenTelemetry, which uses some Node.js-specific functionality, and we need to inform Next.js about it. Learn more in the [Next.js docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages).
+
 ### Tracing AI SDK calls
 
 Then, when you call AI SDK functions in any of your API routes, add the Laminar tracer to the `experimental_telemetry` option.


### PR DESCRIPTION
## Background

Like many other OpenTelemetry instrumentations, Laminar depends on `@opentelemetry/instrumentation`, which, in turn, depends on `require-in-the-middle` and `import-in-the-middle`. Importing and initializing Laminar inside Next.js `instrumentation.ts` file causes Next.js to try resolving these two packages, but fails, and results in:

- Laminar not being able to send traces. This is because unlike many other instrumentation libraries, Laminar is not intrusive and does not set its tracer provider globally (so that others, e.g. `@vercel/otel` can set theirs).
- Error messages (see below)

We have tried many different things to debug, including bundling Laminar differently, shipping those two packages within Laminar as `noExternal`, adding a separate entrypoint in our package for Next.js, but nothing seems to have worked.

The only thing that's worked was adding `@lmnr-ai/lmnr` in `serverExternalPackages` in
[next.config](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages).

## Summary

Add a subsection within the Next.js section that describes
