### PR TITLE
chore (ai): rename continueUntil to stopWhen. Rename maxSteps stop condition to stepCountIs.

### DIFF
--- a/.changeset/rude-bugs-run.md
+++ b/.changeset/rude-bugs-run.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): rename continueUntil to stopWhen. Rename maxSteps stop condition to stepCountIs.

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -165,12 +165,7 @@ import { generateText } from 'ai';
 
 const result = await generateText({
   // ...
-  experimental_prepareStep: async ({
-    model,
-    stepNumber,
-    stepCountIs,
-    steps,
-  }) => {
+  experimental_prepareStep: async ({ model, stepNumber, steps }) => {
     if (stepNumber === 0) {
       return {
         // use a different model for this step:

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -165,7 +165,12 @@ import { generateText } from 'ai';
 
 const result = await generateText({
   // ...
-  experimental_prepareStep: async ({ model, stepNumber, maxSteps, steps }) => {
+  experimental_prepareStep: async ({
+    model,
+    stepNumber,
+    stepCountIs,
+    steps,
+  }) => {
     if (stepNumber === 0) {
       return {
         // use a different model for this step:

--- a/examples/ai-core/src/complex/math-agent/agent-required-tool-choice.ts
+++ b/examples/ai-core/src/complex/math-agent/agent-required-tool-choice.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, maxSteps, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import 'dotenv/config';
 import * as mathjs from 'mathjs';
 import { z } from 'zod';
@@ -31,7 +31,7 @@ async function main() {
       }),
     },
     toolChoice: 'required',
-    continueUntil: maxSteps(10),
+    stopWhen: stepCountIs(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/ai-core/src/complex/math-agent/agent.ts
+++ b/examples/ai-core/src/complex/math-agent/agent.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, maxSteps, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import 'dotenv/config';
 import * as mathjs from 'mathjs';
 import { z } from 'zod';
@@ -16,7 +16,7 @@ async function main() {
         execute: async ({ expression }) => mathjs.evaluate(expression),
       }),
     },
-    continueUntil: maxSteps(10),
+    stopWhen: stepCountIs(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/ai-core/src/e2e/feature-test-suite.ts
+++ b/examples/ai-core/src/e2e/feature-test-suite.ts
@@ -11,7 +11,7 @@ import {
   experimental_generateImage as generateImage,
   generateObject,
   generateText,
-  maxSteps,
+  stepCountIs,
   streamObject,
   streamText,
 } from 'ai';
@@ -708,7 +708,7 @@ export function createFeatureTestSuite({
                       },
                     },
                   },
-                  continueUntil: maxSteps(10),
+                  stopWhen: stepCountIs(10),
                 });
 
                 expect(weatherCalls).toBe(1);

--- a/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
+++ b/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
@@ -153,7 +153,7 @@ const toolTests = (model: LanguageModelV2) => {
         },
         prompt:
           'How can I switch to dark mode? Take a look at the screen and tell me.',
-        continueUntil: maxSteps(5),
+        stopWhen: stepCountIs(5),
       });
 
       console.log(result.text);
@@ -185,7 +185,7 @@ README.md     build         data          node_modules  package.json  src       
           }),
         },
         prompt: 'List the files in my directory.',
-        continueUntil: maxSteps(2),
+        stopWhen: stepCountIs(2),
       });
 
       expect(result.text).toBeTruthy();
@@ -227,7 +227,7 @@ README.md     build         data          node_modules  package.json  src       
           }),
         },
         prompt: 'Update my README file to talk about AI.',
-        continueUntil: maxSteps(5),
+        stopWhen: stepCountIs(5),
       });
 
       expect(result.text).toBeTruthy();

--- a/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
+++ b/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
@@ -8,7 +8,7 @@ import {
   vertexAnthropic as vertexAnthropicEdge,
 } from '@ai-sdk/google-vertex/anthropic/edge';
 import { LanguageModelV2 } from '@ai-sdk/provider';
