### PR TITLE
chore (examples): update gateway examples to use relevant models and latest syntax

### DIFF
--- a/examples/ai-core/src/generate-text/gateway-image-base64.ts
+++ b/examples/ai-core/src/generate-text/gateway-image-base64.ts
@@ -1,11 +1,10 @@
-import { gateway } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 import 'dotenv/config';
 import fs from 'node:fs';
 
 async function main() {
   const result = await generateText({
-    model: gateway('xai/grok-3-beta'),
+    model: 'xai/grok-2-vision',
     messages: [
       {
         role: 'user',

--- a/examples/ai-core/src/generate-text/gateway-image-data-url.ts
+++ b/examples/ai-core/src/generate-text/gateway-image-data-url.ts
@@ -1,0 +1,30 @@
+import { generateText } from 'ai';
+import 'dotenv/config';
+import fs from 'node:fs';
+
+async function main() {
+  // Read the image file and create a proper data URL
+  const imageData = fs.readFileSync('./data/comic-cat.png');
+  const base64Data = imageData.toString('base64');
+  const dataUrl = `data:image/png;base64,${base64Data}`;
+
+  const result = await generateText({
+    model: 'xai/grok-2-vision',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe the image in detail.' },
+          {
+            type: 'image',
+            image: dataUrl,
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/gateway-image-url.ts
+++ b/examples/ai-core/src/generate-text/gateway-image-url.ts
@@ -1,10 +1,9 @@
-import { gateway } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: gateway('xai/grok-3-beta'),
+    model: 'xai/grok-2-vision',
     messages: [
       {
         role: 'user',

--- a/examples/ai-core/src/generate-text/gateway-tool-call.ts
+++ b/examples/ai-core/src/generate-text/gateway-tool-call.ts
@@ -1,4 +1,3 @@
-import { gateway } from '@ai-sdk/gateway';
 import { generateText, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod/v4';
@@ -6,7 +5,7 @@ import { weatherTool } from '../tools/weather-tool';
 
 async function main() {
   const result = await generateText({
-    model: gateway('xai/grok-3-beta'),
+    model: 'xai/grok-3',
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-core/src/stream-text/gateway-pdf.ts
+++ b/examples/ai-core/src/stream-text/gateway-pdf.ts
@@ -1,9 +1,9 @@
-import { generateText } from 'ai';
+import { streamText } from 'ai';
 import 'dotenv/config';
 import fs from 'node:fs';
 
 async function main() {
-  const result = await generateText({
+  const result = streamText({
     model: 'google/gemini-2.0-flash',
     messages: [
       {
@@ -23,7 +23,13 @@ async function main() {
     ],
   });
 
-  console.log(result.text);
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Background

Some gateway example scripts that require vision have a model specified that doesn't support vision. `grok-3-beta` is now just `grok-3` as it has shipped.

## Summary

Updated to use appropriate models and use string model id syntax.
