### PR TITLE
feat: add transcription and speech model support to provider registry

### DIFF
--- a/.changeset/purple-dodos-burn.md
+++ b/.changeset/purple-dodos-burn.md
@@ -4,6 +4,7 @@
 '@ai-sdk/deepgram': patch
 '@ai-sdk/gladia': patch
 '@ai-sdk/revai': patch
+'@ai-sdk/provider': patch
 'ai': patch
 ---
 

--- a/.changeset/purple-dodos-burn.md
+++ b/.changeset/purple-dodos-burn.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/assemblyai': patch
+'@ai-sdk/elevenlabs': patch
+'@ai-sdk/deepgram': patch
+'@ai-sdk/gladia': patch
+'@ai-sdk/revai': patch
+'ai': patch
+---
+
+feat: add transcription and speech model support to provider registry

--- a/examples/ai-core/src/registry/generate-speech-openai.ts
+++ b/examples/ai-core/src/registry/generate-speech-openai.ts
@@ -1,0 +1,13 @@
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import { registry } from './setup-registry';
+
+async function main() {
+  const { audio } = await generateSpeech({
+    model: registry.speechModel('openai:tts-1'),
+    text: 'Hello, this is a test of speech synthesis using the provider registry!',
+  });
+
+  console.log('Generated audio:', audio);
+}
+
+main().catch(console.error); 

