### PR TITLE
feat (provider): support arbitrary media types in tool results

### DIFF
--- a/.changeset/strong-readers-notice.md
+++ b/.changeset/strong-readers-notice.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': major
+---
+
+feat (provider): support arbitrary media types in tool results

--- a/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
+++ b/examples/ai-core/src/e2e/google-vertex-anthropic.test.ts
@@ -145,7 +145,7 @@ const toolTests = (model: LanguageModelV2) => {
                   typeof result === 'string'
                     ? { type: 'text', text: result }
                     : {
-                        type: 'image',
+                        type: 'media',
                         data: result.data,
                         mediaType: 'image/png',
                       },

--- a/examples/ai-core/src/generate-text/amazon-bedrock-tool-call-image-result.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-tool-call-image-result.ts
@@ -34,7 +34,7 @@ async function main() {
             type: 'content',
             value: [
               {
-                type: 'image',
+                type: 'media',
                 data: Buffer.from(result.bytes).toString('base64'),
                 mediaType: 'image/jpeg',
               },

--- a/examples/ai-core/src/generate-text/anthropic-computer-use-computer.ts
+++ b/examples/ai-core/src/generate-text/anthropic-computer-use-computer.ts
@@ -39,7 +39,7 @@ async function main() {
             value: [
               typeof result === 'string'
                 ? { type: 'text', text: result }
-                : { type: 'image', data: result.data, mediaType: 'image/png' },
+                : { type: 'media', data: result.data, mediaType: 'image/png' },
             ],
           };
         },

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-computer.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-computer-use-computer.ts
@@ -39,7 +39,7 @@ async function main() {
             value: [
               typeof result === 'string'
                 ? { type: 'text', text: result }
-                : { type: 'image', data: result.data, mediaType: 'image/png' },
+                : { type: 'media', data: result.data, mediaType: 'image/png' },
             ],
           };
         },

--- a/packages/ai/core/prompt/content-part.ts
+++ b/packages/ai/core/prompt/content-part.ts
@@ -122,9 +122,9 @@ export const outputSchema: z.ZodType<LanguageModelV2ToolResultOutput> =
             text: z.string(),
           }),
           z.object({
-            type: z.literal('image'),
+            type: z.literal('media'),
             data: z.string(),
-            mediaType: z.string().optional(),
+            mediaType: z.string(),
           }),
         ]),
       ),

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -1231,7 +1231,7 @@ describe('convertToLanguageModelMessage', () => {
               output: {
                 type: 'content',
                 value: [
-                  { type: 'image', data: 'dGVzdA==', mediaType: 'image/png' },
+                  { type: 'media', data: 'dGVzdA==', mediaType: 'image/png' },
                 ],
               },
             },
@@ -1250,7 +1250,7 @@ describe('convertToLanguageModelMessage', () => {
                   {
                     "data": "dGVzdA==",
                     "mediaType": "image/png",
-                    "type": "image",
+                    "type": "media",
                   },
                 ],
               },

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -590,7 +590,7 @@ describe('tool messages', () => {
               type: 'content',
               value: [
                 {
-                  type: 'image',
+                  type: 'media',
                   data: 'base64data',
                   mediaType: 'image/jpeg',
                 },
@@ -635,7 +635,7 @@ describe('tool messages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'image',
+                    type: 'media',
                     data: 'base64data',
                     mediaType: 'image/webp', // unsupported format
                   },
@@ -645,10 +645,10 @@ describe('tool messages', () => {
           ],
         },
       ]),
-    ).rejects.toThrow('Unsupported image format: webp');
+    ).rejects.toThrow("'media type: image/webp' functionality not supported.");
   });
 
