### PR TITLE
chore: add language setting to speechv2

### DIFF
--- a/.changeset/lovely-chicken-speak.md
+++ b/.changeset/lovely-chicken-speak.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+chore: add language setting to speechv2

--- a/content/docs/03-ai-sdk-core/37-speech.mdx
+++ b/content/docs/03-ai-sdk-core/37-speech.mdx
@@ -22,6 +22,21 @@ const audio = await generateSpeech({
 });
 ```
 
+### Language Setting
+
+You can specify the language for speech generation (provider support varies):
+
+```ts
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { lmnt } from '@ai-sdk/lmnt';
+
+const audio = await generateSpeech({
+  model: lmnt.speech('aurora'),
+  text: 'Hola, mundo!',
+  language: 'es', // Spanish
+});
+```
+
 To access the generated audio:
 
 ```ts

--- a/content/docs/07-reference/01-ai-sdk-core/12-generate-speech.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/12-generate-speech.mdx
@@ -71,6 +71,12 @@ console.log(audio);
       description: 'The speed of the speech generation.',
     },
     {
+      name: 'language',
+      type: 'string',
+      isOptional: true,
+      description: 'The language for speech generation. This should be an ISO 639-1 language code (e.g. "en", "es", "fr") or "auto" for automatic language detection. Provider support varies.',
+    },
+    {
       name: 'providerOptions',
       type: 'Record<string, Record<string, JSONValue>>',
       isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/12-generate-speech.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/12-generate-speech.mdx
@@ -74,7 +74,8 @@ console.log(audio);
       name: 'language',
       type: 'string',
       isOptional: true,
-      description: 'The language for speech generation. This should be an ISO 639-1 language code (e.g. "en", "es", "fr") or "auto" for automatic language detection. Provider support varies.',
+      description:
+        'The language for speech generation. This should be an ISO 639-1 language code (e.g. "en", "es", "fr") or "auto" for automatic language detection. Provider support varies.',
     },
     {
       name: 'providerOptions',

--- a/content/providers/01-ai-sdk-providers/140-lmnt.mdx
+++ b/content/providers/01-ai-sdk-providers/140-lmnt.mdx
@@ -84,19 +84,6 @@ const result = await generateSpeech({
 });
 ```
 
-You can also use provider-specific options as an alternative:
-
-```ts highlight="6"
-import { experimental_generateSpeech as generateSpeech } from 'ai';
-import { lmnt } from '@ai-sdk/lmnt';
-
-const result = await generateSpeech({
-  model: lmnt.speech('aurora'),
-  text: 'Hello, world!',
-  providerOptions: { lmnt: { language: 'en' } },
-});
-```
-
 ### Provider Options
 
 The LMNT provider accepts the following options:

--- a/content/providers/01-ai-sdk-providers/140-lmnt.mdx
+++ b/content/providers/01-ai-sdk-providers/140-lmnt.mdx
@@ -80,6 +80,19 @@ import { lmnt } from '@ai-sdk/lmnt';
 const result = await generateSpeech({
   model: lmnt.speech('aurora'),
   text: 'Hello, world!',
+  language: 'en', // Standardized language parameter
+});
+```
+
+You can also use provider-specific options as an alternative:
+
+```ts highlight="6"
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { lmnt } from '@ai-sdk/lmnt';
+
+const result = await generateSpeech({
+  model: lmnt.speech('aurora'),
+  text: 'Hello, world!',
   providerOptions: { lmnt: { language: 'en' } },
 });
 ```

--- a/examples/ai-core/src/generate-speech/hume-language.ts
+++ b/examples/ai-core/src/generate-speech/hume-language.ts
@@ -1,0 +1,21 @@
+import { hume } from '@ai-sdk/hume';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import 'dotenv/config';
+import { saveAudioFile } from '../lib/save-audio';
+
+async function main() {
+  const result = await generateSpeech({
+    model: hume.speech(),
+    text: 'Hello from the AI SDK!',
+    language: 'en',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
+
+  await saveAudioFile(result.audio);
+}
+
+main().catch(console.error); 

--- a/examples/ai-core/src/generate-speech/hume-language.ts
+++ b/examples/ai-core/src/generate-speech/hume-language.ts
@@ -18,4 +18,4 @@ async function main() {
   await saveAudioFile(result.audio);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/examples/ai-core/src/generate-speech/lmnt-language.ts
+++ b/examples/ai-core/src/generate-speech/lmnt-language.ts
@@ -1,0 +1,21 @@
+import { lmnt } from '@ai-sdk/lmnt';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import 'dotenv/config';
+import { saveAudioFile } from '../lib/save-audio';
+
+async function main() {
+  const result = await generateSpeech({
+    model: lmnt.speech('aurora'),
+    text: 'Hola desde el AI SDK!',
+    language: 'es', // Spanish using standardized parameter
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
+
+  await saveAudioFile(result.audio);
+}
+
+main().catch(console.error); 

--- a/examples/ai-core/src/generate-speech/lmnt-language.ts
+++ b/examples/ai-core/src/generate-speech/lmnt-language.ts
@@ -18,4 +18,4 @@ async function main() {
   await saveAudioFile(result.audio);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/examples/ai-core/src/generate-speech/openai-language.ts
+++ b/examples/ai-core/src/generate-speech/openai-language.ts
@@ -1,0 +1,21 @@
+import { openai } from '@ai-sdk/openai';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import 'dotenv/config';
+import { saveAudioFile } from '../lib/save-audio';
+
+async function main() {
+  const result = await generateSpeech({
+    model: openai.speech('tts-1'),
+    text: 'Hello from the AI SDK!',
+    language: 'en',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
+
+  await saveAudioFile(result.audio);
+}
+
+main().catch(console.error); 

--- a/examples/ai-core/src/generate-speech/openai-language.ts
+++ b/examples/ai-core/src/generate-speech/openai-language.ts
@@ -18,4 +18,4 @@ async function main() {
   await saveAudioFile(result.audio);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/packages/ai/core/generate-speech/generate-speech.test.ts
+++ b/packages/ai/core/generate-speech/generate-speech.test.ts
@@ -68,6 +68,7 @@ describe('generateSpeech', () => {
       outputFormat: undefined,
       instructions: undefined,
       speed: undefined,
+      language: undefined,
     });
   });
 

--- a/packages/ai/core/generate-speech/generate-speech.ts
+++ b/packages/ai/core/generate-speech/generate-speech.ts
@@ -38,6 +38,7 @@ export async function generateSpeech({
   outputFormat,
   instructions,
   speed,
+  language,
   providerOptions = {},
   maxRetries: maxRetriesArg,
   abortSignal,
@@ -72,6 +73,12 @@ The voice to use for speech generation.
   The speed of the speech generation.
    */
   speed?: number;
+
+  /**
+  The language for speech generation. This should be an ISO 639-1 language code (e.g. "en", "es", "fr")
+  or "auto" for automatic language detection. Provider support varies.
+   */
+  language?: string;
 
   /**
 Additional provider-specific options that are passed through to the provider
@@ -114,6 +121,7 @@ Only applicable for HTTP-based providers.
       outputFormat,
       instructions,
       speed,
+      language,
       abortSignal,
       headers,
       providerOptions,

--- a/packages/hume/src/hume-speech-model.ts
+++ b/packages/hume/src/hume-speech-model.ts
@@ -9,7 +9,6 @@ import { z } from 'zod';
 import { HumeConfig } from './hume-config';
 import { humeFailedResponseHandler } from './hume-error';
 import { HumeSpeechAPITypes } from './hume-api-types';
-import 'dotenv/config';
 
 // https://dev.hume.ai/reference/text-to-speech-tts/synthesize-file
 const humeSpeechCallOptionsSchema = z.object({

--- a/packages/hume/src/hume-speech-model.ts
+++ b/packages/hume/src/hume-speech-model.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { HumeConfig } from './hume-config';
 import { humeFailedResponseHandler } from './hume-error';
 import { HumeSpeechAPITypes } from './hume-api-types';
+import 'dotenv/config';
 
 // https://dev.hume.ai/reference/text-to-speech-tts/synthesize-file
 const humeSpeechCallOptionsSchema = z.object({
@@ -108,6 +109,7 @@ export class HumeSpeechModel implements SpeechModelV2 {
     outputFormat = 'mp3',
     speed,
     instructions,
+    language,
     providerOptions,
   }: Parameters<SpeechModelV2['doGenerate']>[0]) {
     const warnings: SpeechModelV2CallWarning[] = [];
@@ -181,6 +183,14 @@ export class HumeSpeechModel implements SpeechModelV2 {
           (requestBody as Record<string, unknown>)[key] = value;
         }
       }
+    }
+
+    if (language) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'language',
+        details: `Hume speech models do not support language selection. Language parameter "${language}" was ignored.`,
+      });
     }
 
     return {

--- a/packages/lmnt/src/lmnt-speech-model.ts
+++ b/packages/lmnt/src/lmnt-speech-model.ts
@@ -23,15 +23,6 @@ const lmntSpeechCallOptionsSchema = z.object({
     .default('aurora'),
 
   /**
-   * The language of the input text.
-   * @default 'auto'
-   */
-  language: z
-    .union([z.enum(['auto', 'en']), z.string()])
-    .nullish()
-    .default('auto'),
-
-  /**
    * The audio format of the output.
    * @default 'mp3'
    */
@@ -163,12 +154,9 @@ export class LMNTSpeechModel implements SpeechModelV2 {
           requestBody[key] = value;
         }
       }
+    }
 
-      const finalLanguage = language ?? lmntOptions.language;
-      if (finalLanguage) {
-        requestBody.language = finalLanguage;
-      }
-    } else if (language) {
+    if (language) {
       requestBody.language = language;
     }
 

--- a/packages/lmnt/src/lmnt-speech-model.ts
+++ b/packages/lmnt/src/lmnt-speech-model.ts
@@ -10,6 +10,8 @@ import { LMNTConfig } from './lmnt-config';
 import { lmntFailedResponseHandler } from './lmnt-error';
 import { LMNTSpeechModelId } from './lmnt-speech-options';
 import { LMNTSpeechAPITypes } from './lmnt-api-types';
+import 'dotenv/config';
+
 
 // https://docs.lmnt.com/api-reference/speech/synthesize-speech-bytes
 const lmntSpeechCallOptionsSchema = z.object({
@@ -109,6 +111,7 @@ export class LMNTSpeechModel implements SpeechModelV2 {
     voice = 'ava',
     outputFormat = 'mp3',
     speed,
+    language,
     providerOptions,
   }: Parameters<SpeechModelV2['doGenerate']>[0]) {
     const warnings: SpeechModelV2CallWarning[] = [];
@@ -151,6 +154,7 @@ export class LMNTSpeechModel implements SpeechModelV2 {
         temperature: lmntOptions.temperature ?? undefined,
         top_p: lmntOptions.topP ?? undefined,
         sample_rate: lmntOptions.sampleRate ?? undefined,
+
       };
 
       for (const key in speechModelOptions) {
@@ -162,6 +166,13 @@ export class LMNTSpeechModel implements SpeechModelV2 {
           requestBody[key] = value;
         }
       }
+
+      const finalLanguage = language ?? lmntOptions.language;
+      if (finalLanguage) {
+        requestBody.language = finalLanguage;
+      }
+    } else if (language) {
+      requestBody.language = language;
     }
 
     return {

--- a/packages/lmnt/src/lmnt-speech-model.ts
+++ b/packages/lmnt/src/lmnt-speech-model.ts
@@ -10,8 +10,6 @@ import { LMNTConfig } from './lmnt-config';
 import { lmntFailedResponseHandler } from './lmnt-error';
 import { LMNTSpeechModelId } from './lmnt-speech-options';
 import { LMNTSpeechAPITypes } from './lmnt-api-types';
-import 'dotenv/config';
-
 
 // https://docs.lmnt.com/api-reference/speech/synthesize-speech-bytes
 const lmntSpeechCallOptionsSchema = z.object({
@@ -154,7 +152,6 @@ export class LMNTSpeechModel implements SpeechModelV2 {
         temperature: lmntOptions.temperature ?? undefined,
         top_p: lmntOptions.topP ?? undefined,
         sample_rate: lmntOptions.sampleRate ?? undefined,
-
       };
 
       for (const key in speechModelOptions) {

--- a/packages/openai/src/openai-speech-model.ts
+++ b/packages/openai/src/openai-speech-model.ts
@@ -10,6 +10,7 @@ import { OpenAIConfig } from './openai-config';
 import { openaiFailedResponseHandler } from './openai-error';
 import { OpenAISpeechModelId } from './openai-speech-options';
 import { OpenAISpeechAPITypes } from './openai-api-types';
+import 'dotenv/config';
 
 // https://platform.openai.com/docs/api-reference/audio/createSpeech
 const OpenAIProviderOptionsSchema = z.object({
@@ -45,6 +46,7 @@ export class OpenAISpeechModel implements SpeechModelV2 {
     outputFormat = 'mp3',
     speed,
     instructions,
+    language,
     providerOptions,
   }: Parameters<SpeechModelV2['doGenerate']>[0]) {
     const warnings: SpeechModelV2CallWarning[] = [];
@@ -88,6 +90,14 @@ export class OpenAISpeechModel implements SpeechModelV2 {
           requestBody[key] = value;
         }
       }
+    }
+
+    if (language) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'language',
+        details: `OpenAI speech models do not support language selection. Language parameter "${language}" was ignored.`,
+      });
     }
 
     return {

--- a/packages/openai/src/openai-speech-model.ts
+++ b/packages/openai/src/openai-speech-model.ts
@@ -10,7 +10,6 @@ import { OpenAIConfig } from './openai-config';
 import { openaiFailedResponseHandler } from './openai-error';
 import { OpenAISpeechModelId } from './openai-speech-options';
 import { OpenAISpeechAPITypes } from './openai-api-types';
-import 'dotenv/config';
 
 // https://platform.openai.com/docs/api-reference/audio/createSpeech
 const OpenAIProviderOptionsSchema = z.object({

--- a/packages/provider/src/speech-model/v2/speech-model-v2-call-options.ts
+++ b/packages/provider/src/speech-model/v2/speech-model-v2-call-options.ts
@@ -30,6 +30,12 @@ export type SpeechModelV2CallOptions = {
   speed?: number;
 
   /**
+   * The language for speech generation. This should be an ISO 639-1 language code (e.g. "en", "es", "fr")
+   * or "auto" for automatic language detection. Provider support varies.
+   */
+  language?: string;
+
+  /**
    * Additional provider-specific options that are passed through to the provider
    * as body parameters.
    *


### PR DESCRIPTION
## background

speech model v2 lacked language setting support, with only provider-specific options available inconsistently across providers.

## summary

- add standardized `language` parameter to Speech Model v2 core interface
- add language support with warnings for unsupported providers

## verification

- all tests pass including new language-specific examples
- LMNT uses standardized parameter with fallback to provider options
- OpenAI and Hume show appropriate warnings for unsupported language parameter

## tasks

- [x] language parameter added to SpeechModelV2CallOptions
- [x] language parameter added to generateSpeech function
- [x] LMNT provider updated to use core language parameter
- [x] warning implementations for OpenAI and Hume providers
- [x] documentation updated with language examples

## future work

* consider removing warnings if providers add native language support 