### PR TITLE
chore (ai): stable activeTools

### DIFF
--- a/.changeset/famous-peas-arrive.md
+++ b/.changeset/famous-peas-arrive.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): stable activeTools

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -173,7 +173,7 @@ const result = await generateText({
         // force a tool choice for this step:
         toolChoice: { type: 'tool', toolName: 'tool1' },
         // limit the tools that are available for this step:
-        experimental_activeTools: ['tool1'],
+        activeTools: ['tool1'],
       };
     }
 
@@ -576,7 +576,7 @@ const result = await generateText({
 
 Language models can only handle a limited number of tools at a time, depending on the model.
 To allow for static typing using a large number of tools and limiting the available tools to the model at the same time,
-the AI SDK provides the `experimental_activeTools` property.
+the AI SDK provides the `activeTools` property.
 
 It is an array of tool names that are currently active.
 By default, the value is `undefined` and all tools are active.
@@ -588,7 +588,7 @@ import { generateText } from 'ai';
 const { text } = await generateText({
   model: openai('gpt-4o'),
   tools: myToolSet,
-  experimental_activeTools: ['firstTool'],
+  activeTools: ['firstTool'],
 });
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -504,7 +504,7 @@ To see `generateText` in action, check out [these examples](#examples).
         'Provider-specific options. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
     {
-      name: 'experimental_activeTools',
+      name: 'activeTools',
       type: 'Array<TOOLNAME> | undefined',
       isOptional: true,
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -548,7 +548,7 @@ To see `streamText` in action, check out [these examples](#examples).
         'Provider-specific options. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
     {
-      name: 'experimental_activeTools',
+      name: 'activeTools',
       type: 'Array<TOOLNAME> | undefined',
       isOptional: true,
       description:

--- a/examples/ai-core/src/generate-text/openai-active-tools.ts
+++ b/examples/ai-core/src/generate-text/openai-active-tools.ts
@@ -13,7 +13,7 @@ async function main() {
         parameters: z.object({ city: z.string() }),
       }),
     },
-    experimental_activeTools: [], // disable all tools
+    activeTools: [], // disable all tools
     stopWhen: stepCountIs(5),
     prompt:
       'What is the weather in San Francisco and what attractions should I visit?',

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -956,7 +956,7 @@ describe('options.stopWhen', () => {
 
           if (stepNumber === 1) {
             expect(steps.length).toStrictEqual(1);
-            return { model: trueModel, experimental_activeTools: [] };
+            return { model: trueModel, activeTools: [] };
           }
         },
       });

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -1,4 +1,8 @@
-import { LanguageModelV2CallOptions } from '@ai-sdk/provider';
+import {
+  LanguageModelV2CallOptions,
+  LanguageModelV2FunctionTool,
+  LanguageModelV2ProviderDefinedTool,
+} from '@ai-sdk/provider';
 import { jsonSchema } from '@ai-sdk/provider-utils';
 import { mockId } from '@ai-sdk/provider-utils/test';
 import assert from 'node:assert';
@@ -1338,6 +1342,63 @@ describe('options.abortSignal', () => {
         messages: expect.any(Array),
       },
     );
+  });
+});
+
+describe('options.activeTools', () => {
+  it('should filter available tools to only the ones in activeTools', async () => {
+    let tools:
+      | (LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool)[]
+      | undefined;
+
+    await generateText({
+      model: new MockLanguageModelV2({
+        doGenerate: async ({ tools: toolsArg }) => {
+          tools = toolsArg;
+
+          return {
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: 'Hello, world!' }],
+          };
+        },
+      }),
+
+      tools: {
+        tool1: {
+          parameters: z.object({ value: z.string() }),
+          execute: async () => 'result1',
+        },
+        tool2: {
+          parameters: z.object({ value: z.string() }),
+          execute: async () => 'result2',
+        },
+      },
+      prompt: 'test-input',
+      activeTools: ['tool1'],
+    });
+
+    expect(tools).toMatchInlineSnapshot(`
+      [
+        {
+          "description": undefined,
+          "name": "tool1",
+          "parameters": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "value",
+            ],
+            "type": "object",
+          },
+          "type": "function",
+        },
+      ]
+    `);
   });
 });
 

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -119,7 +119,8 @@ export async function generateText<
   experimental_output: output,
   experimental_telemetry: telemetry,
   providerOptions,
-  experimental_activeTools: activeTools,
+  experimental_activeTools,
+  activeTools = experimental_activeTools,
   experimental_prepareStep: prepareStep,
   experimental_repairToolCall: repairToolCall,
   _internal: {
@@ -168,10 +169,15 @@ functionality that can be fully encapsulated in the provider.
     providerOptions?: ProviderOptions;
 
     /**
+     * @deprecated Use `activeTools` instead.
+     */
+    experimental_activeTools?: Array<keyof NoInfer<TOOLS>>;
+
+    /**
 Limits the tools that are available for the model to call without
 changing the tool call and result types in the result.
      */
-    experimental_activeTools?: Array<keyof NoInfer<TOOLS>>;
+    activeTools?: Array<keyof NoInfer<TOOLS>>;
 
     /**
 Optional specification for parsing structured outputs from the LLM response.
@@ -197,7 +203,7 @@ If you return undefined (or for undefined settings), the settings from the outer
       | {
           model?: LanguageModel;
           toolChoice?: ToolChoice<NoInfer<TOOLS>>;
-          experimental_activeTools?: Array<keyof NoInfer<TOOLS>>;
+          activeTools?: Array<keyof NoInfer<TOOLS>>;
         }
       | undefined
     >;
@@ -296,8 +302,7 @@ A function that attempts to repair a tool call that failed to parse.
           prepareToolsAndToolChoice({
             tools,
             toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
-            activeTools:
-              prepareStepResult?.experimental_activeTools ?? activeTools,
+            activeTools: prepareStepResult?.activeTools ?? activeTools,
           });
 
         currentModelResponse = await retry(() =>

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -212,7 +212,8 @@ export function streamText<
   providerOptions,
   experimental_toolCallStreaming = false,
   toolCallStreaming = experimental_toolCallStreaming,
-  experimental_activeTools: activeTools,
+  experimental_activeTools,
+  activeTools = experimental_activeTools,
   experimental_repairToolCall: repairToolCall,
   experimental_transform: transform,
   onChunk,
@@ -265,10 +266,15 @@ functionality that can be fully encapsulated in the provider.
     providerOptions?: ProviderOptions;
 
     /**
-Limits the tools that are available for the model to call without
-changing the tool call and result types in the result.
+     * @deprecated Use `activeTools` instead.
      */
-    experimental_activeTools?: Array<keyof TOOLS>;
+    experimental_activeTools?: Array<keyof NoInfer<TOOLS>>;
+
+    /**
+   Limits the tools that are available for the model to call without
+   changing the tool call and result types in the result.
+        */
+    activeTools?: Array<keyof NoInfer<TOOLS>>;
 
     /**
 Optional specification for parsing structured outputs from the LLM response.


### PR DESCRIPTION
## Background

`activeTools` has been experimental for about 6 months. With the new AI SDK 5 agentic control features, it is clear that it will stay.

## Summary

`activeTools` is now stable. The `experimental_` prefix has been removed.