-import { APICallError, generateText, maxSteps } from 'ai';
+import { APICallError, generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 import fs from 'fs';
 import { describe, expect, it } from 'vitest';

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { ModelMessage, generateText, maxSteps } from 'ai';
+import { ModelMessage, generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { weatherTool } from '../tools/weather-tool';

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning-chatbot.ts
@@ -21,7 +21,7 @@ async function main() {
       tools: { weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
       messages,
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       providerOptions: {
         bedrock: {
           reasoningConfig: { type: 'enabled', budgetTokens: 2048 },

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning.ts
@@ -13,7 +13,7 @@ async function main() {
       },
     },
     maxRetries: 0,
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log('Reasoning:');

--- a/examples/ai-core/src/generate-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-reasoning.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {

--- a/examples/ai-core/src/generate-text/amazon-bedrock-tool-call-image-result.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-tool-call-image-result.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText, maxSteps, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -40,7 +40,7 @@ async function main() {
         },
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-bash.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-bash.ts
@@ -22,7 +22,7 @@ async function main() {
       }),
     },
     prompt: 'List the files in my home directory.',
-    continueUntil: maxSteps(2),
+    stopWhen: stepCountIs(2),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-bash.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-bash.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-computer.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-computer.ts
@@ -42,7 +42,7 @@ async function main() {
     },
     prompt:
       'How can I switch to dark mode? Take a look at the screen and tell me.',
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-computer.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-computer.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 import fs from 'node:fs';
 

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-editor-cache-control.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-editor-cache-control.ts
@@ -45,7 +45,7 @@ This is a test file.
         },
       },
     ],
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-editor-cache-control.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-editor-cache-control.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-editor.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-editor.ts
@@ -35,7 +35,7 @@ This is a test file.
       }),
     },
     prompt: 'Update my README file to talk about AI.',
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-editor.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-editor.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {

--- a/examples/ai-core/src/generate-text/anthropic-reasoning-chatbot.ts
+++ b/examples/ai-core/src/generate-text/anthropic-reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { createAnthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { ModelMessage, generateText, maxSteps } from 'ai';
+import { ModelMessage, generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { weatherTool } from '../tools/weather-tool';

--- a/examples/ai-core/src/generate-text/anthropic-reasoning-chatbot.ts
+++ b/examples/ai-core/src/generate-text/anthropic-reasoning-chatbot.ts
@@ -33,7 +33,7 @@ async function main() {
       tools: { weatherTool },
       system: `You are a helpful, respectful and honest assistant.`,
       messages,
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       providerOptions: {
         anthropic: {
           thinking: { type: 'enabled', budgetTokens: 12000 },

--- a/examples/ai-core/src/generate-text/google-multi-step.ts
+++ b/examples/ai-core/src/generate-text/google-multi-step.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { generateText, maxSteps, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -28,7 +28,7 @@ async function main() {
         }),
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     // prompt: 'What is the weather in my current location?',
     prompt: 'What is the weather in Paris?',
   });

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-bash.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-bash.ts
@@ -22,7 +22,7 @@ async function main() {
       }),
     },
     prompt: 'List the files in my home directory.',
-    continueUntil: maxSteps(2),
+    stopWhen: stepCountIs(2),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-bash.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-bash.ts
@@ -1,5 +1,5 @@
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-computer.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-computer.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import fs from 'node:fs';
 
 async function main() {

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-computer.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-computer.ts
@@ -42,7 +42,7 @@ async function main() {
     },
     prompt:
       'How can I switch to dark mode? Take a look at the screen and tell me.',
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor-cache-control.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor-cache-control.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 
 async function main() {
   let editorContent = `

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor-cache-control.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor-cache-control.ts
@@ -45,7 +45,7 @@ This is a test file.
         },
       },
     ],
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor.ts
@@ -35,7 +35,7 @@ This is a test file.
       }),
     },
     prompt: 'Update my README file to talk about AI.',
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log('TEXT', result.text);

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-editor.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { generateText, maxSteps } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 
 async function main() {
   let editorContent = `

--- a/examples/ai-core/src/generate-text/google-vertex-multi-step.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-multi-step.ts
@@ -1,5 +1,5 @@
 import { vertex } from '@ai-sdk/google-vertex';
-import { generateText, maxSteps, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -28,7 +28,7 @@ async function main() {
         }),
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     // prompt: 'What is the weather in my current location?',
     prompt: 'What is the weather in Paris?',
   });

--- a/examples/ai-core/src/generate-text/google-vertex-tool-call.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-tool-call.ts
@@ -1,5 +1,5 @@
 import { vertex } from '@ai-sdk/google-vertex';
-import { generateText, maxSteps, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -22,7 +22,7 @@ async function main() {
         },
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   console.log(text);

--- a/examples/ai-core/src/generate-text/openai-active-tools.ts
+++ b/examples/ai-core/src/generate-text/openai-active-tools.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, maxSteps, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { weatherTool } from '../tools/weather-tool';
@@ -14,7 +14,7 @@ async function main() {
       }),
     },
     experimental_activeTools: [], // disable all tools
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     prompt:
       'What is the weather in San Francisco and what attractions should I visit?',
   });

