### PR TITLE
feat (ai): use console.error as default error handler for streamText and streamObject

### DIFF
--- a/.changeset/silent-paws-decide.md
+++ b/.changeset/silent-paws-decide.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+feat (ai): use console.error as default error handler for streamText and streamObject

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -283,7 +283,7 @@ Callback that is called when the LLM response and the final object validation ar
     headers,
     experimental_telemetry: telemetry,
     providerOptions,
-    onError,
+    onError = console.error,
     onFinish,
     _internal: {
       generateId = originalGenerateId,

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -216,7 +216,7 @@ export function streamText<
   experimental_repairToolCall: repairToolCall,
   experimental_transform: transform,
   onChunk,
-  onError,
+  onError = console.error,
   onFinish,
   onStepFinish,
   _internal: {


### PR DESCRIPTION
## Background

`streamText` and `streamObject` swallow errors when no error handler is provided. This makes it very hard to debug issues.

## Summary

Use `console.error` as the default `onError` function when no handler is provided.