### PR TITLE
fix: bump `zod` to fix use with Google APIs + `.literal()`

### DIFF
--- a/.changeset/orange-bags-stare.md
+++ b/.changeset/orange-bags-stare.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+---
+
+### fix use with Google APIs + `.literal()`
+
+Before, when using a zod v4 schema to interact with Google's models, requests would fail due to schema errors. The problem was fixed in zod@3.25.49.
+
+pull request: https://github.com/vercel/ai/pull/6609

--- a/.changeset/orange-bags-stare.md
+++ b/.changeset/orange-bags-stare.md
@@ -2,8 +2,8 @@
 'ai': patch
 ---
 
-### fix use with Google APIs + `.literal()`
+### Fix use with Google APIs + zod v4's `.literal()` schema
 
-Before, when using a zod v4 schema to interact with Google's models, requests would fail due to schema errors. The problem was fixed in zod@3.25.49.
+Before [zod@3.25.49](https://github.com/colinhacks/zod/releases/tag/v3.25.49), requests to Google's APIs failed due to a missing `type` in the provided schema. The problem has been resolved for the `ai` SDK by bumping our `zod` peer dependencies to `^3.25.49`.
 
 pull request: https://github.com/vercel/ai/pull/6609

--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -44,7 +44,7 @@
     "mathjs": "14.0.0",
     "sharp": "^0.33.5",
     "terminal-image": "^2.0.0",
-    "zod": "3.25.46",
+    "zod": "3.25.49",
     "zod-to-json-schema": "3.23.5",
     "valibot": "^1.0.0-rc.0 || ^1.0.0"
   },

