### PR TITLE
refactor: use `Object.fromEntries` instead of `.forEach()` for simplicity and performance

### DIFF
--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -97,10 +97,8 @@ describe('doStream', () => {
               value: JSON.parse(chunk),
             }));
         }
-        const headers: Record<string, string> = {};
-        response.headers.forEach((value, key) => {
-          headers[key] = value;
-        });
+        const headers = Object.fromEntries<string>([...response.headers]);
+
         return {
           responseHeaders: headers,
           value: new ReadableStream({

--- a/packages/amazon-bedrock/src/headers-utils.ts
+++ b/packages/amazon-bedrock/src/headers-utils.ts
@@ -30,12 +30,6 @@ export function extractHeaders(
  * @param headers - The Headers object to convert.
  * @returns A record of lowercase keys and values.
  */
-export function convertHeadersToRecord(
-  headers: Headers,
-): Record<string, string> {
-  const record: Record<string, string> = {};
-  headers.forEach((value, key) => {
-    record[key.toLowerCase()] = value;
-  });
-  return record;
+export function convertHeadersToRecord(headers: Headers) {
+  return Object.fromEntries<string>([...headers]);
 }

--- a/packages/provider-utils/src/extract-response-headers.ts
+++ b/packages/provider-utils/src/extract-response-headers.ts
@@ -4,12 +4,6 @@ Extracts the headers from a response object and returns them as a key-value obje
 @param response - The response object to extract headers from.
 @returns The headers as a key-value object.
 */
-export function extractResponseHeaders(
-  response: Response,
-): Record<string, string> {
-  const headers: Record<string, string> = {};
-  response.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-  return headers;
+export function extractResponseHeaders(response: Response) {
+  return Object.fromEntries<string>([...response.headers]);
 }

--- a/tools/tsconfig/ts-library.json
+++ b/tools/tsconfig/ts-library.json
@@ -5,6 +5,7 @@
     "compilerOptions": {
         "lib": [
             "dom",
+            "dom.iterable",
             "ES2018"
         ],
         "module": "ESNext",


### PR DESCRIPTION
## Summary

All modern JavaScript environments support `Object.fromEntries()` which is more efficient than doing the same with a `.forEach()` loop

[Benchmark](https://perf.link/#eyJpZCI6InRmamtpOWR3dXdwIiwidGl0bGUiOiIuZnJvbUVudHJpZXMgdnMgLmZvckVhY2giLCJiZWZvcmUiOiJsZXQgaGVhZGVycyA9IG5ldyBIZWFkZXJzKHtcbiAgXCJhY2Nlc3MtY29udHJvbC1hbGxvdy1vcmlnaW5cIjogXCIqXCIsXG4gIFwiYWx0LXN2Y1wiOiBcImgzPVxcXCI6NDQzXFxcIjsgbWE9ODY0MDBcIixcbiAgXCJjZi1jYWNoZS1zdGF0dXNcIjogXCJEWU5BTUlDXCIsXG4gIFwiY2YtcmF5XCI6IFwiOTQyZTYwYTIwZmIwOTc5ZS1MQVhcIixcbiAgY29ubmVjdGlvbjogXCJrZWVwLWFsaXZlXCIsXG4gIFwiY29udGVudC1sZW5ndGhcIjogXCIxMzQ4OTEzXCIsXG4gIFwiY29udGVudC10eXBlXCI6IFwiaW1hZ2UvcG5nXCIsXG4gIGRhdGU6IFwiVHVlLCAyMCBNYXkgMjAyNSAxOTo1Mjo1OSBHTVRcIixcbiAgXCJmaW5pc2gtcmVhc29uXCI6IFwiU1VDQ0VTU1wiLFxuICBcImZpcmV3b3Jrcy1taWRkbGV3YXJlLXZlcnNpb25cIjogXCJ2MlwiLFxuICBcImZpcmV3b3Jrcy1yZXF1ZXN0LWdlbmVyYXRpb24tbXNcIjogXCI3NTBcIixcbiAgXCJmaXJld29ya3MtcmVxdWVzdC1wb3N0cHJvY2Vzc2luZy1tc1wiOiBcIjM5OFwiLFxuICBcImZpcmV3b3Jrcy1yZXF1ZXN0LXByZXByb2Nlc3NpbmctbXNcIjogXCIxXCIsXG4gIFwiZmlyZXdvcmtzLXJlcXVlc3QtcXVldWVkLW1zXCI6IFwiMFwiLFxuICBcImZpcmV3b3Jrcy1yZXF1ZXN0LXJ1bnRpbWUtbXNcIjogXCIxMTUwXCIsXG4gIGlkOiBcIlwiLFxuICBzZWVkOiBcIjE2NzQ0MTk1NDZcIixcbiAgc2VydmVyOiBcImNsb3VkZmxhcmVcIixcbiAgXCJzZXJ2ZXItdGltaW5nXCI6IFwidG90YWw7ZHVyPTEyNzAuMDtkZXNjPVxcXCJUb3RhbCBSZXNwb25zZSBUaW1lXFxcIlwiLFxuICB2YXJ5OiBcIkFjY2VwdC1FbmNvZGluZ1wiLFxuICBcIngtYmlsbGluZy1pbmZvcm1hdGlvblwiOiBcIntcXFwibW9kZWxfbmFtZVxcXCI6IFxcXCJzdGFibGUtZGlmZnVzaW9uLXhsLTEwMjQtdjEtMFxcXCIsIFxcXCJudW1fc3RlcHNcXFwiOiAzMCwgXFxcIm51bV9zYW1wbGVzXFxcIjogMSwgXFxcImhlaWdodFxcXCI6IDEwMjQsIFxcXCJ3aWR0aFxcXCI6IDEwMjQsIFxcXCJjb250cm9sX25ldF9uYW1lXFxcIjogbnVsbH1cIixcbiAgXCJ4LWVudm95LXVwc3RyZWFtLXNlcnZpY2UtdGltZVwiOiBcIjExNTJcIixcbiAgXCJ4LWZpcmV3b3Jrcy1iaWxsaW5nLWlkZW1wb3RlbmN5LWlkXCI6IFwiMTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjU1NDQwMDAwXCIsXG4gIFwieC1sYXRlbnQtY29kZS11cmlcIjogXCJcIixcbn0pOyIsInRlc3RzIjpbeyJuYW1lIjoiT2JqZWN0LmZyb21FbnRyaWVzKCkiLCJjb2RlIjoiT2JqZWN0LmZyb21FbnRyaWVzKFsuLi5oZWFkZXJzXSk7IiwicnVucyI6WzYwMDAwLDU0MDAwLDI3MDAwLDE5MDAwLDEwMDAwMCw5MjAwMCw2OTAwMCwxNTUwMDAsMTI0MDAwLDE0NTAwMCw4MDAwLDEzODAwMCwxNDMwMDAsMTAwMCw1OTAwMCw2MTAwMCwyMTQwMDAsOTAwMCwzMDAwMCw0MDAwLDg1MDAwLDMxMDAwLDEwMDAsMTI0MDAwLDEwMDAwMCwxMDAwLDMyMDAwLDEyODAwMCwxMTAwMDAsMjMwMDAsOTIwMDAsMTM4MDAwLDUxMDAwLDcxMDAwLDE3MzAwMCw3NTAwMCwyMTAwMCw3OTAwMCw3MjAwMCw3MDAwMCwyNjAwMCwxMTYwMDAsNzEwMDAsODkwMDAsOTAwMDAsOTYwMDAsMzEwMDAsNzIwMDAsNzEwMDAsNzEwMDAsMTQ5MDAwLDk3MDAwLDEwMDAwLDEzMDAwMCw3MTAwMCwxMjQwMDAsMjEwMDAsMTc4MDAwLDEwMzAwMCw4NDAwMCwxNTUwMDAsOTkwMDAsMjE0MDAwLDE3OTAwMCwxODAwMCwxMzYwMDAsNjQwMDAsNDYwMDAsMTM0MDAwLDM5MDAwLDEyMTAwMCwxMDEwMDAsOTAwMDAsMjEwMDAsOTUwMDAsNTMwMDAsNzIwMDAsMzYwMDAsMTEzMDAwLDE5MTAwMCwxOTgwMDAsODgwMDAsMTMyMDAwLDEwODAwMCw4NDAwMCwxNTAwMCw3MDAwMCwyNzAwMCwyMDAwLDE4NDAwMCwxNDcwMDAsNzQwMDAsNTUwMDAsMTUwMDAsMjIxMDAwLDg0MDAwLDExMjAwMCwxNzMwMDAsMTIyMDAwLDE1NDAwMF0sIm9wcyI6ODczMTB9LHsibmFtZSI6Ii5mb3JFYWNoKCkiLCJjb2RlIjoiY29uc3QgaGVhZGVyc09iaiA9IHt9O1xuaGVhZGVycy5mb3JFYWNoKCh2YWx1ZSwga2V5KSA9PiB7XG4gIGhlYWRlcnNPYmpba2V5XSA9IHZhbHVlO1xufSk7IiwicnVucyI6WzQzMDAwLDkzMDAwLDc5MDAwLDEwMDAwLDY0MDAwLDQwMDAsNTIwMDAsOTkwMDAsMTEzMDAwLDEwNzAwMCwzOTAwMCw3ODAwMCw3NDAwMCw2MDAwLDM4MDAwLDI0MDAwLDE4MDAwMCw5MDAwLDIwMDAwLDEyNjAwMCwxMjAwMCwzNzAwMCwxMzIwMDAsNzMwMDAsNzMwMDAsNjMwMDAsMTQwMDAsODQwMDAsMTgwMDAsMzYwMDAsNTMwMDAsMTA3MDAwLDIxMDAwLDE0MDAwLDE2NDAwMCwzMjAwMCw0MjAwMCwxMTUwMDAsNTQwMDAsNjUwMDAsMjgwMDAsODMwMDAsMTQ4MDAwLDc5MDAwLDMxMDAwLDY2MDAwLDMyMDAwLDY0MDAwLDM5MDAwLDM3MDAwLDk5MDAwLDQwMDAwLDY2MDAwLDYzMDAwLDM5MDAwLDYxMDAwLDQyMDAwLDE0MDAwMCw0NDAwMCw2NDAwMCwxNDcwMDAsODcwMDAsMjAwMDAsMTQ3MDAwLDE1MTAwMCwxNDMwMDAsOTQwMDAsNzAwMCwxMTAwMDAsMzIwMDAsMTA2MDAwLDc3MDAwLDg2MDAwLDM1MDAwLDMzMDAwLDY0MDAwLDQzMDAwLDU0MDAwLDI2MDAwLDE0MTAwMCwxNzIwMDAsMjMwMDAsNzcwMDAsOTAwMDAsNjEwMDAsMjgwMDAsNDIwMDAsNTMwMDAsMTUzMDAwLDExNTAwMCw4NDAwMCw1OTAwMCw2NTAwMCwxNjEwMDAsMTY5MDAwLDQ4MDAwLDYwMDAsMTM3MDAwLDMyMDAwLDc3MDAwXSwib3BzIjo2OTg3MH1dLCJ1cGRhdGVkIjoiMjAyNS0wNS0yMVQwNDoxNzoyOS40MDZaIn0%3D)

<img width="826" alt="image" src="https://github.com/user-attachments/assets/ab09cb5e-066a-47ce-bf13-3e7059ab2ae4" />


## Verification

I ran the `./src/generate-image/google-vertex` example

## Tasks

- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

not applicable

- [ ] Tests have been added / updated (for bug fixes / features) 
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)