### PR TITLE
chore (ai): always stream tool calls

### DIFF
--- a/.changeset/shiny-dolphins-lie.md
+++ b/.changeset/shiny-dolphins-lie.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): always stream tool calls

--- a/examples/ai-core/src/stream-text/openai-on-chunk-tool-call-streaming.ts
+++ b/examples/ai-core/src/stream-text/openai-on-chunk-tool-call-streaming.ts
@@ -13,7 +13,6 @@ async function main() {
         parameters: z.object({ city: z.string() }),
       },
     },
-    toolCallStreaming: true,
     onChunk(chunk) {
       console.log('onChunk', chunk);
     },

--- a/examples/next-openai/app/api/use-chat-reasoning-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-reasoning-tools/route.ts
@@ -36,7 +36,6 @@ export async function POST(req: Request) {
       middleware: extractReasoningMiddleware({ tagName: 'think' }),
     }),
     messages: convertToModelMessages(messages),
-    toolCallStreaming: true,
     stopWhen: stepCountIs(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:

--- a/examples/next-openai/app/api/use-chat-streaming-tool-calls/route.ts
+++ b/examples/next-openai/app/api/use-chat-streaming-tool-calls/route.ts
@@ -11,7 +11,6 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-4o'),
     messages: convertToModelMessages(messages),
-    toolCallStreaming: true,
     system:
       'You are a helpful assistant that answers questions about the weather in a given city.' +
       'You use the showWeatherInformation tool to show the weather information to the user instead of talking about it.',

--- a/examples/next-openai/app/api/use-chat-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-tools/route.ts
@@ -12,7 +12,6 @@ export async function POST(req: Request) {
     model: openai('gpt-4o'),
     // model: anthropic('claude-3-5-sonnet-latest'),
     messages: convertToModelMessages(messages),
-    toolCallStreaming: true,
     stopWhen: stepCountIs(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:

--- a/examples/nuxt-openai/server/api/use-chat-tools.ts
+++ b/examples/nuxt-openai/server/api/use-chat-tools.ts
@@ -13,7 +13,6 @@ export default defineLazyEventHandler(async () => {
     const result = streamText({
       model: openai('gpt-4o'),
       messages: convertToModelMessages(messages),
-      toolCallStreaming: true,
       stopWhen: stepCountIs(5), // multi-steps for server-side tools
       tools: {
         // server-side tool with execute function:

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -2155,56 +2155,6 @@ exports[`streamText > result.fullStream > should filter out empty text deltas 1`
 ]
 `;
 
-exports[`streamText > result.fullStream > should not send tool call deltas when toolCallStreaming is disabled 1`] = `
-[
-  {
-    "type": "start",
-  },
-  {
-    "request": {},
-    "type": "start-step",
-    "warnings": [],
-  },
-  {
-    "args": {
-      "value": "Sparkle Day",
-    },
-    "toolCallId": "call_O17Uplv4lJvD6DVdIvFFeRMw",
-    "toolName": "test-tool",
-    "type": "tool-call",
-  },
-  {
-    "finishReason": "tool-calls",
-    "providerMetadata": undefined,
-    "response": {
-      "headers": undefined,
-      "id": "id-0",
-      "modelId": "mock-model-id",
-      "timestamp": 1970-01-01T00:00:00.000Z,
-    },
-    "type": "finish-step",
-    "usage": {
-      "cachedInputTokens": 3,
-      "inputTokens": 3,
-      "outputTokens": 10,
-      "reasoningTokens": 10,
-      "totalTokens": 23,
-    },
-  },
-  {
-    "finishReason": "tool-calls",
-    "totalUsage": {
-      "cachedInputTokens": 3,
-      "inputTokens": 3,
-      "outputTokens": 10,
-      "reasoningTokens": 10,
-      "totalTokens": 23,
-    },
-    "type": "finish",
-  },
-]
-`;
-
 exports[`streamText > result.fullStream > should send delayed asynchronous tool results 1`] = `
 [
   {
@@ -2554,7 +2504,7 @@ exports[`streamText > result.fullStream > should send text deltas 1`] = `
 ]
 `;
 
-exports[`streamText > result.fullStream > should send tool call deltas when toolCallStreaming is enabled 1`] = `
+exports[`streamText > result.fullStream > should send tool call deltas 1`] = `
 [
   {
     "type": "start",
@@ -3583,42 +3533,7 @@ exports[`streamText > result.toUIMessageStream > should send source content when
 ]
 `;
 
-exports[`streamText > result.toUIMessageStream > should send tool call and tool result stream parts 1`] = `
-[
-  {
-    "messageId": undefined,
-    "metadata": undefined,
-    "type": "start",
-  },
-  {
-    "metadata": undefined,
-    "type": "start-step",
-  },
-  {
-    "args": {
-      "value": "value",
-    },
-    "toolCallId": "call-1",
-    "toolName": "tool1",
-    "type": "tool-call",
-  },
-  {
-    "result": "value-result",
-    "toolCallId": "call-1",
-    "type": "tool-result",
-  },
-  {
-    "metadata": undefined,
-    "type": "finish-step",
-  },
-  {
-    "metadata": undefined,
-    "type": "finish",
-  },
-]
-`;
-
-exports[`streamText > result.toUIMessageStream > should send tool call, tool call stream start, tool call deltas, and tool result stream parts when tool call delta flag is enabled 1`] = `
+exports[`streamText > result.toUIMessageStream > should send tool call, tool call stream start, tool call deltas, and tool result stream parts 1`] = `
 [
   {
     "messageId": undefined,

--- a/packages/ai/core/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.test.ts
@@ -31,7 +31,6 @@ it('should forward text deltas correctly', async () => {
   const transformedStream = runToolsTransformation({
     tools: undefined,
     generatorStream: inputStream,
-    toolCallStreaming: false,
     tracer: new MockTracer(),
     telemetry: undefined,
     messages: [],
@@ -88,7 +87,6 @@ it('should handle immediate tool execution', async () => {
       },
     },
     generatorStream: inputStream,
-    toolCallStreaming: false,
     tracer: new MockTracer(),
     telemetry: undefined,
     messages: [],
@@ -160,7 +158,6 @@ it('should hold off on sending finish until the delayed tool result is received'
       },
     },
     generatorStream: inputStream,
-    toolCallStreaming: false,
     tracer: new MockTracer(),
     telemetry: undefined,
     messages: [],
@@ -224,7 +221,6 @@ it('should try to repair tool call when the tool name is not found', async () =>
 
   const transformedStream = runToolsTransformation({
     generatorStream: inputStream,
-    toolCallStreaming: false,
     tracer: new MockTracer(),
     telemetry: undefined,
     messages: [],

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -215,8 +215,6 @@ export function streamText<
   experimental_telemetry: telemetry,
   prepareStep,
   providerOptions,
-  experimental_toolCallStreaming = false,
-  toolCallStreaming = experimental_toolCallStreaming,
   experimental_activeTools,
   activeTools = experimental_activeTools,
   experimental_repairToolCall: repairToolCall,
@@ -307,16 +305,6 @@ A function that attempts to repair a tool call that failed to parse.
     experimental_repairToolCall?: ToolCallRepairFunction<TOOLS>;
 
     /**
-Enable streaming of tool call deltas as they are generated. Disabled by default.
-     */
-    toolCallStreaming?: boolean;
-
-    /**
-@deprecated Use `toolCallStreaming` instead.
-     */
-    experimental_toolCallStreaming?: boolean;
-
-    /**
 Optional stream transformations.
 They are applied in the order they are provided.
 The stream transformations must maintain the stream structure for streamText to work correctly.
@@ -372,7 +360,6 @@ Internal. For test use only. May change without notice.
     messages,
     tools,
     toolChoice,
-    toolCallStreaming,
     transforms: asArray(transform),
     activeTools,
     repairToolCall,
@@ -512,7 +499,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
     messages,
     tools,
     toolChoice,
-    toolCallStreaming,
     transforms,
     activeTools,
     repairToolCall,
@@ -539,7 +525,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
     messages: Prompt['messages'];
     tools: TOOLS | undefined;
     toolChoice: ToolChoice<TOOLS> | undefined;
-    toolCallStreaming: boolean;
     transforms: Array<StreamTextTransform<TOOLS>>;
     activeTools: Array<keyof TOOLS> | undefined;
     repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;
@@ -953,7 +938,6 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
           const streamWithToolResults = runToolsTransformation({
             tools,
             generatorStream: stream,
-            toolCallStreaming,
             tracer,
             telemetry,
             system,


### PR DESCRIPTION
## Background

Tool invocations are slated for removal from UI messages. With custom data being a fully user controlled option, it now makes sense to always have tool call streaming available without opt-in.

## Summary
* always stream tool calls
* remove options that control tool call streaming