--- a/examples/ai-core/src/generate-text/openai-multi-step.ts
+++ b/examples/ai-core/src/generate-text/openai-multi-step.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, maxSteps, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -28,7 +28,7 @@ async function main() {
         }),
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     prompt: 'What is the weather in my current location?',
 
     onStepFinish: step => {

--- a/examples/ai-core/src/generate-text/openai-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-output-object.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, maxSteps, Output, tool } from 'ai';
+import { generateText, stepCountIs, Output, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -25,7 +25,7 @@ async function main() {
         temperature: z.number(),
       }),
     }),
-    continueUntil: maxSteps(2),
+    stopWhen: stepCountIs(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-core/src/generate-text/openai-responses-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-output-object.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, maxSteps, Output, tool } from 'ai';
+import { generateText, stepCountIs, Output, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -25,7 +25,7 @@ async function main() {
         temperature: z.number(),
       }),
     }),
-    continueUntil: maxSteps(2),
+    stopWhen: stepCountIs(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-chatbot.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-chatbot.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -33,7 +33,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { maxSteps, streamText, ToolCallPart, ToolResultPart } from 'ai';
+import { stepCountIs, streamText, ToolCallPart, ToolResultPart } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 import { weatherTool } from '../tools/weather-tool';
@@ -14,7 +14,7 @@ async function main() {
       },
     },
     prompt: 'What is the weather in San Francisco?',
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   let enteredReasoning = false;

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -46,7 +46,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       maxRetries: 0,
       providerOptions: {
         bedrock: {

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { maxSteps, streamText, ToolCallPart, ToolResultPart } from 'ai';
+import { stepCountIs, streamText, ToolCallPart, ToolResultPart } from 'ai';
 import 'dotenv/config';
 import { weatherTool } from '../tools/weather-tool';
 
@@ -15,7 +15,7 @@ async function main() {
         reasoningConfig: { type: 'enabled', budgetTokens: 1024 },
       },
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     maxRetries: 5,
   });
 

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
@@ -1,5 +1,5 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { maxSteps, streamText } from 'ai';
+import { stepCountIs, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -16,7 +16,7 @@ async function main() {
       },
     },
     maxRetries: 0,
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-core/src/stream-text/anthropic-chatbot.ts
+++ b/examples/ai-core/src/stream-text/anthropic-chatbot.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -33,7 +33,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-chatbot.ts
@@ -1,5 +1,5 @@
 import { AnthropicProviderOptions, createAnthropic } from '@ai-sdk/anthropic';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -46,7 +46,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       maxRetries: 0,
       providerOptions: {
         anthropic: {

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
@@ -1,7 +1,7 @@
 import { anthropic } from '@ai-sdk/anthropic';
 import {
   extractReasoningMiddleware,
-  maxSteps,
+  stepCountIs,
   streamText,
   ToolCallPart,
   ToolResultPart,
@@ -29,7 +29,7 @@ async function main() {
       weather: weatherTool,
     },
     prompt: 'What is the weather in San Francisco?',
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
   });
 
   let enteredReasoning = false;

--- a/examples/ai-core/src/stream-text/cohere-chatbot.ts
+++ b/examples/ai-core/src/stream-text/cohere-chatbot.ts
@@ -1,5 +1,5 @@
 import { cohere } from '@ai-sdk/cohere';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -31,7 +31,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/google-chatbot.ts
+++ b/examples/ai-core/src/stream-text/google-chatbot.ts
@@ -1,5 +1,5 @@
 import { google } from '@ai-sdk/google';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -31,7 +31,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/google-vertex-anthropic-chatbot.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-anthropic-chatbot.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 
@@ -33,7 +33,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/mistral-chatbot.ts
+++ b/examples/ai-core/src/stream-text/mistral-chatbot.ts
@@ -1,5 +1,5 @@
 import { mistral } from '@ai-sdk/mistral';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -37,7 +37,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/openai-chatbot.ts
+++ b/examples/ai-core/src/stream-text/openai-chatbot.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -31,7 +31,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/openai-multi-step.ts
+++ b/examples/ai-core/src/stream-text/openai-multi-step.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -28,7 +28,7 @@ async function main() {
         }),
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     prompt: 'What is the weather in my current location?',
 
     onStepFinish: step => {

--- a/examples/ai-core/src/stream-text/openai-on-finish-response-messages.ts
+++ b/examples/ai-core/src/stream-text/openai-on-finish-response-messages.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -15,7 +15,7 @@ async function main() {
         }),
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     onFinish({ response }) {
       console.log(JSON.stringify(response.messages, null, 2));
     },

