### PR TITLE
fix (provider/google): support schemas that allow additional properties

### DIFF
--- a/.changeset/khaki-crabs-reply.md
+++ b/.changeset/khaki-crabs-reply.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Support tool schemas that allow additional properties (e.g `z.record(z.string())`)

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -23,6 +23,53 @@ it('should remove additionalProperties and $schema', () => {
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
 });
 
+it('supports additionalProperties: true', () => {
+  const input: JSONSchema7 = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      age: { type: 'number' },
+    },
+    additionalProperties: true,
+  };
+
+  const expected = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      age: { type: 'number' },
+    },
+    additionalProperties: true,
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});
+
+// z.record(z.string())
+it('supports `additionalProperties` as an object', () => {
+  const input: JSONSchema7 = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      age: { type: 'number' },
+    },
+    additionalProperties: { type: 'string' },
+  };
+
+  const expected = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      age: { type: 'number' },
+    },
+    additionalProperties: { type: 'string' },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});
+
 it('should handle nested objects and arrays', () => {
   const input: JSONSchema7 = {
     type: 'object',

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -46,8 +46,7 @@ it('supports additionalProperties: true', () => {
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
 });
 
-// z.record(z.string())
-it('supports `additionalProperties` as an object', () => {
+it('supports `additionalProperties` as an object (for z.record(z.string()))', () => {
   const input: JSONSchema7 = {
     $schema: 'http://json-schema.org/draft-07/schema#',
     type: 'object',

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -28,6 +28,7 @@ export function convertJSONSchemaToOpenAPISchema(
     const: constValue,
     minLength,
     enum: enumValues,
+    additionalProperties,
   } = jsonSchema;
 
   const result: Record<string, unknown> = {};
@@ -115,6 +116,13 @@ export function convertJSONSchemaToOpenAPISchema(
     result.minLength = minLength;
   }
 
+  if (additionalProperties === true) {
+    result.additionalProperties = true;
+  } else if (additionalProperties) {
+    result.additionalProperties =
+      convertJSONSchemaToOpenAPISchema(additionalProperties);
+  }
+
   return result;
 }
 
@@ -124,6 +132,7 @@ function isEmptyObjectSchema(jsonSchema: JSONSchema7Definition): boolean {
     typeof jsonSchema === 'object' &&
     jsonSchema.type === 'object' &&
     (jsonSchema.properties == null ||
-      Object.keys(jsonSchema.properties).length === 0)
+      Object.keys(jsonSchema.properties).length === 0) &&
+    !jsonSchema.additionalProperties
   );
 }


### PR DESCRIPTION
## Background

`z.record(z.string())` as a property in tool parameters currently gets converted to undefined, which is invalid and causes an error from vertex ai.

## Summary

This now gets converted to `{ type: 'object', additionalProperties: { type: 'string' } }`.

## Related Issues

Fixes #5628
Based on #5626 