### PR TITLE
chore: remove google fonts from examples

### DIFF
--- a/examples/next-langchain/app/layout.tsx
+++ b/examples/next-langchain/app/layout.tsx
@@ -1,7 +1,4 @@
 import './globals.css';
-import { Inter } from 'next/font/google';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
   title: 'Create Next App',
@@ -15,7 +12,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/examples/next-openai-kasada-bot-protection/app/layout.tsx
+++ b/examples/next-openai-kasada-bot-protection/app/layout.tsx
@@ -1,9 +1,6 @@
 import './globals.css';
-import { Inter } from 'next/font/google';
 import Toaster from './toaster';
 import { KasadaClient } from '@/kasada/kasada-client';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
   title: 'Create Next App',
@@ -19,7 +16,7 @@ export default function RootLayout({
     <html lang="en">
       <Toaster />
       <KasadaClient />
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/examples/next-openai-pages/pages/index.tsx
+++ b/examples/next-openai-pages/pages/index.tsx
@@ -1,7 +1,4 @@
-import { Inter } from 'next/font/google';
 import Link from 'next/link';
-
-const inter = Inter({ subsets: ['latin'] });
 
 const examples = [
   {
@@ -64,7 +61,7 @@ const examples = [
 
 export default function Home() {
   return (
-    <main className={`flex flex-col gap-2 p-2 ${inter.className}`}>
+    <main className={`flex flex-col gap-2 p-2`}>
       {examples.map((example, index) => (
         <Link key={example.link} className="flex flex-row" href={example.link}>
           <div className="w-8 text-zinc-400">{index + 1}.</div>

--- a/examples/next-openai-telemetry-sentry/app/layout.tsx
+++ b/examples/next-openai-telemetry-sentry/app/layout.tsx
@@ -1,7 +1,4 @@
 import './globals.css';
-import { Inter } from 'next/font/google';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
   title: 'AI SDK - Next.js OpenAI Examples',
@@ -15,7 +12,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/examples/next-openai-telemetry/app/layout.tsx
+++ b/examples/next-openai-telemetry/app/layout.tsx
@@ -1,7 +1,4 @@
 import './globals.css';
-import { Inter } from 'next/font/google';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
   title: 'AI SDK - Next.js OpenAI Examples',
@@ -15,7 +12,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/examples/next-openai-upstash-rate-limits/app/layout.tsx
+++ b/examples/next-openai-upstash-rate-limits/app/layout.tsx
@@ -1,8 +1,5 @@
 import './globals.css';
-import { Inter } from 'next/font/google';
 import Toaster from './toaster';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
   title: 'Create Next App',
@@ -17,7 +14,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <Toaster />
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/examples/next-openai/app/layout.tsx
+++ b/examples/next-openai/app/layout.tsx
@@ -1,7 +1,4 @@
 import './globals.css';
-import { Inter } from 'next/font/google';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
   title: 'AI SDK - Next.js OpenAI Examples',
@@ -15,7 +12,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Background

OpenAI Codex environment build failure caused by google fonts download.

## Summary

Remove google fonts from examples.
