### PR TITLE
feat (ai): simplify default provider setup

### DIFF
--- a/.changeset/popular-plums-begin.md
+++ b/.changeset/popular-plums-begin.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+feat (ai): simplify default provider setup

--- a/examples/ai-core/src/stream-text/openai-global-provider.ts
+++ b/examples/ai-core/src/stream-text/openai-global-provider.ts
@@ -1,8 +1,8 @@
 import { openai } from '@ai-sdk/openai';
-import { GLOBAL_DEFAULT_PROVIDER, streamText } from 'ai';
+import { streamText } from 'ai';
 import 'dotenv/config';
 
-(globalThis as any)[GLOBAL_DEFAULT_PROVIDER] = openai;
+globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER = openai;
 
 async function main() {
   const result = streamText({

--- a/packages/ai/core/prompt/index.ts
+++ b/packages/ai/core/prompt/index.ts
@@ -35,4 +35,3 @@ export type {
   UserModelMessage,
 } from './message';
 export type { Prompt } from './prompt';
-export { GLOBAL_DEFAULT_PROVIDER } from './resolve-language-model';

--- a/packages/ai/core/prompt/resolve-language-model.test.ts
+++ b/packages/ai/core/prompt/resolve-language-model.test.ts
@@ -1,9 +1,6 @@
 import { customProvider } from '../registry/custom-provider';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
-import {
-  GLOBAL_DEFAULT_PROVIDER,
-  resolveLanguageModel,
-} from './resolve-language-model';
+import { resolveLanguageModel } from './resolve-language-model';
 
 describe('resolveLanguageModel', () => {
   describe('when a language model v2 is provided', () => {
@@ -31,7 +28,7 @@ describe('resolveLanguageModel', () => {
 
   describe('when a string is provided and the global default provider is set', () => {
     beforeEach(() => {
-      (globalThis as any)[GLOBAL_DEFAULT_PROVIDER] = customProvider({
+      globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER = customProvider({
         languageModels: {
           'test-model-id': new MockLanguageModelV2({
             provider: 'global-test-provider',
@@ -42,7 +39,7 @@ describe('resolveLanguageModel', () => {
     });
 
     afterEach(() => {
-      delete (globalThis as any)[GLOBAL_DEFAULT_PROVIDER];
+      delete globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER;
     });
 
     it('should return a language model from the global default provider', () => {

--- a/packages/ai/core/prompt/resolve-language-model.ts
+++ b/packages/ai/core/prompt/resolve-language-model.ts
@@ -1,11 +1,6 @@
 import { gateway } from '@ai-sdk/gateway';
-import { LanguageModelV2, ProviderV2 } from '@ai-sdk/provider';
+import { LanguageModelV2 } from '@ai-sdk/provider';
 import { LanguageModel } from '../types/language-model';
-
-// add type of the global default provider variable to the globalThis object
-declare global {
-  var VERCEL_AI_GLOBAL_DEFAULT_PROVIDER: ProviderV2 | undefined;
-}
 
 export function resolveLanguageModel(model: LanguageModel): LanguageModelV2 {
   if (typeof model !== 'string') {

--- a/packages/ai/core/prompt/resolve-language-model.ts
+++ b/packages/ai/core/prompt/resolve-language-model.ts
@@ -2,18 +2,16 @@ import { gateway } from '@ai-sdk/gateway';
 import { LanguageModelV2, ProviderV2 } from '@ai-sdk/provider';
 import { LanguageModel } from '../types/language-model';
 
-export const GLOBAL_DEFAULT_PROVIDER = Symbol(
-  'vercel.ai.global.defaultProvider',
-);
+// add type of the global default provider variable to the globalThis object
+declare global {
+  var VERCEL_AI_GLOBAL_DEFAULT_PROVIDER: ProviderV2 | undefined;
+}
 
 export function resolveLanguageModel(model: LanguageModel): LanguageModelV2 {
   if (typeof model !== 'string') {
     return model;
   }
 
-  const globalProvider = (globalThis as any)[GLOBAL_DEFAULT_PROVIDER] as
-    | ProviderV2
-    | undefined;
-
+  const globalProvider = globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER;
   return (globalProvider ?? gateway).languageModel(model);
 }

--- a/packages/ai/src/global.ts
+++ b/packages/ai/src/global.ts
@@ -1,0 +1,6 @@
+import { ProviderV2 } from '@ai-sdk/provider';
+
+// add type of the global default provider variable to the globalThis object
+declare global {
+  var VERCEL_AI_GLOBAL_DEFAULT_PROVIDER: ProviderV2 | undefined;
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -17,3 +17,6 @@ export * from './util';
 
 // directory exports from /core
 export * from '../core/';
+
+// import globals
+import './global';


### PR DESCRIPTION
## Background

Changing the default provider was not type safe and required an import.

## Summary

Rename and type the global variable to simplify the default provider setup.

```ts
globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER = openai;
```