### PR TITLE
ci: fix broken assign-team-pr workflow

### DIFF
--- a/.github/workflows/assign-team-pull-request.yml
+++ b/.github/workflows/assign-team-pull-request.yml
@@ -10,10 +10,11 @@ permissions:
 jobs:
   assign:
     runs-on: ubuntu-latest
+    # Only assign pull requests by team members, ignore pull requests from forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      # Only assign pull requests by team members, ignore pull requests from forks
-      - if: github.event.pull_request.head.repo.full_name == github.repository
-        name: Assign pull request to author
+      - uses: actions/checkout@v4
+      - name: Assign pull request to author
         run: gh pr edit $PULL_REQUEST_URL --add-assignee $AUTHOR_LOGIN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Background

The assign-team-pr-to-author CI action has been failing reliably with an error as:

```
Run gh pr edit $PULL_REQUEST_URL --add-assignee $AUTHOR_LOGIN
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## Summary

Claude claims best practices are to check out the repo before running `gh`. While it may have worked without a local checkout in the past, `gh` is typically expected to require the repository to be present locally ahead of time.

## Verification

Will need to see how subsequent PRs go.

## Tasks

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
