### PR TITLE
feat (ui): add onFinish to createUIMessageStream

### DIFF
--- a/.changeset/gentle-mayflies-call.md
+++ b/.changeset/gentle-mayflies-call.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ui): add onFinish to createUIMessageStream

--- a/examples/next-openai/app/api/use-chat-custom-sources/route.ts
+++ b/examples/next-openai/app/api/use-chat-custom-sources/route.ts
@@ -34,8 +34,8 @@ export async function POST(req: Request) {
       );
     },
     originalMessages: messages,
-    onFinish: ({ messages, isContinuation, responseMessage }) => {
-      console.log('onFinish', { messages, isContinuation, responseMessage });
+    onFinish: options => {
+      console.log('onFinish', JSON.stringify(options, null, 2));
     },
   });
 

--- a/examples/next-openai/app/api/use-chat-custom-sources/route.ts
+++ b/examples/next-openai/app/api/use-chat-custom-sources/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const stream = createUIMessageStream({
-    execute: writer => {
+    execute: ({ writer }) => {
       // write a custom url source to the stream:
       writer.write({
         type: 'source-url',

--- a/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
+++ b/examples/next-openai/app/api/use-chat-data-ui-parts/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const stream = createUIMessageStream({
-    execute: writer => {
+    execute: ({ writer }) => {
       const result = streamText({
         model: openai('gpt-4o'),
         stopWhen: stepCountIs(2),

--- a/examples/next-openai/app/api/use-chat-human-in-the-loop/route.ts
+++ b/examples/next-openai/app/api/use-chat-human-in-the-loop/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const stream = createUIMessageStream({
-    execute: async writer => {
+    execute: async ({ writer }) => {
       // Utility function to handle tools that require human confirmation
       // Checks for confirmation in last message and then runs associated tool
       const processedMessages = await processToolCalls(

--- a/examples/next-openai/app/api/use-chat-resume/route.ts
+++ b/examples/next-openai/app/api/use-chat-resume/route.ts
@@ -37,12 +37,12 @@ export async function POST(req: Request) {
     throw new Error('No recent user message found');
   }
 
-  await appendMessageToChat({ chatId: chatId, message: recentUserMessage });
+  await appendMessageToChat({ chatId, message: recentUserMessage });
 
-  await appendStreamId({ chatId: chatId, streamId });
+  await appendStreamId({ chatId, streamId });
 
   const stream = createUIMessageStream({
-    execute: writer => {
+    execute: ({ writer }) => {
       const result = streamText({
         model: openai('gpt-4o'),
         messages: convertToModelMessages(messages),

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -60,7 +60,7 @@ exports[`streamText > multiple stream consumption > should support text stream, 
   ],
   "uiMessageStream": [
     {
-      "messageId": undefined,
+      "messageId": "id-1",
       "metadata": undefined,
       "type": "start",
     },
@@ -2816,7 +2816,7 @@ exports[`streamText > result.fullStream > should use fallback response metadata 
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error messages by default 1`] = `
 [
-  "data: {"type":"start"}
+  "data: {"type":"start","messageId":"id-0"}
 
 ",
   "data: {"type":"start-step"}
@@ -2839,7 +2839,7 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error m
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should omit message finish event (d:) when sendFinish is false 1`] = `
 [
-  "data: {"type":"start"}
+  "data: {"type":"start","messageId":"id-0"}
 
 ",
   "data: {"type":"start-step"}
@@ -2859,7 +2859,7 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should omit message
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should support custom error messages 1`] = `
 [
-  "data: {"type":"start"}
+  "data: {"type":"start","messageId":"id-0"}
 
 ",
   "data: {"type":"start-step"}
@@ -3263,7 +3263,7 @@ exports[`streamText > result.textStream > should swallow error to prevent server
 exports[`streamText > result.toUIMessageStream > should create a data stream 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3297,7 +3297,7 @@ exports[`streamText > result.toUIMessageStream > should create a data stream 1`]
 exports[`streamText > result.toUIMessageStream > should mask error messages by default 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3323,7 +3323,7 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
 exports[`streamText > result.toUIMessageStream > should omit message finish event when sendFinish is false 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3366,7 +3366,7 @@ exports[`streamText > result.toUIMessageStream > should omit message start event
 exports[`streamText > result.toUIMessageStream > should send file content 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3402,7 +3402,7 @@ exports[`streamText > result.toUIMessageStream > should send file content 1`] = 
 exports[`streamText > result.toUIMessageStream > should send reasoning content when sendReasoning is true 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3488,7 +3488,7 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
 exports[`streamText > result.toUIMessageStream > should send source content when sendSources is true 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3536,7 +3536,7 @@ exports[`streamText > result.toUIMessageStream > should send source content when
 exports[`streamText > result.toUIMessageStream > should send tool call and tool result stream parts 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3571,7 +3571,7 @@ exports[`streamText > result.toUIMessageStream > should send tool call and tool 
 exports[`streamText > result.toUIMessageStream > should send tool call, tool call stream start, tool call deltas, and tool result stream parts when tool call delta flag is enabled 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3621,7 +3621,7 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
 exports[`streamText > result.toUIMessageStream > should support custom error messages 1`] = `
 [
   {
-    "messageId": undefined,
+    "messageId": "id-0",
     "metadata": undefined,
     "type": "start",
   },
@@ -3646,7 +3646,7 @@ exports[`streamText > result.toUIMessageStream > should support custom error mes
 
 exports[`streamText > result.toUIMessageStreamResponse > should mask error messages by default 1`] = `
 [
-  "data: {"type":"start"}
+  "data: {"type":"start","messageId":"id-0"}
 
 ",
   "data: {"type":"start-step"}
@@ -3669,7 +3669,7 @@ exports[`streamText > result.toUIMessageStreamResponse > should mask error messa
 
 exports[`streamText > result.toUIMessageStreamResponse > should support custom error messages 1`] = `
 [
-  "data: {"type":"start"}
+  "data: {"type":"start","messageId":"id-0"}
 
 ",
   "data: {"type":"start-step"}

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -822,6 +822,9 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel(),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       result.pipeUIMessageStreamToResponse(mockResponse);
@@ -840,7 +843,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start"}
+          "data: {"type":"start","messageId":"id-0"}
 
         ",
           "data: {"type":"start-step"}
@@ -874,6 +877,9 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel(),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       result.pipeUIMessageStreamToResponse(mockResponse, {
@@ -902,7 +908,7 @@ describe('streamText', () => {
 
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start"}
+          "data: {"type":"start","messageId":"id-0"}
 
         ",
           "data: {"type":"start-step"}
@@ -940,6 +946,9 @@ describe('streamText', () => {
           ]),
         }),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       result.pipeUIMessageStreamToResponse(mockResponse);
@@ -959,6 +968,9 @@ describe('streamText', () => {
           ]),
         }),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       result.pipeUIMessageStreamToResponse(mockResponse, {
@@ -1022,7 +1034,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start"}
+          "data: {"type":"start","messageId":"id-0"}
 
         ",
           "data: {"type":"start-step"}
@@ -1103,7 +1115,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start"}
+          "data: {"type":"start","messageId":"id-0"}
 
         ",
           "data: {"type":"start-step"}
@@ -1155,7 +1167,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start"}
+          "data: {"type":"start","messageId":"id-0"}
 
         ",
           "data: {"type":"start-step"}
@@ -1343,7 +1355,7 @@ describe('streamText', () => {
         .toMatchInlineSnapshot(`
           [
             {
-              "messageId": undefined,
+              "messageId": "id-0",
               "metadata": {
                 "key1": "value1",
               },
@@ -1514,6 +1526,9 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel(),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       const response = result.toUIMessageStreamResponse();
@@ -1533,7 +1548,7 @@ describe('streamText', () => {
       expect(await convertResponseStreamToArray(response))
         .toMatchInlineSnapshot(`
           [
-            "data: {"type":"start"}
+            "data: {"type":"start","messageId":"id-0"}
 
           ",
             "data: {"type":"start-step"}
@@ -1565,6 +1580,9 @@ describe('streamText', () => {
       const result = streamText({
         model: createTestModel(),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       const response = result.toUIMessageStreamResponse({
@@ -1591,7 +1609,7 @@ describe('streamText', () => {
       expect(await convertResponseStreamToArray(response))
         .toMatchInlineSnapshot(`
           [
-            "data: {"type":"start"}
+            "data: {"type":"start","messageId":"id-0"}
 
           ",
             "data: {"type":"start-step"}
@@ -1627,6 +1645,9 @@ describe('streamText', () => {
           ]),
         }),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       const response = result.toUIMessageStreamResponse();
@@ -1642,6 +1663,9 @@ describe('streamText', () => {
           ]),
         }),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       const response = result.toUIMessageStreamResponse({
@@ -1781,6 +1805,9 @@ describe('streamText', () => {
           ]),
         }),
         prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+        },
       });
 
       expect({
@@ -2651,6 +2678,7 @@ describe('streamText', () => {
           stopWhen: stepCountIs(3),
           _internal: {
             now: mockValues(0, 100, 500, 600, 1000),
+            generateId: mockId({ prefix: 'id' }),
           },
         });
       });
@@ -2729,55 +2757,55 @@ describe('streamText', () => {
       it('should have correct ui message stream', async () => {
         expect(await convertReadableStreamToArray(result.toUIMessageStream()))
           .toMatchInlineSnapshot(`
-          [
-            {
-              "messageId": undefined,
-              "metadata": undefined,
-              "type": "start",
-            },
-            {
-              "metadata": undefined,
-              "type": "start-step",
-            },
-            {
-              "args": {
-                "value": "value",
+            [
+              {
+                "messageId": "id-0",
+                "metadata": undefined,
+                "type": "start",
               },
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-            {
-              "result": "result1",
-              "toolCallId": "call-1",
-              "type": "tool-result",
-            },
-            {
-              "metadata": undefined,
-              "type": "finish-step",
-            },
-            {
-              "metadata": undefined,
-              "type": "start-step",
-            },
-            {
-              "text": "Hello, ",
-              "type": "text",
-            },
-            {
-              "text": "world!",
-              "type": "text",
-            },
-            {
-              "metadata": undefined,
-              "type": "finish-step",
-            },
-            {
-              "metadata": undefined,
-              "type": "finish",
-            },
-          ]
-        `);
+              {
+                "metadata": undefined,
+                "type": "start-step",
+              },
+              {
+                "args": {
+                  "value": "value",
+                },
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+              {
+                "result": "result1",
+                "toolCallId": "call-1",
+                "type": "tool-result",
+              },
+              {
+                "metadata": undefined,
+                "type": "finish-step",
+              },
+              {
+                "metadata": undefined,
+                "type": "start-step",
+              },
+              {
+                "text": "Hello, ",
+                "type": "text",
+              },
+              {
+                "text": "world!",
+                "type": "text",
+              },
+              {
+                "metadata": undefined,
+                "type": "finish-step",
+              },
+              {
+                "metadata": undefined,
+                "type": "finish",
+              },
+            ]
+          `);
       });
     });
 
@@ -3456,6 +3484,7 @@ describe('streamText', () => {
           stopWhen: stepCountIs(3),
           _internal: {
             now: mockValues(0, 100, 500, 600, 1000),
+            generateId: mockId({ prefix: 'id' }),
           },
         });
       });
@@ -4323,7 +4352,7 @@ describe('streamText', () => {
           .toMatchInlineSnapshot(`
             [
               {
-                "messageId": undefined,
+                "messageId": "id-0",
                 "metadata": undefined,
                 "type": "start",
               },

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1421,7 +1421,9 @@ However, the LLM results are expected to be small enough to not cause issues.
   }: UIMessageStreamOptions = {}): ReadableStream<UIMessageStreamPart> {
     const lastMessage = originalMessages[originalMessages.length - 1];
     const isContinuation = lastMessage?.role === 'assistant';
-    const messageId = isContinuation ? lastMessage.id : newMessageId;
+    const messageId = isContinuation
+      ? lastMessage.id
+      : (newMessageId ?? this.generateId());
 
     const baseStream = this.fullStream.pipeThrough(
       new TransformStream<TextStreamPart<TOOLS>, UIMessageStreamPart>({
@@ -1578,7 +1580,7 @@ However, the LLM results are expected to be small enough to not cause issues.
 
     const state = createStreamingUIMessageState({
       lastMessage: structuredClone(lastMessage),
-      newMessageId: messageId ?? this.generateId(),
+      newMessageId: messageId,
     });
 
     const runUpdateMessageJob = async (

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -6,13 +6,9 @@ import { NoOutputSpecifiedError } from '../../src/error/no-output-specified-erro
 import { createTextStreamResponse } from '../../src/text-stream/create-text-stream-response';
 import { pipeTextStreamToResponse } from '../../src/text-stream/pipe-text-stream-to-response';
 import { createUIMessageStreamResponse } from '../../src/ui-message-stream/create-ui-message-stream-response';
+import { handleUIMessageStreamFinish } from '../../src/ui-message-stream/handle-ui-message-stream-finish';
 import { pipeUIMessageStreamToResponse } from '../../src/ui-message-stream/pipe-ui-message-stream-to-response';
 import { UIMessageStreamPart } from '../../src/ui-message-stream/ui-message-stream-parts';
-import {
-  createStreamingUIMessageState,
-  processUIMessageStream,
-  StreamingUIMessageState,
-} from '../../src/ui/process-ui-message-stream';
 import { asArray } from '../../src/util/as-array';
 import {
   AsyncIterableStream,
@@ -1574,48 +1570,12 @@ However, the LLM results are expected to be small enough to not cause issues.
       }),
     );
 
-    if (onFinish == null) {
-      return baseStream;
-    }
-
-    const state = createStreamingUIMessageState({
-      lastMessage: structuredClone(lastMessage),
-      newMessageId: messageId,
-    });
-
-    const runUpdateMessageJob = async (
-      job: (options: {
-        state: StreamingUIMessageState;
-        write: () => void;
-      }) => Promise<void>,
-    ) => {
-      await job({ state, write: () => {} });
-    };
-
-    return processUIMessageStream({
+    return handleUIMessageStreamFinish({
       stream: baseStream,
-      runUpdateMessageJob,
-    }).pipeThrough(
-      new TransformStream({
-        transform(chunk, controller) {
-          controller.enqueue(chunk);
-        },
-
-        flush() {
-          const isContinuation = state.message.id === lastMessage?.id;
-          onFinish({
-            isContinuation,
-            responseMessage: state.message,
-            messages: [
-              ...(isContinuation
-                ? originalMessages.slice(0, -1)
-                : originalMessages),
-              state.message,
-            ],
-          });
-        },
-      }),
-    );
+      newMessageId: messageId,
+      originalMessages,
+      onFinish,
+    });
   }
 
   pipeUIMessageStreamToResponse(

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -1,3 +1,8 @@
+import {
+  processUIMessageStream,
+  StreamingUIMessageState,
+} from '../ui/process-ui-message-stream';
+import { createStreamingUIMessageState } from '../ui/process-ui-message-stream';
 import { UIMessage } from '../ui/ui-messages';
 import { UIMessageStreamPart } from './ui-message-stream-parts';
 import { UIMessageStreamWriter } from './ui-message-stream-writer';
@@ -5,6 +10,8 @@ import { UIMessageStreamWriter } from './ui-message-stream-writer';
 export function createUIMessageStream({
   execute,
   onError = () => 'An error occurred.', // mask error messages for safety by default
+  originalMessages = [],
+  onFinish,
 }: {
   execute: (options: { writer: UIMessageStreamWriter }) => Promise<void> | void;
   onError?: (error: unknown) => string;
@@ -105,5 +112,50 @@ export function createUIMessageStream({
     }
   });
 
-  return stream;
+  if (onFinish == null) {
+    return stream;
+  }
+
+  const lastMessage = originalMessages[originalMessages.length - 1];
+  const isContinuation = lastMessage?.role === 'assistant';
+  const messageId = isContinuation ? lastMessage.id : undefined;
+
+  const state = createStreamingUIMessageState({
+    lastMessage: structuredClone(lastMessage),
+    newMessageId: messageId,
+  });
+
+  const runUpdateMessageJob = async (
+    job: (options: {
+      state: StreamingUIMessageState;
+      write: () => void;
+    }) => Promise<void>,
+  ) => {
+    await job({ state, write: () => {} });
+  };
+
+  return processUIMessageStream({
+    stream,
+    runUpdateMessageJob,
+  }).pipeThrough(
+    new TransformStream({
+      transform(chunk, controller) {
+        controller.enqueue(chunk);
+      },
+
+      flush() {
+        const isContinuation = state.message.id === lastMessage?.id;
+        onFinish({
+          isContinuation,
+          responseMessage: state.message,
+          messages: [
+            ...(isContinuation
+              ? originalMessages.slice(0, -1)
+              : originalMessages),
+            state.message,
+          ],
+        });
+      },
+    }),
+  );
 }

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -1,3 +1,4 @@
+import { UIMessage } from '../ui/ui-messages';
 import { UIMessageStreamPart } from './ui-message-stream-parts';
 import { UIMessageStreamWriter } from './ui-message-stream-writer';
 
@@ -7,6 +8,30 @@ export function createUIMessageStream({
 }: {
   execute: (options: { writer: UIMessageStreamWriter }) => Promise<void> | void;
   onError?: (error: unknown) => string;
+
+  /**
+   * The original messages.
+   */
+  originalMessages?: UIMessage[];
+
+  onFinish?: (options: {
+    /**
+     * The updates list of UI messages.
+     */
+    messages: UIMessage[];
+
+    /**
+     * Indicates whether the response message is a continuation of the last original message,
+     * or if a new message was created.
+     */
+    isContinuation: boolean;
+
+    /**
+     * The message that was sent to the client as a response
+     * (including the original message if it was extended).
+     */
+    responseMessage: UIMessage;
+  }) => void;
 }): ReadableStream<UIMessageStreamPart> {
   let controller!: ReadableStreamDefaultController<UIMessageStreamPart>;
 

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -1,0 +1,89 @@
+import {
+  createStreamingUIMessageState,
+  processUIMessageStream,
+  StreamingUIMessageState,
+} from '../ui/process-ui-message-stream';
+import { UIMessage } from '../ui/ui-messages';
+import { UIMessageStreamPart } from './ui-message-stream-parts';
+
+export function handleUIMessageStreamFinish({
+  newMessageId,
+  originalMessages = [],
+  onFinish,
+  stream,
+}: {
+  stream: ReadableStream<UIMessageStreamPart>;
+
+  newMessageId: string;
+
+  /**
+   * The original messages.
+   */
+  originalMessages?: UIMessage[];
+
+  onFinish?: (options: {
+    /**
+     * The updates list of UI messages.
+     */
+    messages: UIMessage[];
+
+    /**
+     * Indicates whether the response message is a continuation of the last original message,
+     * or if a new message was created.
+     */
+    isContinuation: boolean;
+
+    /**
+     * The message that was sent to the client as a response
+     * (including the original message if it was extended).
+     */
+    responseMessage: UIMessage;
+  }) => void;
+}) {
+  if (onFinish == null) {
+    return stream;
+  }
+
+  const lastMessage = originalMessages[originalMessages.length - 1];
+  const isContinuation = lastMessage?.role === 'assistant';
+  const messageId = isContinuation ? lastMessage.id : newMessageId;
+
+  const state = createStreamingUIMessageState({
+    lastMessage: structuredClone(lastMessage),
+    newMessageId: messageId,
+  });
+
+  const runUpdateMessageJob = async (
+    job: (options: {
+      state: StreamingUIMessageState;
+      write: () => void;
+    }) => Promise<void>,
+  ) => {
+    await job({ state, write: () => {} });
+  };
+
+  return processUIMessageStream({
+    stream,
+    runUpdateMessageJob,
+  }).pipeThrough(
+    new TransformStream({
+      transform(chunk, controller) {
+        controller.enqueue(chunk);
+      },
+
+      flush() {
+        const isContinuation = state.message.id === lastMessage?.id;
+        onFinish({
+          isContinuation,
+          responseMessage: state.message,
+          messages: [
+            ...(isContinuation
+              ? originalMessages.slice(0, -1)
+              : originalMessages),
+            state.message,
+          ],
+        });
+      },
+    }),
+  );
+}

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -41,7 +41,7 @@ export function createStreamingUIMessageState<
   UI_DATA_PART_SCHEMAS extends UIDataPartSchemas = UIDataPartSchemas,
 >({
   lastMessage,
-  newMessageId = 'no-id',
+  newMessageId = '',
 }: {
   lastMessage?: UIMessage<
     MESSAGE_METADATA,


### PR DESCRIPTION
## Background

To enable persistence for customized UI message streams, `createUIMessageStream` needs an notification on finish with the reconciled messages.

## Summary

Add `onFinish` and related values to `createUIMessageStream`.