### PR TITLE
 feat(providers/google): Add reasoning token output support

### DIFF
--- a/.changeset/twelve-baboons-sing.md
+++ b/.changeset/twelve-baboons-sing.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+Add reasoning token output support for gemini models via Vertex AI Provider

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -326,6 +326,71 @@ const { text } = await generateText({
 Google Vertex language models can also be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+#### Reasoning (Thinking Tokens)
+
+Google Vertex AI, through its support for Gemini models, can also emit "thinking" tokens, representing the model's reasoning process. The AI SDK exposes these as reasoning information.
+
+To enable thinking tokens for compatible Gemini models via Vertex, set `includeThoughts: true` in the `thinkingConfig` provider option. Since the Vertex provider uses the Google provider's underlying language model, these options are passed through `providerOptions.google`:
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google'; // Note: importing from @ai-sdk/google
+import { generateText, streamText } from 'ai';
+
+// For generateText:
+const { text, reasoning, reasoningDetails } = await generateText({
+  model: vertex('gemini-2.5-flash-preview-04-17'), // Or other supported model via Vertex
+  providerOptions: {
+    google: {
+      // Options are nested under 'google' for Vertex provider
+      thinkingConfig: {
+        includeThoughts: true,
+        // thinkingBudget: 2048, // Optional
+      },
+    } satisfies GoogleGenerativeAIProviderOptions,
+  },
+  prompt: 'Explain quantum computing in simple terms.',
+});
+
+console.log('Reasoning:', reasoning);
+console.log('Reasoning Details:', reasoningDetails);
+console.log('Final Text:', text);
+
+// For streamText:
+const result = streamText({
+  model: vertex('gemini-2.5-flash-preview-04-17'), // Or other supported model via Vertex
+  providerOptions: {
+    google: {
+      // Options are nested under 'google' for Vertex provider
+      thinkingConfig: {
+        includeThoughts: true,
+        // thinkingBudget: 2048, // Optional
+      },
+    } satisfies GoogleGenerativeAIProviderOptions,
+  },
+  prompt: 'Explain quantum computing in simple terms.',
+});
+
+for await (const part of result.fullStream) {
+  if (part.type === 'reasoning') {
+    process.stdout.write(`THOUGHT: ${part.textDelta}\n`);
+  } else if (part.type === 'text-delta') {
+    process.stdout.write(part.textDelta);
+  }
+}
+```
+
+When `includeThoughts` is true, parts of the API response marked with `thought: true` will be processed as reasoning.
+
+- In `generateText`, these contribute to the `reasoning` (string) and `reasoningDetails` (array) fields.
+- In `streamText`, these are emitted as `reasoning` stream parts.
+
+<Note>
+  Refer to the [Google Vertex AI documentation on
+  "thinking"](https://cloud.google.com/vertex-ai/generative-ai/docs/thinking)
+  for model compatibility and further details.
+</Note>
+
 #### File Inputs
 
 The Google Vertex provider supports file inputs, e.g. PDF files.

--- a/examples/ai-core/src/generate-text/google-vertex-reasoning-generate-text.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-reasoning-generate-text.ts
@@ -1,0 +1,29 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText } from 'ai';
+
+async function main() {
+  const result = await generateText({
+    model: vertex('gemini-2.5-flash-preview-04-17'),
+    prompt:
+      "Describe the most unusual or striking architectural feature you've ever seen in a building or structure.",
+    providerOptions: {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: 2048,
+          includeThoughts: true,
+        },
+      },
+    },
+  });
+
+  process.stdout.write('\x1b[34m' + result.reasoning + '\x1b[0m');
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+
+  console.log();
+  console.log('Warnings:', result.warnings);
+}
+
+main().catch(console.log);

--- a/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
@@ -1,0 +1,35 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { streamText } from 'ai';
+
+async function main() {
+  const result = streamText({
+    model: vertex('gemini-2.5-flash-preview-04-17'),
+    prompt:
+      "Describe the most unusual or striking architectural feature you've ever seen in a building or structure.",
+    providerOptions: {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: 2048,
+          includeThoughts: true,
+        },
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'reasoning') {
+      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.textDelta);
+    }
+  }
+
+  console.log();
+  console.log('Warnings:', await result.warnings);
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.log);

--- a/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
@@ -18,9 +18,9 @@ async function main() {
 
   for await (const part of result.fullStream) {
     if (part.type === 'reasoning') {
-      process.stdout.write('\x1b[34m' + part.textDelta + '\x1b[0m');
-    } else if (part.type === 'text-delta') {
-      process.stdout.write(part.textDelta);
+      process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
+    } else if (part.type === 'text') {
+      process.stdout.write(part.text);
     }
   }
 

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -223,24 +223,14 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    const text = content
-      .filter(
-        (item): item is { type: 'text'; text: string } =>
-          item.type === 'text' && (item as any).thought !== true,
-      )
-      .map(item => item.text)
-      .join('');
-    const reasoning = content
-      .filter(
-        (item): item is { type: 'text'; text: string; thought?: boolean } =>
-          item.type === 'text' && (item as any).thought === true,
-      )
-      .map(item => ({ type: 'text', text: item.text }));
-
-    expect(text).toMatchInlineSnapshot(`
-      "Hello, World!"
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        },
+      ]
     `);
-    expect(reasoning).toStrictEqual([]);
   });
 
   it('should extract usage', async () => {
@@ -1298,25 +1288,28 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    const text = content
-      .filter(
-        (item): item is { type: 'text'; text: string } =>
-          item.type === 'text' && (item as any).thought !== true,
-      )
-      .map(item => item.text)
-      .join('');
-    const reasoning = content
-      .filter(
-        (item): item is { type: 'text'; text: string; thought?: boolean } =>
-          item.type === 'text' && (item as any).thought === true,
-      )
-      .map(item => ({ type: 'text', text: item.text }));
-
-    expect(text).toStrictEqual('Visible text part 1. Visible text part 2.');
-    expect(reasoning).toStrictEqual([
-      { type: 'text', text: 'This is a thought process.' },
-      { type: 'text', text: 'Another internal thought.' },
-    ]);
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Visible text part 1. ",
+          "type": "text",
+        },
+        {
+          "text": "This is a thought process.",
+          "thought": true,
+          "type": "text",
+        },
+        {
+          "text": "Visible text part 2.",
+          "type": "text",
+        },
+        {
+          "text": "Another internal thought.",
+          "thought": true,
+          "type": "text",
+        },
+      ]
+    `);
   });
   describe('warnings for includeThoughts option', () => {
     it('should generate a warning if includeThoughts is true for a non-Vertex provider', async () => {
@@ -1343,13 +1336,14 @@ describe('doGenerate', () => {
         },
       });
 
-      expect(warnings).toContainEqual({
-        type: 'other',
-        message:
-          "The 'includeThoughts' option is only supported with the Google Vertex provider " +
-          'and might not be supported or could behave unexpectedly with the current Google provider ' +
-          '(google.generative-ai.chat).',
-      });
+      expect(warnings).toMatchInlineSnapshot(`
+        [
+          {
+            "message": "The 'includeThoughts' option is only supported with the Google Vertex provider and might not be supported or could behave unexpectedly with the current Google provider (google.generative-ai.chat).",
+            "type": "other",
+          },
+        ]
+      `);
     });
 
     it('should NOT generate a warning if includeThoughts is true for a Vertex provider', async () => {
@@ -1375,16 +1369,7 @@ describe('doGenerate', () => {
         },
       });
 
-      const expectedWarningMessage =
-        "The 'includeThoughts' option is only supported with the Google Vertex provider " +
-        'and might not be supported or could behave unexpectedly with the current Google provider ';
-
-      expect(
-        warnings?.some(
-          w =>
-            w.type === 'other' && w.message.startsWith(expectedWarningMessage),
-        ),
-      ).toBe(false);
+      expect(warnings).toMatchInlineSnapshot(`[]`);
     });
 
     it('should NOT generate a warning if includeThoughts is false for a non-Vertex provider', async () => {
@@ -1410,15 +1395,7 @@ describe('doGenerate', () => {
         },
       });
 
-      const expectedWarningMessage =
-        "The 'includeThoughts' option is only supported with the Google Vertex provider " +
-        'and might not be supported or could behave unexpectedly with the current Google provider ';
-      expect(
-        warnings?.some(
-          w =>
-            w.type === 'other' && w.message.startsWith(expectedWarningMessage),
-        ),
-      ).toBe(false);
+      expect(warnings).toMatchInlineSnapshot(`[]`);
     });
 
     it('should NOT generate a warning if thinkingConfig is not provided for a non-Vertex provider', async () => {
@@ -1439,15 +1416,8 @@ describe('doGenerate', () => {
           },
         },
       });
