### PR TITLE
fix(ai): Use custom fetch if provided

### DIFF
--- a/.changeset/mighty-rats-jog.md
+++ b/.changeset/mighty-rats-jog.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix custom `fetch` in HttpChatTransport

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -154,7 +154,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
           };
     const credentials = preparedRequest?.credentials ?? this.credentials;
 
-    const response = await fetch(api, {
+    const response = await this.fetch(api, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -197,7 +197,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
         : { ...this.headers, ...options.headers };
     const credentials = preparedRequest?.credentials ?? this.credentials;
 
-    const response = await fetch(api, {
+    const response = await this.fetch(api, {
       method: 'GET',
       headers,
       credentials,


### PR DESCRIPTION
## Background

Fixes a bug where `fetch` was not used and it always called the global `fetch`. This was introduced in https://github.com/vercel/ai/pull/6746

## Summary

Call `this.fetch()` instead of `fetch()`

## Verification

I verified in a patched package locally.