### PR TITLE
feat(provider/anthropic): add text citation support

### DIFF
--- a/.changeset/friendly-otters-sneeze.md
+++ b/.changeset/friendly-otters-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(anthropic/citation): text support for citations

--- a/examples/ai-core/src/generate-text/anthropic-text-citations.ts
+++ b/examples/ai-core/src/generate-text/anthropic-text-citations.ts
@@ -1,13 +1,8 @@
 import { anthropic } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 import 'dotenv/config';
 
 async function main() {
-  const pdfPath = resolve(process.cwd(), 'data', 'ai.pdf');
-  const pdfBase64 = readFileSync(pdfPath).toString('base64');
-
   const result = await generateText({
     model: anthropic('claude-3-5-sonnet-20241022'),
     messages: [
@@ -16,16 +11,16 @@ async function main() {
         content: [
           {
             type: 'text',
-            text: 'What is generative AI? Use citations.',
+            text: 'What color is the grass? Use citations.',
           },
           {
             type: 'file',
-            data: `data:application/pdf;base64,${pdfBase64}`,
-            mediaType: 'application/pdf',
+            mediaType: 'text/plain',
+            data: 'The grass is green in spring and summer. The sky is blue during clear weather.',
             providerOptions: {
               anthropic: {
                 citations: { enabled: true },
-                title: 'AI Documentation',
+                title: 'Nature Facts',
               },
             },
           },
@@ -44,7 +39,7 @@ async function main() {
     ) {
       const meta = citation.providerMetadata.anthropic;
       console.log(
-        `\n[${i + 1}] "${meta.citedText}" (Pages: ${meta.startPageNumber}-${meta.endPageNumber})`,
+        `\n[${i + 1}] "${meta.citedText}" (chars: ${meta.startCharIndex}-${meta.endCharIndex})`,
       );
     }
   });

--- a/examples/ai-core/src/stream-text/anthropic-text-citations.ts
+++ b/examples/ai-core/src/stream-text/anthropic-text-citations.ts
@@ -1,0 +1,57 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: anthropic('claude-3-5-sonnet-20241022'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What color is the grass? Use citations.',
+          },
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            data: 'The grass is green in spring and summer. The sky is blue during clear weather.',
+            providerOptions: {
+              anthropic: {
+                citations: { enabled: true },
+                title: 'Nature Facts',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  let citationCount = 0;
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text':
+        process.stdout.write(part.text);
+        break;
+
+      case 'source':
+        if (
+          part.sourceType === 'document' &&
+          part.providerMetadata?.anthropic
+        ) {
+          const meta = part.providerMetadata.anthropic;
+          console.log(
+            `\n\n[${++citationCount}] "${meta.citedText}" (chars: ${meta.startCharIndex}-${meta.endCharIndex})`,
+          );
+        }
+        break;
+    }
+  }
+
+  console.log(`\n\nTotal citations: ${citationCount}`);
+}
+
+main().catch(console.error);

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -57,6 +57,11 @@ type AnthropicContentSource =
   | {
       type: 'url';
       url: string;
+    }
+  | {
+      type: 'text';
+      media_type: 'text/plain';
+      data: string;
     };
 
 export interface AnthropicImageContent {

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -37,14 +37,24 @@ describe('AnthropicMessagesLanguageModel', () => {
         | {
             type: 'text';
             text: string;
-            citations?: Array<{
-              type: 'page_location';
-              cited_text: string;
-              document_index: number;
-              document_title: string;
-              start_page_number: number;
-              end_page_number: number;
-            }>;
+            citations?: Array<
+              | {
+                  type: 'page_location';
+                  cited_text: string;
+                  document_index: number;
+                  document_title: string;
+                  start_page_number: number;
+                  end_page_number: number;
+                }
+              | {
+                  type: 'char_location';
+                  cited_text: string;
+                  document_index: number;
+                  document_title: string;
+                  start_char_index: number;
+                  end_char_index: number;
+                }
+            >;
           }
         | { type: 'thinking'; thinking: string; signature: string }
         | { type: 'tool_use'; id: string; name: string; input: unknown }
@@ -732,6 +742,82 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
             "sourceType": "document",
             "title": "Financial Report 2023",
+            "type": "source",
+          },
+        ]
+      `);
+    });
+
+    it('should process text citation responses', async () => {
+      const mockProvider = createAnthropic({
+        apiKey: 'test-api-key',
+        generateId: () => 'test-text-citation-id',
+      });
+      const modelWithMockId = mockProvider('claude-3-haiku-20240307');
+
+      prepareJsonResponse({
+        content: [
+          {
+            type: 'text',
+            text: 'The text shows important information.',
+            citations: [
+              {
+                type: 'char_location',
+                cited_text: 'important information',
+                document_index: 0,
+                document_title: 'Test Document',
+                start_char_index: 15,
+                end_char_index: 35,
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await modelWithMockId.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: 'VGVzdCBkb2N1bWVudCBjb250ZW50',
+                mediaType: 'text/plain',
+                filename: 'test.txt',
+                providerOptions: {
+                  anthropic: {
+                    citations: { enabled: true },
+                  },
+                },
+              },
+              {
+                type: 'text',
+                text: 'What does this say?',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.content).toMatchInlineSnapshot(`
+        [
+          {
+            "text": "The text shows important information.",
+            "type": "text",
+          },
+          {
+            "filename": "test.txt",
+            "id": "test-text-citation-id",
+            "mediaType": "text/plain",
+            "providerMetadata": {
+              "anthropic": {
+                "citedText": "important information",
+                "endCharIndex": 35,
+                "startCharIndex": 15,
+              },
+            },
+            "sourceType": "document",
+            "title": "Test Document",
             "type": "source",
           },
         ]

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@ai-sdk/provider-utils/test';
 import { AnthropicProviderOptions } from './anthropic-messages-options';
 import { createAnthropic } from './anthropic-provider';
+import { type DocumentCitation } from './anthropic-messages-language-model';
 
 const TEST_PROMPT: LanguageModelV2Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -37,24 +38,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         | {
             type: 'text';
             text: string;
-            citations?: Array<
-              | {
-                  type: 'page_location';
-                  cited_text: string;
-                  document_index: number;
-                  document_title: string;
-                  start_page_number: number;
-                  end_page_number: number;
-                }
-              | {
-                  type: 'char_location';
-                  cited_text: string;
-                  document_index: number;
-                  document_title: string;
-                  start_char_index: number;
-                  end_char_index: number;
-                }
-            >;
+            citations?: Array<DocumentCitation>;
           }
         | { type: 'thinking'; thinking: string; signature: string }
         | { type: 'tool_use'; id: string; name: string; input: unknown }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -71,7 +71,7 @@ const documentCitationSchema = z.discriminatedUnion('type', [
 ]);
 
 type Citation = z.infer<typeof citationSchema>;
-type DocumentCitation = z.infer<typeof documentCitationSchema>;
+export type DocumentCitation = z.infer<typeof documentCitationSchema>;
 
 function processCitation(
   citation: Citation,
@@ -398,7 +398,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
     filename?: string;
     mediaType: string;
   }> {
-    const isCitationPart = (part: any) => {
+    const isCitationPart = (part: {
+      type: string;
+      mediaType?: string;
+      providerOptions?: { anthropic?: { citations?: { enabled?: boolean } } };
+    }) => {
       if (part.type !== 'file') {
         return false;
       }

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -212,7 +212,9 @@ describe('user messages', () => {
           content: [
             {
               type: 'file',
-              data: 'sample text content',
+              data: Buffer.from('sample text content', 'utf-8').toString(
+                'base64',
+              ),
               mediaType: 'text/plain',
               filename: 'sample.txt',
             },

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -204,7 +204,51 @@ describe('user messages', () => {
     });
   });
 
-  it('should throw error for non-PDF file types', async () => {
+  it('should add text file parts for text/plain documents', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: 'sample text content',
+              mediaType: 'text/plain',
+              filename: 'sample.txt',
+            },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'document',
+                source: {
+                  type: 'text',
+                  media_type: 'text/plain',
+                  data: 'sample text content',
+                },
+                title: 'sample.txt',
+                cache_control: undefined,
+              },
+            ],
+          },
+        ],
+        system: undefined,
+      },
+      betas: new Set(),
+    });
+  });
+
+  it('should throw error for unsupported file types', async () => {
     await expect(
       convertToAnthropicMessagesPrompt({
         prompt: [
@@ -214,7 +258,7 @@ describe('user messages', () => {
               {
                 type: 'file',
                 data: 'base64data',
-                mediaType: 'text/plain',
+                mediaType: 'video/mp4',
               },
             ],
           },
@@ -222,7 +266,7 @@ describe('user messages', () => {
         sendReasoning: true,
         warnings: [],
       }),
-    ).rejects.toThrow('media type: text/plain');
+    ).rejects.toThrow('media type: video/mp4');
   });
 });
 

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -1,5 +1,6 @@
 import {
   LanguageModelV2CallWarning,
+  LanguageModelV2DataContent,
   LanguageModelV2Message,
   LanguageModelV2Prompt,
   SharedV2ProviderMetadata,
@@ -15,9 +16,7 @@ import { convertToBase64, parseProviderOptions } from '@ai-sdk/provider-utils';
 import { anthropicReasoningMetadataSchema } from './anthropic-messages-language-model';
 import { anthropicFilePartProviderOptions } from './anthropic-messages-options';
 
-function convertToString(
-  data: string | Uint8Array | ArrayBuffer | Buffer,
-): string {
+function convertToString(data: LanguageModelV2DataContent): string {
   if (typeof data === 'string') {
     return data;
   }
@@ -26,12 +25,10 @@ function convertToString(
     return new TextDecoder().decode(data);
   }
 
-  if (data instanceof ArrayBuffer) {
-    return new TextDecoder().decode(new Uint8Array(data));
-  }
-
-  if (globalThis.Buffer?.isBuffer(data)) {
-    return (data as Buffer).toString('utf-8');
+  if (data instanceof URL) {
+    throw new UnsupportedFunctionalityError({
+      functionality: 'URL-based text documents are not supported for citations',
+    });
   }
 
   throw new UnsupportedFunctionalityError({

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -18,7 +18,7 @@ import { anthropicFilePartProviderOptions } from './anthropic-messages-options';
 
 function convertToString(data: LanguageModelV2DataContent): string {
   if (typeof data === 'string') {
-    return data;
+    return Buffer.from(data, 'base64').toString('utf-8');
   }
 
   if (data instanceof Uint8Array) {


### PR DESCRIPTION
## background

users needed character-level citations for plain text documents alongside the existing page-level PDF citations

## summary

- add text citation support with `char_location` type for plain text documents
- extend existing citation infrastructure to handle `text/plain` media type
- add minimal test coverage following established PDF citation patterns

## verification

- all tests pass including new text citation test
- citation processing works for both PDF (`page_location`) and text (`char_location`) types
- examples demonstrate text citations using existing citation patterns
- maintains backward compatibility with PDF citations

## tasks

- [x] extend citation types to support `char_location` with character indices
- [x] add `text/plain` media type support in document processing
- [x] update `createCitationSource` to handle both citation types
- [x] add `convertToString` function for text document conversion
- [x] test coverage for text citation responses
- [x] examples for both `generateText` and `streamText` modes

## future work

- custom content citation support (`content_block_location` type)
- other providers (openai, google) citation support
