### PR TITLE
fix (provider-utils): detect failed fetch in browser environments

### DIFF
--- a/.changeset/small-deers-cover.md
+++ b/.changeset/small-deers-cover.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix (provider-utils): detect failed fetch in browser environments

--- a/packages/google-vertex/tsup.config.bundled_x8ypw9vxg2.mjs
+++ b/packages/google-vertex/tsup.config.bundled_x8ypw9vxg2.mjs
@@ -1,0 +1,36 @@
+// tsup.config.ts
+import { defineConfig } from "tsup";
+var tsup_config_default = defineConfig([
+  {
+    entry: ["src/index.ts"],
+    format: ["cjs", "esm"],
+    dts: true,
+    sourcemap: true,
+    outDir: "dist"
+  },
+  {
+    entry: ["src/edge/index.ts"],
+    format: ["cjs", "esm"],
+    dts: true,
+    sourcemap: true,
+    outDir: "dist/edge"
+  },
+  {
+    entry: ["src/anthropic/index.ts"],
+    format: ["cjs", "esm"],
+    dts: true,
+    sourcemap: true,
+    outDir: "dist/anthropic"
+  },
+  {
+    entry: ["src/anthropic/edge/index.ts"],
+    format: ["cjs", "esm"],
+    dts: true,
+    sourcemap: true,
+    outDir: "dist/anthropic/edge"
+  }
+]);
+export {
+  tsup_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidHN1cC5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9faW5qZWN0ZWRfZmlsZW5hbWVfXyA9IFwiL1VzZXJzL2xhcnNncmFtbWVsL3JlcG9zaXRvcmllcy9haS9wYWNrYWdlcy9nb29nbGUtdmVydGV4L3RzdXAuY29uZmlnLnRzXCI7Y29uc3QgX19pbmplY3RlZF9kaXJuYW1lX18gPSBcIi9Vc2Vycy9sYXJzZ3JhbW1lbC9yZXBvc2l0b3JpZXMvYWkvcGFja2FnZXMvZ29vZ2xlLXZlcnRleFwiO2NvbnN0IF9faW5qZWN0ZWRfaW1wb3J0X21ldGFfdXJsX18gPSBcImZpbGU6Ly8vVXNlcnMvbGFyc2dyYW1tZWwvcmVwb3NpdG9yaWVzL2FpL3BhY2thZ2VzL2dvb2dsZS12ZXJ0ZXgvdHN1cC5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd0c3VwJztcblxuZXhwb3J0IGRlZmF1bHQgZGVmaW5lQ29uZmlnKFtcbiAge1xuICAgIGVudHJ5OiBbJ3NyYy9pbmRleC50cyddLFxuICAgIGZvcm1hdDogWydjanMnLCAnZXNtJ10sXG4gICAgZHRzOiB0cnVlLFxuICAgIHNvdXJjZW1hcDogdHJ1ZSxcbiAgICBvdXREaXI6ICdkaXN0JyxcbiAgfSxcbiAge1xuICAgIGVudHJ5OiBbJ3NyYy9lZGdlL2luZGV4LnRzJ10sXG4gICAgZm9ybWF0OiBbJ2NqcycsICdlc20nXSxcbiAgICBkdHM6IHRydWUsXG4gICAgc291cmNlbWFwOiB0cnVlLFxuICAgIG91dERpcjogJ2Rpc3QvZWRnZScsXG4gIH0sXG4gIHtcbiAgICBlbnRyeTogWydzcmMvYW50aHJvcGljL2luZGV4LnRzJ10sXG4gICAgZm9ybWF0OiBbJ2NqcycsICdlc20nXSxcbiAgICBkdHM6IHRydWUsXG4gICAgc291cmNlbWFwOiB0cnVlLFxuICAgIG91dERpcjogJ2Rpc3QvYW50aHJvcGljJyxcbiAgfSxcbiAge1xuICAgIGVudHJ5OiBbJ3NyYy9hbnRocm9waWMvZWRnZS9pbmRleC50cyddLFxuICAgIGZvcm1hdDogWydjanMnLCAnZXNtJ10sXG4gICAgZHRzOiB0cnVlLFxuICAgIHNvdXJjZW1hcDogdHJ1ZSxcbiAgICBvdXREaXI6ICdkaXN0L2FudGhyb3BpYy9lZGdlJyxcbiAgfSxcbl0pO1xuIl0sCiAgIm1hcHBpbmdzIjogIjtBQUF5VCxTQUFTLG9CQUFvQjtBQUV0VixJQUFPLHNCQUFRLGFBQWE7QUFBQSxFQUMxQjtBQUFBLElBQ0UsT0FBTyxDQUFDLGNBQWM7QUFBQSxJQUN0QixRQUFRLENBQUMsT0FBTyxLQUFLO0FBQUEsSUFDckIsS0FBSztBQUFBLElBQ0wsV0FBVztBQUFBLElBQ1gsUUFBUTtBQUFBLEVBQ1Y7QUFBQSxFQUNBO0FBQUEsSUFDRSxPQUFPLENBQUMsbUJBQW1CO0FBQUEsSUFDM0IsUUFBUSxDQUFDLE9BQU8sS0FBSztBQUFBLElBQ3JCLEtBQUs7QUFBQSxJQUNMLFdBQVc7QUFBQSxJQUNYLFFBQVE7QUFBQSxFQUNWO0FBQUEsRUFDQTtBQUFBLElBQ0UsT0FBTyxDQUFDLHdCQUF3QjtBQUFBLElBQ2hDLFFBQVEsQ0FBQyxPQUFPLEtBQUs7QUFBQSxJQUNyQixLQUFLO0FBQUEsSUFDTCxXQUFXO0FBQUEsSUFDWCxRQUFRO0FBQUEsRUFDVjtBQUFBLEVBQ0E7QUFBQSxJQUNFLE9BQU8sQ0FBQyw2QkFBNkI7QUFBQSxJQUNyQyxRQUFRLENBQUMsT0FBTyxLQUFLO0FBQUEsSUFDckIsS0FBSztBQUFBLElBQ0wsV0FBVztBQUFBLElBQ1gsUUFBUTtBQUFBLEVBQ1Y7QUFDRixDQUFDOyIsCiAgIm5hbWVzIjogW10KfQo=

--- a/packages/provider-utils/src/get-from-api.ts
+++ b/packages/provider-utils/src/get-from-api.ts
@@ -86,6 +86,6 @@ export const getFromApi = async <T>({
       });
     }
   } catch (error) {
-    handleFetchError({ error, url, requestBodyValues: {} });
+    throw handleFetchError({ error, url, requestBodyValues: {} });
   }
 };