--- a/examples/ai-core/src/stream-text/openai-on-finish-steps.ts
+++ b/examples/ai-core/src/stream-text/openai-on-finish-steps.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -15,7 +15,7 @@ async function main() {
         }),
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     onFinish({ steps }) {
       console.log(JSON.stringify(steps, null, 2));
     },

--- a/examples/ai-core/src/stream-text/openai-on-step-finish.ts
+++ b/examples/ai-core/src/stream-text/openai-on-step-finish.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -15,7 +15,7 @@ async function main() {
         }),
       }),
     },
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     onStepFinish(step) {
       console.log(JSON.stringify(step, null, 2));
     },

--- a/examples/ai-core/src/stream-text/openai-output-object.ts
+++ b/examples/ai-core/src/stream-text/openai-output-object.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, Output, streamText, tool } from 'ai';
+import { stepCountIs, Output, streamText, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -30,7 +30,7 @@ async function main() {
         ),
       }),
     }),
-    continueUntil: maxSteps(2),
+    stopWhen: stepCountIs(2),
     prompt:
       'What is the weather and the main tourist attraction in San Francisco, London Paris, and Berlin?',
   });

--- a/examples/ai-core/src/stream-text/openai-responses-chatbot.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-chatbot.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -33,7 +33,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/openai-responses-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-tool-call.ts
@@ -1,13 +1,13 @@
 import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
 import 'dotenv/config';
 import { weatherTool } from '../tools/weather-tool';
