### PR TITLE
feat(ui-utils): expose DataStreamPartType to allow external libs to wrap UI API

### DIFF
--- a/.changeset/strong-queens-whisper.md
+++ b/.changeset/strong-queens-whisper.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/ui-utils': patch
+---
+
+exposed DataStreamPartType

--- a/packages/ui-utils/src/index.ts
+++ b/packages/ui-utils/src/index.ts
@@ -16,7 +16,7 @@ export type {
 export { callChatApi } from './call-chat-api';
 export { callCompletionApi } from './call-completion-api';
 export { formatDataStreamPart, parseDataStreamPart } from './data-stream-parts';
-export type { DataStreamPart, DataStreamString } from './data-stream-parts';
+export type { DataStreamPart, DataStreamString, DataStreamPartType } from './data-stream-parts';
 export { getTextFromDataUrl } from './data-url';
 export type { DeepPartial } from './deep-partial';
 export { extractMaxToolInvocationStep } from './extract-max-tool-invocation-step';


### PR DESCRIPTION
## Background

Working on the VoltAgent library and need to expose so we can append additional data to formatted messages.

## Summary

exported `DataStreamPartType`

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
