### PR TITLE
fix (ai): do not send id with start unless specified

### DIFF
--- a/.changeset/khaki-tomatoes-think.md
+++ b/.changeset/khaki-tomatoes-think.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): do not send id with start unless specified

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -60,7 +60,7 @@ exports[`streamText > multiple stream consumption > should support text stream, 
   ],
   "uiMessageStream": [
     {
-      "messageId": "id-1",
+      "messageId": undefined,
       "metadata": undefined,
       "type": "start",
     },
@@ -2816,7 +2816,7 @@ exports[`streamText > result.fullStream > should use fallback response metadata 
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error messages by default 1`] = `
 [
-  "data: {"type":"start","messageId":"id-0"}
+  "data: {"type":"start"}
 
 ",
   "data: {"type":"start-step"}
@@ -2839,7 +2839,7 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should mask error m
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should omit message finish event (d:) when sendFinish is false 1`] = `
 [
-  "data: {"type":"start","messageId":"id-0"}
+  "data: {"type":"start"}
 
 ",
   "data: {"type":"start-step"}
@@ -2859,7 +2859,7 @@ exports[`streamText > result.pipeUIMessageStreamToResponse > should omit message
 
 exports[`streamText > result.pipeUIMessageStreamToResponse > should support custom error messages 1`] = `
 [
-  "data: {"type":"start","messageId":"id-0"}
+  "data: {"type":"start"}
 
 ",
   "data: {"type":"start-step"}
@@ -3263,7 +3263,7 @@ exports[`streamText > result.textStream > should swallow error to prevent server
 exports[`streamText > result.toUIMessageStream > should create a data stream 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3297,7 +3297,7 @@ exports[`streamText > result.toUIMessageStream > should create a data stream 1`]
 exports[`streamText > result.toUIMessageStream > should mask error messages by default 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3323,7 +3323,7 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
 exports[`streamText > result.toUIMessageStream > should omit message finish event when sendFinish is false 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3366,7 +3366,7 @@ exports[`streamText > result.toUIMessageStream > should omit message start event
 exports[`streamText > result.toUIMessageStream > should send file content 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3402,7 +3402,7 @@ exports[`streamText > result.toUIMessageStream > should send file content 1`] = 
 exports[`streamText > result.toUIMessageStream > should send reasoning content when sendReasoning is true 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3488,7 +3488,7 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
 exports[`streamText > result.toUIMessageStream > should send source content when sendSources is true 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3536,7 +3536,7 @@ exports[`streamText > result.toUIMessageStream > should send source content when
 exports[`streamText > result.toUIMessageStream > should send tool call and tool result stream parts 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3571,7 +3571,7 @@ exports[`streamText > result.toUIMessageStream > should send tool call and tool 
 exports[`streamText > result.toUIMessageStream > should send tool call, tool call stream start, tool call deltas, and tool result stream parts when tool call delta flag is enabled 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3621,7 +3621,7 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
 exports[`streamText > result.toUIMessageStream > should support custom error messages 1`] = `
 [
   {
-    "messageId": "id-0",
+    "messageId": undefined,
     "metadata": undefined,
     "type": "start",
   },
@@ -3646,7 +3646,7 @@ exports[`streamText > result.toUIMessageStream > should support custom error mes
 
 exports[`streamText > result.toUIMessageStreamResponse > should mask error messages by default 1`] = `
 [
-  "data: {"type":"start","messageId":"id-0"}
+  "data: {"type":"start"}
 
 ",
   "data: {"type":"start-step"}
@@ -3669,7 +3669,7 @@ exports[`streamText > result.toUIMessageStreamResponse > should mask error messa
 
 exports[`streamText > result.toUIMessageStreamResponse > should support custom error messages 1`] = `
 [
-  "data: {"type":"start","messageId":"id-0"}
+  "data: {"type":"start"}
 
 ",
   "data: {"type":"start-step"}

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -843,7 +843,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start","messageId":"id-0"}
+          "data: {"type":"start"}
 
         ",
           "data: {"type":"start-step"}
@@ -908,7 +908,7 @@ describe('streamText', () => {
 
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start","messageId":"id-0"}
+          "data: {"type":"start"}
 
         ",
           "data: {"type":"start-step"}
@@ -1032,7 +1032,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start","messageId":"id-0"}
+          "data: {"type":"start"}
 
         ",
           "data: {"type":"start-step"}
@@ -1113,7 +1113,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start","messageId":"id-0"}
+          "data: {"type":"start"}
 
         ",
           "data: {"type":"start-step"}
@@ -1165,7 +1165,7 @@ describe('streamText', () => {
       `);
       expect(mockResponse.getDecodedChunks()).toMatchInlineSnapshot(`
         [
-          "data: {"type":"start","messageId":"id-0"}
+          "data: {"type":"start"}
 
         ",
           "data: {"type":"start-step"}
@@ -1353,7 +1353,7 @@ describe('streamText', () => {
         .toMatchInlineSnapshot(`
           [
             {
-              "messageId": "id-0",
+              "messageId": undefined,
               "metadata": {
                 "key1": "value1",
               },
@@ -1542,7 +1542,7 @@ describe('streamText', () => {
       expect(await convertResponseStreamToArray(response))
         .toMatchInlineSnapshot(`
           [
-            "data: {"type":"start","messageId":"id-0"}
+            "data: {"type":"start"}
 
           ",
             "data: {"type":"start-step"}
@@ -1603,7 +1603,7 @@ describe('streamText', () => {
       expect(await convertResponseStreamToArray(response))
         .toMatchInlineSnapshot(`
           [
-            "data: {"type":"start","messageId":"id-0"}
+            "data: {"type":"start"}
 
           ",
             "data: {"type":"start-step"}
@@ -2753,7 +2753,7 @@ describe('streamText', () => {
           .toMatchInlineSnapshot(`
             [
               {
-                "messageId": "id-0",
+                "messageId": undefined,
                 "metadata": undefined,
                 "type": "start",
               },
@@ -4358,7 +4358,7 @@ describe('streamText', () => {
           .toMatchInlineSnapshot(`
             [
               {
-                "messageId": "id-0",
+                "messageId": undefined,
                 "metadata": undefined,
                 "type": "start",
               },

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1421,9 +1421,7 @@ However, the LLM results are expected to be small enough to not cause issues.
   }: UIMessageStreamOptions = {}): ReadableStream<UIMessageStreamPart> {
     const lastMessage = originalMessages[originalMessages.length - 1];
     const isContinuation = lastMessage?.role === 'assistant';
-    const messageId = isContinuation
-      ? lastMessage.id
-      : (newMessageId ?? this.generateId());
+    const messageId = isContinuation ? lastMessage.id : newMessageId;
 
     const baseStream = this.fullStream.pipeThrough(
       new TransformStream<TextStreamPart<TOOLS>, UIMessageStreamPart>({
@@ -1576,7 +1574,7 @@ However, the LLM results are expected to be small enough to not cause issues.
 
     return handleUIMessageStreamFinish({
       stream: baseStream,
-      newMessageId: messageId,
+      newMessageId: messageId ?? this.generateId(),
       originalMessages,
       onFinish,
     });


### PR DESCRIPTION
## Background

The next-openai tools example was broken. Many assistant messages were appended.

## Summary

Do not automatically generate and send an id with `start` events, because they affect last message replacement.

## Verification

Manually test the next-openai tools example to ensure that the bug is fixed.