### PR TITLE
feat (ui): add state for text and reasoning ui message parts

### DIFF
--- a/.changeset/rare-foxes-rest.md
+++ b/.changeset/rare-foxes-rest.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ui): add state for text and reasoning ui message parts

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -403,6 +403,7 @@ describe('createUIMessageStream', () => {
               "metadata": undefined,
               "parts": [
                 {
+                  "state": "done",
                   "text": "1a",
                   "type": "text",
                 },
@@ -415,6 +416,7 @@ describe('createUIMessageStream', () => {
             "metadata": undefined,
             "parts": [
               {
+                "state": "done",
                 "text": "1a",
                 "type": "text",
               },
@@ -444,7 +446,7 @@ describe('createUIMessageStream', () => {
         {
           id: '1',
           role: 'assistant',
-          parts: [{ type: 'text', text: '1a' }],
+          parts: [{ type: 'text', text: '1a', state: 'done' }],
         },
       ],
       onFinish: options => {
@@ -473,10 +475,12 @@ describe('createUIMessageStream', () => {
               "id": "1",
               "parts": [
                 {
+                  "state": "done",
                   "text": "1a",
                   "type": "text",
                 },
                 {
+                  "state": "done",
                   "text": "1b",
                   "type": "text",
                 },
@@ -488,10 +492,12 @@ describe('createUIMessageStream', () => {
             "id": "1",
             "parts": [
               {
+                "state": "done",
                 "text": "1a",
                 "type": "text",
               },
               {
+                "state": "done",
                 "text": "1b",
                 "type": "text",
               },

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -146,6 +146,7 @@ describe('chat', () => {
                 "type": "step-start",
               },
               {
+                "state": "done",
                 "text": "Hello, world.",
                 "type": "text",
               },
@@ -189,6 +190,34 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "Hello",
                   "type": "text",
                 },
@@ -215,6 +244,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
                   "text": "Hello,",
                   "type": "text",
                 },
@@ -241,6 +271,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
                   "text": "Hello, world",
                   "type": "text",
                 },
@@ -267,6 +298,34 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "Hello, world.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "Hello, world.",
                   "type": "text",
                 },
@@ -321,7 +380,9 @@ describe('chat', () => {
           {
             id: 'id-1',
             role: 'assistant',
-            parts: [{ text: 'How can I help you?', type: 'text' }],
+            parts: [
+              { text: 'How can I help you?', type: 'text', state: 'done' },
+            ],
           },
         ],
       });
@@ -375,6 +436,7 @@ describe('chat', () => {
                 "type": "step-start",
               },
               {
+                "state": "done",
                 "text": "Hello, world.",
                 "type": "text",
               },
@@ -401,6 +463,7 @@ describe('chat', () => {
               "id": "id-1",
               "parts": [
                 {
+                  "state": "done",
                   "text": "How can I help you?",
                   "type": "text",
                 },
@@ -439,6 +502,34 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "newid-0",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "Hello",
                   "type": "text",
                 },
@@ -465,6 +556,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
                   "text": "Hello,",
                   "type": "text",
                 },
@@ -491,6 +583,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
                   "text": "Hello, world",
                   "type": "text",
                 },
@@ -517,6 +610,34 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "Hello, world.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "newid-0",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "Hello, world.",
                   "type": "text",
                 },

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -75,7 +75,7 @@ describe('convertToModelMessages', () => {
       const result = convertToModelMessages([
         {
           role: 'assistant',
-          parts: [{ type: 'text', text: 'Hello, human!' }],
+          parts: [{ type: 'text', text: 'Hello, human!', state: 'done' }],
         },
       ]);
 
@@ -100,6 +100,7 @@ describe('convertToModelMessages', () => {
                   signature: '1234567890',
                 },
               },
+              state: 'done',
             },
             {
               type: 'reasoning',
@@ -107,8 +108,9 @@ describe('convertToModelMessages', () => {
               providerMetadata: {
                 testProvider: { isRedacted: true },
               },
+              state: 'done',
             },
-            { type: 'text', text: 'Hello, human!' },
+            { type: 'text', text: 'Hello, human!', state: 'done' },
           ],
         },
       ]);
@@ -167,7 +169,11 @@ describe('convertToModelMessages', () => {
           role: 'assistant',
           parts: [
             { type: 'step-start' },
-            { type: 'text', text: 'Let me calculate that for you.' },
+            {
+              type: 'text',
+              text: 'Let me calculate that for you.',
+              state: 'done',
+            },
             {
               type: 'tool-calculator',
               state: 'output-available',
@@ -227,7 +233,11 @@ describe('convertToModelMessages', () => {
           role: 'assistant',
           parts: [
             { type: 'step-start' },
-            { type: 'text', text: 'Let me calculate that for you.' },
+            {
+              type: 'text',
+              text: 'Let me calculate that for you.',
+              state: 'done',
+            },
             {
               type: 'tool-calculator',
               state: 'output-error',
@@ -287,7 +297,11 @@ describe('convertToModelMessages', () => {
           role: 'assistant',
           parts: [
             { type: 'step-start' },
-            { type: 'text', text: 'Let me calculate that for you.' },
+            {
+              type: 'text',
+              text: 'Let me calculate that for you.',
+              state: 'done',
+            },
             {
               type: 'tool-calculator',
               state: 'output-available',
@@ -343,7 +357,11 @@ describe('convertToModelMessages', () => {
           role: 'assistant',
           parts: [
             { type: 'step-start' },
-            { type: 'text', text: 'Let me calculate that for you.' },
+            {
+              type: 'text',
+              text: 'Let me calculate that for you.',
+              state: 'done',
+            },
             {
               type: 'tool-calculator',
               state: 'output-error',
@@ -399,7 +417,11 @@ describe('convertToModelMessages', () => {
           role: 'assistant',
           parts: [
             { type: 'step-start' },
-            { type: 'text', text: 'Let me calculate that for you.' },
+            {
+              type: 'text',
+              text: 'Let me calculate that for you.',
+              state: 'done',
+            },
             {
               type: 'tool-screenshot',
               state: 'output-available',
@@ -422,7 +444,7 @@ describe('convertToModelMessages', () => {
         },
         {
           role: 'assistant',
-          parts: [{ type: 'text', text: 'text2' }],
+          parts: [{ type: 'text', text: 'text2', state: 'done' }],
         },
       ]);
 
@@ -435,7 +457,7 @@ describe('convertToModelMessages', () => {
           role: 'assistant',
           parts: [
             { type: 'step-start' },
-            { type: 'text', text: 'response' },
+            { type: 'text', text: 'response', state: 'done' },
             {
               type: 'tool-screenshot',
               state: 'output-available',
@@ -479,7 +501,7 @@ describe('convertToModelMessages', () => {
           role: 'assistant',
           parts: [
             { type: 'step-start' },
-            { type: 'text', text: 'i am gonna use tool1' },
+            { type: 'text', text: 'i am gonna use tool1', state: 'done' },
             {
               type: 'tool-screenshot',
               state: 'output-available',
@@ -488,7 +510,11 @@ describe('convertToModelMessages', () => {
               output: 'result-1',
             },
             { type: 'step-start' },
-            { type: 'text', text: 'i am gonna use tool2 and tool3' },
+            {
+              type: 'text',
+              text: 'i am gonna use tool2 and tool3',
+              state: 'done',
+            },
             {
               type: 'tool-screenshot',
               state: 'output-available',
@@ -512,7 +538,7 @@ describe('convertToModelMessages', () => {
               output: 'result-4',
             },
             { type: 'step-start' },
-            { type: 'text', text: 'final response' },
+            { type: 'text', text: 'final response', state: 'done' },
           ],
         },
       ]);
@@ -530,7 +556,9 @@ describe('convertToModelMessages', () => {
         },
         {
           role: 'assistant',
-          parts: [{ type: 'text', text: "I'll check that for you." }],
+          parts: [
+            { type: 'text', text: "I'll check that for you.", state: 'done' },
+          ],
         },
         {
           role: 'user',
@@ -608,7 +636,7 @@ describe('convertToModelMessages', () => {
               output: 'result-4',
             },
             { type: 'step-start' },
-            { type: 'text', text: 'response' },
+            { type: 'text', text: 'response', state: 'done' },
           ],
         },
         {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -47,16 +47,24 @@ export function convertToModelMessages(
               (part): part is TextUIPart | FileUIPart =>
                 part.type === 'text' || part.type === 'file',
             )
-            .map(part =>
-              part.type === 'file'
-                ? {
+            .map(part => {
+              switch (part.type) {
+                case 'text':
+                  return {
+                    type: 'text' as const,
+                    text: part.text,
+                  };
+                case 'file':
+                  return {
                     type: 'file' as const,
                     mediaType: part.mediaType,
                     filename: part.filename,
                     data: part.url,
-                  }
-                : part,
-            ),
+                  };
+                default:
+                  return part;
+              }
+            }),
         });
 
         break;
@@ -77,7 +85,10 @@ export function convertToModelMessages(
 
             for (const part of block) {
               if (part.type === 'text') {
-                content.push(part);
+                content.push({
+                  type: 'text' as const,
+                  text: part.text,
+                });
               } else if (part.type === 'file') {
                 content.push({
                   type: 'file' as const,

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -86,6 +86,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "Hello, ",
                   "type": "text",
                 },
@@ -102,6 +120,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "Hello, world!",
                   "type": "text",
                 },
@@ -123,6 +159,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "Hello, world!",
               "type": "text",
             },
@@ -259,6 +296,73 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
+                  "text": "The weather in London is sunny.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
                 },
@@ -296,6 +400,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
             },
@@ -482,6 +587,91 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "input": {},
+                  "output": {
+                    "location": "Berlin",
+                  },
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id-original",
+                  "type": "tool-tool-name-original",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
+                  "text": "The weather in London is sunny.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "input": {},
+                  "output": {
+                    "location": "Berlin",
+                  },
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id-original",
+                  "type": "tool-tool-name-original",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
                 },
@@ -528,6 +718,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
             },
@@ -605,6 +796,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "I will ",
                   "type": "text",
                 },
@@ -621,6 +830,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
                 },
@@ -637,6 +847,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
+                  "text": "I will use a tool to get the weather in London.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
                 },
@@ -664,6 +892,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
                 },
@@ -693,6 +922,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
                 },
@@ -713,6 +943,45 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
+                  "text": "I will use a tool to get the weather in London.",
+                  "type": "text",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "The weather in London ",
                   "type": "text",
                 },
@@ -729,6 +998,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
                 },
@@ -749,6 +1019,45 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "The weather in London is sunny.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
+                  "text": "I will use a tool to get the weather in London.",
+                  "type": "text",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
                 },
@@ -770,6 +1079,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "I will use a tool to get the weather in London.",
               "type": "text",
             },
@@ -790,6 +1100,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
             },
@@ -888,6 +1199,7 @@ describe('processUIMessageStream', () => {
                 },
                 {
                   "providerMetadata": undefined,
+                  "state": "streaming",
                   "text": "",
                   "type": "reasoning",
                 },
@@ -909,6 +1221,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "streaming",
                   "text": "I will ",
                   "type": "reasoning",
                 },
@@ -930,6 +1243,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "streaming",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "reasoning",
                 },
@@ -951,6 +1265,29 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
+                  "text": "I will use a tool to get the weather in London.",
+                  "type": "reasoning",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "reasoning",
                 },
@@ -983,6 +1320,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "reasoning",
                 },
@@ -1017,6 +1355,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "reasoning",
                 },
@@ -1038,6 +1377,7 @@ describe('processUIMessageStream', () => {
                 },
                 {
                   "providerMetadata": undefined,
+                  "state": "streaming",
                   "text": "",
                   "type": "reasoning",
                 },
@@ -1059,6 +1399,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "reasoning",
                 },
@@ -1084,6 +1425,7 @@ describe('processUIMessageStream', () => {
                       "signature": "abc123",
                     },
                   },
+                  "state": "streaming",
                   "text": "I now know the weather in London.",
                   "type": "reasoning",
                 },
@@ -1105,6 +1447,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "reasoning",
                 },
@@ -1130,10 +1473,166 @@ describe('processUIMessageStream', () => {
                       "signature": "abc123",
                     },
                   },
+                  "state": "done",
+                  "text": "I now know the weather in London.",
+                  "type": "reasoning",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I will use a tool to get the weather in London.",
+                  "type": "reasoning",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "abc123",
+                    },
+                  },
+                  "state": "done",
                   "text": "I now know the weather in London.",
                   "type": "reasoning",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I will use a tool to get the weather in London.",
+                  "type": "reasoning",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "abc123",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I now know the weather in London.",
+                  "type": "reasoning",
+                },
+                {
+                  "state": "streaming",
+                  "text": "The weather in London is sunny.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I will use a tool to get the weather in London.",
+                  "type": "reasoning",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": {
+                    "weather": "sunny",
+                  },
+                  "providerExecuted": undefined,
+                  "state": "output-available",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "abc123",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I now know the weather in London.",
+                  "type": "reasoning",
+                },
+                {
+                  "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
                 },
@@ -1160,6 +1659,7 @@ describe('processUIMessageStream', () => {
                   "signature": "1234567890",
                 },
               },
+              "state": "done",
               "text": "I will use a tool to get the weather in London.",
               "type": "reasoning",
             },
@@ -1185,10 +1685,12 @@ describe('processUIMessageStream', () => {
                   "signature": "abc123",
                 },
               },
+              "state": "done",
               "text": "I now know the weather in London.",
               "type": "reasoning",
             },
             {
+              "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
             },
@@ -1321,6 +1823,69 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": "error-text",
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": undefined,
+                  "providerExecuted": undefined,
+                  "state": "output-error",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
+                  "text": "The weather in London is sunny.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": "error-text",
+                  "input": {
+                    "city": "London",
+                  },
+                  "output": undefined,
+                  "providerExecuted": undefined,
+                  "state": "output-error",
+                  "toolCallId": "tool-call-id",
+                  "type": "tool-tool-name",
+                },
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
                 },
@@ -1356,6 +1921,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
             },
@@ -1449,6 +2015,30 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": {
+                "shared": {
+                  "key1": "value-1a",
+                  "key2": "value-2a",
+                },
+                "start": "start-1",
+              },
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "t1",
                   "type": "text",
                 },
@@ -1472,6 +2062,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
                   "text": "t1",
                   "type": "text",
                 },
@@ -1495,6 +2086,31 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "t1t2",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": {
+                "metadata": "metadata-1",
+                "shared": {
+                  "key1": "value-1a",
+                  "key2": "value-2a",
+                },
+                "start": "start-1",
+              },
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "t1t2",
                   "type": "text",
                 },
@@ -1520,6 +2136,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
                   "text": "t1t2",
                   "type": "text",
                 },
@@ -1550,6 +2167,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "t1t2",
               "type": "text",
             },
@@ -1611,6 +2229,41 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
+                  "text": "t1",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "t1",
                   "type": "text",
                 },