--- a/packages/provider-utils/src/get-from-api.ts
+++ b/packages/provider-utils/src/get-from-api.ts
@@ -1,9 +1,10 @@
 import { APICallError } from '@ai-sdk/provider';
+import { extractResponseHeaders } from './extract-response-headers';
 import { FetchFunction } from './fetch-function';
+import { handleFetchError } from './handle-fetch-error';
+import { isAbortError } from './is-abort-error';
 import { removeUndefinedEntries } from './remove-undefined-entries';
 import { ResponseHandler } from './response-handler';
-import { isAbortError } from './is-abort-error';
-import { extractResponseHeaders } from './extract-response-headers';
 
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => globalThis.fetch;
@@ -85,23 +86,6 @@ export const getFromApi = async <T>({
       });
     }
   } catch (error) {
-    if (isAbortError(error)) {
-      throw error;
-    }
-
-    if (error instanceof TypeError && error.message === 'fetch failed') {
-      const cause = (error as any).cause;
-      if (cause != null) {
-        throw new APICallError({
-          message: `Cannot connect to API: ${cause.message}`,
-          cause,
-          url,
-          isRetryable: true,
-          requestBodyValues: {},
-        });
-      }
-    }
-
-    throw error;
+    handleFetchError({ error, url, requestBodyValues: {} });
   }
 };

