### PR TITLE
feat (providers/anthropic): add claude v4 models

### DIFF
--- a/.changeset/six-olives-rest.md
+++ b/.changeset/six-olives-rest.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat (providers/anthropic): add claude v4 models

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -113,6 +113,8 @@ Here are the capabilities of popular models:
 | [OpenAI](/providers/ai-sdk-providers/openai)                             | `o1`                                        | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [OpenAI](/providers/ai-sdk-providers/openai)                             | `o1-mini`                                   | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [OpenAI](/providers/ai-sdk-providers/openai)                             | `o1-preview`                                | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
+| [Anthropic](/providers/ai-sdk-providers/anthropic)                       | `claude-4-opus-20250514`                    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [Anthropic](/providers/ai-sdk-providers/anthropic)                       | `claude-4-sonnet-20250514`                  | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Anthropic](/providers/ai-sdk-providers/anthropic)                       | `claude-3-7-sonnet-20250219`                | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Anthropic](/providers/ai-sdk-providers/anthropic)                       | `claude-3-5-sonnet-20241022`                | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Anthropic](/providers/ai-sdk-providers/anthropic)                       | `claude-3-5-sonnet-20240620`                | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -110,7 +110,7 @@ The following optional provider options are available for Anthropic models:
 
 ### Reasoning
 
-Anthropic has reasoning support for the `claude-3-7-sonnet-20250219` model.
+Anthropic has reasoning support for `claude-4-opus-20250514`, `claude-4-sonnet-20250514`, and `claude-3-7-sonnet-20250219` models.
 
 You can enable it using the `thinking` provider option
 and specifying a thinking budget in tokens.
@@ -120,7 +120,7 @@ import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 
 const { text, reasoning, reasoningDetails } = await generateText({
-  model: anthropic('claude-3-7-sonnet-20250219'),
+  model: anthropic('claude-4-opus-20250514'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
     anthropic: {
@@ -415,6 +415,8 @@ and the `mediaType` should be set to `'application/pdf'`.
 
 | Model                        | Image Input         | Object Generation   | Tool Usage          | Computer Use        |
 | ---------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `claude-4-opus-20250514`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `claude-4-sonnet-20250514`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `claude-3-7-sonnet-20250219` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `claude-3-5-sonnet-20241022` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `claude-3-5-sonnet-20240620` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> |

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 
 // https://docs.anthropic.com/claude/docs/models-overview
 export type AnthropicMessagesModelId =
+  | 'claude-4-opus-20250514'
+  | 'claude-4-sonnet-20250514'
   | 'claude-3-7-sonnet-20250219'
   | 'claude-3-5-sonnet-latest'
   | 'claude-3-5-sonnet-20241022'


### PR DESCRIPTION
## Background

This pull request adds support for Anthropic's new Claude v4 models.

## Summary

Updated the model ids to include `claude-4-opus-20250514` and `claude-4-sonnet-20250514`.

## Tasks

- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)