@@ -1629,6 +2282,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
                   "text": "t1",
                   "type": "text",
                 },
@@ -1652,6 +2306,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "t1",
               "type": "text",
             },
@@ -1730,6 +2385,49 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": {
+                "key1": "value-1b",
+                "key2": "value-2b",
+                "key3": "value-3a",
+              },
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
+                  "text": "t1",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": {
+                "key1": "value-1b",
+                "key2": "value-2b",
+                "key3": "value-3a",
+              },
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "t1",
                   "type": "text",
                 },
@@ -1755,6 +2453,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "t1",
               "type": "text",
             },
@@ -2014,6 +2713,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "Hello, ",
                   "type": "text",
                 },
@@ -2030,6 +2747,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "Hello, world!",
                   "type": "text",
                 },
@@ -2051,6 +2786,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "Hello, world!",
               "type": "text",
             },
@@ -2147,6 +2883,7 @@ describe('processUIMessageStream', () => {
                 },
                 {
                   "providerMetadata": undefined,
+                  "state": "streaming",
                   "text": "",
                   "type": "reasoning",
                 },
@@ -2164,6 +2901,7 @@ describe('processUIMessageStream', () => {
                 },
                 {
                   "providerMetadata": undefined,
+                  "state": "streaming",
                   "text": "I will open the conversation",
                   "type": "reasoning",
                 },
@@ -2185,6 +2923,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "streaming",
                   "text": "I will open the conversation with witty banter. ",
                   "type": "reasoning",
                 },
@@ -2206,11 +2945,35 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
+                  "text": "I will open the conversation with witty banter. ",
+                  "type": "reasoning",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
                   "text": "I will open the conversation with witty banter. ",
                   "type": "reasoning",
                 },
                 {
                   "providerMetadata": undefined,
+                  "state": "streaming",
                   "text": "",
                   "type": "reasoning",
                 },
