### PR TITLE
fix (ui/vue): fix `Chat` class reactivity

### DIFF
--- a/.changeset/six-guests-sleep.md
+++ b/.changeset/six-guests-sleep.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/vue': patch
+---
+
+fix (vue): update chat class reactivity
+
+## Problem
+
+In the new Vue `Chat` class, `messages` that were being passed as props or computed values were breaking the class' ability to update its internal state.
+
+## Context
+
+In Vue's reactivity system `ref.value.<push|pop>(item)` is problematic because it mutates the array directly and Vue won’t detect this change in some cases. Creating a new array allows Vue to correctly track and trigger updates to any reactive dependencies. (Vue tracks assignments (`=`), not mutations (`push`, `pop`, `splice`, etc.) on `.value`.)

--- a/examples/nuxt-openai/pages/use-chat-messages/index.vue
+++ b/examples/nuxt-openai/pages/use-chat-messages/index.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import type { UIMessage } from 'ai';
+import { Chat } from '@ai-sdk/vue';
+import { createIdGenerator } from 'ai';
+import { computed, readonly, ref } from 'vue';
+
+const messages: UIMessage[] = [
+  { id: 'message-0', role: 'user', parts: [{ type: 'text', text: 'Greetings.' }] },
+  { id: 'message-1', role: 'assistant', parts: [{ type: 'text', text: 'Hello.' }] },
+];
+
+const chat = new Chat({
+  generateId: createIdGenerator({ prefix: 'msgc', size: 16 }),
+  // @ts-expect-error - simulate messages passed as props
+  messages: readonly(messages),
+});
+
+const messageList = computed(() => chat.messages); // computed property for type inference
+const input = ref('');
+
+const handleSubmit = (e: Event) => {
+  e.preventDefault();
+  chat.sendMessage({ text: input.value });
+  input.value = '';
+};
+</script>
+
+<template>
+  <div class="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+    <div
+      v-for="message in messageList"
+      :key="message.id"
+      class="whitespace-pre-wrap"
+    >
+      <strong>{{ `${message.role}: ` }}</strong>
+      {{
+        message.parts
+          .map(part => (part.type === 'text' ? part.text : ''))
+          .join('')
+      }}
+    </div>
+
+    <form @submit="handleSubmit">
+      <input
+        class="fixed bottom-0 w-full max-w-md p-2 mb-8 border border-gray-300 rounded shadow-xl"
+        v-model="input"
+        placeholder="Say something..."
+      />
+    </form>
+  </div>
+</template>

--- a/examples/nuxt-openai/pages/use-chat-messages/index.vue
+++ b/examples/nuxt-openai/pages/use-chat-messages/index.vue
@@ -2,17 +2,16 @@
 import type { UIMessage } from 'ai';
 import { Chat } from '@ai-sdk/vue';
 import { createIdGenerator } from 'ai';
-import { computed, readonly, ref } from 'vue';
+import { computed, ref } from 'vue';
 
-const messages: UIMessage[] = [
+const messages = ref<UIMessage[]>([
   { id: 'message-0', role: 'user', parts: [{ type: 'text', text: 'Greetings.' }] },
   { id: 'message-1', role: 'assistant', parts: [{ type: 'text', text: 'Hello.' }] },
-];
+]);
 
 const chat = new Chat({
   generateId: createIdGenerator({ prefix: 'msgc', size: 16 }),
-  // @ts-expect-error - simulate messages passed as props
-  messages: readonly(messages),
+  messages: messages.value,
 });
 
 const messageList = computed(() => chat.messages); // computed property for type inference

--- a/packages/vue/src/TestChatInitMessages.vue
+++ b/packages/vue/src/TestChatInitMessages.vue
@@ -1,16 +1,15 @@
 <script setup lang="ts">
 import { UIMessage } from 'ai';
 import { Chat } from './chat.vue';
-import { readonly } from 'vue';
+import { ref } from 'vue';
 
-const messages: UIMessage[] = [
+const messages = ref<UIMessage[]>([
   { id: 'message-0', role: 'user', parts: [{ type: 'text', text: 'Greetings.' }] },
   { id: 'message-1', role: 'assistant', parts: [{ type: 'text', text: 'Hello.' }] },
-];
+]);
 
 const chat = new Chat({
-  // @ts-expect-error - simulate messages passed as props
-  messages: readonly(messages),
+  messages: messages.value,
 });
 </script>
 

