### PR TITLE
feat(anthropic/citation): pdf citation support

### DIFF
--- a/.changeset/good-students-sin.md
+++ b/.changeset/good-students-sin.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(anthropic/citation): request processing

--- a/.changeset/good-students-sin.md
+++ b/.changeset/good-students-sin.md
@@ -2,4 +2,4 @@
 '@ai-sdk/anthropic': patch
 ---
 
-feat(anthropic/citation): request processing
+feat(provider/anthropic): add PDF citation support with document sources for streamText

--- a/examples/ai-core/src/generate-text/anthropic-file-part-citations.ts
+++ b/examples/ai-core/src/generate-text/anthropic-file-part-citations.ts
@@ -1,0 +1,53 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import 'dotenv/config';
+
+async function main() {
+  const pdfPath = resolve(process.cwd(), 'data', 'ai.pdf');
+  const pdfBuffer = readFileSync(pdfPath);
+  const pdfBase64 = pdfBuffer.toString('base64');
+
+  const result = await generateText({
+    model: anthropic('claude-3-5-sonnet-20241022'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What does this document contain? Please provide citations for your analysis.',
+          },
+          {
+            type: 'file',
+            data: `data:application/pdf;base64,${pdfBase64}`,
+            mediaType: 'application/pdf',
+            filename: 'ai.pdf',
+            providerOptions: {
+              anthropic: {
+                citations: { enabled: true },
+                title: 'AI Research Document',
+                context:
+                  'Technical documentation about artificial intelligence',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log('Response:');
+  console.log(result.text);
+
+  console.log('\nExample demonstrates:');
+  console.log('- File part level provider options for documents');
+  console.log('- Custom title and context for the document');
+  console.log('- Citations enabled on the document');
+  console.log(
+    '\nNote: Anthropic citations currently only work with PDF files.',
+  );
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/anthropic-pdf-sources.ts
+++ b/examples/ai-core/src/stream-text/anthropic-pdf-sources.ts
@@ -18,15 +18,18 @@ async function main() {
             type: 'file',
             data: fs.readFileSync('./data/ai.pdf'),
             mediaType: 'application/pdf',
+            providerOptions: {
+              anthropic: {
+                citations: { enabled: true },
+                title: 'AI Handbook',
+                context:
+                  'Technical documentation about AI models and embeddings',
+              },
+            },
           },
         ],
       },
     ],
-    providerOptions: {
-      anthropic: {
-        citations: { enabled: true },
-      },
-    },
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-core/src/stream-text/anthropic-pdf-sources.ts
+++ b/examples/ai-core/src/stream-text/anthropic-pdf-sources.ts
@@ -1,0 +1,57 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText } from 'ai';
+import 'dotenv/config';
+import fs from 'node:fs';
+
+async function main() {
+  const result = streamText({
+    model: anthropic('claude-3-5-sonnet-20241022'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What is an embedding model according to this document? Please cite your sources.',
+          },
+          {
+            type: 'file',
+            data: fs.readFileSync('./data/ai.pdf'),
+            mediaType: 'application/pdf',
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      anthropic: {
+        citations: { enabled: true },
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text': {
+        process.stdout.write(part.text);
+        break;
+      }
+
+      case 'source': {
+        if (part.sourceType === 'document') {
+          console.log(`\n\nDocument Source: ${part.title}`);
+          console.log(`Media Type: ${part.mediaType}`);
+          if (part.filename) {
+            console.log(`Filename: ${part.filename}`);
+          }
+        }
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', part.error);
+        break;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-web-search-tool.ts
+++ b/examples/ai-core/src/stream-text/openai-web-search-tool.ts
@@ -23,7 +23,11 @@ async function main() {
       }
 
       case 'source': {
-        process.stdout.write(`\n\n Source: ${chunk.title} (${chunk.url})`);
+        if (chunk.sourceType === 'url') {
+          process.stdout.write(`\n\n Source: ${chunk.title} (${chunk.url})`);
+        } else {
+          process.stdout.write(`\n\n Document: ${chunk.title}`);
+        }
         break;
       }
 

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -3363,6 +3363,56 @@ exports[`streamText > result.toUIMessageStream > should omit message start event
 ]
 `;
 
+exports[`streamText > result.toUIMessageStream > should send document source content when sendSources is true 1`] = `
+[
+  {
+    "messageId": undefined,
+    "metadata": undefined,
+    "type": "start",
+  },
+  {
+    "metadata": undefined,
+    "type": "start-step",
+  },
+  {
+    "filename": "example.pdf",
+    "mediaType": "application/pdf",
+    "providerMetadata": {
+      "provider": {
+        "custom": "doc-value",
+      },
+    },
+    "sourceId": "doc-123",
+    "title": "Document Example",
+    "type": "source-document",
+  },
+  {
+    "text": "Hello from document!",
+    "type": "text",
+  },
+  {
+    "filename": undefined,
+    "mediaType": "text/plain",
+    "providerMetadata": {
+      "provider": {
+        "custom": "doc-value2",
+      },
+    },
+    "sourceId": "doc-456",
+    "title": "Text Document",
+    "type": "source-document",
+  },
+  {
+    "metadata": undefined,
+    "type": "finish-step",
+  },
+  {
+    "metadata": undefined,
+    "type": "finish",
+  },
+]
+`;
+
 exports[`streamText > result.toUIMessageStream > should send file content 1`] = `
 [
   {

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -119,6 +119,36 @@ const modelWithSources = new MockLanguageModelV2({
   }),
 });
 
+const modelWithDocumentSources = new MockLanguageModelV2({
+  doStream: async () => ({
+    stream: convertArrayToReadableStream([
+      {
+        type: 'source',
+        sourceType: 'document',
+        id: 'doc-123',
+        mediaType: 'application/pdf',
+        title: 'Document Example',
+        filename: 'example.pdf',
+        providerMetadata: { provider: { custom: 'doc-value' } },
+      },
+      { type: 'text', text: 'Hello from document!' },
+      {
+        type: 'source',
+        sourceType: 'document',
+        id: 'doc-456',
+        mediaType: 'text/plain',
+        title: 'Text Document',
+        providerMetadata: { provider: { custom: 'doc-value2' } },
+      },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: testUsage,
+      },
+    ]),
+  }),
+});
+
 const modelWithFiles = new MockLanguageModelV2({
   doStream: async () => ({
     stream: convertArrayToReadableStream([
@@ -1491,6 +1521,19 @@ describe('streamText', () => {
     it('should send source content when sendSources is true', async () => {
       const result = streamText({
         model: modelWithSources,
+        ...defaultSettings(),
+      });
+
+      const uiMessageStream = result.toUIMessageStream({ sendSources: true });
+
+      expect(
+        await convertReadableStreamToArray(uiMessageStream),
+      ).toMatchSnapshot();
+    });
+
+    it('should send document source content when sendSources is true', async () => {
+      const result = streamText({
+        model: modelWithDocumentSources,
         ...defaultSettings(),
       });
 

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1476,6 +1476,17 @@ However, the LLM results are expected to be small enough to not cause issues.
                   providerMetadata: part.providerMetadata,
                 });
               }
+
+              if (sendSources && part.sourceType === 'document') {
+                controller.enqueue({
+                  type: 'source-document',
+                  sourceId: part.id,
+                  mediaType: part.mediaType,
+                  title: part.title,
+                  filename: part.filename,
+                  providerMetadata: part.providerMetadata,
+                });
+              }
               break;
             }
 

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1467,7 +1467,7 @@ However, the LLM results are expected to be small enough to not cause issues.
             }
 
             case 'source': {
-              if (sendSources) {
+              if (sendSources && part.sourceType === 'url') {
                 controller.enqueue({
                   type: 'source-url',
                   sourceId: part.id,

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -45,6 +45,14 @@ export const uiMessageStreamPartSchema = z.union([
     providerMetadata: z.any().optional(), // Use z.any() for generic metadata
   }),
   z.object({
+    type: z.literal('source-document'),
+    sourceId: z.string(),
+    mediaType: z.string(),
+    title: z.string(),
+    filename: z.string().optional(),
+    providerMetadata: z.any().optional(), // Use z.any() for generic metadata
+  }),
+  z.object({
     type: z.literal('file'),
     url: z.string(),
     mediaType: z.string(),
@@ -127,6 +135,14 @@ export type UIMessageStreamPart =
       sourceId: string;
       url: string;
       title?: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'source-document';
+      sourceId: string;
+      mediaType: string;
+      title: string;
+      filename?: string;
       providerMetadata?: ProviderMetadata;
     }
   | {

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -205,6 +205,20 @@ export function processUIMessageStream<
               break;
             }
 
+            case 'source-document': {
+              state.message.parts.push({
+                type: 'source-document',
+                sourceId: part.sourceId,
+                mediaType: part.mediaType,
+                title: part.title,
+                filename: part.filename,
+                providerMetadata: part.providerMetadata,
+              });
+
+              write();
+              break;
+            }
+
             case 'tool-call-streaming-start': {
               const toolInvocations = getToolInvocations(state.message);
 

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -65,6 +65,7 @@ export type UIMessagePart<DATA_TYPES extends UIDataTypes> =
   | ReasoningUIPart
   | ToolInvocationUIPart
   | SourceUrlUIPart
+  | SourceDocumentUIPart
   | FileUIPart
   | DataUIPart<DATA_TYPES>
   | StepStartUIPart;
@@ -139,6 +140,18 @@ export type SourceUrlUIPart = {
   sourceId: string;
   url: string;
   title?: string;
+  providerMetadata?: Record<string, any>;
+};
+
+/**
+ * A document source part of a message.
+ */
+export type SourceDocumentUIPart = {
+  type: 'source-document';
+  sourceId: string;
+  mediaType: string;
+  title: string;
+  filename?: string;
   providerMetadata?: Record<string, any>;
 };
 

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -68,6 +68,9 @@ export interface AnthropicImageContent {
 export interface AnthropicDocumentContent {
   type: 'document';
   source: AnthropicContentSource;
+  title?: string;
+  context?: string;
+  citations?: { enabled: boolean };
   cache_control: AnthropicCacheControl | undefined;
 }
 

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -698,6 +698,11 @@ describe('AnthropicMessagesLanguageModel', () => {
                 data: 'base64PDFdata',
                 mediaType: 'application/pdf',
                 filename: 'financial-report.pdf',
+                providerOptions: {
+                  anthropic: {
+                    citations: { enabled: true },
+                  },
+                },
               },
               {
                 type: 'text',
@@ -706,11 +711,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             ],
           },
         ],
-        providerOptions: {
-          anthropic: {
-            citations: { enabled: true },
-          },
-        },
       });
 
       expect(result.content).toMatchInlineSnapshot(`
@@ -771,6 +771,11 @@ describe('AnthropicMessagesLanguageModel', () => {
                 data: 'base64PDFdata',
                 mediaType: 'application/pdf',
                 filename: 'financial-report.pdf',
+                providerOptions: {
+                  anthropic: {
+                    citations: { enabled: true },
+                  },
+                },
               },
               {
                 type: 'text',
@@ -779,11 +784,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             ],
           },
         ],
-        providerOptions: {
-          anthropic: {
-            citations: { enabled: true },
-          },
-        },
       });
 
       const result = await convertReadableStreamToArray(stream);

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -227,7 +227,6 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         prompt,
         sendReasoning: anthropicOptions?.sendReasoning ?? true,
         warnings,
-        citationsEnabled: anthropicOptions?.citations?.enabled,
       });
 
     const isThinking = anthropicOptions?.thinking?.type === 'enabled';
@@ -367,10 +366,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
     return this.config.transformRequestBody?.(args) ?? args;
   }
 
-  private extractCitationDocuments(
-    prompt: LanguageModelV2Prompt,
-    citationsEnabled?: boolean,
-  ): Array<{
+  private extractCitationDocuments(prompt: LanguageModelV2Prompt): Array<{
     title: string;
     filename?: string;
     mediaType: string;
@@ -381,8 +377,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
       const citationsConfig = anthropic?.citations as
         | { enabled?: boolean }
         | undefined;
-      const fileHasCitations = citationsConfig?.enabled;
-      return fileHasCitations ?? citationsEnabled;
+      return citationsConfig?.enabled ?? false;
     };
 
     return prompt
@@ -412,15 +407,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
       await this.getArgs(options);
 
     // Extract citation documents for response processing
-    const anthropicOptions = await parseProviderOptions({
-      provider: 'anthropic',
-      providerOptions: options.providerOptions,
-      schema: anthropicProviderOptions,
-    });
-    const citationDocuments = this.extractCitationDocuments(
-      options.prompt,
-      anthropicOptions?.citations?.enabled,
-    );
+    const citationDocuments = this.extractCitationDocuments(options.prompt);
 
     const {
       responseHeaders,
@@ -577,15 +564,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
       await this.getArgs(options);
 
     // Extract citation documents for response processing
-    const anthropicOptions = await parseProviderOptions({
-      provider: 'anthropic',
-      providerOptions: options.providerOptions,
-      schema: anthropicProviderOptions,
-    });
-    const citationDocuments = this.extractCitationDocuments(
-      options.prompt,
-      anthropicOptions?.citations?.enabled,
-    );
+    const citationDocuments = this.extractCitationDocuments(options.prompt);
 
     const body = { ...args, stream: true };
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -151,6 +151,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         prompt,
         sendReasoning: anthropicOptions?.sendReasoning ?? true,
         warnings,
+        citationsEnabled: anthropicOptions?.citations?.enabled,
       });
 
     const isThinking = anthropicOptions?.thinking?.type === 'enabled';

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -41,6 +41,19 @@ If you are experiencing issues with the model handling requests involving
     .optional(),
 
   /**
+   * Citation configuration for documents.
+   * When enabled, documents will generate citations in the response.
+   */
+  citations: z
+    .object({
+      /**
+       * Enable citations for documents
+       */
+      enabled: z.boolean(),
+    })
+    .optional(),
+
+  /**
    * Web search tool configuration for Claude models that support it.
    * When provided, automatically adds the web search tool to the request.
    */

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -25,6 +25,42 @@ const webSearchLocationSchema = z.object({
   timezone: z.string().optional(),
 });
 
+/**
+ * Anthropic file part provider options for document-specific features.
+ * These options apply to individual file parts (documents).
+ */
+export const anthropicFilePartProviderOptions = z.object({
+  /**
+   * Citation configuration for this document.
+   * When enabled, this document will generate citations in the response.
+   */
+  citations: z
+    .object({
+      /**
+       * Enable citations for this document
+       */
+      enabled: z.boolean(),
+    })
+    .optional(),
+
+  /**
+   * Custom title for the document.
+   * If not provided, the filename will be used.
+   */
+  title: z.string().optional(),
+
+  /**
+   * Context about the document that will be passed to the model
+   * but not used towards cited content.
+   * Useful for storing document metadata as text or stringified JSON.
+   */
+  context: z.string().optional(),
+});
+
+export type AnthropicFilePartProviderOptions = z.infer<
+  typeof anthropicFilePartProviderOptions
+>;
+
 export const anthropicProviderOptions = z.object({
   /**
 Include reasoning content in requests sent to the model. Defaults to `true`.
@@ -37,19 +73,6 @@ If you are experiencing issues with the model handling requests involving
     .object({
       type: z.union([z.literal('enabled'), z.literal('disabled')]),
       budgetTokens: z.number().optional(),
-    })
-    .optional(),
-
-  /**
-   * Citation configuration for documents.
-   * When enabled, documents will generate citations in the response.
-   */
-  citations: z
-    .object({
-      /**
-       * Enable citations for documents
-       */
-      enabled: z.boolean(),
     })
     .optional(),
 

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1134,3 +1134,225 @@ describe('cache control', () => {
     });
   });
 });
