### PR TITLE
feat (ai): expose ui message stream headers

### DIFF
--- a/.changeset/eighty-flowers-design.md
+++ b/.changeset/eighty-flowers-design.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): expose ui message stream headers

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream-response.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream-response.ts
@@ -1,6 +1,6 @@
 import { prepareHeaders } from '../util/prepare-headers';
 import { JsonToSseTransformStream } from './json-to-sse-transform-stream';
-import { uiMessageStreamHeaders } from './ui-message-stream-headers';
+import { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 import { UIMessageStreamPart } from './ui-message-stream-parts';
 
 export function createUIMessageStreamResponse({
@@ -18,7 +18,7 @@ export function createUIMessageStreamResponse({
     {
       status,
       statusText,
-      headers: prepareHeaders(headers, uiMessageStreamHeaders),
+      headers: prepareHeaders(headers, UI_MESSAGE_STREAM_HEADERS),
     },
   );
 }

--- a/packages/ai/src/ui-message-stream/index.ts
+++ b/packages/ai/src/ui-message-stream/index.ts
@@ -1,6 +1,7 @@
 export { createUIMessageStream } from './create-ui-message-stream';
 export { createUIMessageStreamResponse } from './create-ui-message-stream-response';
+export { JsonToSseTransformStream } from './json-to-sse-transform-stream';
+export { pipeUIMessageStreamToResponse } from './pipe-ui-message-stream-to-response';
+export { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 export type { UIMessageStreamPart } from './ui-message-stream-parts';
 export type { UIMessageStreamWriter } from './ui-message-stream-writer';
-export { pipeUIMessageStreamToResponse } from './pipe-ui-message-stream-to-response';
-export { JsonToSseTransformStream } from './json-to-sse-transform-stream';

--- a/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
+++ b/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
@@ -2,7 +2,7 @@ import { ServerResponse } from 'node:http';
 import { prepareHeaders } from '../util/prepare-headers';
 import { writeToServerResponse } from '../util/write-to-server-response';
 import { JsonToSseTransformStream } from './json-to-sse-transform-stream';
-import { uiMessageStreamHeaders } from './ui-message-stream-headers';
+import { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 import { UIMessageStreamPart } from './ui-message-stream-parts';
 
 export function pipeUIMessageStreamToResponse({
@@ -20,7 +20,7 @@ export function pipeUIMessageStreamToResponse({
     status,
     statusText,
     headers: Object.fromEntries(
-      prepareHeaders(headers, uiMessageStreamHeaders).entries(),
+      prepareHeaders(headers, UI_MESSAGE_STREAM_HEADERS).entries(),
     ),
     stream: stream
       .pipeThrough(new JsonToSseTransformStream())

--- a/packages/ai/src/ui-message-stream/ui-message-stream-headers.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-headers.ts
@@ -1,4 +1,4 @@
-export const uiMessageStreamHeaders = {
+export const UI_MESSAGE_STREAM_HEADERS = {
   'content-type': 'text/event-stream',
   'cache-control': 'no-cache',
   connection: 'keep-alive',


### PR DESCRIPTION
## Background

The UI message stream headers need to sometimes be used in custom responses, e.g. for resume stream endpoints.

## Summary

Rename and expose `UI_MESSAGE_STREAM_HEADERS`.