### PR TITLE
chore (ai): rename default provider global to AI_SDK_DEFAULT_PROVIDER

### DIFF
--- a/.changeset/hot-singers-help.md
+++ b/.changeset/hot-singers-help.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): rename default provider global to AI_SDK_DEFAULT_PROVIDER

--- a/examples/ai-core/src/stream-text/openai-global-provider.ts
+++ b/examples/ai-core/src/stream-text/openai-global-provider.ts
@@ -2,7 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import { streamText } from 'ai';
 import 'dotenv/config';
 
-globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER = openai;
+globalThis.AI_SDK_DEFAULT_PROVIDER = openai;
 
 async function main() {
   const result = streamText({

--- a/packages/ai/core/prompt/resolve-language-model.test.ts
+++ b/packages/ai/core/prompt/resolve-language-model.test.ts
@@ -28,7 +28,7 @@ describe('resolveLanguageModel', () => {
 
   describe('when a string is provided and the global default provider is set', () => {
     beforeEach(() => {
-      globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER = customProvider({
+      globalThis.AI_SDK_DEFAULT_PROVIDER = customProvider({
         languageModels: {
           'test-model-id': new MockLanguageModelV2({
             provider: 'global-test-provider',
@@ -39,7 +39,7 @@ describe('resolveLanguageModel', () => {
     });
 
     afterEach(() => {
-      delete globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER;
+      delete globalThis.AI_SDK_DEFAULT_PROVIDER;
     });
 
     it('should return a language model from the global default provider', () => {

--- a/packages/ai/core/prompt/resolve-language-model.ts
+++ b/packages/ai/core/prompt/resolve-language-model.ts
@@ -7,6 +7,6 @@ export function resolveLanguageModel(model: LanguageModel): LanguageModelV2 {
     return model;
   }
 
-  const globalProvider = globalThis.VERCEL_AI_GLOBAL_DEFAULT_PROVIDER;
+  const globalProvider = globalThis.AI_SDK_DEFAULT_PROVIDER;
   return (globalProvider ?? gateway).languageModel(model);
 }

--- a/packages/ai/src/global.ts
+++ b/packages/ai/src/global.ts
@@ -2,5 +2,5 @@ import { ProviderV2 } from '@ai-sdk/provider';
 
 // add type of the global default provider variable to the globalThis object
 declare global {
-  var VERCEL_AI_GLOBAL_DEFAULT_PROVIDER: ProviderV2 | undefined;
+  var AI_SDK_DEFAULT_PROVIDER: ProviderV2 | undefined;
 }


### PR DESCRIPTION
## Background

The default provider global name was unnecessarily complex.

## Summary

Rename global variable for the default provider to `AI_SDK_DEFAULT_PROVIDER`.