### PR TITLE
chore (ai): send reasoning to the client by default

### DIFF
--- a/.changeset/happy-ads-happen.md
+++ b/.changeset/happy-ads-happen.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): send reasoning to the client by default

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -59,7 +59,7 @@ export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
 
   /**
    * Send reasoning parts to the client.
-   * Default to false.
+   * Default to true.
    */
   sendReasoning?: boolean;
 

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -2651,6 +2651,11 @@ describe('streamText', () => {
                 "type": "start-step",
               },
               {
+                "providerMetadata": undefined,
+                "text": "thinking",
+                "type": "reasoning",
+              },
+              {
                 "args": {
                   "value": "value",
                 },
@@ -4256,6 +4261,11 @@ describe('streamText', () => {
               {
                 "metadata": undefined,
                 "type": "start-step",
+              },
+              {
+                "providerMetadata": undefined,
+                "text": "thinking",
+                "type": "reasoning",
               },
               {
                 "args": {

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1459,7 +1459,7 @@ However, the LLM results are expected to be small enough to not cause issues.
     originalMessages,
     onFinish,
     messageMetadata,
-    sendReasoning = false,
+    sendReasoning = true,
     sendSources = false,
     sendStart = true,
     sendFinish = true,


### PR DESCRIPTION
## Background

Currently sending reasoning to the client is opt-in. However, many users are confused and expect it to just work. Since there is no confidential information in the reasoning, it can be exposed by default.

## Summary

Include reasoning in the ui message stream by default.