### PR TITLE
feat: add shared v2 data content for transcription models

### DIFF
--- a/examples/ai-core/src/transcribe/openai-base64.ts
+++ b/examples/ai-core/src/transcribe/openai-base64.ts
@@ -1,0 +1,21 @@
+import { openai } from '@ai-sdk/openai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'node:fs/promises';
+import 'dotenv/config';
+
+async function main() {
+  // Read audio file and convert to base64
+  const audioBuffer = await readFile('data/galileo.mp3');
+  const base64Audio = audioBuffer.toString('base64');
+
+  const result = await transcribe({
+    model: openai.transcription('whisper-1'),
+    audio: base64Audio,
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+}
+
+main().catch(console.error); 

--- a/examples/ai-core/src/transcribe/openai-base64.ts
+++ b/examples/ai-core/src/transcribe/openai-base64.ts
@@ -18,4 +18,4 @@ async function main() {
   console.log('Language:', result.language);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/examples/ai-core/src/transcribe/openai-data-url.ts
+++ b/examples/ai-core/src/transcribe/openai-data-url.ts
@@ -1,0 +1,22 @@
+import { openai } from '@ai-sdk/openai';
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'node:fs/promises';
+import 'dotenv/config';
+
+async function main() {
+  // Read audio file and create data URL
+  const audioBuffer = await readFile('data/galileo.mp3');
+  const base64Audio = audioBuffer.toString('base64');
+  const dataUrl = new URL(`data:audio/mpeg;base64,${base64Audio}`);
+
+  const result = await transcribe({
+    model: openai.transcription('whisper-1'),
+    audio: dataUrl,
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.language);
+}
+
+main().catch(console.error); 

--- a/examples/ai-core/src/transcribe/openai-data-url.ts
+++ b/examples/ai-core/src/transcribe/openai-data-url.ts
@@ -19,4 +19,4 @@ async function main() {
   console.log('Language:', result.language);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/packages/ai/core/prompt/index.ts
+++ b/packages/ai/core/prompt/index.ts
@@ -7,6 +7,7 @@ export type {
   ToolResultPart,
 } from './content-part';
 export type { DataContent } from './data-content';
+export { convertToLanguageModelV2DataContent } from './data-content';
 export {
   assistantModelMessageSchema,
   coreAssistantMessageSchema,

--- a/packages/ai/core/transcribe/transcribe.ts
+++ b/packages/ai/core/transcribe/transcribe.ts
@@ -1,4 +1,8 @@
-import { JSONValue, TranscriptionModelV2, SharedV2DataContent } from '@ai-sdk/provider';
+import {
+  JSONValue,
+  TranscriptionModelV2,
+  SharedV2DataContent,
+} from '@ai-sdk/provider';
 import { NoTranscriptGeneratedError } from '../../src/error/no-transcript-generated-error';
 import {
   audioMediaTypeSignatures,
@@ -79,14 +83,16 @@ Only applicable for HTTP-based providers.
   headers?: Record<string, string>;
 }): Promise<TranscriptionResult> {
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
-  
-  const { data: processedAudio, mediaType: detectedMediaType } = convertToLanguageModelV2DataContent(audio);
-  
-  const audioData = processedAudio instanceof URL
-    ? (await download({ url: processedAudio })).data
-    : typeof processedAudio === 'string'
-    ? convertDataContentToUint8Array(processedAudio)
-    : processedAudio;
+
+  const { data: processedAudio, mediaType: detectedMediaType } =
+    convertToLanguageModelV2DataContent(audio);
+
+  const audioData =
+    processedAudio instanceof URL
+      ? (await download({ url: processedAudio })).data
+      : typeof processedAudio === 'string'
+        ? convertDataContentToUint8Array(processedAudio)
+        : processedAudio;
 
   const result = await retry(() =>
     model.doGenerate({
@@ -94,11 +100,13 @@ Only applicable for HTTP-based providers.
       abortSignal,
       headers,
       providerOptions,
-      mediaType: detectedMediaType ??
+      mediaType:
+        detectedMediaType ??
         detectMediaType({
           data: audioData,
           signatures: audioMediaTypeSignatures,
-        }) ?? 'audio/wav',
+        }) ??
+        'audio/wav',
     }),
   );
 

--- a/packages/provider/src/language-model/v2/language-model-v2-data-content.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-data-content.ts
@@ -1,4 +1,6 @@
+import { SharedV2DataContent } from '../../shared/v2/shared-v2-data-content';
+
 /**
 Data content. Can be a Uint8Array, base64 encoded data as a string or a URL.
 */
-export type LanguageModelV2DataContent = Uint8Array | string | URL;
+export type LanguageModelV2DataContent = SharedV2DataContent;

--- a/packages/provider/src/shared/v2/index.ts
+++ b/packages/provider/src/shared/v2/index.ts
@@ -1,3 +1,4 @@
+export * from './shared-v2-data-content';
 export * from './shared-v2-headers';
 export * from './shared-v2-provider-metadata';
 export * from './shared-v2-provider-options';

--- a/packages/provider/src/shared/v2/shared-v2-data-content.ts
+++ b/packages/provider/src/shared/v2/shared-v2-data-content.ts
@@ -1,4 +1,4 @@
 /**
 Shared data content for v2 models. Can be a URL, data URL, Uint8Array, or base64 encoded string.
 */
-export type SharedV2DataContent = Uint8Array | string | URL; 
+export type SharedV2DataContent = Uint8Array | string | URL;

--- a/packages/provider/src/shared/v2/shared-v2-data-content.ts
+++ b/packages/provider/src/shared/v2/shared-v2-data-content.ts
@@ -1,0 +1,4 @@
+/**
+Shared data content for v2 models. Can be a URL, data URL, Uint8Array, or base64 encoded string.
+*/
+export type SharedV2DataContent = Uint8Array | string | URL; 


### PR DESCRIPTION
## background

transcription models had inconsistent data content handling compared to language models, requiring separate type definitions and limiting support for URLs and data URLs.

## summary

- add SharedV2DataContent type for unified data handling across model types
- update transcription models to support URLs, data URLs, and base64 strings
- replace LanguageModelV2DataContent with shared type

## verification

- all packages build successfully
- existing transcription examples continue working
- new examples demonstrate URL and data URL support

## tasks

- [x] SharedV2DataContent type in packages/provider/src/shared/v2/
- [x] LanguageModelV2DataContent updated to use shared type
- [x] transcribe() function supports new data content types
- [x] examples for base64 and data URL transcription 