--- a/examples/ai-core/src/registry/generate-speech-openai.ts
+++ b/examples/ai-core/src/registry/generate-speech-openai.ts
@@ -10,4 +10,4 @@ async function main() {
   console.log('Generated audio:', audio);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/examples/ai-core/src/registry/transcribe-openai.ts
+++ b/examples/ai-core/src/registry/transcribe-openai.ts
@@ -1,0 +1,17 @@
+import { experimental_transcribe as transcribe } from 'ai';
+import { readFile } from 'fs/promises';
+import { registry } from './setup-registry';
+
+async function main() {
+  const result = await transcribe({
+    model: registry.transcriptionModel('openai:whisper-1'),
+    audio: await readFile('../data/galileo.mp3'),
+  });
+
+  console.log('Transcript:', result.text);
+  console.log('Language:', result.language);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Segments:', result.segments);
+}
+
+main().catch(console.error); 

--- a/examples/ai-core/src/registry/transcribe-openai.ts
+++ b/examples/ai-core/src/registry/transcribe-openai.ts
@@ -14,4 +14,4 @@ async function main() {
   console.log('Segments:', result.segments);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/packages/ai/core/registry/custom-provider.test.ts
+++ b/packages/ai/core/registry/custom-provider.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockImageModelV2 } from '../test/mock-image-model-v2';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
+import { MockTranscriptionModelV2 } from '../test/mock-transcription-model-v2';
+import { MockSpeechModelV2 } from '../test/mock-speech-model-v2';
 import { customProvider } from './custom-provider';
 
 const mockLanguageModel = new MockLanguageModelV2();
@@ -11,6 +13,8 @@ const mockFallbackProvider = {
   languageModel: vi.fn(),
   textEmbeddingModel: vi.fn(),
   imageModel: vi.fn(),
+  transcriptionModel: vi.fn(),
+  speechModel: vi.fn(),
 };
 
 describe('languageModel', () => {
@@ -100,5 +104,63 @@ describe('imageModel', () => {
     const provider = customProvider({});
 
     expect(() => provider.imageModel('test-model')).toThrow(NoSuchModelError);
+  });
+});
+
+describe('transcriptionModel', () => {
+  const mockTranscriptionModel = new MockTranscriptionModelV2();
+
+  it('should return the transcription model if it exists', () => {
+    const provider = customProvider({
+      transcriptionModels: { 'test-model': mockTranscriptionModel },
+    });
+
+    expect(provider.transcriptionModel('test-model')).toBe(mockTranscriptionModel);
+  });
+
+  it('should use fallback provider if model not found and fallback exists', () => {
+    mockFallbackProvider.transcriptionModel = vi.fn().mockReturnValue(mockTranscriptionModel);
+
+    const provider = customProvider({
+      fallbackProvider: mockFallbackProvider,
+    });
+
+    expect(provider.transcriptionModel('test-model')).toBe(mockTranscriptionModel);
+    expect(mockFallbackProvider.transcriptionModel).toHaveBeenCalledWith('test-model');
+  });
+
+  it('should throw NoSuchModelError if model not found and no fallback', () => {
+    const provider = customProvider({});
+
+    expect(() => provider.transcriptionModel('test-model')).toThrow(NoSuchModelError);
+  });
+});
+
+describe('speechModel', () => {
+  const mockSpeechModel = new MockSpeechModelV2();
+
+  it('should return the speech model if it exists', () => {
+    const provider = customProvider({
+      speechModels: { 'test-model': mockSpeechModel },
+    });
+
+    expect(provider.speechModel('test-model')).toBe(mockSpeechModel);
+  });
+
+  it('should use fallback provider if model not found and fallback exists', () => {
+    mockFallbackProvider.speechModel = vi.fn().mockReturnValue(mockSpeechModel);
+
+    const provider = customProvider({
+      fallbackProvider: mockFallbackProvider,
+    });
+
+    expect(provider.speechModel('test-model')).toBe(mockSpeechModel);
+    expect(mockFallbackProvider.speechModel).toHaveBeenCalledWith('test-model');
+  });
+
+  it('should throw NoSuchModelError if model not found and no fallback', () => {
+    const provider = customProvider({});
+
+    expect(() => provider.speechModel('test-model')).toThrow(NoSuchModelError);
   });
 });

--- a/packages/ai/core/registry/custom-provider.test.ts
+++ b/packages/ai/core/registry/custom-provider.test.ts
@@ -115,24 +115,34 @@ describe('transcriptionModel', () => {
       transcriptionModels: { 'test-model': mockTranscriptionModel },
     });
 
-    expect(provider.transcriptionModel('test-model')).toBe(mockTranscriptionModel);
+    expect(provider.transcriptionModel('test-model')).toBe(
+      mockTranscriptionModel,
+    );
   });
 
   it('should use fallback provider if model not found and fallback exists', () => {
-    mockFallbackProvider.transcriptionModel = vi.fn().mockReturnValue(mockTranscriptionModel);
+    mockFallbackProvider.transcriptionModel = vi
+      .fn()
+      .mockReturnValue(mockTranscriptionModel);
 
     const provider = customProvider({
       fallbackProvider: mockFallbackProvider,
     });
 
-    expect(provider.transcriptionModel('test-model')).toBe(mockTranscriptionModel);
-    expect(mockFallbackProvider.transcriptionModel).toHaveBeenCalledWith('test-model');
+    expect(provider.transcriptionModel('test-model')).toBe(
+      mockTranscriptionModel,
+    );
+    expect(mockFallbackProvider.transcriptionModel).toHaveBeenCalledWith(
+      'test-model',
+    );
   });
 
   it('should throw NoSuchModelError if model not found and no fallback', () => {
     const provider = customProvider({});
 
-    expect(() => provider.transcriptionModel('test-model')).toThrow(NoSuchModelError);
+    expect(() => provider.transcriptionModel('test-model')).toThrow(
+      NoSuchModelError,
+    );
   });
 });
 

--- a/packages/ai/core/registry/custom-provider.ts
+++ b/packages/ai/core/registry/custom-provider.ts
@@ -48,7 +48,9 @@ export function customProvider<
     modelId: ExtractModelId<EMBEDDING_MODELS>,
   ): EmbeddingModelV2<string>;
   imageModel(modelId: ExtractModelId<IMAGE_MODELS>): ImageModelV2;
