### PR TITLE
feat (ai): add output schema for tools

### DIFF
--- a/.changeset/tough-islands-sniff.md
+++ b/.changeset/tough-islands-sniff.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': major
+---
+
+feat (ai): add output schema for tools

--- a/examples/ai-core/src/generate-text/openai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-call.ts
@@ -36,12 +36,11 @@ async function main() {
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
     switch (toolResult.toolName) {
-      // NOT AVAILABLE (NO EXECUTE METHOD)
-      // case 'cityAttractions': {
-      //   toolResult.input.city; // string
-      //   toolResult.result;
-      //   break;
-      // }
+      case 'cityAttractions': {
+        toolResult.input.city; // string
+        toolResult.output; // any since no outputSchema is provided
+        break;
+      }
 
       case 'weather': {
         toolResult.input.location; // string

--- a/examples/next-openai/app/api/use-chat-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-tools/route.ts
@@ -1,7 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import {
   convertToModelMessages,
-  InferToolInput,
   InferUITool,
   stepCountIs,
   streamText,
@@ -50,12 +49,14 @@ const askForConfirmationTool = tool({
   inputSchema: z.object({
     message: z.string().describe('The message to ask for confirmation.'),
   }),
+  outputSchema: z.string(),
 });
 
 const getLocationTool = tool({
   description:
     'Get the user location. Always ask for confirmation before using this tool.',
   inputSchema: z.object({}),
+  outputSchema: z.string(),
 });
 
 export type UseChatToolsMessage = UIMessage<
@@ -63,14 +64,8 @@ export type UseChatToolsMessage = UIMessage<
   UIDataTypes,
   {
     getWeatherInformation: InferUITool<typeof getWeatherInformationTool>;
-    askForConfirmation: {
-      input: InferToolInput<typeof askForConfirmationTool>;
-      output: string;
-    };
-    getLocation: {
-      input: InferToolInput<typeof getLocationTool>;
-      output: string;
-    };
+    askForConfirmation: InferUITool<typeof askForConfirmationTool>;
+    getLocation: InferUITool<typeof getLocationTool>;
   }
 >;
 

--- a/packages/ai/core/tool/tool.test-d.ts
+++ b/packages/ai/core/tool/tool.test-d.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import {
   Tool,
-  ToolCallOptions,
   ToolExecuteFunction,
   FlexibleSchema,
 } from '@ai-sdk/provider-utils';
@@ -37,7 +36,7 @@ describe('tool helper', () => {
 
     expectTypeOf(toolType).toEqualTypeOf<Tool<never, 'test'>>();
     expectTypeOf(toolType.execute).toMatchTypeOf<
-      ToolExecuteFunction<never, 'test'>
+      ToolExecuteFunction<never, 'test'> | undefined
     >();
     expectTypeOf(toolType.execute).not.toEqualTypeOf<undefined>();
     expectTypeOf(toolType.inputSchema).toEqualTypeOf<undefined>();
@@ -54,10 +53,7 @@ describe('tool helper', () => {
 
     expectTypeOf(toolType).toEqualTypeOf<Tool<{ number: number }, 'test'>>();
     expectTypeOf(toolType.execute).toMatchTypeOf<
-      (
-        input: { number: number },
-        options: ToolCallOptions,
-      ) => PromiseLike<'test'> | 'test'
+      ToolExecuteFunction<{ number: number }, 'test'> | undefined
     >();
     expectTypeOf(toolType.execute).not.toEqualTypeOf<undefined>();
     expectTypeOf(toolType.inputSchema).toEqualTypeOf<

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -88,15 +88,6 @@ Use descriptions to make the input understandable for the language model.
     OUTPUT,
     {
       /**
-An async function that is called with the arguments from the tool call and produces a result.
-If not provided, the tool will not be executed automatically.
-
-@args is the input of the tool call.
-@options.abortSignal is a signal that can be used to abort the tool call.
-      */
-      execute: ToolExecuteFunction<INPUT, OUTPUT>;
-
-      /**
 Optional conversion function that maps the tool result to an output that can be used by the language model.
 
 If not provided, the tool result will be sent as a JSON object.
@@ -104,7 +95,25 @@ If not provided, the tool result will be sent as a JSON object.
       toModelOutput?: (
         output: OUTPUT,
       ) => LanguageModelV2ToolResultPart['output'];
-    }
+    } & (
+      | {
+          /**
+An async function that is called with the arguments from the tool call and produces a result.
+If not provided, the tool will not be executed automatically.
+
+@args is the input of the tool call.
+@options.abortSignal is a signal that can be used to abort the tool call.
+      */
+          execute: ToolExecuteFunction<INPUT, OUTPUT>;
+
+          outputSchema?: FlexibleSchema<OUTPUT>;
+        }
+      | {
+          outputSchema: FlexibleSchema<OUTPUT>;
+
+          execute?: never;
+        }
+    )
   > &
   (
     | {

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -47,6 +47,30 @@ Will be used by the language model to decide whether to use the tool.
 Not used for provider-defined-client tools.
    */
   description?: string;
+
+  /**
+   * Optional function that is called when the argument streaming starts.
+   * Only called when the tool is used in a streaming context.
+   */
+  onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
+
+  /**
+   * Optional function that is called when an argument streaming delta is available.
+   * Only called when the tool is used in a streaming context.
+   */
+  onInputDelta?: (
+    options: { inputTextDelta: string } & ToolCallOptions,
+  ) => void | PromiseLike<void>;
+
+  /**
+   * Optional function that is called when a tool call can be started,
+   * even if the execute function is not provided.
+   */
+  onInputAvailable?: (
+    options: {
+      input: INPUT extends never ? undefined : INPUT;
+    } & ToolCallOptions,
+  ) => void | PromiseLike<void>;
 } & NeverOptional<
   INPUT,
   {
@@ -78,30 +102,6 @@ If not provided, the tool result will be sent as a JSON object.
       toModelOutput?: (
         output: OUTPUT,
       ) => LanguageModelV2ToolResultPart['output'];
-
-      /**
-       * Optional function that is called when the argument streaming starts.
-       * Only called when the tool is used in a streaming context.
-       */
-      onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
-
-      /**
-       * Optional function that is called when an argument streaming delta is available.
-       * Only called when the tool is used in a streaming context.
-       */
-      onInputDelta?: (
-        options: { inputTextDelta: string } & ToolCallOptions,
-      ) => void | PromiseLike<void>;
-
-      /**
-       * Optional function that is called when a tool call can be started,
-       * even if the execute function is not provided.
-       */
-      onInputAvailable?: (
-        options: {
-          input: [INPUT] extends [never] ? undefined : INPUT;
-        } & ToolCallOptions,
-      ) => void | PromiseLike<void>;
     }
   > &
   (

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -25,6 +25,8 @@ export type ToolExecuteFunction<INPUT, OUTPUT> = (
   options: ToolCallOptions,
 ) => PromiseLike<OUTPUT> | OUTPUT;
 
+// 0 extends 1 & N checks for any
+// [N] extends [never] checks for never
 type NeverOptional<N, T> = 0 extends 1 & N
   ? Partial<T>
   : [N] extends [never]
@@ -47,30 +49,6 @@ Will be used by the language model to decide whether to use the tool.
 Not used for provider-defined-client tools.
    */
   description?: string;
-
-  /**
-   * Optional function that is called when the argument streaming starts.
-   * Only called when the tool is used in a streaming context.
-   */
-  onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
-
-  /**
-   * Optional function that is called when an argument streaming delta is available.
-   * Only called when the tool is used in a streaming context.
-   */
-  onInputDelta?: (
-    options: { inputTextDelta: string } & ToolCallOptions,
-  ) => void | PromiseLike<void>;
-
-  /**
-   * Optional function that is called when a tool call can be started,
-   * even if the execute function is not provided.
-   */
-  onInputAvailable?: (
-    options: {
-      input: INPUT extends never ? undefined : INPUT;
-    } & ToolCallOptions,
-  ) => void | PromiseLike<void>;
 } & NeverOptional<
   INPUT,
   {
@@ -80,6 +58,30 @@ It is also used to validate the output of the language model.
 Use descriptions to make the input understandable for the language model.
    */
     inputSchema: FlexibleSchema<INPUT>;
+
+    /**
+     * Optional function that is called when the argument streaming starts.
+     * Only called when the tool is used in a streaming context.
+     */
+    onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
+
+    /**
+     * Optional function that is called when an argument streaming delta is available.
+     * Only called when the tool is used in a streaming context.
+     */
+    onInputDelta?: (
+      options: { inputTextDelta: string } & ToolCallOptions,
+    ) => void | PromiseLike<void>;
+
+    /**
+     * Optional function that is called when a tool call can be started,
+     * even if the execute function is not provided.
+     */
+    onInputAvailable?: (
+      options: {
+        input: [INPUT] extends [never] ? undefined : INPUT;
+      } & ToolCallOptions,
+    ) => void | PromiseLike<void>;
   }
 > &
   NeverOptional<


### PR DESCRIPTION
## Background

Server side tools and tools without an execute method need a way to specify the output schema to drive type inference and validation.

## Summary

Add optional `outputSchema` property to tools.