### PR TITLE
fix (ai): catch errors in ui message stream

### DIFF
--- a/.changeset/spotty-countries-appear.md
+++ b/.changeset/spotty-countries-appear.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): catch errors in ui message stream

--- a/examples/next-openai-kasada-bot-protection/app/page.tsx
+++ b/examples/next-openai-kasada-bot-protection/app/page.tsx
@@ -8,7 +8,7 @@ export default function Chat() {
   const [input, setInput] = useState('');
   const { messages, sendMessage, status } = useChat({
     onError: err => {
-      toast.error(err as any);
+      toast.error(err.message);
     },
   });
 

--- a/examples/next-openai-kasada-bot-protection/app/page.tsx
+++ b/examples/next-openai-kasada-bot-protection/app/page.tsx
@@ -8,12 +8,12 @@ export default function Chat() {
   const [input, setInput] = useState('');
   const { messages, sendMessage, status } = useChat({
     onError: err => {
-      toast.error(err.message);
+      toast.error(err as any);
     },
   });
 
   return (
-    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
       {messages.length > 0
         ? messages.map(m => (
             <div key={m.id} className="whitespace-pre-wrap">
@@ -33,7 +33,7 @@ export default function Chat() {
         }}
       >
         <input
-          className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          className="fixed bottom-0 p-2 mb-8 w-full max-w-md rounded border border-gray-300 shadow-xl"
           value={input}
           placeholder="Say something..."
           onChange={e => setInput(e.target.value)}

--- a/examples/next-openai-upstash-rate-limits/app/page.tsx
+++ b/examples/next-openai-upstash-rate-limits/app/page.tsx
@@ -7,11 +7,11 @@ import { toast } from 'sonner';
 export default function Chat() {
   const [input, setInput] = useState('');
   const { messages, sendMessage } = useChat({
-    onError: err => toast.error(err.message),
+    onError: err => toast.error(err as any),
   });
 
   return (
-    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
       {messages.length > 0
         ? messages.map(m => (
             <div key={m.id} className="whitespace-pre-wrap">
@@ -31,7 +31,7 @@ export default function Chat() {
         }}
       >
         <input
-          className="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+          className="fixed bottom-0 p-2 mb-8 w-full max-w-md rounded border border-gray-300 shadow-xl"
           value={input}
           placeholder="Say something..."
           onChange={e => setInput(e.target.value)}

--- a/examples/next-openai-upstash-rate-limits/app/page.tsx
+++ b/examples/next-openai-upstash-rate-limits/app/page.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner';
 export default function Chat() {
   const [input, setInput] = useState('');
   const { messages, sendMessage } = useChat({
-    onError: err => toast.error(err as any),
+    onError: err => toast.error(err.message),
   });
 
   return (

--- a/examples/next-openai/app/api/chat/route.ts
+++ b/examples/next-openai/app/api/chat/route.ts
@@ -1,41 +1,17 @@
 import { openai } from '@ai-sdk/openai';
-import {
-  convertToModelMessages,
-  createUIMessageStream,
-  createUIMessageStreamResponse,
-  streamText,
-  UIMessage,
-} from 'ai';
+import { convertToModelMessages, streamText, UIMessage } from 'ai';
 
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
-  const modelMessages = convertToModelMessages(messages);
+  const prompt = convertToModelMessages(messages);
 
-  const stream = createUIMessageStream({
-    execute: ({ writer }) => {
-      throw new Error('test');
-      // const result = streamText({
-      //   model: anthropic('claude-sonnet-4-20250514'),
-      //   messages: modelMessages,
-      //   onError: (err) => {
-      //     const errorMessage = 'Error during streamText';
-      //     logger.error({ err }, errorMessage);
-      //   },
-      // });
-      // writer.merge(result.toUIMessageStream());
-    },
-    onFinish: () => {
-      // error message doesn't show if onFinish isn't defined
-    },
-    onError: err => {
-      const errorMessage = 'Error during createUIMessageStream';
-      console.error(errorMessage, err);
-      return errorMessage;
-    },
+  const result = streamText({
+    model: openai('gpt-4o'),
+    prompt,
   });
 
-  return createUIMessageStreamResponse({ stream });
+  return result.toUIMessageStreamResponse();
 }

--- a/examples/next-openai/app/api/chat/route.ts
+++ b/examples/next-openai/app/api/chat/route.ts
@@ -1,17 +1,41 @@
 import { openai } from '@ai-sdk/openai';
-import { convertToModelMessages, streamText, UIMessage } from 'ai';
+import {
+  convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  streamText,
+  UIMessage,
+} from 'ai';
 
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
-  const prompt = convertToModelMessages(messages);
+  const modelMessages = convertToModelMessages(messages);
 
-  const result = streamText({
-    model: openai('gpt-4o'),
-    prompt,
+  const stream = createUIMessageStream({
+    execute: ({ writer }) => {
+      throw new Error('test');
+      // const result = streamText({
+      //   model: anthropic('claude-sonnet-4-20250514'),
+      //   messages: modelMessages,
+      //   onError: (err) => {
+      //     const errorMessage = 'Error during streamText';
+      //     logger.error({ err }, errorMessage);
+      //   },
+      // });
+      // writer.merge(result.toUIMessageStream());
+    },
+    onFinish: () => {
+      // error message doesn't show if onFinish isn't defined
+    },
+    onError: err => {
+      const errorMessage = 'Error during createUIMessageStream';
+      console.error(errorMessage, err);
+      return errorMessage;
+    },
   });
 
-  return result.toUIMessageStreamResponse();
+  return createUIMessageStreamResponse({ stream });
 }

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -20,6 +20,7 @@ import { StepResult } from './step-result';
 import { ToolCallUnion } from './tool-call';
 import { ToolErrorUnion, ToolResultUnion } from './tool-output';
 import { ToolSet } from './tool-set';
+import { ErrorHandler } from '../../src/util/error-handler';
 
 export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
   /**
@@ -98,7 +99,7 @@ export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
 };
 
 export type ConsumeStreamOptions = {
-  onError?: (error: unknown) => void;
+  onError?: ErrorHandler;
 };
 
 /**

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -1803,6 +1803,7 @@ However, the LLM results are expected to be small enough to not cause issues.
       messageId: responseMessageId ?? this.generateId(),
       originalMessages,
       onFinish,
+      onError,
     });
   }
 

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -135,5 +135,6 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
     messageId: generateId(),
     originalMessages,
     onFinish,
+    onError,
   });
 }

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -4,6 +4,7 @@ import {
   StreamingUIMessageState,
 } from '../ui/process-ui-message-stream';
 import { UIMessage } from '../ui/ui-messages';
+import { ErrorHandler } from '../util/error-handler';
 import {
   InferUIMessageStreamPart,
   UIMessageStreamPart,
@@ -25,7 +26,7 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
    */
   originalMessages?: UI_MESSAGE[];
 
-  onError: (error: unknown) => void;
+  onError: ErrorHandler;
 
   onFinish?: (options: {
     /**

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -13,6 +13,7 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   messageId,
   originalMessages = [],
   onFinish,
+  onError,
   stream,
 }: {
   stream: ReadableStream<InferUIMessageStreamPart<UI_MESSAGE>>;
@@ -23,6 +24,8 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
    * The original messages.
    */
   originalMessages?: UI_MESSAGE[];
+
+  onError: (error: unknown) => void;
 
   onFinish?: (options: {
     /**
@@ -87,6 +90,7 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
       }),
     ),
     runUpdateMessageJob,
+    onError,
   }).pipeThrough(
     new TransformStream<
       InferUIMessageStreamPart<UI_MESSAGE>,

--- a/packages/ai/src/ui-message-stream/ui-message-stream-writer.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-writer.ts
@@ -1,4 +1,5 @@
 import { UIMessage } from '../ui';
+import { ErrorHandler } from '../util/error-handler';
 import { InferUIMessageStreamPart } from './ui-message-stream-parts';
 
 export interface UIMessageStreamWriter<
@@ -19,5 +20,5 @@ export interface UIMessageStreamWriter<
    * This is intended for forwarding when merging streams
    * to prevent duplicated error masking.
    */
-  onError: ((error: unknown) => string) | undefined;
+  onError: ErrorHandler | undefined;
 }

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -173,6 +173,56 @@ describe('processUIMessageStream', () => {
     });
   });
 
+  describe('errors', () => {
+    let errors: Array<unknown>;
+
+    beforeEach(async () => {
+      errors = [];
+
+      const stream = createUIMessageStream([
+        { type: 'error', errorText: 'test error' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            errors.push(error);
+          },
+        }),
+      });
+    });
+
+    it('should call the update function with the correct arguments', async () => {
+      expect(writeCalls).toMatchInlineSnapshot(`[]`);
+    });
+
+    it('should have the correct final message state', async () => {
+      expect(state!.message).toMatchInlineSnapshot(`
+        {
+          "id": "msg-123",
+          "metadata": undefined,
+          "parts": [],
+          "role": "assistant",
+        }
+      `);
+    });
+
+    it('should call the onError function with the correct arguments', async () => {
+      expect(errors).toMatchInlineSnapshot(`
+        [
+          "test error",
+        ]
+      `);
+    });
+  });
+
   describe('server-side tool roundtrip', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -62,6 +62,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -208,6 +211,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -462,6 +468,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -772,6 +781,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -1174,6 +1186,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -1739,6 +1754,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -1979,6 +1997,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -2205,6 +2226,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -2353,6 +2377,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -2508,6 +2535,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -2689,6 +2719,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -2858,6 +2891,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -3426,6 +3462,9 @@ describe('processUIMessageStream', () => {
           stream,
           runUpdateMessageJob,
           onToolCall: vi.fn().mockResolvedValue('test-result'),
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -3549,6 +3588,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -3705,6 +3747,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -3968,6 +4013,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -4051,6 +4099,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -4159,6 +4210,9 @@ describe('processUIMessageStream', () => {
         stream: processUIMessageStream({
           stream,
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -4307,6 +4361,9 @@ describe('processUIMessageStream', () => {
             return 'client-result';
           },
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
     });
@@ -4557,6 +4614,9 @@ describe('processUIMessageStream', () => {
             return 'client-result';
           },
           runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
         }),
       });
 

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -217,7 +217,7 @@ describe('processUIMessageStream', () => {
     it('should call the onError function with the correct arguments', async () => {
       expect(errors).toMatchInlineSnapshot(`
         [
-          "test error",
+          [Error: test error],
         ]
       `);
     });

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -9,21 +9,22 @@ import {
   isDataUIMessageStreamPart,
   UIMessageStreamPart,
 } from '../ui-message-stream/ui-message-stream-parts';
+import { ErrorHandler } from '../util/error-handler';
 import { mergeObjects } from '../util/merge-objects';
 import { parsePartialJson } from '../util/parse-partial-json';
+import { UIDataTypesToSchemas } from './chat';
 import {
+  getToolName,
   InferUIMessageData,
   InferUIMessageMetadata,
   InferUIMessageTools,
-  ReasoningUIPart,
   isToolUIPart,
+  ReasoningUIPart,
   TextUIPart,
   ToolUIPart,
   UIMessage,
   UIMessagePart,
-  getToolName,
 } from './ui-messages';
-import { UIDataTypesToSchemas } from './chat';
 
 export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
   message: UI_MESSAGE;
@@ -84,7 +85,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
       write: () => void;
     }) => Promise<void>,
   ) => Promise<void>;
-  onError: (error: unknown) => void;
+  onError: ErrorHandler;
 }): ReadableStream<InferUIMessageStreamPart<UI_MESSAGE>> {
   return stream.pipeThrough(
     new TransformStream<

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -462,7 +462,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'error': {
-              onError?.(part.errorText);
+              onError?.(new Error(part.errorText));
               break;
             }
 

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -67,6 +67,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
   messageMetadataSchema,
   dataPartSchemas,
   runUpdateMessageJob,
+  onError,
 }: {
   // input stream is not fully typed yet:
   stream: ReadableStream<UIMessageStreamPart>;
@@ -83,6 +84,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
       write: () => void;
     }) => Promise<void>,
   ) => Promise<void>;
+  onError: (error: unknown) => void;
 }): ReadableStream<InferUIMessageStreamPart<UI_MESSAGE>> {
   return stream.pipeThrough(
     new TransformStream<
@@ -459,7 +461,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'error': {
-              throw new Error(part.errorText);
+              onError?.(part.errorText);
+              break;
             }
 
             default: {

--- a/packages/ai/src/util/create-resolvable-promise.ts
+++ b/packages/ai/src/util/create-resolvable-promise.ts
@@ -1,3 +1,5 @@
+import { ErrorHandler } from './error-handler';
+
 /**
  * Creates a Promise with externally accessible resolve and reject functions.
  *
@@ -10,10 +12,10 @@
 export function createResolvablePromise<T = any>(): {
   promise: Promise<T>;
   resolve: (value: T) => void;
-  reject: (error: unknown) => void;
+  reject: ErrorHandler;
 } {
   let resolve: (value: T) => void;
-  let reject: (error: unknown) => void;
+  let reject: ErrorHandler;
 
   const promise = new Promise<T>((res, rej) => {
     resolve = res;

--- a/packages/ai/src/util/error-handler.ts
+++ b/packages/ai/src/util/error-handler.ts
@@ -1,0 +1,1 @@
+export type ErrorHandler = (error: unknown) => void;

--- a/packages/ai/src/util/index.ts
+++ b/packages/ai/src/util/index.ts
@@ -1,6 +1,7 @@
 export { cosineSimilarity } from './cosine-similarity';
 export { getTextFromDataUrl } from './data-url';
 export type { DeepPartial } from './deep-partial';
+export { type ErrorHandler } from './error-handler';
 export { isDeepEqualData } from './is-deep-equal-data';
 export { parsePartialJson } from './parse-partial-json';
 export { SerialJobExecutor } from './serial-job-executor';


### PR DESCRIPTION
## Background

Adding error parts to the ui message stream leads to processing failures.

## Summary

* add `ErrorHandler` type
* add default error handler with console logging to `Chat`
* use error handler in stream processing

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

- [x] add test for handleUIMessageStreamFinish error case
- [x] changeset

## Related Issues

#6879