-  transcriptionModel(modelId: ExtractModelId<TRANSCRIPTION_MODELS>): TranscriptionModelV2;
+  transcriptionModel(
+    modelId: ExtractModelId<TRANSCRIPTION_MODELS>,
+  ): TranscriptionModelV2;
   speechModel(modelId: ExtractModelId<SPEECH_MODELS>): SpeechModelV2;
 } {
   return {
@@ -90,7 +92,9 @@ export function customProvider<
       throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
     },
 
-    transcriptionModel(modelId: ExtractModelId<TRANSCRIPTION_MODELS>): TranscriptionModelV2 {
+    transcriptionModel(
+      modelId: ExtractModelId<TRANSCRIPTION_MODELS>,
+    ): TranscriptionModelV2 {
       if (transcriptionModels != null && modelId in transcriptionModels) {
         return transcriptionModels[modelId];
       }

--- a/packages/ai/core/registry/custom-provider.ts
+++ b/packages/ai/core/registry/custom-provider.ts
@@ -4,17 +4,21 @@ import {
   LanguageModelV2,
   NoSuchModelError,
   ProviderV2,
+  SpeechModelV2,
+  TranscriptionModelV2,
 } from '@ai-sdk/provider';
 
 /**
- * Creates a custom provider with specified language models, text embedding models, and an optional fallback provider.
+ * Creates a custom provider with specified language models, text embedding models, image models, transcription models, speech models, and an optional fallback provider.
  *
  * @param {Object} options - The options for creating the custom provider.
  * @param {Record<string, LanguageModel>} [options.languageModels] - A record of language models, where keys are model IDs and values are LanguageModel instances.
  * @param {Record<string, EmbeddingModel<string>>} [options.textEmbeddingModels] - A record of text embedding models, where keys are model IDs and values are EmbeddingModel<string> instances.
  * @param {Record<string, ImageModel>} [options.imageModels] - A record of image models, where keys are model IDs and values are ImageModel instances.
+ * @param {Record<string, TranscriptionModel>} [options.transcriptionModels] - A record of transcription models, where keys are model IDs and values are TranscriptionModel instances.
+ * @param {Record<string, SpeechModel>} [options.speechModels] - A record of speech models, where keys are model IDs and values are SpeechModel instances.
  * @param {Provider} [options.fallbackProvider] - An optional fallback provider to use when a requested model is not found in the custom provider.
- * @returns {Provider} A Provider object with languageModel, textEmbeddingModel, and imageModel methods.
+ * @returns {Provider} A Provider object with languageModel, textEmbeddingModel, imageModel, transcriptionModel, and speechModel methods.
  *
  * @throws {NoSuchModelError} Throws when a requested model is not found and no fallback provider is available.
  */
@@ -22,15 +26,21 @@ export function customProvider<
   LANGUAGE_MODELS extends Record<string, LanguageModelV2>,
   EMBEDDING_MODELS extends Record<string, EmbeddingModelV2<string>>,
   IMAGE_MODELS extends Record<string, ImageModelV2>,
+  TRANSCRIPTION_MODELS extends Record<string, TranscriptionModelV2>,
+  SPEECH_MODELS extends Record<string, SpeechModelV2>,
 >({
   languageModels,
   textEmbeddingModels,
   imageModels,
+  transcriptionModels,
+  speechModels,
   fallbackProvider,
 }: {
   languageModels?: LANGUAGE_MODELS;
   textEmbeddingModels?: EMBEDDING_MODELS;
   imageModels?: IMAGE_MODELS;
+  transcriptionModels?: TRANSCRIPTION_MODELS;
+  speechModels?: SPEECH_MODELS;
   fallbackProvider?: ProviderV2;
 }): ProviderV2 & {
   languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModelV2;
@@ -38,6 +48,8 @@ export function customProvider<
     modelId: ExtractModelId<EMBEDDING_MODELS>,
   ): EmbeddingModelV2<string>;
   imageModel(modelId: ExtractModelId<IMAGE_MODELS>): ImageModelV2;
+  transcriptionModel(modelId: ExtractModelId<TRANSCRIPTION_MODELS>): TranscriptionModelV2;
+  speechModel(modelId: ExtractModelId<SPEECH_MODELS>): SpeechModelV2;
 } {
   return {
     languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModelV2 {
@@ -76,6 +88,30 @@ export function customProvider<
       }
 
       throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+    },
+
+    transcriptionModel(modelId: ExtractModelId<TRANSCRIPTION_MODELS>): TranscriptionModelV2 {
+      if (transcriptionModels != null && modelId in transcriptionModels) {
+        return transcriptionModels[modelId];
+      }
+
+      if (fallbackProvider?.transcriptionModel) {
+        return fallbackProvider.transcriptionModel(modelId);
+      }
+
+      throw new NoSuchModelError({ modelId, modelType: 'transcriptionModel' });
+    },
+
+    speechModel(modelId: ExtractModelId<SPEECH_MODELS>): SpeechModelV2 {
+      if (speechModels != null && modelId in speechModels) {
+        return speechModels[modelId];
+      }
+
+      if (fallbackProvider?.speechModel) {
+        return fallbackProvider.speechModel(modelId);
+      }
+
+      throw new NoSuchModelError({ modelId, modelType: 'speechModel' });
     },
   };
 }

--- a/packages/ai/core/registry/no-such-provider-error.ts
+++ b/packages/ai/core/registry/no-such-provider-error.ts
@@ -18,7 +18,12 @@ export class NoSuchProviderError extends NoSuchModelError {
     message = `No such provider: ${providerId} (available providers: ${availableProviders.join()})`,
   }: {
     modelId: string;
-    modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel' | 'transcriptionModel' | 'speechModel';
+    modelType:
+      | 'languageModel'
+      | 'textEmbeddingModel'
+      | 'imageModel'
+      | 'transcriptionModel'
+      | 'speechModel';
     providerId: string;
     availableProviders: string[];
     message?: string;

--- a/packages/ai/core/registry/no-such-provider-error.ts
+++ b/packages/ai/core/registry/no-such-provider-error.ts
@@ -18,7 +18,7 @@ export class NoSuchProviderError extends NoSuchModelError {
     message = `No such provider: ${providerId} (available providers: ${availableProviders.join()})`,
   }: {
     modelId: string;
-    modelType: 'languageModel' | 'textEmbeddingModel';
+    modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel' | 'transcriptionModel' | 'speechModel';
     providerId: string;
     availableProviders: string[];
     message?: string;

--- a/packages/ai/core/registry/provider-registry.test.ts
+++ b/packages/ai/core/registry/provider-registry.test.ts
@@ -370,7 +370,9 @@ describe('transcriptionModel', () => {
     const registry = createProviderRegistry({});
 
     // @ts-expect-error - should not accept arbitrary strings
-    expect(() => registry.transcriptionModel('model')).toThrowError(NoSuchModelError);
+    expect(() => registry.transcriptionModel('model')).toThrowError(
+      NoSuchModelError,
+    );
   });
 });
 

--- a/packages/ai/core/registry/provider-registry.test.ts
+++ b/packages/ai/core/registry/provider-registry.test.ts
@@ -4,6 +4,8 @@ import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
 import { NoSuchProviderError } from './no-such-provider-error';
 import { createProviderRegistry } from './provider-registry';
 import { MockImageModelV2 } from '../test/mock-image-model-v2';
+import { MockTranscriptionModelV2 } from '../test/mock-transcription-model-v2';
+import { MockSpeechModelV2 } from '../test/mock-speech-model-v2';
 
 describe('languageModel', () => {
   it('should return language model from provider', () => {
@@ -69,6 +71,12 @@ describe('languageModel', () => {
         imageModel: () => {
           return null as any;
         },
+        transcriptionModel: () => {
+          return null as any;
+        },
+        speechModel: () => {
+          return null as any;
+        },
       },
     });
 
@@ -102,6 +110,12 @@ describe('languageModel', () => {
           imageModel: () => {
             return null as any;
           },
+          transcriptionModel: () => {
+            return null as any;
+          },
+          speechModel: () => {
+            return null as any;
+          },
         },
       },
       { separator: '|' },
@@ -124,6 +138,12 @@ describe('languageModel', () => {
             return null as any;
           },
           imageModel: () => {
+            return null as any;
+          },
+          transcriptionModel: () => {
+            return null as any;
+          },
+          speechModel: () => {
             return null as any;
           },
         },
@@ -149,6 +169,12 @@ describe('textEmbeddingModel', () => {
           return null as any;
         },
         imageModel: () => {
+          return null as any;
+        },
+        transcriptionModel: () => {
+          return null as any;
+        },
+        speechModel: () => {
           return null as any;
         },
       },
@@ -211,6 +237,12 @@ describe('textEmbeddingModel', () => {
           imageModel: () => {
             return null as any;
           },
+          transcriptionModel: () => {
+            return null as any;
+          },
+          speechModel: () => {
+            return null as any;
+          },
         },
       },
       { separator: '|' },
@@ -232,6 +264,8 @@ describe('imageModel', () => {
         },
         languageModel: () => null as any,
         textEmbeddingModel: () => null as any,
+        transcriptionModel: () => null as any,
+        speechModel: () => null as any,
       },
     });
 
@@ -286,5 +320,107 @@ describe('imageModel', () => {
     );
 
     expect(modelRegistry.imageModel('provider|model')).toEqual(model);
+  });
+});
+
+describe('transcriptionModel', () => {
+  it('should return transcription model from provider', () => {
+    const model = new MockTranscriptionModelV2();
+
+    const modelRegistry = createProviderRegistry({
+      provider: {
+        transcriptionModel: id => {
+          expect(id).toEqual('model');
+          return model;
+        },
+        languageModel: () => null as any,
+        textEmbeddingModel: () => null as any,
+        imageModel: () => null as any,
+      },
+    });
+
+    expect(modelRegistry.transcriptionModel('provider:model')).toEqual(model);
+  });
+
+  it('should throw NoSuchProviderError if provider does not exist', () => {
+    const registry = createProviderRegistry({});
+
+    // @ts-expect-error - should not accept arbitrary strings
+    expect(() => registry.transcriptionModel('provider:model')).toThrowError(
+      NoSuchProviderError,
+    );
+  });
+
+  it('should throw NoSuchModelError if provider does not return a model', () => {
+    const registry = createProviderRegistry({
+      provider: {
+        transcriptionModel: () => null as any,
+        languageModel: () => null as any,
+        textEmbeddingModel: () => null as any,
+        imageModel: () => null as any,
+      },
+    });
+
+    expect(() => registry.transcriptionModel('provider:model')).toThrowError(
+      NoSuchModelError,
+    );
+  });
+
+  it("should throw NoSuchModelError if model id doesn't contain a colon", () => {
+    const registry = createProviderRegistry({});
+
+    // @ts-expect-error - should not accept arbitrary strings
+    expect(() => registry.transcriptionModel('model')).toThrowError(NoSuchModelError);
+  });
+});
+
+describe('speechModel', () => {
+  it('should return speech model from provider', () => {
+    const model = new MockSpeechModelV2();
+
+    const modelRegistry = createProviderRegistry({
+      provider: {
+        speechModel: id => {
+          expect(id).toEqual('model');
+          return model;
+        },
+        languageModel: () => null as any,
+        textEmbeddingModel: () => null as any,
+        imageModel: () => null as any,
+      },
+    });
+
+    expect(modelRegistry.speechModel('provider:model')).toEqual(model);
+  });
+
+  it('should throw NoSuchProviderError if provider does not exist', () => {
+    const registry = createProviderRegistry({});
+
+    // @ts-expect-error - should not accept arbitrary strings
+    expect(() => registry.speechModel('provider:model')).toThrowError(
+      NoSuchProviderError,
+    );
+  });
+
+  it('should throw NoSuchModelError if provider does not return a model', () => {
+    const registry = createProviderRegistry({
+      provider: {
+        speechModel: () => null as any,
+        languageModel: () => null as any,
+        textEmbeddingModel: () => null as any,
+        imageModel: () => null as any,
+      },
+    });
+
+    expect(() => registry.speechModel('provider:model')).toThrowError(
+      NoSuchModelError,
+    );
+  });
+
+  it("should throw NoSuchModelError if model id doesn't contain a colon", () => {
+    const registry = createProviderRegistry({});
+
+    // @ts-expect-error - should not accept arbitrary strings
+    expect(() => registry.speechModel('model')).toThrowError(NoSuchModelError);
   });
 });