+
+describe('citations', () => {
+  it('should not include citations by default', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: 'base64PDFdata',
+              mediaType: 'application/pdf',
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'document',
+                source: {
+                  type: 'base64',
+                  media_type: 'application/pdf',
+                  data: 'base64PDFdata',
+                },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      },
+      betas: new Set(['pdfs-2024-09-25']),
+    });
+  });
+
+  it('should include citations when enabled globally', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: 'base64PDFdata',
+              mediaType: 'application/pdf',
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      citationsEnabled: true,
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'document',
+                source: {
+                  type: 'base64',
+                  media_type: 'application/pdf',
+                  data: 'base64PDFdata',
+                },
+                citations: { enabled: true },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      },
+      betas: new Set(['pdfs-2024-09-25']),
+    });
+  });
+
+  it('should include citations when enabled on file part', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: 'base64PDFdata',
+              mediaType: 'application/pdf',
+              providerOptions: {
+                anthropic: {
+                  citations: { enabled: true },
+                },
+              },
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'document',
+                source: {
+                  type: 'base64',
+                  media_type: 'application/pdf',
+                  data: 'base64PDFdata',
+                },
+                citations: { enabled: true },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      },
+      betas: new Set(['pdfs-2024-09-25']),
+    });
+  });
+
+  it('should prioritize file-level citations over global setting', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: 'base64PDFdata',
+              mediaType: 'application/pdf',
+              providerOptions: {
+                anthropic: {
+                  citations: { enabled: false },
+                },
+              },
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      citationsEnabled: true,
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'document',
+                source: {
+                  type: 'base64',
+                  media_type: 'application/pdf',
+                  data: 'base64PDFdata',
+                },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      },
+      betas: new Set(['pdfs-2024-09-25']),
+    });
+  });
+
+  it('should not include citations for non-PDF files', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: 'base64ImageData',
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      citationsEnabled: true,
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  data: 'base64ImageData',
+                  media_type: 'image/png',
+                },
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      },
+      betas: new Set(),
+    });
+  });
+});

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -57,10 +57,9 @@ export async function convertToAnthropicMessagesPrompt({
     const citationsConfig = anthropic?.citations as
       | { enabled?: boolean }
       | undefined;
-    const filePartCitations = citationsConfig?.enabled;
 
     // Use file part settings first, then fall back to global citation setting
-    return filePartCitations ?? citationsEnabled ?? false;
+    return citationsConfig?.enabled ?? citationsEnabled ?? false;
   }
 
   for (let i = 0; i < blocks.length; i++) {

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -51,10 +51,8 @@ export async function convertToAnthropicMessagesPrompt({
   function shouldEnableCitations(
     providerMetadata: SharedV2ProviderMetadata | undefined,
   ): boolean {
-    const anthropic = providerMetadata?.anthropic;
-
     // Check if citations are enabled in provider options on the file part
-    const citationsConfig = anthropic?.citations as
+    const citationsConfig = providerMetadata?.anthropic?.citations as
       | { enabled?: boolean }
       | undefined;
 

--- a/packages/provider/src/language-model/v2/language-model-v2-source.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-source.ts
@@ -7,24 +7,36 @@ export type LanguageModelV2Source = {
   type: 'source';
 
   /**
-   * A URL source. This is return by web search RAG models.
+   * The type of source.
    */
-  sourceType: 'url';
+  sourceType: 'url' | 'document';
 
   /**
    * The ID of the source.
    */
   id: string;
 
+  // URL source fields
   /**
-   * The URL of the source.
+   * The URL of the source. Only present for URL sources.
    */
-  url: string;
+  url?: string;
+
+  // Document source fields
+  /**
+   * IANA media type of the file. Only present for document sources.
+   */
+  mediaType?: string;
 
   /**
    * The title of the source.
    */
   title?: string;
+
+  /**
+   * Optional filename of the file. Only present for document sources.
+   */
+  filename?: string;
 
   /**
    * Additional provider metadata for the source.

--- a/packages/provider/src/language-model/v2/language-model-v2-source.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-source.ts
@@ -6,18 +6,62 @@ A source that has been used as input to generate the response.
 export type LanguageModelV2Source =
   | {
       type: 'source';
+
+      /**
+       * The type of source - URL sources reference web content.
+       */
       sourceType: 'url';
+
+      /**
+       * The ID of the source.
+       */
       id: string;
+
+      /**
+       * The URL of the source.
+       */
       url: string;
+
+      /**
+       * The title of the source.
+       */
       title?: string;
+
+      /**
+       * Additional provider metadata for the source.
+       */
       providerMetadata?: SharedV2ProviderMetadata;
     }
   | {
       type: 'source';
+
+      /**
+       * The type of source - document sources reference files/documents.
+       */
       sourceType: 'document';
+
+      /**
+       * The ID of the source.
+       */
       id: string;
+
+      /**
+       * IANA media type of the document (e.g., 'application/pdf').
+       */
       mediaType: string;
+
+      /**
+       * The title of the document.
+       */
       title: string;
+
+      /**
+       * Optional filename of the document.
+       */
       filename?: string;
+
+      /**
+       * Additional provider metadata for the source.
+       */
       providerMetadata?: SharedV2ProviderMetadata;
     };

--- a/packages/provider/src/language-model/v2/language-model-v2-source.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-source.ts
@@ -3,43 +3,21 @@ import { SharedV2ProviderMetadata } from '../../shared/v2/shared-v2-provider-met
 /**
 A source that has been used as input to generate the response.
  */
-export type LanguageModelV2Source = {
-  type: 'source';
-
-  /**
-   * The type of source.
-   */
-  sourceType: 'url' | 'document';
-
-  /**
-   * The ID of the source.
-   */
-  id: string;
-
-  // URL source fields
-  /**
-   * The URL of the source. Only present for URL sources.
-   */
-  url?: string;
-
-  // Document source fields
-  /**
-   * IANA media type of the file. Only present for document sources.
-   */
-  mediaType?: string;
-
-  /**
-   * The title of the source.
-   */
-  title?: string;
-
-  /**
-   * Optional filename of the file. Only present for document sources.
-   */
-  filename?: string;
-
-  /**
-   * Additional provider metadata for the source.
-   */
-  providerMetadata?: SharedV2ProviderMetadata;
-};
+export type LanguageModelV2Source =
+  | {
+      type: 'source';
+      sourceType: 'url';
+      id: string;
+      url: string;
+      title?: string;
+      providerMetadata?: SharedV2ProviderMetadata;
+    }
+  | {
+      type: 'source';
+      sourceType: 'document';
+      id: string;
+      mediaType: string;
+      title: string;
+      filename?: string;
+      providerMetadata?: SharedV2ProviderMetadata;
+    };


### PR DESCRIPTION
# Anthropic Citation Support - Step 1 (PDF Citations)

## background

github issue #4497 requests citation support in the ai sdk. this is step 1 of a larger citation feature - adding pdf citation support for anthropic's citation api. we're using existing file parts + provider metadata to control inputs, following a minimal design approach for easier extension.

## summary

implemented complete pdf citation support for anthropic provider (step 1 of citation feature):

**request processing:**

- extended `LanguageModelV2Source` type to support 'document' sourceType alongside existing 'url'
- added citation configuration options to anthropic provider schema
- updated anthropic document content interface with citation fields
- modified prompt conversion to handle citations with file-level and global controls
- implemented `shouldEnableCitations` helper for intelligent citation activation

**response processing:**

- extract citation data from anthropic api responses
- convert citations to document sources with minimal structure
- map citation references back to original pdf files
- generate sources following established sdk patterns

## verification

- type extensions maintain backward compatibility
- citation options integrate cleanly with existing file parts infrastructure
- request processing sends proper `citations: {enabled: true}` to anthropic
- response processing creates valid document sources
- follows existing patterns from xai/perplexity source generation

## tasks

- [x] extend LanguageModelV2Source type for document sources
- [x] add citation options to anthropic provider schema
- [x] update anthropic document content interface
- [x] modify prompt conversion for citation support
- [x] implement citation control logic (file-level + global)
- [x] implement response processing for citation extraction
- [x] create document sources from citation data
- [x] add comprehensive test coverage
- [x] add changeset for anthropic package

## future work

- step 2: plain text citation support
- step 3: custom content citation support
- other providers (openai, google, cohere) citation support
- location/page/start/end/text citation details
- citation ui docs and examples

## personal note

followed lars' guidance on minimal design approach using existing file parts + provider metadata. kept it simple and extensible - step 1 focuses purely on pdf citations for anthropic to establish the foundation pattern.

links to [#4497](https://github.com/vercel/ai/issues/4497) - this is only step one of many more steps to fully implement citation support across the ai sdk.
