### PR TITLE
feat (provider/anthropic): enable streaming tool calls

### DIFF
--- a/.changeset/wet-meals-pretend.md
+++ b/.changeset/wet-meals-pretend.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat (provider/anthropic): enable streaming tool calls

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -489,6 +489,7 @@ describe('AnthropicMessagesLanguageModel', () => {
 
       expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
         {
+          "anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
           "anthropic-version": "2023-06-01",
           "content-type": "application/json",
           "custom-provider-header": "provider-header-value",
@@ -1980,6 +1981,7 @@ describe('AnthropicMessagesLanguageModel', () => {
 
       expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
         {
+          "anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
           "anthropic-version": "2023-06-01",
           "content-type": "application/json",
           "custom-provider-header": "provider-header-value",

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -339,7 +339,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         tool_choice: anthropicToolChoice,
       },
       warnings: [...warnings, ...toolWarnings],
-      betas: new Set([...messagesBetas, ...toolsBetas]),
+      betas: new Set([
+        'fine-grained-tool-streaming-2025-05-14',
+        ...messagesBetas,
+        ...toolsBetas,
+      ]),
       usesJsonResponseTool: jsonResponseTool != null,
     };
   }


### PR DESCRIPTION
## Background

Anthropic enabled tool call streaming using a beta header.

## Summary

Send 'fine-grained-tool-streaming-2025-05-14' header.

## Verification

Run stream object example.

## Related Issues

Fixes #3422 