### PR TITLE
tool onInputStart should use toolCallId not chunk id

### DIFF
--- a/.changeset/lucky-eagles-wash.md
+++ b/.changeset/lucky-eagles-wash.md
@@ -1,0 +1,5 @@
+---
+'ai': minor
+---
+
+tool onInputStart should use toolCallId not chunk id

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1232,7 +1232,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                       const tool = tools?.[chunk.toolName];
                       if (tool?.onInputStart != null) {
                         await tool.onInputStart({
-                          toolCallId: chunk.id,
+                          toolCallId: chunk.toolCallId,
                           messages: stepInputMessages,
                           abortSignal,
                         });

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1227,7 +1227,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                     }
 
                     case 'tool-input-start': {
-                      activeToolCallToolNames[chunk.id] = chunk.toolName;
+                      activeToolCallToolNames[chunk.toolCallId] = chunk.toolName;
 
                       const tool = tools?.[chunk.toolName];
                       if (tool?.onInputStart != null) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Tool streaming is broken after a recent PR changed this from toolCallId to chunk id. This was working in alpha-15 but not beta-1. When the tool input starts the id is set to the chunk id. When a delta arrives it tries to use the toolCallId to find the part but can't find it.

The specific error message:

```
[backend]           TypeError: Cannot read properties of undefined (reading 'text')
[backend]               at <anonymous> (ai/src/ui/process-ui-message-stream.ts:296:15)
[backend]               at runUpdateMessageJob (ai/src/ui-message-stream/handle-ui-message-stream-finish.ts:65:11)
[backend]               at Object.transform (ai/src/ui/process-ui-message-stream.ts:93:15)
```

## Summary

<!-- What did you change? -->

Switch back to using `chunk.toolCallId` instead of `chunk.id` in the `tool-input-start` case of `process-ui-message-stream.ts`

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
