### PR TITLE
feat (providers/gateway): add gateway error types with error detail

### DIFF
--- a/.changeset/smooth-carpets-bathe.md
+++ b/.changeset/smooth-carpets-bathe.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (providers/gateway): add gateway error types with error detail

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createGatewayErrorFromResponse,
+  GatewayAuthenticationError,
+  GatewayInvalidRequestError,
+  GatewayRateLimitError,
+  GatewayModelNotFoundError,
+  GatewayInternalServerError,
+  GatewayResponseError,
+  type GatewayErrorResponse,
+} from './index';
+
+describe('Valid error responses', () => {
+  it('should create GatewayAuthenticationError for authentication_error type', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Invalid API key',
+        type: 'authentication_error',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 401,
+    });
+
+    expect(error).toBeInstanceOf(GatewayAuthenticationError);
+    expect(error.message).toBe('Invalid API key');
+    expect(error.statusCode).toBe(401);
+    expect(error.type).toBe('authentication_error');
+  });
+
+  it('should create GatewayInvalidRequestError for invalid_request_error type', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Missing required parameter',
+        type: 'invalid_request_error',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 400,
+    });
+
+    expect(error).toBeInstanceOf(GatewayInvalidRequestError);
+    expect(error.message).toBe('Missing required parameter');
+    expect(error.statusCode).toBe(400);
+  });
+
+  it('should create GatewayRateLimitError for rate_limit_exceeded type', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Rate limit exceeded. Try again later.',
+        type: 'rate_limit_exceeded',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 429,
+    });
+
+    expect(error).toBeInstanceOf(GatewayRateLimitError);
+    expect(error.message).toBe('Rate limit exceeded. Try again later.');
+    expect(error.statusCode).toBe(429);
+  });
+
+  it('should create GatewayModelNotFoundError for model_not_found type', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Model not available',
+        type: 'model_not_found',
+        param: { modelId: 'gpt-4-turbo' },
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 404,
+    });
+
+    expect(error).toBeInstanceOf(GatewayModelNotFoundError);
+    expect(error.message).toBe('Model not available');
+    expect(error.statusCode).toBe(404);
+    expect((error as GatewayModelNotFoundError).modelId).toBe('gpt-4-turbo');
+  });
+
+  it('should create GatewayModelNotFoundError without modelId for invalid param', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Model not available',
+        type: 'model_not_found',
+        param: { invalidField: 'value' },
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 404,
+    });
+
+    expect(error).toBeInstanceOf(GatewayModelNotFoundError);
+    expect((error as GatewayModelNotFoundError).modelId).toBeUndefined();
+  });
+
+  it('should create GatewayInternalServerError for internal_server_error type', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Internal server error occurred',
+        type: 'internal_server_error',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+    });
+
+    expect(error).toBeInstanceOf(GatewayInternalServerError);
+    expect(error.message).toBe('Internal server error occurred');
+    expect(error.statusCode).toBe(500);
+  });
+
+  it('should create GatewayInternalServerError for unknown error type', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Unknown error occurred',
+        type: 'unknown_error_type',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+    });
+
+    expect(error).toBeInstanceOf(GatewayInternalServerError);
+    expect(error.message).toBe('Unknown error occurred');
+    expect(error.statusCode).toBe(500);
+  });
+});
+
+describe('Error response edge cases', () => {
+  it('should preserve empty string messages from Gateway', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: '',
+        type: 'authentication_error',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 401,
+      defaultMessage: 'Custom default message',
+    });
+
+    expect(error.message).toBe(''); // Empty string from Gateway is preserved
+  });
+
+  it('should use defaultMessage when response message is null', () => {
+    const response = {
+      error: {
+        message: null,
+        type: 'authentication_error',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 401,
+      defaultMessage: 'Custom default message',
+    });
+
+    // When the response doesn't pass schema validation, it creates a response error
+    expect(error).toBeInstanceOf(GatewayResponseError);
+    expect(error.message).toBe(
+      'Invalid error response format: Custom default message',
+    );
+
+    // Verify debugging information is included
+    const responseError = error as GatewayResponseError;
+    expect(responseError.response).toBe(response);
+    expect(responseError.validationError).toBeDefined();
+  });
+
+  it('should handle error type as null', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Some error',
+        type: null,
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+    });
+
+    expect(error).toBeInstanceOf(GatewayInternalServerError);
+  });
+
+  it('should include cause in the created error', () => {
+    const originalCause = new Error('Original network error');
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Gateway timeout',
+        type: 'internal_server_error',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 504,
+      cause: originalCause,
+    });
+
+    expect(error.cause).toBe(originalCause);
+  });
+});
+
+describe('Malformed responses', () => {
+  it('should create GatewayResponseError for completely invalid response', () => {
+    const response = {
+      invalidField: 'value',
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+    });
+
+    expect(error).toBeInstanceOf(GatewayResponseError);
+    expect(error.message).toBe(
+      'Invalid error response format: Gateway request failed',
+    );
+    expect(error.statusCode).toBe(500);
+
+    // Verify debugging information is included
+    const responseError = error as GatewayResponseError;
+    expect(responseError.response).toBe(response);
+    expect(responseError.validationError).toBeDefined();
+    expect(responseError.validationError?.issues).toBeDefined();
+  });
+
+  it('should create GatewayResponseError for missing error field', () => {
+    const response = {
+      data: 'some data',
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+      defaultMessage: 'Custom error message',
+    });
+
+    expect(error).toBeInstanceOf(GatewayResponseError);
+    expect(error.message).toBe(
+      'Invalid error response format: Custom error message',
+    );
+
+    // Verify debugging information is included
+    const responseError = error as GatewayResponseError;
+    expect(responseError.response).toBe(response);
+    expect(responseError.validationError).toBeDefined();
+  });
+
+  it('should create GatewayResponseError for null response', () => {
+    const response = null;
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+    });
+
+    expect(error).toBeInstanceOf(GatewayResponseError);
+    expect(error.message).toBe(
+      'Invalid error response format: Gateway request failed',
+    );
+
+    // Verify debugging information is included
+    const responseError = error as GatewayResponseError;
+    expect(responseError.response).toBe(response);
+    expect(responseError.validationError).toBeDefined();
+  });
+
+  it('should create GatewayResponseError for string response', () => {
+    const response = 'Error string';
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+    });
+
+    expect(error).toBeInstanceOf(GatewayResponseError);
+    expect(error.message).toBe(
+      'Invalid error response format: Gateway request failed',
+    );
+
+    // Verify debugging information is included
+    const responseError = error as GatewayResponseError;
+    expect(responseError.response).toBe(response);
+    expect(responseError.validationError).toBeDefined();
+  });
+
+  it('should create GatewayResponseError for array response', () => {
+    const response = ['error', 'array'];
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+    });
+
+    expect(error).toBeInstanceOf(GatewayResponseError);
+    expect(error.message).toBe(
+      'Invalid error response format: Gateway request failed',
+    );
+
+    // Verify debugging information is included
+    const responseError = error as GatewayResponseError;
+    expect(responseError.response).toBe(response);
+    expect(responseError.validationError).toBeDefined();
+  });
+});
+
+describe('Object parameter validation', () => {
+  it('should use default defaultMessage when not provided', () => {
+    const response = {
+      invalidField: 'value',
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 500,
+    });
+
+    expect(error).toBeInstanceOf(GatewayResponseError);
+    expect(error.message).toBe(
+      'Invalid error response format: Gateway request failed',
+    );
+
+    // Verify debugging information is included
+    const responseError = error as GatewayResponseError;
+    expect(responseError.response).toBe(response);
+    expect(responseError.validationError).toBeDefined();
+  });
+
+  it('should handle undefined cause', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Test error',
+        type: 'authentication_error',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 401,
+      cause: undefined,
+    });
+
+    expect(error.cause).toBeUndefined();
+  });
+});
+
+describe('Complex scenarios', () => {
+  it('should handle model_not_found with missing param field', () => {
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Model not found',
+        type: 'model_not_found',
+        // param field missing
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 404,
+    });
+
+    expect(error).toBeInstanceOf(GatewayModelNotFoundError);
+    expect((error as GatewayModelNotFoundError).modelId).toBeUndefined();
+  });
+
+  it('should handle response with extra fields', () => {
+    const response = {
+      error: {
+        message: 'Test error',
+        type: 'authentication_error',
+        code: 'AUTH_FAILED',
+        param: null,
+        extraField: 'should be ignored',
+      },
+      metadata: 'should be ignored',
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 401,
+    });
+
+    expect(error).toBeInstanceOf(GatewayAuthenticationError);
+    expect(error.message).toBe('Test error');
+  });
+
+  it('should preserve error properties correctly', () => {
+    const originalCause = new TypeError('Type error');
+    const response: GatewayErrorResponse = {
+      error: {
+        message: 'Rate limit hit',
+        type: 'rate_limit_exceeded',
+      },
+    };
+
+    const error = createGatewayErrorFromResponse({
+      response,
+      statusCode: 429,
+      defaultMessage: 'Fallback message',
+      cause: originalCause,
+    });
+
+    expect(error).toBeInstanceOf(GatewayRateLimitError);
+    expect(error.message).toBe('Rate limit hit'); // Uses response message, not default
+    expect(error.statusCode).toBe(429);
+    expect(error.cause).toBe(originalCause);
+    expect(error.name).toBe('GatewayRateLimitError');
+    expect(error.type).toBe('rate_limit_exceeded');
+  });
+});

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import type { GatewayError } from './gateway-error';
+import { GatewayAuthenticationError } from './gateway-authentication-error';
+import { GatewayInvalidRequestError } from './gateway-invalid-request-error';
+import { GatewayRateLimitError } from './gateway-rate-limit-error';
+import {
+  GatewayModelNotFoundError,
+  modelNotFoundParamSchema,
+} from './gateway-model-not-found-error';
+import { GatewayInternalServerError } from './gateway-internal-server-error';
+import { GatewayResponseError } from './gateway-response-error';
+
+export function createGatewayErrorFromResponse({
+  response,
+  statusCode,
+  defaultMessage = 'Gateway request failed',
+  cause,
+}: {
+  response: unknown;
+  statusCode: number;
+  defaultMessage?: string;
+  cause?: unknown;
+}): GatewayError {
+  const parseResult = gatewayErrorResponseSchema.safeParse(response);
+  if (!parseResult.success) {
+    return new GatewayResponseError({
+      message: `Invalid error response format: ${defaultMessage}`,
+      statusCode,
+      response,
+      validationError: parseResult.error,
+      cause,
+    });
+  }
+
+  const validatedResponse: GatewayErrorResponse = parseResult.data;
+  const errorType = validatedResponse.error.type;
+  const message = validatedResponse.error.message;
+
+  switch (errorType) {
+    case 'authentication_error':
+      return new GatewayAuthenticationError({ message, statusCode, cause });
+    case 'invalid_request_error':
+      return new GatewayInvalidRequestError({ message, statusCode, cause });
+    case 'rate_limit_exceeded':
+      return new GatewayRateLimitError({ message, statusCode, cause });
+    case 'model_not_found': {
+      const modelResult = modelNotFoundParamSchema.safeParse(
+        validatedResponse.error.param,
+      );
+      return new GatewayModelNotFoundError({
+        message,
+        statusCode,
+        modelId: modelResult.success ? modelResult.data.modelId : undefined,
+        cause,
+      });
+    }
+    case 'internal_server_error':
+      return new GatewayInternalServerError({ message, statusCode, cause });
+    default:
+      return new GatewayInternalServerError({ message, statusCode, cause });
+  }
+}
+
+const gatewayErrorResponseSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    type: z.string().nullish(),
+    param: z.unknown().nullish(),
+    code: z.union([z.string(), z.number()]).nullish(),
+  }),
+});
+
+export type GatewayErrorResponse = z.infer<typeof gatewayErrorResponseSchema>;

