### PR TITLE
feat (ai): add consumeSseStream option to UI message stream responses

### DIFF
--- a/.changeset/tricky-lions-deliver.md
+++ b/.changeset/tricky-lions-deliver.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): add consumeSseStream option to UI message stream responses

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -19,6 +19,7 @@ import { StepResult } from './step-result';
 import { ToolCallUnion } from './tool-call';
 import { ToolResultUnion } from './tool-result';
 import { ToolSet } from './tool-set';
+import { UIMessageStreamResponseInit } from '../../src/ui-message-stream/ui-message-stream-response-init';
 
 export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
   /**
@@ -281,7 +282,7 @@ If an error occurs, it is passed to the optional `onError` callback.
      */
   pipeUIMessageStreamToResponse<UI_MESSAGE extends UIMessage>(
     response: ServerResponse,
-    options?: ResponseInit & UIMessageStreamOptions<UI_MESSAGE>,
+    options?: UIMessageStreamResponseInit & UIMessageStreamOptions<UI_MESSAGE>,
   ): void;
 
   /**
@@ -305,7 +306,7 @@ If an error occurs, it is passed to the optional `onError` callback.
   @return A response object.
      */
   toUIMessageStreamResponse<UI_MESSAGE extends UIMessage>(
-    options?: ResponseInit & UIMessageStreamOptions<UI_MESSAGE>,
+    options?: UIMessageStreamResponseInit & UIMessageStreamOptions<UI_MESSAGE>,
   ): Response;
 
   /**

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -77,6 +77,7 @@ import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { ToolResultUnion } from './tool-result';
 import { ToolSet } from './tool-set';
 import { getResponseUIMessageId } from '../../src/ui-message-stream/get-response-ui-message-id';
+import { UIMessageStreamResponseInit } from '../../src/ui-message-stream/ui-message-stream-response-init';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -1668,7 +1669,7 @@ However, the LLM results are expected to be small enough to not cause issues.
       sendStart,
       onError,
       ...init
-    }: ResponseInit & UIMessageStreamOptions<UI_MESSAGE> = {},
+    }: UIMessageStreamResponseInit & UIMessageStreamOptions<UI_MESSAGE> = {},
   ) {
     pipeUIMessageStreamToResponse({
       response,
@@ -1704,7 +1705,8 @@ However, the LLM results are expected to be small enough to not cause issues.
     sendStart,
     onError,
     ...init
-  }: ResponseInit & UIMessageStreamOptions<UI_MESSAGE> = {}): Response {
+  }: UIMessageStreamResponseInit &
+    UIMessageStreamOptions<UI_MESSAGE> = {}): Response {
     return createUIMessageStreamResponse({
       stream: this.toUIMessageStream({
         originalMessages,

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream-response.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream-response.test.ts
@@ -74,4 +74,192 @@ describe('createUIMessageStreamResponse', () => {
       ]
     `);
   });
+
+  it('should call consumeSseStream with a teed stream', async () => {
+    const consumedData: string[] = [];
+    const consumeSseStream = vi.fn(
+      async ({ stream }: { stream: ReadableStream<string> }) => {
+        const data = await convertReadableStreamToArray(stream);
+        consumedData.push(...data);
+      },
+    );
+
+    const response = createUIMessageStreamResponse({
+      status: 200,
+      stream: convertArrayToReadableStream([
+        { type: 'text', text: 'test-data-1' },
+        { type: 'text', text: 'test-data-2' },
+      ]),
+      consumeSseStream,
+    });
+
+    // Verify consumeSseStream was called
+    expect(consumeSseStream).toHaveBeenCalledTimes(1);
+    expect(consumeSseStream).toHaveBeenCalledWith({
+      stream: expect.any(ReadableStream),
+    });
+
+    // Verify the response stream still works correctly
+    const responseData = await convertReadableStreamToArray(
+      response.body!.pipeThrough(new TextDecoderStream()),
+    );
+
+    expect(responseData).toMatchInlineSnapshot(`
+      [
+        "data: {"type":"text","text":"test-data-1"}
+
+      ",
+        "data: {"type":"text","text":"test-data-2"}
+
+      ",
+        "data: [DONE]
+
+      ",
+      ]
+    `);
+
+    // Wait for consumeSseStream to complete
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Verify consumeSseStream received the same data
+    expect(consumedData).toMatchInlineSnapshot(`
+      [
+        "data: {"type":"text","text":"test-data-1"}
+
+      ",
+        "data: {"type":"text","text":"test-data-2"}
+
+      ",
+        "data: [DONE]
+
+      ",
+      ]
+    `);
+  });
+
+  it('should not block the response when consumeSseStream takes time', async () => {
+    let consumeResolve: () => void;
+    const consumePromise = new Promise<void>(resolve => {
+      consumeResolve = resolve;
+    });
+
+    const consumeSseStream = vi.fn(
+      async ({ stream }: { stream: ReadableStream<string> }) => {
+        // Consume the stream but wait for external resolution
+        await convertReadableStreamToArray(stream);
+        await consumePromise;
+      },
+    );
+
+    const response = createUIMessageStreamResponse({
+      status: 200,
+      stream: convertArrayToReadableStream([
+        { type: 'text', text: 'test-data' },
+      ]),
+      consumeSseStream,
+    });
+
+    // The response should be immediately available even though consumeSseStream hasn't finished
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(200);
+
+    // The response body should be readable immediately
+    const responseData = await convertReadableStreamToArray(
+      response.body!.pipeThrough(new TextDecoderStream()),
+    );
+
+    expect(responseData).toMatchInlineSnapshot(`
+      [
+        "data: {"type":"text","text":"test-data"}
+
+      ",
+        "data: [DONE]
+
+      ",
+      ]
+    `);
+
+    // Verify consumeSseStream was called but may still be running
+    expect(consumeSseStream).toHaveBeenCalledTimes(1);
+
+    // Now resolve the consumeSseStream
+    consumeResolve!();
+  });
+
+  it('should handle synchronous consumeSseStream', async () => {
+    const consumedData: string[] = [];
+    const consumeSseStream = vi.fn(
+      ({ stream }: { stream: ReadableStream<string> }) => {
+        // Synchronous consumption (not returning a promise)
+        stream.pipeTo(
+          new WritableStream({
+            write(chunk) {
+              consumedData.push(chunk);
+            },
+          }),
+        );
+      },
+    );
+
+    const response = createUIMessageStreamResponse({
+      status: 200,
+      stream: convertArrayToReadableStream([
+        { type: 'text', text: 'sync-test' },
+      ]),
+      consumeSseStream,
+    });
+
+    expect(consumeSseStream).toHaveBeenCalledTimes(1);
+
+    const responseData = await convertReadableStreamToArray(
+      response.body!.pipeThrough(new TextDecoderStream()),
+    );
+
+    expect(responseData).toMatchInlineSnapshot(`
+      [
+        "data: {"type":"text","text":"sync-test"}
+
+      ",
+        "data: [DONE]
+
+      ",
+      ]
+    `);
+  });
+
+  it('should handle consumeSseStream errors gracefully', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const consumeSseStream = vi.fn(async () => {
+      throw new Error('consumeSseStream error');
+    });
+
+    const response = createUIMessageStreamResponse({
+      status: 200,
+      stream: convertArrayToReadableStream([
+        { type: 'text', text: 'error-test' },
+      ]),
+      consumeSseStream,
+    });
+
+    // The response should still work even if consumeSseStream fails
+    const responseData = await convertReadableStreamToArray(
+      response.body!.pipeThrough(new TextDecoderStream()),
+    );
+
+    expect(responseData).toMatchInlineSnapshot(`
+      [
+        "data: {"type":"text","text":"error-test"}
+
+      ",
+        "data: [DONE]
+
+      ",
+      ]
+    `);
+
+    expect(consumeSseStream).toHaveBeenCalledTimes(1);
+
+    consoleSpy.mockRestore();
+  });
 });

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream-response.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream-response.ts
@@ -2,23 +2,31 @@ import { prepareHeaders } from '../util/prepare-headers';
 import { JsonToSseTransformStream } from './json-to-sse-transform-stream';
 import { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 import { UIMessageStreamPart } from './ui-message-stream-parts';
+import { UIMessageStreamResponseInit } from './ui-message-stream-response-init';
 
 export function createUIMessageStreamResponse({
   status,
   statusText,
   headers,
   stream,
-}: ResponseInit & {
+  consumeSseStream,
+}: UIMessageStreamResponseInit & {
   stream: ReadableStream<UIMessageStreamPart>;
 }): Response {
-  return new Response(
-    stream
-      .pipeThrough(new JsonToSseTransformStream())
-      .pipeThrough(new TextEncoderStream()),
-    {
-      status,
-      statusText,
-      headers: prepareHeaders(headers, UI_MESSAGE_STREAM_HEADERS),
-    },
-  );
+  let sseStream = stream.pipeThrough(new JsonToSseTransformStream());
+
+  // when the consumeSseStream is provided, we need to tee the stream
+  // and send the second part to the consumeSseStream function
+  // so that it can be consumed by the client independently
+  if (consumeSseStream) {
+    const [stream1, stream2] = sseStream.tee();
+    sseStream = stream1;
+    consumeSseStream({ stream: stream2 }); // no await (do not block the response)
+  }
+
+  return new Response(sseStream.pipeThrough(new TextEncoderStream()), {
+    status,
+    statusText,
+    headers: prepareHeaders(headers, UI_MESSAGE_STREAM_HEADERS),
+  });
 }

--- a/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
+++ b/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
@@ -4,6 +4,7 @@ import { writeToServerResponse } from '../util/write-to-server-response';
 import { JsonToSseTransformStream } from './json-to-sse-transform-stream';
 import { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 import { UIMessageStreamPart } from './ui-message-stream-parts';
+import { UIMessageStreamResponseInit } from './ui-message-stream-response-init';
 
 export function pipeUIMessageStreamToResponse({
   response,
@@ -11,10 +12,22 @@ export function pipeUIMessageStreamToResponse({
   statusText,
   headers,
   stream,
+  consumeSseStream,
 }: {
   response: ServerResponse;
   stream: ReadableStream<UIMessageStreamPart>;
-} & ResponseInit): void {
+} & UIMessageStreamResponseInit): void {
+  let sseStream = stream.pipeThrough(new JsonToSseTransformStream());
+
+  // when the consumeSseStream is provided, we need to tee the stream
+  // and send the second part to the consumeSseStream function
+  // so that it can be consumed by the client independently
+  if (consumeSseStream) {
+    const [stream1, stream2] = sseStream.tee();
+    sseStream = stream1;
+    consumeSseStream({ stream: stream2 }); // no await (do not block the response)
+  }
+
   writeToServerResponse({
     response,
     status,
@@ -22,8 +35,6 @@ export function pipeUIMessageStreamToResponse({
     headers: Object.fromEntries(
       prepareHeaders(headers, UI_MESSAGE_STREAM_HEADERS).entries(),
     ),
-    stream: stream
-      .pipeThrough(new JsonToSseTransformStream())
-      .pipeThrough(new TextEncoderStream()),
+    stream: sseStream.pipeThrough(new TextEncoderStream()),
   });
 }

--- a/packages/ai/src/ui-message-stream/ui-message-stream-response-init.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-response-init.ts
@@ -1,0 +1,5 @@
+export type UIMessageStreamResponseInit = ResponseInit & {
+  consumeSseStream?: (options: {
+    stream: ReadableStream<string>;
+  }) => PromiseLike<void> | void;
+};


### PR DESCRIPTION
## Background

Resumable streams need to consume a branch of the JSON SSE output without being affect by stream abortion.

## Summary

Add `consumeSseStream` that invokes callback with a teed branch of the SSE stream.