### PR TITLE
docs (changeset): the change from #6189 is not a breaking change

### DIFF
--- a/.changeset/two-otters-whisper.md
+++ b/.changeset/two-otters-whisper.md
@@ -1,5 +1,5 @@
 ---
-'ai': major
+'ai': patch
 ---
 
 feat (ai): support model message array in prompt


### PR DESCRIPTION
Ran into this as I was looking through changes for the v5 migration guide and codemods