### PR TITLE
refactoring: use abortSignal

### DIFF
--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -11,7 +11,7 @@ export interface ChatTransport<
     options: {
       chatId: string;
       messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
-      abortController: AbortController;
+      abortSignal: AbortSignal | undefined;
       requestType: 'generate' | 'resume'; // TODO have separate functions
     } & ChatRequestOptions,
   ) => Promise<ReadableStream<UIMessageStreamPart>>;

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -399,7 +399,7 @@ export abstract class AbstractChat<
       const stream = await this.transport.submitMessages({
         chatId: this.id,
         messages: this.state.messages,
-        abortController: activeResponse.abortController,
+        abortSignal: activeResponse.abortController.signal,
         metadata,
         headers,
         body,

--- a/packages/ai/src/ui/default-chat-transport.ts
+++ b/packages/ai/src/ui/default-chat-transport.ts
@@ -19,7 +19,7 @@ async function fetchUIMessageStream({
   body,
   credentials,
   headers,
-  abortController,
+  abortSignal,
   fetch = getOriginalFetch(),
   requestType = 'generate',
 }: {
@@ -27,7 +27,7 @@ async function fetchUIMessageStream({
   body: Record<string, any>;
   credentials: RequestCredentials | undefined;
   headers: HeadersInit | undefined;
-  abortController: (() => AbortController | null) | undefined;
+  abortSignal: AbortSignal | undefined;
   fetch: ReturnType<typeof getOriginalFetch> | undefined;
   requestType?: 'generate' | 'resume';
 }): Promise<ReadableStream<UIMessageStreamPart>> {
@@ -39,7 +39,7 @@ async function fetchUIMessageStream({
             'Content-Type': 'application/json',
             ...headers,
           },
-          signal: abortController?.()?.signal,
+          signal: abortSignal,
           credentials,
         })
       : await fetch(api, {
@@ -49,7 +49,7 @@ async function fetchUIMessageStream({
             'Content-Type': 'application/json',
             ...headers,
           },
-          signal: abortController?.()?.signal,
+          signal: abortSignal,
           credentials,
         });
 
@@ -154,7 +154,7 @@ export class DefaultChatTransport<
   submitMessages({
     chatId,
     messages,
-    abortController,
+    abortSignal,
     metadata,
     headers,
     body,
@@ -182,7 +182,7 @@ export class DefaultChatTransport<
           ? preparedRequest.headers
           : { ...this.headers, ...headers },
       credentials: preparedRequest?.credentials ?? this.credentials,
-      abortController: () => abortController, // TODO: why is this a function?
+      abortSignal,
       fetch: this.fetch,
       requestType,
     });

--- a/packages/ai/src/ui/text-stream-chat-transport.ts
+++ b/packages/ai/src/ui/text-stream-chat-transport.ts
@@ -13,7 +13,7 @@ async function fetchTextStream({
   body,
   credentials,
   headers,
-  abortController,
+  abortSignal,
   fetch = getOriginalFetch(),
   requestType = 'generate',
 }: {
@@ -21,7 +21,7 @@ async function fetchTextStream({
   body: Record<string, any>;
   credentials: RequestCredentials | undefined;
   headers: HeadersInit | undefined;
-  abortController: (() => AbortController | null) | undefined;
+  abortSignal: AbortSignal | undefined;
   fetch: ReturnType<typeof getOriginalFetch> | undefined;
   requestType?: 'generate' | 'resume';
 }): Promise<ReadableStream<UIMessageStreamPart>> {
@@ -33,7 +33,7 @@ async function fetchTextStream({
             'Content-Type': 'application/json',
             ...headers,
           },
-          signal: abortController?.()?.signal,
+          signal: abortSignal,
           credentials,
         })
       : await fetch(api, {
@@ -43,7 +43,7 @@ async function fetchTextStream({
             'Content-Type': 'application/json',
             ...headers,
           },
-          signal: abortController?.()?.signal,
+          signal: abortSignal,
           credentials,
         });
 
@@ -138,7 +138,7 @@ export class TextStreamChatTransport<
   submitMessages({
     chatId,
     messages,
-    abortController,
+    abortSignal,
     metadata,
     headers,
     body,
@@ -167,7 +167,7 @@ export class TextStreamChatTransport<
           ? preparedRequest.headers
           : { ...this.headers, ...headers },
       credentials: preparedRequest?.credentials ?? this.credentials,
-      abortController: () => abortController, // TODO: why is this a function?
+      abortSignal,
       fetch: this.fetch,
       requestType,
     });


### PR DESCRIPTION
## Background

Multiple unnecessary levels of indirection where an `AbortSignal` would be sufficient.

## Summary

Refactor to use `AbortSignal`.