### PR TITLE
feat (providers/gateway): opt-in auto-refresh of oidc token in local development

### DIFF
--- a/.changeset/twelve-swans-hide.md
+++ b/.changeset/twelve-swans-hide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (providers/gateway): opt-in auto-refresh of oidc token in local development

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -159,6 +159,7 @@ describe('GatewayProvider', () => {
         let currentTime = new Date('2024-01-01T00:00:00Z').getTime();
         const provider = createGatewayProvider({
           baseURL: 'https://api.example.com',
+          apiKey: 'test-api-key', // Add API key to avoid OIDC auth flow
           metadataCacheRefreshMillis: 10000, // 10 seconds
           _internal: {
             currentDate: () => new Date(currentTime),
@@ -192,6 +193,7 @@ describe('GatewayProvider', () => {
         let currentTime = new Date('2024-01-01T00:00:00Z').getTime();
         const provider = createGatewayProvider({
           baseURL: 'https://api.example.com',
+          apiKey: 'test-api-key', // Add API key to avoid OIDC auth flow
           _internal: {
             currentDate: () => new Date(currentTime),
           },

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -10,6 +10,7 @@ import {
   GatewayFetchMetadata,
   type GatewayFetchMetadataResponse,
 } from './gateway-fetch-metadata';
+import { attemptOidcAutoRefresh } from './oidc-auto-refresh';
 import { GatewayLanguageModel } from './gateway-language-model';
 import type { GatewayModelId } from './gateway-language-model-settings';
 import { getVercelOidcToken, getVercelRequestId } from './vercel-environment';
@@ -202,6 +203,8 @@ export async function getGatewayAuthToken(
   }
 
   try {
+    await attemptOidcAutoRefresh();
+
     const oidcToken = await getVercelOidcToken();
     return {
       token: oidcToken,

--- a/packages/gateway/src/oidc-auto-refresh.test.ts
+++ b/packages/gateway/src/oidc-auto-refresh.test.ts
@@ -722,7 +722,7 @@ OTHER_VAR=value`;
 
       const envFileContent = `OTHER_VAR=value\nANOTHER_VAR=another`;
 
-      mockExistsSync.mockImplementation((path: string) => {
+      mockExistsSync.mockImplementation(path => {
         if (path.toString().includes('.env.local')) return true;
         return path.toString().includes('package.json');
       });
@@ -743,7 +743,7 @@ OTHER_VAR=value`;
       process.env.NODE_ENV = 'development';
       process.env.VERCEL_OIDC_TOKEN = createTokenNeedingRefresh();
 
-      mockExistsSync.mockImplementation((path: string) => {
+      mockExistsSync.mockImplementation(path => {
         if (path.toString().includes('.env.local')) return false;
         return path.toString().includes('package.json');
       });
@@ -763,7 +763,7 @@ OTHER_VAR=value`;
       process.env.NODE_ENV = 'development';
       process.env.VERCEL_OIDC_TOKEN = createTokenNeedingRefresh();
 
-      mockExistsSync.mockImplementation((path: string) => {
+      mockExistsSync.mockImplementation(path => {
         if (path.toString().includes('.env.local')) return true;
         return path.toString().includes('package.json');
       });

--- a/packages/gateway/src/oidc-auto-refresh.test.ts
+++ b/packages/gateway/src/oidc-auto-refresh.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { OidcAutoRefresh, attemptOidcAutoRefresh } from './oidc-auto-refresh';
+
+// Mock dependencies
+vi.mock('child_process');
+vi.mock('fs');
+
+const mockExecSync = vi.mocked(execSync);
+const mockExistsSync = vi.mocked(existsSync);
+
+describe('OidcAutoRefresh', () => {
+  const originalEnv = process.env;
+  const originalCwd = process.cwd;
+
+  beforeEach(() => {
+    // Reset state before each test
+    OidcAutoRefresh.resetState();
+
+    // Reset environment variables
+    process.env = { ...originalEnv };
+
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock console methods to avoid test output pollution
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.cwd = originalCwd;
+    vi.restoreAllMocks();
+  });
+
+  describe('isEnabled', () => {
+    it('should return false when AI_GATEWAY_OIDC_REFRESH is not set', async () => {
+      delete process.env.AI_GATEWAY_OIDC_REFRESH;
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
+
+    it('should return true when AI_GATEWAY_OIDC_REFRESH is "true"', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.any(Object),
+      );
+    });
+
+    it('should return true when AI_GATEWAY_OIDC_REFRESH is "1"', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = '1';
+      process.env.NODE_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('development environment check', () => {
+    it('should skip when VERCEL_ENV is "production"', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.VERCEL_ENV = 'production';
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
+
+    it('should skip when VERCEL_ENV is "preview"', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.VERCEL_ENV = 'preview';
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
+
+    it('should proceed when VERCEL_ENV is "development"', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.VERCEL_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.any(Object),
+      );
+    });
+
+    it('should proceed when VERCEL_ENV is empty', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.VERCEL_ENV = '';
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.any(Object),
+      );
+    });
+
+    it('should skip when NODE_ENV is "production" and VERCEL_ENV is not set', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      delete process.env.VERCEL_ENV;
+      process.env.NODE_ENV = 'production';
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
+
+    it('should proceed when NODE_ENV is "development" and VERCEL_ENV is not set', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      delete process.env.VERCEL_ENV;
+      process.env.NODE_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.any(Object),
+      );
+    });
+
+    it('should proceed when both VERCEL_ENV and NODE_ENV are not set', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      delete process.env.VERCEL_ENV;
+      delete process.env.NODE_ENV;
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('findRepoRoot', () => {
+    it('should find repo root when .git exists', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      process.cwd = vi.fn().mockReturnValue('/test/project');
+
+      mockExistsSync.mockImplementation(path => {
+        return path.toString().includes('.git');
+      });
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.objectContaining({
+          cwd: '/test/project',
+        }),
+      );
+    });
+
+    it('should find repo root when package.json exists', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      process.cwd = vi.fn().mockReturnValue('/test/project');
+
+      mockExistsSync.mockImplementation(path => {
+        return path.toString().includes('package.json');
+      });
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.objectContaining({
+          cwd: '/test/project',
+        }),
+      );
+    });
+
+    it('should warn when repo root cannot be found', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      process.cwd = vi.fn().mockReturnValue('/');
+
+      mockExistsSync.mockReturnValue(false);
+      const warnSpy = vi.spyOn(console, 'warn');
+
+      await attemptOidcAutoRefresh();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[AI Gateway OIDC Auto-Refresh] WARNING: Could not find repository root. Skipping auto-refresh.',
+      );
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('vercel binary availability', () => {
+    it('should warn when vercel is not available and using default command', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+
+      // Mock vercel not being available
+      mockExecSync.mockImplementation((command: string) => {
+        if (
+          command.includes('which vercel') ||
+          command.includes('where vercel')
+        ) {
+          throw new Error('Command not found');
+        }
+        return Buffer.from('');
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn');
+
+      await attemptOidcAutoRefresh();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Vercel CLI is not available in PATH'),
+      );
+    });
+
+    it('should proceed when vercel is available', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+
+      mockExecSync.mockImplementation((command: string) => {
+        if (command.includes('which vercel')) {
+          return Buffer.from('/usr/local/bin/vercel');
+        }
+        return Buffer.from('');
+      });
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('custom command', () => {
+    it('should use custom command when AI_GATEWAY_OIDC_REFRESH_COMMAND is set', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      process.env.AI_GATEWAY_OIDC_REFRESH_COMMAND = 'custom-env-pull';
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'custom-env-pull',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('custom directory', () => {
+    it('should use custom directory when AI_GATEWAY_OIDC_REFRESH_DIR is set', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      process.env.AI_GATEWAY_OIDC_REFRESH_DIR = '/custom/dir';
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      const infoSpy = vi.spyOn(console, 'info');
+
+      await attemptOidcAutoRefresh();
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        '[AI Gateway OIDC Auto-Refresh] Using custom directory: /custom/dir',
+      );
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.objectContaining({
+          cwd: '/custom/dir',
+        }),
+      );
+    });
+
+    it('should skip repo root detection when custom directory is provided', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      process.env.AI_GATEWAY_OIDC_REFRESH_DIR = '/custom/dir';
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      // existsSync should not be called for repo root detection
+      expect(mockExistsSync).not.toHaveBeenCalled();
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.objectContaining({
+          cwd: '/custom/dir',
+        }),
+      );
+    });
+
+    it('should combine custom directory with custom command', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      process.env.AI_GATEWAY_OIDC_REFRESH_DIR = '/custom/dir';
+      process.env.AI_GATEWAY_OIDC_REFRESH_COMMAND = 'custom-env-pull';
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'custom-env-pull',
+        expect.objectContaining({
+          cwd: '/custom/dir',
+        }),
+      );
+    });
+
+    it('should fall back to repo root detection when custom directory is not set', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      delete process.env.AI_GATEWAY_OIDC_REFRESH_DIR;
+      process.cwd = vi.fn().mockReturnValue('/test/project');
+
+      mockExistsSync.mockImplementation(path => {
+        return path.toString().includes('package.json');
+      });
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      await attemptOidcAutoRefresh();
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'vercel env pull',
+        expect.objectContaining({
+          cwd: '/test/project',
+        }),
+      );
+    });
+  });
+
+  describe('refresh state management', () => {
+    it('should only refresh once per session', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      // Call twice
+      await attemptOidcAutoRefresh();
+      await attemptOidcAutoRefresh();
+
+      // Should only execute once
+      expect(mockExecSync).toHaveBeenCalledTimes(2); // once for vercel check, once for env pull
+    });
+
+    it('should reset state correctly', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+
+      // First call
+      await attemptOidcAutoRefresh();
+      expect(mockExecSync).toHaveBeenCalledTimes(2);
+
+      // Reset and call again
+      OidcAutoRefresh.resetState();
+      await attemptOidcAutoRefresh();
+      expect(mockExecSync).toHaveBeenCalledTimes(4); // Should execute again
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle command execution errors gracefully', async () => {
+      process.env.AI_GATEWAY_OIDC_REFRESH = 'true';
+      process.env.NODE_ENV = 'development';
+      mockExistsSync.mockReturnValue(true);
+
+      mockExecSync.mockImplementation((command: string) => {
+        if (command.includes('which vercel')) {
+          return Buffer.from('/usr/local/bin/vercel');
+        }
+        if (command === 'vercel env pull') {
+          throw new Error('Command failed');
+        }
+        return Buffer.from('');
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn');
+
+      // Should not throw
+      await expect(attemptOidcAutoRefresh()).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to refresh environment variables'),
+      );
+    });
+  });
+});

--- a/packages/gateway/src/oidc-auto-refresh.ts
+++ b/packages/gateway/src/oidc-auto-refresh.ts
@@ -1,0 +1,208 @@
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+
+/**
+ * Auto-refreshes OIDC tokens by pulling environment variables from Vercel
+ * when AI_GATEWAY_OIDC_REFRESH is enabled.
+ */
+export class OidcAutoRefresh {
+  private static hasRefreshed = false;
+  private static isRefreshing = false;
+
+  /**
+   * Checks if auto-refresh is enabled via environment variable
+   */
+  private static isEnabled(): boolean {
+    const refreshEnv = process.env.AI_GATEWAY_OIDC_REFRESH;
+    return refreshEnv === 'true' || refreshEnv === '1';
+  }
+
+  /**
+   * Checks if we're in a development environment
+   */
+  private static isDevelopmentEnvironment(): boolean {
+    const vercelEnv = process.env.VERCEL_ENV;
+    const nodeEnv = process.env.NODE_ENV;
+
+    // In Vercel, VERCEL_ENV is empty or 'development' for local dev
+    if (vercelEnv !== undefined) {
+      return vercelEnv === '' || vercelEnv === 'development';
+    }
+
+    // For general Node.js environments, check NODE_ENV
+    return nodeEnv === 'development' || nodeEnv === undefined;
+  }
+
+  /**
+   * Gets the command to execute for pulling environment variables
+   */
+  private static getRefreshCommand(): string {
+    return process.env.AI_GATEWAY_OIDC_REFRESH_COMMAND || 'vercel env pull';
+  }
+
+  /**
+   * Gets the directory to run the refresh command in
+   */
+  private static getRefreshDirectory(): string | null {
+    return process.env.AI_GATEWAY_OIDC_REFRESH_DIR || null;
+  }
+
+  /**
+   * Finds the root directory of the repository by looking for common root indicators
+   */
+  private static findRepoRoot(
+    startPath: string = process.cwd(),
+  ): string | null {
+    let currentPath = startPath;
+
+    while (currentPath !== dirname(currentPath)) {
+      // Check for common repository root indicators
+      const indicators = [
+        '.git',
+        'package.json',
+        'pnpm-lock.yaml',
+        'yarn.lock',
+      ];
+
+      for (const indicator of indicators) {
+        if (existsSync(join(currentPath, indicator))) {
+          return currentPath;
+        }
+      }
+
+      currentPath = dirname(currentPath);
+    }
+
+    return null;
+  }
+
+  /**
+   * Checks if the vercel binary is available in PATH
+   */
+  private static isVercelAvailable(): boolean {
+    try {
+      execSync('which vercel', { stdio: 'ignore' });
+      return true;
+    } catch {
+      try {
+        execSync('where vercel', { stdio: 'ignore' });
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Logs a warning message
+   */
+  private static warn(message: string): void {
+    console.warn(`[AI Gateway OIDC Auto-Refresh] WARNING: ${message}`);
+  }
+
+  /**
+   * Logs an info message
+   */
+  private static info(message: string): void {
+    console.info(`[AI Gateway OIDC Auto-Refresh] ${message}`);
+  }
+
+  /**
+   * Executes the environment refresh command
+   */
+  private static async executeRefresh(
+    workingDir: string,
+    command: string,
+  ): Promise<void> {
+    try {
+      this.info(`Executing: ${command}`);
+      execSync(command, {
+        cwd: workingDir,
+        stdio: 'inherit',
+        timeout: 30000, // 30 second timeout
+      });
+      this.info('Environment variables refreshed successfully');
+    } catch (error) {
+      this.warn(`Failed to refresh environment variables: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Attempts to auto-refresh OIDC tokens if enabled and conditions are met
+   */
+  public static async attemptAutoRefresh(): Promise<void> {
+    // Skip if not enabled
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    // Skip if not in development environment
+    if (!this.isDevelopmentEnvironment()) {
+      return;
+    }
+
+    // Skip if already refreshed or currently refreshing
+    if (this.hasRefreshed || this.isRefreshing) {
+      return;
+    }
+
+    this.isRefreshing = true;
+
+    try {
+      // Get the directory to run the command in
+      const customDir = this.getRefreshDirectory();
+      let workingDir: string;
+
+      if (customDir) {
+        workingDir = customDir;
+        this.info(`Using custom directory: ${workingDir}`);
+      } else {
+        // Find repository root
+        const repoRoot = this.findRepoRoot();
+        if (!repoRoot) {
+          this.warn('Could not find repository root. Skipping auto-refresh.');
+          return;
+        }
+        workingDir = repoRoot;
+      }
+
+      const command = this.getRefreshCommand();
+
+      // Check if using default vercel command and warn if vercel is not available
+      if (command === 'vercel env pull' && !this.isVercelAvailable()) {
+        this.warn(
+          'Vercel CLI is not available in PATH. Please install it with "npm install -g vercel" ' +
+            'or set AI_GATEWAY_OIDC_REFRESH_COMMAND to use a different command.',
+        );
+        return;
+      }
+
+      this.info(
+        `Auto-refreshing environment variables from directory: ${workingDir}`,
+      );
+      await this.executeRefresh(workingDir, command);
+      this.hasRefreshed = true;
+    } catch (error) {
+      // Error already logged in executeRefresh
+    } finally {
+      this.isRefreshing = false;
+    }
+  }
+
+  /**
+   * Resets the refresh state (useful for testing)
+   */
+  public static resetState(): void {
+    this.hasRefreshed = false;
+    this.isRefreshing = false;
+  }
+}
+
+/**
+ * Convenience function to attempt auto-refresh
+ */
+export async function attemptOidcAutoRefresh(): Promise<void> {
+  return OidcAutoRefresh.attemptAutoRefresh();
+}

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,9 @@
       "dependsOn": ["^build"],
       "env": [
         "AI_GATEWAY_API_KEY",
+        "AI_GATEWAY_OIDC_REFRESH",
+        "AI_GATEWAY_OIDC_REFRESH_COMMAND",
+        "AI_GATEWAY_OIDC_REFRESH_DIR",
         "ANTHROPIC_API_KEY",
         "ASSISTANT_ID",
         "AWS_REGION",


### PR DESCRIPTION
## Background

The Vercel OIDC token can expire and require manual intervention during development iteration. This is a poor DX. Using `vc dev` will auto-refresh, but many developers don't use `vc dev`.

## Summary

Add logic to the `gateway` provider to run `vc env pull` on their behalf if:
- they aren't using a Gateway API key
- the token is expired
- they have opted in to the behavior by setting `AI_GATEWAY_OIDC_REFRESH=true`

## Verification

Packed the module and tested locally in a demo app. Added unit tests.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
