### PR TITLE
Add Vercel SDK Provider list

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -25,6 +25,7 @@ Here is an overview of the AI SDK Provider Architecture:
 The AI SDK comes with a wide range of providers that you can use to interact with different language models:
 
 - [xAI Grok Provider](/providers/ai-sdk-providers/xai) (`@ai-sdk/xai`)
+- [Vercel Provider](/providers/ai-sdk-providers/vercel) (`@ai-sdk/vercel`)
 - [OpenAI Provider](/providers/ai-sdk-providers/openai) (`@ai-sdk/openai`)
 - [Azure OpenAI Provider](/providers/ai-sdk-providers/azure) (`@ai-sdk/azure`)
 - [Anthropic Provider](/providers/ai-sdk-providers/anthropic) (`@ai-sdk/anthropic`)


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

I noticed that in the [Providers and Models docs](https://ai-sdk.dev/docs/foundations/providers-and-models), we mention the Vercel (v0) model in the [Model Capabilities](https://ai-sdk.dev/docs/foundations/providers-and-models#model-capabilities) but not in the [AI SDK Providers](https://ai-sdk.dev/docs/foundations/providers-and-models#ai-sdk-providers). 

## Summary

<!-- What did you change? -->

This PR adds the Vercel Provider to the [Providers and Models docs](https://ai-sdk.dev/docs/foundations/providers-and-models#ai-sdk-providers) list.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
