### PR TITLE
chore (providers/gateway): update language model ids

### DIFF
--- a/.changeset/gorgeous-carrots-reflect.md
+++ b/.changeset/gorgeous-carrots-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+chore (providers/gateway): update language model ids

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -9,7 +9,6 @@ export type GatewayModelId =
   | 'amazon/nova-pro'
   | 'anthropic/claude-3-haiku'
   | 'anthropic/claude-3-opus'
-  | 'anthropic/claude-3-sonnet'
   | 'anthropic/claude-3.5-haiku'
   | 'anthropic/claude-3.5-sonnet'
   | 'anthropic/claude-3.7-sonnet'


### PR DESCRIPTION
## Background

The original sonnet 3 model is deprecated/unavailable in anthropic API.

## Summary

Removed model id from list.
