### PR TITLE
fix (providers/gateway): fix timestamp error when streaming objects

### DIFF
--- a/.changeset/stale-rockets-hope.md
+++ b/.changeset/stale-rockets-hope.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix (providers/gateway): fix timestamp error when streaming objects

--- a/examples/ai-core/src/stream-object/gateway.ts
+++ b/examples/ai-core/src/stream-object/gateway.ts
@@ -4,7 +4,7 @@ import { z } from 'zod/v4';
 
 async function main() {
   const result = streamObject({
-    model: 'xai/grok-3-beta',
+    model: 'xai/grok-3',
     schema: z.object({
       characters: z.array(
         z.object({

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1059,29 +1059,29 @@ describe('GatewayLanguageModel', () => {
       const chunks = await convertReadableStreamToArray(stream);
 
       expect(chunks).toMatchInlineSnapshot(`
-          [
-            {
-              "type": "stream-start",
-              "warnings": [],
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "textDelta": "Hello",
+            "type": "text-delta",
+          },
+          {
+            "textDelta": " world",
+            "type": "text-delta",
+          },
+          {
+            "finishReason": "stop",
+            "type": "finish",
+            "usage": {
+              "completion_tokens": 5,
+              "prompt_tokens": 10,
             },
-            {
-              "textDelta": "Hello",
-              "type": "text-delta",
-            },
-            {
-              "textDelta": " world",
-              "type": "text-delta",
-            },
-            {
-              "finishReason": "stop",
-              "type": "finish",
-              "usage": {
-                "completion_tokens": 5,
-                "prompt_tokens": 10,
-              },
-            },
-          ]
-        `);
+          },
+        ]
+      `);
     });
 
     it('should include raw chunks when includeRawChunks is true', async () => {
@@ -1103,39 +1103,39 @@ describe('GatewayLanguageModel', () => {
       const chunks = await convertReadableStreamToArray(stream);
 
       expect(chunks).toMatchInlineSnapshot(`
-          [
-            {
-              "type": "stream-start",
-              "warnings": [],
-            },
-            {
-              "rawValue": {
-                "choices": [
-                  {
-                    "delta": {
-                      "content": "Hello",
-                    },
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "rawValue": {
+              "choices": [
+                {
+                  "delta": {
+                    "content": "Hello",
                   },
-                ],
-                "id": "test-chunk",
-                "object": "chat.completion.chunk",
-              },
-              "type": "raw",
+                },
+              ],
+              "id": "test-chunk",
+              "object": "chat.completion.chunk",
             },
-            {
-              "textDelta": "Hello",
-              "type": "text-delta",
+            "type": "raw",
+          },
+          {
+            "textDelta": "Hello",
+            "type": "text-delta",
+          },
+          {
+            "finishReason": "stop",
+            "type": "finish",
+            "usage": {
+              "completion_tokens": 5,
+              "prompt_tokens": 10,
             },
-            {
-              "finishReason": "stop",
-              "type": "finish",
-              "usage": {
-                "completion_tokens": 5,
-                "prompt_tokens": 10,
-              },
-            },
-          ]
-        `);
+          },
+        ]
+      `);
     });
   });
 

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1035,29 +1035,30 @@ describe('GatewayLanguageModel', () => {
         }
       });
     });
+  });
 
-    describe('raw chunks filtering', () => {
-      it('should filter raw chunks based on includeRawChunks option', async () => {
-        server.urls['https://api.test.com/language-model'].response = {
-          type: 'stream-chunks',
-          chunks: [
-            `data: {"type":"stream-start","warnings":[]}\n\n`,
-            `data: {"type":"raw","rawValue":{"id":"test-chunk","object":"chat.completion.chunk","choices":[{"delta":{"content":"Hello"}}]}}\n\n`,
-            `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
-            `data: {"type":"raw","rawValue":{"id":"test-chunk-2","object":"chat.completion.chunk","choices":[{"delta":{"content":" world"}}]}}\n\n`,
-            `data: {"type":"text-delta","textDelta":" world"}\n\n`,
-            `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
-          ],
-        };
+  describe('raw chunks filtering', () => {
+    it('should filter raw chunks based on includeRawChunks option', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"raw","rawValue":{"id":"test-chunk","object":"chat.completion.chunk","choices":[{"delta":{"content":"Hello"}}]}}\n\n`,
+          `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
+          `data: {"type":"raw","rawValue":{"id":"test-chunk-2","object":"chat.completion.chunk","choices":[{"delta":{"content":" world"}}]}}\n\n`,
+          `data: {"type":"text-delta","textDelta":" world"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
 
-        const { stream } = await createTestModel().doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: false, // Raw chunks should be filtered out
-        });
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false, // Raw chunks should be filtered out
+      });
 
-        const chunks = await convertReadableStreamToArray(stream);
+      const chunks = await convertReadableStreamToArray(stream);
 
-        expect(chunks).toMatchInlineSnapshot(`
+      expect(chunks).toMatchInlineSnapshot(`
           [
             {
               "type": "stream-start",
@@ -1081,27 +1082,27 @@ describe('GatewayLanguageModel', () => {
             },
           ]
         `);
+    });
+
+    it('should include raw chunks when includeRawChunks is true', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"raw","rawValue":{"id":"test-chunk","object":"chat.completion.chunk","choices":[{"delta":{"content":"Hello"}}]}}\n\n`,
+          `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: true, // Raw chunks should be included
       });
 
-      it('should include raw chunks when includeRawChunks is true', async () => {
-        server.urls['https://api.test.com/language-model'].response = {
-          type: 'stream-chunks',
-          chunks: [
-            `data: {"type":"stream-start","warnings":[]}\n\n`,
-            `data: {"type":"raw","rawValue":{"id":"test-chunk","object":"chat.completion.chunk","choices":[{"delta":{"content":"Hello"}}]}}\n\n`,
-            `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
-            `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
-          ],
-        };
+      const chunks = await convertReadableStreamToArray(stream);
 
-        const { stream } = await createTestModel().doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: true, // Raw chunks should be included
-        });
-
-        const chunks = await convertReadableStreamToArray(stream);
-
-        expect(chunks).toMatchInlineSnapshot(`
+      expect(chunks).toMatchInlineSnapshot(`
           [
             {
               "type": "stream-start",
@@ -1135,180 +1136,179 @@ describe('GatewayLanguageModel', () => {
             },
           ]
         `);
+    });
+  });
+
+  describe('timestamp conversion', () => {
+    it('should convert timestamp strings to Date objects in response-metadata chunks', async () => {
+      const timestampString = '2023-12-07T10:30:00.000Z';
+
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"response-metadata","id":"test-id","modelId":"test-model","timestamp":"${timestampString}"}\n\n`,
+          `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks).toHaveLength(4);
+      expect(chunks[0]).toEqual({
+        type: 'stream-start',
+        warnings: [],
+      });
+
+      // Check that the response-metadata chunk has timestamp converted to Date
+      const responseMetadataChunk = chunks[1] as any;
+      expect(responseMetadataChunk).toMatchObject({
+        type: 'response-metadata',
+        id: 'test-id',
+        modelId: 'test-model',
+      });
+      expect(responseMetadataChunk.timestamp).toBeInstanceOf(Date);
+      expect(responseMetadataChunk.timestamp.toISOString()).toBe(
+        timestampString,
+      );
+    });
+
+    it('should not modify timestamp if it is already a Date object', async () => {
+      const timestampDate = new Date('2023-12-07T10:30:00.000Z');
+
+      // Use standard stream-chunks format with Date serialized as string, then manually parse
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"response-metadata","id":"test-id","modelId":"test-model","timestamp":"${timestampDate.toISOString()}"}\n\n`,
+          `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks).toHaveLength(4);
+
+      // Check that the response-metadata chunk timestamp is converted to Date
+      const responseMetadataChunk = chunks[1] as any;
+      expect(responseMetadataChunk).toMatchObject({
+        type: 'response-metadata',
+        id: 'test-id',
+        modelId: 'test-model',
+      });
+      expect(responseMetadataChunk.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('should not modify response-metadata chunks without timestamp', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"response-metadata","id":"test-id","modelId":"test-model"}\n\n`,
+          `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks).toHaveLength(4);
+
+      // Check that the response-metadata chunk without timestamp is unchanged
+      const responseMetadataChunk = chunks[1] as any;
+      expect(responseMetadataChunk).toEqual({
+        type: 'response-metadata',
+        id: 'test-id',
+        modelId: 'test-model',
+      });
+      expect(responseMetadataChunk.timestamp).toBeUndefined();
+    });
+
+    it('should handle null timestamp values gracefully', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"response-metadata","id":"test-id","modelId":"test-model","timestamp":null}\n\n`,
+          `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks).toHaveLength(4);
+
+      // Check that null timestamp is left as null
+      const responseMetadataChunk = chunks[1] as any;
+      expect(responseMetadataChunk).toEqual({
+        type: 'response-metadata',
+        id: 'test-id',
+        modelId: 'test-model',
+        timestamp: null,
       });
     });
 
-    describe('timestamp conversion', () => {
-      it('should convert timestamp strings to Date objects in response-metadata chunks', async () => {
-        const timestampString = '2023-12-07T10:30:00.000Z';
+    it('should only convert timestamps for response-metadata chunks, not other chunk types', async () => {
+      const timestampString = '2023-12-07T10:30:00.000Z';
 
-        server.urls['https://api.test.com/language-model'].response = {
-          type: 'stream-chunks',
-          chunks: [
-            `data: {"type":"stream-start","warnings":[]}\n\n`,
-            `data: {"type":"response-metadata","id":"test-id","modelId":"test-model","timestamp":"${timestampString}"}\n\n`,
-            `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
-            `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
-          ],
-        };
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"text-delta","textDelta":"Hello","timestamp":"${timestampString}"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5},"timestamp":"${timestampString}"}\n\n`,
+        ],
+      };
 
-        const { stream } = await createTestModel().doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: false,
-        });
-
-        const chunks = await convertReadableStreamToArray(stream);
-
-        expect(chunks).toHaveLength(4);
-        expect(chunks[0]).toEqual({
-          type: 'stream-start',
-          warnings: [],
-        });
-
-        // Check that the response-metadata chunk has timestamp converted to Date
-        const responseMetadataChunk = chunks[1] as any;
-        expect(responseMetadataChunk).toMatchObject({
-          type: 'response-metadata',
-          id: 'test-id',
-          modelId: 'test-model',
-        });
-        expect(responseMetadataChunk.timestamp).toBeInstanceOf(Date);
-        expect(responseMetadataChunk.timestamp.toISOString()).toBe(
-          timestampString,
-        );
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
       });
 