@@ -2232,6 +2995,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will open the conversation with witty banter. ",
                   "type": "reasoning",
                 },
@@ -2241,6 +3005,7 @@ describe('processUIMessageStream', () => {
                       "isRedacted": true,
                     },
                   },
+                  "state": "streaming",
                   "text": "redacted-data",
                   "type": "reasoning",
                 },
@@ -2262,6 +3027,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will open the conversation with witty banter. ",
                   "type": "reasoning",
                 },
@@ -2271,11 +3037,45 @@ describe('processUIMessageStream', () => {
                       "isRedacted": true,
                     },
                   },
+                  "state": "done",
+                  "text": "redacted-data",
+                  "type": "reasoning",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I will open the conversation with witty banter. ",
+                  "type": "reasoning",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "isRedacted": true,
+                    },
+                  },
+                  "state": "done",
                   "text": "redacted-data",
                   "type": "reasoning",
                 },
                 {
                   "providerMetadata": undefined,
+                  "state": "streaming",
                   "text": "",
                   "type": "reasoning",
                 },
@@ -2297,6 +3097,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will open the conversation with witty banter. ",
                   "type": "reasoning",
                 },
@@ -2306,11 +3107,13 @@ describe('processUIMessageStream', () => {
                       "isRedacted": true,
                     },
                   },
