### PR TITLE
fix (provider/anthropic): send tool call id in tool-input-start chunk

### DIFF
--- a/.changeset/sharp-walls-rush.md
+++ b/.changeset/sharp-walls-rush.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix (provider/anthropic): send tool call id in tool-input-start chunk

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -1753,7 +1753,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "type": "text-end",
           },
           {
-            "id": "1",
+            "id": "toolu_01DBsB4vvYLnBDzZ5rBSxSLs",
             "toolName": "test-tool",
             "type": "tool-input-start",
           },

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -730,7 +730,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
                         ? { type: 'text-start', id: String(value.index) }
                         : {
                             type: 'tool-input-start',
-                            id: String(value.index),
+                            id: value.content_block.id,
                             toolName: value.content_block.name,
                           },
                     );


### PR DESCRIPTION
## Background

Tool calls did not work with the anthropic provider.

## Summary

send tool call id in tool-input-start chunk

## Related Issues

#6856