-      it('should not modify timestamp if it is already a Date object', async () => {
-        const timestampDate = new Date('2023-12-07T10:30:00.000Z');
+      const chunks = await convertReadableStreamToArray(stream);
 
-        // Use standard stream-chunks format with Date serialized as string, then manually parse
-        server.urls['https://api.test.com/language-model'].response = {
-          type: 'stream-chunks',
-          chunks: [
-            `data: {"type":"stream-start","warnings":[]}\n\n`,
-            `data: {"type":"response-metadata","id":"test-id","modelId":"test-model","timestamp":"${timestampDate.toISOString()}"}\n\n`,
-            `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
-            `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
-          ],
-        };
+      expect(chunks).toHaveLength(3);
 
-        const { stream } = await createTestModel().doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: false,
-        });
-
-        const chunks = await convertReadableStreamToArray(stream);
-
-        expect(chunks).toHaveLength(4);
-
-        // Check that the response-metadata chunk timestamp is converted to Date
-        const responseMetadataChunk = chunks[1] as any;
-        expect(responseMetadataChunk).toMatchObject({
-          type: 'response-metadata',
-          id: 'test-id',
-          modelId: 'test-model',
-        });
-        expect(responseMetadataChunk.timestamp).toBeInstanceOf(Date);
+      // Check that timestamps in non-response-metadata chunks are left as strings
+      // Note: These chunks don't typically have timestamp properties in the real types,
+      // but this test verifies our conversion logic only affects response-metadata chunks
+      const textDeltaChunk = chunks[1] as any;
+      expect(textDeltaChunk).toEqual({
+        type: 'text-delta',
+        textDelta: 'Hello',
+        timestamp: timestampString, // Should remain a string
       });
 
