### PR TITLE
fix (ai/ui): avoid job executor deadlock when adding tool result

### DIFF
--- a/.changeset/new-pens-remain.md
+++ b/.changeset/new-pens-remain.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix: avoid job executor deadlock when adding tool result

--- a/packages/ai/src/ui/chat-store.ts
+++ b/packages/ai/src/ui/chat-store.ts
@@ -441,7 +441,7 @@ export class ChatStore<
           requestType: 'generate',
           chatId,
         });
-      }      
+      }
     });
   }
 

--- a/packages/ai/src/ui/chat-store.ts
+++ b/packages/ai/src/ui/chat-store.ts
@@ -436,11 +436,12 @@ export class ChatStore<
       // auto-submit when all tool calls in the last assistant message have results:
       const lastMessage = chat.messages[chat.messages.length - 1];
       if (isAssistantMessageWithCompletedToolCalls(lastMessage)) {
-        await this.triggerRequest({
+        // we do not await this call to avoid a deadlock in the serial job executor; triggerRequest also uses the job executor internally.
+        this.triggerRequest({
           requestType: 'generate',
           chatId,
         });
-      }
+      }      
     });
   }
 

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -13,8 +13,8 @@ import {
   type UseChatOptions,
 } from 'ai';
 import { useCallback, useRef, useState, useSyncExternalStore } from 'react';
-import { throttle } from './throttle';
 import { createChatStore } from './chat-store';
+import { throttle } from './throttle';
 
 export type { CreateUIMessage, UIMessage, UseChatOptions };
 

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1082,11 +1082,9 @@ describe('tool invocations', () => {
 
   it('should delay tool result submission until the stream is finished', async () => {
     const controller1 = new TestResponseController();
-    // const controller2 = new TestResponseController();
 
     server.urls['/api/chat'].response = [
       { type: 'controlled-stream', controller: controller1 },
-      // { type: 'controlled-stream', controller: controller2 },
     ];
 
     await userEvent.click(screen.getByTestId('do-append'));
@@ -1209,11 +1207,6 @@ describe('tool invocations', () => {
 
     // should trigger second request w/ tool result
     expect(server.calls.length).toBe(2);
-
-    // 2nd call should happen after the stream is finished
-    await waitFor(() => {
-      expect(server.calls.length).toBe(2);
-    });
 
     controller2.write(formatStreamPart({ type: 'start' }));
     controller2.write(formatStreamPart({ type: 'start-step' }));

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -789,6 +789,13 @@ describe('tool invocations', () => {
                 </div>
               );
             })}
+            {m.role === 'assistant' && (
+              <div data-testid={`message-${idx}-text`}>
+                {m.parts
+                  .map(part => (part.type === 'text' ? part.text : ''))
+                  .join('')}
+              </div>
+            )}
           </div>
         ))}
 
@@ -1075,11 +1082,11 @@ describe('tool invocations', () => {
 
   it('should delay tool result submission until the stream is finished', async () => {
     const controller1 = new TestResponseController();
-    const controller2 = new TestResponseController();
+    // const controller2 = new TestResponseController();
 
     server.urls['/api/chat'].response = [
       { type: 'controlled-stream', controller: controller1 },
-      { type: 'controlled-stream', controller: controller2 },
+      // { type: 'controlled-stream', controller: controller2 },
     ];
 
     await userEvent.click(screen.getByTestId('do-append'));
@@ -1139,6 +1146,90 @@ describe('tool invocations', () => {
     // 2nd call should happen after the stream is finished
     await waitFor(() => {
       expect(server.calls.length).toBe(2);
+    });
+  });
+
+  it('should trigger request when all tool calls are completed', async () => {
+    const controller1 = new TestResponseController();
+    const controller2 = new TestResponseController();
+
+    server.urls['/api/chat'].response = [
+      { type: 'controlled-stream', controller: controller1 },
+      { type: 'controlled-stream', controller: controller2 },
+    ];
+
+    await userEvent.click(screen.getByTestId('do-append'));
+
+    // start stream
+    controller1.write(formatStreamPart({ type: 'start' }));
+    controller1.write(formatStreamPart({ type: 'start-step' }));
+
+    // tool call
+    controller1.write(
+      formatStreamPart({
+        type: 'tool-call',
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        args: { testArg: 'test-value' },
+      }),
+    );
+    // finish stream
+    controller1.write(formatStreamPart({ type: 'finish-step' }));
+    controller1.write(formatStreamPart({ type: 'finish' }));
+    await controller1.close();
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'call',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+      });
+    });
+
+    // user submits the tool result
+    await userEvent.click(screen.getByTestId('add-result-0'));
+
+    // UI should show the tool result
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId('message-1').textContent ?? ''),
+      ).toStrictEqual({
+        state: 'result',
+        step: 0,
+        args: { testArg: 'test-value' },
+        toolCallId: 'tool-call-0',
+        toolName: 'test-tool',
+        result: 'test-result',
+      });
+    });
+
+    // should trigger second request w/ tool result
+    expect(server.calls.length).toBe(2);
+
+    // 2nd call should happen after the stream is finished
+    await waitFor(() => {
+      expect(server.calls.length).toBe(2);
+    });
+
+    controller2.write(formatStreamPart({ type: 'start' }));
+    controller2.write(formatStreamPart({ type: 'start-step' }));
+
+    controller2.write(formatStreamPart({ type: 'text', text: 'final result' }));
+
+    controller2.write(formatStreamPart({ type: 'finish-step' }));
+    controller2.write(formatStreamPart({ type: 'finish' }));
+
+    await controller2.close();
+
+    // chunks from second request should show up in UI
+    await waitFor(() => {
+      expect(screen.getByTestId('message-1-text')).toHaveTextContent(
+        'final result',
+      );
     });
   });
 });


### PR DESCRIPTION
## Background

Addresses bug report https://github.com/vercel/ai/issues/6435

## Summary

Removes `await`-ing trigger request call in the `addToolResult` method
to avoid deadlocking the job executor.

## Verification

A new test was added to simulate this behavior!

## Related Issues

Fixes #6435