### PR TITLE
fix (provider/google): remove non-functional models

### DIFF
--- a/.changeset/nine-falcons-yell.md
+++ b/.changeset/nine-falcons-yell.md
@@ -2,4 +2,4 @@
 '@ai-sdk/google': patch
 ---
 
-fix: remove non-functional models(google)
+fix: remove non-functional models

--- a/.changeset/nine-falcons-yell.md
+++ b/.changeset/nine-falcons-yell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix: remove non-functional models(google)

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -28,7 +28,6 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-exp-1206'
   | 'gemma-3-12b-it'
   | 'gemma-3-27b-it'
-  | 'learnlm-1.5-pro-experimental'
   | (string & {});
 
 const dynamicRetrievalConfig = z.object({


### PR DESCRIPTION
## background

users reported that `learnlm-1.5-pro-experimental` model was non-functional, returning 404 errors when attempting to use it via the google generative ai api

## summary

- remove non-functional `learnlm-1.5-pro-experimental` from GoogleGenerativeAIModelId type
- keep `gemma-3-27b-it` as it's fully functional via API

## verification

- tested both models with proper usage patterns including educational system instructions
- `gemma-3-27b-it` responds correctly with existing system instruction fix
- `learnlm-1.5-pro-experimental` returns 404 NOT_FOUND consistently

## tasks

- [x] remove `learnlm-1.5-pro-experimental` from google-generative-ai-options.ts
- [x] verify gemma models remain functional
- [x] test both generateText and streamText

issue #6481