### PR TITLE
feat (ai): introduce GLOBAL_DEFAULT_PROVIDER

### DIFF
--- a/.changeset/green-dogs-kick.md
+++ b/.changeset/green-dogs-kick.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): introduce GLOBAL_DEFAULT_PROVIDER

--- a/examples/ai-core/src/stream-text/openai-global-provider.ts
+++ b/examples/ai-core/src/stream-text/openai-global-provider.ts
@@ -1,0 +1,22 @@
+import { openai } from '@ai-sdk/openai';
+import { GLOBAL_DEFAULT_PROVIDER, streamText } from 'ai';
+import 'dotenv/config';
+
+(globalThis as any)[GLOBAL_DEFAULT_PROVIDER] = openai;
+
+async function main() {
+  const result = streamText({
+    model: 'gpt-4o',
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/ai/core/prompt/index.ts
+++ b/packages/ai/core/prompt/index.ts
@@ -35,3 +35,4 @@ export type {
   UserModelMessage,
 } from './message';
 export type { Prompt } from './prompt';
+export { GLOBAL_DEFAULT_PROVIDER } from './resolve-language-model';

--- a/packages/ai/core/prompt/resolve-language-model.test.ts
+++ b/packages/ai/core/prompt/resolve-language-model.test.ts
@@ -1,0 +1,18 @@
+import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
+import { resolveLanguageModel } from './resolve-language-model';
+
+describe('resolveLanguageModel', () => {
+  describe('when a language model v2 is provided', () => {
+    it('should return the language model v2', () => {
+      const resolvedModel = resolveLanguageModel(
+        new MockLanguageModelV2({
+          provider: 'test-provider',
+          modelId: 'test-model-id',
+        }),
+      );
+
+      expect(resolvedModel.provider).toBe('test-provider');
+      expect(resolvedModel.modelId).toBe('test-model-id');
+    });
+  });
+});

--- a/packages/ai/core/prompt/resolve-language-model.test.ts
+++ b/packages/ai/core/prompt/resolve-language-model.test.ts
@@ -1,5 +1,9 @@
+import { customProvider } from '../registry/custom-provider';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
-import { resolveLanguageModel } from './resolve-language-model';
+import {
+  GLOBAL_DEFAULT_PROVIDER,
+  resolveLanguageModel,
+} from './resolve-language-model';
 
 describe('resolveLanguageModel', () => {
   describe('when a language model v2 is provided', () => {
@@ -16,12 +20,36 @@ describe('resolveLanguageModel', () => {
     });
   });
 
-  describe('when a string is provided', () => {
-    it('should return a gateway language model when the default provider is not set', () => {
+  describe('when a string is provided and the global default provider is not set', () => {
+    it('should return a gateway language model', () => {
       const resolvedModel = resolveLanguageModel('test-model-id');
 
       expect(resolvedModel.provider).toBe('gateway');
       expect(resolvedModel.modelId).toBe('test-model-id');
+    });
+  });
+
+  describe('when a string is provided and the global default provider is set', () => {
+    beforeEach(() => {
+      (globalThis as any)[GLOBAL_DEFAULT_PROVIDER] = customProvider({
+        languageModels: {
+          'test-model-id': new MockLanguageModelV2({
+            provider: 'global-test-provider',
+            modelId: 'actual-test-model-id',
+          }),
+        },
+      });
+    });
+
+    afterEach(() => {
+      delete (globalThis as any)[GLOBAL_DEFAULT_PROVIDER];
+    });
+
+    it('should return a language model from the global default provider', () => {
+      const resolvedModel = resolveLanguageModel('test-model-id');
+
+      expect(resolvedModel.provider).toBe('global-test-provider');
+      expect(resolvedModel.modelId).toBe('actual-test-model-id');
     });
   });
 });

--- a/packages/ai/core/prompt/resolve-language-model.test.ts
+++ b/packages/ai/core/prompt/resolve-language-model.test.ts
@@ -15,4 +15,13 @@ describe('resolveLanguageModel', () => {
       expect(resolvedModel.modelId).toBe('test-model-id');
     });
   });
+
+  describe('when a string is provided', () => {
+    it('should return a gateway language model when the default provider is not set', () => {
+      const resolvedModel = resolveLanguageModel('test-model-id');
+
+      expect(resolvedModel.provider).toBe('gateway');
+      expect(resolvedModel.modelId).toBe('test-model-id');
+    });
+  });
 });

--- a/packages/ai/core/prompt/resolve-language-model.ts
+++ b/packages/ai/core/prompt/resolve-language-model.ts
@@ -1,7 +1,19 @@
 import { gateway } from '@ai-sdk/gateway';
-import { LanguageModelV2 } from '@ai-sdk/provider';
+import { LanguageModelV2, ProviderV2 } from '@ai-sdk/provider';
 import { LanguageModel } from '../types/language-model';
 
+export const GLOBAL_DEFAULT_PROVIDER = Symbol(
+  'vercel.ai.global.defaultProvider',
+);
+
 export function resolveLanguageModel(model: LanguageModel): LanguageModelV2 {
-  return typeof model === 'string' ? gateway.languageModel(model) : model;
+  if (typeof model !== 'string') {
+    return model;
+  }
+
+  const globalProvider = (globalThis as any)[GLOBAL_DEFAULT_PROVIDER] as
+    | ProviderV2
+    | undefined;
+
+  return (globalProvider ?? gateway).languageModel(model);
 }

--- a/packages/ai/core/types/language-model.ts
+++ b/packages/ai/core/types/language-model.ts
@@ -1,4 +1,3 @@
-import { GatewayModelId } from '@ai-sdk/gateway';
 import {
   LanguageModelV2,
   LanguageModelV2CallWarning,
@@ -9,7 +8,7 @@ import {
 /**
 Language model that is used by the AI SDK Core functions.
 */
-export type LanguageModel = GatewayModelId | LanguageModelV2;
+export type LanguageModel = string | LanguageModelV2;
 
 /**
 Reason why a language model finished generating a response.


### PR DESCRIPTION
## Background

AI SDK 5 introduces using strings as model ids. By default this uses the Vercel AI gateway. We want to allow users to be able to set other providers as global default to allow for alternatives to the gateway.

## Summary

You can now set any provider as global default. When none is set, gateway is used. Model id autocomplete was removed.

## Verification

Tested with global openai provider.

```ts
import { openai } from "@ai-sdk/openai";
import { GLOBAL_DEFAULT_PROVIDER, streamText } from "ai";

(globalThis as any)[GLOBAL_DEFAULT_PROVIDER] = openai;

const result = streamText({
  model: "gpt-4o",
  prompt: "Invent a new holiday and describe its traditions.",
});
```
