### PR TITLE
feat (ai): allow sync prepareStep

### DIFF
--- a/.changeset/plenty-dingos-bow.md
+++ b/.changeset/plenty-dingos-bow.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): allow sync prepareStep

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -29,6 +29,7 @@ import { extractContentText } from './extract-content-text';
 import { GenerateTextResult } from './generate-text-result';
 import { Output } from './output';
 import { parseToolCall } from './parse-tool-call';
+import { PrepareStepFunction } from './prepare-step';
 import { ResponseMessage } from './response-message';
 import { DefaultStepResult, StepResult } from './step-result';
 import {
@@ -189,42 +190,12 @@ Optional specification for parsing structured outputs from the LLM response.
     /**
      * @deprecated Use `prepareStep` instead.
      */
-    experimental_prepareStep?: (options: {
-      steps: Array<StepResult<NoInfer<TOOLS>>>;
-      stepNumber: number;
-      model: LanguageModel;
-    }) => PromiseLike<
-      | {
-          model?: LanguageModel;
-          toolChoice?: ToolChoice<NoInfer<TOOLS>>;
-          activeTools?: Array<keyof NoInfer<TOOLS>>;
-        }
-      | undefined
-    >;
+    experimental_prepareStep?: PrepareStepFunction<NoInfer<TOOLS>>;
 
     /**
 Optional function that you can use to provide different settings for a step.
-
-@param options - The options for the step.
-@param options.steps - The steps that have been executed so far.
-@param options.stepNumber - The number of the step that is being executed.
-@param options.model - The model that is being used.
-
-@returns An object that contains the settings for the step.
-If you return undefined (or for undefined settings), the settings from the outer level will be used.
     */
-    prepareStep?: (options: {
-      steps: Array<StepResult<NoInfer<TOOLS>>>;
-      stepNumber: number;
-      model: LanguageModel;
-    }) => PromiseLike<
-      | {
-          model?: LanguageModel;
-          toolChoice?: ToolChoice<NoInfer<TOOLS>>;
-          activeTools?: Array<keyof NoInfer<TOOLS>>;
-        }
-      | undefined
-    >;
+    prepareStep?: PrepareStepFunction<NoInfer<TOOLS>>;
 
     /**
 A function that attempts to repair a tool call that failed to parse.

--- a/packages/ai/core/generate-text/index.ts
+++ b/packages/ai/core/generate-text/index.ts
@@ -6,6 +6,7 @@ export type {
   GeneratedFile,
 } from './generated-file';
 export * as Output from './output';
+export type { PrepareStepFunction } from './prepare-step';
 export { smoothStream, type ChunkDetector } from './smooth-stream';
 export type { StepResult } from './step-result';
 export { hasToolCall, stepCountIs, type StopCondition } from './stop-condition';

--- a/packages/ai/core/generate-text/prepare-step.ts
+++ b/packages/ai/core/generate-text/prepare-step.ts
@@ -1,0 +1,36 @@
+import { Tool } from '../tool/tool';
+import { LanguageModel, ToolChoice } from '../types/language-model';
+import { StepResult } from './step-result';
+
+/**
+Function that you can use to provide different settings for a step.
+
+@param options - The options for the step.
+@param options.steps - The steps that have been executed so far.
+@param options.stepNumber - The number of the step that is being executed.
+@param options.model - The model that is being used.
+
+@returns An object that contains the settings for the step.
+If you return undefined (or for undefined settings), the settings from the outer level will be used.
+    */
+export type PrepareStepFunction<
+  TOOLS extends Record<string, Tool> = Record<string, Tool>,
+> = (options: {
+  steps: Array<StepResult<NoInfer<TOOLS>>>;
+  stepNumber: number;
+  model: LanguageModel;
+}) =>
+  | PromiseLike<
+      | {
+          model?: LanguageModel;
+          toolChoice?: ToolChoice<NoInfer<TOOLS>>;
+          activeTools?: Array<keyof NoInfer<TOOLS>>;
+        }
+      | undefined
+    >
+  | {
+      model?: LanguageModel;
+      toolChoice?: ToolChoice<NoInfer<TOOLS>>;
+      activeTools?: Array<keyof NoInfer<TOOLS>>;
+    }
+  | undefined;

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -47,6 +47,7 @@ import { ProviderMetadata, ProviderOptions } from '../types/provider-metadata';
 import { addLanguageModelUsage, LanguageModelUsage } from '../types/usage';
 import { ContentPart } from './content-part';
 import { Output } from './output';
+import { PrepareStepFunction } from './prepare-step';
 import { ResponseMessage } from './response-message';
 import {
   runToolsTransformation,
@@ -293,18 +294,7 @@ Optional function that you can use to provide different settings for a step.
 @returns An object that contains the settings for the step.
 If you return undefined (or for undefined settings), the settings from the outer level will be used.
     */
-    prepareStep?: (options: {
-      steps: Array<StepResult<NoInfer<TOOLS>>>;
-      stepNumber: number;
-      model: LanguageModel;
-    }) => PromiseLike<
-      | {
-          model?: LanguageModel;
-          toolChoice?: ToolChoice<NoInfer<TOOLS>>;
-          activeTools?: Array<keyof NoInfer<TOOLS>>;
-        }
-      | undefined
-    >;
+    prepareStep?: PrepareStepFunction<NoInfer<TOOLS>>;
 
     /**
 A function that attempts to repair a tool call that failed to parse.
@@ -551,20 +541,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
     stopConditions: Array<StopCondition<NoInfer<TOOLS>>>;
     output: Output<OUTPUT, PARTIAL_OUTPUT> | undefined;
     providerOptions: ProviderOptions | undefined;
-    prepareStep:
-      | ((options: {
-          steps: Array<StepResult<NoInfer<TOOLS>>>;
-          stepNumber: number;
-          model: LanguageModel;
-        }) => PromiseLike<
-          | {
-              model?: LanguageModel;
-              toolChoice?: ToolChoice<NoInfer<TOOLS>>;
-              activeTools?: Array<keyof NoInfer<TOOLS>>;
-            }
-          | undefined
-        >)
-      | undefined;
+    prepareStep: PrepareStepFunction<NoInfer<TOOLS>> | undefined;
     now: () => number;
     currentDate: () => Date;
     generateId: () => string;


### PR DESCRIPTION
## Background

Most times, `prepareStep` does not have asynchronous parts.

## Summary

Allow prepareStep without async.