### PR TITLE
fix (react): `structuredClone` message in `replaceMessage`

### DIFF
--- a/.changeset/pretty-plants-watch.md
+++ b/.changeset/pretty-plants-watch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix (react): structuredClone message in replaceMessage

--- a/packages/react/src/chat.react.ts
+++ b/packages/react/src/chat.react.ts
@@ -18,8 +18,6 @@ class ReactChatState<UI_MESSAGE extends UIMessage>
   #statusCallbacks = new Set<() => void>();
   #errorCallbacks = new Set<() => void>();
 
-  #clonedMessages = new WeakMap();
-
   constructor(initialMessages: UI_MESSAGE[] = []) {
     this.#messages = initialMessages;
   }

--- a/packages/react/src/chat.react.ts
+++ b/packages/react/src/chat.react.ts
@@ -1,13 +1,4 @@
-import {
-  AbstractChat,
-  ChatInit,
-  ChatState,
-  ChatStatus,
-  InferUIDataParts,
-  UIDataPartSchemas,
-  UIDataTypes,
-  UIMessage,
-} from 'ai';
+import { AbstractChat, ChatInit, ChatState, ChatStatus, UIMessage } from 'ai';
 import { throttle } from './throttle';
 
 type SubscriptionRegistrars = {
@@ -26,6 +17,8 @@ class ReactChatState<UI_MESSAGE extends UIMessage>
   #messagesCallbacks = new Set<() => void>();
   #statusCallbacks = new Set<() => void>();
   #errorCallbacks = new Set<() => void>();
+
+  #clonedMessages = new WeakMap();
 
   constructor(initialMessages: UI_MESSAGE[] = []) {
     this.#messages = initialMessages;
@@ -71,7 +64,7 @@ class ReactChatState<UI_MESSAGE extends UIMessage>
   replaceMessage = (index: number, message: UI_MESSAGE) => {
     this.#messages = [
       ...this.#messages.slice(0, index),
-      message,
+      this.snapshot(message),
       ...this.#messages.slice(index + 1),
     ];
     this.#callMessagesCallbacks();

--- a/packages/react/src/chat.react.ts
+++ b/packages/react/src/chat.react.ts
@@ -62,6 +62,7 @@ class ReactChatState<UI_MESSAGE extends UIMessage>
   replaceMessage = (index: number, message: UI_MESSAGE) => {
     this.#messages = [
       ...this.#messages.slice(0, index),
+      // We deep clone the message here to ensure the new React Compiler (currently in RC) detects deeply nested parts/metadata changes:
       this.snapshot(message),
       ...this.#messages.slice(index + 1),
     ];


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

When using the React Compiler (currently in RC), deeply nested mutations to message parts (and likely metadata) fail to trigger re-renders even though we are re-creating the entire array messages array upon every chunk (in `replaceMessage`) 

## Summary

In `replaceMessage`, we use `structuredClone` to guarantee the message being updated reflected deeply nested changes in the React state manager

Alternatives considered:

- Apply snapshot when executing mutate job (in `AbstractChat`); this approach was vetoed because the snapshotting should be collocated to the React implementation
- Add custom cloning approach to avoid deep cloning the entire message; if users report a huge impact on performance, we can potentially pivot to this approach. For now, this is the simplest solution!

## Verification

Tested in demo Next.js project with React Compiler enabled

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

See custom clone/snapshot method snippet above

## Related Issues

Addresses https://github.com/vercel/ai/issues/6466
