### PR TITLE
feat (providers/gateway): include deployment and request id

### DIFF
--- a/.changeset/chilly-chairs-press.md
+++ b/.changeset/chilly-chairs-press.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (providers/gateway): include deployment and request id

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -12,6 +12,7 @@ import {
   postJsonToApi,
   resolve,
   type ParseResult,
+  type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import type { GatewayConfig } from './gateway-config';
@@ -20,7 +21,7 @@ import { asGatewayError } from './errors';
 
 type GatewayChatConfig = GatewayConfig & {
   provider: string;
-  o11yHeaders: Record<string, string>;
+  o11yHeaders: Resolvable<Record<string, string>>;
 };
 
 export class GatewayLanguageModel implements LanguageModelV2 {
@@ -51,7 +52,7 @@ export class GatewayLanguageModel implements LanguageModelV2 {
           await resolve(this.config.headers()),
           options.headers,
           this.getModelConfigHeaders(this.modelId, false),
-          this.config.o11yHeaders,
+          await resolve(this.config.o11yHeaders),
         ),
         body: this.maybeEncodeFileParts(body),
         successfulResponseHandler: createJsonResponseHandler(z.any()),
@@ -86,7 +87,7 @@ export class GatewayLanguageModel implements LanguageModelV2 {
           await resolve(this.config.headers()),
           options.headers,
           this.getModelConfigHeaders(this.modelId, true),
-          this.config.o11yHeaders,
+          await resolve(this.config.o11yHeaders),
         ),
         body: this.maybeEncodeFileParts(body),
         successfulResponseHandler: createEventSourceResponseHandler(z.any()),

--- a/packages/gateway/src/vercel-environment.test.ts
+++ b/packages/gateway/src/vercel-environment.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { getVercelOidcToken } from './get-vercel-oidc-token';
-import { GatewayAuthenticationError } from './errors';
+import { getVercelOidcToken, getVercelRequestId } from './vercel-environment';
 
 const SYMBOL_FOR_REQ_CONTEXT = Symbol.for('@vercel/request-context');
 
@@ -89,5 +88,66 @@ describe('getVercelOidcToken', () => {
 
     const token = await getVercelOidcToken();
     expect(token).toBe('env-token-value');
+  });
+});
+
+describe('getVercelRequestId', () => {
+  const originalSymbolValue = (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT];
+
+  beforeEach(() => {
+    (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT] = undefined;
+  });
+
+  afterEach(() => {
+    if (originalSymbolValue) {
+      (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT] = originalSymbolValue;
+    } else {
+      (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT] = undefined;
+    }
+  });
+
+  it('should get request ID from request headers when available', async () => {
+    (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT] = {
+      get: () => ({
+        headers: {
+          'x-vercel-id': 'req_1234567890abcdef',
+        },
+      }),
+    };
+
+    const requestId = await getVercelRequestId();
+    expect(requestId).toBe('req_1234567890abcdef');
+  });
+
+  it('should return undefined when request ID header is not available', async () => {
+    (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT] = {
+      get: () => ({ headers: {} }),
+    };
+
+    const requestId = await getVercelRequestId();
+    expect(requestId).toBeUndefined();
+  });
+
+  it('should return undefined when no headers are available', async () => {
+    (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT] = {
+      get: () => ({}),
+    };
+
+    const requestId = await getVercelRequestId();
+    expect(requestId).toBeUndefined();
+  });
+
+  it('should handle missing request context gracefully', async () => {
+    (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT] = undefined;
+
+    const requestId = await getVercelRequestId();
+    expect(requestId).toBeUndefined();
+  });
+
+  it('should handle missing get method in request context', async () => {
+    (globalThis as any)[SYMBOL_FOR_REQ_CONTEXT] = {};
+
+    const requestId = await getVercelRequestId();
+    expect(requestId).toBeUndefined();
   });
 });

--- a/packages/gateway/src/vercel-environment.ts
+++ b/packages/gateway/src/vercel-environment.ts
@@ -20,6 +20,10 @@ The token is expected to be provided via the 'VERCEL_OIDC_TOKEN' environment var
   return token;
 }
 
+export async function getVercelRequestId(): Promise<string | undefined> {
+  return getContext().headers?.['x-vercel-id'];
+}
+
 type Context = {
   headers?: Record<string, string>;
 };


### PR DESCRIPTION
## Background

For o11y it is useful to have a developer's deployment and request id. The deployment id variable name was incorrect, and we don't yet include logic to look up the request id.

## Summary

Corrected the environment variable name to look up the deployment id, and added logic to look for the request id in the headers as `x-vercel-id`.

## Verification

Added verbose logging and deployed to a preview deployment to observe correct data being logged.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
