### PR TITLE
feat add onParts support for chat API and processing functions

### DIFF
--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -392,6 +392,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
       api,
       extraMetadataRef,
       onResponse,
+      onParts,
       onFinish,
       onError,
       setError,
@@ -420,11 +421,12 @@ By default, it's set to 1, which means that only a single LLM call is made.
         headers,
         body,
         experimental_attachments = message.experimental_attachments,
+        experimental_attachmentGenerator,
       }: ChatRequestOptions = {},
     ) => {
-      const attachmentsForRequest = await prepareAttachmentsForRequest(
-        experimental_attachments,
-      );
+      const attachmentsForRequest = experimental_attachmentGenerator
+        ? await experimental_attachmentGenerator()
+        : await prepareAttachmentsForRequest(experimental_attachments);
 
       const messages = messagesRef.current.concat({
         ...message,
@@ -524,9 +526,9 @@ By default, it's set to 1, which means that only a single LLM call is made.
         };
       }
 
-      const attachmentsForRequest = await prepareAttachmentsForRequest(
-        options.experimental_attachments,
-      );
+      const attachmentsForRequest = options?.experimental_attachmentGenerator
+        ? await options.experimental_attachmentGenerator()
+        : await prepareAttachmentsForRequest(options.experimental_attachments);
 
       const messages = messagesRef.current.concat({
         id: generateId(),

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -127,6 +127,7 @@ export function useChat({
   streamProtocol = 'data',
   onResponse,
   onFinish,
+  onParts,
   onError,
   credentials,
   headers,
@@ -152,7 +153,7 @@ export function useChat({
     messages: UIMessage[];
     requestData?: JSONValue;
     requestBody?: object;
-  }) => unknown;
+  }) => Promise<unknown> | unknown;
 
   /**
 Custom throttle wait in ms for the chat messages and data updates.
@@ -298,12 +299,12 @@ By default, it's set to 1, which means that only a single LLM call is made.
 
         await callChatApi({
           api,
-          body: experimental_prepareRequestBody?.({
+          body: (await experimental_prepareRequestBody?.({
             id: chatId,
             messages: chatMessages,
             requestData: chatRequest.data,
             requestBody: chatRequest.body,
-          }) ?? {
+          })) ?? {
             id: chatId,
             messages: constructedMessagesPayload,
             data: chatRequest.data,
@@ -322,6 +323,7 @@ By default, it's set to 1, which means that only a single LLM call is made.
               throttledMutate(previousMessages, false);
             }
           },
+          onParts,
           onResponse,
           onUpdate({ message, data, replaceLastMessage }) {
             mutateStatus('streaming');

--- a/packages/ui-utils/src/call-chat-api.ts
+++ b/packages/ui-utils/src/call-chat-api.ts
@@ -114,9 +114,9 @@ export async function callChatApi({
         lastMessage,
         onToolCall,
         onParts,
-        onFinish({ message, finishReason, usage }) {
+        async onFinish({ message, finishReason, usage }) {
           if (onFinish && message != null) {
-            onFinish(message, { usage, finishReason });
+            await onFinish(message, { usage, finishReason });
           }
         },
         generateId,

--- a/packages/ui-utils/src/call-chat-api.ts
+++ b/packages/ui-utils/src/call-chat-api.ts
@@ -1,6 +1,12 @@
 import { processChatResponse } from './process-chat-response';
 import { processChatTextResponse } from './process-chat-text-response';
-import { IdGenerator, JSONValue, UIMessage, UseChatOptions } from './types';
+import {
+  IdGenerator,
+  JSONValue,
+  onParts,
+  UIMessage,
+  UseChatOptions,
+} from './types';
 
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => fetch;
@@ -13,6 +19,7 @@ export async function callChatApi({
   headers,
   abortController,
   restoreMessagesOnFailure,
+  onParts,
   onResponse,
   onUpdate,
   onFinish,
@@ -29,6 +36,7 @@ export async function callChatApi({
   headers: HeadersInit | undefined;
   abortController: (() => AbortController | null) | undefined;
   restoreMessagesOnFailure: () => void;
+  onParts?: onParts;
   onResponse: ((response: Response) => void | Promise<void>) | undefined;
   onUpdate: (options: {
     message: UIMessage;
@@ -105,6 +113,7 @@ export async function callChatApi({
         update: onUpdate,
         lastMessage,
         onToolCall,
+        onParts,
         onFinish({ message, finishReason, usage }) {
           if (onFinish && message != null) {
             onFinish(message, { usage, finishReason });

--- a/packages/ui-utils/src/process-chat-response.ts
+++ b/packages/ui-utils/src/process-chat-response.ts
@@ -39,7 +39,7 @@ export async function processChatResponse({
     message: UIMessage | undefined;
     finishReason: LanguageModelV1FinishReason;
     usage: LanguageModelUsage;
-  }) => void;
+  }) => void | Promise<void>;
   onParts?: onParts;
   generateId?: () => string;
   getCurrentDate?: () => Date;
@@ -395,5 +395,5 @@ export async function processChatResponse({
     },
   });
 
-  onFinish?.({ message, finishReason, usage });
+  await onFinish?.({ message, finishReason, usage });
 }

--- a/packages/ui-utils/src/process-chat-text-response.ts
+++ b/packages/ui-utils/src/process-chat-text-response.ts
@@ -46,7 +46,7 @@ export async function processChatTextResponse({
   });
 
   // in text mode, we don't have usage information or finish reason:
-  onFinish?.(resultMessage, {
+  await onFinish?.(resultMessage, {
     usage: { completionTokens: NaN, promptTokens: NaN, totalTokens: NaN },
     finishReason: 'unknown',
   });

--- a/packages/ui-utils/src/types.ts
+++ b/packages/ui-utils/src/types.ts
@@ -335,7 +335,7 @@ either synchronously or asynchronously.
       usage: LanguageModelUsage;
       finishReason: LanguageModelV1FinishReason;
     },
-  ) => void;
+  ) => void | Promise<void>;
 
   /**
    * Callback function to be called when an error is encountered.

--- a/packages/ui-utils/src/types.ts
+++ b/packages/ui-utils/src/types.ts
@@ -269,6 +269,8 @@ Additional data to be sent to the API endpoint.
    * Allow submitting an empty message. Defaults to `false`.
    */
   allowEmptySubmit?: boolean;
+
+  experimental_attachmentGenerator?: () => Promise<Attachment[]> | Attachment[];
 };
 
 export type UseChatOptions = {

--- a/packages/ui-utils/src/types.ts
+++ b/packages/ui-utils/src/types.ts
@@ -4,6 +4,7 @@ import {
 } from '@ai-sdk/provider';
 import { FetchFunction, ToolCall, ToolResult } from '@ai-sdk/provider-utils';
 import { LanguageModelUsage } from './duplicated/usage';
+import { DataStreamPartType } from './data-stream-parts';
 
 export * from './use-assistant-types';
 
@@ -388,6 +389,11 @@ Custom fetch implementation. You can use it as a middleware to intercept request
 or to provide a custom fetch implementation for e.g. testing.
     */
   fetch?: FetchFunction;
+
+  /**
+   * Callback function to be called when a part is received while streaming.
+   */
+  onParts?: onParts;
 };
 
 export type UseCompletionOptions = {
@@ -500,4 +506,10 @@ export type DataMessage = {
   id?: string; // optional id, implement if needed (e.g. for persistence)
   role: 'data';
   data: JSONValue; // application-specific data
+};
+
+export type onParts = {
+  onFilePart?: (
+    streamPart: (DataStreamPartType & { type: 'file' })['value'],
+  ) => Promise<FileUIPart> | FileUIPart;
 };


### PR DESCRIPTION
Currently this is made for my personal use. It's a hook for any transformation when each part of stream is recieved. Also made prepareBody support async functions. Currently only onFilePart is added and only on react.

Would this feature be appreciated? If so I can make a proper PR.