### PR TITLE
fix (provider/google): omit system message for gemma models

### DIFF
--- a/.changeset/mean-rice-deny.md
+++ b/.changeset/mean-rice-deny.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix: google models

--- a/.changeset/mean-rice-deny.md
+++ b/.changeset/mean-rice-deny.md
@@ -2,4 +2,4 @@
 '@ai-sdk/google': patch
 ---
 
-fix: google models
+fix: omit system message for gemma models

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2304,7 +2304,7 @@ describe('GEMMA Model System Instruction Fix', () => {
     // Verify that systemInstruction was NOT sent for GEMMA model
     const lastCall = server.calls[server.calls.length - 1];
     const requestBody = await lastCall.requestBodyJson;
-    
+
     expect(requestBody).not.toHaveProperty('systemInstruction');
   });
 
@@ -2335,7 +2335,7 @@ describe('GEMMA Model System Instruction Fix', () => {
 
     const lastCall = server.calls[server.calls.length - 1];
     const requestBody = await lastCall.requestBodyJson;
-    
+
     expect(requestBody).not.toHaveProperty('systemInstruction');
   });
 
@@ -2366,10 +2366,10 @@ describe('GEMMA Model System Instruction Fix', () => {
 
     const lastCall = server.calls[server.calls.length - 1];
     const requestBody = await lastCall.requestBodyJson;
-    
+
     expect(requestBody).toHaveProperty('systemInstruction');
     expect(requestBody.systemInstruction).toEqual({
-      parts: [{ text: 'You are a helpful assistant.' }]
+      parts: [{ text: 'You are a helpful assistant.' }],
     });
   });
 });

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2372,4 +2372,99 @@ describe('GEMMA Model System Instruction Fix', () => {
       parts: [{ text: 'You are a helpful assistant.' }],
     });
   });
+
+  it('should generate warning when GEMMA model is used with system instructions', async () => {
+    server.urls[TEST_URL_GEMMA_3_12B_IT].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Hello!' }], role: 'model' },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      },
+    };
+
+    const model = new GoogleGenerativeAILanguageModel('gemma-3-12b-it', {
+      provider: 'google.generative-ai',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    const { warnings } = await model.doGenerate({
+      prompt: TEST_PROMPT_WITH_SYSTEM,
+    });
+
+    expect(warnings).toMatchInlineSnapshot(`
+      [
+        {
+          "message": "GEMMA models do not support system instructions. System messages will be ignored. Consider including instructions in the first user message instead.",
+          "type": "other",
+        },
+      ]
+    `);
+  });
+
+  it('should NOT generate warning when GEMMA model is used without system instructions', async () => {
+    server.urls[TEST_URL_GEMMA_3_12B_IT].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Hello!' }], role: 'model' },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      },
+    };
+
+    const model = new GoogleGenerativeAILanguageModel('gemma-3-12b-it', {
+      provider: 'google.generative-ai',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    const TEST_PROMPT_WITHOUT_SYSTEM: LanguageModelV2Prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ];
+
+    const { warnings } = await model.doGenerate({
+      prompt: TEST_PROMPT_WITHOUT_SYSTEM,
+    });
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('should NOT generate warning when Gemini model is used with system instructions', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Hello!' }], role: 'model' },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      },
+    };
+
+    const model = new GoogleGenerativeAILanguageModel('gemini-pro', {
+      provider: 'google.generative-ai',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    const { warnings } = await model.doGenerate({
+      prompt: TEST_PROMPT_WITH_SYSTEM,
+    });
+
+    expect(warnings).toHaveLength(0);
+  });
 });

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2254,3 +2254,122 @@ describe('doStream', () => {
     });
   });
 });