--- a/packages/ai/core/registry/provider-registry.ts
+++ b/packages/ai/core/registry/provider-registry.ts
@@ -120,7 +120,15 @@ class DefaultProviderRegistry<
     this.providers[id] = provider;
   }
 
-  private getProvider(id: string, modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel' | 'transcriptionModel' | 'speechModel'): ProviderV2 {
+  private getProvider(
+    id: string,
+    modelType:
+      | 'languageModel'
+      | 'textEmbeddingModel'
+      | 'imageModel'
+      | 'transcriptionModel'
+      | 'speechModel',
+  ): ProviderV2 {
     const provider = this.providers[id as keyof PROVIDERS];
 
     if (provider == null) {
@@ -137,7 +145,12 @@ class DefaultProviderRegistry<
 
   private splitId(
     id: string,
-    modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel' | 'transcriptionModel' | 'speechModel',
+    modelType:
+      | 'languageModel'
+      | 'textEmbeddingModel'
+      | 'imageModel'
+      | 'transcriptionModel'
+      | 'speechModel',
   ): [string, string] {
     const index = id.indexOf(this.separator);
 
@@ -158,7 +171,9 @@ class DefaultProviderRegistry<
     id: `${KEY & string}${SEPARATOR}${string}`,
   ): LanguageModelV2 {
     const [providerId, modelId] = this.splitId(id, 'languageModel');
-    const model = this.getProvider(providerId, 'languageModel').languageModel?.(modelId);
+    const model = this.getProvider(providerId, 'languageModel').languageModel?.(
+      modelId,
+    );
 
     if (model == null) {
       throw new NoSuchModelError({ modelId: id, modelType: 'languageModel' });
@@ -209,7 +224,10 @@ class DefaultProviderRegistry<
     const model = provider.transcriptionModel?.(modelId);
 
     if (model == null) {
-      throw new NoSuchModelError({ modelId: id, modelType: 'transcriptionModel' });
+      throw new NoSuchModelError({
+        modelId: id,
+        modelType: 'transcriptionModel',
+      });
     }
 
     return model;

--- a/packages/assemblyai/src/assemblyai-provider.ts
+++ b/packages/assemblyai/src/assemblyai-provider.ts
@@ -1,10 +1,13 @@
-import { TranscriptionModelV2, ProviderV2 } from '@ai-sdk/provider';
+import {
+  TranscriptionModelV2,
+  ProviderV2,
+  NoSuchModelError,
+} from '@ai-sdk/provider';
 import { FetchFunction, loadApiKey } from '@ai-sdk/provider-utils';
 import { AssemblyAITranscriptionModel } from './assemblyai-transcription-model';
 import { AssemblyAITranscriptionModelId } from './assemblyai-transcription-settings';
 
-export interface AssemblyAIProvider
-  extends Pick<ProviderV2, 'transcriptionModel'> {
+export interface AssemblyAIProvider extends ProviderV2 {
   (
     modelId: 'best',
     settings?: {},
@@ -67,6 +70,30 @@ export function createAssemblyAI(
 
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
+
+  provider.languageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'languageModel',
+      message: 'AssemblyAI does not provide language models',
+    });
+  };
+
+  provider.textEmbeddingModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'textEmbeddingModel',
+      message: 'AssemblyAI does not provide text embedding models',
+    });
+  };
+
+  provider.imageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'imageModel',
+      message: 'AssemblyAI does not provide image models',
+    });
+  };
 
   return provider as AssemblyAIProvider;
 }

