### PR TITLE
changed to LanguageModelV2ProviderDefinedClientTool

### DIFF
--- a/.changeset/cold-bags-move.md
+++ b/.changeset/cold-bags-move.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+update to LanguageModelV2ProviderDefinedClientTool to add server side tool later on

--- a/content/docs/02-guides/05-computer-use.mdx
+++ b/content/docs/02-guides/05-computer-use.mdx
@@ -83,7 +83,7 @@ First, ensure you have the AI SDK and [Anthropic AI SDK provider](/providers/ai-
 
 <Snippet text="pnpm add ai@alpha @ai-sdk/anthropic@alpha" />
 
-You can add Computer Use to your AI SDK applications using provider-defined tools. These tools accept various input parameters (like display height and width in the case of the computer tool) and then require that you define an execute function.
+You can add Computer Use to your AI SDK applications using provider-defined-client tools. These tools accept various input parameters (like display height and width in the case of the computer tool) and then require that you define an execute function.
 
 Here's how you could set up the Computer Tool with the AI SDK:
 

--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -96,9 +96,9 @@ const result = await generateText({
   - `operation.name`: `ai.generateText.doGenerate` and the functionId that was set through `telemetry.functionId`
   - `ai.operationId`: `"ai.generateText.doGenerate"`
   - `ai.prompt.messages`: the messages that were passed into the provider
-  - `ai.prompt.tools`: array of stringified tool definitions. The tools can be of type `function` or `provider-defined`.
+  - `ai.prompt.tools`: array of stringified tool definitions. The tools can be of type `function` or `provider-defined-client`.
     Function tools have a `name`, `description` (optional), and `parameters` (JSON schema).
-    Provider-defined tools have a `name`, `id`, and `args` (Record).
+    Provider-defined-client tools have a `name`, `id`, and `args` (Record).
   - `ai.prompt.toolChoice`: the stringified tool choice setting (JSON). It has a `type` property
     (`auto`, `none`, `required`, `tool`), and if the type is `tool`, a `toolName` property with the specific tool.
   - `ai.response.text`: the text that was generated
@@ -129,9 +129,9 @@ const result = await generateText({
   - `operation.name`: `ai.streamText.doStream` and the functionId that was set through `telemetry.functionId`
   - `ai.operationId`: `"ai.streamText.doStream"`
   - `ai.prompt.messages`: the messages that were passed into the provider
-  - `ai.prompt.tools`: array of stringified tool definitions. The tools can be of type `function` or `provider-defined`.
+  - `ai.prompt.tools`: array of stringified tool definitions. The tools can be of type `function` or `provider-defined-client`.
     Function tools have a `name`, `description` (optional), and `parameters` (JSON schema).
-    Provider-defined tools have a `name`, `id`, and `args` (Record).
+    Provider-defined-client tools have a `name`, `id`, and `args` (Record).
   - `ai.prompt.toolChoice`: the stringified tool choice setting (JSON). It has a `type` property
     (`auto`, `none`, `required`, `tool`), and if the type is `tool`, a `toolName` property with the specific tool.
   - `ai.response.text`: the text that was generated

--- a/content/providers/03-community-providers/01-custom-providers.mdx
+++ b/content/providers/03-community-providers/01-custom-providers.mdx
@@ -341,7 +341,7 @@ type LanguageModelV2FunctionTool = {
 Native provider capabilities exposed as tools:
 
 ```ts
-export type LanguageModelV2ProviderDefinedTool = {
+export type LanguageModelV2ProviderClientDefinedTool = {
   type: 'provider-defined';
   id: string; // e.g., 'anthropic.computer-use'
   name: string; // Human-readable name

--- a/content/providers/03-community-providers/01-custom-providers.mdx
+++ b/content/providers/03-community-providers/01-custom-providers.mdx
@@ -336,13 +336,13 @@ type LanguageModelV2FunctionTool = {
 };
 ```
 
-#### Provider-Defined Tools
+#### Provider-Defined Client Tools
 
 Native provider capabilities exposed as tools:
 
 ```ts
 export type LanguageModelV2ProviderClientDefinedTool = {
-  type: 'provider-defined';
+  type: 'provider-defined-client';
   id: string; // e.g., 'anthropic.computer-use'
   name: string; // Human-readable name
   args: Record<string, unknown>;

--- a/packages/ai/core/generate-text/generate-text.test.ts
+++ b/packages/ai/core/generate-text/generate-text.test.ts
@@ -1,7 +1,7 @@
 import {
   LanguageModelV2CallOptions,
   LanguageModelV2FunctionTool,
-  LanguageModelV2ProviderDefinedTool,
+  LanguageModelV2ProviderDefinedClientTool,
 } from '@ai-sdk/provider';
 import { jsonSchema } from '@ai-sdk/provider-utils';
 import { mockId } from '@ai-sdk/provider-utils/test';
@@ -1361,7 +1361,10 @@ describe('options.abortSignal', () => {
 describe('options.activeTools', () => {
   it('should filter available tools to only the ones in activeTools', async () => {
     let tools:
-      | (LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool)[]
+      | (
+          | LanguageModelV2FunctionTool
+          | LanguageModelV2ProviderDefinedClientTool
+        )[]
       | undefined;
 
     await generateText({

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -3,7 +3,7 @@ import {
   LanguageModelV2CallOptions,
   LanguageModelV2CallWarning,
   LanguageModelV2FunctionTool,
-  LanguageModelV2ProviderDefinedTool,
+  LanguageModelV2ProviderDefinedClientTool,
   LanguageModelV2StreamPart,
   SharedV2ProviderMetadata,
 } from '@ai-sdk/provider';
@@ -6463,7 +6463,10 @@ describe('streamText', () => {
   describe('options.activeTools', () => {
     it('should filter available tools to only the ones in activeTools', async () => {
       let tools:
-        | (LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool)[]
+        | (
+            | LanguageModelV2FunctionTool
+            | LanguageModelV2ProviderDefinedClientTool
+          )[]
         | undefined;
 
       const result = streamText({

--- a/packages/ai/core/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/core/prompt/prepare-tools-and-tool-choice.test.ts
@@ -15,7 +15,7 @@ const mockTools: ToolSet = {
 };
 
 const mockProviderDefinedTool: Tool = {
-  type: 'provider-defined',
+  type: 'provider-defined-client',
   id: 'provider.tool-id',
   args: { key: 'value' },
   parameters: z.object({}),
@@ -97,7 +97,7 @@ it('should correctly map tool properties', () => {
   });
 });
 
-it('should handle provider-defined tool type', () => {
+it('should handle provider-defined-client tool type', () => {
   const result = prepareToolsAndToolChoice({
     tools: mockToolsWithProviderDefined,
     toolChoice: undefined,
@@ -105,7 +105,7 @@ it('should handle provider-defined tool type', () => {
   });
   expect(result.tools).toHaveLength(3);
   expect(result.tools?.[2]).toEqual({
-    type: 'provider-defined',
+    type: 'provider-defined-client',
     name: 'providerTool',
     id: 'provider.tool-id',
     args: { key: 'value' },

--- a/packages/ai/core/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/core/prompt/prepare-tools-and-tool-choice.ts
@@ -51,9 +51,9 @@ export function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
             description: tool.description,
             parameters: asSchema(tool.parameters).jsonSchema,
           };
-        case 'provider-defined':
+        case 'provider-defined-client':
           return {
-            type: 'provider-defined' as const,
+            type: 'provider-defined-client' as const,
             name,
             id: tool.id,
             args: tool.args,

--- a/packages/ai/core/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/core/prompt/prepare-tools-and-tool-choice.ts
@@ -1,6 +1,6 @@
 import {
   LanguageModelV2FunctionTool,
-  LanguageModelV2ProviderDefinedTool,
+  LanguageModelV2ProviderDefinedClientTool,
   LanguageModelV2ToolChoice,
 } from '@ai-sdk/provider';
 import { asSchema } from '@ai-sdk/provider-utils';
@@ -18,7 +18,9 @@ export function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
   activeTools: Array<keyof TOOLS> | undefined;
 }): {
   tools:
-    | Array<LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool>
+    | Array<
+        LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedClientTool
+      >
     | undefined;
   toolChoice: LanguageModelV2ToolChoice | undefined;
 } {

--- a/packages/ai/core/tool/tool.ts
+++ b/packages/ai/core/tool/tool.ts
@@ -47,7 +47,7 @@ export type Tool<
   /**
 An optional description of what the tool does.
 Will be used by the language model to decide whether to use the tool.
-Not used for provider-defined tools.
+Not used for provider-defined-client tools.
    */
   description?: string;
 } & NeverOptional<
@@ -119,9 +119,9 @@ Function tool.
       }
     | {
         /**
-Provider-defined tool.
+Provider-defined-client tool.
      */
-        type: 'provider-defined';
+        type: 'provider-defined-client';
 
         /**
 The ID of the tool. Should follow the format `<provider-name>.<tool-name>`.

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -30,7 +30,7 @@ export function prepareTools({
   const bedrockTools: BedrockTool[] = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider-defined-client') {
       toolWarnings.push({ type: 'unsupported-tool', tool });
     } else {
       bedrockTools.push({

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -42,23 +42,23 @@ it('should correctly prepare function tools', () => {
   expect(result.toolWarnings).toEqual([]);
 });
 
-it('should correctly prepare provider-defined tools', () => {
+it('should correctly prepare provider-defined-client tools', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider-defined-client',
         id: 'anthropic.computer_20241022',
         name: 'computer',
         args: { displayWidthPx: 800, displayHeightPx: 600, displayNumber: 1 },
       },
       {
-        type: 'provider-defined',
+        type: 'provider-defined-client',
         id: 'anthropic.text_editor_20241022',
         name: 'text_editor',
         args: {},
       },
       {
-        type: 'provider-defined',
+        type: 'provider-defined-client',
         id: 'anthropic.bash_20241022',
         name: 'bash',
         args: {},
@@ -90,7 +90,7 @@ it('should add warnings for unsupported tools', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider-defined-client',
         id: 'unsupported.tool',
         name: 'unsupportedProviderTool',
         args: {},
@@ -103,7 +103,7 @@ it('should add warnings for unsupported tools', () => {
     {
       type: 'unsupported-tool',
       tool: {
-        type: 'provider-defined',
+        type: 'provider-defined-client',
         id: 'unsupported.tool',
         name: 'unsupportedProviderTool',
         args: {},

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -55,7 +55,7 @@ export function prepareTools({
           input_schema: tool.parameters,
         });
         break;
-      case 'provider-defined':
+      case 'provider-defined-client':
         switch (tool.id) {
           case 'anthropic.computer_20250124':
             betas.add('computer-use-2025-01-24');

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -39,7 +39,7 @@ function bashTool_20241022<RESULT>(
     experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
   } = {},
 ): {
-  type: 'provider-defined';
+  type: 'provider-defined-client';
   id: 'anthropic.bash_20241022';
   args: {};
   parameters: typeof Bash20241022Parameters;
@@ -47,7 +47,7 @@ function bashTool_20241022<RESULT>(
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
 } {
   return {
-    type: 'provider-defined',
+    type: 'provider-defined-client',
     id: 'anthropic.bash_20241022',
     args: {},
     parameters: Bash20241022Parameters,
@@ -87,7 +87,7 @@ function bashTool_20250124<RESULT>(
     experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
   } = {},
 ): {
-  type: 'provider-defined';
+  type: 'provider-defined-client';
   id: 'anthropic.bash_20250124';
   args: {};
   parameters: typeof Bash20250124Parameters;
@@ -95,7 +95,7 @@ function bashTool_20250124<RESULT>(
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
 } {
   return {
-    type: 'provider-defined',
+    type: 'provider-defined-client',
     id: 'anthropic.bash_20250124',
     args: {},
     parameters: Bash20250124Parameters,
@@ -165,7 +165,7 @@ function textEditorTool_20241022<RESULT>(
     experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
   } = {},
 ): {
-  type: 'provider-defined';
+  type: 'provider-defined-client';
   id: 'anthropic.text_editor_20241022';
   args: {};
   parameters: typeof TextEditor20241022Parameters;
@@ -176,7 +176,7 @@ function textEditorTool_20241022<RESULT>(
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
 } {
   return {
-    type: 'provider-defined',
+    type: 'provider-defined-client',
     id: 'anthropic.text_editor_20241022',
     args: {},
     parameters: TextEditor20241022Parameters,
@@ -246,7 +246,7 @@ function textEditorTool_20250124<RESULT>(
     experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
   } = {},
 ): {
-  type: 'provider-defined';
+  type: 'provider-defined-client';
   id: 'anthropic.text_editor_20250124';
   args: {};
   parameters: typeof TextEditor20250124Parameters;
@@ -257,7 +257,7 @@ function textEditorTool_20250124<RESULT>(
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
 } {
   return {
-    type: 'provider-defined',
+    type: 'provider-defined-client',
     id: 'anthropic.text_editor_20250124',
     args: {},
     parameters: TextEditor20250124Parameters,
@@ -340,7 +340,7 @@ function computerTool_20241022<RESULT>(options: {
   >;
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
 }): {
-  type: 'provider-defined';
+  type: 'provider-defined-client';
   id: 'anthropic.computer_20241022';
   args: {};
   parameters: typeof Computer20241022Parameters;
@@ -348,7 +348,7 @@ function computerTool_20241022<RESULT>(options: {
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
 } {
   return {
-    type: 'provider-defined',
+    type: 'provider-defined-client',
     id: 'anthropic.computer_20241022',
     args: {
       displayWidthPx: options.displayWidthPx,
@@ -476,7 +476,7 @@ function computerTool_20250124<RESULT>(options: {
   >;
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
 }): {
-  type: 'provider-defined';
+  type: 'provider-defined-client';
   id: 'anthropic.computer_20250124';
   args: {};
   parameters: typeof Computer20250124Parameters;
@@ -484,7 +484,7 @@ function computerTool_20250124<RESULT>(options: {
   experimental_toToolResultContent?: (result: RESULT) => ToolResultContent;
 } {
   return {
-    type: 'provider-defined',
+    type: 'provider-defined-client',
     id: 'anthropic.computer_20250124',
     args: {
       displayWidthPx: options.displayWidthPx,

--- a/packages/cohere/src/cohere-prepare-tools.test.ts
+++ b/packages/cohere/src/cohere-prepare-tools.test.ts
@@ -40,11 +40,11 @@ it('should process function tools correctly', () => {
   });
 });
 
-it('should add warnings for provider-defined tools', () => {
+it('should add warnings for provider-defined-client tools', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined' as const,
+        type: 'provider-defined-client' as const,
         name: 'providerTool',
         id: 'provider.tool',
         args: {},
@@ -59,7 +59,7 @@ it('should add warnings for provider-defined tools', () => {
       {
         type: 'unsupported-tool',
         tool: {
-          type: 'provider-defined' as const,
+          type: 'provider-defined-client' as const,
           name: 'providerTool',
           id: 'provider.tool',
           args: {},

--- a/packages/cohere/src/cohere-prepare-tools.ts
+++ b/packages/cohere/src/cohere-prepare-tools.ts
@@ -44,7 +44,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider-defined-client') {
       toolWarnings.push({ type: 'unsupported-tool', tool });
     } else {
       cohereTools.push({

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -77,7 +77,7 @@ export function prepareTools({
 
   const functionDeclarations = [];
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider-defined-client') {
       toolWarnings.push({ type: 'unsupported-tool', tool });
     } else {
       functionDeclarations.push({

--- a/packages/groq/src/groq-prepare-tools.ts
+++ b/packages/groq/src/groq-prepare-tools.ts
@@ -48,7 +48,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider-defined-client') {
       toolWarnings.push({ type: 'unsupported-tool', tool });
     } else {
       groqTools.push({

--- a/packages/mistral/src/mistral-prepare-tools.ts
+++ b/packages/mistral/src/mistral-prepare-tools.ts
@@ -44,7 +44,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider-defined-client') {
       toolWarnings.push({ type: 'unsupported-tool', tool });
     } else {
       mistralTools.push({

--- a/packages/openai-compatible/src/openai-compatible-prepare-tools.ts
+++ b/packages/openai-compatible/src/openai-compatible-prepare-tools.ts
@@ -48,7 +48,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider-defined-client') {
       toolWarnings.push({ type: 'unsupported-tool', tool });
     } else {
       openaiCompatTools.push({

--- a/packages/openai/src/openai-prepare-tools.ts
+++ b/packages/openai/src/openai-prepare-tools.ts
@@ -51,7 +51,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider-defined-client') {
       toolWarnings.push({ type: 'unsupported-tool', tool });
     } else {
       openaiTools.push({

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -15,13 +15,13 @@ function webSearchPreviewTool({
     timezone?: string;
   };
 } = {}): {
-  type: 'provider-defined';
+  type: 'provider-defined-client';
   id: 'openai.web_search_preview';
   args: {};
   parameters: typeof WebSearchPreviewParameters;
 } {
   return {
-    type: 'provider-defined',
+    type: 'provider-defined-client',
     id: 'openai.web_search_preview',
     args: {
       searchContextSize,

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -655,7 +655,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider-defined-client',
               id: 'openai.web_search_preview',
               name: 'web_search_preview',
               args: {
@@ -695,7 +695,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           },
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider-defined-client',
               id: 'openai.web_search_preview',
               name: 'web_search_preview',
               args: {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -45,7 +45,7 @@ export function prepareResponsesTools({
           strict: strict ? true : undefined,
         });
         break;
-      case 'provider-defined':
+      case 'provider-defined-client':
         switch (tool.id) {
           case 'openai.web_search_preview':
             openaiTools.push({

--- a/packages/provider/src/language-model/v2/index.ts
+++ b/packages/provider/src/language-model/v2/index.ts
@@ -7,7 +7,7 @@ export * from './language-model-v2-file';
 export * from './language-model-v2-finish-reason';
 export * from './language-model-v2-function-tool';
 export * from './language-model-v2-prompt';
-export * from './language-model-v2-provider-defined-tool';
+export * from './language-model-v2-provider-defined-client-tool';
 export * from './language-model-v2-reasoning';
 export * from './language-model-v2-response-metadata';
 export * from './language-model-v2-source';

--- a/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
@@ -2,7 +2,7 @@ import { JSONSchema7 } from 'json-schema';
 import { SharedV2ProviderOptions } from '../../shared/v2/shared-v2-provider-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
 import { LanguageModelV2Prompt } from './language-model-v2-prompt';
-import { LanguageModelV2ProviderDefinedTool } from './language-model-v2-provider-defined-tool';
+import { LanguageModelV2ProviderDefinedClientTool } from './language-model-v2-provider-defined-client-tool';
 import { LanguageModelV2ToolChoice } from './language-model-v2-tool-choice';
 
 export type LanguageModelV2CallOptions = {
@@ -94,7 +94,7 @@ by the model, calls will generate deterministic results.
 The tools that are available for the model.
   */
   tools?: Array<
-    LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool
+    LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedClientTool
   >;
 
   /**

--- a/packages/provider/src/language-model/v2/language-model-v2-call-warning.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-warning.ts
@@ -1,6 +1,6 @@
 import { LanguageModelV2CallOptions } from './language-model-v2-call-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
-import { LanguageModelV2ProviderDefinedTool } from './language-model-v2-provider-defined-tool';
+import { LanguageModelV2ProviderDefinedClientTool } from './language-model-v2-provider-defined-client-tool';
 
 /**
 Warning from the model provider for this call. The call will proceed, but e.g.
@@ -14,7 +14,9 @@ export type LanguageModelV2CallWarning =
     }
   | {
       type: 'unsupported-tool';
-      tool: LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool;
+      tool:
+        | LanguageModelV2FunctionTool
+        | LanguageModelV2ProviderDefinedClientTool;
       details?: string;
     }
   | {

--- a/packages/provider/src/language-model/v2/language-model-v2-provider-defined-client-tool.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-provider-defined-client-tool.ts
@@ -1,7 +1,7 @@
 /**
 The configuration of a tool that is defined by the provider.
  */
-export type LanguageModelV2ProviderDefinedTool = {
+export type LanguageModelV2ProviderDefinedClientTool = {
   /**
 The type of the tool (always 'provider-defined').
    */

--- a/packages/provider/src/language-model/v2/language-model-v2-provider-defined-client-tool.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-provider-defined-client-tool.ts
@@ -3,9 +3,9 @@ The configuration of a tool that is defined by the provider.
  */
 export type LanguageModelV2ProviderDefinedClientTool = {
   /**
-The type of the tool (always 'provider-defined').
+The type of the tool (always 'provider-defined-client').
    */
-  type: 'provider-defined';
+  type: 'provider-defined-client';
 
   /**
 The ID of the tool. Should follow the format `<provider-name>.<tool-name>`.

--- a/packages/xai/src/xai-prepare-tools.ts
+++ b/packages/xai/src/xai-prepare-tools.ts
@@ -45,7 +45,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider-defined-client') {
       toolWarnings.push({ type: 'unsupported-tool', tool });
     } else {
       xaiTools.push({


### PR DESCRIPTION
## background

The `LanguageModelV2ProviderDefinedClientTool` type was renamed from `LanguageModelV2ProviderDefinedTool` so we can add a defined server tool later on

## summary

- updated all export for `LanguageModelV2ProviderDefinedClientTool` type

## verification

- updated imports resolved 
- type is properly exported from `@ai-sdk/provider`

## tasks

- [x] update export path in language-model v2 index to reference renamed file