### PR TITLE
chore (ui): rename experimental_resume to resumeStream

### DIFF
--- a/.changeset/ninety-cameras-wonder.md
+++ b/.changeset/ninety-cameras-wonder.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ui): rename experimental_resume to resumeStream

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -316,11 +316,9 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   };
 
   /**
-   * Resume an ongoing chat generation stream. This does not resume an aborted generation.
+   * Attempt to resume an ongoing streaming response.
    */
-  experimental_resume = async (
-    options: ChatRequestOptions = {},
-  ): Promise<void> => {
+  resumeStream = async (options: ChatRequestOptions = {}): Promise<void> => {
     await this.makeRequest({ trigger: 'resume-stream', ...options });
   };
 

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -30,7 +30,7 @@ export type UseChatHelpers<UI_MESSAGE extends UIMessage> = {
   | 'sendMessage'
   | 'regenerate'
   | 'stop'
-  | 'experimental_resume'
+  | 'resumeStream'
   | 'addToolResult'
   | 'status'
   | 'messages'
@@ -98,7 +98,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
 
   useEffect(() => {
     if (resume) {
-      chatRef.current.experimental_resume();
+      chatRef.current.resumeStream();
     }
   }, [resume, chatRef]);
 
@@ -110,7 +110,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     regenerate: chatRef.current.regenerate,
     stop: chatRef.current.stop,
     error,
-    experimental_resume: chatRef.current.experimental_resume,
+    resumeStream: chatRef.current.resumeStream,
     status,
     addToolResult: chatRef.current.addToolResult,
   };


### PR DESCRIPTION
## Background

Resume is no longer experimental.

## Summary

Rename `experimental_resume` to `resumeStream`.