### PR TITLE
fix (telemetry): serialize UInt8Arrays as base64 for inner telemetry spans

### DIFF
--- a/.changeset/rotten-apples-attend.md
+++ b/.changeset/rotten-apples-attend.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Avoid JSON.strinfigy on UInt8Arrays for telemetry

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -35,6 +35,7 @@ import { GenerateObjectResult } from './generate-object-result';
 import { injectJsonInstruction } from './inject-json-instruction';
 import { getOutputStrategy } from './output-strategy';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
+import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -633,7 +634,7 @@ export async function generateObject<SCHEMA, RESULT>({
                     input: () => inputFormat,
                   },
                   'ai.prompt.messages': {
-                    input: () => JSON.stringify(promptMessages),
+                    input: () => stringifyForTelemetry(promptMessages),
                   },
                   'ai.settings.mode': mode,
 

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -53,6 +53,7 @@ import { injectJsonInstruction } from './inject-json-instruction';
 import { OutputStrategy, getOutputStrategy } from './output-strategy';
 import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
+import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -717,7 +718,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
                   input: () => callOptions.inputFormat,
                 },
                 'ai.prompt.messages': {
-                  input: () => JSON.stringify(callOptions.prompt),
+                  input: () => stringifyForTelemetry(callOptions.prompt),
                 },
                 'ai.settings.mode': mode,
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -36,6 +36,7 @@ import { ToolCallArray } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair';
 import { ToolResultArray } from './tool-result';
 import { ToolSet } from './tool-set';
