### PR TITLE
feat (provider): support changing provider, model, supportedUrls in middleware

### DIFF
--- a/.changeset/bright-turtles-give.md
+++ b/.changeset/bright-turtles-give.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': major
+---
+
+feat (provider): support changing provider, model, supportedUrls in middleware

--- a/packages/ai/core/middleware/default-settings-middleware.test.ts
+++ b/packages/ai/core/middleware/default-settings-middleware.test.ts
@@ -1,11 +1,14 @@
 import { LanguageModelV2CallOptions } from '@ai-sdk/provider';
 import { defaultSettingsMiddleware } from './default-settings-middleware';
+import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
 
 const BASE_PARAMS: LanguageModelV2CallOptions = {
   prompt: [
     { role: 'user', content: [{ type: 'text', text: 'Hello, world!' }] },
   ],
 };
+
+const MOCK_MODEL = new MockLanguageModelV2();
 
 describe('defaultSettingsMiddleware', () => {
   describe('transformParams', () => {
@@ -16,9 +19,8 @@ describe('defaultSettingsMiddleware', () => {
 
       const result = await middleware.transformParams!({
         type: 'generate',
-        params: {
-          ...BASE_PARAMS,
-        },
+        params: { ...BASE_PARAMS },
+        model: MOCK_MODEL,
       });
 
       expect(result.temperature).toBe(0.7);
@@ -35,6 +37,7 @@ describe('defaultSettingsMiddleware', () => {
           ...BASE_PARAMS,
           temperature: 0.5,
         },
+        model: MOCK_MODEL,
       });
 
       expect(result.temperature).toBe(0.5);
@@ -54,9 +57,8 @@ describe('defaultSettingsMiddleware', () => {
 
       const result = await middleware.transformParams!({
         type: 'generate',
-        params: {
-          ...BASE_PARAMS,
-        },
+        params: { ...BASE_PARAMS },
+        model: MOCK_MODEL,
       });
 
       expect(result.temperature).toBe(0.7);
@@ -93,6 +95,7 @@ describe('defaultSettingsMiddleware', () => {
             },
           },
         },
+        model: MOCK_MODEL,
       });
 
       expect(result.providerOptions).toEqual({
@@ -134,6 +137,7 @@ describe('defaultSettingsMiddleware', () => {
             },
           },
         },
+        model: MOCK_MODEL,
       });
 
       expect(result.providerOptions).toEqual({
@@ -157,6 +161,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, temperature: 0 },
+        model: MOCK_MODEL,
       });
 
       expect(result.temperature).toBe(0);
@@ -170,6 +175,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, temperature: undefined },
+        model: MOCK_MODEL,
       });
 
       expect(result.temperature).toBe(0.7);
@@ -183,6 +189,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, temperature: null as any },
+        model: MOCK_MODEL,
       });
 
       expect(result.temperature).toBe(null);
@@ -196,6 +203,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, temperature: 0.9 },
+        model: MOCK_MODEL,
       });
 
       expect(result.temperature).toBe(0.9);
@@ -210,6 +218,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: BASE_PARAMS,
+        model: MOCK_MODEL,
       });
       expect(result.maxOutputTokens).toBe(100);
     });
@@ -221,6 +230,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, maxOutputTokens: 50 },
+        model: MOCK_MODEL,
       });
       expect(result.maxOutputTokens).toBe(50);
     });
@@ -232,6 +242,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: BASE_PARAMS,
+        model: MOCK_MODEL,
       });
       expect(result.stopSequences).toEqual(['stop']);
     });
@@ -243,6 +254,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, stopSequences: ['end'] },
+        model: MOCK_MODEL,
       });
       expect(result.stopSequences).toEqual(['end']);
     });
@@ -252,6 +264,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: BASE_PARAMS,
+        model: MOCK_MODEL,
       });
       expect(result.topP).toBe(0.9);
     });
@@ -261,6 +274,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, topP: 0.5 },
+        model: MOCK_MODEL,
       });
       expect(result.topP).toBe(0.5);
     });
@@ -280,6 +294,7 @@ describe('defaultSettingsMiddleware', () => {
           ...BASE_PARAMS,
           headers: { 'X-Custom-Header': 'test2' },
         },
+        model: MOCK_MODEL,
       });
 
       expect(result.headers).toEqual({
@@ -295,6 +310,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, headers: { 'X-Param-Header': 'param' } },
+        model: MOCK_MODEL,
       });
       expect(result.headers).toEqual({ 'X-Param-Header': 'param' });
     });
@@ -306,6 +322,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, headers: {} },
+        model: MOCK_MODEL,
       });
       expect(result.headers).toEqual({ 'X-Default-Header': 'default' });
     });
