### PR TITLE
fix: use appropriate domain for vertex global

### DIFF
--- a/.changeset/dull-grapes-remember.md
+++ b/.changeset/dull-grapes-remember.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': minor
+---
+
+Fixed global region for vertex provider

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -140,4 +140,40 @@ describe('google-vertex-anthropic-provider', () => {
     // Verify that supportedUrls returns empty object to force base64 conversion
     expect(config.supportedUrls?.()).toEqual({});
   });
+  
+  it('should use correct URL for global location', () => {
+    const provider = createVertexAnthropic({
+      project: 'test-project',
+      location: 'global',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      {},
+      expect.objectContaining({
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/anthropic/models',
+        provider: 'vertex.anthropic.messages',
+      }),
+    );
+  });
+
+  it('should use region-prefixed URL for non-global locations', () => {
+    const provider = createVertexAnthropic({
+      project: 'test-project',
+      location: 'us-east5',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      {},
+      expect.objectContaining({
+        baseURL:
+          'https://us-east5-aiplatform.googleapis.com/v1/projects/test-project/locations/us-east5/publishers/anthropic/models',
+        provider: 'vertex.anthropic.messages',
+      }),
+    );
+  });
 });

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -140,7 +140,7 @@ describe('google-vertex-anthropic-provider', () => {
     // Verify that supportedUrls returns empty object to force base64 conversion
     expect(config.supportedUrls?.()).toEqual({});
   });