+                  "state": "done",
                   "text": "redacted-data",
                   "type": "reasoning",
                 },
                 {
                   "providerMetadata": undefined,
+                  "state": "streaming",
                   "text": "Once the user has relaxed,",
                   "type": "reasoning",
                 },
@@ -2332,6 +3135,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will open the conversation with witty banter. ",
                   "type": "reasoning",
                 },
@@ -2341,6 +3145,7 @@ describe('processUIMessageStream', () => {
                       "isRedacted": true,
                     },
                   },
+                  "state": "done",
                   "text": "redacted-data",
                   "type": "reasoning",
                 },
@@ -2350,6 +3155,7 @@ describe('processUIMessageStream', () => {
                       "signature": "abc123",
                     },
                   },
+                  "state": "streaming",
                   "text": "Once the user has relaxed, I will pry for valuable information.",
                   "type": "reasoning",
                 },
@@ -2371,6 +3177,7 @@ describe('processUIMessageStream', () => {
                       "signature": "1234567890",
                     },
                   },
+                  "state": "done",
                   "text": "I will open the conversation with witty banter. ",
                   "type": "reasoning",
                 },
@@ -2380,6 +3187,7 @@ describe('processUIMessageStream', () => {
                       "isRedacted": true,
                     },
                   },
+                  "state": "done",
                   "text": "redacted-data",
                   "type": "reasoning",
                 },