--- a/packages/gateway/src/errors/extract-api-call-response.test.ts
+++ b/packages/gateway/src/errors/extract-api-call-response.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+import { APICallError } from '@ai-sdk/provider';
+import { extractApiCallResponse } from './extract-api-call-response';
+
+describe('extractResponseFromAPICallError', () => {
+  describe('when error.data is available', () => {
+    it('should return error.data when successfully parsed by AI SDK', () => {
+      const parsedData = {
+        error: { message: 'Parsed error', type: 'authentication_error' },
+      };
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 401,
+        data: parsedData,
+        responseHeaders: {},
+        responseBody: JSON.stringify({ different: 'data' }),
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe(parsedData); // Should prefer parsed data over responseBody
+    });
+
+    it('should return error.data even when it is null', () => {
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: null,
+        responseHeaders: {},
+        responseBody: '{"fallback": "data"}',
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBeNull(); // Should return null, not fallback to responseBody
+    });
+
+    it('should return error.data even when it is an empty object', () => {
+      const emptyData = {};
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 400,
+        data: emptyData,
+        responseHeaders: {},
+        responseBody: '{"fallback": "data"}',
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe(emptyData); // Should return empty object, not fallback
+    });
+  });
+
+  describe('when error.data is undefined', () => {
+    it('should parse and return responseBody as JSON when valid', () => {
+      const responseData = {
+        ferror: { message: 'Malformed error', type: 'model_not_found' },
+      };
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 404,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: JSON.stringify(responseData),
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toEqual(responseData);
+    });
+
+    it('should return raw responseBody when JSON parsing fails', () => {
+      const invalidJson = 'This is not valid JSON';
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: invalidJson,
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe(invalidJson);
+    });
+
+    it('should handle HTML error responses', () => {
+      const htmlResponse =
+        '<html><body><h1>500 Internal Server Error</h1></body></html>';
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: htmlResponse,
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe(htmlResponse);
+    });
+
+    it('should handle empty string responseBody', () => {
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 502,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: '',
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe('');
+    });
+
+    it('should handle malformed JSON gracefully', () => {
+      const malformedJson = '{"incomplete": json';
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: malformedJson,
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe(malformedJson); // Should return raw string, not throw
+    });
+
+    it('should parse complex nested JSON structures', () => {
+      const complexData = {
+        error: {
+          message: 'Complex error',
+          type: 'validation_error',
+          details: {
+            field: 'prompt',
+            issues: [
+              { code: 'too_long', message: 'Prompt exceeds maximum length' },
+              {
+                code: 'invalid_format',
+                message: 'Contains invalid characters',
+              },
+            ],
+          },
+        },
+        metadata: {
+          requestId: '12345',
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+      };
+
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 400,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: JSON.stringify(complexData),
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toEqual(complexData);
+    });
+  });
+
+  describe('when responseBody is not available', () => {
+    it('should return empty object when both data and responseBody are undefined', () => {
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: undefined as any, // Simulating missing responseBody
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when responseBody is null', () => {
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: null as any,
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle numeric responseBody', () => {
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: '404',
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe(404); // Should parse as number
+    });
+
+    it('should handle boolean responseBody', () => {
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 500,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: 'true',
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toBe(true); // Should parse as boolean
+    });
+
+    it('should handle array responseBody', () => {
+      const arrayData = ['error1', 'error2', 'error3'];
+      const apiCallError = new APICallError({
+        message: 'Request failed',
+        statusCode: 400,
+        data: undefined,
+        responseHeaders: {},
+        responseBody: JSON.stringify(arrayData),
+        url: 'http://test.url',
+        requestBodyValues: {},
+      });
+
+      const result = extractApiCallResponse(apiCallError);
+
+      expect(result).toEqual(arrayData);
+    });
+  });
+});

--- a/packages/gateway/src/errors/extract-api-call-response.ts
+++ b/packages/gateway/src/errors/extract-api-call-response.ts
@@ -1,0 +1,15 @@
+import type { APICallError } from '@ai-sdk/provider';
+
+export function extractApiCallResponse(error: APICallError): unknown {
+  if (error.data !== undefined) {
+    return error.data;
+  }
+  if (error.responseBody != null) {
+    try {
+      return JSON.parse(error.responseBody);
+    } catch {
+      return error.responseBody;
+    }
+  }
+  return {};
+}

--- a/packages/gateway/src/errors/gateway-authentication-error.ts
+++ b/packages/gateway/src/errors/gateway-authentication-error.ts
@@ -1,0 +1,31 @@
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayAuthenticationError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Authentication failed - invalid API key or OIDC token
+ */
+export class GatewayAuthenticationError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'authentication_error';
+
+  constructor({
+    message = 'Authentication failed',
+    statusCode = 401,
+    cause,
+  }: {
+    message?: string;
+    statusCode?: number;
+    cause?: unknown;
+  } = {}) {
+    super({ message, statusCode, cause });
+  }
+
+  static isInstance(error: unknown): error is GatewayAuthenticationError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/gateway-error-types.test.ts
+++ b/packages/gateway/src/errors/gateway-error-types.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GatewayError,
+  GatewayAuthenticationError,
+  GatewayInvalidRequestError,
+  GatewayRateLimitError,
+  GatewayModelNotFoundError,
+  GatewayInternalServerError,
+  GatewayResponseError,
+} from './index';
+
+describe('GatewayAuthenticationError', () => {
+  it('should create error with default values', () => {
+    const error = new GatewayAuthenticationError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(GatewayError);
+    expect(error.name).toBe('GatewayAuthenticationError');
+    expect(error.type).toBe('authentication_error');
+    expect(error.message).toBe('Authentication failed');
+    expect(error.statusCode).toBe(401);
+    expect(error.cause).toBeUndefined();
+  });
+
+  it('should create error with custom values', () => {
+    const cause = new Error('Original error');
+    const error = new GatewayAuthenticationError({
+      message: 'Custom auth failed',
+      statusCode: 403,
+      cause,
+    });
+
+    expect(error.message).toBe('Custom auth failed');
+    expect(error.statusCode).toBe(403);
+    expect(error.cause).toBe(cause);
+  });
+
+  it('should be identifiable via instance check', () => {
+    const error = new GatewayAuthenticationError();
+    const otherError = new Error('Not a gateway error');
+
+    expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
+    expect(GatewayAuthenticationError.isInstance(otherError)).toBe(false);
+    expect(GatewayError.isInstance(error)).toBe(true);
+  });
+});
+
+describe('GatewayInvalidRequestError', () => {
+  it('should create error with default values', () => {
+    const error = new GatewayInvalidRequestError();
+
+    expect(error.name).toBe('GatewayInvalidRequestError');
+    expect(error.type).toBe('invalid_request_error');
+    expect(error.message).toBe('Invalid request');
+    expect(error.statusCode).toBe(400);
+  });
+
+  it('should create error with custom values', () => {
+    const error = new GatewayInvalidRequestError({
+      message: 'Missing required field',
+      statusCode: 422,
+    });
+
+    expect(error.message).toBe('Missing required field');
+    expect(error.statusCode).toBe(422);
+  });
+
+  it('should be identifiable via instance check', () => {
+    const error = new GatewayInvalidRequestError();
+
+    expect(GatewayInvalidRequestError.isInstance(error)).toBe(true);
+    expect(GatewayAuthenticationError.isInstance(error)).toBe(false);
+    expect(GatewayError.isInstance(error)).toBe(true);
+  });
+});
+
+describe('GatewayRateLimitError', () => {
+  it('should create error with default values', () => {
+    const error = new GatewayRateLimitError();
+
+    expect(error.name).toBe('GatewayRateLimitError');
+    expect(error.type).toBe('rate_limit_exceeded');
+    expect(error.message).toBe('Rate limit exceeded');
+    expect(error.statusCode).toBe(429);
+  });
+
+  it('should be identifiable via instance check', () => {
+    const error = new GatewayRateLimitError();
+
+    expect(GatewayRateLimitError.isInstance(error)).toBe(true);
+    expect(GatewayError.isInstance(error)).toBe(true);
+  });
+});
+
+describe('GatewayModelNotFoundError', () => {
+  it('should create error with default values', () => {
+    const error = new GatewayModelNotFoundError();
+
+    expect(error.name).toBe('GatewayModelNotFoundError');
+    expect(error.type).toBe('model_not_found');
+    expect(error.message).toBe('Model not found');
+    expect(error.statusCode).toBe(404);
+    expect(error.modelId).toBeUndefined();
+  });
+
+  it('should create error with model ID', () => {
+    const error = new GatewayModelNotFoundError({
+      message: 'Model gpt-4 not found',
+      modelId: 'gpt-4',
+    });
+
+    expect(error.message).toBe('Model gpt-4 not found');
+    expect(error.modelId).toBe('gpt-4');
+  });
+
+  it('should be identifiable via instance check', () => {
+    const error = new GatewayModelNotFoundError();
+
+    expect(GatewayModelNotFoundError.isInstance(error)).toBe(true);
+    expect(GatewayError.isInstance(error)).toBe(true);
+  });
+});
+
+describe('GatewayInternalServerError', () => {
+  it('should create error with default values', () => {
+    const error = new GatewayInternalServerError();
+
+    expect(error.name).toBe('GatewayInternalServerError');
+    expect(error.type).toBe('internal_server_error');
+    expect(error.message).toBe('Internal server error');
+    expect(error.statusCode).toBe(500);
+  });
+
+  it('should be identifiable via instance check', () => {
+    const error = new GatewayInternalServerError();
+
+    expect(GatewayInternalServerError.isInstance(error)).toBe(true);
+    expect(GatewayError.isInstance(error)).toBe(true);
+  });
+});
+
+describe('GatewayResponseError', () => {
+  it('should create error with default values', () => {
+    const error = new GatewayResponseError();
+
+    expect(error.name).toBe('GatewayResponseError');
+    expect(error.type).toBe('response_error');
+    expect(error.message).toBe('Invalid response from Gateway');
+    expect(error.statusCode).toBe(502);
+    expect(error.response).toBeUndefined();
+    expect(error.validationError).toBeUndefined();
+  });
+
+  it('should create error with response and validation error details', () => {
+    const response = { invalidField: 'value' };
+    const validationError = {
+      issues: [{ path: ['error'], message: 'Required' }],
+    } as any; // Mock ZodError structure
+
+    const error = new GatewayResponseError({
+      message: 'Custom parsing error',
+      statusCode: 422,
+      response,
+      validationError,
+    });
+
+    expect(error.message).toBe('Custom parsing error');
+    expect(error.statusCode).toBe(422);
+    expect(error.response).toBe(response);
+    expect(error.validationError).toBe(validationError);
+  });
+
+  it('should be identifiable via instance check', () => {
+    const error = new GatewayResponseError();
+
+    expect(GatewayResponseError.isInstance(error)).toBe(true);
+    expect(GatewayError.isInstance(error)).toBe(true);
+  });
+});
+
+describe('Cross-realm instance checking', () => {
+  it('should work with symbol-based type checking', () => {
+    const error = new GatewayAuthenticationError();
+
+    // Simulate different realm by creating a new instance in different context
+    const gatewayErrorMarker = Symbol.for('vercel.ai.gateway.error');
+    const authErrorMarker = Symbol.for(
+      'vercel.ai.gateway.error.GatewayAuthenticationError',
+    );
+
+    // Verify the symbols are present
+    expect((error as any)[gatewayErrorMarker]).toBe(true);
+    expect((error as any)[authErrorMarker]).toBe(true);
+
+    // Test cross-realm safety
+    expect(GatewayError.hasMarker(error)).toBe(true);
+    expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
+  });
+});
+
+describe('Error inheritance chain', () => {
+  it('should maintain proper inheritance', () => {
+    const error = new GatewayAuthenticationError();
+
+    expect(error instanceof Error).toBe(true);
+    expect(error instanceof GatewayError).toBe(true);
+    expect(error instanceof GatewayAuthenticationError).toBe(true);
+  });
+
+  it('should have proper stack traces', () => {
+    const error = new GatewayAuthenticationError({
+      message: 'Test error',
+    });
+
+    expect(error.stack).toBeDefined();
+    expect(error.stack).toContain('GatewayAuthenticationError');
+    expect(error.stack).toContain('Test error');
+  });
+});

