### PR TITLE
feat (ui): extended regenerate support

### DIFF
--- a/.changeset/seven-fans-speak.md
+++ b/.changeset/seven-fans-speak.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+feat (ui): extended regenerate support

--- a/examples/next-openai/app/mcp/page.tsx
+++ b/examples/next-openai/app/mcp/page.tsx
@@ -5,7 +5,7 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat({
+  const { error, status, sendMessage, messages, regenerate, stop } = useChat({
     transport: new DefaultChatTransport({ api: '/mcp/chat' }),
   });
 
@@ -39,7 +39,7 @@ export default function Chat() {
           <button
             type="button"
             className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-            onClick={() => reload()}
+            onClick={() => regenerate()}
           >
             Retry
           </button>

--- a/examples/next-openai/app/page.tsx
+++ b/examples/next-openai/app/page.tsx
@@ -4,7 +4,7 @@ import { useChat } from '@ai-sdk/react';
 import ChatInput from '@/component/chat-input';
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat();
+  const { error, status, sendMessage, messages, regenerate, stop } = useChat();
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
@@ -38,7 +38,7 @@ export default function Chat() {
           <button
             type="button"
             className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-            onClick={() => reload()}
+            onClick={() => regenerate()}
           >
             Retry
           </button>

--- a/examples/next-openai/app/use-chat-custom-sources/page.tsx
+++ b/examples/next-openai/app/use-chat-custom-sources/page.tsx
@@ -5,7 +5,7 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat({
+  const { error, status, sendMessage, messages, regenerate, stop } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/use-chat-custom-sources',
     }),
@@ -60,7 +60,7 @@ export default function Chat() {
           <button
             type="button"
             className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-            onClick={() => reload()}
+            onClick={() => regenerate()}
           >
             Retry
           </button>

--- a/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
+++ b/examples/next-openai/app/use-chat-data-ui-parts/page.tsx
@@ -16,7 +16,7 @@ type MyMessage = UIMessage<
 >;
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } =
+  const { error, status, sendMessage, messages, regenerate, stop } =
     useChat<MyMessage>({
       transport: new DefaultChatTransport({
         api: '/api/use-chat-data-ui-parts',
@@ -84,7 +84,7 @@ export default function Chat() {
           <button
             type="button"
             className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-            onClick={() => reload()}
+            onClick={() => regenerate()}
           >
             Retry
           </button>

--- a/examples/next-openai/app/use-chat-message-metadata/page.tsx
+++ b/examples/next-openai/app/use-chat-message-metadata/page.tsx
@@ -8,7 +8,7 @@ import { ExampleMetadata } from '../api/use-chat-message-metadata/example-metada
 type MyMessage = UIMessage<ExampleMetadata>;
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } =
+  const { error, status, sendMessage, messages, regenerate, stop } =
     useChat<MyMessage>({
       transport: new DefaultChatTransport({
         api: '/api/use-chat-message-metadata',
@@ -60,7 +60,7 @@ export default function Chat() {
           <button
             type="button"
             className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-            onClick={() => reload()}
+            onClick={() => regenerate()}
           >
             Retry
           </button>

--- a/examples/next-openai/app/use-chat-persistence-single-message/[id]/chat.tsx
+++ b/examples/next-openai/app/use-chat-persistence-single-message/[id]/chat.tsx
@@ -14,7 +14,7 @@ export default function Chat({
     transport: new DefaultChatTransport({
       api: '/api/use-chat-persistence-single-message',
       // only send the last message to the server:
-      prepareSubmitMessagesRequest({ messages, id }) {
+      prepareSendMessagesRequest({ messages, id }) {
         return { body: { message: messages[messages.length - 1], id } };
       },
     }),

--- a/examples/next-openai/app/use-chat-reasoning/page.tsx
+++ b/examples/next-openai/app/use-chat-reasoning/page.tsx
@@ -5,7 +5,7 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat({
+  const { error, status, sendMessage, messages, regenerate, stop } = useChat({
     transport: new DefaultChatTransport({ api: '/api/use-chat-reasoning' }),
   });
 
@@ -66,7 +66,7 @@ export default function Chat() {
           <button
             type="button"
             className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-            onClick={() => reload()}
+            onClick={() => regenerate()}
           >
             Retry
           </button>

--- a/examples/next-openai/app/use-chat-resume/chat.tsx
+++ b/examples/next-openai/app/use-chat-resume/chat.tsx
@@ -14,7 +14,7 @@ export function Chat({
   autoResume: boolean;
   initialMessages: UIMessage[];
 }) {
-  const { error, status, sendMessage, messages, reload, stop } = useChat({
+  const { error, status, sendMessage, messages, regenerate, stop } = useChat({
     id,
     messages: initialMessages,
     transport: new DefaultChatTransport({ api: '/api/use-chat-resume' }),
@@ -70,7 +70,7 @@ export function Chat({
           <button
             type="button"
             className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-            onClick={() => reload()}
+            onClick={() => regenerate()}
           >
             Retry
           </button>

--- a/examples/next-openai/app/use-chat-sources/page.tsx
+++ b/examples/next-openai/app/use-chat-sources/page.tsx
@@ -5,7 +5,7 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 
 export default function Chat() {
-  const { error, status, sendMessage, messages, reload, stop } = useChat({
+  const { error, status, sendMessage, messages, regenerate, stop } = useChat({
     transport: new DefaultChatTransport({ api: '/api/use-chat-sources' }),
   });
 
@@ -58,7 +58,7 @@ export default function Chat() {
           <button
             type="button"
             className="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-            onClick={() => reload()}
+            onClick={() => regenerate()}
           >
             Retry
           </button>

--- a/examples/next/app/api/chat/route.ts
+++ b/examples/next/app/api/chat/route.ts
@@ -28,12 +28,17 @@ export async function POST(req: Request) {
         ? messages.length - 1
         : messages.findIndex(message => message.id === messageId);
 
-    if (messageIndex === -1 || messages[messageIndex].role !== 'assistant') {
-      throw new Error(`message ${messageId} is not an assistant message`);
+    if (messageIndex === -1) {
+      throw new Error(`message ${messageId} not found`);
     }
 
     // set the messages to the message before the assistant message
-    messages = messages.slice(0, messageIndex);
+    messages = messages.slice(
+      0,
+      messages[messageIndex].role === 'assistant'
+        ? messageIndex
+        : messageIndex + 1,
+    );
   }
 
   // save the user message

--- a/examples/next/app/api/chat/route.ts
+++ b/examples/next/app/api/chat/route.ts
@@ -5,11 +5,36 @@ import { after } from 'next/server';
 import { createResumableStreamContext } from 'resumable-stream';
 
 export async function POST(req: Request) {
-  const { message, id }: { message: MyUIMessage; id: string } =
-    await req.json();
+  const {
+    message,
+    id,
+    trigger,
+    messageId,
+  }: {
+    message: MyUIMessage | undefined;
+    id: string;
+    trigger: 'submit-user-message' | 'regenerate-assistant-message';
+    messageId: string | undefined;
+  } = await req.json();
 
   const chat = await readChat(id);
-  const messages = [...chat.messages, message];
+  let messages: MyUIMessage[] = chat.messages;
+
+  if (trigger === 'submit-user-message') {
+    messages = [...messages, message!];
+  } else if (trigger === 'regenerate-assistant-message') {
+    const messageIndex =
+      messageId == null
+        ? messages.length - 1
+        : messages.findIndex(message => message.id === messageId);
+
+    if (messageIndex === -1 || messages[messageIndex].role !== 'assistant') {
+      throw new Error(`message ${messageId} is not an assistant message`);
+    }
+
+    // set the messages to the message before the assistant message
+    messages = messages.slice(0, messageIndex);
+  }
 
   // save the user message
   saveChat({ id, messages, activeStreamId: null });

--- a/examples/next/app/chat/[chatId]/chat.tsx
+++ b/examples/next/app/chat/[chatId]/chat.tsx
@@ -25,7 +25,7 @@ export default function ChatComponent({
     resume,
     transport: new DefaultChatTransport({
       // only send the last message to the server to limit the request size:
-      prepareSubmitMessagesRequest: ({ id, messages }) => ({
+      prepareSendMessagesRequest: ({ id, messages }) => ({
         body: { id, message: messages[messages.length - 1] },
       }),
     }),

--- a/examples/next/app/chat/[chatId]/chat.tsx
+++ b/examples/next/app/chat/[chatId]/chat.tsx
@@ -19,15 +19,37 @@ export default function ChatComponent({
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { status, sendMessage, messages } = useChat({
+  const { status, sendMessage, messages, regenerate } = useChat({
     id: chatData.id,
     messages: chatData.messages,
     resume,
     transport: new DefaultChatTransport({
-      // only send the last message to the server to limit the request size:
-      prepareSendMessagesRequest: ({ id, messages }) => ({
-        body: { id, message: messages[messages.length - 1] },
-      }),
+      prepareSendMessagesRequest: ({ id, messages, trigger, messageId }) => {
+        switch (trigger) {
+          case 'regenerate-assistant-message':
+            // omit messages data transfer, only send the messageId:
+            return {
+              body: {
+                trigger: 'regenerate-assistant-message',
+                id,
+                messageId,
+              },
+            };
+
+          case 'submit-user-message':
+            // only send the last message to the server to limit the request size:
+            return {
+              body: {
+                trigger: 'submit-user-message',
+                id,
+                message: messages[messages.length - 1],
+              },
+            };
+
+          case 'submit-tool-result':
+            throw new Error(`submit-tool-result is not supported`);
+        }
+      },
     }),
     onFinish() {
       // for new chats, the router cache needs to be invalidated so
@@ -51,7 +73,7 @@ export default function ChatComponent({
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {messages.map(message => (
-        <Message key={message.id} message={message} />
+        <Message key={message.id} message={message} regenerate={regenerate} />
       ))}
       <ChatInput
         status={status}

--- a/examples/next/app/chat/[chatId]/message.tsx
+++ b/examples/next/app/chat/[chatId]/message.tsx
@@ -1,6 +1,12 @@
 import { MyUIMessage } from '@/util/chat-schema';
 
-export default function Message({ message }: { message: MyUIMessage }) {
+export default function Message({
+  message,
+  regenerate,
+}: {
+  message: MyUIMessage;
+  regenerate: ({ messageId }: { messageId: string }) => void;
+}) {
   const date = message.metadata?.createdAt
     ? new Date(message.metadata.createdAt).toLocaleString()
     : '';
@@ -18,6 +24,14 @@ export default function Message({ message }: { message: MyUIMessage }) {
           .map(part => (part.type === 'text' ? part.text : ''))
           .join('')}
       </div>
+      {message.role === 'assistant' && (
+        <button
+          onClick={() => regenerate({ messageId: message.id })}
+          className="px-3 py-1 mt-2 text-sm transition-colors bg-gray-200 rounded-md hover:bg-gray-300"
+        >
+          Regenerate
+        </button>
+      )}
     </div>
   );
 }

--- a/examples/next/app/chat/[chatId]/message.tsx
+++ b/examples/next/app/chat/[chatId]/message.tsx
@@ -24,7 +24,7 @@ export default function Message({
           .map(part => (part.type === 'text' ? part.text : ''))
           .join('')}
       </div>
-      {message.role === 'assistant' && (
+      {message.role === 'user' && (
         <button
           onClick={() => regenerate({ messageId: message.id })}
           className="px-3 py-1 mt-2 text-sm transition-colors bg-gray-200 rounded-md hover:bg-gray-300"

--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -9,7 +9,11 @@ export interface ChatTransport<UI_MESSAGE extends UIMessage> {
       messages: UI_MESSAGE[];
       abortSignal: AbortSignal | undefined;
     } & {
-      trigger: 'submit-user-message' | 'submit-tool-result';
+      trigger:
+        | 'submit-user-message'
+        | 'submit-tool-result'
+        | 'regenerate-assistant-message';
+      messageId: string | undefined;
     } & ChatRequestOptions,
   ) => Promise<ReadableStream<UIMessageStreamPart>>;
 

--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -3,12 +3,13 @@ import { ChatRequestOptions } from './chat';
 import { UIMessage } from './ui-messages';
 
 export interface ChatTransport<UI_MESSAGE extends UIMessage> {
-  // TODO better name
-  submitMessages: (
+  sendMessages: (
     options: {
       chatId: string;
       messages: UI_MESSAGE[];
       abortSignal: AbortSignal | undefined;
+    } & {
+      trigger: 'submit-user-message' | 'submit-tool-result';
     } & ChatRequestOptions,
   ) => Promise<ReadableStream<UIMessageStreamPart>>;
 

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -492,10 +492,11 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       })
     ) {
       await this.makeRequest({
-        trigger,
         metadata,
         headers,
         body,
+        // secondary requests are triggered by automatic tool execution
+        trigger: 'submit-tool-result',
       });
     }
   }

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -295,15 +295,18 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         ? this.state.messages.length - 1
         : this.state.messages.findIndex(message => message.id === messageId);
 
-    if (
-      messageIndex === -1 ||
-      this.state.messages[messageIndex].role !== 'assistant'
-    ) {
-      throw new Error('Message is not an assistant message');
+    if (messageIndex === -1) {
+      throw new Error(`message ${messageId} not found`);
     }
 
     // set the messages to the message before the assistant message
-    this.state.messages = this.state.messages.slice(0, messageIndex);
+    this.state.messages = this.state.messages.slice(
+      0,
+      // if the message is a user message, we need to include it in the request:
+      this.messages[messageIndex].role === 'assistant'
+        ? messageIndex
+        : messageIndex + 1,
+    );
 
     await this.makeRequest({
       trigger: 'regenerate-assistant-message',

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -14,6 +14,7 @@ export type PrepareSubmitMessagesRequest<UI_MESSAGE extends UIMessage> =
     body: Record<string, any> | undefined;
     credentials: RequestCredentials | undefined;
     headers: HeadersInit | undefined;
+    api: string;
   }) => {
     body: object;
     headers?: HeadersInit;
@@ -27,6 +28,7 @@ export type PrepareReconnectToStreamRequest = (options: {
   body: Record<string, any> | undefined;
   credentials: RequestCredentials | undefined;
   headers: HeadersInit | undefined;
+  api: string;
 }) => {
   headers?: HeadersInit;
   credentials?: RequestCredentials;
@@ -116,6 +118,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
     ...options
   }: Parameters<ChatTransport<UI_MESSAGE>['submitMessages']>[0]) {
     const preparedRequest = this.prepareSubmitMessagesRequest?.({
+      api: this.api,
       id: options.chatId,
       messages: options.messages,
       body: { ...this.body, ...options.body },
@@ -168,6 +171,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
     options: Parameters<ChatTransport<UI_MESSAGE>['reconnectToStream']>[0],
   ): Promise<ReadableStream<UIMessageStreamPart> | null> {
     const preparedRequest = this.prepareReconnectToStreamRequest?.({
+      api: this.api,
       id: options.chatId,
       body: { ...this.body, ...options.body },
       headers: { ...this.headers, ...options.headers },

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -149,6 +149,8 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
             ...options.body,
             id: options.chatId,
             messages: options.messages,
+            trigger: options.trigger,
+            messageId: options.messageId,
           };
     const credentials = preparedRequest?.credentials ?? this.credentials;
 

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -16,7 +16,11 @@ export type PrepareSendMessagesRequest<UI_MESSAGE extends UIMessage> = (
     headers: HeadersInit | undefined;
     api: string;
   } & {
-    trigger: 'submit-user-message' | 'submit-tool-result';
+    trigger:
+      | 'submit-user-message'
+      | 'submit-tool-result'
+      | 'regenerate-assistant-message';
+    messageId: string | undefined;
   },
 ) => {
   body: object;
@@ -129,6 +133,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
       credentials: this.credentials,
       requestMetadata: options.metadata,
       trigger: options.trigger,
+      messageId: options.messageId,
     });
 
     const api = preparedRequest?.api ?? this.api;

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -28,7 +28,7 @@ export type UseChatHelpers<UI_MESSAGE extends UIMessage> = {
 } & Pick<
   AbstractChat<UI_MESSAGE>,
   | 'sendMessage'
-  | 'reload'
+  | 'regenerate'
   | 'stop'
   | 'experimental_resume'
   | 'addToolResult'
@@ -107,7 +107,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     messages,
     setMessages,
     sendMessage: chatRef.current.sendMessage,
-    reload: chatRef.current.reload,
+    regenerate: chatRef.current.regenerate,
     stop: chatRef.current.stop,
     error,
     experimental_resume: chatRef.current.experimental_resume,

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -324,6 +324,7 @@ describe('data protocol stream', () => {
               "role": "user",
             },
           ],
+          "trigger": "submit-user-message",
         }
       `);
     });
@@ -1427,6 +1428,7 @@ describe('file attachments with data url', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1509,6 +1511,7 @@ describe('file attachments with data url', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1624,6 +1627,7 @@ describe('file attachments with url', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1722,6 +1726,7 @@ describe('attachments with empty submit', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1831,6 +1836,7 @@ describe('should send message with attachments', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1911,6 +1917,7 @@ describe('regenerate', () => {
           },
         ],
         "request-body-key": "request-body-value",
+        "trigger": "regenerate-assistant-message",
       }
     `);
 
@@ -1988,6 +1995,7 @@ describe('test sending additional fields during message submission', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -568,6 +568,7 @@ describe('prepareChatRequest', () => {
 
     expect(options).toMatchInlineSnapshot(`
       {
+        "api": "/api/chat",
         "body": {
           "body-key": "body-value",
           "request-body-key": "request-body-value",
@@ -593,6 +594,7 @@ describe('prepareChatRequest', () => {
         "requestMetadata": {
           "request-metadata-key": "request-metadata-value",
         },
+        "trigger": "submit-user-message",
       }
     `);
 

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -504,7 +504,7 @@ describe('prepareChatRequest', () => {
       transport: new DefaultChatTransport({
         body: { 'body-key': 'body-value' },
         headers: { 'header-key': 'header-value' },
-        prepareSubmitMessagesRequest(optionsArg) {
+        prepareSendMessagesRequest(optionsArg) {
           options = optionsArg;
           return {
             body: { 'request-body-key': 'request-body-value' },

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -579,6 +579,7 @@ describe('prepareChatRequest', () => {
           "request-header-key": "request-header-value",
         },
         "id": "id-0",
+        "messageId": undefined,
         "messages": [
           {
             "id": "id-1",
@@ -1835,9 +1836,9 @@ describe('should send message with attachments', () => {
   });
 });
 
-describe('reload', () => {
+describe('regenerate', () => {
   setupTestComponent(() => {
-    const { messages, sendMessage, reload } = useChat({
+    const { messages, sendMessage, regenerate } = useChat({
       generateId: mockId(),
     });
 
@@ -1860,9 +1861,9 @@ describe('reload', () => {
         />
 
         <button
-          data-testid="do-reload"
+          data-testid="do-regenerate"
           onClick={() => {
-            reload({
+            regenerate({
               body: { 'request-body-key': 'request-body-value' },
               headers: { 'header-key': 'header-value' },
             });
@@ -1892,7 +1893,7 @@ describe('reload', () => {
     await screen.findByTestId('message-1');
 
     // setup done, click reload:
-    await userEvent.click(screen.getByTestId('do-reload'));
+    await userEvent.click(screen.getByTestId('do-regenerate'));
 
     expect(await server.calls[1].requestBodyJson).toMatchInlineSnapshot(`
       {

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -1213,8 +1213,8 @@ describe('reload', () => {
       }),
     );
 
-    // Setup done, call reload:
-    await chat.reload({
+    // Setup done, call regenerate:
+    await chat.regenerate({
       body: { 'request-body-key': 'request-body-value' },
       headers: { 'header-key': 'header-value' },
     });

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -212,6 +212,7 @@ describe('data protocol stream', () => {
               "role": "user",
             },
           ],
+          "trigger": "submit-user-message",
         }
       `);
     });
@@ -925,6 +926,7 @@ describe('file attachments with data url', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1002,6 +1004,7 @@ describe('file attachments with data url', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1089,6 +1092,7 @@ describe('file attachments with url', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1169,6 +1173,7 @@ describe('file attachments with empty text content', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });
@@ -1235,6 +1240,7 @@ describe('reload', () => {
           },
         ],
         "request-body-key": "request-body-value",
+        "trigger": "regenerate-assistant-message",
       }
     `);
 
@@ -1297,6 +1303,7 @@ describe('test sending additional fields during message submission', () => {
             "role": "user",
           },
         ],
+        "trigger": "submit-user-message",
       }
     `);
   });

--- a/packages/vue/src/TestChatPrepareRequestBodyComponent.vue
+++ b/packages/vue/src/TestChatPrepareRequestBodyComponent.vue
@@ -8,7 +8,7 @@ const options = ref<any>();
 const chat = new Chat({
   transport: new DefaultChatTransport({
     api: '/api/chat',
-    prepareSubmitMessagesRequest(optionsArg) {
+    prepareSendMessagesRequest(optionsArg) {
       options.value = JSON.parse(JSON.stringify(optionsArg));
       return {
         body: { 'body-key': 'body-value' },

--- a/packages/vue/src/TestChatReloadComponent.vue
+++ b/packages/vue/src/TestChatReloadComponent.vue
@@ -25,9 +25,9 @@ const chat = new Chat({
     <button data-testid="do-append" @click="chat.sendMessage({ text: 'hi' })" />
 
     <button
-      data-testid="do-reload"
+      data-testid="do-regenerate"
       @click="
-        chat.reload({
+        chat.regenerate({
           body: { 'request-body-key': 'request-body-value' },
           headers: { 'header-key': 'header-value' },
         })

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -318,7 +318,7 @@ describe('reload', () => {
     await screen.findByTestId('message-1');
 
     // setup done, click reload:
-    await userEvent.click(screen.getByTestId('do-reload'));
+    await userEvent.click(screen.getByTestId('do-regenerate'));
 
     expect(await server.calls[1].requestBodyJson).toStrictEqual({
       id: expect.any(String),

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -53,6 +53,8 @@ describe('prepareSubmitMessagesRequest', () => {
 
     expect(value).toStrictEqual({
       id: expect.any(String),
+      api: '/api/chat',
+      trigger: 'submit-user-message',
       body: { 'request-body-key': 'request-body-value' },
       headers: { 'request-header-key': 'request-header-value' },
       requestMetadata: { 'request-metadata-key': 'request-metadata-value' },

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -295,7 +295,7 @@ describe('text stream', () => {
   });
 });
 
-describe('reload', () => {
+describe('regenerate', () => {
   setupTestComponent(TestChatReloadComponent);
 
   it('should show streamed response', async () => {

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -335,6 +335,7 @@ describe('regenerate', () => {
         },
       ],
       'request-body-key': 'request-body-value',
+      trigger: 'regenerate-assistant-message',
     });
 
     expect(server.calls[1].requestHeaders).toStrictEqual({


### PR DESCRIPTION
## Background

Reload was slightly misleading as a name. Regenerating any assistant message should be supported.

## Summary

* rename `reload` to `regenerate` on chat
* support optional `messageId` param and regenerate on user msgs
* rename transport `submitMessages` and related to `sendMessages`

## Verification

Tested with `next` example.