### PR TITLE
fix (provider/google): prevent error when thinking signature is used

### DIFF
--- a/.changeset/proud-buckets-guess.md
+++ b/.changeset/proud-buckets-guess.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix (provider/google): prevent error when thinking signature is used

--- a/examples/ai-core/src/stream-text/google-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-reasoning.ts
@@ -1,25 +1,54 @@
-import { google } from '@ai-sdk/google';
+import { google, GoogleGenerativeAIProviderOptions } from '@ai-sdk/google';
 import { streamText } from 'ai';
 import 'dotenv/config';
+import { weatherTool } from '../tools/weather-tool';
 
 async function main() {
   const result = streamText({
-    model: google('gemini-2.5-flash-preview-04-17'),
-    prompt: 'Tell me the history of the San Francisco Mission-style burrito.',
+    model: google('gemini-2.5-flash-preview-05-20'),
+    tools: { weather: weatherTool },
+    prompt: 'What is the weather in San Francisco?',
+    maxSteps: 2,
     providerOptions: {
       google: {
         thinkingConfig: {
           thinkingBudget: 1024,
         },
-      },
+      } satisfies GoogleGenerativeAIProviderOptions,
     },
+    onError: console.error,
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
-      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
-    } else if (part.type === 'text-delta') {
-      process.stdout.write(part.textDelta);
+    switch (part.type) {
+      case 'text-delta': {
+        process.stdout.write(part.textDelta);
+        break;
+      }
+
+      case 'reasoning': {
+        process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
+        break;
+      }
+
+      case 'tool-call': {
+        process.stdout.write(
+          `\nTool call: '${part.toolName}' ${JSON.stringify(part.args)}`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        process.stdout.write(
+          `\nTool response: '${part.toolName}' ${JSON.stringify(part.result)}`,
+        );
+        break;
+      }
+
+      case 'error': {
+        process.stdout.write('\x1b[31m' + part.error + '\x1b[0m');
+        break;
+      }
     }
   }
 

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2165,6 +2165,19 @@ describe('doStream', () => {
                 parts: [{ text: 'Reasoning delta 2.', thought: true }],
                 role: 'model',
               },
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                // currently ignored:
+                parts: [{ thoughtSignature: 'test-signature', thought: true }],
+                role: 'model',
+              },
               finishReason: 'STOP', // Mark finish reason in a chunk that has content
               index: 0,
               safetyRatings: SAFETY_RATINGS,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -508,7 +508,8 @@ function getReasoningDetailsFromParts(
   parts: z.infer<typeof contentSchema>['parts'],
 ): Array<{ type: 'text'; text: string }> | undefined {
   const reasoningParts = parts?.filter(
-    part => 'text' in part && (part as any).thought === true,
+    part =>
+      'text' in part && (part as any).thought === true && part.text != null,
   ) as Array<
     GoogleGenerativeAIContentPart & { text: string; thought?: boolean }
   >;
@@ -552,14 +553,10 @@ function extractSources({
 }
 
 const contentSchema = z.object({
-  role: z.string(),
   parts: z
     .array(
       z.union([
-        z.object({
-          text: z.string(),
-          thought: z.boolean().nullish(),
-        }),
+        // note: order matters since text can be fully empty
         z.object({
           functionCall: z.object({
             name: z.string(),
@@ -571,6 +568,10 @@ const contentSchema = z.object({
             mimeType: z.string(),
             data: z.string(),
           }),
+        }),
+        z.object({
+          text: z.string().nullish(),
+          thought: z.boolean().nullish(),
         }),
       ]),
     )


### PR DESCRIPTION
## Background

The Google API for reasoning was changed in their latest model, leading to Zod errors.

## Summary

Make text optional in thinking chunks. Ignore thinking chunks without text.

## Verification

Tested example against google api.

## Future work
Expose thinking signature using provider metadata, and explore sending it to google in follow-up requests.

## Related Issues
Fixes #6589