-      it('should not modify response-metadata chunks without timestamp', async () => {
-        server.urls['https://api.test.com/language-model'].response = {
-          type: 'stream-chunks',
-          chunks: [
-            `data: {"type":"stream-start","warnings":[]}\n\n`,
-            `data: {"type":"response-metadata","id":"test-id","modelId":"test-model"}\n\n`,
-            `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
-            `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
-          ],
-        };
-
-        const { stream } = await createTestModel().doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: false,
-        });
-
-        const chunks = await convertReadableStreamToArray(stream);
-
-        expect(chunks).toHaveLength(4);
-
-        // Check that the response-metadata chunk without timestamp is unchanged
-        const responseMetadataChunk = chunks[1] as any;
-        expect(responseMetadataChunk).toEqual({
-          type: 'response-metadata',
-          id: 'test-id',
-          modelId: 'test-model',
-        });
-        expect(responseMetadataChunk.timestamp).toBeUndefined();
-      });
-
-      it('should handle null timestamp values gracefully', async () => {
-        server.urls['https://api.test.com/language-model'].response = {
-          type: 'stream-chunks',
-          chunks: [
-            `data: {"type":"stream-start","warnings":[]}\n\n`,
-            `data: {"type":"response-metadata","id":"test-id","modelId":"test-model","timestamp":null}\n\n`,
-            `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
-            `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
-          ],
-        };
-
-        const { stream } = await createTestModel().doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: false,
-        });
-
-        const chunks = await convertReadableStreamToArray(stream);
-
-        expect(chunks).toHaveLength(4);
-
-        // Check that null timestamp is left as null
-        const responseMetadataChunk = chunks[1] as any;
-        expect(responseMetadataChunk).toEqual({
-          type: 'response-metadata',
-          id: 'test-id',
-          modelId: 'test-model',
-          timestamp: null,
-        });
-      });
-
-      it('should only convert timestamps for response-metadata chunks, not other chunk types', async () => {
-        const timestampString = '2023-12-07T10:30:00.000Z';
-
-        server.urls['https://api.test.com/language-model'].response = {
-          type: 'stream-chunks',
-          chunks: [
-            `data: {"type":"stream-start","warnings":[]}\n\n`,
-            `data: {"type":"text-delta","textDelta":"Hello","timestamp":"${timestampString}"}\n\n`,
-            `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5},"timestamp":"${timestampString}"}\n\n`,
-          ],
-        };
-
-        const { stream } = await createTestModel().doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: false,
-        });
-
-        const chunks = await convertReadableStreamToArray(stream);
-
-        expect(chunks).toHaveLength(3);
-
-        // Check that timestamps in non-response-metadata chunks are left as strings
-        // Note: These chunks don't typically have timestamp properties in the real types,
-        // but this test verifies our conversion logic only affects response-metadata chunks
-        const textDeltaChunk = chunks[1] as any;
-        expect(textDeltaChunk).toEqual({
-          type: 'text-delta',
-          textDelta: 'Hello',
-          timestamp: timestampString, // Should remain a string
-        });
-
-        const finishChunk = chunks[2] as any;
-        expect(finishChunk).toEqual({
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { prompt_tokens: 10, completion_tokens: 5 },
-          timestamp: timestampString, // Should remain a string
-        });
+      const finishChunk = chunks[2] as any;
+      expect(finishChunk).toEqual({
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+        timestamp: timestampString, // Should remain a string
       });
     });
   });

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -117,7 +117,6 @@ export class GatewayLanguageModel implements LanguageModelV2 {
                   return; // Skip raw chunks if not requested
                 }
 
