### PR TITLE
feat (google-vertex): Set `.providerMetaData` for image model responses

### DIFF
--- a/.changeset/fifty-shrimps-kick.md
+++ b/.changeset/fifty-shrimps-kick.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+feat (google-vertex): Set `.providerMetaData` for image model responses

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -666,6 +666,32 @@ The following provider options are available:
   parameter instead.
 </Note>
 
+Additional information about the images can be retrieved using Google Vertex meta data.
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { GoogleVertexImageProviderOptions } from '@ai-sdk/google-vertex';
+import { generateImage } from 'ai';
+
+const { image, providerMetadata } = await generateImage({
+  model: vertex.image('imagen-3.0-generate-002'),
+  prompt: 'A futuristic cityscape at sunset',
+  aspectRatio: '16:9',
+});
+
+console.log(
+  `Revised prompt: ${providerMetadata.vertex.images[0].revisedPrompt}`,
+);
+```
+
+The following provider meta data is available:
+
+- **revisedPrompt** _string_
+  The prompt that was used to generate the image
+
+- **contentType** _string_
+  The mime type of the image
+
 #### Model Capabilities
 
 | Model                          | Aspect Ratios             |

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -684,14 +684,6 @@ console.log(
 );
 ```
 
-The following provider meta data is available:
-
-- **revisedPrompt** _string_
-  The prompt that was used to generate the image
-
-- **contentType** _string_
-  The mime type of the image
-
 #### Model Capabilities
 
 | Model                          | Aspect Ratios             |

--- a/packages/google-vertex/src/google-vertex-image-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.test.ts
@@ -329,11 +329,9 @@ describe('GoogleVertexImageModel', () => {
       expect(result.providerMetadata?.vertex).toStrictEqual({
         images: [
           {
-            contentType: 'image/png',
             revisedPrompt: 'revised prompt 1',
           },
           {
-            contentType: 'image/png',
             revisedPrompt: 'revised prompt 2',
           },
         ],

--- a/packages/google-vertex/src/google-vertex-image-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.test.ts
@@ -27,8 +27,17 @@ describe('GoogleVertexImageModel', () => {
         headers,
         body: {
           predictions: [
-            { bytesBase64Encoded: 'base64-image-1' },
-            { bytesBase64Encoded: 'base64-image-2' },
+            {
+              mimeType: 'image/png',
+              prompt: 'revised prompt 1',
+              bytesBase64Encoded: 'base64-image-1',
+            },
+            {
+              mimeType: 'image/png',
+              prompt: 'revised prompt 2',
+              bytesBase64Encoded: 'base64-image-2',
+              someFutureField: 'some future value',
+            },
           ],
         },
       };
@@ -242,7 +251,7 @@ describe('GoogleVertexImageModel', () => {
         timestamp: testDate,
         modelId: 'imagen-3.0-generate-002',
         headers: {
-          'content-length': '97',
+          'content-length': '237',
           'content-type': 'application/json',
           'request-id': 'test-request-id',
           'x-goog-quota-remaining': '123',
@@ -302,6 +311,32 @@ describe('GoogleVertexImageModel', () => {
           personGeneration: 'allow_all',
           aspectRatio: '16:9',
         },
+      });
+    });
+
+    it('should return image meta data', async () => {
+      prepareJsonResponse();
+
+      const result = await model.doGenerate({
+        prompt,
+        n: 2,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata?.vertex).toStrictEqual({
+        images: [
+          {
+            contentType: 'image/png',
+            revisedPrompt: 'revised prompt 1',
+          },
+          {
+            contentType: 'image/png',
+            revisedPrompt: 'revised prompt 2',
+          },
+        ],
       });
     });
   });

--- a/packages/google-vertex/src/google-vertex-image-model.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.ts
@@ -104,14 +104,11 @@ export class GoogleVertexImageModel implements ImageModelV2 {
           images:
             response.predictions?.map(prediction => {
               const {
-                // normalize mime type property
-                mimeType: contentType,
                 // normalize revised prompt property
                 prompt: revisedPrompt,
               } = prediction;
 
               return {
-                contentType,
                 revisedPrompt,
               };
             }) ?? [],

--- a/packages/google-vertex/src/google-vertex-image-model.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.ts
@@ -91,13 +91,31 @@ export class GoogleVertexImageModel implements ImageModelV2 {
     return {
       images:
         response.predictions?.map(
-          (p: { bytesBase64Encoded: string }) => p.bytesBase64Encoded,
+          ({ bytesBase64Encoded }) => bytesBase64Encoded,
         ) ?? [],
       warnings,
       response: {
         timestamp: currentDate,
         modelId: this.modelId,
         headers: responseHeaders,
+      },
+      providerMetadata: {
+        vertex: {
+          images:
+            response.predictions?.map(prediction => {
+              const {
+                // normalize mime type property
+                mimeType: contentType,
+                // normalize revised prompt property
+                prompt: revisedPrompt,
+              } = prediction;
+
+              return {
+                contentType,
+                revisedPrompt,
+              };
+            }) ?? [],
+        },
       },
     };
   }
@@ -106,7 +124,15 @@ export class GoogleVertexImageModel implements ImageModelV2 {
 // minimal version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
 const vertexImageResponseSchema = z.object({
-  predictions: z.array(z.object({ bytesBase64Encoded: z.string() })).nullish(),
+  predictions: z
+    .array(
+      z.object({
+        bytesBase64Encoded: z.string(),
+        mimeType: z.string(),
+        prompt: z.string(),
+      }),
+    )
+    .nullish(),
 });
 
 const vertexImageProviderOptionsSchema = z.object({


### PR DESCRIPTION
## Background

Google's Vertex Image Models return extra information besides the images themselves. This pull request exposes that information as `.providerMetaData.vertex.*` on the `generateImage()` return object.

Example response

```js
{
    predictions: [
        {
            mimeType: "image/png",
            prompt: "A vibrant, high-contrast image ...",
            bytesBase64Encoded: "iVBORw...",
        },
    ]
}
```

## Summary

I updated the response schema for Vertex' Image Model API responses and set the `.providerMetaData` key to the return object of `GoogleVertexImageModel#doGenerate()`.

## Verification

I altered `examples/ai-core/src/generate-image/google-vertex.ts`

<img width="594" alt="image" src="https://github.com/user-attachments/assets/1c5b3b43-9914-4994-8af1-74dee5594ab3" />

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

Part of #6405