+
+describe('GEMMA Model System Instruction Fix', () => {
+  const TEST_PROMPT_WITH_SYSTEM: LanguageModelV2Prompt = [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+  ];
+
+  const TEST_URL_GEMMA_3_12B_IT =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemma-3-12b-it:generateContent';
+
+  const TEST_URL_GEMMA_3_27B_IT =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemma-3-27b-it:generateContent';
+
+  const TEST_URL_GEMINI_PRO =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
+
+  const server = createTestServer({
+    [TEST_URL_GEMMA_3_12B_IT]: {},
+    [TEST_URL_GEMMA_3_27B_IT]: {},
+    [TEST_URL_GEMINI_PRO]: {},
+  });
+
+  it('should NOT send systemInstruction for GEMMA-3-12b-it model', async () => {
+    server.urls[TEST_URL_GEMMA_3_12B_IT].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Hello!' }], role: 'model' },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      },
+    };
+
+    const model = new GoogleGenerativeAILanguageModel('gemma-3-12b-it', {
+      provider: 'google.generative-ai',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT_WITH_SYSTEM,
+    });
+
+    // Verify that systemInstruction was NOT sent for GEMMA model
+    const lastCall = server.calls[server.calls.length - 1];
+    const requestBody = await lastCall.requestBodyJson;
+    
+    expect(requestBody).not.toHaveProperty('systemInstruction');
+  });
+
+  it('should NOT send systemInstruction for GEMMA-3-27b-it model', async () => {
+    server.urls[TEST_URL_GEMMA_3_27B_IT].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Hello!' }], role: 'model' },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      },
+    };
+
+    const model = new GoogleGenerativeAILanguageModel('gemma-3-27b-it', {
+      provider: 'google.generative-ai',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT_WITH_SYSTEM,
+    });
+
+    const lastCall = server.calls[server.calls.length - 1];
+    const requestBody = await lastCall.requestBodyJson;
+    
+    expect(requestBody).not.toHaveProperty('systemInstruction');
+  });
+
+  it('should still send systemInstruction for Gemini models (regression test)', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Hello!' }], role: 'model' },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      },
+    };
+
+    const model = new GoogleGenerativeAILanguageModel('gemini-pro', {
+      provider: 'google.generative-ai',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT_WITH_SYSTEM,
+    });
+
+    const lastCall = server.calls[server.calls.length - 1];
+    const requestBody = await lastCall.requestBodyJson;
+    
+    expect(requestBody).toHaveProperty('systemInstruction');
+    expect(requestBody.systemInstruction).toEqual({
+      parts: [{ text: 'You are a helpful assistant.' }]
+    });
+  });
+});

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -80,7 +80,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
     responseFormat,
     seed,
     tools,
-    toolChoice /*  */,
+    toolChoice,
     providerOptions,
   }: Parameters<LanguageModelV2['doGenerate']>[0]) {
     const warnings: LanguageModelV2CallWarning[] = [];

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -80,7 +80,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
     responseFormat,
     seed,
     tools,
-    toolChoice,/*  */
+    toolChoice /*  */,
     providerOptions,
   }: Parameters<LanguageModelV2['doGenerate']>[0]) {
     const warnings: LanguageModelV2CallWarning[] = [];
@@ -154,8 +154,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
           thinkingConfig: googleOptions?.thinkingConfig,
         },
         contents,
-        systemInstruction: this.modelId.toLowerCase().includes('gemma') 
-          ? undefined 
+        systemInstruction: this.modelId.toLowerCase().includes('gemma')
+          ? undefined
           : systemInstruction,
         safetySettings: googleOptions?.safetySettings,
         tools: googleTools,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -80,7 +80,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
     responseFormat,
     seed,
     tools,
-    toolChoice,
+    toolChoice,/*  */
     providerOptions,
   }: Parameters<LanguageModelV2['doGenerate']>[0]) {
     const warnings: LanguageModelV2CallWarning[] = [];
@@ -154,7 +154,9 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
           thinkingConfig: googleOptions?.thinkingConfig,
         },
         contents,
-        systemInstruction,
+        systemInstruction: this.modelId.toLowerCase().includes('gemma') 
+          ? undefined 
+          : systemInstruction,
         safetySettings: googleOptions?.safetySettings,
         tools: googleTools,
         toolConfig: googleToolConfig,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -108,7 +108,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
     const { contents, systemInstruction } =
       convertToGoogleGenerativeAIMessages(prompt);
 
-    const isGemmaModel = this.modelId.toLowerCase().includes('gemma');
+    const isGemmaModel = this.modelId.toLowerCase().startsWith('gemma-');
     if (
       isGemmaModel &&
       systemInstruction &&

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -26,6 +26,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.5-pro-exp-03-25'
   | 'gemini-2.5-flash-preview-04-17'
   | 'gemini-exp-1206'
+  | 'gemma-3-12b-it'
   | 'gemma-3-27b-it'
   | 'learnlm-1.5-pro-experimental'
   | (string & {});


### PR DESCRIPTION
## background

GEMMA models do not support system instructions but the AI SDK was silently stripping them without warning users, leading to confusion when system prompts were ignored.

## summary

- add runtime warning when system instructions are used with GEMMA models
- maintain existing behavior of stripping system instructions for GEMMA

## verification

- all tests pass including new warning-specific tests
- warning appears when system instructions are provided to GEMMA models
- no warning when system instructions are omitted or used with Gemini models

## tasks

- [x] warning logic added to google-generative-ai-language-model.ts
- [x] comprehensive test coverage for warning scenarios
- [x] maintains backward compatibility with existing GEMMA fix 

issue #6854