### PR TITLE
feat (ai): support string model ids through gateway

### DIFF
--- a/.changeset/eleven-pets-clean.md
+++ b/.changeset/eleven-pets-clean.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+chore (provider): tweak provider definition

--- a/.changeset/hip-rocks-mix.md
+++ b/.changeset/hip-rocks-mix.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): support string model ids through gateway

--- a/examples/ai-core/src/stream-text/gateway.ts
+++ b/examples/ai-core/src/stream-text/gateway.ts
@@ -1,14 +1,11 @@
-import { gateway } from '@ai-sdk/gateway';
 import { streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
   const result = streamText({
-    model: gateway('xai/grok-3-beta'),
+    model: 'openai/gpt-4.1',
     prompt: 'Invent a new holiday and describe its traditions.',
-    onError: (error: unknown) => {
-      console.error(error);
-    },
+    onError: console.error,
   });
 
   for await (const textPart of result.textStream) {

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -37,6 +37,7 @@ import { LanguageModelUsage } from '../types/usage';
 import { GenerateObjectResult } from './generate-object-result';
 import { getOutputStrategy } from './output-strategy';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
+import { resolveLanguageModel } from '../prompt/resolve-language-model';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -215,7 +216,7 @@ Default and recommended: 'auto' (best mode for the model).
     },
 ): Promise<GenerateObjectResult<RESULT>> {
   const {
-    model,
+    model: modelArg,
     output = 'object',
     system,
     prompt,
@@ -232,6 +233,8 @@ Default and recommended: 'auto' (best mode for the model).
     } = {},
     ...settings
   } = options;