@@ -317,6 +334,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS },
+        model: MOCK_MODEL,
       });
       expect(result.headers).toBeUndefined();
     });
@@ -333,6 +351,7 @@ describe('defaultSettingsMiddleware', () => {
           ...BASE_PARAMS,
           providerOptions: { openai: { user: 'param-user' } },
         },
+        model: MOCK_MODEL,
       });
       expect(result.providerOptions).toEqual({
         openai: { user: 'param-user' },
@@ -346,6 +365,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS, providerOptions: {} },
+        model: MOCK_MODEL,
       });
       expect(result.providerOptions).toEqual({
         anthropic: { user: 'default-user' },
@@ -359,6 +379,7 @@ describe('defaultSettingsMiddleware', () => {
       const result = await middleware.transformParams!({
         type: 'generate',
         params: { ...BASE_PARAMS },
+        model: MOCK_MODEL,
       });
       expect(result.providerOptions).toBeUndefined();
     });

--- a/packages/ai/core/middleware/wrap-language-model.test.ts
+++ b/packages/ai/core/middleware/wrap-language-model.test.ts
@@ -89,6 +89,43 @@ describe('wrapLanguageModel', () => {
     });
   });
 
+  describe('supportedUrls property', () => {
+    it('should pass through by default', async () => {
+      const supportedUrls = {
+        'original/*': [/^https:\/\/.*$/],
+      };
+
+      const wrappedModel = wrapLanguageModel({
+        model: new MockLanguageModelV2({ supportedUrls }),
+        middleware: {
+          middlewareVersion: 'v2',
+        },
+      });
+
+      expect(await wrappedModel.supportedUrls).toStrictEqual(supportedUrls);
+    });
+
+    it('should use middleware overrideSupportedUrls if provided', () => {
+      const wrappedModel = wrapLanguageModel({
+        model: new MockLanguageModelV2({
+          supportedUrls: {
+            'original/*': [/^https:\/\/.*$/],
+          },
+        }),
+        middleware: {
+          middlewareVersion: 'v2',
+          overrideSupportedUrls: ({ model }) => ({
+            'override/*': [/^https:\/\/.*$/],
+          }),
+        },
+      });
+
+      expect(wrappedModel.supportedUrls).toStrictEqual({
+        'override/*': [/^https:\/\/.*$/],
+      });
+    });
+  });
+
   it('should call transformParams middleware for doGenerate', async () => {
     const mockModel = new MockLanguageModelV2({
       doGenerate: [],
@@ -215,21 +252,6 @@ describe('wrapLanguageModel', () => {
       params,
       model: mockModel,
     });
-  });
-
-  it('should pass through supportedUrls', async () => {
-    const supportedUrls = {
-      'image/*': [/^https:\/\/.*$/],
-    };
-
-    const wrappedModel = wrapLanguageModel({
-      model: new MockLanguageModelV2({ supportedUrls }),
-      middleware: {
-        middlewareVersion: 'v2',
-      },
-    });
-
-    expect(await wrappedModel.supportedUrls).toStrictEqual(supportedUrls);
   });
 
   it('should support models that use "this" context in supportedUrls', async () => {

--- a/packages/ai/core/middleware/wrap-language-model.test.ts
+++ b/packages/ai/core/middleware/wrap-language-model.test.ts
@@ -17,7 +17,7 @@ describe('wrapLanguageModel', () => {
       expect(wrappedModel.modelId).toBe('test-model');
     });
 
-    it('it should use middleware overrideModelId if provided', () => {
+    it('should use middleware overrideModelId if provided', () => {
       const wrappedModel = wrapLanguageModel({
         model: new MockLanguageModelV2({
           modelId: 'test-model',
@@ -31,7 +31,7 @@ describe('wrapLanguageModel', () => {
       expect(wrappedModel.modelId).toBe('override-model');
     });
 
-    it('it should use modelId parameter if provided', () => {
+    it('should use modelId parameter if provided', () => {
       const wrappedModel = wrapLanguageModel({
         model: new MockLanguageModelV2({
           modelId: 'test-model',
@@ -60,7 +60,7 @@ describe('wrapLanguageModel', () => {
       expect(wrappedModel.provider).toBe('test-provider');
     });
 
-    it('it should use middleware overrideProvider if provided', () => {
+    it('should use middleware overrideProvider if provided', () => {
       const wrappedModel = wrapLanguageModel({
         model: new MockLanguageModelV2({
           provider: 'test-provider',
@@ -74,7 +74,7 @@ describe('wrapLanguageModel', () => {
       expect(wrappedModel.provider).toBe('override-provider');
     });
 
-    it('it should use providerId parameter if provided', () => {
+    it('should use providerId parameter if provided', () => {
       const wrappedModel = wrapLanguageModel({
         model: new MockLanguageModelV2({
           provider: 'test-provider',
@@ -265,7 +265,7 @@ describe('wrapLanguageModel', () => {
     expect(supportedUrlsCalled).toBe(true);
   });
 
-  describe('wrapLanguageModel with multiple middlewares', () => {
+  describe('multiple middlewares', () => {
     it('should call multiple transformParams middlewares in sequence for doGenerate', async () => {
       const mockModel = new MockLanguageModelV2({
         doGenerate: [],

--- a/packages/ai/core/middleware/wrap-language-model.test.ts
+++ b/packages/ai/core/middleware/wrap-language-model.test.ts
@@ -3,33 +3,90 @@ import { wrapLanguageModel } from '../middleware/wrap-language-model';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
 
 describe('wrapLanguageModel', () => {
-  it('should pass through model properties', () => {
-    const wrappedModel = wrapLanguageModel({
-      model: new MockLanguageModelV2({
-        provider: 'test-provider',
-        modelId: 'test-model',
-      }),
-      middleware: {
-        middlewareVersion: 'v2',
-      },
+  describe('model property', () => {
+    it('should pass through by default', () => {
+      const wrappedModel = wrapLanguageModel({
+        model: new MockLanguageModelV2({
+          modelId: 'test-model',
+        }),
+        middleware: {
+          middlewareVersion: 'v2',
+        },
+      });
+
+      expect(wrappedModel.modelId).toBe('test-model');
     });
 
-    expect(wrappedModel.provider).toBe('test-provider');
-    expect(wrappedModel.modelId).toBe('test-model');
+    it('it should use middleware overrideModelId if provided', () => {
+      const wrappedModel = wrapLanguageModel({
+        model: new MockLanguageModelV2({
+          modelId: 'test-model',
+        }),
+        middleware: {
+          middlewareVersion: 'v2',
+          overrideModelId: ({ model }) => 'override-model',
+        },
+      });
+
+      expect(wrappedModel.modelId).toBe('override-model');
+    });
+
+    it('it should use modelId parameter if provided', () => {
+      const wrappedModel = wrapLanguageModel({
+        model: new MockLanguageModelV2({
+          modelId: 'test-model',
+        }),
+        middleware: {
+          middlewareVersion: 'v2',
+        },
+        modelId: 'override-model',
+      });
+
+      expect(wrappedModel.modelId).toBe('override-model');
+    });
   });
 
-  it('should override provider and modelId if provided', () => {
-    const wrappedModel = wrapLanguageModel({
-      model: new MockLanguageModelV2(),
-      middleware: {
-        middlewareVersion: 'v2',
-      },
-      providerId: 'override-provider',
-      modelId: 'override-model',
+  describe('provider property', () => {
+    it('should pass through by default', () => {
+      const wrappedModel = wrapLanguageModel({
+        model: new MockLanguageModelV2({
+          provider: 'test-provider',
+        }),
+        middleware: {
+          middlewareVersion: 'v2',
+        },
+      });
+
+      expect(wrappedModel.provider).toBe('test-provider');
     });
 
-    expect(wrappedModel.provider).toBe('override-provider');
-    expect(wrappedModel.modelId).toBe('override-model');
+    it('it should use middleware overrideProvider if provided', () => {
+      const wrappedModel = wrapLanguageModel({
+        model: new MockLanguageModelV2({
+          provider: 'test-provider',
+        }),
+        middleware: {
+          middlewareVersion: 'v2',
+          overrideProvider: ({ model }) => 'override-provider',
+        },
+      });
+
+      expect(wrappedModel.provider).toBe('override-provider');
+    });
+
+    it('it should use providerId parameter if provided', () => {
+      const wrappedModel = wrapLanguageModel({
+        model: new MockLanguageModelV2({
+          provider: 'test-provider',
+        }),
+        middleware: {
+          middlewareVersion: 'v2',
+        },
+        providerId: 'override-provider',
+      });
+
+      expect(wrappedModel.provider).toBe('override-provider');
+    });
   });
 
   it('should call transformParams middleware for doGenerate', async () => {

--- a/packages/ai/core/middleware/wrap-language-model.test.ts
+++ b/packages/ai/core/middleware/wrap-language-model.test.ts
@@ -58,6 +58,7 @@ describe('wrapLanguageModel', () => {
     expect(transformParams).toHaveBeenCalledWith({
       params,
       type: 'generate',
+      model: expect.any(Object),
     });
 
     expect(mockModel.doGenerateCalls[0]).toStrictEqual({
@@ -123,6 +124,7 @@ describe('wrapLanguageModel', () => {
     expect(transformParams).toHaveBeenCalledWith({
       params,
       type: 'stream',
+      model: expect.any(Object),
     });
     expect(mockModel.doStreamCalls[0]).toStrictEqual({
       ...params,
@@ -244,11 +246,13 @@ describe('wrapLanguageModel', () => {
       expect(transformParams1).toHaveBeenCalledWith({
         params,
         type: 'generate',
+        model: expect.any(Object),
       });
 
       expect(transformParams2).toHaveBeenCalledWith({
         params: { ...params, transformationStep1: true },
         type: 'generate',
+        model: expect.any(Object),
       });
 
       expect(mockModel.doGenerateCalls[0]).toStrictEqual(
@@ -296,10 +300,12 @@ describe('wrapLanguageModel', () => {
       expect(transformParams1).toHaveBeenCalledWith({
         params,
         type: 'stream',
+        model: expect.any(Object),
       });
       expect(transformParams2).toHaveBeenCalledWith({
         params: expect.objectContaining({ transformationStep1: true }),
         type: 'stream',
+        model: mockModel,
       });
       expect(mockModel.doStreamCalls[0]).toStrictEqual(
         expect.objectContaining({

--- a/packages/ai/core/middleware/wrap-language-model.ts
+++ b/packages/ai/core/middleware/wrap-language-model.ts
@@ -53,7 +53,9 @@ const doWrap = ({
     params: LanguageModelV2CallOptions;
     type: 'generate' | 'stream';
   }) {
-    return transformParams ? await transformParams({ params, type }) : params;
+    return transformParams
+      ? await transformParams({ params, type, model })
+      : params;
   }
 
   return {

--- a/packages/ai/core/middleware/wrap-language-model.ts
+++ b/packages/ai/core/middleware/wrap-language-model.ts
@@ -37,7 +37,14 @@ export const wrapLanguageModel = ({
 
 const doWrap = ({
   model,
-  middleware: { transformParams, wrapGenerate, wrapStream },
+  middleware: {
+    transformParams,
+    wrapGenerate,
+    wrapStream,
+    overrideProvider,
+    overrideModelId,
+    overrideSupportedUrls,
+  },
   modelId,
   providerId,
 }: {
@@ -61,13 +68,9 @@ const doWrap = ({
   return {
     specificationVersion: 'v2',
 
-    provider: providerId ?? model.provider,
-    modelId: modelId ?? model.modelId,
-
-    // TODO middleware should be able to modify the supported urls
-    get supportedUrls(): LanguageModelV2['supportedUrls'] {
-      return model.supportedUrls;
-    },
+    provider: providerId ?? overrideProvider?.({ model }) ?? model.provider,
+    modelId: modelId ?? overrideModelId?.({ model }) ?? model.modelId,
+    supportedUrls: overrideSupportedUrls?.({ model }) ?? model.supportedUrls,
 
     async doGenerate(
       params: LanguageModelV2CallOptions,

--- a/packages/provider/src/language-model-middleware/v2/language-model-v2-middleware.ts
+++ b/packages/provider/src/language-model-middleware/v2/language-model-v2-middleware.ts
@@ -13,6 +13,26 @@ export type LanguageModelV2Middleware = {
   middlewareVersion?: 'v2' | undefined; // backwards compatibility
 
   /**
+   * Override the provider name if desired.
+   * @param options.model - The language model instance.
+   */
+  overrideProvider?: (options: { model: LanguageModelV2 }) => string;
+
+  /**
+   * Override the model ID if desired.
+   * @param options.model - The language model instance.
+   */
+  overrideModelId?: (options: { model: LanguageModelV2 }) => string;
+
+  /**
+   * Override the supported URLs if desired.
+   * @param options.model - The language model instance.
+   */
+  overrideSupportedUrls?: (options: {
+    model: LanguageModelV2;
+  }) => PromiseLike<Record<string, RegExp[]>> | Record<string, RegExp[]>;
+
+  /**
    * Transforms the parameters before they are passed to the language model.
    * @param options - Object containing the type of operation and the parameters.
    * @param options.type - The type of operation ('generate' or 'stream').
@@ -22,6 +42,7 @@ export type LanguageModelV2Middleware = {
   transformParams?: (options: {
     type: 'generate' | 'stream';
     params: LanguageModelV2CallOptions;
+    model: LanguageModelV2;
   }) => PromiseLike<LanguageModelV2CallOptions>;
 
   /**


### PR DESCRIPTION
## Background

Language model middleware may need to change the model, provider, and supported urls of a model.

## Summary

support changing provider, model, supportedUrls in middleware