### PR TITLE
feat (ai): add InferToolInput and InferToolOutput helpers

### DIFF
--- a/.changeset/shy-hotels-allow.md
+++ b/.changeset/shy-hotels-allow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+feat (ai): add InferToolInput and InferToolOutput helpers

--- a/examples/ai-core/src/generate-text/anthropic-web-search.ts
+++ b/examples/ai-core/src/generate-text/anthropic-web-search.ts
@@ -32,7 +32,7 @@ async function main() {
     switch (toolResult.toolName) {
       case 'web_search': {
         toolResult.input.query; // string
-        toolResult.output.results; // string
+        // toolResult.output.results; // string
         break;
       }
     }

--- a/examples/next-openai/app/api/use-chat-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-tools/route.ts
@@ -1,6 +1,8 @@
 import { openai } from '@ai-sdk/openai';
 import {
   convertToModelMessages,
+  InferToolInput,
+  InferUITool,
   stepCountIs,
   streamText,
   tool,
@@ -12,20 +14,61 @@ import { z } from 'zod';
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
 
+const getWeatherInformationTool = tool({
+  description: 'show the weather in a given city to the user',
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }: { city: string }, { messages }) => {
+    // count the number of assistant messages. throw error if 2 or less
+    const assistantMessageCount = messages.filter(
+      message => message.role === 'assistant',
+    ).length;
+
+    if (assistantMessageCount <= 2) {
+      throw new Error('could not get weather information');
+    }
+
+    // Add artificial delay of 5 seconds
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
+    return weatherOptions[Math.floor(Math.random() * weatherOptions.length)];
+  },
+
+  onInputStart: () => {
+    console.log('onInputStart');
+  },
+  onInputDelta: ({ inputTextDelta }) => {
+    console.log('onInputDelta', inputTextDelta);
+  },
+  onInputAvailable: ({ input }) => {
+    console.log('onInputAvailable', input);
+  },
+});
+
+const askForConfirmationTool = tool({
+  description: 'Ask the user for confirmation.',
+  inputSchema: z.object({
+    message: z.string().describe('The message to ask for confirmation.'),
+  }),
+});
+
+const getLocationTool = tool({
+  description:
+    'Get the user location. Always ask for confirmation before using this tool.',
+  inputSchema: z.object({}),
+});
+
 export type UseChatToolsMessage = UIMessage<
   never,
   UIDataTypes,
   {
-    getWeatherInformation: {
-      input: { city: string };
-      output: string;
-    };
+    getWeatherInformation: InferUITool<typeof getWeatherInformationTool>;
     askForConfirmation: {
-      input: { message: string };
+      input: InferToolInput<typeof askForConfirmationTool>;
       output: string;
     };
     getLocation: {
-      input: {};
+      input: InferToolInput<typeof getLocationTool>;
       output: string;
     };
   }
@@ -36,56 +79,15 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: openai('gpt-4o'),
-    // model: anthropic('claude-3-5-sonnet-latest'),
     messages: convertToModelMessages(messages),
     stopWhen: stepCountIs(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:
-      getWeatherInformation: tool({
-        description: 'show the weather in a given city to the user',
-        inputSchema: z.object({ city: z.string() }),
-        execute: async ({ city }: { city: string }, { messages }) => {
-          // count the number of assistant messages. throw error if 2 or less
-          const assistantMessageCount = messages.filter(
-            message => message.role === 'assistant',
-          ).length;
-
-          if (assistantMessageCount <= 2) {
-            throw new Error('could not get weather information');
-          }
-
-          // Add artificial delay of 5 seconds
-          await new Promise(resolve => setTimeout(resolve, 5000));
-
-          const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
-          return weatherOptions[
-            Math.floor(Math.random() * weatherOptions.length)
-          ];
-        },
-
-        onInputStart: () => {
-          console.log('onInputStart');
-        },
-        onInputDelta: ({ inputTextDelta }) => {
-          console.log('onInputDelta', inputTextDelta);
-        },
-        onInputAvailable: ({ input }) => {
-          console.log('onInputAvailable', input);
-        },
-      }),
+      getWeatherInformation: getWeatherInformationTool,
       // client-side tool that starts user interaction:
-      askForConfirmation: tool({
-        description: 'Ask the user for confirmation.',
-        inputSchema: z.object({
-          message: z.string().describe('The message to ask for confirmation.'),
-        }),
-      }),
+      askForConfirmation: askForConfirmationTool,
       // client-side tool that is automatically executed on the client:
-      getLocation: tool({
-        description:
-          'Get the user location. Always ask for confirmation before using this tool.',
-        inputSchema: z.object({}),
-      }),
+      getLocation: getLocationTool,
     },
   });
 