--- a/packages/vue/src/TestChatInitMessages.vue
+++ b/packages/vue/src/TestChatInitMessages.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { UIMessage } from 'ai';
+import { Chat } from './chat.vue';
+import { readonly } from 'vue';
+
+const messages: UIMessage[] = [
+  { id: 'message-0', role: 'user', parts: [{ type: 'text', text: 'Greetings.' }] },
+  { id: 'message-1', role: 'assistant', parts: [{ type: 'text', text: 'Hello.' }] },
+];
+
+const chat = new Chat({
+  // @ts-expect-error - simulate messages passed as props
+  messages: readonly(messages),
+});
+</script>
+
+<template>
+  <div>
+    <div data-testid="status">{{ chat.status }}</div>
+    <div data-testid="error">{{ chat.error?.toString() }}</div>
+    <div
+      v-for="(m, idx) in chat.messages"
+      key="m.id"
+      :data-testid="`message-${idx}`"
+    >
+      {{ m.role === 'user' ? 'User: ' : 'AI: ' }}
+      {{
+        m.parts.map(part => (part.type === 'text' ? part.text : '')).join('')
+      }}
+    </div>
+
+    <button data-testid="do-append" @click="chat.sendMessage({ text: 'Hi.' })" />
+  </div>
+</template>

--- a/packages/vue/src/chat.vue.ts
+++ b/packages/vue/src/chat.vue.ts
@@ -43,11 +43,11 @@ class VueChatState<UI_MESSAGE extends UIMessage>
   }
 
   pushMessage = (message: UI_MESSAGE) => {
-    this.messagesRef.value.push(message);
+    this.messagesRef.value = [...this.messagesRef.value, message];
   };
 
   popMessage = () => {
-    this.messagesRef.value.pop();
+    this.messagesRef.value = this.messagesRef.value.slice(0, -1);
   };
 
   replaceMessage = (index: number, message: UI_MESSAGE) => {

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -10,6 +10,7 @@ import { setupTestComponent } from './setup-test-component';
 import TestChatAppendAttachmentsComponent from './TestChatAppendAttachmentsComponent.vue';
 import TestChatAttachmentsComponent from './TestChatAttachmentsComponent.vue';
 import TestChatComponent from './TestChatComponent.vue';
+import TestChatInitMessages from './TestChatInitMessages.vue';
 import TestChatPrepareRequestBodyComponent from './TestChatPrepareRequestBodyComponent.vue';
 import TestChatReloadComponent from './TestChatReloadComponent.vue';
 import TestChatTextStreamComponent from './TestChatTextStreamComponent.vue';
@@ -1016,5 +1017,33 @@ describe('should append message with attachments', () => {
         },
       ]);
     });
+  });
+});
+
+describe('init messages', () => {
+  setupTestComponent(TestChatInitMessages);
+
+  it('should show streamed response', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatStreamPart({ type: 'text-start', id: '0' }),
+        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
+        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
+        formatStreamPart({ type: 'text-end', id: '0' }),
+      ],
+    };
+
+    await userEvent.click(screen.getByTestId('do-append'));
+
+    await screen.findByTestId('message-2');
+    expect(screen.getByTestId('message-2')).toHaveTextContent('User: Hi.');
+
+    await screen.findByTestId('message-3');
+    expect(screen.getByTestId('message-3')).toHaveTextContent(
+      'AI: Hello, world.',
+    );
   });
 });


### PR DESCRIPTION
<!-- https://github.com/vercel/ai/blob/main/CONTRIBUTING.md -->

## Background

In the new Vue `Chat` class, `messages` that are passed as props or computed values will break the class' ability to update its internal state.

In Vue's reactivity system `ref.value.<push|pop>(item)` is problematic because it mutates the array directly and Vue won’t detect this change in some cases. Creating a new array allows Vue to correctly track and trigger updates to any reactive dependencies. (Vue tracks assignments (`=`), not mutations (`push`, `pop`, `splice`, etc.) on `.value`.)

## Summary

- Added failing tests in first commit to demonstrate the issue.
- Fixed failing tests in second commit with updates to the core class methods.

## Verification

Added tests.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