--- a/packages/deepgram/src/deepgram-provider.ts
+++ b/packages/deepgram/src/deepgram-provider.ts
@@ -1,10 +1,13 @@
-import { TranscriptionModelV2, ProviderV2 } from '@ai-sdk/provider';
+import {
+  TranscriptionModelV2,
+  ProviderV2,
+  NoSuchModelError,
+} from '@ai-sdk/provider';
 import { FetchFunction, loadApiKey } from '@ai-sdk/provider-utils';
 import { DeepgramTranscriptionModel } from './deepgram-transcription-model';
 import { DeepgramTranscriptionModelId } from './deepgram-transcription-options';
 
-export interface DeepgramProvider
-  extends Pick<ProviderV2, 'transcriptionModel'> {
+export interface DeepgramProvider extends ProviderV2 {
   (
     modelId: 'nova-3',
     settings?: {},
@@ -67,6 +70,31 @@ export function createDeepgram(
 
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
+
+  // Required ProviderV2 methods that are not supported
+  provider.languageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'languageModel',
+      message: 'Deepgram does not provide language models',
+    });
+  };
+
+  provider.textEmbeddingModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'textEmbeddingModel',
+      message: 'Deepgram does not provide text embedding models',
+    });
+  };
+
+  provider.imageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'imageModel',
+      message: 'Deepgram does not provide image models',
+    });
+  };
 
   return provider as DeepgramProvider;
 }

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -1,10 +1,13 @@
-import { TranscriptionModelV2, ProviderV2 } from '@ai-sdk/provider';
+import {
+  TranscriptionModelV2,
+  ProviderV2,
+  NoSuchModelError,
+} from '@ai-sdk/provider';
 import { FetchFunction, loadApiKey } from '@ai-sdk/provider-utils';
 import { ElevenLabsTranscriptionModel } from './elevenlabs-transcription-model';
 import { ElevenLabsTranscriptionModelId } from './elevenlabs-transcription-options';
 