--- a/examples/ai-core/src/generate-object/google-vertex.ts
+++ b/examples/ai-core/src/generate-object/google-vertex.ts
@@ -1,14 +1,14 @@
 import { vertex } from '@ai-sdk/google-vertex';
 import { generateObject } from 'ai';
 import 'dotenv/config';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 async function main() {
   const result = await generateObject({
     model: vertex('gemini-1.5-pro'),
     schema: z.object({
       recipe: z.object({
-        name: z.string(),
+        name: z.literal('Lasagna'),
         ingredients: z.array(
           z.object({
             name: z.string(),

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -19,7 +19,7 @@
     "ai": "workspace:*",
     "dotenv": "16.4.5",
     "express": "5.0.1",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "devDependencies": {
     "@types/express": "5.0.0",

--- a/examples/next-openai-pages/package.json
+++ b/examples/next-openai-pages/package.json
@@ -15,7 +15,7 @@
     "next": "latest",
     "react": "^18",
     "react-dom": "^18",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "devDependencies": {
     "@types/node": "20.17.24",

--- a/examples/next-openai-telemetry-sentry/package.json
+++ b/examples/next-openai-telemetry-sentry/package.json
@@ -21,7 +21,7 @@
     "next": "latest",
     "react": "^18",
     "react-dom": "^18",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "devDependencies": {
     "@types/node": "20.17.24",

--- a/examples/next-openai-telemetry/package.json
+++ b/examples/next-openai-telemetry/package.json
@@ -19,7 +19,7 @@
     "next": "latest",
     "react": "^18",
     "react-dom": "^18",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "devDependencies": {
     "@types/node": "20.17.24",

--- a/examples/next-openai/package.json
+++ b/examples/next-openai/package.json
@@ -28,7 +28,7 @@
     "react-markdown": "9.0.1",
     "redis": "^4.7.0",
     "resumable-stream": "^2.0.0",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "devDependencies": {
     "@types/node": "20.17.24",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -18,7 +18,7 @@
     "react-markdown": "9.0.1",
     "redis": "^4.7.0",
     "resumable-stream": "^2.0.0",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "devDependencies": {
     "@types/node": "20.17.24",

--- a/examples/node-http-server/package.json
+++ b/examples/node-http-server/package.json
@@ -6,7 +6,7 @@
     "@ai-sdk/openai": "workspace:*",
     "ai": "workspace:*",
     "dotenv": "16.4.5",
-    "zod": "3.25.46",
+    "zod": "3.25.49",
     "zod-to-json-schema": "3.23.5"
   },
   "scripts": {

--- a/examples/nuxt-openai/package.json
+++ b/examples/nuxt-openai/package.json
@@ -12,7 +12,7 @@
     "@ai-sdk/vue": "workspace:*",
     "@ai-sdk/openai": "workspace:*",
     "ai": "workspace:*",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "devDependencies": {
     "@nuxt/devtools": "1.6.3",

--- a/examples/sveltekit-openai/package.json
+++ b/examples/sveltekit-openai/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.20.0",
     "vite": "^6.0.0",
-    "zod": "3.25.46",
+    "zod": "3.25.49",
     "@vercel/ai-tsconfig": "workspace:*"
   }
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -68,10 +68,10 @@
     "eslint-config-vercel-ai": "workspace:*",
     "tsup": "^7.2.0",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -43,10 +43,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8.3.0",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -47,10 +47,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/assemblyai/package.json
+++ b/packages/assemblyai/package.json
@@ -39,10 +39,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.6.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/cerebras/package.json
+++ b/packages/cerebras/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/cohere/package.json
+++ b/packages/cohere/package.json
@@ -40,10 +40,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/deepgram/package.json
+++ b/packages/deepgram/package.json
@@ -39,10 +39,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.6.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/deepinfra/package.json
+++ b/packages/deepinfra/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/deepseek/package.json
+++ b/packages/deepseek/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/elevenlabs/package.json
+++ b/packages/elevenlabs/package.json
@@ -40,10 +40,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.6.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/fal/package.json
+++ b/packages/fal/package.json
@@ -40,10 +40,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/fireworks/package.json
+++ b/packages/fireworks/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/gladia/package.json
+++ b/packages/gladia/package.json
@@ -39,10 +39,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.6.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -61,10 +61,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -47,10 +47,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -40,10 +40,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/hume/package.json
+++ b/packages/hume/package.json
@@ -39,10 +39,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.6.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/lmnt/package.json
+++ b/packages/lmnt/package.json
@@ -39,10 +39,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.6.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/luma/package.json
+++ b/packages/luma/package.json
@@ -40,10 +40,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/mistral/package.json
+++ b/packages/mistral/package.json
@@ -40,10 +40,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/openai-compatible/package.json
+++ b/packages/openai-compatible/package.json
@@ -47,10 +47,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -47,10 +47,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/perplexity/package.json
+++ b/packages/perplexity/package.json
@@ -40,10 +40,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -49,10 +49,10 @@
     "msw": "2.7.0",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/provider-utils/src/__snapshots__/zod-schema.test.ts.snap
+++ b/packages/provider-utils/src/__snapshots__/zod-schema.test.ts.snap
@@ -275,3 +275,29 @@ exports[`zodSchema > json schema conversion > should use references when useRefe
   "type": "object",
 }
 `;
+
+exports[`zodSchema > json schema conversion > z4 schema > generates correct JSON SChema for z4 and .literal and .enum 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "number": {
+      "enum": [
+        "one",
+        "two",
+        "three",
+      ],
+      "type": "string",
+    },
+    "text": {
+      "const": "hello",
+      "type": "string",
+    },
+  },
+  "required": [
+    "text",
+    "number",
+  ],
+  "type": "object",
+}
+`;

--- a/packages/provider-utils/src/zod-schema.test.ts
+++ b/packages/provider-utils/src/zod-schema.test.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { z as z4 } from 'zod/v4';
 import { zodSchema } from './zod-schema';
 import { safeParseJSON } from './parse-json';
 
@@ -138,6 +139,19 @@ describe('zodSchema', () => {
         const schema = zodSchema(
           z.object({
             location: z.string().nullable(),
+          }),
+        );
+
+        expect(schema.jsonSchema).toMatchSnapshot();
+      });
+    });
+
+    describe('z4 schema', () => {
+      it('generates correct JSON SChema for z4 and .literal and .enum', () => {
+        const schema = zodSchema(
+          z4.object({
+            text: z4.literal('hello'),
+            number: z4.enum(['one', 'two', 'three']),
           }),
         );
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,11 +50,11 @@
     "react-dom": "^18",
     "tsup": "^7.2.0",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
     "react": "^18 || ^19 || ^19.0.0-rc",
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "peerDependenciesMeta": {
     "zod": {

--- a/packages/replicate/package.json
+++ b/packages/replicate/package.json
@@ -40,10 +40,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/revai/package.json
+++ b/packages/revai/package.json
@@ -39,10 +39,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.6.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -61,11 +61,11 @@
     "msw": "2.6.4",
     "tsup": "^7.2.0",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
     "react": "^18 || ^19 || ^19.0.0-rc",
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "peerDependenciesMeta": {
     "zod": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "svelte": "^5.31.0",
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "peerDependenciesMeta": {
     "zod": {
@@ -75,7 +75,7 @@
     "typescript-eslint": "^8.20.0",
     "vite": "^6.0.0",
     "vitest": "^3.0.0",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "homepage": "https://ai-sdk.dev/docs",
   "repository": {

--- a/packages/togetherai/package.json
+++ b/packages/togetherai/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -41,10 +41,10 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
     "typescript": "5.8.3",
-    "zod": "3.25.46"
+    "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.46"
+    "zod": "^3.25.49"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,11 +189,11 @@ importers:
         specifier: ^1.0.0-rc.0 || ^1.0.0
         version: 1.0.0-rc.0(typescript@5.8.3)
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
       zod-to-json-schema:
         specifier: 3.23.5
-        version: 3.23.5(zod@3.25.46)
+        version: 3.23.5(zod@3.25.49)
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -316,8 +316,8 @@ importers:
         specifier: 5.0.1
         version: 5.0.1
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
     devDependencies:
       '@types/express':
         specifier: 5.0.0
@@ -456,8 +456,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -712,8 +712,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -825,8 +825,8 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -892,8 +892,8 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -962,8 +962,8 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -1069,11 +1069,11 @@ importers:
         specifier: 16.4.5
         version: 16.4.5
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
       zod-to-json-schema:
         specifier: 3.23.5
-        version: 3.23.5(zod@3.25.46)
+        version: 3.23.5(zod@3.25.49)
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -1100,8 +1100,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ai
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
     devDependencies:
       '@nuxt/devtools':
         specifier: 1.6.3
@@ -1227,8 +1227,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.3(@types/node@22.7.4)(jiti@2.4.0)(terser@5.31.3)(tsx@4.19.2)(yaml@2.7.0)
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/ai:
     dependencies:
@@ -1270,8 +1270,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/amazon-bedrock:
     dependencies:
@@ -1304,8 +1304,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/anthropic:
     dependencies:
@@ -1329,8 +1329,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/assemblyai:
     dependencies:
@@ -1354,8 +1354,8 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/azure:
     dependencies:
@@ -1382,8 +1382,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/cerebras:
     dependencies:
@@ -1410,8 +1410,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/codemod:
     dependencies:
@@ -1487,8 +1487,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/deepgram:
     dependencies:
@@ -1512,8 +1512,8 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/deepinfra:
     dependencies:
@@ -1540,8 +1540,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/deepseek:
     dependencies:
@@ -1568,8 +1568,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/elevenlabs:
     dependencies:
@@ -1593,8 +1593,8 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/fal:
     dependencies:
@@ -1618,8 +1618,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/fireworks:
     dependencies:
@@ -1646,8 +1646,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/gateway:
     dependencies:
@@ -1671,8 +1671,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/gladia:
     dependencies:
@@ -1696,8 +1696,8 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/google:
     dependencies:
@@ -1721,8 +1721,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/google-vertex:
     dependencies:
@@ -1755,8 +1755,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/groq:
     dependencies:
@@ -1780,8 +1780,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/hume:
     dependencies:
@@ -1805,8 +1805,8 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/langchain:
     dependencies:
@@ -1868,8 +1868,8 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/luma:
     dependencies:
@@ -1893,8 +1893,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/mistral:
     dependencies:
@@ -1918,8 +1918,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/openai:
     dependencies:
@@ -1943,8 +1943,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/openai-compatible:
     dependencies:
@@ -1968,8 +1968,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/perplexity:
     dependencies:
@@ -1993,8 +1993,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/provider:
     dependencies:
@@ -2028,7 +2028,7 @@ importers:
         version: 1.0.0
       zod-to-json-schema:
         specifier: ^3.24.1
-        version: 3.24.1(zod@3.25.46)
+        version: 3.24.1(zod@3.25.49)
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -2046,8 +2046,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/react:
     dependencies:
@@ -2110,8 +2110,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/replicate:
     dependencies:
@@ -2135,8 +2135,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/revai:
     dependencies:
@@ -2160,8 +2160,8 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/rsc:
     dependencies:
@@ -2230,8 +2230,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/rsc/tests/e2e/next-server:
     dependencies:
@@ -2315,8 +2315,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.7(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.4.0)(jsdom@26.0.0)(msw@2.7.0(@types/node@20.17.24)(typescript@5.6.3))(terser@5.31.3)(tsx@4.19.2)(yaml@2.7.0)
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/togetherai:
     dependencies:
@@ -2343,8 +2343,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/valibot:
     dependencies:
@@ -2396,8 +2396,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   packages/vue:
     dependencies:
@@ -2479,8 +2479,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       zod:
-        specifier: 3.25.46
-        version: 3.25.46
+        specifier: 3.25.49
+        version: 3.25.49
 
   tools/analyze-downloads:
     devDependencies:
@@ -15330,8 +15330,8 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
-  zod@3.25.46:
-    resolution: {integrity: sha512-IqRxcHEIjqLd4LNS/zKffB3Jzg3NwqJxQQ0Ns7pdrvgGkwQsEBdEQcOHaBVqvvZArShRzI39+aMST3FBGmTrLQ==}
+  zod@3.25.49:
+    resolution: {integrity: sha512-JMMPMy9ZBk3XFEdbM3iL1brx4NUSejd6xr3ELrrGEfGb355gjhiAWtG3K5o+AViV/3ZfkIrCzXsZn6SbLwTR8Q==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -18123,8 +18123,8 @@ snapshots:
       flat: 5.0.2
       langsmith: 0.1.23(openai@4.52.6)
       uuid: 9.0.1
-      zod: 3.25.46
-      zod-to-json-schema: 3.24.1(zod@3.25.46)
+      zod: 3.25.49
+      zod-to-json-schema: 3.24.1(zod@3.25.49)
     optionalDependencies:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/client-bedrock-runtime': 3.663.0
@@ -18153,8 +18153,8 @@ snapshots:
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
-      zod: 3.25.46
-      zod-to-json-schema: 3.23.5(zod@3.25.46)
+      zod: 3.25.49
+      zod-to-json-schema: 3.23.5(zod@3.25.49)
     transitivePeerDependencies:
       - openai
 
@@ -18163,8 +18163,8 @@ snapshots:
       '@langchain/core': 0.1.63(openai@4.52.6)
       js-tiktoken: 1.0.12
       openai: 4.52.6
-      zod: 3.25.46
-      zod-to-json-schema: 3.23.5(zod@3.25.46)
+      zod: 3.25.49
+      zod-to-json-schema: 3.23.5(zod@3.25.49)
     transitivePeerDependencies:
       - encoding
 
@@ -18235,8 +18235,8 @@ snapshots:
       express-rate-limit: 7.5.0(express@5.0.1)
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
-      zod: 3.25.46
-      zod-to-json-schema: 3.24.1(zod@3.25.46)
+      zod: 3.25.49
+      zod-to-json-schema: 3.24.1(zod@3.25.49)
     transitivePeerDependencies:
       - supports-color
 
@@ -26581,8 +26581,8 @@ snapshots:
       p-retry: 4.6.2
       uuid: 9.0.1
       yaml: 2.4.2
-      zod: 3.25.46
-      zod-to-json-schema: 3.23.5(zod@3.25.46)
+      zod: 3.25.49
+      zod-to-json-schema: 3.23.5(zod@3.25.49)
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.662.0(@aws-sdk/client-sso-oidc@3.662.0(@aws-sdk/client-sts@3.662.0))(@aws-sdk/client-sts@3.662.0)
       '@vercel/kv': 0.2.4
@@ -31556,14 +31556,14 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.5.2
 
-  zod-to-json-schema@3.23.5(zod@3.25.46):
+  zod-to-json-schema@3.23.5(zod@3.25.49):
     dependencies:
-      zod: 3.25.46
+      zod: 3.25.49
 
-  zod-to-json-schema@3.24.1(zod@3.25.46):
+  zod-to-json-schema@3.24.1(zod@3.25.49):
     dependencies:
-      zod: 3.25.46
+      zod: 3.25.49
 
-  zod@3.25.46: {}
+  zod@3.25.49: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Background

Follow up to #6421.

One known issue is that zod v4's `.toJSONSchema()` does not set `"type"` for `.literal()` types, which causes problems with Google's APIs, see

- https://github.com/colinhacks/zod/issues/4249
- https://github.com/colinhacks/zod/pull/4590

Since the fix was now merged and released in `zod`, we are bumping the minimal zod version.

## Summary

Bump `zod` to [v3.25.49](https://github.com/colinhacks/zod/releases/tag/v3.25.49)

## Verification

I updated the example at `examples/ai-core/src/generate-object/google-vertex.ts` to use `import { z } from 'zod/v4';` and `name: z.literal('Lasagna'),`. It currently fails on v5, but works with the patch in this pull request

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

#5682