-                // Convert timestamp strings back to Date objects for response-metadata chunks
                 if (
                   streamPart.type === 'response-metadata' &&
                   streamPart.timestamp &&

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -117,6 +117,15 @@ export class GatewayLanguageModel implements LanguageModelV2 {
                   return; // Skip raw chunks if not requested
                 }
 
+                // Convert timestamp strings back to Date objects for response-metadata chunks
+                if (
+                  streamPart.type === 'response-metadata' &&
+                  streamPart.timestamp &&
+                  typeof streamPart.timestamp === 'string'
+                ) {
+                  streamPart.timestamp = new Date(streamPart.timestamp);
+                }
+
                 controller.enqueue(streamPart);
               } else {
                 controller.error(


### PR DESCRIPTION
## Background

Using `streamObject` with the gateway provider throws an exception like the below at the end:

```
TypeError: fullResponse.timestamp.toISOString is not a function
    at Object.flush (/Users/shaper/workspace/ai/packages/ai/core/generate-object/stream-object.ts:760:50)
```

This is due to the `Date` object in the `response-metadata` chunk getting serialized to a string over the wire.

## Summary

Look for and rehydrate the stream part's timestamp field into a `Date` object.

## Verification

Ran example script.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

Review the v2 language model spec for other similar cases where we may have missed lossy object types like `Date` and `URL`.