-      const expectedWarningMessage =
-        "The 'includeThoughts' option is only supported with the Google Vertex provider " +
-        'and might not be supported or could behave unexpectedly with the current Google provider ';
-      expect(
-        warnings?.some(
-          w =>
-            w.type === 'other' && w.message.startsWith(expectedWarningMessage),
-        ),
-      ).toBe(false);
+
+      expect(warnings).toMatchInlineSnapshot(`[]`);
     });
   });
 });
@@ -1595,165 +1565,6 @@ describe('doStream', () => {
 
   it('should stream text deltas', async () => {
     prepareStreamResponse({ content: ['Hello', ', ', 'world!'] });
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
-      [
-        {
-          "type": "stream-start",
-          "warnings": [],
-        },
-        {
-          "text": "Hello",
-          "type": "text",
-        },
-        {
-          "text": ", ",
-          "type": "text",
-        },
-        {
-          "text": "world!",
-          "type": "text",
-        },
-        {
-          "finishReason": "stop",
-          "providerMetadata": {
-            "google": {
-              "groundingMetadata": null,
-              "safetyRatings": [
-                {
-                  "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
-                  "probability": "NEGLIGIBLE",
-                },
-                {
-                  "category": "HARM_CATEGORY_HATE_SPEECH",
-                  "probability": "NEGLIGIBLE",
-                },
-                {
-                  "category": "HARM_CATEGORY_HARASSMENT",
-                  "probability": "NEGLIGIBLE",
-                },
-                {
-                  "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
-                  "probability": "NEGLIGIBLE",
-                },
-              ],
-            },
-          },
-          "type": "finish",
-          "usage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 294,
-            "outputTokens": 233,
-            "reasoningTokens": undefined,
-            "totalTokens": 527,
-          },
-        },
-      ]
-    `);
-  });
-
-  it('should expose the raw response headers', async () => {
-    prepareStreamResponse({
-      content: [],
-      headers: { 'test-header': 'test-value' },
-    });
-
-    const { response } = await model.doStream({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(response?.headers).toStrictEqual({
-      // default headers:
-      'content-type': 'text/event-stream',
-      'cache-control': 'no-cache',
-      connection: 'keep-alive',
-
-      // custom header
-      'test-header': 'test-value',
-    });
-  });
-
-  it('should pass the messages', async () => {
-    prepareStreamResponse({ content: [''] });
-    await model.doStream({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      contents: [
-        {
-          role: 'user',
-          parts: [{ text: 'Hello' }],
-        },
-      ],
-      generationConfig: {},
-    });
-  });
-
-  it('should set streaming mode search param', async () => {
-    prepareStreamResponse({ content: [''] });
-    await model.doStream({
-      prompt: TEST_PROMPT,
-    });
-
-    const searchParams = server.calls[0].requestUrlSearchParams;
-    expect(searchParams.get('alt')).toStrictEqual('sse');
-  });
-
-  it('should pass headers', async () => {
-    prepareStreamResponse({ content: [''] });
-    const provider = createGoogleGenerativeAI({
-      apiKey: 'test-api-key',
-      headers: {
-        'Custom-Provider-Header': 'provider-header-value',
-      },
-    });
-
-    await provider.chat('gemini-pro').doStream({
-      prompt: TEST_PROMPT,
-      headers: {
-        'Custom-Request-Header': 'request-header-value',
-      },
-    });
-
-    expect(server.calls[0].requestHeaders).toStrictEqual({
-      'content-type': 'application/json',
-      'custom-provider-header': 'provider-header-value',
-      'custom-request-header': 'request-header-value',
-      'x-goog-api-key': 'test-api-key',
-    });
-  });
-
-  it('should send request body', async () => {
-    prepareStreamResponse({ content: [''] });
-
-    const { request } = await model.doStream({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      generationConfig: {},
-      contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
-    });
-  });
-
-  it('should support empty candidates array', async () => {
-    server.urls[TEST_URL_GEMINI_PRO].response = {
-      type: 'stream-chunks',
-      chunks: [
-        `data: {"candidates": [{"content": {"parts": [{"text": "test"}],"role": "model"},` +
-          `"finishReason": "STOP","index": 0,"safetyRatings": [` +
-          `{"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT","probability": "NEGLIGIBLE"},` +
-          `{"category": "HARM_CATEGORY_HATE_SPEECH","probability": "NEGLIGIBLE"},` +
-          `{"category": "HARM_CATEGORY_HARASSMENT","probability": "NEGLIGIBLE"},` +
-          `{"category": "HARM_CATEGORY_DANGEROUS_CONTENT","probability": "NEGLIGIBLE"}]}]}\n\n`,
-        `data: {"usageMetadata": {"promptTokenCount": 294,"candidatesTokenCount": 233,"totalTokenCount": 527}}\n\n`,
-      ],
-    };
 
     const { stream } = await model.doStream({
       prompt: TEST_PROMPT,
@@ -2092,6 +1903,19 @@ describe('doStream', () => {
       ],
     };
     const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          parameters: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+        },
+      ],
       prompt: TEST_PROMPT,
     });
 
@@ -2123,94 +1947,6 @@ describe('doStream', () => {
       generationConfig: {
         responseModalities: ['TEXT', 'IMAGE'],
       },
-    });
-  });
-
-  it('should correctly stream reasoning parts and text deltas separately', async () => {
-    server.urls[TEST_URL_GEMINI_PRO].response = {
-      type: 'stream-chunks',
-      chunks: [
-        `data: ${JSON.stringify({
-          candidates: [
-            {
-              content: { parts: [{ text: 'Text delta 1. ' }], role: 'model' },
-              index: 0,
-              safetyRatings: SAFETY_RATINGS,
-            },
-          ],
-        })}\n\n`,
-        `data: ${JSON.stringify({
-          candidates: [
-            {
-              content: {
-                parts: [{ text: 'Reasoning delta 1.', thought: true }],
-                role: 'model',
-              },
-              index: 0,
-              safetyRatings: SAFETY_RATINGS,
-            },
-          ],
-        })}\n\n`,
-        `data: ${JSON.stringify({
-          candidates: [
-            {
-              content: { parts: [{ text: 'Text delta 2.' }], role: 'model' },
-              index: 0,
-              safetyRatings: SAFETY_RATINGS,
-            },
-          ],
-        })}\n\n`,
-        `data: ${JSON.stringify({
-          candidates: [
-            {
-              content: {
-                parts: [{ text: 'Reasoning delta 2.', thought: true }],
-                role: 'model',
-              },
-              finishReason: 'STOP', // Mark finish reason in a chunk that has content
-              index: 0,
-              safetyRatings: SAFETY_RATINGS,
-            },
-          ],
-        })}\n\n`,
-        `data: ${JSON.stringify({
-          // Final chunk for usage metadata
-          usageMetadata: {
-            promptTokenCount: 15,
-            candidatesTokenCount: 25,
-            totalTokenCount: 40,
-          },
-        })}\n\n`,
-      ],
-    };
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-    });
-
-    const events = await convertReadableStreamToArray(stream);
-
-    const relevantEvents = events.filter(
-      event => event.type === 'text' || event.type === 'reasoning',
-    );
-
-    expect(relevantEvents).toStrictEqual([
-      { type: 'text', text: 'Text delta 1. ' },
-      { type: 'reasoning', text: 'Reasoning delta 1.' },
-      { type: 'text', text: 'Text delta 2.' },
-      { type: 'reasoning', text: 'Reasoning delta 2.' },
-    ]);
-
-    const finishEvent = events.find(event => event.type === 'finish');
-    expect(finishEvent).toBeDefined();
-    expect(finishEvent?.type === 'finish' && finishEvent.finishReason).toEqual(
-      'stop',
-    );
-    expect(finishEvent?.type === 'finish' && finishEvent.usage).toStrictEqual({
-      inputTokens: 15,
-      outputTokens: 25,
-      totalTokens: 40,
-      reasoningTokens: undefined,
-      cachedInputTokens: undefined,
     });
   });
 });

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1296,8 +1296,7 @@ describe('doGenerate', () => {
         },
         {
           "text": "This is a thought process.",
-          "thought": true,
-          "type": "text",
+          "type": "reasoning",
         },
         {
           "text": "Visible text part 2.",
@@ -1305,8 +1304,7 @@ describe('doGenerate', () => {
         },
         {
           "text": "Another internal thought.",
-          "thought": true,
-          "type": "text",
+          "type": "reasoning",
         },
       ]
     `);
@@ -1577,7 +1575,15 @@ describe('doStream', () => {
           "warnings": [],
         },
         {
-          "text": "test",
+          "text": "Hello",
+          "type": "text",
+        },
+        {
+          "text": ", ",
+          "type": "text",
+        },
+        {
+          "text": "world!",
           "type": "text",
         },
         {

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1256,6 +1256,202 @@ describe('doGenerate', () => {
       ]
     `);
   });
+  it('should correctly parse and separate reasoning parts from text output', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: 'Visible text part 1. ' },
+                { text: 'This is a thought process.', thought: true },
+                { text: 'Visible text part 2.' },
+                { text: 'Another internal thought.', thought: true },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    const { text, reasoning } = await model.doGenerate({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(text).toStrictEqual('Visible text part 1. Visible text part 2.');
+    expect(reasoning).toStrictEqual([
+      { type: 'text', text: 'This is a thought process.' },
+      { type: 'text', text: 'Another internal thought.' },
+    ]);
+  });
+  describe('warnings for includeThoughts option', () => {
+    it('should generate a warning if includeThoughts is true for a non-Vertex provider', async () => {
+      prepareJsonResponse({ content: 'test' }); // Mock API response
+
+      // Manually create a model instance to control the provider string
+      const nonVertexModel = new GoogleGenerativeAILanguageModel(
+        'gemini-pro',
+        {},
+        {
+          provider: 'google.generative-ai.chat', // Simulate non-Vertex provider
+          baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+          headers: {},
+          generateId: () => 'test-id',
+          isSupportedUrl: () => false, // Dummy implementation
+        },
+      );
+
+      const { warnings } = await nonVertexModel.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+        providerMetadata: {
+          google: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingBudget: 500,
+            },
+          },
+        },
+      });
+
+      expect(warnings).toContainEqual({
+        type: 'other',
+        message:
+          "The 'includeThoughts' option is only supported with the Google Vertex provider " +
+          'and might not be supported or could behave unexpectedly with the current Google provider ' +
+          '(google.generative-ai.chat).',
+      });
+    });
+
+    it('should NOT generate a warning if includeThoughts is true for a Vertex provider', async () => {
+      prepareJsonResponse({ content: 'test' }); // Mock API response
+
+      const vertexModel = new GoogleGenerativeAILanguageModel(
+        'gemini-pro',
+        {},
+        {
+          provider: 'google.vertex.chat', // Simulate Vertex provider
+          baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+          headers: {},
+          generateId: () => 'test-id',
+          isSupportedUrl: () => false,
+        },
+      );
+
+      const { warnings } = await vertexModel.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+        providerMetadata: {
+          google: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingBudget: 500,
+            },
+          },
+        },
+      });
+
+      const expectedWarningMessage =
+        "The 'includeThoughts' option is only supported with the Google Vertex provider " +
+        'and might not be supported or could behave unexpectedly with the current Google provider ';
+
+      expect(
+        warnings?.some(
+          w =>
+            w.type === 'other' && w.message.startsWith(expectedWarningMessage),
+        ),
+      ).toBe(false);
+    });
+
+    it('should NOT generate a warning if includeThoughts is false for a non-Vertex provider', async () => {
+      prepareJsonResponse({ content: 'test' }); // Mock API response
+
+      const nonVertexModel = new GoogleGenerativeAILanguageModel(
+        'gemini-pro',
+        {},
+        {
+          provider: 'google.generative-ai.chat', // Simulate non-Vertex provider
+          baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+          headers: {},
+          generateId: () => 'test-id',
+          isSupportedUrl: () => false,
+        },
+      );
+
+      const { warnings } = await nonVertexModel.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+        providerMetadata: {
+          google: {
+            thinkingConfig: {
+              includeThoughts: false,
+              thinkingBudget: 500,
+            },
+          },
+        },
+      });
+
+      const expectedWarningMessage =
+        "The 'includeThoughts' option is only supported with the Google Vertex provider " +
+        'and might not be supported or could behave unexpectedly with the current Google provider ';
+      expect(
+        warnings?.some(
+          w =>
+            w.type === 'other' && w.message.startsWith(expectedWarningMessage),
+        ),
+      ).toBe(false);
+    });
+
+    it('should NOT generate a warning if thinkingConfig is not provided for a non-Vertex provider', async () => {
+      prepareJsonResponse({ content: 'test' }); // Mock API response
+      const nonVertexModel = new GoogleGenerativeAILanguageModel(
+        'gemini-pro',
+        {},
+        {
+          provider: 'google.generative-ai.chat', // Simulate non-Vertex provider
+          baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+          headers: {},
+          generateId: () => 'test-id',
+          isSupportedUrl: () => false,
+        },
+      );
+
+      const { warnings } = await nonVertexModel.doGenerate({
+        inputFormat: 'prompt',
+        mode: { type: 'regular' },
+        prompt: TEST_PROMPT,
+        providerMetadata: {
+          google: {
+            // No thinkingConfig
+          },
+        },
+      });
+      const expectedWarningMessage =
+        "The 'includeThoughts' option is only supported with the Google Vertex provider " +
+        'and might not be supported or could behave unexpectedly with the current Google provider ';
+      expect(
+        warnings?.some(
+          w =>
+            w.type === 'other' && w.message.startsWith(expectedWarningMessage),
+        ),
+      ).toBe(false);
+    });
+  });
 });
 
 describe('doStream', () => {
@@ -1942,6 +2138,93 @@ describe('doStream', () => {
       generationConfig: {
         responseModalities: ['TEXT', 'IMAGE'],
       },
+    });
+  });
+
+  it('should correctly stream reasoning parts and text deltas separately', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: 'Text delta 1. ' }], role: 'model' },
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'Reasoning delta 1.', thought: true }],
+                role: 'model',
+              },
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: 'Text delta 2.' }], role: 'model' },
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'Reasoning delta 2.', thought: true }],
+                role: 'model',
+              },
+              finishReason: 'STOP', // Mark finish reason in a chunk that has content
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          // Final chunk for usage metadata
+          usageMetadata: {
+            promptTokenCount: 15,
+            candidatesTokenCount: 25,
+            totalTokenCount: 40,
+          },
+        })}\n\n`,
+      ],
+    };
+    const { stream } = await model.doStream({
+      inputFormat: 'prompt',
+      mode: { type: 'regular' },
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+
+    const relevantEvents = events.filter(
+      event => event.type === 'text-delta' || event.type === 'reasoning',
+    );
+
+    expect(relevantEvents).toStrictEqual([
+      { type: 'text-delta', textDelta: 'Text delta 1. ' },
+      { type: 'reasoning', textDelta: 'Reasoning delta 1.' },
+      { type: 'text-delta', textDelta: 'Text delta 2.' },
+      { type: 'reasoning', textDelta: 'Reasoning delta 2.' },
+    ]);
+
+    const finishEvent = events.find(event => event.type === 'finish');
+    expect(finishEvent).toBeDefined();
+    expect(finishEvent?.type === 'finish' && finishEvent.finishReason).toEqual(
+      'stop',
+    );
+    expect(finishEvent?.type === 'finish' && finishEvent.usage).toStrictEqual({
+      promptTokens: 15,
+      completionTokens: 25,
     });
   });
 });

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -343,9 +343,16 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
 
             // Process tool call's parts before determining finishReason to ensure hasToolCalls is properly set
             if (content != null) {
-              const deltaText = getTextFromParts(content.parts);
-              if (deltaText != null) {
-                controller.enqueue(deltaText);
+              // Process text parts individually to handle reasoning parts
+              const parts = content.parts ?? [];
+              for (const part of parts) {
+                if ('text' in part && part.text.length > 0) {
+                  if (part.thought === true) {
+                    controller.enqueue({ type: 'reasoning', text: part.text });
+                  } else {
+                    controller.enqueue({ type: 'text', text: part.text });
+                  }
+                }
               }
 
               const inlineDataParts = getInlineDataParts(content.parts);

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -51,6 +51,7 @@ export const googleGenerativeAIProviderOptions = z.object({
   thinkingConfig: z
     .object({
       thinkingBudget: z.number().optional(),
+      includeThoughts: z.boolean().optional(),
     })
     .optional(),
 


### PR DESCRIPTION
## Background

[Vertex now supports extraction of thinking tokens in certain Gemini models](https://cloud.google.com/vertex-ai/generative-ai/docs/thinking).

When the configuration is passed via `providerOptions`, the sdk:
1. Did not extract reasoning tokens
2. Did not pass `include_thoughts` to the provider

## Summary

Added extraction logic to google-generative-ai package to parse reasoning tokens.

Added a `includeThoughts` switch to the `thinkingConfig` for vertex models.

## Verification

I verified it manually. Testable via examples/ai-core/src/stream-text/google-vertex-reasoning.ts. Easily copiable to google provider.

Tests have been added.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features) - c1264af
- [x] Examples have been updated
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues
Fixes #6259
