### PR TITLE
v5-mirror: serialize UInt8Arrays as base64 for inner telemetry spans

### DIFF
--- a/.changeset/warm-eagles-play.md
+++ b/.changeset/warm-eagles-play.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Avoid JSON.strinfigy on Uint8Arrays for telemetry

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -36,6 +36,7 @@ import { LanguageModelUsage } from '../types/usage';
 import { GenerateObjectResult } from './generate-object-result';
 import { getOutputStrategy } from './output-strategy';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
+import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -322,7 +323,7 @@ Default and recommended: 'auto' (best mode for the model).
               }),
               ...baseTelemetryAttributes,
               'ai.prompt.messages': {
-                input: () => JSON.stringify(promptMessages),
+                input: () => stringifyForTelemetry(promptMessages),
               },
 
               // standardized gen-ai llm span attributes:

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -40,6 +40,7 @@ import { LanguageModelUsage } from '../types/usage';
 import { getOutputStrategy, OutputStrategy } from './output-strategy';
 import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
+import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -517,7 +518,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
                 }),
                 ...baseTelemetryAttributes,
                 'ai.prompt.messages': {
-                  input: () => JSON.stringify(callOptions.prompt),
+                  input: () => stringifyForTelemetry(callOptions.prompt),
                 },
 
                 // standardized gen-ai llm span attributes:

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -35,6 +35,7 @@ import { ToolCallArray } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair';
 import { ToolResultArray } from './tool-result';
 import { ToolSet } from './tool-set';
+import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -302,7 +303,7 @@ A function that attempts to repair a tool call that failed to parse.
                 'ai.model.id': stepModel.modelId,
                 // prompt:
                 'ai.prompt.messages': {
-                  input: () => JSON.stringify(promptMessages),
+                  input: () => stringifyForTelemetry(promptMessages),
                 },
                 'ai.prompt.tools': {
                   // convert the language model level tools:

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -64,6 +64,7 @@ import { ToolCallUnion } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair';
 import { ToolResultUnion } from './tool-result';
 import { ToolSet } from './tool-set';
+import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -848,7 +849,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                   }),
                   ...baseTelemetryAttributes,
                   'ai.prompt.messages': {
-                    input: () => JSON.stringify(promptMessages),
+                    input: () => stringifyForTelemetry(promptMessages),
                   },
                   'ai.prompt.tools': {
                     // convert the language model level tools:

--- a/packages/ai/core/prompt/stringify-for-telemetry.test.ts
+++ b/packages/ai/core/prompt/stringify-for-telemetry.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { stringifyForTelemetry } from './stringify-for-telemetry';
+import { LanguageModelV2Prompt } from '@ai-sdk/provider';
+
+describe('stringifyForTelemetry', () => {
+  it('should stringify a prompt with text parts', () => {
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello!' }],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    expect(result).toBe(JSON.stringify(prompt));
+  });
+
+  it('should convert Uint8Array images to base64 strings', () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0xff, 0xff]);
+    const base64Data = 'data:image/png;base64,iVBOR///';
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          { type: 'file', data: pngBytes, mediaType: 'image/png' },
+        ],
+      },
+    ];
+
+    const expected = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          { type: 'file', data: base64Data, mediaType: 'image/png' },
+        ],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    expect(result).toBe(JSON.stringify(expected));
+  });
+
+  it('should preserve the file name and provider options', () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0xff, 0xff]);
+    const base64Data = 'data:image/png;base64,iVBOR///';
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          {
+            type: 'file',
+            filename: 'image.png',
+            data: pngBytes,
+            mediaType: 'image/png',
+            providerOptions: {
+              anthropic: {
+                key: 'value',
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const expected = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          {
+            type: 'file',
+            filename: 'image.png',
+            data: base64Data,
+            mediaType: 'image/png',
+            providerOptions: {
+              anthropic: {
+                key: 'value',
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    expect(result).toBe(JSON.stringify(expected));
+  });
+
+  it('should keep URL images as is', () => {
+    const imageUrl = new URL('https://example.com/image.jpg');
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check this image:' },
+          { type: 'file', data: imageUrl, mediaType: 'image/jpeg' },
+        ],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+
+    expect(JSON.parse(result)[0].content[1].data).toBe(imageUrl.toString());
+  });
+
+  it('should handle a mixed prompt with various content types', () => {
+    const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0xff, 0xff]);
+    const base64Data = 'data:image/png;base64,iVBOR///';
+    const imageUrl = new URL('https://example.com/image.jpg');
+
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Check these images:' },
+          { type: 'file', data: imageData, mediaType: 'image/png' },
+          { type: 'file', data: imageUrl, mediaType: 'image/jpeg' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I see the images!' }],
+      },
+    ];
+
+    const result = stringifyForTelemetry(prompt);
+    const parsed = JSON.parse(result);
+
+    expect(parsed[0]).toEqual(prompt[0]);
+    expect(parsed[1].content[0]).toEqual(prompt[1].content[0]);
+    expect(parsed[1].content[1].data).toBe(base64Data);
+    expect(parsed[1].content[2].data).toBe(imageUrl.toString());
+    expect(parsed[2]).toEqual(prompt[2]);
+  });
+});

