### PR TITLE
fix (providers/google): update supportedUrls to only support native URL

### DIFF
--- a/.changeset/empty-flowers-sniff.md
+++ b/.changeset/empty-flowers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+update supportedUrls to only support native URL

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -103,8 +103,9 @@ export function createGoogleGenerativeAI(
       generateId: options.generateId ?? generateId,
       supportedUrls: () => ({
         '*': [
-          // HTTP URLs:
-          /^https?:\/\/.*$/,
+          // Only allow requests to the Google Generative Language "files" endpoint
+          // e.g. https://generativelanguage.googleapis.com/v1beta/files/...
+          new RegExp(`^${baseURL}/files/.*$`),
         ],
       }),
       fetch: options.fetch,


### PR DESCRIPTION
## Background

Fixes the ability to use non-native links to files in file parts when using the Google provider.

## Summary

Updated the `supportedUrls` of the google provider specification to only include the native URL, which is `https://generativelanguage.googleapis.com/v1beta/files/...`.

## Verification
Manually verified by running the `next-openai` example, switching the provider to use `google("gemini-2.0-flash")`, and testing the example at `/use-chat-attachments-url`.

## Tasks
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues
Fixes #6558