-import { maxSteps, streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 async function main() {
   const result = streamText({
     model: openai.responses('gpt-4o-mini'),
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     tools: {
       currentLocation: tool({
         description: 'Get the current location.',

--- a/examples/ai-core/src/stream-text/openai-tool-abort.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-abort.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -8,7 +8,7 @@ async function main() {
 
   const result = streamText({
     model: openai('gpt-4o'),
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     tools: {
       currentLocation: tool({
         description: 'Get the weather in a location',

--- a/examples/ai-core/src/stream-text/openai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call.ts
@@ -1,13 +1,13 @@
 import { openai } from '@ai-sdk/openai';
 import 'dotenv/config';
 import { weatherTool } from '../tools/weather-tool';
-import { maxSteps, streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 async function main() {
   const result = streamText({
     model: openai('gpt-4-turbo'),
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     tools: {
       currentLocation: tool({
         description: 'Get the current location.',

--- a/examples/ai-core/src/stream-text/openai-web-search-tool.ts
+++ b/examples/ai-core/src/stream-text/openai-web-search-tool.ts
@@ -1,11 +1,11 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, streamText } from 'ai';
+import { stepCountIs, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
   const result = streamText({
     model: openai.responses('gpt-4o-mini'),
-    continueUntil: maxSteps(5),
+    stopWhen: stepCountIs(5),
     tools: {
       web_search_preview: openai.tools.webSearchPreview({
         searchContextSize: 'high',

--- a/examples/ai-core/src/stream-text/xai-chatbot.ts
+++ b/examples/ai-core/src/stream-text/xai-chatbot.ts
@@ -1,5 +1,5 @@
 import { xai } from '@ai-sdk/xai';
-import { maxSteps, ModelMessage, streamText, tool } from 'ai';
+import { stepCountIs, ModelMessage, streamText, tool } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
@@ -33,7 +33,7 @@ async function main() {
           }),
         }),
       },
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       messages,
     });
 

--- a/examples/mcp/src/http/client.ts
+++ b/examples/mcp/src/http/client.ts
@@ -18,7 +18,7 @@ async function main() {
     const { text: answer } = await generateText({
       model: openai('gpt-4o-mini'),
       tools,
-      continueUntil: maxSteps(10),
+      stopWhen: stepCountIs(10),
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },

--- a/examples/mcp/src/http/client.ts
+++ b/examples/mcp/src/http/client.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { experimental_createMCPClient, generateText, maxSteps } from 'ai';
+import { experimental_createMCPClient, generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {

--- a/examples/mcp/src/sse/client.ts
+++ b/examples/mcp/src/sse/client.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_createMCPClient, generateText, maxSteps } from 'ai';
+import { experimental_createMCPClient, generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {

--- a/examples/mcp/src/sse/client.ts
+++ b/examples/mcp/src/sse/client.ts
@@ -18,7 +18,7 @@ async function main() {
   const { text: answer } = await generateText({
     model: openai('gpt-4o-mini'),
     tools,
-    continueUntil: maxSteps(10),
+    stopWhen: stepCountIs(10),
     onStepFinish: async ({ toolResults }) => {
       console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
     },

--- a/examples/mcp/src/stdio/client.ts
+++ b/examples/mcp/src/stdio/client.ts
@@ -31,7 +31,7 @@ async function main() {
           },
         },
       }),
-      continueUntil: maxSteps(10),
+      stopWhen: stepCountIs(10),
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },

--- a/examples/mcp/src/stdio/client.ts
+++ b/examples/mcp/src/stdio/client.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { experimental_createMCPClient, generateText, maxSteps } from 'ai';
+import { experimental_createMCPClient, generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 

--- a/examples/next-openai/app/api/mcp-zapier/route.ts
+++ b/examples/next-openai/app/api/mcp-zapier/route.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { experimental_createMCPClient, maxSteps, streamText } from 'ai';
+import { experimental_createMCPClient, stepCountIs, streamText } from 'ai';
 
 export const maxDuration = 30;
 
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
       onFinish: async () => {
         await mcpClient.close();
       },
-      continueUntil: maxSteps(10),
+      stopWhen: stepCountIs(10),
     });
 
     return result.toUIMessageStreamResponse();

--- a/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
+++ b/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
@@ -4,7 +4,7 @@ import {
   convertToModelMessages,
   createUIMessageStream,
   createUIMessageStreamResponse,
-  maxSteps,
+  stepCountIs,
   streamText,
 } from 'ai';
 import { z } from 'zod';
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
     execute: writer => {
       const result = streamText({
         model: openai('gpt-4o'),
-        continueUntil: maxSteps(2),
+        stopWhen: stepCountIs(2),
         tools: {
           weather: {
             description: 'Get the weather in a city',

--- a/examples/next-openai/app/api/use-chat-reasoning-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-reasoning-tools/route.ts
@@ -3,7 +3,7 @@ import { fireworks } from '@ai-sdk/fireworks';
 import {
   convertToModelMessages,
   extractReasoningMiddleware,
-  maxSteps,
+  stepCountIs,
   streamText,
   tool,
   wrapLanguageModel,
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
     }),
     messages: convertToModelMessages(messages),
     toolCallStreaming: true,
-    continueUntil: maxSteps(5), // multi-steps for server-side tools
+    stopWhen: stepCountIs(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:
       getWeatherInformation: tool({

--- a/examples/next-openai/app/api/use-chat-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-tools/route.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { convertToModelMessages, maxSteps, streamText, tool } from 'ai';
+import { convertToModelMessages, stepCountIs, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 // Allow streaming responses up to 30 seconds
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
     // model: anthropic('claude-3-5-sonnet-latest'),
     messages: convertToModelMessages(messages),
     toolCallStreaming: true,
-    continueUntil: maxSteps(5), // multi-steps for server-side tools
+    stopWhen: stepCountIs(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:
       getWeatherInformation: tool({

--- a/examples/next-openai/app/api/use-completion-server-side-multi-step/route.ts
+++ b/examples/next-openai/app/api/use-completion-server-side-multi-step/route.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { maxSteps, streamText, tool } from 'ai';
+import { stepCountIs, streamText, tool } from 'ai';
 import { z } from 'zod';
 
 // Allow streaming responses up to 60 seconds
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
         }),
       }),
     },
-    continueUntil: maxSteps(4),
+    stopWhen: stepCountIs(4),
     prompt,
   });
 

--- a/examples/next-openai/app/mcp/chat/route.ts
+++ b/examples/next-openai/app/mcp/chat/route.ts
@@ -3,7 +3,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import {
   convertToModelMessages,
   experimental_createMCPClient,
-  maxSteps,
+  stepCountIs,
   streamText,
 } from 'ai';
 
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     const result = streamText({
       model: openai('gpt-4o-mini'),
       tools,
-      continueUntil: maxSteps(5),
+      stopWhen: stepCountIs(5),
       onStepFinish: async ({ toolResults }) => {
         console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
       },

--- a/examples/nuxt-openai/server/api/use-chat-tools.ts
+++ b/examples/nuxt-openai/server/api/use-chat-tools.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai';
-import { maxSteps, streamText } from 'ai';
+import { stepCountIs, streamText } from 'ai';
 import { z } from 'zod';
 
 export default defineLazyEventHandler(async () => {
@@ -14,7 +14,7 @@ export default defineLazyEventHandler(async () => {
       model: openai('gpt-4o'),
       messages,
       toolCallStreaming: true,
-      continueUntil: maxSteps(5), // multi-steps for server-side tools
+      stopWhen: stepCountIs(5), // multi-steps for server-side tools
       tools: {
         // server-side tool with execute function:
         getWeatherInformation: {

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -3,7 +3,7 @@ import { jsonSchema } from '@ai-sdk/provider-utils';
 import { mockId } from '@ai-sdk/provider-utils/test';
 import assert from 'node:assert';
 import { z } from 'zod';
-import { maxSteps, Output } from '.';
+import { stepCountIs, Output } from '.';
 import { ToolExecutionError } from '../../src/error/tool-execution-error';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
 import { MockTracer } from '../test/mock-tracer';
@@ -735,7 +735,7 @@ describe('options.maxSteps', () => {
           }),
         },
         prompt: 'test-input',
-        continueUntil: maxSteps(3),
+        stopWhen: stepCountIs(3),
         onStepFinish: async event => {
           onStepFinishResults.push(event);
         },
@@ -936,7 +936,7 @@ describe('options.maxSteps', () => {
           }),
         },
         prompt: 'test-input',
-        continueUntil: maxSteps(3),
+        stopWhen: stepCountIs(3),
         onStepFinish: async event => {
           onStepFinishResults.push(event);
         },

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -29,7 +29,7 @@ import { Output } from './output';
 import { parseToolCall } from './parse-tool-call';
 import { ResponseMessage } from './response-message';
 import { DefaultStepResult, StepResult } from './step-result';
-import { maxSteps, StopCondition } from './stop-condition';
+import { stepCountIs, StopCondition } from './stop-condition';
 import { toResponseMessages } from './to-response-messages';
 import { ToolCallArray } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair';
@@ -110,7 +110,7 @@ export async function generateText<
   maxRetries: maxRetriesArg,
   abortSignal,
   headers,
-  continueUntil = maxSteps(1),
+  stopWhen = stepCountIs(1),
   experimental_output: output,
   experimental_telemetry: telemetry,
   providerOptions,
@@ -140,7 +140,7 @@ The tool choice strategy. Default: 'auto'.
      */
     toolChoice?: ToolChoice<NoInfer<TOOLS>>;
 
-    continueUntil?: StopCondition<NoInfer<TOOLS>>;
+    stopWhen?: StopCondition<NoInfer<TOOLS>>;
 
     /**
 Optional telemetry configuration (experimental).
@@ -459,7 +459,7 @@ A function that attempts to repair a tool call that failed to parse.
         // all current tool calls have results:
         currentToolResults.length === currentToolCalls.length &&
         // continue until the stop condition is met:
-        !(await continueUntil({ steps }))
+        !(await stopWhen({ steps }))
       );
 
       // Add response information to the span:

--- a/packages/ai/core/generate-text/index.ts
+++ b/packages/ai/core/generate-text/index.ts
@@ -8,7 +8,7 @@ export type {
 export * as Output from './output';
 export { smoothStream, type ChunkDetector } from './smooth-stream';
 export type { StepResult } from './step-result';
-export { hasToolCall, maxSteps, type StopCondition } from './stop-condition';
+export { hasToolCall, stepCountIs, type StopCondition } from './stop-condition';
 export { streamText } from './stream-text';
 export type {
   StreamTextOnChunkCallback,

--- a/packages/ai/core/generate-text/stop-condition.ts
+++ b/packages/ai/core/generate-text/stop-condition.ts
@@ -5,8 +5,8 @@ export type StopCondition<TOOLS extends ToolSet> = (options: {
   steps: Array<StepResult<TOOLS>>;
 }) => PromiseLike<boolean> | boolean;
 
-export function maxSteps(maxSteps: number): StopCondition<any> {
-  return ({ steps }) => steps.length >= maxSteps;
+export function stepCountIs(stepCount: number): StopCondition<any> {
+  return ({ steps }) => steps.length === stepCount;
 }
 
 export function hasToolCall(toolName: string): StopCondition<any> {

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -25,7 +25,7 @@ import { StepResult } from './step-result';
 import { streamText } from './stream-text';
 import { StreamTextResult, TextStreamPart } from './stream-text-result';
 import { ToolSet } from './tool-set';
-import { maxSteps } from './stop-condition';
+import { stepCountIs } from './stop-condition';
 
 const defaultSettings = () =>
   ({
@@ -2646,7 +2646,7 @@ describe('streamText', () => {
             onStepFinishResults.push(event);
           },
           experimental_telemetry: { isEnabled: true, tracer },
-          continueUntil: maxSteps(3),
+          stopWhen: stepCountIs(3),
           _internal: {
             now: mockValues(0, 100, 500, 600, 1000),
           },
@@ -2964,7 +2964,7 @@ describe('streamText', () => {
             onStepFinishResults.push(event);
           },
           experimental_telemetry: { isEnabled: true, tracer },
-          continueUntil: maxSteps(3),
+          stopWhen: stepCountIs(3),
           _internal: {
             now: mockValues(0, 100, 500, 600, 1000),
           },


### PR DESCRIPTION
## Background

The multi-step loop is terminated when a LLM returns a stop response, i.e. generates text and finishes the response. However, the name `continueUntil` suggested it might run until the stop condition is met.

## Summary

* Rename `continueUntil` to `stopWhen` 
* Rename the related `maxSteps` stop condition to `stepCountIs` to clarify the predicate function