### PR TITLE
feat(providers/google): Add support for Gemini 2.5 Pro and Gemini 2.5 Flash (now stable)

### DIFF
--- a/.changeset/spotty-dolls-divide.md
+++ b/.changeset/spotty-dolls-divide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(providers/google): Add support for Gemini 2.5 Pro and Gemini 2.5 Flash (now stable)

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -558,6 +558,8 @@ The following Zod features are known to not work with Google Generative AI:
 
 | Model                            | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | -------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gemini-2.5-pro`                 | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-2.5-flash`               | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-2.5-pro-preview-05-06`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-2.5-flash-preview-04-17` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-2.5-pro-exp-03-25`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/examples/ai-core/src/generate-text/google-output-object.ts
+++ b/examples/ai-core/src/generate-text/google-output-object.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 async function main() {
   const { experimental_output } = await generateText({
-    model: google('gemini-1.5-flash'),
+    model: google('gemini-2.5-flash'),
     experimental_output: Output.object({
       schema: z.object({
         name: z.string(),

--- a/examples/ai-core/src/generate-text/google-reasoning.ts
+++ b/examples/ai-core/src/generate-text/google-reasoning.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: google('gemini-2.5-pro-preview-05-06'),
+    model: google('gemini-2.5-pro'),
     prompt: 'How many "r"s are in the word "strawberry"?',
   });
 

--- a/packages/google/src/google-generative-ai-settings.ts
+++ b/packages/google/src/google-generative-ai-settings.ts
@@ -19,6 +19,8 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.0-pro-exp-02-05'
   | 'gemini-2.0-flash-thinking-exp-01-21'
   | 'gemini-2.0-flash-exp'
+  | 'gemini-2.5-pro'
+  | 'gemini-2.5-flash'
   // Experimental models
   // https://ai.google.dev/gemini-api/docs/models/experimental-models
   | 'gemini-2.5-pro-exp-03-25'


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Gemini 2.5 Pro and Gemini 2.5 Flash are now generally available.


## Summary

<!-- What did you change? -->

Added support for Gemini 2.5 Pro and Gemini 2.5 Flash in the Google provider.

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

Tried example locally

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

N/A

