### PR TITLE
fix (provider/google): prevent error when thinking signature is used 

### DIFF
--- a/.changeset/proud-buckets-guess.md
+++ b/.changeset/proud-buckets-guess.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix (provider/google): prevent error when thinking signature is used

--- a/examples/ai-core/src/stream-text/google-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-reasoning.ts
@@ -1,18 +1,22 @@
-import { google } from '@ai-sdk/google';
-import { streamText } from 'ai';
+import { google, GoogleGenerativeAIProviderOptions } from '@ai-sdk/google';
+import { stepCountIs, streamText } from 'ai';
 import 'dotenv/config';
+import { weatherTool } from '../tools/weather-tool';
 
 async function main() {
   const result = streamText({
-    model: google('gemini-2.5-flash-preview-04-17'),
-    prompt: 'Tell me the history of the San Francisco Mission-style burrito.',
+    model: google('gemini-2.5-flash-preview-05-20'),
+    tools: { weather: weatherTool },
+    prompt: 'What is the weather in San Francisco?',
+    stopWhen: stepCountIs(2),
     providerOptions: {
       google: {
         thinkingConfig: {
           thinkingBudget: 1024,
         },
-      },
+      } satisfies GoogleGenerativeAIProviderOptions,
     },
+    onError: console.error,
   });
 
   for await (const part of result.fullStream) {

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2000,6 +2000,20 @@ describe('doStream', () => {
           candidates: [
             {
               content: {
+                // currently ignored:
+                parts: [{ thoughtSignature: 'test-signature', thought: true }],
+                role: 'model',
+              },
+              finishReason: 'STOP', // Mark finish reason in a chunk that has content
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
                 parts: [{ text: 'Another internal thought.', thought: true }],
                 role: 'model',
               },

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -475,21 +475,6 @@ function getTextFromParts(parts: z.infer<typeof contentSchema>['parts']) {
     : textParts.map(part => part.text).join('');
 }
 
-function getReasoningDetailsFromParts(
-  parts: z.infer<typeof contentSchema>['parts'],
-): Array<{ type: 'text'; text: string }> | undefined {
-  const reasoningParts = parts?.filter(
-    part =>
-      'text' in part && (part as any).thought === true && part.text != null,
-  ) as Array<
-    GoogleGenerativeAIContentPart & { text: string; thought?: boolean }
-  >;
-
-  return reasoningParts == null || reasoningParts.length === 0
-    ? undefined
-    : reasoningParts.map(part => ({ type: 'text', text: part.text }));
-}
-
 function getInlineDataParts(parts: z.infer<typeof contentSchema>['parts']) {
   return parts?.filter(
     (

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -206,7 +206,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
 
     // Build content array from all parts
     for (const part of parts) {
-      if ('text' in part && part.text.length > 0) {
+      if ('text' in part && part.text != null && part.text.length > 0) {
         if (part.thought === true) {
           content.push({ type: 'reasoning', text: part.text });
         } else {
@@ -346,7 +346,11 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
               // Process text parts individually to handle reasoning parts
               const parts = content.parts ?? [];
               for (const part of parts) {
-                if ('text' in part && part.text.length > 0) {
+                if (
+                  'text' in part &&
+                  part.text != null &&
+                  part.text.length > 0
+                ) {
                   if (part.thought === true) {
                     controller.enqueue({ type: 'reasoning', text: part.text });
                   } else {
@@ -468,10 +472,22 @@ function getTextFromParts(parts: z.infer<typeof contentSchema>['parts']) {
 
   return textParts == null || textParts.length === 0
     ? undefined
-    : {
-        type: 'text' as const,
-        text: textParts.map(part => part.text).join(''),
-      };
+    : textParts.map(part => part.text).join('');
+}
+
+function getReasoningDetailsFromParts(
+  parts: z.infer<typeof contentSchema>['parts'],
+): Array<{ type: 'text'; text: string }> | undefined {
+  const reasoningParts = parts?.filter(
+    part =>
+      'text' in part && (part as any).thought === true && part.text != null,
+  ) as Array<
+    GoogleGenerativeAIContentPart & { text: string; thought?: boolean }
+  >;
+
+  return reasoningParts == null || reasoningParts.length === 0
+    ? undefined
+    : reasoningParts.map(part => ({ type: 'text', text: part.text }));
 }
 
 function getInlineDataParts(parts: z.infer<typeof contentSchema>['parts']) {
@@ -509,14 +525,10 @@ function extractSources({
 }
 
 const contentSchema = z.object({
-  role: z.string(),
   parts: z
     .array(
       z.union([
-        z.object({
-          text: z.string(),
-          thought: z.boolean().nullish(),
-        }),
+        // note: order matters since text can be fully empty
         z.object({
           functionCall: z.object({
             name: z.string(),
@@ -528,6 +540,10 @@ const contentSchema = z.object({
             mimeType: z.string(),
             data: z.string(),
           }),
+        }),
+        z.object({
+          text: z.string().nullish(),
+          thought: z.boolean().nullish(),
         }),
       ]),
     )


### PR DESCRIPTION
## Background

The Google API for reasoning was changed in their latest model, leading to Zod errors.

## Summary

Make text optional in thinking chunks. Ignore thinking chunks without text.

## Verification

Tested example against google api.

## Future work
Expose thinking signature using provider metadata, and explore sending it to google in follow-up requests.

## Related Issues
Fixes #6589