@@ -2389,10 +3197,148 @@ describe('processUIMessageStream', () => {
                       "signature": "abc123",
                     },
                   },
+                  "state": "done",
+                  "text": "Once the user has relaxed, I will pry for valuable information.",
+                  "type": "reasoning",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I will open the conversation with witty banter. ",
+                  "type": "reasoning",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "isRedacted": true,
+                    },
+                  },
+                  "state": "done",
+                  "text": "redacted-data",
+                  "type": "reasoning",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "abc123",
+                    },
+                  },
+                  "state": "done",
                   "text": "Once the user has relaxed, I will pry for valuable information.",
                   "type": "reasoning",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I will open the conversation with witty banter. ",
+                  "type": "reasoning",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "isRedacted": true,
+                    },
+                  },
+                  "state": "done",
+                  "text": "redacted-data",
+                  "type": "reasoning",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "abc123",
+                    },
+                  },
+                  "state": "done",
+                  "text": "Once the user has relaxed, I will pry for valuable information.",
+                  "type": "reasoning",
+                },
+                {
+                  "state": "streaming",
+                  "text": "Hi there!",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1234567890",
+                    },
+                  },
+                  "state": "done",
+                  "text": "I will open the conversation with witty banter. ",
+                  "type": "reasoning",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "isRedacted": true,
+                    },
+                  },
+                  "state": "done",
+                  "text": "redacted-data",
+                  "type": "reasoning",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "abc123",
+                    },
+                  },
+                  "state": "done",
+                  "text": "Once the user has relaxed, I will pry for valuable information.",
+                  "type": "reasoning",
+                },
+                {
+                  "state": "done",
                   "text": "Hi there!",
                   "type": "text",
                 },
