### PR TITLE
feat(openai-compatible): passing config to chat models

### DIFF
--- a/.changeset/hot-eggs-obey.md
+++ b/.changeset/hot-eggs-obey.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai-compatible': patch
 ---
 
-Allow passing config to chat models; Refine the `stream_options` handling in `OpenAICompatibleChatLanguageModel` to correctly omit the `stream_options` field when `includeUsage` is false/undefined, preventing `undefined` from being sent in the request body.
+Allow passing config to chat models

--- a/.changeset/hot-eggs-obey.md
+++ b/.changeset/hot-eggs-obey.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Allow passing config to chat models; Refine the `stream_options` handling in `OpenAICompatibleChatLanguageModel` to correctly omit the `stream_options` field when `includeUsage` is false/undefined, preventing `undefined` from being sent in the request body.

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -385,9 +385,9 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV1 {
       stream: true,
 
       // only include stream_options when in strict compatibility mode:
-      stream_options: this.config.includeUsage
-        ? { include_usage: true }
-        : undefined,
+      ...(this.config.includeUsage
+        ? { stream_options: { include_usage: true } }
+        : {}),
     };
 
     const metadataExtractor =

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -385,9 +385,9 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV1 {
       stream: true,
 
       // only include stream_options when in strict compatibility mode:
-      ...(this.config.includeUsage
-        ? { stream_options: { include_usage: true } }
-        : {}),
+      stream_options: this.config.includeUsage
+        ? { include_usage: true }
+        : undefined,
     };
 
     const metadataExtractor =

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -5,7 +5,10 @@ import {
   ProviderV1,
 } from '@ai-sdk/provider';
 import { FetchFunction, withoutTrailingSlash } from '@ai-sdk/provider-utils';
-import { OpenAICompatibleChatLanguageModel } from './openai-compatible-chat-language-model';
+import {
+  OpenAICompatibleChatConfig,
+  OpenAICompatibleChatLanguageModel,
+} from './openai-compatible-chat-language-model';
 import { OpenAICompatibleChatSettings } from './openai-compatible-chat-settings';
 import { OpenAICompatibleCompletionLanguageModel } from './openai-compatible-completion-language-model';
 import { OpenAICompatibleCompletionSettings } from './openai-compatible-completion-settings';
@@ -23,16 +26,19 @@ export interface OpenAICompatibleProvider<
   (
     modelId: CHAT_MODEL_IDS,
     settings?: OpenAICompatibleChatSettings,
+    config?: Partial<OpenAICompatibleChatConfig>,
   ): LanguageModelV1;
 
   languageModel(
     modelId: CHAT_MODEL_IDS,
     settings?: OpenAICompatibleChatSettings,
+    config?: Partial<OpenAICompatibleChatConfig>,
   ): LanguageModelV1;
 
   chatModel(
     modelId: CHAT_MODEL_IDS,
     settings?: OpenAICompatibleChatSettings,
+    config?: Partial<OpenAICompatibleChatConfig>,
   ): LanguageModelV1;
 
   completionModel(
@@ -134,15 +140,18 @@ export function createOpenAICompatible<
   const createLanguageModel = (
     modelId: CHAT_MODEL_IDS,
     settings: OpenAICompatibleChatSettings = {},
-  ) => createChatModel(modelId, settings);
+    config?: Partial<OpenAICompatibleChatConfig>,
+  ) => createChatModel(modelId, settings, config);
 
   const createChatModel = (
     modelId: CHAT_MODEL_IDS,
     settings: OpenAICompatibleChatSettings = {},
+    config?: Partial<OpenAICompatibleChatConfig>,
   ) =>
     new OpenAICompatibleChatLanguageModel(modelId, settings, {
       ...getCommonModelConfig('chat'),
       defaultObjectGenerationMode: 'tool',
+      ...config,
     });
 
   const createCompletionModel = (
@@ -178,7 +187,8 @@ export function createOpenAICompatible<
   const provider = (
     modelId: CHAT_MODEL_IDS,
     settings?: OpenAICompatibleChatSettings,
-  ) => createLanguageModel(modelId, settings);
+    config?: Partial<OpenAICompatibleChatConfig>,
+  ) => createLanguageModel(modelId, settings, config);
 
   provider.languageModel = createLanguageModel;
   provider.chatModel = createChatModel;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Cannot pass the `stream_options` to the OpenAICompatible Providers.

## Summary

- Allow passing config to chat models
- Refine the `stream_options` handling in `OpenAICompatibleChatLanguageModel` to correctly omit the `stream_options` field when `includeUsage` is false/undefined, preventing `undefined` from being sent in the request body.

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

Fixes #6774 
