### PR TITLE
fix (provider/anthropic): return stop finish reason for json output with tool

### DIFF
--- a/.changeset/olive-wombats-pretend.md
+++ b/.changeset/olive-wombats-pretend.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix (provider/anthropic): return stop finish reason for json output with tool

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -777,7 +777,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "type": "text",
             },
             {
-              "finishReason": "tool-calls",
+              "finishReason": "stop",
               "providerMetadata": {
                 "anthropic": {
                   "cacheCreationInputTokens": null,

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -344,7 +344,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
 
     return {
       content,
-      finishReason: mapAnthropicStopReason(response.stop_reason),
+      finishReason: mapAnthropicStopReason({
+        finishReason: response.stop_reason,
+        isJsonResponseFromTool: jsonResponseTool != null,
+      }),
       usage: {
         inputTokens: response.usage.input_tokens,
         outputTokens: response.usage.output_tokens,
@@ -607,7 +610,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
                 usage.totalTokens =
                   (usage.inputTokens ?? 0) + (value.usage.output_tokens ?? 0);
 
-                finishReason = mapAnthropicStopReason(value.delta.stop_reason);
+                finishReason = mapAnthropicStopReason({
+                  finishReason: value.delta.stop_reason,
+                  isJsonResponseFromTool: jsonResponseTool != null,
+                });
                 return;
               }
 

--- a/packages/anthropic/src/map-anthropic-stop-reason.ts
+++ b/packages/anthropic/src/map-anthropic-stop-reason.ts
@@ -1,14 +1,18 @@
 import { LanguageModelV2FinishReason } from '@ai-sdk/provider';
 
-export function mapAnthropicStopReason(
-  finishReason: string | null | undefined,
-): LanguageModelV2FinishReason {
+export function mapAnthropicStopReason({
+  finishReason,
+  isJsonResponseFromTool,
+}: {
+  finishReason: string | null | undefined;
+  isJsonResponseFromTool?: boolean;
+}): LanguageModelV2FinishReason {
   switch (finishReason) {
     case 'end_turn':
     case 'stop_sequence':
       return 'stop';
     case 'tool_use':
-      return 'tool-calls';
+      return isJsonResponseFromTool ? 'stop' : 'tool-calls';
     case 'max_tokens':
       return 'length';
     default:


### PR DESCRIPTION
## Background

The anthropic provider uses tool calls to generate structured outputs. However, since the output is returned in text parts, the finish reason should be `stop` to prevent issues when tools are provided by the user.

## Summary

Change the finish reason of anthropic tool calls to `stop` when a tool is used to generate a json response.