### PR TITLE
temperature does not default to 0

### DIFF
--- a/packages/ai/core/prompt/call-settings.ts
+++ b/packages/ai/core/prompt/call-settings.ts
@@ -9,8 +9,6 @@ Temperature setting. This is a number between 0 (almost no randomness) and
 1 (very random).
 
 It is recommended to set either `temperature` or `topP`, but not both.
-
-@default 0
    */
   temperature?: number;
 


### PR DESCRIPTION
I could not find any evidence that the `temperature` value is actually being set to 0 by the ai sdk if not provided by the caller to `generateText`.

The current jsdoc is misleading:

![Screenshot from 2025-06-25 14-39-31](https://github.com/user-attachments/assets/9c463b33-fcb2-425d-aaf9-a8fca5719a00)

If the caller doesn't provide a temperature, no temperature value is passed to the API, and many models (such as claude) default to 1.0 in this case, not 0.