@@ -2419,6 +3365,7 @@ describe('processUIMessageStream', () => {
                   "signature": "1234567890",
                 },
               },
+              "state": "done",
               "text": "I will open the conversation with witty banter. ",
               "type": "reasoning",
             },
@@ -2428,6 +3375,7 @@ describe('processUIMessageStream', () => {
                   "isRedacted": true,
                 },
               },
+              "state": "done",
               "text": "redacted-data",
               "type": "reasoning",
             },
@@ -2437,10 +3385,12 @@ describe('processUIMessageStream', () => {
                   "signature": "abc123",
                 },
               },
+              "state": "done",
               "text": "Once the user has relaxed, I will pry for valuable information.",
               "type": "reasoning",
             },
             {
+              "state": "done",
               "text": "Hi there!",
               "type": "text",
             },
@@ -2623,6 +3573,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "The weather in London is sunny.",
                   "type": "text",
                 },
@@ -2639,6 +3607,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
+                  "text": "The weather in London is sunny.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
                 },
@@ -2667,6 +3653,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
             },
@@ -2742,6 +3729,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
                   "text": "Here is a file:",
                   "type": "text",
                 },
@@ -2758,6 +3763,24 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
+                  "text": "Here is a file:",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
                 },
@@ -2779,6 +3802,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
                 },
@@ -2788,6 +3812,34 @@ describe('processUIMessageStream', () => {
                   "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
                 },
                 {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
+                  "text": "Here is a file:",
+                  "type": "text",
+                },
+                {
+                  "mediaType": "text/plain",
+                  "type": "file",
+                  "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
+                },
+                {
+                  "state": "streaming",
                   "text": "And another one:",
                   "type": "text",
                 },
@@ -2804,6 +3856,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
                 },
@@ -2813,6 +3866,34 @@ describe('processUIMessageStream', () => {
                   "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
                 },
                 {
+                  "state": "done",
+                  "text": "And another one:",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
+                  "text": "Here is a file:",
+                  "type": "text",
+                },
+                {
+                  "mediaType": "text/plain",
+                  "type": "file",
+                  "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
+                },
+                {
+                  "state": "done",
                   "text": "And another one:",
                   "type": "text",
                 },
@@ -2839,6 +3920,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "Here is a file:",
               "type": "text",
             },
@@ -2848,6 +3930,7 @@ describe('processUIMessageStream', () => {
               "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
             },
             {
+              "state": "done",
               "text": "And another one:",
               "type": "text",
             },

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -172,9 +172,14 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 
           switch (part.type) {
             case 'text-start': {
-              const textPart: TextUIPart = { type: 'text', text: '' };
+              const textPart: TextUIPart = {
+                type: 'text',
+                text: '',
+                state: 'streaming',
+              };
               state.activeTextParts[part.id] = textPart;
               state.message.parts.push(textPart);
+              write();
               break;
             }
 
@@ -185,7 +190,10 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-end': {
+              const textPart = state.activeTextParts[part.id];
+              textPart.state = 'done';
               delete state.activeTextParts[part.id];
+              write();
               break;
             }
 
@@ -194,10 +202,10 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 type: 'reasoning',
                 text: '',
                 providerMetadata: part.providerMetadata,
+                state: 'streaming',
               };
               state.activeReasoningParts[part.id] = reasoningPart;
               state.message.parts.push(reasoningPart);
-
               write();
               break;
             }
@@ -215,12 +223,10 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               const reasoningPart = state.activeReasoningParts[part.id];
               reasoningPart.providerMetadata =
                 part.providerMetadata ?? reasoningPart.providerMetadata;
+              reasoningPart.state = 'done';
               delete state.activeReasoningParts[part.id];
 
-              if (part.providerMetadata != null) {
-                write();
-              }
-
+              write();
               break;
             }
 

