### PR TITLE
feat (ui): use UI_MESSAGE generic

### DIFF
--- a/.changeset/sharp-apes-tickle.md
+++ b/.changeset/sharp-apes-tickle.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/svelte': major
+'@ai-sdk/react': major
+'@ai-sdk/vue': major
+'ai': major
+---
+
+feat (ui): use UI_MESSAGE generic

--- a/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
+++ b/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
@@ -3,32 +3,25 @@
 import ChatInput from '@/component/chat-input';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, UIMessage } from 'ai';
-import { z } from 'zod';
+
+type MyMessage = UIMessage<
+  never,
+  {
+    weather: {
+      city: string;
+      weather: string;
+      status: 'loading' | 'success';
+    };
+  }
+>;
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat<
-    UIMessage<
-      never,
-      {
-        weather: {
-          city: string;
-          weather: string;
-          status: 'loading' | 'success';
-        };
-      }
-    >
-  >({
-    transport: new DefaultChatTransport({
-      api: '/api/use-chat-data-ui-parts',
-    }),
-    dataPartSchemas: {
-      weather: z.object({
-        city: z.string(),
-        weather: z.string(),
-        status: z.enum(['loading', 'success']),
+  const { error, status, sendMessage, messages, reload, stop } =
+    useChat<MyMessage>({
+      transport: new DefaultChatTransport({
+        api: '/api/use-chat-data-ui-parts',
       }),
-    },
-  });
+    });
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">

--- a/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
+++ b/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
@@ -2,11 +2,22 @@
 
 import ChatInput from '@/component/chat-input';
 import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport } from 'ai';
+import { DefaultChatTransport, UIMessage } from 'ai';
 import { z } from 'zod';
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat({
+  const { error, status, sendMessage, messages, reload, stop } = useChat<
+    UIMessage<
+      never,
+      {
+        weather: {
+          city: string;
+          weather: string;
+          status: 'loading' | 'success';
+        };
+      }
+    >
+  >({
     transport: new DefaultChatTransport({
       api: '/api/use-chat-data-ui-parts',
     }),

--- a/examples/next-openai/app/use-chat-message-metadata/page.tsx
+++ b/examples/next-openai/app/use-chat-message-metadata/page.tsx
@@ -1,23 +1,19 @@
 'use client';
 
-import { zodSchema } from '@ai-sdk/provider-utils';
+import ChatInput from '@/component/chat-input';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, UIMessage } from 'ai';
-import {
-  ExampleMetadata,
-  exampleMetadataSchema,
-} from '../api/use-chat-message-metadata/example-metadata-schema';
-import ChatInput from '@/component/chat-input';
+import { ExampleMetadata } from '../api/use-chat-message-metadata/example-metadata-schema';
+
+type MyMessage = UIMessage<ExampleMetadata>;
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat<
-    UIMessage<ExampleMetadata>
-  >({
-    transport: new DefaultChatTransport({
-      api: '/api/use-chat-message-metadata',
-    }),
-    messageMetadataSchema: zodSchema(exampleMetadataSchema),
-  });
+  const { error, status, sendMessage, messages, reload, stop } =
+    useChat<MyMessage>({
+      transport: new DefaultChatTransport({
+        api: '/api/use-chat-message-metadata',
+      }),
+    });
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">

--- a/examples/next-openai/app/use-chat-message-metadata/page.tsx
+++ b/examples/next-openai/app/use-chat-message-metadata/page.tsx
@@ -2,12 +2,17 @@
 
 import { zodSchema } from '@ai-sdk/provider-utils';
 import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport } from 'ai';
-import { exampleMetadataSchema } from '../api/use-chat-message-metadata/example-metadata-schema';
+import { DefaultChatTransport, UIMessage } from 'ai';
+import {
+  ExampleMetadata,
+  exampleMetadataSchema,
+} from '../api/use-chat-message-metadata/example-metadata-schema';
 import ChatInput from '@/component/chat-input';
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat({
+  const { error, status, sendMessage, messages, reload, stop } = useChat<
+    UIMessage<ExampleMetadata>
+  >({
     transport: new DefaultChatTransport({
       api: '/api/use-chat-message-metadata',
     }),

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -3,11 +3,7 @@ import {
   processUIMessageStream,
   StreamingUIMessageState,
 } from '../ui/process-ui-message-stream';
-import {
-  InferUIMessageData,
-  InferUIMessageMetadata,
-  UIMessage,
-} from '../ui/ui-messages';
+import { UIMessage } from '../ui/ui-messages';
 import {
   InferUIMessageStreamPart,
   UIMessageStreamPart,
@@ -53,27 +49,16 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
 
   const lastMessage = originalMessages?.[originalMessages.length - 1];
 
-  const state = createStreamingUIMessageState<
-    InferUIMessageMetadata<UI_MESSAGE>,
-    InferUIMessageData<UI_MESSAGE>
-  >({
+  const state = createStreamingUIMessageState<UI_MESSAGE>({
     lastMessage: lastMessage
-      ? (structuredClone(lastMessage) as UIMessage<
-          InferUIMessageMetadata<UI_MESSAGE>,
-          InferUIMessageData<UI_MESSAGE>
-        >)
+      ? (structuredClone(lastMessage) as UI_MESSAGE)
       : undefined,
     messageId, // will be overridden by the stream
   });
 
   const runUpdateMessageJob = async (
     job: (options: {
-      state: StreamingUIMessageState<
-        UIMessage<
-          InferUIMessageMetadata<UI_MESSAGE>,
-          InferUIMessageData<UI_MESSAGE>
-        >
-      >;
+      state: StreamingUIMessageState<UI_MESSAGE>;
       write: () => void;
     }) => Promise<void>,
   ) => {

--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -1,16 +1,13 @@
 import { UIMessageStreamPart } from '../ui-message-stream';
 import { ChatRequestOptions } from './chat';
-import { UIDataTypes, UIMessage } from './ui-messages';
+import { UIMessage } from './ui-messages';
 
-export interface ChatTransport<
-  MESSAGE_METADATA,
-  DATA_TYPES extends UIDataTypes,
-> {
+export interface ChatTransport<UI_MESSAGE extends UIMessage> {
   // TODO better name
   submitMessages: (
     options: {
       chatId: string;
-      messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
+      messages: UI_MESSAGE[];
       abortSignal: AbortSignal | undefined;
       requestType: 'generate' | 'resume'; // TODO have separate functions
     } & ChatRequestOptions,

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -22,12 +22,9 @@ import {
 import type {
   CreateUIMessage,
   FileUIPart,
-  InferUIDataParts,
   InferUIMessageData,
   InferUIMessageMetadata,
   ToolInvocationUIPart,
-  UIDataPartSchemas,
-  UIDataTypes,
   UIDataTypesToSchemas,
   UIMessage,
 } from './ui-messages';

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -253,7 +253,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
             ? [{ type: 'text' as const, text: message.text }]
             : []),
         ],
-      };
+      } as UI_MESSAGE;
     } else {
       uiMessage = message;
     }

--- a/packages/ai/src/ui/default-chat-transport.ts
+++ b/packages/ai/src/ui/default-chat-transport.ts
@@ -9,7 +9,7 @@ import {
 } from '../ui-message-stream/ui-message-stream-parts';
 import { ChatTransport } from './chat-transport';
 import { PrepareRequest } from './prepare-request';
-import { UIDataTypes } from './ui-messages';
+import { UIMessage } from './ui-messages';
 
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => fetch;
@@ -78,17 +78,15 @@ async function fetchUIMessageStream({
   );
 }
 
-export class DefaultChatTransport<
-  MESSAGE_METADATA,
-  DATA_TYPES extends UIDataTypes,
-> implements ChatTransport<MESSAGE_METADATA, DATA_TYPES>
+export class DefaultChatTransport<UI_MESSAGE extends UIMessage>
+  implements ChatTransport<UI_MESSAGE>
 {
   private api: string;
   private credentials?: RequestCredentials;
   private headers?: Record<string, string> | Headers;
   private body?: object;
   private fetch?: FetchFunction;
-  private prepareRequest?: PrepareRequest<MESSAGE_METADATA, DATA_TYPES>;
+  private prepareRequest?: PrepareRequest<UI_MESSAGE>;
 
   constructor({
     api = '/api/chat',
@@ -141,7 +139,7 @@ export class DefaultChatTransport<
      * @param messages The current messages in the chat.
      * @param requestBody The request body object passed in the chat request.
      */
-    prepareRequest?: PrepareRequest<MESSAGE_METADATA, DATA_TYPES>;
+    prepareRequest?: PrepareRequest<UI_MESSAGE>;
   } = {}) {
     this.api = api;
     this.credentials = credentials;
@@ -159,9 +157,7 @@ export class DefaultChatTransport<
     headers,
     body,
     requestType,
-  }: Parameters<
-    ChatTransport<MESSAGE_METADATA, DATA_TYPES>['submitMessages']
-  >[0]) {
+  }: Parameters<ChatTransport<UI_MESSAGE>['submitMessages']>[0]) {
     const preparedRequest = this.prepareRequest?.({
       id: chatId,
       messages,

--- a/packages/ai/src/ui/prepare-request.ts
+++ b/packages/ai/src/ui/prepare-request.ts
@@ -1,11 +1,8 @@
-import { UIDataTypes, UIMessage } from './ui-messages';
+import { UIMessage } from './ui-messages';
 
-export type PrepareRequest<
-  MESSAGE_METADATA,
-  DATA_TYPES extends UIDataTypes,
-> = (options: {
+export type PrepareRequest<UI_MESSAGE extends UIMessage> = (options: {
   id: string;
-  messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
+  messages: UI_MESSAGE[];
   requestMetadata: unknown;
   body: Record<string, any> | undefined;
   credentials: RequestCredentials | undefined;

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -1,5 +1,4 @@
 import {
-  IdGenerator,
   StandardSchemaV1,
   ToolCall,
   validateTypes,
@@ -20,7 +19,6 @@ import type {
   TextUIPart,
   ToolInvocation,
   ToolInvocationUIPart,
-  UIDataTypes,
   UIDataTypesToSchemas,
   UIMessage,
   UIMessagePart,
@@ -36,26 +34,23 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
   >;
 };
 
-export function createStreamingUIMessageState<
-  MESSAGE_METADATA = unknown,
-  UI_DATA_TYPES extends UIDataTypes = UIDataTypes,
->({
+export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
   lastMessage,
   messageId,
 }: {
-  lastMessage: UIMessage<MESSAGE_METADATA, UI_DATA_TYPES> | undefined;
+  lastMessage: UI_MESSAGE | undefined;
   messageId: string;
-}): StreamingUIMessageState<UIMessage<MESSAGE_METADATA, UI_DATA_TYPES>> {
+}): StreamingUIMessageState<UI_MESSAGE> {
   return {
     message:
       lastMessage?.role === 'assistant'
         ? lastMessage
-        : {
+        : ({
             id: messageId,
             metadata: undefined,
             role: 'assistant',
-            parts: [],
-          },
+            parts: [] as UIMessagePart<InferUIMessageData<UI_MESSAGE>>[],
+          } as UI_MESSAGE),
     activeTextPart: undefined,
     activeReasoningPart: undefined,
     partialToolCalls: {},
@@ -80,12 +75,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
   }) => void | Promise<unknown> | unknown;
   runUpdateMessageJob: (
     job: (options: {
-      state: StreamingUIMessageState<
-        UIMessage<
-          InferUIMessageMetadata<UI_MESSAGE>,
-          InferUIMessageData<UI_MESSAGE>
-        >
-      >;
+      state: StreamingUIMessageState<UI_MESSAGE>;
       write: () => void;
     }) => Promise<void>,
   ) => Promise<void>;

--- a/packages/ai/src/ui/text-stream-chat-transport.ts
+++ b/packages/ai/src/ui/text-stream-chat-transport.ts
@@ -3,7 +3,7 @@ import { UIMessageStreamPart } from '../ui-message-stream/ui-message-stream-part
 import { ChatTransport } from './chat-transport';
 import { PrepareRequest } from './prepare-request';
 import { transformTextToUiMessageStream } from './transform-text-to-ui-message-stream';
-import { UIDataTypes } from './ui-messages';
+import { UIDataTypes, UIMessage } from './ui-messages';
 
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => fetch;
@@ -62,17 +62,15 @@ async function fetchTextStream({
   });
 }
 
-export class TextStreamChatTransport<
-  MESSAGE_METADATA,
-  DATA_TYPES extends UIDataTypes,
-> implements ChatTransport<MESSAGE_METADATA, DATA_TYPES>
+export class TextStreamChatTransport<UI_MESSAGE extends UIMessage>
+  implements ChatTransport<UI_MESSAGE>
 {
   private api: string;
   private credentials?: RequestCredentials;
   private headers?: Record<string, string> | Headers;
   private body?: object;
   private fetch?: FetchFunction;
-  private prepareRequest?: PrepareRequest<MESSAGE_METADATA, DATA_TYPES>;
+  private prepareRequest?: PrepareRequest<UI_MESSAGE>;
 
   constructor({
     api,
@@ -125,7 +123,7 @@ export class TextStreamChatTransport<
      * @param messages The current messages in the chat.
      * @param requestBody The request body object passed in the chat request.
      */
-    prepareRequest?: NoInfer<PrepareRequest<MESSAGE_METADATA, DATA_TYPES>>;
+    prepareRequest?: NoInfer<PrepareRequest<UI_MESSAGE>>;
   }) {
     this.api = api;
     this.credentials = credentials;
@@ -143,9 +141,7 @@ export class TextStreamChatTransport<
     headers,
     body,
     requestType,
-  }: Parameters<
-    ChatTransport<MESSAGE_METADATA, DATA_TYPES>['submitMessages']
-  >[0]) {
+  }: Parameters<ChatTransport<UI_MESSAGE>['submitMessages']>[0]) {
     const preparedRequest = this.prepareRequest?.({
       id: chatId,
       messages,

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -197,10 +197,10 @@ export type StepStartUIPart = {
   type: 'step-start';
 };
 
-export type CreateUIMessage<
-  METADATA = unknown,
-  DATA_TYPES extends UIDataTypes = UIDataTypes,
-> = Omit<UIMessage<METADATA, DATA_TYPES>, 'id' | 'role'> & {
-  id?: UIMessage<METADATA, DATA_TYPES>['id'];
-  role?: UIMessage<METADATA, DATA_TYPES>['role'];
+export type CreateUIMessage<UI_MESSAGE extends UIMessage> = Omit<
+  UI_MESSAGE,
+  'id' | 'role'
+> & {
+  id?: UI_MESSAGE['id'];
+  role?: UI_MESSAGE['role'];
 };

--- a/packages/react/src/chat.react.ts
+++ b/packages/react/src/chat.react.ts
@@ -16,10 +16,10 @@ type SubscriptionRegistrars = {
   '~registerErrorCallback': (onChange: () => void) => () => void;
 };
 
-class ReactChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
-  implements ChatState<MESSAGE_METADATA, DATA_TYPES>
+class ReactChatState<UI_MESSAGE extends UIMessage>
+  implements ChatState<UI_MESSAGE>
 {
-  #messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
+  #messages: UI_MESSAGE[];
   #status: ChatStatus = 'ready';
   #error: Error | undefined = undefined;
 
@@ -27,7 +27,7 @@ class ReactChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
   #statusCallbacks = new Set<() => void>();
   #errorCallbacks = new Set<() => void>();
 
-  constructor(initialMessages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[] = []) {
+  constructor(initialMessages: UI_MESSAGE[] = []) {
     this.#messages = initialMessages;
   }
 
@@ -49,16 +49,16 @@ class ReactChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
     this.#callErrorCallbacks();
   }
 
-  get messages(): UIMessage<MESSAGE_METADATA, DATA_TYPES>[] {
+  get messages(): UI_MESSAGE[] {
     return this.#messages;
   }
 
-  set messages(newMessages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[]) {
+  set messages(newMessages: UI_MESSAGE[]) {
     this.#messages = [...newMessages];
     this.#callMessagesCallbacks();
   }
 
-  pushMessage = (message: UIMessage<MESSAGE_METADATA, DATA_TYPES>) => {
+  pushMessage = (message: UI_MESSAGE) => {
     this.#messages = this.#messages.concat(message);
     this.#callMessagesCallbacks();
   };
@@ -68,10 +68,7 @@ class ReactChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
     this.#callMessagesCallbacks();
   };
 
-  replaceMessage = (
-    index: number,
-    message: UIMessage<MESSAGE_METADATA, DATA_TYPES>,
-  ) => {
+  replaceMessage = (index: number, message: UI_MESSAGE) => {
     this.#messages = [
       ...this.#messages.slice(0, index),
       message,
@@ -122,22 +119,13 @@ class ReactChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
   };
 }
 
-export class Chat<
-    MESSAGE_METADATA,
-    UI_DATA_PART_SCHEMAS extends UIDataPartSchemas = UIDataPartSchemas,
-  >
-  extends AbstractChat<MESSAGE_METADATA, UI_DATA_PART_SCHEMAS>
+export class Chat<UI_MESSAGE extends UIMessage>
+  extends AbstractChat<UI_MESSAGE>
   implements SubscriptionRegistrars
 {
-  #state: ReactChatState<
-    MESSAGE_METADATA,
-    InferUIDataParts<UI_DATA_PART_SCHEMAS>
-  >;
+  #state: ReactChatState<UI_MESSAGE>;
 
-  constructor({
-    messages,
-    ...init
-  }: ChatInit<MESSAGE_METADATA, UI_DATA_PART_SCHEMAS>) {
+  constructor({ messages, ...init }: ChatInit<UI_MESSAGE>) {
     const state = new ReactChatState(messages);
     super({ ...init, state });
     this.#state = state;

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -1,8 +1,6 @@
 import {
   AbstractChat,
   ChatInit,
-  InferUIDataParts,
-  UIDataPartSchemas,
   type CreateUIMessage,
   type UIMessage,
 } from 'ai';
@@ -11,10 +9,7 @@ import { Chat } from './chat.react';
 
 export type { CreateUIMessage, UIMessage };
 
-export type UseChatHelpers<
-  MESSAGE_METADATA = unknown,
-  DATA_PART_SCHEMAS extends UIDataPartSchemas = UIDataPartSchemas,
-> = {
+export type UseChatHelpers<UI_MESSAGE extends UIMessage> = {
   /**
    * The id of the chat.
    */
@@ -26,22 +21,12 @@ export type UseChatHelpers<
    * manually to regenerate the AI response.
    */
   setMessages: (
-    messages:
-      | UIMessage<MESSAGE_METADATA, InferUIDataParts<DATA_PART_SCHEMAS>>[]
-      | ((
-          messages: UIMessage<
-            MESSAGE_METADATA,
-            InferUIDataParts<DATA_PART_SCHEMAS>
-          >[],
-        ) => UIMessage<
-          MESSAGE_METADATA,
-          InferUIDataParts<DATA_PART_SCHEMAS>
-        >[]),
+    messages: UI_MESSAGE[] | ((messages: UI_MESSAGE[]) => UI_MESSAGE[]),
   ) => void;
 
   error: Error | undefined;
 } & Pick<
-  AbstractChat<MESSAGE_METADATA, DATA_PART_SCHEMAS>,
+  AbstractChat<UI_MESSAGE>,
   | 'sendMessage'
   | 'reload'
   | 'stop'
@@ -51,12 +36,9 @@ export type UseChatHelpers<
   | 'messages'
 >;
 
-export type UseChatOptions<
-  MESSAGE_METADATA = unknown,
-  DATA_TYPE_SCHEMAS extends UIDataPartSchemas = UIDataPartSchemas,
-> = (
-  | { chat: Chat<MESSAGE_METADATA, DATA_TYPE_SCHEMAS> }
-  | ChatInit<MESSAGE_METADATA, DATA_TYPE_SCHEMAS>
+export type UseChatOptions<UI_MESSAGE extends UIMessage> = (
+  | { chat: Chat<UI_MESSAGE> }
+  | ChatInit<UI_MESSAGE>
 ) & {
   /**
 Custom throttle wait in ms for the chat messages and data updates.
@@ -65,16 +47,10 @@ Default is undefined, which disables throttling.
   experimental_throttle?: number;
 };
 
-export function useChat<
-  MESSAGE_METADATA = unknown,
-  DATA_PART_SCHEMAS extends UIDataPartSchemas = UIDataPartSchemas,
->({
+export function useChat<UI_MESSAGE extends UIMessage>({
   experimental_throttle: throttleWaitMs,
   ...options
-}: UseChatOptions<MESSAGE_METADATA, DATA_PART_SCHEMAS> = {}): UseChatHelpers<
-  MESSAGE_METADATA,
-  DATA_PART_SCHEMAS
-> {
+}: UseChatOptions<UI_MESSAGE> = {}): UseChatHelpers<UI_MESSAGE> {
   const chatRef = useRef('chat' in options ? options.chat : new Chat(options));
 
   const subscribeToMessages = useCallback(
@@ -103,17 +79,7 @@ export function useChat<
 
   const setMessages = useCallback(
     (
-      messagesParam:
-        | UIMessage<MESSAGE_METADATA, InferUIDataParts<DATA_PART_SCHEMAS>>[]
-        | ((
-            messages: UIMessage<
-              MESSAGE_METADATA,
-              InferUIDataParts<DATA_PART_SCHEMAS>
-            >[],
-          ) => UIMessage<
-            MESSAGE_METADATA,
-            InferUIDataParts<DATA_PART_SCHEMAS>
-          >[]),
+      messagesParam: UI_MESSAGE[] | ((messages: UI_MESSAGE[]) => UI_MESSAGE[]),
     ) => {
       if (typeof messagesParam === 'function') {
         messagesParam = messagesParam(messages);

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -47,7 +47,7 @@ Default is undefined, which disables throttling.
   experimental_throttle?: number;
 };
 
-export function useChat<UI_MESSAGE extends UIMessage>({
+export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   experimental_throttle: throttleWaitMs,
   ...options
 }: UseChatOptions<UI_MESSAGE> = {}): UseChatHelpers<UI_MESSAGE> {

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -1929,7 +1929,9 @@ describe('reload', () => {
 
 describe('test sending additional fields during message submission', () => {
   setupTestComponent(() => {
-    const { messages, sendMessage } = useChat({
+    type Message = UIMessage<{ test: string }>;
+
+    const { messages, sendMessage } = useChat<Message>({
       generateId: mockId(),
     });
 

--- a/packages/svelte/src/chat.svelte.ts
+++ b/packages/svelte/src/chat.svelte.ts
@@ -4,18 +4,15 @@ import {
   type ChatState,
   type ChatStatus,
   type CreateUIMessage,
-  type UIDataPartSchemas,
-  type UIDataTypes,
   type UIMessage,
 } from 'ai';
 
 export type { CreateUIMessage, UIMessage };
 
 export class Chat<
-  MESSAGE_METADATA = unknown,
-  DATA_PART_SCHEMAS extends UIDataPartSchemas = UIDataPartSchemas,
-> extends AbstractChat<MESSAGE_METADATA, DATA_PART_SCHEMAS> {
-  constructor(init: ChatInit<MESSAGE_METADATA, DATA_PART_SCHEMAS>) {
+  UI_MESSAGE extends UIMessage = UIMessage,
+> extends AbstractChat<UI_MESSAGE> {
+  constructor(init: ChatInit<UI_MESSAGE>) {
     super({
       ...init,
       state: new SvelteChatState(init.messages),
@@ -23,22 +20,22 @@ export class Chat<
   }
 }
 
-class SvelteChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
-  implements ChatState<MESSAGE_METADATA, DATA_TYPES>
+class SvelteChatState<UI_MESSAGE extends UIMessage>
+  implements ChatState<UI_MESSAGE>
 {
-  messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[];
+  messages: UI_MESSAGE[];
   status = $state<ChatStatus>('ready');
   error = $state<Error | undefined>(undefined);
 
-  constructor(messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[] = []) {
+  constructor(messages: UI_MESSAGE[] = []) {
     this.messages = $state(messages);
   }
 
-  setMessages = (messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[]) => {
+  setMessages = (messages: UI_MESSAGE[]) => {
     this.messages = messages;
   };
 
-  pushMessage = (message: UIMessage<MESSAGE_METADATA, DATA_TYPES>) => {
+  pushMessage = (message: UI_MESSAGE) => {
     this.messages.push(message);
   };
 
@@ -46,10 +43,7 @@ class SvelteChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
     this.messages.pop();
   };
 
-  replaceMessage = (
-    index: number,
-    message: UIMessage<MESSAGE_METADATA, DATA_TYPES>,
-  ) => {
+  replaceMessage = (index: number, message: UI_MESSAGE) => {
     this.messages[index] = message;
   };
 

--- a/packages/vue/src/chat.vue.ts
+++ b/packages/vue/src/chat.vue.ts
@@ -3,30 +3,26 @@ import {
   ChatInit as BaseChatInit,
   ChatState,
   ChatStatus,
-  UIDataPartSchemas,
-  UIDataTypes,
   UIMessage,
 } from 'ai';
 import { Ref, ref } from 'vue';
 
-class VueChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
-  implements ChatState<MESSAGE_METADATA, DATA_TYPES>
+class VueChatState<UI_MESSAGE extends UIMessage>
+  implements ChatState<UI_MESSAGE>
 {
-  private messagesRef: Ref<UIMessage<MESSAGE_METADATA, DATA_TYPES>[]>;
+  private messagesRef: Ref<UI_MESSAGE[]>;
   private statusRef = ref<ChatStatus>('ready');
   private errorRef = ref<Error | undefined>(undefined);
 
-  constructor(messages?: UIMessage<MESSAGE_METADATA, DATA_TYPES>[]) {
-    this.messagesRef = ref(messages ?? []) as Ref<
-      UIMessage<MESSAGE_METADATA, DATA_TYPES>[]
-    >;
+  constructor(messages?: UI_MESSAGE[]) {
+    this.messagesRef = ref(messages ?? []) as Ref<UI_MESSAGE[]>;
   }
 
-  get messages(): UIMessage<MESSAGE_METADATA, DATA_TYPES>[] {
+  get messages(): UI_MESSAGE[] {
     return this.messagesRef.value;
   }
 
-  set messages(messages: UIMessage<MESSAGE_METADATA, DATA_TYPES>[]) {
+  set messages(messages: UI_MESSAGE[]) {
     this.messagesRef.value = messages;
   }
 
@@ -46,7 +42,7 @@ class VueChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
     this.errorRef.value = error;
   }
 
-  pushMessage = (message: UIMessage<MESSAGE_METADATA, DATA_TYPES>) => {
+  pushMessage = (message: UI_MESSAGE) => {
     this.messagesRef.value.push(message);
   };
 
@@ -54,10 +50,7 @@ class VueChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
     this.messagesRef.value.pop();
   };
 
-  replaceMessage = (
-    index: number,
-    message: UIMessage<MESSAGE_METADATA, DATA_TYPES>,
-  ) => {
+  replaceMessage = (index: number, message: UI_MESSAGE) => {
     // message is cloned here because vue's deep reactivity shows unexpected behavior, particularly when updating tool invocation parts
     this.messagesRef.value[index] = { ...message };
   };
@@ -66,13 +59,9 @@ class VueChatState<MESSAGE_METADATA, DATA_TYPES extends UIDataTypes>
 }
 
 export class Chat<
-  MESSAGE_METADATA,
-  UI_DATA_PART_SCHEMAS extends UIDataPartSchemas = UIDataPartSchemas,
-> extends AbstractChat<MESSAGE_METADATA, UI_DATA_PART_SCHEMAS> {
-  constructor({
-    messages,
-    ...init
-  }: BaseChatInit<MESSAGE_METADATA, UI_DATA_PART_SCHEMAS>) {
+  UI_MESSAGE extends UIMessage,
+> extends AbstractChat<UI_MESSAGE> {
+  constructor({ messages, ...init }: BaseChatInit<UI_MESSAGE>) {
     super({
       ...init,
       state: new VueChatState(messages),


### PR DESCRIPTION
## Background

`useChat` and related types are currently parameterized on message metadata and data types. This can be simplified to a parameterized ui message type, from which the other generic parameters can then be derived.

## Summary

Use a generic `UIMessage` in `Chat` and related types.

## Future Work

* parameterize tool invocations