### PR TITLE
fix (ai): use user-provided media type when available

### DIFF
--- a/.changeset/clean-cheetahs-pump.md
+++ b/.changeset/clean-cheetahs-pump.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): mediatype for providers

--- a/.changeset/clean-cheetahs-pump.md
+++ b/.changeset/clean-cheetahs-pump.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-fix (ai): mediatype for providers
+fix (ai): use user-provided media type when available

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.test.ts
@@ -618,8 +618,6 @@ describe('convertToLanguageModelPrompt', () => {
           ]
         `);
       });
-
-
     });
 
     describe('provider options', async () => {

--- a/packages/ai/core/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/core/prompt/convert-to-language-model-prompt.ts
@@ -294,7 +294,7 @@ function convertPartToLanguageModelPart(
     const downloadedFile = downloadedAssets[data.toString()];
     if (downloadedFile) {
       data = downloadedFile.data;
-      mediaType = downloadedFile.mediaType ?? mediaType;
+      mediaType ??= downloadedFile.mediaType;
     }
   }
 


### PR DESCRIPTION
## background
fixed media type bug where user-provided specific media types 
were being overwritten by generic downloaded file media types.


## summary
before: mediaType = downloadedFile.mediaType ?? mediaType
- downloaded "application/octet-stream" would override user's "image/jpeg"
- caused Google Gemini and other providers to fail file identification

after: mediaType ??= downloadedFile.mediaType  
- user's "image/jpeg" is preserved, downloaded type used only as fallback
- providers now receive correct, specific media types for proper handling

## Related issues
related to issue #6664