-export interface ElevenLabsProvider
-  extends Pick<ProviderV2, 'transcriptionModel'> {
+export interface ElevenLabsProvider extends ProviderV2 {
   (
     modelId: 'scribe_v1',
     settings?: {},
@@ -67,6 +70,30 @@ export function createElevenLabs(
 
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
+
+  provider.languageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'languageModel',
+      message: 'ElevenLabs does not provide language models',
+    });
+  };
+
+  provider.textEmbeddingModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'textEmbeddingModel',
+      message: 'ElevenLabs does not provide text embedding models',
+    });
+  };
+
+  provider.imageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'imageModel',
+      message: 'ElevenLabs does not provide image models',
+    });
+  };
 
   return provider as ElevenLabsProvider;
 }

--- a/packages/gladia/src/gladia-provider.ts
+++ b/packages/gladia/src/gladia-provider.ts
@@ -1,8 +1,12 @@
-import { TranscriptionModelV2, ProviderV2 } from '@ai-sdk/provider';
+import {
+  TranscriptionModelV2,
+  ProviderV2,
+  NoSuchModelError,
+} from '@ai-sdk/provider';
 import { FetchFunction, loadApiKey } from '@ai-sdk/provider-utils';
 import { GladiaTranscriptionModel } from './gladia-transcription-model';
 