--- a/packages/ai/core/prompt/stringify-for-telemetry.ts
+++ b/packages/ai/core/prompt/stringify-for-telemetry.ts
@@ -1,0 +1,54 @@
+/**
+ * Helper utility to serialize prompt content for OpenTelemetry tracing.
+ * It is initially created because normalized LanguageModelV1Prompt carries
+ * images as Uint8Arrays, on which JSON.stringify acts weirdly, converting
+ * them to objects with stringified indices as keys, e.g. {"0": 42, "1": 69 }.
+ */
+
+import {
+  LanguageModelV2DataContent,
+  LanguageModelV2FilePart,
+  LanguageModelV2Message,
+  LanguageModelV2Prompt,
+} from '@ai-sdk/provider';
+import { convertDataContentToBase64String } from './data-content';
+
+export function stringifyForTelemetry(prompt: LanguageModelV2Prompt): string {
+  const processedPrompt = prompt.map((message: LanguageModelV2Message) => {
+    return {
+      ...message,
+      content:
+        typeof message.content === 'string'
+          ? message.content
+          : message.content.map(processPart),
+    };
+  });
+
+  return JSON.stringify(processedPrompt);
+}
+
+type MessageContentPart = Exclude<
+  LanguageModelV2Message['content'],
+  string
+>[number];
+
+type ProcessedFilePart = LanguageModelV2FilePart & {
+  data: Exclude<LanguageModelV2DataContent, Uint8Array>;
+};
+
+type ProcessedMessageContentPart =
+  | Exclude<MessageContentPart, LanguageModelV2FilePart>
+  | ProcessedFilePart;
+
+function processPart(part: MessageContentPart): ProcessedMessageContentPart {
+  if (part.type === 'file') {
+    return {
+      ...part,
+      data:
+        part.data instanceof Uint8Array
+          ? `data:${part.mediaType};base64,${convertDataContentToBase64String(part.data)}`
+          : part.data,
+    };
+  }
+  return part;
+}


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

### Clone of #6357 but for v5.

Description below is copy-pasted from there

<!-- Why was this change necessary? -->

`generateObject`, `generateText`, `streamText`, and `streamObject` currently call `JSON.stringify` on the input messages. If the input messages contain an image, it is most likely normalized into a `Uint8Array`.

`JSON.stringify` does not the most obvious things to TypedArrays including `Uint8Array`.

```javascript
// this returns '{"0": 1,"1": 2,"2": 3}', where I'd expect this to be '[1,2,3]'
JSON.stringify(new Uint8array([1, 2, 3]))
```

In practice, this results in bloating images by about 5-15x depending on the original image size. For Laminar, for example, a span with 3 avg sized images will not be able to be sent as it is larger than the (reasonably high) gRPC payload size for our traces endpoint.

From [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#examples):
```javascript
// TypedArray
JSON.stringify([new Int8Array([1]), new Int16Array([1]), new Int32Array([1])]);
// '[{"0":1},{"0":1},{"0":1}]'
JSON.stringify([
  new Uint8Array([1]),
  new Uint8ClampedArray([1]),
  new Uint16Array([1]),
  new Uint32Array([1]),
]);
// '[{"0":1},{"0":1},{"0":1},{"0":1}]'
JSON.stringify([new Float32Array([1]), new Float64Array([1])]);
// '[{"0":1},{"0":1}]'
```

## Summary

<!-- What did you change? -->

Added a function that maps over messages in a `LanguageModelV2Prompt` and maps over content parts in each message, replacing `Uint8Array`s with raw base64 strings instead.

Call this function when calling `recordSpan` for the inner (doStream/doGenerate) span in `generateObject`, `generateText`, `streamText`, and `streamObject`.

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->
Ran this small script against a local instance of Laminar and logged the Telemetry payloads (span attributes) on the backend to verify that they are indeed base64.

```javascript
import { Laminar, getTracer } from '@lmnr-ai/lmnr'

Laminar.initialize();

import { openai } from '@ai-sdk/openai'
import { generateText, generateObject, streamText, streamObject, tool } from "ai";
import { z } from "zod";
import dotenv from "dotenv";

dotenv.config();

const handle = async () => {
  const imageUrl = "https://upload.wikimedia.org/wikipedia/commons/b/bc/CoinEx.png"
  const imageData = await fetch(imageUrl)
    .then(response => response.arrayBuffer())
    .then(buffer => Buffer.from(buffer).toString('base64'));

  const o = streamObject({
    schema: z.object({
      text: z.string(),
      companyName: z.string().optional().nullable(),
    }),
    messages: [
      {
        role: "user",
        content: [
          {
            type: "text",
            text: "Describe this image briefly"
          },
          {
            type: "image",
            image: imageData,
            mimeType: "image/png"
          }
        ]
      }
    ],
    model: openai("gpt-4.1-nano"),
    experimental_telemetry: {
      isEnabled: true,
      tracer: getTracer()
    }
  });

  for await (const chunk of o.fullStream) {
    console.log(chunk);
  }
  await Laminar.shutdown();
};

handle().then((r) => {
    console.log(r);
});
```

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
    -  telemetry is experimental, so I reckon a doc update for this small fix is not required
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
    - The destination is not main, and v5 is now in alpha releases, so I wasn't sure of the procedure here
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

Fixes #6210 for v5
