### PR TITLE
feat (ui): support message replacement in chat via messageId param on sendMessage

### DIFF
--- a/.changeset/tall-garlics-sit.md
+++ b/.changeset/tall-garlics-sit.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ui): support message replacement in chat via messageId param on sendMessage

--- a/examples/next/app/api/chat/route.ts
+++ b/examples/next/app/api/chat/route.ts
@@ -21,7 +21,18 @@ export async function POST(req: Request) {
   let messages: MyUIMessage[] = chat.messages;
 
   if (trigger === 'submit-user-message') {
-    messages = [...messages, message!];
+    if (messageId != null) {
+      const messageIndex = messages.findIndex(m => m.id === messageId);
+
+      if (messageIndex === -1) {
+        throw new Error(`message ${messageId} not found`);
+      }
+
+      messages = messages.slice(0, messageIndex);
+      messages.push(message!);
+    } else {
+      messages = [...messages, message!];
+    }
   } else if (trigger === 'regenerate-assistant-message') {
     const messageIndex =
       messageId == null

--- a/examples/next/app/chat/[chatId]/chat.tsx
+++ b/examples/next/app/chat/[chatId]/chat.tsx
@@ -43,6 +43,7 @@ export default function ChatComponent({
                 trigger: 'submit-user-message',
                 id,
                 message: messages[messages.length - 1],
+                messageId,
               },
             };
 
@@ -73,7 +74,13 @@ export default function ChatComponent({
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       {messages.map(message => (
-        <Message key={message.id} message={message} regenerate={regenerate} />
+        <Message
+          key={message.id}
+          message={message}
+          regenerate={regenerate}
+          sendMessage={sendMessage}
+          status={status}
+        />
       ))}
       <ChatInput
         status={status}

--- a/examples/next/app/chat/[chatId]/message.tsx
+++ b/examples/next/app/chat/[chatId]/message.tsx
@@ -1,9 +1,13 @@
 import { MyUIMessage } from '@/util/chat-schema';
+import { ChatStatus } from 'ai';
 
 export default function Message({
   message,
+  status,
   regenerate,
+  sendMessage,
 }: {
+  status: ChatStatus;
   message: MyUIMessage;
   regenerate: ({ messageId }: { messageId: string }) => void;
   sendMessage: ({
@@ -32,12 +36,24 @@ export default function Message({
           .join('')}
       </div>
       {message.role === 'user' && (
-        <button
-          onClick={() => regenerate({ messageId: message.id })}
-          className="px-3 py-1 mt-2 text-sm transition-colors bg-gray-200 rounded-md hover:bg-gray-300"
-        >
-          Regenerate
-        </button>
+        <>
+          <button
+            onClick={() => regenerate({ messageId: message.id })}
+            className="px-3 py-1 mt-2 text-sm transition-colors bg-gray-200 rounded-md hover:bg-gray-300"
+            disabled={status !== 'ready'}
+          >
+            Regenerate
+          </button>
+          <button
+            onClick={() =>
+              sendMessage({ text: 'Hello', messageId: message.id })
+            }
+            className="px-3 py-1 mt-2 text-sm transition-colors bg-gray-200 rounded-md hover:bg-gray-300"
+            disabled={status !== 'ready'}
+          >
+            Replace with Hello
+          </button>
+        </>
       )}
     </div>
   );

--- a/examples/next/app/chat/[chatId]/message.tsx
+++ b/examples/next/app/chat/[chatId]/message.tsx
@@ -6,6 +6,13 @@ export default function Message({
 }: {
   message: MyUIMessage;
   regenerate: ({ messageId }: { messageId: string }) => void;
+  sendMessage: ({
+    text,
+    messageId,
+  }: {
+    text: string;
+    messageId?: string;
+  }) => void;
 }) {
   const date = message.metadata?.createdAt
     ? new Date(message.metadata.createdAt).toLocaleString()

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -7,20 +7,25 @@ import { UIMessage } from './ui-messages';
 class TestChatState<UI_MESSAGE extends UIMessage>
   implements ChatState<UI_MESSAGE>
 {
+  history: UI_MESSAGE[][] = [];
+
   status: ChatStatus = 'ready';
   messages: UI_MESSAGE[];
   error: Error | undefined = undefined;
 
   constructor(initialMessages: UI_MESSAGE[] = []) {
     this.messages = initialMessages;
+    this.history.push(structuredClone(initialMessages));
   }
 
   pushMessage = (message: UI_MESSAGE) => {
     this.messages = this.messages.concat(message);
+    this.history.push(structuredClone(this.messages));
   };
 
   popMessage = () => {
     this.messages = this.messages.slice(0, -1);
+    this.history.push(structuredClone(this.messages));
   };
 
   replaceMessage = (index: number, message: UI_MESSAGE) => {
@@ -29,6 +34,7 @@ class TestChatState<UI_MESSAGE extends UIMessage>
       message,
       ...this.messages.slice(index + 1),
     ];
+    this.history.push(structuredClone(this.messages));
   };
 
   snapshot = <T>(value: T): T => value;
@@ -40,6 +46,10 @@ class TestChat extends AbstractChat<UIMessage> {
       ...init,
       state: new TestChatState(),
     });
+  }
+
+  get history() {
+    return (this.state as TestChatState<UIMessage>).history;
   }
 }
 
@@ -111,6 +121,128 @@ describe('chat', () => {
             ],
             "role": "assistant",
           },
+        ]
+      `);
+
+      expect(chat.history).toMatchInlineSnapshot(`
+        [
+          [],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "text": "Hello,",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "text": "Hello, world",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "text": "Hello, world.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
         ]
       `);
     });

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -53,15 +53,17 @@ const server = createTestServer({
 
 describe('chat', () => {
   describe('sendMessage', () => {
-    it('should send a message', async () => {
+    it('should send a simple message', async () => {
       server.urls['http://localhost:3000/api/chat'].response = {
         type: 'stream-chunks',
         chunks: [
           formatStreamPart({ type: 'start' }),
+          formatStreamPart({ type: 'start-step' }),
           formatStreamPart({ type: 'text', text: 'Hello' }),
           formatStreamPart({ type: 'text', text: ',' }),
           formatStreamPart({ type: 'text', text: ' world' }),
           formatStreamPart({ type: 'text', text: '.' }),
+          formatStreamPart({ type: 'finish-step' }),
           formatStreamPart({ type: 'finish' }),
         ],
       };
@@ -99,6 +101,9 @@ describe('chat', () => {
             "id": "id-1",
             "metadata": undefined,
             "parts": [
+              {
+                "type": "step-start",
+              },
               {
                 "text": "Hello, world.",
                 "type": "text",

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1,0 +1,113 @@
+import { createTestServer, mockId } from '@ai-sdk/provider-utils/test';
+import { DefaultChatTransport, UIMessageStreamPart } from '..';
+import { createResolvablePromise } from '../util/create-resolvable-promise';
+import { AbstractChat, ChatInit, ChatState, ChatStatus } from './chat';
+import { UIMessage } from './ui-messages';
+
+class TestChatState<UI_MESSAGE extends UIMessage>
+  implements ChatState<UI_MESSAGE>
+{
+  status: ChatStatus = 'ready';
+  messages: UI_MESSAGE[];
+  error: Error | undefined = undefined;
+
+  constructor(initialMessages: UI_MESSAGE[] = []) {
+    this.messages = initialMessages;
+  }
+
+  pushMessage = (message: UI_MESSAGE) => {
+    this.messages = this.messages.concat(message);
+  };
+
+  popMessage = () => {
+    this.messages = this.messages.slice(0, -1);
+  };
+
+  replaceMessage = (index: number, message: UI_MESSAGE) => {
+    this.messages = [
+      ...this.messages.slice(0, index),
+      message,
+      ...this.messages.slice(index + 1),
+    ];
+  };
+
+  snapshot = <T>(value: T): T => value;
+}
+
+class TestChat extends AbstractChat<UIMessage> {
+  constructor(init: ChatInit<UIMessage>) {
+    super({
+      ...init,
+      state: new TestChatState(),
+    });
+  }
+}
+
+function formatStreamPart(part: UIMessageStreamPart) {
+  return `data: ${JSON.stringify(part)}\n\n`;
+}
+
+const server = createTestServer({
+  'http://localhost:3000/api/chat': {},
+});
+
+describe('chat', () => {
+  describe('sendMessage', () => {
+    it('should send a message', async () => {
+      server.urls['http://localhost:3000/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatStreamPart({ type: 'start' }),
+          formatStreamPart({ type: 'text', text: 'Hello' }),
+          formatStreamPart({ type: 'text', text: ',' }),
+          formatStreamPart({ type: 'text', text: ' world' }),
+          formatStreamPart({ type: 'text', text: '.' }),
+          formatStreamPart({ type: 'finish' }),
+        ],
+      };
+
+      const finishPromise = createResolvablePromise<void>();
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: new DefaultChatTransport({
+          api: 'http://localhost:3000/api/chat',
+        }),
+        onFinish: () => finishPromise.resolve(),
+      });
+
+      chat.sendMessage({
+        text: 'Hello, world!',
+      });
+
+      await finishPromise.promise;
+
+      expect(chat.messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "id-0",
+            "parts": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "id": "id-1",
+            "metadata": undefined,
+            "parts": [
+              {
+                "text": "Hello, world.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -308,7 +308,7 @@ describe('chat', () => {
 
       chat.sendMessage({
         text: 'Hello, world!',
-        id: 'id-0',
+        messageId: 'id-0',
       });
 
       await finishPromise.promise;

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -240,20 +240,20 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       | (CreateUIMessage<UI_MESSAGE> & {
           text?: never;
           files?: never;
-          id?: string;
+          messageId?: string;
         })
       | {
           text: string;
           files?: FileList | FileUIPart[];
           metadata?: InferUIMessageMetadata<UI_MESSAGE>;
           parts?: never;
-          id?: string;
+          messageId?: string;
         }
       | {
           files: FileList | FileUIPart[];
           metadata?: InferUIMessageMetadata<UI_MESSAGE>;
           parts?: never;
-          id?: string;
+          messageId?: string;
         },
     options: ChatRequestOptions = {},
   ): Promise<void> => {
@@ -276,17 +276,19 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       uiMessage = message;
     }
 
-    if (message.id != null) {
+    if (message.messageId != null) {
       const messageIndex = this.state.messages.findIndex(
-        m => m.id === message.id,
+        m => m.id === message.messageId,
       );
 
       if (messageIndex === -1) {
-        throw new Error(`message with id ${message.id} not found`);
+        throw new Error(`message with id ${message.messageId} not found`);
       }
 
       if (this.state.messages[messageIndex].role !== 'user') {
-        throw new Error(`message with id ${message.id} is not a user message`);
+        throw new Error(
+          `message with id ${message.messageId} is not a user message`,
+        );
       }
 
       // remove all messages after the message with the given id
@@ -295,7 +297,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       // update the message with the new content
       this.state.replaceMessage(messageIndex, {
         ...uiMessage,
-        id: message.id,
+        id: message.messageId,
         role: uiMessage.role ?? 'user',
       } as UI_MESSAGE);
     } else {
@@ -308,7 +310,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
     await this.makeRequest({
       trigger: 'submit-user-message',
-      messageId: message.id,
+      messageId: message.messageId,
       ...options,
     });
   };

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -230,22 +230,29 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   }
 
   /**
-   * Append a user message to the chat list. This triggers the API call to fetch
+   * Appends or replaces a user message to the chat list. This triggers the API call to fetch
    * the assistant's response.
+   * If a messageId is provided, the message will be replaced.
    */
   sendMessage = async (
     message:
-      | (CreateUIMessage<UI_MESSAGE> & { text?: never; files?: never })
+      | (CreateUIMessage<UI_MESSAGE> & {
+          text?: never;
+          files?: never;
+          messageId?: string;
+        })
       | {
           text: string;
           files?: FileList | FileUIPart[];
           metadata?: InferUIMessageMetadata<UI_MESSAGE>;
           parts?: never;
+          messageId?: string;
         }
       | {
           files: FileList | FileUIPart[];
           metadata?: InferUIMessageMetadata<UI_MESSAGE>;
           parts?: never;
+          messageId?: string;
         },
     options: ChatRequestOptions = {},
   ): Promise<void> => {

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -15,7 +15,7 @@ import {
   UIMessage,
   UIMessageStreamPart,
 } from 'ai';
-import React, { act, useEffect, useRef, useState } from 'react';
+import React, { act, useRef, useState } from 'react';
 import { setupTestComponent } from './setup-test-component';
 import { useChat } from './use-chat';
 


### PR DESCRIPTION
## Background

Editing and submitting user messages is a common task in advanced chat UIs that should be easy to do with the AI SDK.

## Summary

Add `messageId` option to `sendMessage`. If set, it replaces an existing message.

## Verification

Integrated message replace into `next` example and tested it manually.