+import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -371,7 +372,7 @@ A function that attempts to repair a tool call that failed to parse.
                 // prompt:
                 'ai.prompt.format': { input: () => promptFormat },
                 'ai.prompt.messages': {
-                  input: () => JSON.stringify(promptMessages),
+                  input: () => stringifyForTelemetry(promptMessages),
                 },
                 'ai.prompt.tools': {
                   // convert the language model level tools:

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -64,6 +64,7 @@ import { ToolCallUnion } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair';
 import { ToolResultUnion } from './tool-result';
 import { ToolSet } from './tool-set';
+import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -998,7 +999,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                     input: () => promptFormat,
                   },
                   'ai.prompt.messages': {
-                    input: () => JSON.stringify(promptMessages),
+                    input: () => stringifyForTelemetry(promptMessages),
                   },
                   'ai.prompt.tools': {
                     // convert the language model level tools:

--- a/packages/ai/core/prompt/stringify-for-telemetry.test.ts
+++ b/packages/ai/core/prompt/stringify-for-telemetry.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { stringifyForTelemetry } from './stringify-for-telemetry';
+import { LanguageModelV1Prompt } from '@ai-sdk/provider';
+
+describe('stringifyForTelemetry', () => {
+  it('should stringify a prompt with string content', () => {
+    const prompt: LanguageModelV1Prompt = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: [{ type: 'text', text: 'Hello!' }] },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    expect(result).toBe(JSON.stringify(prompt));
+  });
+
+  it('should stringify a prompt with text parts', () => {
+    const prompt: LanguageModelV1Prompt = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello!' }],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    expect(result).toBe(JSON.stringify(prompt));
+  });
+
+  it('should convert Uint8Array images to base64 strings', () => {
+    const imageData = new Uint8Array([1, 2, 3]);
+    // https://cryptii.com/pipes/binary-to-base64 with 010203 in hex format input
+    const base64Data = 'AQID';
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          { type: 'image', image: imageData },
+        ],
+      },
+    ];
+
+    const expected = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          { type: 'image', image: base64Data },
+        ],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    expect(result).toBe(JSON.stringify(expected));
+  });
+
+  it('should preserve the mime type and provider metadata', () => {
+    const imageData = new Uint8Array([1, 2, 3]);
+    // https://cryptii.com/pipes/binary-to-base64 with 010203 in hex format input
+    const base64Data = 'AQID';
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          {
+            type: 'image',
+            image: imageData,
+            mimeType: 'image/png',
+            providerMetadata: {
+              anthropic: {
+                key: 'value',
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const expected = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          {
+            type: 'image',
+            image: base64Data,
+            mimeType: 'image/png',
+            providerMetadata: {
+              anthropic: {
+                key: 'value',
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    expect(result).toBe(JSON.stringify(expected));
+  });
+
+  it('should keep URL images as is', () => {
+    const imageUrl = new URL('https://example.com/image.jpg');
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          { type: 'image', image: imageUrl },
+        ],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    // We expect the URL to be preserved as is
+    expect(JSON.parse(result)[0].content[1].image).toBe(imageUrl.toString());
+  });
+
+  it('should handle a mixed prompt with various content types', () => {
+    const imageData = new Uint8Array([1, 2, 3]);
+    // https://cryptii.com/pipes/binary-to-base64 with 010203 in hex format input
+    const base64Data = 'AQID';
+    const imageUrl = new URL('https://example.com/image.jpg');
+
+    const prompt: LanguageModelV1Prompt = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check these images:' },
+          { type: 'image', image: imageData },
+          { type: 'image', image: imageUrl },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I see the images!' }],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+    const parsed = JSON.parse(result);
+
+    expect(parsed[0]).toEqual(prompt[0]);
+    expect(parsed[1].content[0]).toEqual(prompt[1].content[0]);
+    expect(parsed[1].content[1].image).toBe(base64Data);
+    expect(parsed[1].content[2].image).toBe(imageUrl.toString());
+    expect(parsed[2]).toEqual(prompt[2]);
+  });
+});

--- a/packages/ai/core/prompt/stringify-for-telemetry.ts
+++ b/packages/ai/core/prompt/stringify-for-telemetry.ts
@@ -1,0 +1,54 @@
+/**
+ * Helper utility to serialize prompt content for OpenTelemetry tracing.
+ * It is initially created because normalized LanguageModelV1Prompt carries
+ * images as Uint8Arrays, on which JSON.stringify acts weirdly, converting
+ * them to objects with stringified indices as keys, e.g. {"0": 42, "1": 69 }.
+ */
+
+import {
+  LanguageModelV1ImagePart,
+  LanguageModelV1Message,
+  LanguageModelV1Prompt,
+  LanguageModelV1ProviderMetadata,
+} from '@ai-sdk/provider';
+import { convertDataContentToBase64String } from './data-content';
+
+export function stringifyForTelemetry(prompt: LanguageModelV1Prompt): string {
+  const processedPrompt = prompt.map((message: LanguageModelV1Message) => {
+    return {
+      ...message,
+      content:
+        typeof message.content === 'string'
+          ? message.content
+          : message.content.map(processPart),
+    };
+  });
+
+  return JSON.stringify(processedPrompt);
+}
+
+type MessageContentPart = Exclude<
+  LanguageModelV1Message['content'],
+  string
+>[number];
+type ProcessedMessageContentPart =
+  | Exclude<MessageContentPart, LanguageModelV1ImagePart>
+  | {
+      type: 'image';
+      image: string | URL;
+      mimeType?: string;
+      providerMetadata?: LanguageModelV1ProviderMetadata;
+    };
+
+function processPart(part: MessageContentPart): ProcessedMessageContentPart {
+  if (part.type === 'image') {
+    return {
+      ...part,
+      image:
+        part.image instanceof Uint8Array
+          ? convertDataContentToBase64String(part.image)
+          : part.image,
+    };
+  }
+  return part;
+}


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

`generateObject`, `generateText`, `streamText`, and `streamObject` currently call `JSON.stringify` on the input messages. If the input messages contain an image, it is most likely normalized into a `Uint8Array`.

`JSON.stringify` does not the most obvious things to TypedArrays including `Uint8Array`.

```javascript
// this returns '{"0": 1,"1": 2,"2": 3}', where I'd expect this to be '[1,2,3]'
JSON.stringify(new Uint8array([1, 2, 3]))
```

In practice, this results in bloating images by about 5-15x depending on the original image size. For Laminar, for example, a span with 3 avg sized images will not be able to be sent as it is larger than the (reasonably high) gRPC payload size for our traces endpoint.

From [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#examples):
```javascript
// TypedArray
JSON.stringify([new Int8Array([1]), new Int16Array([1]), new Int32Array([1])]);
// '[{"0":1},{"0":1},{"0":1}]'
JSON.stringify([
  new Uint8Array([1]),
  new Uint8ClampedArray([1]),
  new Uint16Array([1]),
  new Uint32Array([1]),
]);
// '[{"0":1},{"0":1},{"0":1},{"0":1}]'
JSON.stringify([new Float32Array([1]), new Float64Array([1])]);
// '[{"0":1},{"0":1}]'
```

## Summary

<!-- What did you change? -->

Added a function that maps over messages in a `LanguageModelV1Prompt` and maps over content parts in each message, replacing `UInt8Array`s with raw base64 strings instead.

Call this function when calling `recordSpan` for the inner (doStream/doGenerate) span in `generateObject`, `generateText`, `streamText`, and `streamObject`.

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->
Ran this small script against a local instance of Laminar and logged the Telemetry payloads (span attributes) on the backend to verify that they are indeed base64.

```javascript
import { Laminar, getTracer } from '@lmnr-ai/lmnr'

Laminar.initialize();

import { openai } from '@ai-sdk/openai'
import { generateText, generateObject, streamText, streamObject, tool } from "ai";
import { z } from "zod";
import dotenv from "dotenv";

dotenv.config();

const handle = async () => {
  const imageUrl = "https://upload.wikimedia.org/wikipedia/commons/b/bc/CoinEx.png"
  const imageData = await fetch(imageUrl)
    .then(response => response.arrayBuffer())
    .then(buffer => Buffer.from(buffer).toString('base64'));

  const o = streamObject({
    schema: z.object({
      text: z.string(),
      companyName: z.string().optional().nullable(),
    }),
    messages: [
      {
        role: "user",
        content: [
          {
            type: "text",
            text: "Describe this image briefly"
          },
          {
            type: "image",
            image: imageData,
            mimeType: "image/png"
          }
        ]
      }
    ],
    model: openai("gpt-4.1-nano"),
    experimental_telemetry: {
      isEnabled: true,
      tracer: getTracer()
    }
  });

  for await (const chunk of o.fullStream) {
    console.log(chunk);
  }
  await Laminar.shutdown();
};

handle().then((r) => {
    console.log(r);
});
```

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
    -  telemetry is experimental, so I reckon a doc update for this small fix is not required
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

Fixes #6210 
