### PR TITLE
spec (ai): add provider options to tools

### DIFF
--- a/.changeset/long-dancers-wait.md
+++ b/.changeset/long-dancers-wait.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+spec (ai): add provider options to tools

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -1,6 +1,7 @@
 import { JSONValue, LanguageModelV2ToolResultPart } from '@ai-sdk/provider';
 import { FlexibleSchema } from '../schema';
 import { ModelMessage } from './model-message';
+import { ProviderOptions } from './provider-options';
 
 export interface ToolCallOptions {
   /**
@@ -49,6 +50,13 @@ Will be used by the language model to decide whether to use the tool.
 Not used for provider-defined tools.
    */
   description?: string;
+
+  /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+   */
+  providerOptions?: ProviderOptions;
 } & NeverOptional<
   INPUT,
   {

--- a/packages/provider/src/language-model/v2/language-model-v2-function-tool.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-function-tool.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7 } from 'json-schema';
-import { SharedV2ProviderMetadata } from '../../shared/v2/shared-v2-provider-metadata';
+import { SharedV2ProviderOptions } from '../../shared';
 
 /**
 A tool has a name, a description, and a set of parameters.
@@ -31,7 +31,7 @@ understand the tool's input requirements and to provide matching suggestions.
   inputSchema: JSONSchema7;
 
   /**
-The provider-specific metadata for the tool.
+The provider-specific options for the tool.
    */
-  providerMetadata?: SharedV2ProviderMetadata;
+  providerOptions?: SharedV2ProviderOptions;
 };


### PR DESCRIPTION
## Background

Provider specific settings on tools are needed for e.g. caching.

## Summary

Add provider options to tool spec in language model and ai lib.

## Future Work

Implement forwarding the provider options and using them in the providers.