### PR TITLE
refactoring (ai): restructure message metadata transfer

### DIFF
--- a/.changeset/dirty-eggs-breathe.md
+++ b/.changeset/dirty-eggs-breathe.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+refactoring (ai): restructure message metadata transfer

--- a/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/core/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -61,11 +61,10 @@ exports[`streamText > multiple stream consumption > should support text stream, 
   "uiMessageStream": [
     {
       "messageId": undefined,
-      "metadata": undefined,
+      "messageMetadata": undefined,
       "type": "start",
     },
     {
-      "metadata": undefined,
       "type": "start-step",
     },
     {
@@ -81,11 +80,10 @@ exports[`streamText > multiple stream consumption > should support text stream, 
       "type": "text",
     },
     {
-      "metadata": undefined,
       "type": "finish-step",
     },
     {
-      "metadata": undefined,
+      "messageMetadata": undefined,
       "type": "finish",
     },
   ],
@@ -3214,11 +3212,10 @@ exports[`streamText > result.toUIMessageStream > should create a data stream 1`]
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3234,11 +3231,10 @@ exports[`streamText > result.toUIMessageStream > should create a data stream 1`]
     "type": "text",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]
@@ -3248,11 +3244,10 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3260,11 +3255,10 @@ exports[`streamText > result.toUIMessageStream > should mask error messages by d
     "type": "error",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]
@@ -3274,11 +3268,10 @@ exports[`streamText > result.toUIMessageStream > should omit message finish even
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3286,7 +3279,6 @@ exports[`streamText > result.toUIMessageStream > should omit message finish even
     "type": "text",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
 ]
@@ -3295,7 +3287,6 @@ exports[`streamText > result.toUIMessageStream > should omit message finish even
 exports[`streamText > result.toUIMessageStream > should omit message start event when sendStart is false 1`] = `
 [
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3303,11 +3294,10 @@ exports[`streamText > result.toUIMessageStream > should omit message start event
     "type": "text",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]
@@ -3317,11 +3307,10 @@ exports[`streamText > result.toUIMessageStream > should send document source con
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3353,11 +3342,10 @@ exports[`streamText > result.toUIMessageStream > should send document source con
     "type": "source-document",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]
@@ -3367,11 +3355,10 @@ exports[`streamText > result.toUIMessageStream > should send file content 1`] = 
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3389,11 +3376,10 @@ exports[`streamText > result.toUIMessageStream > should send file content 1`] = 
     "url": "data:image/jpeg;base64,QkFVRw==",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]
