### PR TITLE
feat (ai): allow sync tool.execute

### DIFF
--- a/.changeset/tricky-baboons-switch.md
+++ b/.changeset/tricky-baboons-switch.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): allow sync tool.execute

--- a/packages/ai/core/tool/tool.test-d.ts
+++ b/packages/ai/core/tool/tool.test-d.ts
@@ -33,7 +33,10 @@ describe('tool helper', () => {
 
     expectTypeOf(toolType).toEqualTypeOf<Tool<never, 'test'>>();
     expectTypeOf(toolType.execute).toMatchTypeOf<
-      (args: undefined, options: ToolCallOptions) => PromiseLike<'test'>
+      (
+        input: undefined,
+        options: ToolCallOptions,
+      ) => PromiseLike<'test'> | 'test'
     >();
     expectTypeOf(toolType.execute).not.toEqualTypeOf<undefined>();
     expectTypeOf(toolType.inputSchema).toEqualTypeOf<undefined>();
@@ -52,9 +55,9 @@ describe('tool helper', () => {
     expectTypeOf(toolType).toEqualTypeOf<Tool<{ number: number }, 'test'>>();
     expectTypeOf(toolType.execute).toMatchTypeOf<
       (
-        args: { number: number },
+        input: { number: number },
         options: ToolCallOptions,
-      ) => PromiseLike<'test'>
+      ) => PromiseLike<'test'> | 'test'
     >();
     expectTypeOf(toolType.execute).not.toEqualTypeOf<undefined>();
     expectTypeOf(toolType.inputSchema).toEqualTypeOf<

--- a/packages/ai/core/tool/tool.ts
+++ b/packages/ai/core/tool/tool.ts
@@ -74,7 +74,7 @@ If not provided, the tool will not be executed automatically.
       execute: (
         input: [INPUT] extends [never] ? undefined : INPUT,
         options: ToolCallOptions,
-      ) => PromiseLike<OUTPUT>;
+      ) => PromiseLike<OUTPUT> | OUTPUT;
 
       /**
   Optional conversion function that maps the tool result to multi-part tool content for LLMs.


### PR DESCRIPTION
## Background

Even tools with sync execution need to be async atm, leading to unnecessary DX overhead.

## Summary

Allow for tool.execute that is not async.