--- a/packages/gateway/src/errors/gateway-error.ts
+++ b/packages/gateway/src/errors/gateway-error.ts
@@ -1,0 +1,43 @@
+const marker = 'vercel.ai.gateway.error';
+const symbol = Symbol.for(marker);
+
+export abstract class GatewayError extends Error {
+  private readonly [symbol] = true; // used in isInstance
+
+  abstract readonly name: string;
+  abstract readonly type: string;
+  readonly statusCode: number;
+  readonly cause?: unknown;
+
+  constructor({
+    message,
+    statusCode = 500,
+    cause,
+  }: {
+    message: string;
+    statusCode?: number;
+    cause?: unknown;
+  }) {
+    super(message);
+    this.statusCode = statusCode;
+    this.cause = cause;
+  }
+
+  /**
+   * Checks if the given error is a Gateway Error.
+   * @param {unknown} error - The error to check.
+   * @returns {boolean} True if the error is a Gateway Error, false otherwise.
+   */
+  static isInstance(error: unknown): error is GatewayError {
+    return GatewayError.hasMarker(error);
+  }
+
+  static hasMarker(error: unknown): error is GatewayError {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      symbol in error &&
+      (error as any)[symbol] === true
+    );
+  }
+}

--- a/packages/gateway/src/errors/gateway-internal-server-error.ts
+++ b/packages/gateway/src/errors/gateway-internal-server-error.ts
@@ -1,0 +1,31 @@
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayInternalServerError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Internal server error from the Gateway
+ */
+export class GatewayInternalServerError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'internal_server_error';
+
+  constructor({
+    message = 'Internal server error',
+    statusCode = 500,
+    cause,
+  }: {
+    message?: string;
+    statusCode?: number;
+    cause?: unknown;
+  } = {}) {
+    super({ message, statusCode, cause });
+  }
+
+  static isInstance(error: unknown): error is GatewayInternalServerError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/gateway-invalid-request-error.ts
+++ b/packages/gateway/src/errors/gateway-invalid-request-error.ts
@@ -1,0 +1,31 @@
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayInvalidRequestError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Invalid request - missing headers, malformed data, etc.
+ */
+export class GatewayInvalidRequestError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'invalid_request_error';
+
+  constructor({
+    message = 'Invalid request',
+    statusCode = 400,
+    cause,
+  }: {
+    message?: string;
+    statusCode?: number;
+    cause?: unknown;
+  } = {}) {
+    super({ message, statusCode, cause });
+  }
+
+  static isInstance(error: unknown): error is GatewayInvalidRequestError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/gateway-model-not-found-error.ts
+++ b/packages/gateway/src/errors/gateway-model-not-found-error.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayModelNotFoundError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+export const modelNotFoundParamSchema = z.object({
+  modelId: z.string(),
+});
+
+/**
+ * Model not found or not available
+ */
+export class GatewayModelNotFoundError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'model_not_found';
+  readonly modelId?: string;
+
+  constructor({
+    message = 'Model not found',
+    statusCode = 404,
+    modelId,
+    cause,
+  }: {
+    message?: string;
+    statusCode?: number;
+    modelId?: string;
+    cause?: unknown;
+  } = {}) {
+    super({ message, statusCode, cause });
+    this.modelId = modelId;
+  }
+
+  static isInstance(error: unknown): error is GatewayModelNotFoundError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/gateway-rate-limit-error.ts
+++ b/packages/gateway/src/errors/gateway-rate-limit-error.ts
@@ -1,0 +1,31 @@
+import { GatewayError } from './gateway-error';
+
+const name = 'GatewayRateLimitError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Rate limit exceeded.
+ */
+export class GatewayRateLimitError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'rate_limit_exceeded';
+
+  constructor({
+    message = 'Rate limit exceeded',
+    statusCode = 429,
+    cause,
+  }: {
+    message?: string;
+    statusCode?: number;
+    cause?: unknown;
+  } = {}) {
+    super({ message, statusCode, cause });
+  }
+
+  static isInstance(error: unknown): error is GatewayRateLimitError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/gateway-response-error.ts
+++ b/packages/gateway/src/errors/gateway-response-error.ts
@@ -1,0 +1,40 @@
+import { GatewayError } from './gateway-error';
+import type { ZodError } from 'zod';
+
+const name = 'GatewayResponseError';
+const marker = `vercel.ai.gateway.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Gateway response parsing error
+ */
+export class GatewayResponseError extends GatewayError {
+  private readonly [symbol] = true; // used in isInstance
+
+  readonly name = name;
+  readonly type = 'response_error';
+  readonly response?: unknown;
+  readonly validationError?: ZodError;
+
+  constructor({
+    message = 'Invalid response from Gateway',
+    statusCode = 502,
+    response,
+    validationError,
+    cause,
+  }: {
+    message?: string;
+    statusCode?: number;
+    response?: unknown;
+    validationError?: ZodError;
+    cause?: unknown;
+  } = {}) {
+    super({ message, statusCode, cause });
+    this.response = response;
+    this.validationError = validationError;
+  }
+
+  static isInstance(error: unknown): error is GatewayResponseError {
+    return GatewayError.hasMarker(error) && symbol in error;
+  }
+}

--- a/packages/gateway/src/errors/index.ts
+++ b/packages/gateway/src/errors/index.ts
@@ -1,0 +1,15 @@
+export { GatewayError } from './gateway-error';
+export { GatewayAuthenticationError } from './gateway-authentication-error';
+export { GatewayInvalidRequestError } from './gateway-invalid-request-error';
+export { GatewayRateLimitError } from './gateway-rate-limit-error';
+export {
+  GatewayModelNotFoundError,
+  modelNotFoundParamSchema,
+} from './gateway-model-not-found-error';
+export { GatewayInternalServerError } from './gateway-internal-server-error';
+export { GatewayResponseError } from './gateway-response-error';
+export {
+  createGatewayErrorFromResponse,
+  type GatewayErrorResponse,
+} from './create-gateway-error';
+export { extractApiCallResponse } from './extract-api-call-response';

--- a/packages/gateway/src/gateway-fetch-metadata.test.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.test.ts
@@ -1,7 +1,14 @@
 import { createTestServer } from '@ai-sdk/provider-utils/test';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { GatewayFetchMetadata } from './gateway-fetch-metadata';
 import type { FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  GatewayAuthenticationError,
+  GatewayInternalServerError,
+  GatewayRateLimitError,
+  GatewayResponseError,
+  GatewayError,
+} from './errors';
 
 function createBasicMetadataFetcher({
   headers,
@@ -72,15 +79,72 @@ describe('GatewayFetchMetadata', () => {
       server.urls['https://api.example.com/*'].response = {
         type: 'error',
         status: 401,
-        body: 'Unauthorized',
+        body: JSON.stringify({
+          error: {
+            message: 'Unauthorized',
+            type: 'authentication_error',
+          },
+        }),
       };
 
       const metadata = createBasicMetadataFetcher();
 
-      await expect(metadata.getAvailableModels()).rejects.toMatchObject({
-        message: 'Unauthorized',
-        name: 'AI_APICallError',
-      });
+      try {
+        await metadata.getAvailableModels();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
+        const authError = error as GatewayAuthenticationError;
+        expect(authError.message).toBe('Unauthorized');
+        expect(authError.type).toBe('authentication_error');
+        expect(authError.statusCode).toBe(401);
+      }
+    });
+
+    it('should convert API call errors to Gateway errors', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 403,
+        body: JSON.stringify({
+          error: {
+            message: 'Forbidden access',
+            type: 'authentication_error',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      try {
+        await metadata.getAvailableModels();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
+        const authError = error as GatewayAuthenticationError;
+        expect(authError.message).toBe('Forbidden access');
+        expect(authError.type).toBe('authentication_error');
+        expect(authError.statusCode).toBe(403);
+      }
+    });
+
+    it('should handle malformed JSON error responses', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 500,
+        body: '{ invalid json',
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      try {
+        await metadata.getAvailableModels();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayResponseError.isInstance(error)).toBe(true);
+        const responseError = error as GatewayResponseError;
+        expect(responseError.statusCode).toBe(500);
+        expect(responseError.type).toBe('response_error');
+      }
     });
 
     it('should handle malformed response data', async () => {
@@ -94,6 +158,102 @@ describe('GatewayFetchMetadata', () => {
       const metadata = createBasicMetadataFetcher();
 
       await expect(metadata.getAvailableModels()).rejects.toThrow();
+    });
+    it('should not double-wrap existing Gateway errors', async () => {
+      // Create a Gateway error and verify it doesn't get wrapped
+      const existingError = new GatewayAuthenticationError({
+        message: 'Already wrapped',
+        statusCode: 401,
+      });
+
+      // Test the catch block logic directly
+      try {
+        throw existingError;
+      } catch (error: unknown) {
+        if (GatewayError.isInstance(error)) {
+          expect(error).toBe(existingError); // Should be the same instance
+          expect(error.message).toBe('Already wrapped');
+          return;
+        }
+        throw new Error('Should not reach here');
+      }
+    });
+
+    it('should handle various server error types', async () => {
+      // Test rate limit error
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 429,
+        body: JSON.stringify({
+          error: {
+            message: 'Rate limit exceeded',
+            type: 'rate_limit_exceeded',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      try {
+        await metadata.getAvailableModels();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayRateLimitError.isInstance(error)).toBe(true);
+        const rateLimitError = error as GatewayRateLimitError;
+        expect(rateLimitError.message).toBe('Rate limit exceeded');
+        expect(rateLimitError.type).toBe('rate_limit_exceeded');
+        expect(rateLimitError.statusCode).toBe(429);
+      }
+    });
+
+    it('should handle internal server errors', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          error: {
+            message: 'Database connection failed',
+            type: 'internal_server_error',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      try {
+        await metadata.getAvailableModels();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayInternalServerError.isInstance(error)).toBe(true);
+        const serverError = error as GatewayInternalServerError;
+        expect(serverError.message).toBe('Database connection failed');
+        expect(serverError.type).toBe('internal_server_error');
+        expect(serverError.statusCode).toBe(500);
+      }
+    });
+
+    it('should preserve error cause chain', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 401,
+        body: JSON.stringify({
+          error: {
+            message: 'Token expired',
+            type: 'authentication_error',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      try {
+        await metadata.getAvailableModels();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
+        const authError = error as GatewayAuthenticationError;
+        expect(authError.cause).toBeDefined();
+      }
     });
 
     it('should use custom fetch function when provided', async () => {

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -7,6 +7,10 @@ import {
 import { z } from 'zod';
 import type { GatewayConfig } from './gateway-config';
 import type { GatewayLanguageModelEntry } from './gateway-model-entry';
+import { GatewayError } from './errors';
+import { extractApiCallResponse } from './errors';
+import { createGatewayErrorFromResponse } from './errors';
+import { APICallError } from '@ai-sdk/provider';
 
 type GatewayFetchMetadataConfig = GatewayConfig;
 
@@ -18,20 +22,45 @@ export class GatewayFetchMetadata {
   constructor(private readonly config: GatewayFetchMetadataConfig) {}
 
   async getAvailableModels(): Promise<GatewayFetchMetadataResponse> {
-    const { value } = await getFromApi({
-      url: `${this.config.baseURL}/config`,
-      headers: await resolve(this.config.headers()),
-      successfulResponseHandler: createJsonResponseHandler(
-        gatewayFetchMetadataSchema,
-      ),
-      failedResponseHandler: createJsonErrorResponseHandler({
-        errorSchema: z.any(),
-        errorToMessage: data => data,
-      }),
-      fetch: this.config.fetch,
-    });
+    try {
+      const { value } = await getFromApi({
+        url: `${this.config.baseURL}/config`,
+        headers: await resolve(this.config.headers()),
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewayFetchMetadataSchema,
+        ),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        fetch: this.config.fetch,
+      });
 
-    return value as GatewayFetchMetadataResponse;
+      return value;
+    } catch (error) {
+      if (GatewayError.isInstance(error)) {
+        throw error;
+      }
+
+      if (APICallError.isInstance(error)) {
+        throw createGatewayErrorFromResponse({
+          response: extractApiCallResponse(error),
+          statusCode: error.statusCode ?? 500,
+          defaultMessage: 'Failed to fetch Gateway configuration',
+          cause: error,
+        });
+      }
+
+      throw createGatewayErrorFromResponse({
+        response: {},
+        statusCode: 500,
+        defaultMessage:
+          error instanceof Error
+            ? `Failed to fetch Gateway configuration: ${error.message}`
+            : 'Unknown error fetching Gateway configuration',
+        cause: error,
+      });
+    }
   }
 }
 

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -75,7 +75,7 @@ export class GatewayLanguageModel implements LanguageModelV2 {
         warnings: [],
       };
     } catch (error) {
-      throw this.handleError(error);
+      throw asGatewayError(error);
     }
   }
 
@@ -124,33 +124,8 @@ export class GatewayLanguageModel implements LanguageModelV2 {
         response: { headers: responseHeaders },
       };
     } catch (error) {
-      throw this.handleError(error);
+      throw asGatewayError(error);
     }
-  }
-
-  private handleError(error: unknown) {
-    if (GatewayError.isInstance(error)) {
-      return error;
-    }
-
-    if (APICallError.isInstance(error)) {
-      return createGatewayErrorFromResponse({
-        response: extractApiCallResponse(error),
-        statusCode: error.statusCode ?? 500,
-        defaultMessage: 'Gateway request failed',
-        cause: error,
-      });
-    }
-
-    return createGatewayErrorFromResponse({
-      response: {},
-      statusCode: 500,
-      defaultMessage:
-        error instanceof Error
-          ? `Gateway request failed: ${error.message}`
-          : 'Unknown Gateway error',
-      cause: error,
-    });
   }
 
   private isFilePart(part: unknown) {
@@ -197,4 +172,29 @@ export class GatewayLanguageModel implements LanguageModelV2 {
       'ai-language-model-streaming': String(streaming),
     };
   }
+}
+
+function asGatewayError(error: unknown) {
+  if (GatewayError.isInstance(error)) {
+    return error;
+  }
+
+  if (APICallError.isInstance(error)) {
+    return createGatewayErrorFromResponse({
+      response: extractApiCallResponse(error),
+      statusCode: error.statusCode ?? 500,
+      defaultMessage: 'Gateway request failed',
+      cause: error,
+    });
+  }
+
+  return createGatewayErrorFromResponse({
+    response: {},
+    statusCode: 500,
+    defaultMessage:
+      error instanceof Error
+        ? `Gateway request failed: ${error.message}`
+        : 'Unknown Gateway error',
+    cause: error,
+  });
 }

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -1,5 +1,5 @@
 import type { LanguageModelV2, ProviderV2 } from '@ai-sdk/provider';
-import { NoSuchModelError } from '@ai-sdk/provider';
+import { NoSuchModelError, APICallError } from '@ai-sdk/provider';
 import { loadOptionalSetting } from '@ai-sdk/provider-utils';
 import {
   type FetchFunction,
@@ -12,6 +12,13 @@ import {
   GatewayFetchMetadata,
   type GatewayFetchMetadataResponse,
 } from './gateway-fetch-metadata';
+import {
+  GatewayAuthenticationError,
+  GatewayModelNotFoundError,
+  createGatewayErrorFromResponse,
+  GatewayError,
+  extractApiCallResponse,
+} from './errors';
 
 export interface GatewayProvider extends ProviderV2 {
   (modelId: GatewayModelId): LanguageModelV2;
@@ -77,19 +84,16 @@ export async function getGatewayAuthToken(options: GatewayProviderSettings) {
       error instanceof Error &&
       error.message.includes("'x-vercel-oidc-token' header is missing")
     ) {
-      // The missing vercel oidc token error has an obtuse message that doesn't
-      // provide much context about what to do for an AI Gateway user, so we
-      // intervene to provide more guidance and then rethrow.
-      const enhancedError = new Error(
-        `Failed to get Vercel OIDC token for AI Gateway access.
+      throw new GatewayAuthenticationError({
+        message: `Failed to get Vercel OIDC token for AI Gateway access.
 The token is expected to be provided via the 'VERCEL_OIDC_TOKEN' environment variable. It expires every 12 hours.
 - make sure your Vercel project settings have OIDC enabled
 - if you're running locally with 'vercel dev' the token is automatically obtained and refreshed for you
 - if you're running locally with your own dev server script you can fetch/update the token by running 'vercel env pull'
 - in production or preview the token is automatically obtained and refreshed for you`,
-      );
-      (enhancedError as Error & { cause: unknown }).cause = error;
-      throw enhancedError;
+        statusCode: 401,
+        cause: error,
+      });
     }
     throw error;
   }