-export interface GladiaProvider extends Pick<ProviderV2, 'transcriptionModel'> {
+export interface GladiaProvider extends ProviderV2 {
   (): {
     transcription: GladiaTranscriptionModel;
   };
@@ -62,6 +66,31 @@ export function createGladia(
 
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
+
+  // Required ProviderV2 methods that are not supported
+  provider.languageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'languageModel',
+      message: 'Gladia does not provide language models',
+    });
+  };
+
+  provider.textEmbeddingModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'textEmbeddingModel',
+      message: 'Gladia does not provide text embedding models',
+    });
+  };
+
+  provider.imageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'imageModel',
+      message: 'Gladia does not provide image models',
+    });
+  };
 
   return provider as GladiaProvider;
 }

--- a/packages/provider/src/errors/no-such-model-error.ts
+++ b/packages/provider/src/errors/no-such-model-error.ts
@@ -8,7 +8,12 @@ export class NoSuchModelError extends AISDKError {
   private readonly [symbol] = true; // used in isInstance
 
   readonly modelId: string;
-  readonly modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel' | 'transcriptionModel' | 'speechModel';
+  readonly modelType:
+    | 'languageModel'
+    | 'textEmbeddingModel'
+    | 'imageModel'
+    | 'transcriptionModel'
+    | 'speechModel';
 
   constructor({
     errorName = name,
@@ -18,7 +23,12 @@ export class NoSuchModelError extends AISDKError {
   }: {
     errorName?: string;
     modelId: string;
-    modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel' | 'transcriptionModel' | 'speechModel';
+    modelType:
+      | 'languageModel'
+      | 'textEmbeddingModel'
+      | 'imageModel'
+      | 'transcriptionModel'
+      | 'speechModel';
     message?: string;
   }) {
     super({ name: errorName, message });

--- a/packages/provider/src/errors/no-such-model-error.ts
+++ b/packages/provider/src/errors/no-such-model-error.ts
@@ -8,7 +8,7 @@ export class NoSuchModelError extends AISDKError {
   private readonly [symbol] = true; // used in isInstance
 
   readonly modelId: string;
-  readonly modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel';
+  readonly modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel' | 'transcriptionModel' | 'speechModel';
 
   constructor({
     errorName = name,
@@ -18,7 +18,7 @@ export class NoSuchModelError extends AISDKError {
   }: {
     errorName?: string;
     modelId: string;
-    modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel';
+    modelType: 'languageModel' | 'textEmbeddingModel' | 'imageModel' | 'transcriptionModel' | 'speechModel';
     message?: string;
   }) {
     super({ name: errorName, message });

--- a/packages/provider/src/provider/v2/provider-v2.ts
+++ b/packages/provider/src/provider/v2/provider-v2.ts
@@ -50,7 +50,7 @@ The model id is then passed to the provider function to get the model.
 
 @returns {TranscriptionModel} The transcription model associated with the id
   */
-  readonly transcriptionModel?: (modelId: string) => TranscriptionModelV2;
+  transcriptionModel(modelId: string): TranscriptionModelV2;
 
   /**
 Returns the speech model with the given id.
@@ -60,5 +60,5 @@ The model id is then passed to the provider function to get the model.
 
 @returns {SpeechModel} The speech model associated with the id
   */
-  readonly speechModel?: (modelId: string) => SpeechModelV2;
+  speechModel(modelId: string): SpeechModelV2;
 }

--- a/packages/provider/src/provider/v2/provider-v2.ts
+++ b/packages/provider/src/provider/v2/provider-v2.ts
@@ -50,7 +50,7 @@ The model id is then passed to the provider function to get the model.
 
 @returns {TranscriptionModel} The transcription model associated with the id
   */
-  transcriptionModel(modelId: string): TranscriptionModelV2;
+  transcriptionModel?(modelId: string): TranscriptionModelV2;
 
   /**
 Returns the speech model with the given id.
@@ -60,5 +60,5 @@ The model id is then passed to the provider function to get the model.
 
 @returns {SpeechModel} The speech model associated with the id
   */
-  speechModel(modelId: string): SpeechModelV2;
+  speechModel?(modelId: string): SpeechModelV2;
 }

--- a/packages/revai/src/revai-provider.ts
+++ b/packages/revai/src/revai-provider.ts
@@ -1,9 +1,13 @@
-import { TranscriptionModelV2, ProviderV2 } from '@ai-sdk/provider';
+import {
+  TranscriptionModelV2,
+  ProviderV2,
+  NoSuchModelError,
+} from '@ai-sdk/provider';
 import { FetchFunction, loadApiKey } from '@ai-sdk/provider-utils';
 import { RevaiTranscriptionModel } from './revai-transcription-model';
 import { RevaiTranscriptionModelId } from './revai-transcription-options';
 
-export interface RevaiProvider extends Pick<ProviderV2, 'transcriptionModel'> {
+export interface RevaiProvider extends ProviderV2 {
   (
     modelId: 'machine',
     settings?: {},
@@ -66,6 +70,30 @@ export function createRevai(
 
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
+
+  provider.languageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'languageModel',
+      message: 'Rev.ai does not provide language models',
+    });
+  };
+
+  provider.textEmbeddingModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'textEmbeddingModel',
+      message: 'Rev.ai does not provide text embedding models',
+    });
+  };
+
+  provider.imageModel = () => {
+    throw new NoSuchModelError({
+      modelId: 'unknown',
+      modelType: 'imageModel',
+      message: 'Rev.ai does not provide image models',
+    });
+  };
 
   return provider as RevaiProvider;
 }


### PR DESCRIPTION
## background

we want transcription and speech models to work in the registry like other model types do.

## summary

- add transcriptionModel and speechModel to provider registry
- fix transcription providers to work with registry

## verification

- all tests pass including new registry-specific tests for transcription/speech models
- autocomplete works for provider names and model IDs
- runtime errors for unsupported model combinations
- elevenlabs registry integration confirmed working

## tasks

- [x] make transcriptionModel and speechModel optional in ProviderV2
- [x] add transcriptionModel and speechModel methods to registry
- [x] update error handling for new model types
- [x] convert transcription providers from Pick to full ProviderV2
- [x] add proper error messages for unsupported model types
- [x] test coverage for registry integration

## future work

* consider adding more transcription/speech providers to registry examples 