--- a/packages/provider-utils/src/handle-fetch-error.ts
+++ b/packages/provider-utils/src/handle-fetch-error.ts
@@ -1,0 +1,39 @@
+import { APICallError } from '@ai-sdk/provider';
+import { isAbortError } from './is-abort-error';
+
+const FETCH_FAILED_ERROR_MESSAGES = ['fetch failed', 'failed to fetch'];
+
+export function handleFetchError({
+  error,
+  url,
+  requestBodyValues,
+}: {
+  error: unknown;
+  url: string;
+  requestBodyValues: unknown;
+}) {
+  if (isAbortError(error)) {
+    throw error;
+  }
+
+  // unwrap original error when fetch failed (for easier debugging):
+  if (
+    error instanceof TypeError &&
+    FETCH_FAILED_ERROR_MESSAGES.includes(error.message.toLowerCase())
+  ) {
+    const cause = (error as any).cause;
+
+    if (cause != null) {
+      // Failed to connect to server:
+      throw new APICallError({
+        message: `Cannot connect to API: ${cause.message}`,
+        cause,
+        url,
+        requestBodyValues,
+        isRetryable: true, // retry when network error
+      });
+    }
+  }
+
+  throw error;
+}

--- a/packages/provider-utils/src/handle-fetch-error.ts
+++ b/packages/provider-utils/src/handle-fetch-error.ts
@@ -13,7 +13,7 @@ export function handleFetchError({
   requestBodyValues: unknown;
 }) {
   if (isAbortError(error)) {
-    throw error;
+    return error;
   }
 
   // unwrap original error when fetch failed (for easier debugging):
@@ -25,7 +25,7 @@ export function handleFetchError({
 
     if (cause != null) {
       // Failed to connect to server:
-      throw new APICallError({
+      return new APICallError({
         message: `Cannot connect to API: ${cause.message}`,
         cause,
         url,
@@ -35,5 +35,5 @@ export function handleFetchError({
     }
   }
 
-  throw error;
+  return error;
 }

--- a/packages/provider-utils/src/post-to-api.ts
+++ b/packages/provider-utils/src/post-to-api.ts
@@ -155,6 +155,6 @@ export const postToApi = async <T>({
       });
     }
   } catch (error) {
-    handleFetchError({ error, url, requestBodyValues: body.values });
+    throw handleFetchError({ error, url, requestBodyValues: body.values });
   }
 };

--- a/packages/provider-utils/src/post-to-api.ts
+++ b/packages/provider-utils/src/post-to-api.ts
@@ -1,6 +1,7 @@
 import { APICallError } from '@ai-sdk/provider';
 import { extractResponseHeaders } from './extract-response-headers';
 import { FetchFunction } from './fetch-function';
+import { handleFetchError } from './handle-fetch-error';
 import { isAbortError } from './is-abort-error';
 import { removeUndefinedEntries } from './remove-undefined-entries';
 import { ResponseHandler } from './response-handler';
@@ -154,26 +155,6 @@ export const postToApi = async <T>({
       });
     }
   } catch (error) {
-    if (isAbortError(error)) {
-      throw error;
-    }
-
-    // unwrap original error when fetch failed (for easier debugging):
-    if (error instanceof TypeError && error.message === 'fetch failed') {
-      const cause = (error as any).cause;
-
-      if (cause != null) {
-        // Failed to connect to server:
-        throw new APICallError({
-          message: `Cannot connect to API: ${cause.message}`,
-          cause,
-          url,
-          requestBodyValues: body.values,
-          isRetryable: true, // retry when network error
-        });
-      }
-    }
-
-    throw error;
+    handleFetchError({ error, url, requestBodyValues: body.values });
   }
 };


### PR DESCRIPTION
## Background

Failed fetch detection did not work in browser-based environments (see #6370 ).

## Summary

Check for `failed to fetch` error message.

## Related Issues

Fixes #6370