@@ -158,6 +162,30 @@ export function createGatewayProvider(
         .then(metadata => {
           metadataCache = metadata;
           return metadata;
+        })
+        .catch((error: unknown) => {
+          if (GatewayError.isInstance(error)) {
+            throw error;
+          }
+
+          if (APICallError.isInstance(error)) {
+            throw createGatewayErrorFromResponse({
+              response: extractApiCallResponse(error),
+              statusCode: error.statusCode ?? 500,
+              defaultMessage: 'Failed to fetch available models',
+              cause: error,
+            });
+          }
+
+          throw createGatewayErrorFromResponse({
+            response: {},
+            statusCode: 500,
+            defaultMessage:
+              error instanceof Error
+                ? `Failed to fetch available models: ${error.message}`
+                : 'Unknown error fetching models',
+            cause: error,
+          });
         });
     }
 

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -14,7 +14,6 @@ import {
 } from './gateway-fetch-metadata';
 import {
   GatewayAuthenticationError,
-  GatewayModelNotFoundError,
   createGatewayErrorFromResponse,
   GatewayError,
   extractApiCallResponse,
@@ -72,31 +71,12 @@ How frequently to refresh the metadata cache in milliseconds.
 const AI_GATEWAY_PROTOCOL_VERSION = '0.0.1';
 
 export async function getGatewayAuthToken(options: GatewayProviderSettings) {
-  try {
-    return (
-      loadOptionalSetting({
-        settingValue: options.apiKey,
-        environmentVariableName: 'AI_GATEWAY_API_KEY',
-      }) ?? (await getVercelOidcToken())
-    );
-  } catch (error: unknown) {
-    if (
-      error instanceof Error &&
-      error.message.includes("'x-vercel-oidc-token' header is missing")
-    ) {
-      throw new GatewayAuthenticationError({
-        message: `Failed to get Vercel OIDC token for AI Gateway access.
-The token is expected to be provided via the 'VERCEL_OIDC_TOKEN' environment variable. It expires every 12 hours.
-- make sure your Vercel project settings have OIDC enabled
-- if you're running locally with 'vercel dev' the token is automatically obtained and refreshed for you
-- if you're running locally with your own dev server script you can fetch/update the token by running 'vercel env pull'
-- in production or preview the token is automatically obtained and refreshed for you`,
-        statusCode: 401,
-        cause: error,
-      });
-    }
-    throw error;
-  }
+  return (
+    loadOptionalSetting({
+      settingValue: options.apiKey,
+      environmentVariableName: 'AI_GATEWAY_API_KEY',
+    }) ?? (await getVercelOidcToken())
+  );
 }
 
 /**

--- a/packages/gateway/src/get-vercel-oidc-token.ts
+++ b/packages/gateway/src/get-vercel-oidc-token.ts
@@ -1,12 +1,20 @@
+import { GatewayAuthenticationError } from './errors';
+
 export async function getVercelOidcToken(): Promise<string> {
   const token =
     getContext().headers?.['x-vercel-oidc-token'] ??
     process.env.VERCEL_OIDC_TOKEN;
 
   if (!token) {
-    throw new Error(
-      `The 'x-vercel-oidc-token' header is missing from the request. Do you have the OIDC option enabled in the Vercel project settings?`,
-    );
+    throw new GatewayAuthenticationError({
+      message: `Failed to get Vercel OIDC token for AI Gateway access.
+The token is expected to be provided via the 'VERCEL_OIDC_TOKEN' environment variable. It expires every 12 hours.
+- make sure your Vercel project settings have OIDC enabled
+- if you're running locally with 'vercel dev' the token is automatically obtained and refreshed for you
+- if you're running locally with your own dev server script you can fetch/update the token by running 'vercel env pull'
+- in production or preview the token is automatically obtained and refreshed for you`,
+      statusCode: 401,
+    });
   }
 
   return token;

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -8,3 +8,13 @@ export type {
   GatewayProvider,
   GatewayProviderSettings,
 } from './gateway-provider';
+export {
+  GatewayError,
+  GatewayAuthenticationError,
+  GatewayInvalidRequestError,
+  GatewayRateLimitError,
+  GatewayModelNotFoundError,
+  GatewayInternalServerError,
+  GatewayResponseError,
+} from './errors';
+export type { GatewayErrorResponse } from './errors';


### PR DESCRIPTION
## Background

The current Gateway provider offers minimal error insight, limiting external code's ability to handle failures effectively.

## Summary

Improve error handling in Gateway provider by exposing error types and details. Add new more granular error types. Add detail for model-not-found and response validation failed errors. Authentication and rate limit errors are also surfaced more cleanly to the user when appropriate. 

## Verification

Executed provider against Gateway with example scripts, modifying inputs and server so as to create the various failure cases.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

Complexity/boilerplate: there is extra boilerplate in a few places where we reach into an APICallError to extract detail and stuff it into the Gateway error. This may be overkill and/or we could refactor to share logic more cleanly.

Error hierarchy/layering improvement: the `generate-text/gateway-pdf.ts` example script (not yet functional regardless of this change, but mentioning here re: its error reporting behavior) throws a `GatewayInternalServerError`. The underlying error is `UnsupportedFunctionalityError`. This error detail is included and reported, but it's buried beneath the top level `GatewayInternalServerError` and an `APICallError` beneath that. More clarity could be worthwhile. The status code is 400, not 500, so "internal server error" doesn't seem quite right.