-  it('should throw error for missing mime type in tool result image content', async () => {
+  it('should throw error for unsupported mime type in tool result image content', async () => {
     await expect(
       convertToBedrockChatMessages([
         {
@@ -662,9 +662,9 @@ describe('tool messages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'image',
+                    type: 'media',
                     data: 'base64data',
-                    // missing mediaType
+                    mediaType: 'unsupported/mime-type',
                   },
                 ],
               },
@@ -673,7 +673,7 @@ describe('tool messages', () => {
         },
       ]),
     ).rejects.toThrow(
-      'Image mime type is required in tool result part content',
+      "'media type: unsupported/mime-type' functionality not supported.",
     );
   });
 

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -130,25 +130,25 @@ export async function convertToBedrockChatMessages(
                       switch (contentPart.type) {
                         case 'text':
                           return { text: contentPart.text };
-                        case 'image':
-                          if (!contentPart.mediaType) {
-                            throw new Error(
-                              'Image mime type is required in tool result part content',
-                            );
+                        case 'media':
+                          if (!contentPart.mediaType.startsWith('image/')) {
+                            throw new UnsupportedFunctionalityError({
+                              functionality: `media type: ${contentPart.mediaType}`,
+                            });
                           }
 
                           const format = contentPart.mediaType.split('/')[1];
+
                           if (!isBedrockImageFormat(format)) {
-                            throw new Error(
-                              `Unsupported image format: ${format}`,
-                            );
+                            throw new UnsupportedFunctionalityError({
+                              functionality: `media type: ${contentPart.mediaType}`,
+                            });
                           }
+
                           return {
                             image: {
                               format,
-                              source: {
-                                bytes: contentPart.data,
-                              },
+                              source: { bytes: contentPart.data },
                             },
                           };
                       }

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -437,7 +437,7 @@ describe('tool messages', () => {
                     text: 'Image generated successfully',
                   },
                   {
-                    type: 'image',
+                    type: 'media',
                     data: 'AAECAw==',
                     mediaType: 'image/png',
                   },

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -272,16 +272,23 @@ export async function convertToAnthropicMessagesPrompt({
                             text: contentPart.text,
                             cache_control: undefined,
                           };
-                        case 'image':
-                          return {
-                            type: 'image',
-                            source: {
-                              type: 'base64',
-                              media_type: contentPart.mediaType ?? 'image/jpeg',
-                              data: contentPart.data,
-                            },
-                            cache_control: undefined,
-                          };
+                        case 'media': {
+                          if (contentPart.mediaType.startsWith('image/')) {
+                            return {
+                              type: 'image',
+                              source: {
+                                type: 'base64',
+                                media_type: contentPart.mediaType,
+                                data: contentPart.data,
+                              },
+                              cache_control: undefined,
+                            };
+                          }
+
+                          throw new UnsupportedFunctionalityError({
+                            functionality: `media type: ${contentPart.mediaType}`,
+                          });
+                        }
                       }
                     });
                     break;

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -169,7 +169,7 @@ describe('tool calls', () => {
               type: 'content',
               value: [
                 { type: 'text', text: 'Here is the result:' },
-                { type: 'image', data: 'base64data', mediaType: 'image/png' },
+                { type: 'media', data: 'base64data', mediaType: 'image/png' },
               ],
             },
           },
@@ -195,7 +195,7 @@ describe('tool calls', () => {
           ],
         },
         {
-          "content": "[{"type":"text","text":"Here is the result:"},{"type":"image","data":"base64data","mediaType":"image/png"}]",
+          "content": "[{"type":"text","text":"Here is the result:"},{"type":"media","data":"base64data","mediaType":"image/png"}]",
           "name": "image-tool",
           "role": "tool",
           "tool_call_id": "tool-call-id-3",

--- a/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
@@ -201,18 +201,18 @@ Text content.
             text: string;
           }
         | {
-            type: 'image';
+            type: 'media';
 
             /**
-base-64 encoded image data
+Base-64 encoded media data.
 */
             data: string;
 
             /**
-IANA media type of the image.
+IANA media type.
 @see https://www.iana.org/assignments/media-types/media-types.xhtml
 */
-            mediaType?: string;
+            mediaType: string;
           }
       >;
     };


### PR DESCRIPTION
## Background

Tool results currently only support text and image parts. However, it can be expected that especially MCP tools will support other result type in the future.

## Summary

Change image type to media type and require mediaType information.