### PR TITLE
chore: setup v4 branch ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, v5]
+    branches: [v4]
   pull_request:
-    branches: [main, v5]
+    branches: [v4]
 
 jobs:
   test:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,9 +2,9 @@ name: Quality
 
 on:
   push:
-    branches: [main, v5]
+    branches: [v4]
   pull_request:
-    branches: [main, v5]
+    branches: [v4]
 
 jobs:
   prettier:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
-      - v5
+      - v4
     paths:
       - '.changeset/**'
       - '.github/workflows/release.yml'

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
-      - main
+      - v4
     paths:
       - '.changeset/*.md'
 


### PR DESCRIPTION
 ## Background

Enable publishing v4 branch.

## Summary

Change main to v4 in github files.