### PR TITLE
feat (providers/gateway): add createGateway shorthand alias for createGatewayProvider

### DIFF
--- a/.changeset/serious-trains-raise.md
+++ b/.changeset/serious-trains-raise.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (providers/gateway): add createGateway shorthand alias for createGatewayProvider

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -3,7 +3,11 @@ export type {
   GatewayLanguageModelEntry,
   GatewayLanguageModelSpecification,
 } from './gateway-model-entry';
-export { createGatewayProvider, gateway } from './gateway-provider';
+export {
+  createGatewayProvider,
+  createGatewayProvider as createGateway,
+  gateway,
+} from './gateway-provider';
 export type {
   GatewayProvider,
   GatewayProviderSettings,


### PR DESCRIPTION
## Background

The Gateway provider deviates from most other AI SDK provider with its custom provider creation method having the `Provider` suffix.

## Summary

This change adds a shorthand alias for the function as just `createGateway`. This lines up more clearly with custom provider methods in other modules, e.g. `google` has `createGoogleGenerativeAi` and `xai` has `createXai`.