### PR TITLE
feat (ai): inject message id in createUIMessageStream

### DIFF
--- a/.changeset/seven-tools-type.md
+++ b/.changeset/seven-tools-type.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+feat (ai): inject message id in createUIMessageStream

--- a/examples/next-openai/app/page.tsx
+++ b/examples/next-openai/app/page.tsx
@@ -6,8 +6,6 @@ import ChatInput from '@/component/chat-input';
 export default function Chat() {
   const { error, status, sendMessage, messages, reload, stop } = useChat();
 
-  console.log(messages);
-
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {messages.map(m => (

--- a/examples/next-openai/app/page.tsx
+++ b/examples/next-openai/app/page.tsx
@@ -6,6 +6,8 @@ import ChatInput from '@/component/chat-input';
 export default function Chat() {
   const { error, status, sendMessage, messages, reload, stop } = useChat();
 
+  console.log(messages);
+
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {messages.map(m => (

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -22,15 +22,8 @@ import { ToolSet } from './tool-set';
 
 export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
   /**
-   * Message ID that is sent to the client if a new message is created.
-   * This is intended to be used for the UI message,
-   * if the last original message is not an assistant message
-   * (in which case that message ID is used).
-   */
-  newMessageId?: string;
-
-  /**
-   * The original messages.
+   * The original messages. If they are provided, persistence mode is assumed,
+   * and a message ID is provided for the response message.
    */
   originalMessages?: UI_MESSAGE[];
 

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -13,7 +13,10 @@ import {
   InferUIMessageStreamPart,
   UIMessageStreamPart,
 } from '../../src/ui-message-stream/ui-message-stream-parts';
-import { InferUIMessageMetadata } from '../../src/ui/ui-messages';
+import {
+  InferUIMessageData,
+  InferUIMessageMetadata,
+} from '../../src/ui/ui-messages';
 import { asArray } from '../../src/util/as-array';
 import {
   AsyncIterableStream,
@@ -73,6 +76,7 @@ import { ToolCallUnion } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair';
 import { ToolResultUnion } from './tool-result';
 import { ToolSet } from './tool-set';
+import { getResponseUIMessageId } from '../../src/ui-message-stream/get-response-ui-message-id';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -1448,8 +1452,7 @@ However, the LLM results are expected to be small enough to not cause issues.
   }
 
   toUIMessageStream<UI_MESSAGE extends UIMessage>({
-    newMessageId,
-    originalMessages = [],
+    originalMessages,
     onFinish,
     messageMetadata,
     sendReasoning = false,
@@ -1460,14 +1463,18 @@ However, the LLM results are expected to be small enough to not cause issues.
   }: UIMessageStreamOptions<UI_MESSAGE> = {}): ReadableStream<
     InferUIMessageStreamPart<UI_MESSAGE>
   > {
-    const lastMessage = originalMessages[originalMessages.length - 1];
-    const isContinuation = lastMessage?.role === 'assistant';
-    const messageId = isContinuation ? lastMessage.id : newMessageId;
+    const responseMessageId = getResponseUIMessageId({
+      originalMessages,
+      responseMessageId: this.generateId,
+    });
 
     const baseStream = this.fullStream.pipeThrough(
       new TransformStream<
         TextStreamPart<TOOLS>,
-        UIMessageStreamPart<InferUIMessageMetadata<UI_MESSAGE>, UIDataTypes>
+        UIMessageStreamPart<
+          InferUIMessageMetadata<UI_MESSAGE>,
+          InferUIMessageData<UI_MESSAGE>
+        >
       >({
         transform: async (part, controller) => {
           const partType = part.type;
@@ -1600,7 +1607,7 @@ However, the LLM results are expected to be small enough to not cause issues.
                 const metadata = messageMetadata?.({ part });
                 controller.enqueue({
                   type: 'start',
-                  messageId,
+                  messageId: responseMessageId,
                   metadata,
                 });
               }
@@ -1635,7 +1642,7 @@ However, the LLM results are expected to be small enough to not cause issues.
 
     return handleUIMessageStreamFinish<UI_MESSAGE>({
       stream: baseStream,
-      newMessageId: messageId ?? this.generateId(),
+      messageId: responseMessageId,
       originalMessages,
       onFinish,
     });
@@ -1644,7 +1651,6 @@ However, the LLM results are expected to be small enough to not cause issues.
   pipeUIMessageStreamToResponse<UI_MESSAGE extends UIMessage>(
     response: ServerResponse,
     {
-      newMessageId,
       originalMessages,
       onFinish,
       messageMetadata,
@@ -1659,7 +1665,6 @@ However, the LLM results are expected to be small enough to not cause issues.
     pipeUIMessageStreamToResponse({
       response,
       stream: this.toUIMessageStream({
-        newMessageId,
         originalMessages,
         onFinish,
         messageMetadata,
@@ -1682,7 +1687,6 @@ However, the LLM results are expected to be small enough to not cause issues.
   }
 
   toUIMessageStreamResponse<UI_MESSAGE extends UIMessage>({
-    newMessageId,
     originalMessages,
     onFinish,
     messageMetadata,
@@ -1695,7 +1699,6 @@ However, the LLM results are expected to be small enough to not cause issues.
   }: ResponseInit & UIMessageStreamOptions<UI_MESSAGE> = {}): Response {
     return createUIMessageStreamResponse({
       stream: this.toUIMessageStream({
-        newMessageId,
         originalMessages,
         onFinish,
         messageMetadata,

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1642,7 +1642,7 @@ However, the LLM results are expected to be small enough to not cause issues.
 
     return handleUIMessageStreamFinish<UI_MESSAGE>({
       stream: baseStream,
-      messageId: responseMessageId,
+      messageId: responseMessageId ?? this.generateId(),
       originalMessages,
       onFinish,
     });

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -350,7 +350,7 @@ describe('createUIMessageStream', () => {
           "messages": [
             {
               "id": "",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "1a",
@@ -362,7 +362,7 @@ describe('createUIMessageStream', () => {
           ],
           "responseMessage": {
             "id": "",
-            "metadata": {},
+            "metadata": undefined,
             "parts": [
               {
                 "text": "1a",

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -15,7 +15,8 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
   onError?: (error: unknown) => string;
 
   /**
-   * The original messages.
+   * The original messages. If they are provided, persistence mode is assumed,
+   * and a message ID is provided for the response message.
    */
   originalMessages?: UI_MESSAGE[];
 
@@ -121,9 +122,9 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
     }
   });
 
-  return handleUIMessageStreamFinish({
+  return handleUIMessageStreamFinish<UI_MESSAGE>({
     stream,
-    newMessageId: '',
+    messageId: '',
     originalMessages,
     onFinish,
   });

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -1,3 +1,7 @@
+import {
+  generateId as generateIdFunc,
+  IdGenerator,
+} from '@ai-sdk/provider-utils';
 import { UIMessage } from '../ui/ui-messages';
 import { handleUIMessageStreamFinish } from './handle-ui-message-stream-finish';
 import { InferUIMessageStreamPart } from './ui-message-stream-parts';
@@ -8,6 +12,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
   onError = () => 'An error occurred.', // mask error messages for safety by default
   originalMessages,
   onFinish,
+  generateId = generateIdFunc,
 }: {
   execute: (options: {
     writer: UIMessageStreamWriter<UI_MESSAGE>;
@@ -38,6 +43,8 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
      */
     responseMessage: UI_MESSAGE;
   }) => void;
+
+  generateId?: IdGenerator;
 }): ReadableStream<InferUIMessageStreamPart<UI_MESSAGE>> {
   let controller!: ReadableStreamDefaultController<
     InferUIMessageStreamPart<UI_MESSAGE>
@@ -124,7 +131,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
 
   return handleUIMessageStreamFinish<UI_MESSAGE>({
     stream,
-    messageId: '',
+    messageId: generateId(),
     originalMessages,
     onFinish,
   });

--- a/packages/ai/src/ui-message-stream/get-response-ui-message-id.test.ts
+++ b/packages/ai/src/ui-message-stream/get-response-ui-message-id.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { getResponseUIMessageId } from './get-response-ui-message-id';
+import { UIMessage } from '../ui/ui-messages';
+
+describe('getResponseUIMessageId', () => {
+  const mockGenerateId = () => 'new-id';
+
+  it('should return undefined when originalMessages is null', () => {
+    const result = getResponseUIMessageId({
+      originalMessages: undefined,
+      responseMessageId: mockGenerateId,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the last assistant message id when present', () => {
+    const messages: UIMessage[] = [
+      { id: 'msg-1', role: 'user', parts: [] },
+      { id: 'msg-2', role: 'assistant', parts: [] },
+    ];
+    const result = getResponseUIMessageId({
+      originalMessages: messages,
+      responseMessageId: mockGenerateId,
+    });
+    expect(result).toBe('msg-2');
+  });
+
+  it('should generate new id when last message is not from assistant', () => {
+    const messages: UIMessage[] = [
+      { id: 'msg-1', role: 'assistant', parts: [] },
+      { id: 'msg-2', role: 'user', parts: [] },
+    ];
+    const result = getResponseUIMessageId({
+      originalMessages: messages,
+      responseMessageId: mockGenerateId,
+    });
+    expect(result).toBe('new-id');
+  });
+
+  it('should generate new id when messages array is empty', () => {
+    const result = getResponseUIMessageId({
+      originalMessages: [],
+      responseMessageId: mockGenerateId,
+    });
+    expect(result).toBe('new-id');
+  });
+
+  it('should use the responseMessageId when it is a string', () => {
+    const result = getResponseUIMessageId({
+      originalMessages: [],
+      responseMessageId: 'response-id',
+    });
+    expect(result).toBe('response-id');
+  });
+});

--- a/packages/ai/src/ui-message-stream/get-response-ui-message-id.ts
+++ b/packages/ai/src/ui-message-stream/get-response-ui-message-id.ts
@@ -1,0 +1,24 @@
+import { IdGenerator } from '@ai-sdk/provider-utils';
+import { UIMessage } from '../ui/ui-messages';
+
+export function getResponseUIMessageId({
+  originalMessages,
+  responseMessageId,
+}: {
+  originalMessages: UIMessage[] | undefined;
+  responseMessageId: string | IdGenerator;
+}) {
+  // when there are no original messages (i.e. no persistence),
+  // the assistant message id generation is handled on the client side.
+  if (originalMessages == null) {
+    return undefined;
+  }
+
+  const lastMessage = originalMessages[originalMessages.length - 1];
+
+  return lastMessage?.role === 'assistant'
+    ? lastMessage.id
+    : typeof responseMessageId === 'function'
+      ? responseMessageId()
+      : responseMessageId;
+}

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -8,7 +8,10 @@ import {
   InferUIMessageMetadata,
   UIMessage,
 } from '../ui/ui-messages';
-import { InferUIMessageStreamPart } from './ui-message-stream-parts';
+import {
+  InferUIMessageStreamPart,
+  UIMessageStreamPart,
+} from './ui-message-stream-parts';
 
 export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   messageId,
@@ -87,12 +90,11 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
           // when there is no messageId in the start chunk,
           // but the user checked for persistence,
           // inject the messageId into the chunk
-          if (
-            chunk.type === 'start' &&
-            'messageId' in chunk &&
-            chunk.messageId == null
-          ) {
-            chunk.messageId = messageId;
+          if (chunk.type === 'start') {
+            const startChunk = chunk as UIMessageStreamPart & { type: 'start' };
+            if (startChunk.messageId == null) {
+              startChunk.messageId = messageId;
+            }
           }
 
           controller.enqueue(chunk);

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -402,7 +402,7 @@ export abstract class AbstractChat<
       const activeResponse = {
         state: createStreamingUIMessageState({
           lastMessage: this.state.snapshot(lastMessage),
-          generateId: this.generateId,
+          messageId: this.generateId(),
         }),
         abortController: new AbortController(),
       };

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -402,7 +402,7 @@ export abstract class AbstractChat<
       const activeResponse = {
         state: createStreamingUIMessageState({
           lastMessage: this.state.snapshot(lastMessage),
-          newMessageId: this.generateId(),
+          generateId: this.generateId,
         }),
         abortController: new AbortController(),
       };

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -2518,7 +2518,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        generateId: mockId(),
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -2642,7 +2645,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        generateId: mockId(),
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -2806,7 +2812,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        generateId: mockId(),
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -2898,7 +2907,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        generateId: mockId(),
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -3015,7 +3027,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        generateId: mockId(),
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -51,7 +51,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -67,7 +70,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -75,7 +78,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -87,7 +90,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -103,7 +106,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -124,7 +127,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -163,7 +166,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -179,7 +185,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -187,7 +193,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -199,7 +205,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -222,7 +228,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -248,7 +254,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -277,7 +283,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -315,7 +321,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -372,6 +378,7 @@ describe('processUIMessageStream', () => {
       ]);
 
       state = createStreamingUIMessageState({
+        messageId: 'msg-123',
         lastMessage: {
           role: 'assistant',
           id: 'original-id',
@@ -685,7 +692,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -701,7 +711,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -709,7 +719,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -721,7 +731,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -737,7 +747,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -753,7 +763,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -780,7 +790,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -810,7 +820,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -843,7 +853,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -880,7 +890,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -922,7 +932,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -999,7 +1009,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -1015,7 +1028,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -1023,7 +1036,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1035,7 +1048,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1052,7 +1065,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1073,7 +1086,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1105,7 +1118,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1140,7 +1153,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1178,7 +1191,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1225,7 +1238,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1281,7 +1294,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -1390,7 +1403,10 @@ describe('processUIMessageStream', () => {
         },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -1625,7 +1641,10 @@ describe('processUIMessageStream', () => {
         },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -1641,7 +1660,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -1649,7 +1668,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1661,7 +1680,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1735,6 +1754,7 @@ describe('processUIMessageStream', () => {
       ]);
 
       state = createStreamingUIMessageState({
+        messageId: 'msg-123',
         lastMessage: {
           role: 'assistant',
           id: 'original-id',
@@ -1867,7 +1887,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -1883,7 +1906,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -1891,7 +1914,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1903,7 +1926,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1924,7 +1947,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1947,7 +1970,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1970,7 +1993,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -1993,7 +2016,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2022,7 +2045,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -2057,7 +2080,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -2073,7 +2099,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -2081,7 +2107,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2093,7 +2119,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2109,7 +2135,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2130,7 +2156,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -2186,7 +2212,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -2202,7 +2231,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -2210,7 +2239,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2222,7 +2251,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2239,7 +2268,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2260,7 +2289,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2281,7 +2310,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2298,7 +2327,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2319,7 +2348,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2349,7 +2378,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -2389,7 +2418,10 @@ describe('processUIMessageStream', () => {
         { type: 'finish' },
       ]);
 
-      state = createStreamingUIMessageState();
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
 
       await consumeStream({
         stream: processUIMessageStream({
@@ -2406,7 +2438,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -2414,7 +2446,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2426,7 +2458,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2449,7 +2481,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2478,7 +2510,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -2519,7 +2551,7 @@ describe('processUIMessageStream', () => {
       ]);
 
       state = createStreamingUIMessageState({
-        generateId: mockId(),
+        messageId: 'msg-123',
         lastMessage: undefined,
       });
 
@@ -2537,7 +2569,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -2545,7 +2577,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2557,7 +2589,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2573,7 +2605,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2601,7 +2633,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -2646,7 +2678,7 @@ describe('processUIMessageStream', () => {
       ]);
 
       state = createStreamingUIMessageState({
-        generateId: mockId(),
+        messageId: 'msg-123',
         lastMessage: undefined,
       });
 
@@ -2664,7 +2696,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -2672,7 +2704,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2684,7 +2716,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2700,7 +2732,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2721,7 +2753,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2742,7 +2774,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2773,7 +2805,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -2813,7 +2845,7 @@ describe('processUIMessageStream', () => {
       ]);
 
       state = createStreamingUIMessageState({
-        generateId: mockId(),
+        messageId: 'msg-123',
         lastMessage: undefined,
       });
 
@@ -2831,7 +2863,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -2839,7 +2871,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2851,7 +2883,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2872,7 +2904,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -2908,7 +2940,7 @@ describe('processUIMessageStream', () => {
       ]);
 
       state = createStreamingUIMessageState({
-        generateId: mockId(),
+        messageId: 'msg-123',
         lastMessage: undefined,
       });
 
@@ -2926,7 +2958,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -2934,7 +2966,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2946,7 +2978,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2963,7 +2995,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -2985,7 +3017,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -3028,7 +3060,7 @@ describe('processUIMessageStream', () => {
       ]);
 
       state = createStreamingUIMessageState({
-        generateId: mockId(),
+        messageId: 'msg-123',
         lastMessage: undefined,
       });
 
@@ -3046,7 +3078,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [],
               "role": "assistant",
             },
@@ -3054,7 +3086,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -3066,7 +3098,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -3086,7 +3118,7 @@ describe('processUIMessageStream', () => {
           {
             "message": {
               "id": "msg-123",
-              "metadata": {},
+              "metadata": undefined,
               "parts": [
                 {
                   "type": "step-start",
@@ -3112,7 +3144,7 @@ describe('processUIMessageStream', () => {
       expect(state!.message).toMatchInlineSnapshot(`
         {
           "id": "msg-123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -41,24 +41,21 @@ export function createStreamingUIMessageState<
   UI_DATA_TYPES extends UIDataTypes = UIDataTypes,
 >({
   lastMessage,
-  generateId,
+  messageId,
 }: {
   lastMessage: UIMessage<MESSAGE_METADATA, UI_DATA_TYPES> | undefined;
-  generateId: IdGenerator;
+  messageId: string;
 }): StreamingUIMessageState<UIMessage<MESSAGE_METADATA, UI_DATA_TYPES>> {
-  const isContinuation = lastMessage?.role === 'assistant';
-
-  const message: UIMessage<MESSAGE_METADATA, UI_DATA_TYPES> = isContinuation
-    ? lastMessage
-    : {
-        id: generateId(),
-        metadata: {} as MESSAGE_METADATA,
-        role: 'assistant',
-        parts: [],
-      };
-
   return {
-    message,
+    message:
+      lastMessage?.role === 'assistant'
+        ? lastMessage
+        : {
+            id: messageId,
+            metadata: undefined,
+            role: 'assistant',
+            parts: [],
+          },
     activeTextPart: undefined,
     activeReasoningPart: undefined,
     partialToolCalls: {},

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -1,4 +1,5 @@
 import {
+  IdGenerator,
   StandardSchemaV1,
   ToolCall,
   validateTypes,
@@ -40,17 +41,17 @@ export function createStreamingUIMessageState<
   UI_DATA_TYPES extends UIDataTypes = UIDataTypes,
 >({
   lastMessage,
-  newMessageId = '',
+  generateId,
 }: {
-  lastMessage?: UIMessage<MESSAGE_METADATA, UI_DATA_TYPES>;
-  newMessageId?: string;
-} = {}): StreamingUIMessageState<UIMessage<MESSAGE_METADATA, UI_DATA_TYPES>> {
+  lastMessage: UIMessage<MESSAGE_METADATA, UI_DATA_TYPES> | undefined;
+  generateId: IdGenerator;
+}): StreamingUIMessageState<UIMessage<MESSAGE_METADATA, UI_DATA_TYPES>> {
   const isContinuation = lastMessage?.role === 'assistant';
 
   const message: UIMessage<MESSAGE_METADATA, UI_DATA_TYPES> = isContinuation
     ? lastMessage
     : {
-        id: newMessageId,
+        id: generateId(),
         metadata: {} as MESSAGE_METADATA,
         role: 'assistant',
         parts: [],

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -108,7 +108,6 @@ describe('data protocol stream', () => {
         {
           id: 'id-1',
           role: 'assistant',
-          metadata: {},
           parts: [
             {
               type: 'text',
@@ -357,7 +356,6 @@ describe('data protocol stream', () => {
           },
           {
             id: 'id-1',
-            metadata: {},
             parts: [
               {
                 text: 'Hello, world.',
@@ -479,7 +477,7 @@ describe('text stream', () => {
         {
           "message": {
             "id": "id-2",
-            "metadata": {},
+            "metadata": undefined,
             "parts": [
               {
                 "type": "step-start",
@@ -985,7 +983,6 @@ describe('tool invocations', () => {
         },
         {
           id: 'id-2',
-          metadata: {},
           parts: [
             {
               type: 'step-start',
@@ -1399,7 +1396,6 @@ describe('file attachments with data url', () => {
         },
         {
           id: 'id-2',
-          metadata: {},
           parts: [
             {
               text: 'Response to message with text attachment',
@@ -1483,7 +1479,6 @@ describe('file attachments with data url', () => {
         {
           role: 'assistant',
           id: 'id-2',
-          metadata: {},
           parts: [
             {
               type: 'text',
@@ -1600,7 +1595,6 @@ describe('file attachments with url', () => {
         {
           role: 'assistant',
           id: 'id-2',
-          metadata: {},
           parts: [
             {
               type: 'text',
@@ -1702,7 +1696,6 @@ describe('attachments with empty submit', () => {
         {
           id: 'id-2',
           role: 'assistant',
-          metadata: {},
           parts: [
             {
               type: 'text',
@@ -1808,7 +1801,6 @@ describe('should send message with attachments', () => {
         },
         {
           id: 'id-2',
-          metadata: {},
           parts: [
             {
               text: 'Response to message with image attachment',

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -258,7 +258,7 @@ describe('text stream', () => {
         },
         {
           "id": "id-2",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "type": "step-start",
@@ -292,7 +292,7 @@ describe('text stream', () => {
         expect.objectContaining({
           id: expect.any(String),
           role: 'assistant',
-          metadata: {},
+          metadata: undefined,
           parts: [{ type: 'step-start' }, { text: 'He', type: 'text' }],
         }),
       ),
@@ -334,7 +334,7 @@ describe('text stream', () => {
       message: {
         id: expect.any(String),
         role: 'assistant',
-        metadata: {},
+        metadata: undefined,
         parts: [
           { type: 'step-start' },
           { text: 'Hello, world.', type: 'text' },
@@ -782,7 +782,7 @@ describe('maxSteps', () => {
           },
           {
             "id": "id-1",
-            "metadata": {},
+            "metadata": undefined,
             "parts": [
               {
                 "toolInvocation": {
@@ -908,7 +908,7 @@ describe('file attachments with data url', () => {
         },
         {
           "id": "id-2",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "text": "Response to message with text attachment",
@@ -985,7 +985,7 @@ describe('file attachments with data url', () => {
         },
         {
           "id": "id-2",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "text": "Response to message with image attachment",
@@ -1072,7 +1072,7 @@ describe('file attachments with url', () => {
         },
         {
           "id": "id-2",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "text": "Response to message with image attachment",
@@ -1156,7 +1156,7 @@ describe('file attachments with empty text content', () => {
         },
         {
           "id": "id-2",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "text": "Response to message with image attachment",
@@ -1354,7 +1354,7 @@ describe('generateId function', () => {
         },
         {
           "id": "123",
-          "metadata": {},
+          "metadata": undefined,
           "parts": [
             {
               "text": "Hello, world.",

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -233,7 +233,6 @@ describe('data protocol stream', () => {
       {
         message: {
           id: expect.any(String),
-          metadata: {},
           role: 'assistant',
           parts: [{ text: 'Hello, world.', type: 'text' }],
         },
@@ -284,7 +283,6 @@ describe('text stream', () => {
         message: {
           id: expect.any(String),
           role: 'assistant',
-          metadata: {},
           parts: [
             { type: 'step-start' },
             { text: 'Hello, world.', type: 'text' },
@@ -681,7 +679,6 @@ describe('file attachments with data url', () => {
         },
         {
           id: 'id-1',
-          metadata: {},
           parts: [
             {
               text: 'Response to message with text attachment',
@@ -741,7 +738,6 @@ describe('file attachments with data url', () => {
         {
           role: 'assistant',
           id: 'id-1',
-          metadata: {},
           parts: [
             {
               type: 'text',
@@ -796,7 +792,6 @@ describe('file attachments with url', () => {
         {
           role: 'assistant',
           id: 'id-1',
-          metadata: {},
           parts: [
             {
               type: 'text',
@@ -856,7 +851,6 @@ describe('attachments with empty submit', () => {
         {
           id: 'id-1',
           role: 'assistant',
-          metadata: {},
           parts: [
             {
               type: 'text',
@@ -907,7 +901,6 @@ describe('should append message with attachments', () => {
         },
         {
           id: 'id-1',
-          metadata: {},
           parts: [
             {
               text: 'Response to message with image attachment',


### PR DESCRIPTION
## Background

When `createUIMessageStream` is used to construct the final UI message for persistence, it relies on the message id from the inner stream. If that is not available, it'll be the empty string. This currently makes it necessary to pass the original messages in several places.

## Summary

* remove `newMessageId` from `streamText` result ui message stream methods
* add support for inserting the ui message id in `createUIMessageStream`
* metadata is `undefined` by default (and not `{}` which is not matching the expected type)