### PR TITLE
Add `codeExecution` support to google providers and more safely handle provider and user tools

### DIFF
--- a/.changeset/chilly-trainers-serve.md
+++ b/.changeset/chilly-trainers-serve.md
@@ -1,0 +1,6 @@
+---
+'ai-core-examples': patch
+'@ai-sdk/google': patch
+---
+
+Added codeExecution support for Google providers

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -132,6 +132,14 @@ The following optional settings are available for Google Generative AI models:
     - `BLOCK_ONLY_HIGH`
     - `BLOCK_NONE`
 
+- **useSearchGrounding** _boolean_
+
+  Optional. When enabled, the model will [use Google search to ground the response](https://ai.google.dev/gemini-api/docs/grounding).
+
+- **useCodeExecution** _boolean_
+
+  Optional. When enabled, the model will make use of a code execution tool that [enables the model to generate and run Python code](https://ai.google.dev/gemini-api/docs/code-execution).
+
 Further configuration can be done using Google Generative AI provider options. You can validate the provider options using the `GoogleGenerativeAIProviderOptions` type.
 
 ```ts
@@ -403,6 +411,116 @@ const { sources } = await generateText({
   prompt: 'List the top 5 San Francisco news from the past week.',
 });
 ```
+
+### Code Execution
+
+With [Code Execution](https://ai.google.dev/gemini-api/docs/code-execution), certain models can generate and execute Python code to perform calculations, solve problems, or provide more accurate information.
+
+To enable this feature, set `useCodeExecution: true` in the model settings:
+
+```ts highlight="4"
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+
+const { text, providerMetadata, ...rest } = await generateText({
+  model: google('gemini-2.5-pro-preview-05-06', {
+    // Ensure model supports Code Execution
+    useCodeExecution: true,
+  }),
+  prompt:
+    'Calculate the 20th Fibonacci number. Then find the nearest palindrome to it.',
+});
+
+console.log('Final Text:', text);
+
+// For detailed execution steps (non-streaming):
+const rawBody = rest.response?.body as any; // Use appropriate type if available
+const parts = rawBody?.candidates?.[0]?.content?.parts;
+if (parts && Array.isArray(parts)) {
+  parts.forEach((part, index) => {
+    if ('executableCode' in part && part.executableCode) {
+      console.log(`\nPart ${index + 1}: Executable Code`);
+      console.log('Language:', part.executableCode.language);
+      console.log('Code:\n', part.executableCode.code);
+    } else if ('codeExecutionResult' in part && part.codeExecutionResult) {
+      console.log(`\nPart ${index + 1}: Code Execution Result`);
+      console.log('Outcome:', part.codeExecutionResult.outcome);
+      console.log('Output:\n', part.codeExecutionResult.output);
+    } else if ('text' in part) {
+      // Regular text part
+      // console.log(`\nPart ${index + 1}: Text\n`, part.text);
+    }
+  });
+}
+```
+
+When Code Execution is enabled, the model's response might include sequences of `executableCode` and `codeExecutionResult` parts.
+
+- **`executableCode`**: Contains the `language` (e.g., "PYTHON") and the `code` that the model intends to run.
+- **`codeExecutionResult`**: Contains the `outcome` (e.g., "OUTCOME_OK") and the `output` from the executed code.
+
+#### Streaming Code Execution Details
+
+When using `streamText` with `useCodeExecution: true`, the steps of code generation and execution are surfaced as `text-delta` stream parts. You can identify them by their specific formatting:
+
+- An `executableCode` part from the API, indicating the code the model is about to run, is streamed as a `text-delta` event. The text will be formatted like:
+
+  ```
+  Executable Code (PYTHON):
+  # Python code to be executed
+  print(1 + 1)
+  ```
+
+- A `codeExecutionResult` part from the API, showing the outcome of the execution, is also streamed as a `text-delta` event. The text will be formatted like:
+  ```
+  Code Execution Result (Outcome: OUTCOME_OK):
+  # Output from the code execution
+  2
+  ```
+
+Here's an example of how you might process the stream:
+
+```ts
+import { google } from '@ai-sdk/google';
+import { streamText } from 'ai';
+
+async function main() {
+  const result = await streamText({
+    model: google('gemini-2.5-flash-preview-04-17', {
+      useCodeExecution: true,
+    }),
+    prompt: 'What is the square root of 256 plus 7?',
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'text-delta') {
+      // You can check the content of textDelta to identify
+      // executable code or results if needed for special handling.
+      if (part.textDelta.startsWith('Executable Code')) {
+        process.stdout.write(
+          `\n--- EXECUTABLE CODE ---\n${part.textDelta}\n-----------------------\n`,
+        );
+      } else if (part.textDelta.startsWith('Code Execution Result')) {
+        process.stdout.write(
+          `\n--- EXECUTION RESULT ---\n${part.textDelta}\n------------------------\n`,
+        );
+      } else {
+        process.stdout.write(part.textDelta);
+      }
+    }
+  }
+  console.log();
+}
+
+main();
+```
+
+<Note>
+  Code Execution capabilities and specific model support are subject to Google
+  Cloud's offerings. Always refer to the [official Google AI
+  documentation](https://ai.google.dev/gemini-api/docs/code-execution) for the
+  most current information on compatible models and features.
+</Note>
 
 ### Image Outputs
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -294,6 +294,10 @@ The following optional settings are available for Google Vertex models:
 
   Optional. When enabled, the model will [use Google search to ground the response](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview).
 
+- **useCodeExecution** _boolean_
+
+  Optional. When enabled, the model will make use of a code execution tool that enables the model to [generate and run Python code](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/code-execution).
+
 - **audioTimestamp** _boolean_
 
   Optional. Enables timestamp understanding for audio files. Defaults to false.
@@ -496,6 +500,112 @@ Example response excerpt:
 <Note>
   The Google Vertex provider does not yet support [dynamic retrieval mode and
   threshold](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/ground-gemini#dynamic-retrieval).
+</Note>
+
+#### Code Execution
+
+With [Code Execution](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/code-execution), certain Gemini models on Vertex AI can generate and execute Python code. This allows the model to perform calculations, data manipulation, and other programmatic tasks to enhance its responses.
+
+To enable this feature, set `useCodeExecution: true` in the model settings when creating the Vertex model instance:
+
+```ts highlight="4"
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText } from 'ai';
+
+const { text, providerMetadata, ...rest } = await generateText({
+  model: vertex('gemini-1.5-pro', {
+    // Ensure model supports Code Execution on Vertex
+    useCodeExecution: true,
+  }),
+  prompt: 'What is the result of 7 factorial divided by 3 factorial?',
+});
+
+console.log('Final Text:', text);
+
+// For detailed execution steps (non-streaming):
+const rawBody = rest.response?.body as any; // Use appropriate type if available
+const parts = rawBody?.candidates?.[0]?.content?.parts;
+if (parts && Array.isArray(parts)) {
+  parts.forEach((part, index) => {
+    if ('executableCode' in part && part.executableCode) {
+      console.log(`\nPart ${index + 1}: Executable Code`);
+      console.log('Language:', part.executableCode.language);
+      console.log('Code:\n', part.executableCode.code);
+    } else if ('codeExecutionResult' in part && part.codeExecutionResult) {
+      console.log(`\nPart ${index + 1}: Code Execution Result`);
+      console.log('Outcome:', part.codeExecutionResult.outcome);
+      console.log('Output:\n', part.codeExecutionResult.output);
+    }
+  });
+}
+```
+
+When Code Execution is active, the model's response (both in `generateText` and `streamText`) may include sequences of `executableCode` and `codeExecutionResult` parts within the raw content.
+
+- **`executableCode`**: Contains the `language` (typically "PYTHON") and the `code` the model generated and executed.
+- **`codeExecutionResult`**: Contains the `outcome` (e.g., "OUTCOME_OK") and the `output` from the code execution.
+
+##### Streaming Code Execution Details
+
+When using `streamText` with a Vertex model that has `useCodeExecution: true`, the code generation and execution steps are streamed as `text-delta` parts. You can identify them by their specific formatting:
+
+- An `executableCode` part from the API, indicating the code the model generated for execution, is streamed as a `text-delta` event. The text will be formatted like:
+
+  ```
+  Executable Code (PYTHON):
+  # Python code to be executed
+  print(5**3)
+  ```
+
+- A `codeExecutionResult` part from the API, showing the outcome of the execution, is also streamed as a `text-delta` event. The text will be formatted like:
+  ```
+  Code Execution Result (Outcome: OUTCOME_OK):
+  # Output from the code execution
+  125
+  ```
+
+Here's an example of how you might process the stream:
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { streamText } from 'ai';
+
+async function main() {
+  const result = await streamText({
+    model: vertex('gemini-2.5-flash-preview-04-17', {
+      useCodeExecution: true,
+    }),
+    prompt: 'Calculate 5 to the power of 3.',
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'text-delta') {
+      // You can check the content of textDelta to identify
+      // executable code or results if needed for special handling.
+      if (part.textDelta.startsWith('Executable Code')) {
+        process.stdout.write(
+          `\n--- EXECUTABLE CODE ---\n${part.textDelta}\n-----------------------\n`,
+        );
+      } else if (part.textDelta.startsWith('Code Execution Result')) {
+        process.stdout.write(
+          `\n--- EXECUTION RESULT ---\n${part.textDelta}\n------------------------\n`,
+        );
+      } else {
+        process.stdout.write(part.textDelta);
+      }
+    }
+  }
+  console.log();
+}
+
+main();
+```
+
+<Note>
+  Code Execution capabilities and specific model support on Vertex AI are
+  subject to Google Cloud's offerings. Always refer to the [official Vertex AI
+  documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/code-execution-api)
+  for the most current information on compatible models and features.
 </Note>
 
 ### Sources

--- a/examples/ai-core/src/generate-text/google-code-execution.ts
+++ b/examples/ai-core/src/generate-text/google-code-execution.ts
@@ -1,0 +1,41 @@
+import { google } from '@ai-sdk/google';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: google('gemini-2.5-flash-preview-04-17 ', {
+      useCodeExecution: true,
+      useSearchGrounding: true,
+    }),
+    maxTokens: 2048,
+    prompt:
+      'Calculate 20th fibonacci number. Then find the nearest palindrome to it.',
+  });
+
+  const parts = (result.response?.body as any)?.candidates?.[0]?.content?.parts;
+
+  if (parts && Array.isArray(parts)) {
+    parts.forEach((part, index) => {
+      if ('text' in part) {
+        console.log('\nType: Text');
+        console.log('Content:', part.text);
+      } else if ('executableCode' in part && part.executableCode) {
+        console.log('\nType: Executable Code');
+        console.log('Language:', part.executableCode.language);
+        console.log('Code:\n', part.executableCode.code);
+      } else if ('codeExecutionResult' in part && part.codeExecutionResult) {
+        console.log('\nType: Code Execution Result');
+        console.log('Outcome:', part.codeExecutionResult.outcome);
+        console.log('Output:\n', part.codeExecutionResult.output);
+      } else {
+        console.log('\nType: Unknown');
+        console.log(JSON.stringify(part, null, 2));
+      }
+    });
+  } else {
+    console.warn('Could not find parts');
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/google-vertex-code-execution.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-code-execution.ts
@@ -1,0 +1,38 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: vertex('gemini-2.5-pro-preview-05-06', { useCodeExecution: true }),
+    maxTokens: 65000,
+    prompt:
+      'Calculate 20th fibonacci number. Then find the nearest palindrome to it.',
+  });
+
+  const parts = (result.response?.body as any)?.candidates?.[0]?.content?.parts;
+
+  if (parts && Array.isArray(parts)) {
+    parts.forEach((part, index) => {
+      if ('text' in part) {
+        console.log('\nType: Text');
+        console.log('Content:', part.text);
+      } else if ('executableCode' in part && part.executableCode) {
+        console.log('\nType: Executable Code');
+        console.log('Language:', part.executableCode.language);
+        console.log('Code:\n', part.executableCode.code);
+      } else if ('codeExecutionResult' in part && part.codeExecutionResult) {
+        console.log('\nType: Code Execution Result');
+        console.log('Outcome:', part.codeExecutionResult.outcome);
+        console.log('Output:\n', part.codeExecutionResult.output);
+      } else {
+        console.log('\nType: Unknown');
+        console.log(JSON.stringify(part, null, 2));
+      }
+    });
+  } else {
+    console.warn('Could not find parts');
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/google-code-execution.ts
+++ b/examples/ai-core/src/stream-text/google-code-execution.ts
@@ -1,0 +1,33 @@
+import { google } from '@ai-sdk/google';
+import { streamText } from 'ai';
+
+async function main() {
+  const result = streamText({
+    model: google('gemini-2.5-flash-preview-04-17', { useCodeExecution: true }),
+    maxTokens: 10000,
+    prompt:
+      'Calculate 20th fibonacci number. Then find the nearest palindrome to it.',
+  });
+
+  let fullResponse = '';
+
+  for await (const delta of result.fullStream) {
+    switch (delta.type) {
+      case 'text-delta': {
+        fullResponse += delta.textDelta;
+        process.stdout.write(delta.textDelta);
+        break;
+      }
+    }
+  }
+  process.stdout.write('\n\n');
+
+  console.log();
+  console.log('Warnings:', await result.warnings);
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.log);

--- a/examples/ai-core/src/stream-text/google-vertex-code-execution.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-code-execution.ts
@@ -1,0 +1,33 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { streamText } from 'ai';
+
+async function main() {
+  const result = streamText({
+    model: vertex('gemini-2.5-flash-preview-04-17', { useCodeExecution: true }),
+    maxTokens: 10000,
+    prompt:
+      'Calculate 20th fibonacci number. Then find the nearest palindrome to it.',
+  });
+
+  let fullResponse = '';
+
+  for await (const delta of result.fullStream) {
+    switch (delta.type) {
+      case 'text-delta': {
+        fullResponse += delta.textDelta;
+        process.stdout.write(delta.textDelta);
+        break;
+      }
+    }
+  }
+  process.stdout.write('\n\n');
+
+  console.log();
+  console.log('Warnings:', await result.warnings);
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.log);

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -184,16 +184,12 @@ describe('doGenerate', () => {
   const TEST_URL_GEMINI_1_5_FLASH =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
 
-  const TEST_URL_GEMINI_2_5_FLASH_EXP =
-    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-04-17:generateContent';
-
   const server = createTestServer({
     [TEST_URL_GEMINI_PRO]: {},
     [TEST_URL_GEMINI_2_0_PRO]: {},
     [TEST_URL_GEMINI_2_0_FLASH_EXP]: {},
     [TEST_URL_GEMINI_1_0_PRO]: {},
     [TEST_URL_GEMINI_1_5_FLASH]: {},
-    [TEST_URL_GEMINI_2_5_FLASH_EXP]: {},
   });
 
   const prepareJsonResponse = ({
@@ -220,8 +216,7 @@ describe('doGenerate', () => {
       | typeof TEST_URL_GEMINI_2_0_PRO
       | typeof TEST_URL_GEMINI_2_0_FLASH_EXP
       | typeof TEST_URL_GEMINI_1_0_PRO
-      | typeof TEST_URL_GEMINI_1_5_FLASH
-      | typeof TEST_URL_GEMINI_2_5_FLASH_EXP;
+      | typeof TEST_URL_GEMINI_1_5_FLASH;
   }) => {
     server.urls[url].response = {
       type: 'json-value',
@@ -1494,220 +1489,6 @@ describe('doGenerate', () => {
             w.type === 'other' && w.message.startsWith(expectedWarningMessage),
         ),
       ).toBe(false);
-    });
-  });
-  describe('tests code execution tool option', () => {
-    const prepareJsonResponseWithParts = ({
-      parts,
-      usage = {
-        promptTokenCount: 1,
-        candidatesTokenCount: 2,
-        totalTokenCount: 3,
-      },
-      finishReason = 'STOP',
-      url = TEST_URL_GEMINI_2_5_FLASH_EXP,
-    }: {
-      parts: Array<any>;
-      usage?: {
-        promptTokenCount: number;
-        candidatesTokenCount: number;
-        totalTokenCount: number;
-      };
-      finishReason?: string;
-      url?: string;
-    }) => {
-      server.urls[TEST_URL_GEMINI_2_5_FLASH_EXP].response = {
-        type: 'json-value',
-        body: {
-          candidates: [
-            {
-              content: {
-                parts,
-                role: 'model',
-              },
-              finishReason,
-              index: 0,
-              safetyRatings: SAFETY_RATINGS,
-            },
-          ],
-          promptFeedback: { safetyRatings: SAFETY_RATINGS },
-          usageMetadata: usage,
-        },
-      };
-    };
-
-    it('should correctly parse response with executableCode and codeExecutionResult parts', async () => {
-      prepareJsonResponseWithParts({
-        parts: [
-          { text: 'Initial text. ' },
-          {
-            executableCode: {
-              language: 'PYTHON',
-              code: 'print("Hello from Python!")',
-            },
-          },
-          {
-            codeExecutionResult: {
-              outcome: 'OUTCOME_OK',
-              output: 'Hello from Python!\n',
-            },
-          },
-          { text: 'Follow-up text.' },
-        ],
-      });
-
-      const { text, toolCalls, reasoning, files } = await model.doGenerate({
-        inputFormat: 'prompt',
-        mode: { type: 'regular' },
-        prompt: TEST_PROMPT,
-      });
-
-      expect(text).toStrictEqual('Initial text. Follow-up text.');
-      expect(toolCalls).toBeUndefined();
-      expect(reasoning).toBeUndefined();
-      expect(files).toStrictEqual([]);
-    });
-
-    it('should produce undefined text if only code execution parts are present', async () => {
-      prepareJsonResponseWithParts({
-        parts: [
-          {
-            executableCode: {
-              language: 'PYTHON',
-              code: 'print(fib_20 = 6765)',
-            },
-          },
-          {
-            codeExecutionResult: {
-              outcome: 'OUTCOME_OK',
-              output: '', // No textual output from this specific execution
-            },
-          },
-        ],
-      });
-
-      const { text, toolCalls } = await model.doGenerate({
-        inputFormat: 'prompt',
-        mode: { type: 'regular' },
-        prompt: TEST_PROMPT,
-      });
-
-      expect(text).toBeUndefined();
-      expect(toolCalls).toBeUndefined();
-    });
-
-    it('should not interfere with standard functionCall parts', async () => {
-      prepareJsonResponseWithParts({
-        parts: [
-          { text: 'Thinking about using a tool. ' },
-          {
-            executableCode: { language: 'PYTHON', code: 'a = 1 + 1' },
-          },
-          {
-            codeExecutionResult: { outcome: 'OUTCOME_OK', output: '2' },
-          },
-          {
-            functionCall: {
-              name: 'user_tool_1',
-              args: { param: 'value' },
-            },
-          },
-          { text: 'Tool called.' },
-        ],
-      });
-
-      const { text, toolCalls } = await model.doGenerate({
-        inputFormat: 'prompt',
-        mode: {
-          type: 'regular',
-          tools: [
-            {
-              type: 'function',
-              name: 'user_tool_1',
-              parameters: { type: 'object', properties: {} },
-            },
-          ],
-        },
-        prompt: TEST_PROMPT,
-      });
-
-      expect(text).toStrictEqual('Thinking about using a tool. Tool called.');
-      expect(toolCalls).toEqual([
-        {
-          toolCallId: 'test-id',
-          toolCallType: 'function',
-          toolName: 'user_tool_1',
-          args: '{"param":"value"}',
-        },
-      ]);
-    });
-
-    it('should correctly extract reasoning parts alongside code execution parts', async () => {
-      prepareJsonResponseWithParts({
-        parts: [
-          { text: 'Initial text. ' },
-          { text: 'This is a thought.', thought: true },
-          {
-            executableCode: {
-              language: 'PYTHON',
-              code: 'print("Hello from Python!")',
-            },
-          },
-          { text: 'Another thought after code.', thought: true },
-          {
-            codeExecutionResult: {
-              outcome: 'OUTCOME_OK',
-              output: 'Hello from Python!\n',
-            },
-          },
-          { text: 'Follow-up text.' },
-        ],
-      });
-
-      const { text, reasoning } = await model.doGenerate({
-        inputFormat: 'prompt',
-        mode: { type: 'regular' },
-        prompt: TEST_PROMPT,
-      });
-
-      expect(text).toStrictEqual('Initial text. Follow-up text.');
-      expect(reasoning).toEqual([
-        { type: 'text', text: 'This is a thought.' },
-        { type: 'text', text: 'Another thought after code.' },
-      ]);
-    });
-
-    // Test case for when content is an empty object (e.g. MALFORMED_FUNCTION_CALL) to ensure the schema changes for parts don't break this.
-    it('should handle empty content object after schema changes for parts', async () => {
-      server.urls[TEST_URL_GEMINI_2_5_FLASH_EXP].response = {
-        type: 'json-value',
-        body: {
-          candidates: [
-            {
-              content: {}, // Empty content object
-              finishReason: 'MALFORMED_FUNCTION_CALL',
-              index: 0,
-              safetyRatings: SAFETY_RATINGS,
-            },
-          ],
-          promptFeedback: { safetyRatings: SAFETY_RATINGS },
-          usageMetadata: {
-            promptTokenCount: 1,
-            candidatesTokenCount: 0,
-            totalTokenCount: 1,
-          },
-        },
-      };
-
-      const { text, finishReason, toolCalls } = await model.doGenerate({
-        inputFormat: 'prompt',
-        mode: { type: 'regular' },
-        prompt: TEST_PROMPT,
-      });
-
-      expect(text).toBeUndefined();
-      expect(toolCalls).toBeUndefined();
-      expect(finishReason).toEqual('error'); // MALFORMED_FUNCTION_CALL should map to 'error'
     });
   });
 });

--- a/packages/google/src/google-generative-ai-settings.ts
+++ b/packages/google/src/google-generative-ai-settings.ts
@@ -101,6 +101,14 @@ Optional. Specifies the dynamic retrieval configuration.
 @see https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/ground-with-google-search#dynamic-retrieval
    */
   dynamicRetrievalConfig?: DynamicRetrievalConfig;
+  /**
+Optional. When enabled, the model will make use of a code execution tool that enables the model to generate and run Python code.
+
+@note Multi-tool usage with the code execution tool is only compatible with Flash experimental models
+
+@see https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/code-execution-api
+   */
+  useCodeExecution?: boolean;
 }
 
 export interface InternalGoogleGenerativeAISettings

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -49,6 +49,15 @@ export function prepareTools(
   const supportsDynamicRetrieval =
     modelId.includes('gemini-1.5-flash') && !modelId.includes('-8b');
 
+  // Throw error if both search grounding and user tools are present
+  if (useSearchGrounding && tools) {
+    throw new UnsupportedFunctionalityError({
+      functionality:
+        "Search grounding (useSearchGrounding: true) cannot be used in combination with user-defined tools. Please disable useSearchGrounding or remove your custom tools.",
+    });
+  }
+
+  // Search Grounding Only (no user tools)
   if (useSearchGrounding) {
     return {
       tools: isGemini2
@@ -64,6 +73,7 @@ export function prepareTools(
     };
   }
 
+  // No tools passed
   if (tools == null) {
     return { tools: undefined, toolConfig: undefined, toolWarnings };
   }


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The google and google-vertex providers would silently drop user defined tools when used in combination with `useSearchGrounding`. Using `useSearchGrounding` in combination with user defined tools is not supported. This change throws an error if that happens.

In addition, this change also adds support for the Code Execution feature in both the [Google Generative AI](https://ai.google.dev/gemini-api/docs/code-execution) and [Vertex](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/code-execution) providers.

## Summary

- Throw an error when tools are used in conjunction with `useSearchGrounding` and `useCodeExecution` on the Google Generative AI and thus Vertex providers
- Added logic to call the google defined `codeExecution` tool, and extract those as text parts.
- Added documentation to both providers regarding the `codeExecution` feature.

## Verification

I added examples for both the google and google-vertex providers and have tested the both of them.

I originally added tests for the code execution logic, but removed them in b75484bf because apparently the test url doesn't support the 2.5 models.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

I would more likely prefer that the `executableCode` part be treated as a tool-call, and the `codeExecutionResultPartSchema` be treated as the tool-result of that call, but i could not get that to function properly.

This is particularly difficult in a stream. The shape of both are the same regardless of whether it's being returned in a stream or in a generation.

Unit tests likely need to be added.

## Related Issues

Fixes #6302
Fixes #6219
