### PR TITLE
fix: anthropic computer tool

### DIFF
--- a/.changeset/weak-rice-wait.md
+++ b/.changeset/weak-rice-wait.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix: anthropic computer tool

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -74,7 +74,7 @@ it('should correctly prepare provider-defined tools', () => {
       display_number: 1,
     },
     {
-      name: 'text_editor',
+      name: 'str_replace_editor',
       type: 'text_editor_20241022',
     },
     {

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -81,14 +81,14 @@ export function prepareTools({
           case 'anthropic.text_editor_20250124':
             betas.add('computer-use-2025-01-24');
             anthropicTools.push({
-              name: 'text_editor',
+              name: 'str_replace_editor',
               type: 'text_editor_20250124',
             });
             break;
           case 'anthropic.text_editor_20241022':
             betas.add('computer-use-2024-10-22');
             anthropicTools.push({
-              name: 'text_editor',
+              name: 'str_replace_editor',
               type: 'text_editor_20241022',
             });
             break;

--- a/packages/anthropic/src/tool/text-editor_20241022.ts
+++ b/packages/anthropic/src/tool/text-editor_20241022.ts
@@ -41,7 +41,7 @@ export const textEditor_20241022 = createProviderDefinedToolFactory<
   {}
 >({
   id: 'anthropic.text_editor_20241022',
-  name: 'text_editor',
+  name: 'str_replace_editor',
   inputSchema: z.object({
     command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
     path: z.string(),

--- a/packages/anthropic/src/tool/text-editor_20250124.ts
+++ b/packages/anthropic/src/tool/text-editor_20250124.ts
@@ -41,7 +41,7 @@ export const textEditor_20250124 = createProviderDefinedToolFactory<
   {}
 >({
   id: 'anthropic.text_editor_20250124',
-  name: 'text_editor',
+  name: 'str_replace_editor',
   inputSchema: z.object({
     command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
     path: z.string(),


### PR DESCRIPTION
## background

anthropic text editor tools were failing with API validation errors because the tool was sending incorrect tool names (`text_editor` instead of `str_replace_editor`) to the anthropic API.

## summary

- fix anthropic text editor tool name mapping in provider

## verification

- anthropic-computer-use-editor.ts now works with 20250124 version
- anthropic-computer-use-editor-cache-control.ts now works with 20241022 version
- all examples successfully execute text editing operations
- tests all pass

## tasks

- [x] update tool name from `text_editor` to `str_replace_editor` in anthropic-prepare-tools.ts
- [x] fix applies to both 20241022 and 20250124 tool versions

## future work

* none - this was a bug fix 