+
+  const model = resolveLanguageModel(modelArg);
 
   const enumValues = 'enum' in options ? options.enum : undefined;
   const {

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -41,6 +41,7 @@ import { LanguageModelUsage } from '../types/usage';
 import { getOutputStrategy, OutputStrategy } from './output-strategy';
 import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
+import { resolveLanguageModel } from '../prompt/resolve-language-model';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -361,7 +362,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
   >;
 
   constructor({
-    model,
+    model: modelArg,
     headers,
     telemetry,
     settings,
@@ -399,6 +400,8 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
     currentDate: () => Date;
     now: () => number;
   }) {
+    const model = resolveLanguageModel(modelArg);
+
     const { maxRetries, retry } = prepareRetries({
       maxRetries: maxRetriesArg,
     });

--- a/packages/ai/core/prompt/resolve-language-model.ts
+++ b/packages/ai/core/prompt/resolve-language-model.ts
@@ -1,0 +1,7 @@
+import { gateway } from '@ai-sdk/gateway';
+import { LanguageModelV2 } from '@ai-sdk/provider';
+import { LanguageModel } from '../types/language-model';
+
+export function resolveLanguageModel(model: LanguageModel): LanguageModelV2 {
+  return typeof model === 'string' ? gateway.languageModel(model) : model;
+}

--- a/packages/ai/core/registry/custom-provider.ts
+++ b/packages/ai/core/registry/custom-provider.ts
@@ -1,5 +1,10 @@
-import { NoSuchModelError, ProviderV2 } from '@ai-sdk/provider';
-import { EmbeddingModel, ImageModel, LanguageModel, Provider } from '../types';
+import {
+  EmbeddingModelV2,
+  ImageModelV2,
+  LanguageModelV2,
+  NoSuchModelError,
+  ProviderV2,
+} from '@ai-sdk/provider';
 
 /**
  * Creates a custom provider with specified language models, text embedding models, and an optional fallback provider.
@@ -14,9 +19,9 @@ import { EmbeddingModel, ImageModel, LanguageModel, Provider } from '../types';
  * @throws {NoSuchModelError} Throws when a requested model is not found and no fallback provider is available.
  */
 export function customProvider<
-  LANGUAGE_MODELS extends Record<string, LanguageModel>,
-  EMBEDDING_MODELS extends Record<string, EmbeddingModel<string>>,
-  IMAGE_MODELS extends Record<string, ImageModel>,
+  LANGUAGE_MODELS extends Record<string, LanguageModelV2>,
+  EMBEDDING_MODELS extends Record<string, EmbeddingModelV2<string>>,
+  IMAGE_MODELS extends Record<string, ImageModelV2>,
 >({
   languageModels,
   textEmbeddingModels,
@@ -27,15 +32,15 @@ export function customProvider<
   textEmbeddingModels?: EMBEDDING_MODELS;
   imageModels?: IMAGE_MODELS;
   fallbackProvider?: ProviderV2;
-}): Provider & {
-  languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModel;
+}): ProviderV2 & {
+  languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModelV2;
   textEmbeddingModel(
     modelId: ExtractModelId<EMBEDDING_MODELS>,
-  ): EmbeddingModel<string>;
-  imageModel(modelId: ExtractModelId<IMAGE_MODELS>): ImageModel;
+  ): EmbeddingModelV2<string>;
+  imageModel(modelId: ExtractModelId<IMAGE_MODELS>): ImageModelV2;
 } {
   return {
-    languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModel {
+    languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModelV2 {
       if (languageModels != null && modelId in languageModels) {
         return languageModels[modelId];
       }
@@ -49,7 +54,7 @@ export function customProvider<
 
     textEmbeddingModel(
       modelId: ExtractModelId<EMBEDDING_MODELS>,
-    ): EmbeddingModel<string> {
+    ): EmbeddingModelV2<string> {
       if (textEmbeddingModels != null && modelId in textEmbeddingModels) {
         return textEmbeddingModels[modelId];
       }
@@ -61,7 +66,7 @@ export function customProvider<
       throw new NoSuchModelError({ modelId, modelType: 'textEmbeddingModel' });
     },
 
-    imageModel(modelId: ExtractModelId<IMAGE_MODELS>): ImageModel {
+    imageModel(modelId: ExtractModelId<IMAGE_MODELS>): ImageModelV2 {
       if (imageModels != null && modelId in imageModels) {
         return imageModels[modelId];
       }

--- a/packages/ai/core/registry/provider-registry.ts
+++ b/packages/ai/core/registry/provider-registry.ts
@@ -1,5 +1,10 @@
-import { NoSuchModelError, ProviderV2 } from '@ai-sdk/provider';
-import { EmbeddingModel, ImageModel, LanguageModel } from '../types';
+import {
+  EmbeddingModelV2,
+  ImageModelV2,
+  LanguageModelV2,
+  NoSuchModelError,
+  ProviderV2,
+} from '@ai-sdk/provider';
 import { NoSuchProviderError } from './no-such-provider-error';
 
 type ExtractLiteralUnion<T> = T extends string
@@ -16,28 +21,28 @@ export interface ProviderRegistryProvider<
     id: KEY extends string
       ? `${KEY & string}${SEPARATOR}${ExtractLiteralUnion<Parameters<NonNullable<PROVIDERS[KEY]['languageModel']>>[0]>}`
       : never,
-  ): LanguageModel;
+  ): LanguageModelV2;
   languageModel<KEY extends keyof PROVIDERS>(
     id: KEY extends string ? `${KEY & string}${SEPARATOR}${string}` : never,
-  ): LanguageModel;
+  ): LanguageModelV2;
 
   textEmbeddingModel<KEY extends keyof PROVIDERS>(
     id: KEY extends string
       ? `${KEY & string}${SEPARATOR}${ExtractLiteralUnion<Parameters<NonNullable<PROVIDERS[KEY]['textEmbeddingModel']>>[0]>}`
       : never,
-  ): EmbeddingModel<string>;
+  ): EmbeddingModelV2<string>;
   textEmbeddingModel<KEY extends keyof PROVIDERS>(
     id: KEY extends string ? `${KEY & string}${SEPARATOR}${string}` : never,
-  ): EmbeddingModel<string>;
+  ): EmbeddingModelV2<string>;
 
   imageModel<KEY extends keyof PROVIDERS>(
     id: KEY extends string
       ? `${KEY & string}${SEPARATOR}${ExtractLiteralUnion<Parameters<NonNullable<PROVIDERS[KEY]['imageModel']>>[0]>}`
       : never,
-  ): ImageModel;
+  ): ImageModelV2;
   imageModel<KEY extends keyof PROVIDERS>(
     id: KEY extends string ? `${KEY & string}${SEPARATOR}${string}` : never,
-  ): ImageModel;
+  ): ImageModelV2;
 }
 
 /**
@@ -131,7 +136,7 @@ class DefaultProviderRegistry<
 
   languageModel<KEY extends keyof PROVIDERS>(
     id: `${KEY & string}${SEPARATOR}${string}`,
-  ): LanguageModel {
+  ): LanguageModelV2 {
     const [providerId, modelId] = this.splitId(id, 'languageModel');
     const model = this.getProvider(providerId).languageModel?.(modelId);
 
@@ -144,7 +149,7 @@ class DefaultProviderRegistry<
 
   textEmbeddingModel<KEY extends keyof PROVIDERS>(
     id: `${KEY & string}${SEPARATOR}${string}`,
-  ): EmbeddingModel<string> {
+  ): EmbeddingModelV2<string> {
     const [providerId, modelId] = this.splitId(id, 'textEmbeddingModel');
     const provider = this.getProvider(providerId);
 
@@ -162,7 +167,7 @@ class DefaultProviderRegistry<
 
   imageModel<KEY extends keyof PROVIDERS>(
     id: `${KEY & string}${SEPARATOR}${string}`,
-  ): ImageModel {
+  ): ImageModelV2 {
     const [providerId, modelId] = this.splitId(id, 'imageModel');
     const provider = this.getProvider(providerId);
 

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -1,3 +1,4 @@
+import { GatewayModelId } from '@ai-sdk/gateway';
 import {
   LanguageModelV2,
   LanguageModelV2CallWarning,
@@ -8,7 +9,7 @@ import {
 /**
 Language model that is used by the AI SDK Core functions.
 */
-export type LanguageModel = LanguageModelV2;
+export type LanguageModel = GatewayModelId | LanguageModelV2;
 
 /**
 Reason why a language model finished generating a response.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -54,6 +54,7 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/gateway": "workspace:*",
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
     "@opentelemetry/api": "1.9.0"

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -24,6 +24,9 @@
     },
     {
       "path": "../provider-utils"
+    },
+    {
+      "path": "../gateway"
     }
   ]
 }

--- a/packages/provider/src/provider/v2/provider-v2.ts
+++ b/packages/provider/src/provider/v2/provider-v2.ts
@@ -38,5 +38,5 @@ The model id is then passed to the provider function to get the model.
 
 @returns {ImageModel} The image model associated with the id
 */
-  readonly imageModel: (modelId: string) => ImageModelV2;
+  imageModel(modelId: string): ImageModelV2;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1168,6 +1168,9 @@ importers:
 
   packages/ai:
     dependencies:
+      '@ai-sdk/gateway':
+        specifier: workspace:*
+        version: link:../gateway
       '@ai-sdk/provider':
         specifier: workspace:*
         version: link:../provider


### PR DESCRIPTION
## Background

 To make it easy to get started with AI, the AI SDK will support string model ids through the Vercel AI gateway service.

## Summary

Add string model id support through the Vercel AI gateway.