### PR TITLE
feat(provider/amazon-bedrock): add Claude 4 model ids

### DIFF
--- a/.changeset/stale-cherries-heal.md
+++ b/.changeset/stale-cherries-heal.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat (provider/amazon-bedrock): add Claude 4 model ids (claude-sonnet-4-20250514-v1:0, claude-opus-4-20250514-v1:0)

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -390,6 +390,8 @@ on how to integrate reasoning into your chatbot.
 | `amazon.nova-micro-v1:0`                    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `amazon.nova-lite-v1:0`                     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `amazon.nova-pro-v1:0`                      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `anthropic.claude-4-sonnet-20250514-v1:0`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `anthropic.claude-4-opus-20250514-v1:0`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `anthropic.claude-3-7-sonnet-20250219-v1:0` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `anthropic.claude-3-5-sonnet-20241022-v2:0` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `anthropic.claude-3-5-sonnet-20240620-v1:0` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/packages/amazon-bedrock/src/bedrock-chat-settings.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-settings.ts
@@ -5,6 +5,8 @@ export type BedrockChatModelId =
   | 'anthropic.claude-v2'
   | 'anthropic.claude-v2:1'
   | 'anthropic.claude-instant-v1'
+  | 'anthropic.claude-sonnet-4-20250514-v1:0'
+  | 'anthropic.claude-opus-4-20250514-v1:0'
   | 'anthropic.claude-3-7-sonnet-20250219-v1:0'
   | 'anthropic.claude-3-5-sonnet-20240620-v1:0'
   | 'anthropic.claude-3-5-sonnet-20241022-v2:0'


### PR DESCRIPTION
## Description
Add support for new Claude 4 models in Amazon Bedrock provider:
- `anthropic.claude-sonnet-4-20250514-v1:0`
- `anthropic.claude-opus-4-20250514-v1:0`

## Changes
- Added new model IDs to `BedrockChatModelId` type in `bedrock-chat-settings.ts`
- Added changeset for version bump

## Testing
- [x] All existing tests pass
- [ ] Manual testing with new models (if you have access to test)

## Notes
These are the latest Claude 4 models available in Amazon Bedrock as of May 2025.