### PR TITLE
fix (ai): fix invalid fetch call

### DIFF
--- a/.changeset/tall-deers-obey.md
+++ b/.changeset/tall-deers-obey.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): fix invalid fetch call

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -154,7 +154,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
           };
     const credentials = preparedRequest?.credentials ?? this.credentials;
 
-    const response = await this.fetch(api, {
+    const response = await this.fetch.call(undefined, api, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -197,7 +197,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
         : { ...this.headers, ...options.headers };
     const credentials = preparedRequest?.credentials ?? this.credentials;
 
-    const response = await this.fetch(api, {
+    const response = await this.fetch.call(undefined, api, {
       method: 'GET',
       headers,
       credentials,


### PR DESCRIPTION
## Background

`useChat` threw an invalid invocation error.

## Summary

Invoke fetch without `this` arg.

## Verification

Test next-openai manually.

## Related Issues

Caused by #6787