### PR TITLE
feat (providers/gateway): share common gateway error transform logic

### DIFF
--- a/.changeset/healthy-humans-burn.md
+++ b/.changeset/healthy-humans-burn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (providers/gateway): share common gateway error transform logic

--- a/packages/gateway/src/errors/as-gateway-error.ts
+++ b/packages/gateway/src/errors/as-gateway-error.ts
@@ -1,0 +1,28 @@
+import { APICallError } from '@ai-sdk/provider';
+import { extractApiCallResponse, GatewayError } from '.';
+import { createGatewayErrorFromResponse } from './create-gateway-error';
+
+export function asGatewayError(error: unknown) {
+  if (GatewayError.isInstance(error)) {
+    return error;
+  }
+
+  if (APICallError.isInstance(error)) {
+    return createGatewayErrorFromResponse({
+      response: extractApiCallResponse(error),
+      statusCode: error.statusCode ?? 500,
+      defaultMessage: 'Gateway request failed',
+      cause: error,
+    });
+  }
+
+  return createGatewayErrorFromResponse({
+    response: {},
+    statusCode: 500,
+    defaultMessage:
+      error instanceof Error
+        ? `Gateway request failed: ${error.message}`
+        : 'Unknown Gateway error',
+    cause: error,
+  });
+}

--- a/packages/gateway/src/errors/index.ts
+++ b/packages/gateway/src/errors/index.ts
@@ -1,15 +1,16 @@
-export { GatewayError } from './gateway-error';
-export { GatewayAuthenticationError } from './gateway-authentication-error';
-export { GatewayInvalidRequestError } from './gateway-invalid-request-error';
-export { GatewayRateLimitError } from './gateway-rate-limit-error';
-export {
-  GatewayModelNotFoundError,
-  modelNotFoundParamSchema,
-} from './gateway-model-not-found-error';
-export { GatewayInternalServerError } from './gateway-internal-server-error';
-export { GatewayResponseError } from './gateway-response-error';
+export { asGatewayError } from './as-gateway-error';
 export {
   createGatewayErrorFromResponse,
   type GatewayErrorResponse,
 } from './create-gateway-error';
 export { extractApiCallResponse } from './extract-api-call-response';
+export { GatewayError } from './gateway-error';
+export { GatewayAuthenticationError } from './gateway-authentication-error';
+export { GatewayInternalServerError } from './gateway-internal-server-error';
+export { GatewayInvalidRequestError } from './gateway-invalid-request-error';
+export {
+  GatewayModelNotFoundError,
+  modelNotFoundParamSchema,
+} from './gateway-model-not-found-error';
+export { GatewayRateLimitError } from './gateway-rate-limit-error';
+export { GatewayResponseError } from './gateway-response-error';

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -4,13 +4,10 @@ import {
   getFromApi,
   resolve,
 } from '@ai-sdk/provider-utils';
-import { z } from 'zod';
+import { asGatewayError } from './errors';
 import type { GatewayConfig } from './gateway-config';
 import type { GatewayLanguageModelEntry } from './gateway-model-entry';
-import { GatewayError } from './errors';
-import { extractApiCallResponse } from './errors';
-import { createGatewayErrorFromResponse } from './errors';
-import { APICallError } from '@ai-sdk/provider';
+import { z } from 'zod';
 
 type GatewayFetchMetadataConfig = GatewayConfig;
 
@@ -38,28 +35,7 @@ export class GatewayFetchMetadata {
 
       return value;
     } catch (error) {
-      if (GatewayError.isInstance(error)) {
-        throw error;
-      }
-
-      if (APICallError.isInstance(error)) {
-        throw createGatewayErrorFromResponse({
-          response: extractApiCallResponse(error),
-          statusCode: error.statusCode ?? 500,
-          defaultMessage: 'Failed to fetch Gateway configuration',
-          cause: error,
-        });
-      }
-
-      throw createGatewayErrorFromResponse({
-        response: {},
-        statusCode: 500,
-        defaultMessage:
-          error instanceof Error
-            ? `Failed to fetch Gateway configuration: ${error.message}`
-            : 'Unknown error fetching Gateway configuration',
-        cause: error,
-      });
+      throw asGatewayError(error);
     }
   }
 }

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -4,7 +4,6 @@ import type {
   LanguageModelV2FilePart,
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider';
-import { APICallError } from '@ai-sdk/provider';
 import {
   combineHeaders,
   createEventSourceResponseHandler,
@@ -17,11 +16,7 @@ import {
 import { z } from 'zod';
 import type { GatewayConfig } from './gateway-config';
 import type { GatewayModelId } from './gateway-language-model-settings';
-import {
-  createGatewayErrorFromResponse,
-  GatewayError,
-  extractApiCallResponse,
-} from './errors';
+import { asGatewayError } from './errors';
 
 type GatewayChatConfig = GatewayConfig & {
   provider: string;
@@ -172,29 +167,4 @@ export class GatewayLanguageModel implements LanguageModelV2 {
       'ai-language-model-streaming': String(streaming),
     };
   }
-}
-
-function asGatewayError(error: unknown) {
-  if (GatewayError.isInstance(error)) {
-    return error;
-  }
-
-  if (APICallError.isInstance(error)) {
-    return createGatewayErrorFromResponse({
-      response: extractApiCallResponse(error),
-      statusCode: error.statusCode ?? 500,
-      defaultMessage: 'Gateway request failed',
-      cause: error,
-    });
-  }
-
-  return createGatewayErrorFromResponse({
-    response: {},
-    statusCode: 500,
-    defaultMessage:
-      error instanceof Error
-        ? `Gateway request failed: ${error.message}`
-        : 'Unknown Gateway error',
-    cause: error,
-  });
 }


### PR DESCRIPTION
## Background

Gateway error transformation logic has redundant code in several places for turning a variety of possible errors into a `GatewayError` class as appropriate.

## Summary

Move shared logic to a common error routine and call it where appropriate.

## Verification

Manually executed test gateway example scripts.

## Tasks

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

https://github.com/vercel/ai/pull/6565