### PR TITLE
refactoring (ai): move mapped type

### DIFF
--- a/packages/ai/core/tool/mcp/types.ts
+++ b/packages/ai/core/tool/mcp/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { MappedTool, ToolInputSchema } from '../tool';
+import { Tool, ToolInputSchema } from '../tool';
 import { JSONObject } from '@ai-sdk/provider';
 
 export const LATEST_PROTOCOL_VERSION = '2024-11-05';
@@ -12,6 +12,13 @@ export type ToolSchemas =
   | Record<string, { inputSchema: ToolInputSchema<JSONObject | unknown> }>
   | 'automatic'
   | undefined;
+
+type MappedTool<T extends Tool | JSONObject, OUTPUT extends any> =
+  T extends Tool<infer INPUT>
+    ? Tool<INPUT, OUTPUT>
+    : T extends JSONObject
+      ? Tool<T, OUTPUT>
+      : never;
 
 export type McpToolSet<TOOL_SCHEMAS extends ToolSchemas = 'automatic'> =
   TOOL_SCHEMAS extends Record<string, { inputSchema: ToolInputSchema<unknown> }>

--- a/packages/ai/core/tool/tool.ts
+++ b/packages/ai/core/tool/tool.ts
@@ -42,7 +42,7 @@ The tool can also contain an optional execute function for the actual execution 
  */
 export type Tool<
   INPUT extends JSONValue | unknown | never = any,
-  OUTPUT = any,
+  OUTPUT extends JSONValue | unknown | never = any,
 > = {
   /**
 An optional description of what the tool does.
@@ -160,10 +160,3 @@ export function tool(tool: Tool<never, never>): Tool<never, never>;
 export function tool(tool: any): any {
   return tool;
 }
-
-export type MappedTool<T extends Tool | JSONObject, OUTPUT extends any> =
-  T extends Tool<infer INPUT>
-    ? Tool<INPUT, OUTPUT>
-    : T extends JSONObject
-      ? Tool<T, OUTPUT>
-      : never;


### PR DESCRIPTION
## Background

Mapped type was only used for MCP client. Output was untyped.

## Summary
* move mapped type
* add type for output generic