### PR TITLE
feat (provider/openai): add `reasoning-part-finish` to openai responses provider

### DIFF
--- a/.changeset/empty-walls-rest.md
+++ b/.changeset/empty-walls-rest.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add reasoning-part-finish parts for reasoning models in the responses API

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1527,10 +1527,16 @@ describe('OpenAIResponsesLanguageModel', () => {
             "type": "reasoning",
           },
           {
+            "type": "reasoning-part-finish",
+          },
+          {
             "text": "**Investigating burrito origins**
 
         There's a fascinating debate about who created the Mission burrito.",
             "type": "reasoning",
+          },
+          {
+            "type": "reasoning-part-finish",
           },
           {
             "text": "Taqueria La Cumbre",

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -639,7 +639,7 @@ const responseReasoningSummaryPartDoneSchema = z.object({
   item_id: z.string(),
   output_index: z.number(),
   summary_index: z.number(),
-  part: z.unknown().optional(),
+  part: z.unknown().nullish(),
 });
 
 const openaiResponsesChunkSchema = z.union([


### PR DESCRIPTION
## Background

The openai responses provider was missing the reasoning-part-finish parts, which makes it impossible to distinguish reasoning summaries in the UI.

## Summary

Add `reasoning-part-finish` to openai responses provider.

## Related Issues

Fixes #6629