-  
+
   it('should use correct URL for global location', () => {
     const provider = createVertexAnthropic({
       project: 'test-project',

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -150,7 +150,6 @@ describe('google-vertex-anthropic-provider', () => {
 
     expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
       'test-model-id',
-      {},
       expect.objectContaining({
         baseURL:
           'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/anthropic/models',
@@ -168,7 +167,6 @@ describe('google-vertex-anthropic-provider', () => {
 
     expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
       'test-model-id',
-      {},
       expect.objectContaining({
         baseURL:
           'https://us-east5-aiplatform.googleapis.com/v1/projects/test-project/locations/us-east5/publishers/anthropic/models',

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -74,9 +74,10 @@ export function createVertexAnthropic(
     settingValue: options.project,
     environmentVariableName: 'GOOGLE_VERTEX_PROJECT',
   });
+
   const baseURL =
     withoutTrailingSlash(options.baseURL) ??
-    `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`;
+    `https://${location === 'global' ? '' : location + '-'}aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`;
 
   const createChatModel = (modelId: GoogleVertexAnthropicMessagesModelId) =>
     new AnthropicMessagesLanguageModel(modelId, {

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -154,4 +154,104 @@ describe('google-vertex-provider', () => {
       }),
     );
   });
+
+  it('should create an image model with custom maxImagesPerCall', () => {
+    const provider = createVertex({
+      project: 'test-project',
+      location: 'test-location',
+    });
+    const imageSettings = {
+      maxImagesPerCall: 4,
+    };
+    provider.image('imagen-3.0-generate-002', imageSettings);
+
+    expect(GoogleVertexImageModel).toHaveBeenCalledWith(
+      'imagen-3.0-generate-002',
+      imageSettings,
+      expect.objectContaining({
+        provider: 'google.vertex.image',
+        headers: expect.any(Object),
+        baseURL:
+          'https://test-location-aiplatform.googleapis.com/v1/projects/test-project/locations/test-location/publishers/google',
+      }),
+    );
+  });
+
+  it('should use correct URL for global region', () => {
+    const provider = createVertex({
+      project: 'test-project',
+      location: 'global',
+    });
+    provider('test-model-id');
+
+    expect(GoogleGenerativeAILanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      {},
+      expect.objectContaining({
+        provider: 'google.vertex.chat',
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/google',
+        headers: expect.any(Object),
+        generateId: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should use correct URL for global region with embedding model', () => {
+    const provider = createVertex({
+      project: 'test-project',
+      location: 'global',
+    });
+    provider.textEmbeddingModel('test-embedding-model');
+
+    expect(GoogleVertexEmbeddingModel).toHaveBeenCalledWith(
+      'test-embedding-model',
+      {},
+      expect.objectContaining({
+        provider: 'google.vertex.embedding',
+        headers: expect.any(Object),
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/google',
+      }),
+    );
+  });
+
+  it('should use correct URL for global region with image model', () => {
+    const provider = createVertex({
+      project: 'test-project',
+      location: 'global',
+    });
+    provider.image('imagen-3.0-generate-002');
+
+    expect(GoogleVertexImageModel).toHaveBeenCalledWith(
+      'imagen-3.0-generate-002',
+      {},
+      expect.objectContaining({
+        provider: 'google.vertex.image',
+        baseURL:
+          'https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/google',
+        headers: expect.any(Object),
+      }),
+    );
+  });
+
+  it('should use region-prefixed URL for non-global regions', () => {
+    const provider = createVertex({
+      project: 'test-project',
+      location: 'us-central1',
+    });
+    provider('test-model-id');
+
+    expect(GoogleGenerativeAILanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      {},
+      expect.objectContaining({
+        provider: 'google.vertex.chat',
+        baseURL:
+          'https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google',
+        headers: expect.any(Object),
+        generateId: expect.any(Function),
+      }),
+    );
+  });
 });

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -155,27 +155,6 @@ describe('google-vertex-provider', () => {
     );
   });
 
-  it('should create an image model with custom maxImagesPerCall', () => {
-    const provider = createVertex({
-      project: 'test-project',
-      location: 'test-location',
-    });
-    const imageSettings = {
-      maxImagesPerCall: 4,
-    };
-    provider.image('imagen-3.0-generate-002', imageSettings);
-
-    expect(GoogleVertexImageModel).toHaveBeenCalledWith(
-      'imagen-3.0-generate-002',
-      expect.objectContaining({
-        provider: 'google.vertex.image',
-        headers: expect.any(Object),
-        baseURL:
-          'https://test-location-aiplatform.googleapis.com/v1/projects/test-project/locations/test-location/publishers/google',
-      }),
-    );
-  });
-
   it('should use correct URL for global region', () => {
     const provider = createVertex({
       project: 'test-project',

--- a/packages/google-vertex/src/google-vertex-provider.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider.test.ts
@@ -167,7 +167,6 @@ describe('google-vertex-provider', () => {
 
     expect(GoogleVertexImageModel).toHaveBeenCalledWith(
       'imagen-3.0-generate-002',
-      imageSettings,
       expect.objectContaining({
         provider: 'google.vertex.image',
         headers: expect.any(Object),
@@ -186,7 +185,6 @@ describe('google-vertex-provider', () => {
 
     expect(GoogleGenerativeAILanguageModel).toHaveBeenCalledWith(
       'test-model-id',
-      {},
       expect.objectContaining({
         provider: 'google.vertex.chat',
         baseURL:
@@ -206,7 +204,6 @@ describe('google-vertex-provider', () => {
 
     expect(GoogleVertexEmbeddingModel).toHaveBeenCalledWith(
       'test-embedding-model',
-      {},
       expect.objectContaining({
         provider: 'google.vertex.embedding',
         headers: expect.any(Object),
@@ -225,7 +222,6 @@ describe('google-vertex-provider', () => {
 
     expect(GoogleVertexImageModel).toHaveBeenCalledWith(
       'imagen-3.0-generate-002',
-      {},
       expect.objectContaining({
         provider: 'google.vertex.image',
         baseURL:
@@ -244,7 +240,6 @@ describe('google-vertex-provider', () => {
 
     expect(GoogleGenerativeAILanguageModel).toHaveBeenCalledWith(
       'test-model-id',
-      {},
       expect.objectContaining({
         provider: 'google.vertex.chat',
         baseURL:

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -97,7 +97,7 @@ export function createVertex(
     // For global region, use aiplatform.googleapis.com directly
     // For other regions, use region-aiplatform.googleapis.com
     const baseHost = `${region === 'global' ? '' : region + '-'}aiplatform.googleapis.com`;
-    
+
     return (
       withoutTrailingSlash(options.baseURL) ??
       `https://${baseHost}/v1/projects/${project}/locations/${region}/publishers/google`

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -93,9 +93,14 @@ export function createVertex(
   const loadBaseURL = () => {
     const region = loadVertexLocation();
     const project = loadVertexProject();
+
+    // For global region, use aiplatform.googleapis.com directly
+    // For other regions, use region-aiplatform.googleapis.com
+    const baseHost = `${region === 'global' ? '' : region + '-'}aiplatform.googleapis.com`;
+    
     return (
       withoutTrailingSlash(options.baseURL) ??
-      `https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/publishers/google`
+      `https://${baseHost}/v1/projects/${project}/locations/${region}/publishers/google`
     );
   };
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
Global region for google vertex does not work, this is especially necessary as some models in their first release are exclusively available on global region. As of today this is the case for gemini-2.5-flash-lite.

To test this just set the following env flag
`GOOGLE_VERTEX_LOCATION="global"`

The pattern used in @ai-sdk/google-vertex is 
`https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/publishers/google`

However for global endpoints the domain is different ([see docs](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#genai-partner-models))
`https://aiplatform.googleapis.com/v1/...`

Resulting in the following error
```js
error: APICallError [AI_APICallError]: Publisher Model `projects/[PROJECT_ID]/locations/us-central1/publishers/google/models/gemini-2.5-flash-lite-preview-06-17` was not found or your project does not have access to it. Please ensure you are using a valid model version. For more information, see: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions
      at <anonymous> ([LOCAL_PATH]/node_modules/@ai-sdk/provider-utils/src/response-handler.ts:59:16)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async postToApi ([LOCAL_PATH]/node_modules/@ai-sdk/provider-utils/src/post-to-api.ts:111:28)
      at async GoogleGenerativeAILanguageModel.doStream ([LOCAL_PATH]/node_modules/@ai-sdk/google/src/google-generative-ai-language-model.ts:311:50)
      at async fn ([LOCAL_PATH]/node_modules/ai/core/generate-text/stream-text.ts:1032:25)
      at async <anonymous> ([LOCAL_PATH]/node_modules/ai/core/telemetry/record-span.ts:18:22)
      at async _retryWithExponentialBackoff ([LOCAL_PATH]/node_modules/ai/util/retry-with-exponential-backoff.ts:36:12)
      at async streamStep ([LOCAL_PATH]/node_modules/ai/core/generate-text/stream-text.ts:987:15)
      at async fn ([LOCAL_PATH]/node_modules/ai/core/generate-text/stream-text.ts:1466:9)
      at async <anonymous> ([LOCAL_PATH]/node_modules/ai/core/telemetry/record-span.ts:18:22) {
    cause: undefined,
    url: 'https://global-aiplatform.googleapis.com/v1/projects/[PROJECT_ID]/locations/us-central1/publishers/google/models/gemini-2.5-flash-lite-preview-06-17:streamGenerateContent?alt=sse',
```

## Summary

Toggle to use a different pattern in case `region === 'global'`

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