--- a/packages/ai/src/ui/should-resubmit-messages.test.ts
+++ b/packages/ai/src/ui/should-resubmit-messages.test.ts
@@ -19,7 +19,7 @@ describe('shouldResubmitMessages', () => {
           {
             id: '2',
             role: 'assistant',
-            parts: [{ type: 'text', text: 'Hello' }],
+            parts: [{ type: 'text', text: 'Hello', state: 'done' }],
           },
         ],
       }),
@@ -77,6 +77,7 @@ describe('isAssistantMessageWithCompletedToolCalls', () => {
           {
             type: 'text',
             text: 'The current weather in New York is windy.',
+            state: 'done',
           },
         ],
       }),
@@ -102,6 +103,7 @@ describe('isAssistantMessageWithCompletedToolCalls', () => {
           {
             type: 'text',
             text: 'The current weather in New York is windy.',
+            state: 'done',
           },
         ],
       }),

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -78,6 +78,11 @@ export type TextUIPart = {
    * The text content.
    */
   text: string;
+
+  /**
+   * The state of the text part.
+   */
+  state?: 'streaming' | 'done';
 };
 
 /**
@@ -90,6 +95,11 @@ export type ReasoningUIPart = {
    * The reasoning text.
    */
   text: string;
+
+  /**
+   * The state of the reasoning part.
+   */
+  state?: 'streaming' | 'done';
 
   /**
    * The provider metadata.

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -115,6 +115,7 @@ describe('data protocol stream', () => {
             {
               type: 'text',
               text: 'Hello, world.',
+              state: 'done',
             },
           ],
         },
@@ -284,6 +285,7 @@ describe('data protocol stream', () => {
             {
               type: 'text',
               text: 'Hello, world.',
+              state: 'done',
             },
           ],
         },
@@ -300,6 +302,7 @@ describe('data protocol stream', () => {
             },
             "parts": [
               {
+                "state": "done",
                 "text": "Hello, world.",
                 "type": "text",
               },
@@ -382,6 +385,7 @@ describe('data protocol stream', () => {
               {
                 text: 'Hello, world.',
                 type: 'text',
+                state: 'done',
               },
             ],
             role: 'assistant',
@@ -505,6 +509,7 @@ describe('text stream', () => {
                 "type": "step-start",
               },
               {
+                "state": "done",
                 "text": "Hello, world.",
                 "type": "text",
               },
@@ -1027,6 +1032,7 @@ describe('tool invocations', () => {
             {
               text: 'more text',
               type: 'text',
+              state: 'done',
             },
           ],
           role: 'assistant',
@@ -1443,6 +1449,7 @@ describe('file attachments with data url', () => {
             {
               text: 'Response to message with text attachment',
               type: 'text',
+              state: 'done',
             },
           ],
           role: 'assistant',
@@ -1533,6 +1540,7 @@ describe('file attachments with data url', () => {
             {
               type: 'text',
               text: 'Response to message with image attachment',
+              state: 'done',
             },
           ],
         },
@@ -1656,6 +1664,7 @@ describe('file attachments with url', () => {
             {
               type: 'text',
               text: 'Response to message with image attachment',
+              state: 'done',
             },
           ],
         },
@@ -1761,6 +1770,7 @@ describe('attachments with empty submit', () => {
             {
               type: 'text',
               text: 'Response to message with image attachment',
+              state: 'done',
             },
           ],
         },
@@ -1868,6 +1878,7 @@ describe('should send message with attachments', () => {
           id: 'id-2',
           parts: [
             {
+              state: 'done',
               text: 'Response to message with image attachment',
               type: 'text',
             },

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -70,7 +70,7 @@ describe('data protocol stream', () => {
     expect(chat.messages.at(1)).toStrictEqual(
       expect.objectContaining({
         role: 'assistant',
-        parts: [{ type: 'text', text: 'Hello, world.' }],
+        parts: [{ type: 'text', text: 'Hello, world.', state: 'done' }],
       }),
     );
   });
@@ -186,6 +186,7 @@ describe('data protocol stream', () => {
           {
             text: 'Hello, world.',
             type: 'text',
+            state: 'done',
           },
         ],
         role: 'assistant',
@@ -272,6 +273,7 @@ describe('text stream', () => {
               "type": "step-start",
             },
             {
+              "state": "done",
               "text": "Hello, world.",
               "type": "text",
             },
@@ -301,7 +303,10 @@ describe('text stream', () => {
           id: expect.any(String),
           role: 'assistant',
           metadata: undefined,
-          parts: [{ type: 'step-start' }, { text: 'He', type: 'text' }],
+          parts: [
+            { type: 'step-start' },
+            { text: 'He', type: 'text', state: 'streaming' },
+          ],
         }),
       ),
     );
@@ -345,7 +350,7 @@ describe('text stream', () => {
         metadata: undefined,
         parts: [
           { type: 'step-start' },
-          { text: 'Hello, world.', type: 'text' },
+          { text: 'Hello, world.', type: 'text', state: 'done' },
         ],
       },
     });
@@ -826,6 +831,7 @@ describe('maxSteps', () => {
                 "type": "tool-test-tool",
               },
               {
+                "state": "done",
                 "text": "final result",
                 "type": "text",
               },
@@ -949,6 +955,7 @@ describe('file attachments with data url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "state": "done",
               "text": "Response to message with text attachment",
               "type": "text",
             },
@@ -1036,6 +1043,7 @@ describe('file attachments with data url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
             },
@@ -1133,6 +1141,7 @@ describe('file attachments with url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
             },
@@ -1227,6 +1236,7 @@ describe('file attachments with empty text content', () => {
           "metadata": undefined,
           "parts": [
             {
+              "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
             },
@@ -1310,7 +1320,7 @@ describe('reload', () => {
     expect(chat.messages.at(1)).toStrictEqual(
       expect.objectContaining({
         role: 'assistant',
-        parts: [{ text: 'first response', type: 'text' }],
+        parts: [{ text: 'first response', type: 'text', state: 'done' }],
       }),
     );
 
@@ -1348,7 +1358,7 @@ describe('reload', () => {
     expect(chat.messages.at(1)).toStrictEqual(
       expect.objectContaining({
         role: 'assistant',
-        parts: [{ text: 'second response', type: 'text' }],
+        parts: [{ text: 'second response', type: 'text', state: 'done' }],
       }),
     );
   });
@@ -1446,6 +1456,7 @@ describe('generateId function', () => {
           "metadata": undefined,
           "parts": [
             {
+              "state": "done",
               "text": "Hello, world.",
               "type": "text",
             },

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -252,7 +252,7 @@ describe('data protocol stream', () => {
         message: {
           id: expect.any(String),
           role: 'assistant',
-          parts: [{ text: 'Hello, world.', type: 'text' }],
+          parts: [{ text: 'Hello, world.', type: 'text', state: 'done' }],
         },
       },
     ]);
@@ -303,7 +303,7 @@ describe('text stream', () => {
           role: 'assistant',
           parts: [
             { type: 'step-start' },
-            { text: 'Hello, world.', type: 'text' },
+            { text: 'Hello, world.', type: 'text', state: 'done' },
           ],
         },
       },
@@ -759,6 +759,7 @@ describe('file attachments with data url', () => {
             {
               text: 'Response to message with text attachment',
               type: 'text',
+              state: 'done',
             },
           ],
           role: 'assistant',
@@ -824,6 +825,7 @@ describe('file attachments with data url', () => {
             {
               type: 'text',
               text: 'Response to message with image attachment',
+              state: 'done',
             },
           ],
         },
@@ -884,6 +886,7 @@ describe('file attachments with url', () => {
             {
               type: 'text',
               text: 'Response to message with image attachment',
+              state: 'done',
             },
           ],
         },
@@ -949,6 +952,7 @@ describe('attachments with empty submit', () => {
             {
               type: 'text',
               text: 'Response to empty message with attachment',
+              state: 'done',
             },
           ],
         },
@@ -1005,6 +1009,7 @@ describe('should append message with attachments', () => {
             {
               text: 'Response to message with image attachment',
               type: 'text',
+              state: 'done',
             },
           ],
           role: 'assistant',


### PR DESCRIPTION
## Background

Including the streaming state of text and reasoning parts is important for rsc (end stream) and can be used to show e.g. a progress indicator.

## Summary

Add `state` property to assistant text and reasoning parts in ui messages.