### PR TITLE
docs (v5): Update AI SDK migration guide with Zod dependency

### DIFF
--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -31,6 +31,10 @@ You need to update the following packages to the following versions in your `pac
 - `@ai-sdk/provider-utils` package: `3.0.0-beta`
 - `@ai-sdk/*` packages: `2.0.0-beta` (other `@ai-sdk` packages)
 
+Additionally, you need to update the following peer dependencies:
+
+- `zod` package: `3.25.0` or later
+
 ## AI SDK Core Changes
 
 ### generateText and streamText Changes


### PR DESCRIPTION
## Background

v5 requires zod update

## Summary

Updated migration guide.