### PR TITLE
feat (provider/anthropic): json response schema support via tool calls

### DIFF
--- a/.changeset/chilly-teachers-brush.md
+++ b/.changeset/chilly-teachers-brush.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat (provider/anthropic): json response schema support via tool calls

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
-    "build:watch": "pnpm clean && tsup --watch",
+    "build:watch": "pnpm clean && tsup --watch --tsconfig tsconfig.build.json",
     "clean": "rm -rf dist *.tsbuildinfo",
     "lint": "eslint \"./**/*.ts*\"",
     "type-check": "tsc --build",

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -110,6 +110,41 @@ describe('AnthropicMessagesLanguageModel', () => {
           },
         ]);
       });
+
+      it('should extract reasoning response', async () => {
+        prepareJsonResponse({
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'I am thinking...',
+              signature: '1234567890',
+            },
+            { type: 'text', text: 'Hello, World!' },
+          ],
+        });
+
+        const { content } = await model.doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(content).toMatchInlineSnapshot(`
+          [
+            {
+              "providerMetadata": {
+                "anthropic": {
+                  "signature": "1234567890",
+                },
+              },
+              "text": "I am thinking...",
+              "type": "reasoning",
+            },
+            {
+              "text": "Hello, World!",
+              "type": "text",
+            },
+          ]
+        `);
+      });
     });
 
     it('should extract text response', async () => {
@@ -123,41 +158,6 @@ describe('AnthropicMessagesLanguageModel', () => {
 
       expect(content).toMatchInlineSnapshot(`
         [
-          {
-            "text": "Hello, World!",
-            "type": "text",
-          },
-        ]
-      `);
-    });
-
-    it('should extract reasoning response', async () => {
-      prepareJsonResponse({
-        content: [
-          {
-            type: 'thinking',
-            thinking: 'I am thinking...',
-            signature: '1234567890',
-          },
-          { type: 'text', text: 'Hello, World!' },
-        ],
-      });
-
-      const { content } = await model.doGenerate({
-        prompt: TEST_PROMPT,
-      });
-
-      expect(content).toMatchInlineSnapshot(`
-        [
-          {
-            "providerMetadata": {
-              "anthropic": {
-                "signature": "1234567890",
-              },
-            },
-            "text": "I am thinking...",
-            "type": "reasoning",
-          },
           {
             "text": "Hello, World!",
             "type": "text",
@@ -389,7 +389,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         },
       });
 
-      expect(await server.calls[0].requestHeaders).toStrictEqual({
+      expect(server.calls[0].requestHeaders).toStrictEqual({
         'anthropic-version': '2023-06-01',
         'content-type': 'application/json',
         'custom-provider-header': 'provider-header-value',

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -745,13 +745,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           [
             {
               "type": "stream-start",
-              "warnings": [
-                {
-                  "details": "JSON response format is not supported.",
-                  "setting": "responseFormat",
-                  "type": "unsupported-setting",
-                },
-              ],
+              "warnings": [],
             },
             {
               "id": "msg_01GouTqNCGXzrj5LQ5jEkw67",

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -664,7 +664,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Okay"}    }\n\n`,
             `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!"}   }\n\n`,
             `data: {"type":"content_block_stop","index":0    }\n\n`,
-            `data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01DBsB4vvYLnBDzZ5rBSxSLs","name":"test-tool","input":{}}      }\n\n`,
+            `data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01DBsB4vvYLnBDzZ5rBSxSLs","name":"json","input":{}}      }\n\n`,
             `data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}           }\n\n`,
             `data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"value"}              }\n\n`,
             `data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\\":"}      }\n\n`,

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -280,7 +280,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         case 'text': {
           // when a json response tool is used, the tool call is returned as text,
           // so we ignore the text content:
-          if (jsonResponseTool != null) {
+          if (jsonResponseTool == null) {
             content.push({ type: 'text', text: part.text });
           }
           break;

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -110,13 +110,17 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         warnings.push({
           type: 'unsupported-setting',
           setting: 'responseFormat',
-          details: 'JSON response format requires a schema.',
+          details:
+            'JSON response format requires a schema. ' +
+            'The response format is ignored.',
         });
       } else if (tools != null) {
         warnings.push({
           type: 'unsupported-setting',
           setting: 'tools',
-          details: 'JSON response format does not support tools.',
+          details:
+            'JSON response format does not support tools. ' +
+            'The provided tools are ignored.',
         });
       }
     }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -105,13 +105,20 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
       });
     }
 
-    // TODO update
-    if (responseFormat != null && responseFormat.type !== 'text') {
-      warnings.push({
-        type: 'unsupported-setting',
-        setting: 'responseFormat',
-        details: 'JSON response format is not supported.',
-      });
+    if (responseFormat?.type === 'json') {
+      if (responseFormat.schema == null) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'responseFormat',
+          details: 'JSON response format requires a schema.',
+        });
+      } else if (tools != null) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'tools',
+          details: 'JSON response format does not support tools.',
+        });
+      }
     }
 
     const jsonResponseTool: LanguageModelV2FunctionTool | undefined =

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -473,13 +473,17 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
                 if (toolCallContentBlocks[value.index] != null) {
                   const contentBlock = toolCallContentBlocks[value.index];
 
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallType: 'function',
-                    toolCallId: contentBlock.toolCallId,
-                    toolName: contentBlock.toolName,
-                    args: contentBlock.jsonText,
-                  });
+                  // when a json response tool is used, the tool call is returned as text,
+                  // so we ignore the tool call content:
+                  if (jsonResponseTool == null) {
+                    controller.enqueue({
+                      type: 'tool-call',
+                      toolCallType: 'function',
+                      toolCallId: contentBlock.toolCallId,
+                      toolName: contentBlock.toolName,
+                      args: contentBlock.jsonText,
+                    });
+                  }
 
                   delete toolCallContentBlocks[value.index];
                 }


### PR DESCRIPTION
## Background

In AI SDK 5, the different object generation modes have been removed. It is now the responsibility of the provider implementation to map JSON response format requirements to what is needed by the provider API, e.g. tool calls.

## Summary

Add JSON response support with schemas through tool use to the Anthropic provider.

## Verification

Run the anthropic object generation examples. 

## Tasks

- [x] implementation generate
   - [x] change
   - [x] test
- [x] implementation stream
   - [x] change
   - [x] test
- [x] warnings
   - [x] existing tools
   - [x] json without schema
- [x] changeset

## Related Issues

Fixes #6510