@@ -3403,11 +3389,10 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3475,11 +3460,10 @@ exports[`streamText > result.toUIMessageStream > should send reasoning content w
     "type": "text",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]
@@ -3489,11 +3473,10 @@ exports[`streamText > result.toUIMessageStream > should send source content when
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3523,11 +3506,10 @@ exports[`streamText > result.toUIMessageStream > should send source content when
     "url": "https://example.com/2",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]
@@ -3537,11 +3519,10 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3573,11 +3554,10 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
     "type": "tool-result",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]
@@ -3587,11 +3567,10 @@ exports[`streamText > result.toUIMessageStream > should support custom error mes
 [
   {
     "messageId": undefined,
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "start",
   },
   {
-    "metadata": undefined,
     "type": "start-step",
   },
   {
@@ -3599,11 +3578,10 @@ exports[`streamText > result.toUIMessageStream > should support custom error mes
     "type": "error",
   },
   {
-    "metadata": undefined,
     "type": "finish-step",
   },
   {
-    "metadata": undefined,
+    "messageMetadata": undefined,
     "type": "finish",
   },
 ]

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -52,9 +52,7 @@ export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
    * Called on `start` and `finish` events.
    */
   messageMetadata?: (options: {
-    part: TextStreamPart<ToolSet> & {
-      type: 'start' | 'finish' | 'start-step' | 'finish-step';
-    };
+    part: TextStreamPart<ToolSet>;
   }) => InferUIMessageMetadata<UI_MESSAGE> | undefined;
 
   /**

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -1217,6 +1217,9 @@ describe('streamText', () => {
           { key2: 'value2' },
           { key3: 'value3' },
           { key4: 'value4' },
+          { key5: 'value5' },
+          { key6: 'value6' },
+          { key7: 'value7' },
         ),
       });
 
@@ -1225,38 +1228,62 @@ describe('streamText', () => {
           [
             {
               "messageId": undefined,
-              "metadata": {
+              "messageMetadata": {
                 "key1": "value1",
               },
               "type": "start",
             },
             {
-              "metadata": {
+              "type": "start-step",
+            },
+            {
+              "messageMetadata": {
                 "key2": "value2",
               },
-              "type": "start-step",
+              "type": "message-metadata",
             },
             {
               "text": "Hello",
               "type": "text",
             },
             {
+              "messageMetadata": {
+                "key3": "value3",
+              },
+              "type": "message-metadata",
+            },
+            {
               "text": ", ",
               "type": "text",
+            },
+            {
+              "messageMetadata": {
+                "key4": "value4",
+              },
+              "type": "message-metadata",
             },
             {
               "text": "world!",
               "type": "text",
             },
             {
-              "metadata": {
-                "key3": "value3",
+              "messageMetadata": {
+                "key5": "value5",
               },
+              "type": "message-metadata",
+            },
+            {
               "type": "finish-step",
             },
             {
-              "metadata": {
-                "key4": "value4",
+              "messageMetadata": {
+                "key6": "value6",
+              },
+              "type": "message-metadata",
+            },
+            {
+              "messageMetadata": {
+                "key7": "value7",
               },
               "type": "finish",
             },
@@ -2643,11 +2670,10 @@ describe('streamText', () => {
             [
               {
                 "messageId": undefined,
-                "metadata": undefined,
+                "messageMetadata": undefined,
                 "type": "start",
               },
               {
-                "metadata": undefined,
                 "type": "start-step",
               },
               {
@@ -2669,11 +2695,9 @@ describe('streamText', () => {
                 "type": "tool-result",
               },
               {
-                "metadata": undefined,
                 "type": "finish-step",
               },
               {
-                "metadata": undefined,
                 "type": "start-step",
               },
               {
@@ -2685,11 +2709,10 @@ describe('streamText', () => {
                 "type": "text",
               },
               {
-                "metadata": undefined,
                 "type": "finish-step",
               },
               {
-                "metadata": undefined,
+                "messageMetadata": undefined,
                 "type": "finish",
               },
             ]
@@ -4255,11 +4278,10 @@ describe('streamText', () => {
             [
               {
                 "messageId": undefined,
-                "metadata": undefined,
+                "messageMetadata": undefined,
                 "type": "start",
               },
               {
-                "metadata": undefined,
                 "type": "start-step",
               },
               {
@@ -4281,11 +4303,9 @@ describe('streamText', () => {
                 "type": "tool-result",
               },
               {
-                "metadata": undefined,
                 "type": "finish-step",
               },
               {
-                "metadata": undefined,
                 "type": "start-step",
               },
               {
@@ -4297,11 +4317,10 @@ describe('streamText', () => {
                 "type": "text",
               },
               {
-                "metadata": undefined,
                 "type": "finish-step",
               },
               {
-                "metadata": undefined,
+                "messageMetadata": undefined,
                 "type": "finish",
               },
             ]

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1481,6 +1481,8 @@ However, the LLM results are expected to be small enough to not cause issues.
         >
       >({
         transform: async (part, controller) => {
+          const messageMetadataValue = messageMetadata?.({ part });
+
           const partType = part.type;
           switch (partType) {
             case 'text': {
@@ -1588,31 +1590,21 @@ However, the LLM results are expected to be small enough to not cause issues.
             }
 
             case 'start-step': {
-              const metadata = messageMetadata?.({ part });
-              controller.enqueue({
-                type: 'start-step',
-                metadata,
-              });
+              controller.enqueue({ type: 'start-step' });
               break;
             }
 
             case 'finish-step': {
-              const metadata = messageMetadata?.({ part });
-              controller.enqueue({
-                type: 'finish-step',
-                metadata,
-              });
-
+              controller.enqueue({ type: 'finish-step' });
               break;
             }
 
             case 'start': {
               if (sendStart) {
-                const metadata = messageMetadata?.({ part });
                 controller.enqueue({
                   type: 'start',
                   messageId: responseMessageId,
-                  metadata,
+                  messageMetadata: messageMetadataValue,
                 });
               }
               break;
@@ -1620,10 +1612,9 @@ However, the LLM results are expected to be small enough to not cause issues.
 
             case 'finish': {
               if (sendFinish) {
-                const metadata = messageMetadata?.({ part });
                 controller.enqueue({
                   type: 'finish',
-                  metadata,
+                  messageMetadata: messageMetadataValue,
                 });
               }
               break;
@@ -1639,6 +1630,19 @@ However, the LLM results are expected to be small enough to not cause issues.
               const exhaustiveCheck: never = partType;
               throw new Error(`Unknown chunk type: ${exhaustiveCheck}`);
             }
+          }
+
+          // start and finish events already have metadata
+          // so we only need to send metadata for other parts
+          if (
+            messageMetadataValue != null &&
+            partType !== 'start' &&
+            partType !== 'finish'
+          ) {
+            controller.enqueue({
+              type: 'message-metadata',
+              messageMetadata: messageMetadataValue,
+            });
           }
         },
       }),

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -9,49 +9,52 @@ import {
 import { ProviderMetadata } from '../../core/types/provider-metadata';
 
 export const uiMessageStreamPartSchema = z.union([
-  z.object({
+  z.strictObject({
     type: z.literal('text'),
     text: z.string(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('error'),
     errorText: z.string(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('tool-call-streaming-start'),
     toolCallId: z.string(),
     toolName: z.string(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('tool-call-delta'),
     toolCallId: z.string(),
     argsTextDelta: z.string(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('tool-call'),
     toolCallId: z.string(),
     toolName: z.string(),
     args: z.unknown(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('tool-result'),
     toolCallId: z.string(),
     result: z.unknown(),
     providerMetadata: z.any().optional(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('reasoning'),
     text: z.string(),
     providerMetadata: z.record(z.any()).optional(),
   }),
-  z.object({
+  z.strictObject({
+    type: z.literal('reasoning-part-finish'),
+  }),
+  z.strictObject({
     type: z.literal('source-url'),
     sourceId: z.string(),
     url: z.string(),
     title: z.string().optional(),
     providerMetadata: z.any().optional(), // Use z.any() for generic metadata
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('source-document'),
     sourceId: z.string(),
     mediaType: z.string(),
@@ -59,39 +62,34 @@ export const uiMessageStreamPartSchema = z.union([
     filename: z.string().optional(),
     providerMetadata: z.any().optional(), // Use z.any() for generic metadata
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('file'),
     url: z.string(),
     mediaType: z.string(),
   }),
-  z.object({
+  z.strictObject({
     type: z.string().startsWith('data-'),
     id: z.string().optional(),
     data: z.unknown(),
   }),
-  z.object({
-    type: z.literal('metadata'),
-    value: z.object({ metadata: z.unknown() }),
-  }),
-  z.object({
+  z.strictObject({
     type: z.literal('start-step'),
-    metadata: z.unknown().optional(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('finish-step'),
-    metadata: z.unknown().optional(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('start'),
     messageId: z.string().optional(),
-    metadata: z.unknown().optional(),
+    messageMetadata: z.unknown().optional(),
   }),
-  z.object({
+  z.strictObject({
     type: z.literal('finish'),
-    metadata: z.unknown().optional(),
+    messageMetadata: z.unknown().optional(),
   }),
-  z.object({
-    type: z.literal('reasoning-part-finish'),
+  z.strictObject({
+    type: z.literal('message-metadata'),
+    messageMetadata: z.unknown(),
   }),
 ]);
 

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -143,6 +143,9 @@ export type UIMessageStreamPart<
       providerMetadata?: ProviderMetadata;
     }
   | {
+      type: 'reasoning-part-finish';
+    }
+  | {
       type: 'source-url';
       sourceId: string;
       url: string;
@@ -164,28 +167,23 @@ export type UIMessageStreamPart<
     }
   | DataUIMessageStreamPart<DATA_TYPES>
   | {
-      type: 'metadata';
-      metadata: METADATA;
-    }
-  | {
       type: 'start-step';
-      metadata?: METADATA;
     }
   | {
       type: 'finish-step';
-      metadata?: METADATA;
     }
   | {
       type: 'start';
       messageId?: string;
-      metadata?: METADATA;
+      messageMetadata?: METADATA;
     }
   | {
       type: 'finish';
-      metadata?: METADATA;
+      messageMetadata?: METADATA;
     }
   | {
-      type: 'reasoning-part-finish';
+      type: 'message-metadata';
+      messageMetadata: METADATA;
     };
 
 export function isDataUIMessageStreamPart(

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -83,18 +83,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
                 {
                   "text": "Hello, ",
                   "type": "text",
@@ -198,18 +186,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
                 {
                   "toolInvocation": {
                     "args": {
@@ -246,35 +222,6 @@ describe('processUIMessageStream', () => {
                     "toolName": "tool-name",
                   },
                   "type": "tool-invocation",
-                },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-                {
-                  "toolInvocation": {
-                    "args": {
-                      "city": "London",
-                    },
-                    "result": {
-                      "weather": "sunny",
-                    },
-                    "state": "result",
-                    "toolCallId": "tool-call-id",
-                    "toolName": "tool-name",
-                  },
-                  "type": "tool-invocation",
-                },
-                {
-                  "type": "step-start",
                 },
               ],
               "role": "assistant",
@@ -450,30 +397,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "toolInvocation": {
-                    "args": {},
-                    "result": {
-                      "location": "Berlin",
-                    },
-                    "state": "result",
-                    "toolCallId": "tool-call-id-original",
-                    "toolName": "tool-name-original",
-                  },
-                  "type": "tool-invocation",
-                },
-                {
-                  "type": "step-start",
-                },
                 {
                   "toolInvocation": {
                     "args": {
@@ -522,47 +445,6 @@ describe('processUIMessageStream', () => {
                     "toolName": "tool-name",
                   },
                   "type": "tool-invocation",
-                },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "toolInvocation": {
-                    "args": {},
-                    "result": {
-                      "location": "Berlin",
-                    },
-                    "state": "result",
-                    "toolCallId": "tool-call-id-original",
-                    "toolName": "tool-name-original",
-                  },
-                  "type": "tool-invocation",
-                },
-                {
-                  "type": "step-start",
-                },
-                {
-                  "toolInvocation": {
-                    "args": {
-                      "city": "London",
-                    },
-                    "result": {
-                      "weather": "sunny",
-                    },
-                    "state": "result",
-                    "toolCallId": "tool-call-id",
-                    "toolName": "tool-name",
-                  },
-                  "type": "tool-invocation",
-                },
-                {
-                  "type": "step-start",
                 },
               ],
               "role": "assistant",
@@ -724,18 +606,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
                 {
                   "text": "I will ",
                   "type": "text",
@@ -812,39 +682,6 @@ describe('processUIMessageStream', () => {
                     "toolName": "tool-name",
                   },
                   "type": "tool-invocation",
-                },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-                {
-                  "text": "I will use a tool to get the weather in London.",
-                  "type": "text",
-                },
-                {
-                  "toolInvocation": {
-                    "args": {
-                      "city": "London",
-                    },
-                    "result": {
-                      "weather": "sunny",
-                    },
-                    "state": "result",
-                    "toolCallId": "tool-call-id",
-                    "toolName": "tool-name",
-                  },
-                  "type": "tool-invocation",
-                },
-                {
-                  "type": "step-start",
                 },
               ],
               "role": "assistant",
@@ -1041,18 +878,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
                 {
                   "providerMetadata": undefined,
                   "text": "I will ",
@@ -1145,44 +970,6 @@ describe('processUIMessageStream', () => {
                     "toolName": "tool-name",
                   },
                   "type": "tool-invocation",
-                },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-                {
-                  "providerMetadata": {
-                    "testProvider": {
-                      "signature": "1234567890",
-                    },
-                  },
-                  "text": "I will use a tool to get the weather in London.",
-                  "type": "reasoning",
-                },
-                {
-                  "toolInvocation": {
-                    "args": {
-                      "city": "London",
-                    },
-                    "result": {
-                      "weather": "sunny",
-                    },
-                    "state": "result",
-                    "toolCallId": "tool-call-id",
-                    "toolName": "tool-name",
-                  },
-                  "type": "tool-invocation",
-                },
-                {
-                  "type": "step-start",
                 },
               ],
               "role": "assistant",
@@ -1351,7 +1138,7 @@ describe('processUIMessageStream', () => {
         {
           type: 'start',
           messageId: 'msg-123',
-          metadata: {
+          messageMetadata: {
             start: 'start-1',
             shared: {
               key1: 'value-1a',
@@ -1359,41 +1146,19 @@ describe('processUIMessageStream', () => {
             },
           },
         },
-        {
-          type: 'start-step',
-          metadata: {
-            startStep: 'start-step-1',
-            shared: {
-              key1: 'value-1b',
-              key3: 'value-3b',
-            },
-          },
-        },
+        { type: 'start-step' },
         { type: 'text', text: 't1' },
         {
-          type: 'metadata',
-          metadata: {
+          type: 'message-metadata',
+          messageMetadata: {
             metadata: 'metadata-1',
-            shared: {
-              key1: 'value-1c',
-              key4: 'value-4c',
-            },
           },
         },
         { type: 'text', text: 't2' },
-        {
-          type: 'finish-step',
-          metadata: {
-            finishStep: 'finish-step-1',
-            shared: {
-              key1: 'value-1d',
-              key5: 'value-5d',
-            },
-          },
-        },
+        { type: 'finish-step' },
         {
           type: 'finish',
-          metadata: {
+          messageMetadata: {
             finish: 'finish-1',
             shared: {
               key1: 'value-1e',
@@ -1438,32 +1203,10 @@ describe('processUIMessageStream', () => {
               "id": "msg-123",
               "metadata": {
                 "shared": {
-                  "key1": "value-1b",
+                  "key1": "value-1a",
                   "key2": "value-2a",
-                  "key3": "value-3b",
                 },
                 "start": "start-1",
-                "startStep": "start-step-1",
-              },
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": {
-                "shared": {
-                  "key1": "value-1b",
-                  "key2": "value-2a",
-                  "key3": "value-3b",
-                },
-                "start": "start-1",
-                "startStep": "start-step-1",
               },
               "parts": [
                 {
@@ -1483,13 +1226,10 @@ describe('processUIMessageStream', () => {
               "metadata": {
                 "metadata": "metadata-1",
                 "shared": {
-                  "key1": "value-1c",
+                  "key1": "value-1a",
                   "key2": "value-2a",
-                  "key3": "value-3b",
-                  "key4": "value-4c",
                 },
                 "start": "start-1",
-                "startStep": "start-step-1",
               },
               "parts": [
                 {
@@ -1509,41 +1249,10 @@ describe('processUIMessageStream', () => {
               "metadata": {
                 "metadata": "metadata-1",
                 "shared": {
-                  "key1": "value-1c",
+                  "key1": "value-1a",
                   "key2": "value-2a",
-                  "key3": "value-3b",
-                  "key4": "value-4c",
                 },
                 "start": "start-1",
-                "startStep": "start-step-1",
-              },
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-                {
-                  "text": "t1t2",
-                  "type": "text",
-                },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": {
-                "finishStep": "finish-step-1",
-                "metadata": "metadata-1",
-                "shared": {
-                  "key1": "value-1d",
-                  "key2": "value-2a",
-                  "key3": "value-3b",
-                  "key4": "value-4c",
-                  "key5": "value-5d",
-                },
-                "start": "start-1",
-                "startStep": "start-step-1",
               },
               "parts": [
                 {
@@ -1562,18 +1271,13 @@ describe('processUIMessageStream', () => {
               "id": "msg-123",
               "metadata": {
                 "finish": "finish-1",
-                "finishStep": "finish-step-1",
                 "metadata": "metadata-1",
                 "shared": {
                   "key1": "value-1e",
                   "key2": "value-2a",
-                  "key3": "value-3b",
-                  "key4": "value-4c",
-                  "key5": "value-5d",
                   "key6": "value-6e",
                 },
                 "start": "start-1",
-                "startStep": "start-step-1",
               },
               "parts": [
                 {
@@ -1597,18 +1301,13 @@ describe('processUIMessageStream', () => {
           "id": "msg-123",
           "metadata": {
             "finish": "finish-1",
-            "finishStep": "finish-step-1",
             "metadata": "metadata-1",
             "shared": {
               "key1": "value-1e",
               "key2": "value-2a",
-              "key3": "value-3b",
-              "key4": "value-4c",
-              "key5": "value-5d",
               "key6": "value-6e",
             },
             "start": "start-1",
-            "startStep": "start-step-1",
           },
           "parts": [
             {
@@ -1634,8 +1333,8 @@ describe('processUIMessageStream', () => {
         { type: 'finish-step' },
         { type: 'finish' },
         {
-          type: 'metadata',
-          metadata: {
+          type: 'message-metadata',
+          messageMetadata: {
             key1: 'value-1',
           },
         },
@@ -1662,18 +1361,6 @@ describe('processUIMessageStream', () => {
               "id": "msg-123",
               "metadata": undefined,
               "parts": [],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-              ],
               "role": "assistant",
             },
           },
@@ -1740,14 +1427,15 @@ describe('processUIMessageStream', () => {
   describe('message metadata with existing assistant lastMessage', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
-        { type: 'start', messageId: 'msg-123' },
         {
-          type: 'start-step',
-          metadata: {
+          type: 'start',
+          messageId: 'msg-123',
+          messageMetadata: {
             key1: 'value-1b',
             key2: 'value-2b',
           },
         },
+        { type: 'start-step' },
         { type: 'text', text: 't1' },
         { type: 'finish-step' },
         { type: 'finish' },
@@ -1781,26 +1469,11 @@ describe('processUIMessageStream', () => {
             "message": {
               "id": "msg-123",
               "metadata": {
-                "key1": "value-1a",
-                "key3": "value-3a",
-              },
-              "parts": [],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": {
                 "key1": "value-1b",
                 "key2": "value-2b",
                 "key3": "value-3a",
               },
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-              ],
+              "parts": [],
               "role": "assistant",
             },
           },
@@ -1908,18 +1581,6 @@ describe('processUIMessageStream', () => {
               "id": "msg-123",
               "metadata": undefined,
               "parts": [],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-              ],
               "role": "assistant",
             },
           },
@@ -2112,18 +1773,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
                 {
                   "text": "Hello, ",
                   "type": "text",
@@ -2233,18 +1882,6 @@ describe('processUIMessageStream', () => {
               "id": "msg-123",
               "metadata": undefined,
               "parts": [],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-              ],
               "role": "assistant",
             },
           },
@@ -2451,18 +2088,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
                 {
                   "toolInvocation": {
                     "args": {
@@ -2582,18 +2207,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
                 {
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -2698,18 +2311,6 @@ describe('processUIMessageStream', () => {
               "id": "msg-123",
               "metadata": undefined,
               "parts": [],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-              ],
               "role": "assistant",
             },
           },
@@ -2876,18 +2477,6 @@ describe('processUIMessageStream', () => {
                 {
                   "type": "step-start",
                 },
-              ],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
                 {
                   "data": "example-data-can-be-anything",
                   "type": "data-test",
@@ -2960,18 +2549,6 @@ describe('processUIMessageStream', () => {
               "id": "msg-123",
               "metadata": undefined,
               "parts": [],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-              ],
               "role": "assistant",
             },
           },
@@ -3080,18 +2657,6 @@ describe('processUIMessageStream', () => {
               "id": "msg-123",
               "metadata": undefined,
               "parts": [],
-              "role": "assistant",
-            },
-          },
-          {
-            "message": {
-              "id": "msg-123",
-              "metadata": undefined,
-              "parts": [
-                {
-                  "type": "step-start",
-                },
-              ],
               "role": "assistant",
             },
           },

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -320,9 +320,6 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             case 'start-step': {
               // add a step boundary part to the message
               state.message.parts.push({ type: 'step-start' });
-
-              await updateMessageMetadata(part.metadata);
-              write();
               break;
             }
 
@@ -330,11 +327,6 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               // reset the current text and reasoning parts
               state.activeTextPart = undefined;
               state.activeReasoningPart = undefined;
-
-              await updateMessageMetadata(part.metadata);
-              if (part.metadata != null) {
-                write();
-              }
               break;
             }
 
@@ -343,25 +335,25 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 state.message.id = part.messageId;
               }
 
-              await updateMessageMetadata(part.metadata);
+              await updateMessageMetadata(part.messageMetadata);
 
-              if (part.messageId != null || part.metadata != null) {
+              if (part.messageId != null || part.messageMetadata != null) {
                 write();
               }
               break;
             }
 
             case 'finish': {
-              await updateMessageMetadata(part.metadata);
-              if (part.metadata != null) {
+              await updateMessageMetadata(part.messageMetadata);
+              if (part.messageMetadata != null) {
                 write();
               }
               break;
             }
 
-            case 'metadata': {
-              await updateMessageMetadata(part.metadata);
-              if (part.metadata != null) {
+            case 'message-metadata': {
+              await updateMessageMetadata(part.messageMetadata);
+              if (part.messageMetadata != null) {
                 write();
               }
               break;

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -235,7 +235,7 @@ describe('data protocol stream', () => {
     controller.write(
       formatStreamPart({
         type: 'finish',
-        metadata: {
+        messageMetadata: {
           example: 'metadata',
         },
       }),

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -152,7 +152,7 @@ describe('data protocol stream', () => {
         formatStreamPart({ type: 'text', text: '.' }),
         formatStreamPart({
           type: 'finish',
-          metadata: {
+          messageMetadata: {
             example: 'metadata',
           },
         }),


### PR DESCRIPTION
## Background

Currently only certain chunk types support message metadata in the `metadata` function.

## Summary

* remove `metadata` property from `step-start` and `step-finish` parts
* rename `metadata` property to `message-metadata` on `start` and `finish` parts
* allow for metadata to be added for any chunk in the `metadata` function
* update ui message stream part schemas to use `strictObject`