### PR TITLE
fix (providers/openai): pdf parts when passed as a string url (or Uint8Array)

### DIFF
--- a/.changeset/wicked-snakes-march.md
+++ b/.changeset/wicked-snakes-march.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Fix PDF file parts when passed as a string url or Uint8Array

--- a/packages/openai/src/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.test.ts
@@ -276,6 +276,42 @@ describe('user messages', () => {
       ]);
     });
 
+    it('should convert messages with binary PDF file parts', async () => {
+      const data = Uint8Array.from([1, 2, 3, 4, 5]);
+
+      const result = convertToOpenAIChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data,
+                filename: 'document.pdf',
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                filename: 'document.pdf',
+                file_data: 'data:application/pdf;base64,AQIDBAU=',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should use default filename for PDF file parts when not provided', async () => {
       const base64Data = 'AQIDBAU=';
 

--- a/packages/openai/src/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.ts
@@ -125,7 +125,7 @@ export function convertToOpenAIChatMessages({
                     type: 'file',
                     file: {
                       filename: part.filename ?? `part-${index}.pdf`,
-                      file_data: `data:application/pdf;base64,${part.data}`,
+                      file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
                     },
                   };
                 } else {


### PR DESCRIPTION
## Background

When you pass a `UIMessage` with a pdf file as a URL, the file doesn't get properly converted to base64. It ends up sending a string of byte integers because it's stringifying a `Uint8Array`.

## Summary

Error:

```
"Invalid file data: 'messages[1].content[1].file.file_data'. Expected a base64-encoded data URL with an application/pdf MIME type (e.g. 'data:application/pdf;base64,SGVsbG8sIFdvcmxkIQ=='), but got an invalid base64-encoded value.
```

I think the problem is this PR https://github.com/vercel/ai/pull/5660 just missed the `application/pdf` case, which is what this PR addresses.

Example `UIMessage` that causes the problem:

```json
{
  "type": "file",
  "url": "https://example.com/document.pdf",
  "filename": "document.pdf",
  "mediaType": "application/pdf"
}
```

Here is a screenshot of what it sends to OpenAI:

![CleanShot 2025-06-01 at 15 33 22@2x](https://github.com/user-attachments/assets/a33c64b2-40d5-473a-bee0-3cc860bf4292)

## Verification

I added a test case and verified it works locally.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work


## Related Issues