--- a/packages/ai/core/generate-text/tool-output.ts
+++ b/packages/ai/core/generate-text/tool-output.ts
@@ -1,5 +1,5 @@
 import { ValueOf } from '../../src/util/value-of';
-import { Tool } from '@ai-sdk/provider-utils';
+import { InferToolInput, InferToolOutput, Tool } from '@ai-sdk/provider-utils';
 import { ToolSet } from './tool-set';
 
 // limits the tools to those that have execute !== undefined
@@ -15,8 +15,8 @@ type ToToolResultObject<TOOLS extends ToolSet> = ValueOf<{
     type: 'tool-result';
     toolCallId: string;
     toolName: NAME & string;
-    input: TOOLS[NAME] extends Tool<infer P> ? P : never;
-    output: Awaited<ReturnType<Exclude<TOOLS[NAME]['execute'], undefined>>>;
+    input: InferToolInput<TOOLS[NAME]>;
+    output: InferToolOutput<TOOLS[NAME]>;
   };
 }>;
 
@@ -33,7 +33,7 @@ type ToToolErrorObject<TOOLS extends ToolSet> = ValueOf<{
     type: 'tool-error';
     toolCallId: string;
     toolName: NAME & string;
-    input: TOOLS[NAME] extends Tool<infer P> ? P : never;
+    input: InferToolInput<TOOLS[NAME]>;
     error: unknown;
   };
 }>;

--- a/packages/ai/core/tool/index.ts
+++ b/packages/ai/core/tool/index.ts
@@ -8,3 +8,13 @@ export type {
 export { createMCPClient as experimental_createMCPClient } from './mcp/mcp-client';
 export type { MCPTransport } from './mcp/mcp-transport';
 export { tool } from './tool';
+
+// re-export types from provider-utils
+export type {
+  Tool,
+  ToolCallOptions,
+  ToolExecuteFunction,
+  ToolInputSchema,
+  InferToolInput,
+  InferToolOutput,
+} from '@ai-sdk/provider-utils';

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -18,6 +18,9 @@ export {
 export { DefaultChatTransport } from './default-chat-transport';
 export { TextStreamChatTransport } from './text-stream-chat-transport';
 export {
+  type UITool,
+  type InferUITool,
+  type UITools,
   type DataUIPart,
   type FileUIPart,
   type ReasoningUIPart,

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -1,3 +1,4 @@
+import { InferToolInput, InferToolOutput, Tool } from '@ai-sdk/provider-utils';
 import { DeepPartial } from '../util/deep-partial';
 import { ValueOf } from '../util/value-of';
 
@@ -6,13 +7,17 @@ The data types that can be used in the UI message for the UI message data parts.
  */
 export type UIDataTypes = Record<string, unknown>;
 
-export type UITools = Record<
-  string,
-  {
-    input: unknown;
-    output: unknown | undefined;
-  }
->;
+export type UITool = {
+  input: unknown;
+  output: unknown | undefined;
+};
+
+export type InferUITool<TOOL extends Tool> = {
+  input: InferToolInput<TOOL>;
+  output: InferToolOutput<TOOL>;
+};
+
+export type UITools = Record<string, UITool>;
 
 /**
 AI SDK UI Messages. They are used in the client and to communicate between the frontend and the API routes.

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -19,6 +19,8 @@ export type {
   ToolCallOptions,
   ToolExecuteFunction,
   ToolInputSchema,
+  InferToolInput,
+  InferToolOutput,
 } from './tool';
 export type { ToolCall } from './tool-call';
 export type { ToolContent, ToolModelMessage } from './tool-model-message';

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -155,3 +155,15 @@ The arguments for configuring the tool. Must match the expected arguments define
         args: Record<string, unknown>;
       }
   );
+
+/**
+ * Infer the input type of a tool.
+ */
+export type InferToolInput<TOOL extends Tool> =
+  TOOL extends Tool<infer INPUT, any> ? INPUT : never;
+
+/**
+ * Infer the output type of a tool.
+ */
+export type InferToolOutput<TOOL extends Tool> =
+  TOOL extends Tool<any, infer OUTPUT> ? OUTPUT : never;


### PR DESCRIPTION
## Background

Helpers for inferring tool inputs and output simplify the ui tool setup and are a step towards supporting server side tools.

## Summary

* add `InferToolInput`, `InferToolOutput`, and `InferUITool` helpers.

## Verification

Test type inference in next-open tools example.