### PR TITLE
chore (provider/openai): switch default to openai responses api

### DIFF
--- a/.changeset/cyan-scissors-applaud.md
+++ b/.changeset/cyan-scissors-applaud.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': major
+---
+
+chore (provider/openai): switch default to openai responses api

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -28,16 +28,12 @@ import { OpenAISpeechModel } from './openai-speech-model';
 import { OpenAISpeechModelId } from './openai-speech-options';
 
 export interface OpenAIProvider extends ProviderV2 {
-  (modelId: 'gpt-3.5-turbo-instruct'): OpenAICompletionLanguageModel;
-  (modelId: OpenAIChatModelId): LanguageModelV2;
+  (modelId: OpenAIResponsesModelId): LanguageModelV2;
 
   /**
 Creates an OpenAI model for text generation.
    */
-  languageModel(
-    modelId: 'gpt-3.5-turbo-instruct',
-  ): OpenAICompletionLanguageModel;
-  languageModel(modelId: OpenAIChatModelId): LanguageModelV2;
+  languageModel(modelId: OpenAIResponsesModelId): OpenAIResponsesLanguageModel;
 
   /**
 Creates an OpenAI chat model for text generation.
@@ -206,20 +202,14 @@ export function createOpenAI(
       fetch: options.fetch,
     });
 
-  const createLanguageModel = (
-    modelId: OpenAIChatModelId | OpenAICompletionModelId,
-  ) => {
+  const createLanguageModel = (modelId: OpenAIResponsesModelId) => {
     if (new.target) {
       throw new Error(
         'The OpenAI model function cannot be called with the new keyword.',
       );
     }
 
-    if (modelId === 'gpt-3.5-turbo-instruct') {
-      return createCompletionModel(modelId);
-    }
-
-    return createChatModel(modelId);
+    return createResponsesModel(modelId);
   };
 
   const createResponsesModel = (modelId: OpenAIResponsesModelId) => {
@@ -231,9 +221,7 @@ export function createOpenAI(
     });
   };
 
-  const provider = function (
-    modelId: OpenAIChatModelId | OpenAICompletionModelId,
-  ) {
+  const provider = function (modelId: OpenAIResponsesModelId) {
     return createLanguageModel(modelId);
   };
 


### PR DESCRIPTION
## Background

Many newer OpenAI features are only available on the responses API.

## Summary

Switch default factory method for OpenAI to their responses API.