### PR TITLE
fix (provider/openai): default strict mode to false

### DIFF
--- a/.changeset/spicy-bats-impress.md
+++ b/.changeset/spicy-bats-impress.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': major
+---
+
+chore (provider/openai): default strict mode to false

--- a/.changeset/spicy-bats-impress.md
+++ b/.changeset/spicy-bats-impress.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai': major
 ---
 
-chore (provider/openai): default strict mode to false
+fix (provider/openai): default strict mode to false

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -545,7 +545,7 @@ describe('doGenerate', () => {
                 ],
                 "type": "object",
               },
-              "strict": true,
+              "strict": false,
             },
             "type": "function",
           },
@@ -732,24 +732,37 @@ describe('doGenerate', () => {
         },
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'gpt-4o-2024-08-06',
-        messages: [{ role: 'user', content: 'Hello' }],
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'response',
-            strict: true,
-            schema: {
-              type: 'object',
-              properties: { value: { type: 'string' } },
-              required: ['value'],
-              additionalProperties: false,
-              $schema: 'http://json-schema.org/draft-07/schema#',
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
             },
+          ],
+          "model": "gpt-4o-2024-08-06",
+          "response_format": {
+            "json_schema": {
+              "name": "response",
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "value",
+                ],
+                "type": "object",
+              },
+              "strict": false,
+            },
+            "type": "json_schema",
           },
-        },
-      });
+        }
+      `);
 
       expect(warnings).toEqual([]);
     });
@@ -773,24 +786,37 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'gpt-4o-2024-08-06',
-        messages: [{ role: 'user', content: 'Hello' }],
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'response',
-            strict: true,
-            schema: {
-              type: 'object',
-              properties: { value: { type: 'string' } },
-              required: ['value'],
-              additionalProperties: false,
-              $schema: 'http://json-schema.org/draft-07/schema#',
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
             },
+          ],
+          "model": "gpt-4o-2024-08-06",
+          "response_format": {
+            "json_schema": {
+              "name": "response",
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "value",
+                ],
+                "type": "object",
+              },
+              "strict": false,
+            },
+            "type": "json_schema",
           },
-        },
-      });
+        }
+      `);
     });
 
     it('should set name & description with responseFormat json when structuredOutputs are enabled', async () => {
@@ -814,25 +840,38 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'gpt-4o-2024-08-06',
-        messages: [{ role: 'user', content: 'Hello' }],
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'test-name',
-            description: 'test description',
-            strict: true,
-            schema: {
-              type: 'object',
-              properties: { value: { type: 'string' } },
-              required: ['value'],
-              additionalProperties: false,
-              $schema: 'http://json-schema.org/draft-07/schema#',
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
             },
+          ],
+          "model": "gpt-4o-2024-08-06",
+          "response_format": {
+            "json_schema": {
+              "description": "test description",
+              "name": "test-name",
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "value",
+                ],
+                "type": "object",
+              },
+              "strict": false,
+            },
+            "type": "json_schema",
           },
-        },
-      });
+        }
+      `);
     });
 
     it('should allow for undefined schema with responseFormat json when structuredOutputs are enabled', async () => {
@@ -893,28 +932,41 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'gpt-4o-2024-08-06',
-        messages: [{ role: 'user', content: 'Hello' }],
-        tool_choice: 'required',
-        tools: [
-          {
-            type: 'function',
-            function: {
-              name: 'test-tool',
-              description: 'test description',
-              parameters: {
-                type: 'object',
-                properties: { value: { type: 'string' } },
-                required: ['value'],
-                additionalProperties: false,
-                $schema: 'http://json-schema.org/draft-07/schema#',
-              },
-              strict: true,
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
             },
-          },
-        ],
-      });
+          ],
+          "model": "gpt-4o-2024-08-06",
+          "tool_choice": "required",
+          "tools": [
+            {
+              "function": {
+                "description": "test description",
+                "name": "test-tool",
+                "parameters": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "additionalProperties": false,
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "value",
+                  ],
+                  "type": "object",
+                },
+                "strict": false,
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
 
       expect(result.content).toMatchInlineSnapshot(`
         [
@@ -966,27 +1018,45 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'gpt-4o-2024-08-06',
-      messages: [{ role: 'user', content: 'Hello' }],
-      tool_choice: { type: 'function', function: { name: 'test-tool' } },
-      tools: [
-        {
-          type: 'function',
-          function: {
-            name: 'test-tool',
-            parameters: {
-              type: 'object',
-              properties: { value: { type: 'string' } },
-              required: ['value'],
-              additionalProperties: false,
-              $schema: 'http://json-schema.org/draft-07/schema#',
-            },
-            strict: true,
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello",
+            "role": "user",
           },
+        ],
+        "model": "gpt-4o-2024-08-06",
+        "tool_choice": {
+          "function": {
+            "name": "test-tool",
+          },
+          "type": "function",
         },
-      ],
-    });
+        "tools": [
+          {
+            "function": {
+              "name": "test-tool",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "value",
+                ],
+                "type": "object",
+              },
+              "strict": false,
+            },
+            "type": "function",
+          },
+        ],
+      }
+    `);
 
     expect(result.content).toMatchInlineSnapshot(`
       [

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -117,6 +117,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
 
     warnings.push(...messageWarnings);
 
+    const strictJsonSchema = openaiOptions.strictJsonSchema ?? false;
+
     const baseArgs = {
       // model id:
       model: this.modelId,
@@ -147,13 +149,12 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       presence_penalty: presencePenalty,
       response_format:
         responseFormat?.type === 'json'
-          ? // TODO convert into provider option
-            structuredOutputs && responseFormat.schema != null
+          ? structuredOutputs && responseFormat.schema != null
             ? {
                 type: 'json_schema',
                 json_schema: {
                   schema: responseFormat.schema,
-                  strict: true,
+                  strict: strictJsonSchema,
                   name: responseFormat.name ?? 'response',
                   description: responseFormat.description,
                 },
@@ -276,6 +277,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       tools,
       toolChoice,
       structuredOutputs,
+      strictJsonSchema,
     });
 
     return {

--- a/packages/openai/src/openai-chat-options.ts
+++ b/packages/openai/src/openai-chat-options.ts
@@ -118,6 +118,13 @@ export const openaiProviderOptions = z.object({
    * @default 'auto'
    */
   serviceTier: z.enum(['auto', 'flex']).optional(),
+
+  /**
+   * Whether to use strict JSON schema validation.
+   *
+   * @default true
+   */
+  strictJsonSchema: z.boolean().optional(),
 });
 
 export type OpenAIProviderOptions = z.infer<typeof openaiProviderOptions>;

--- a/packages/openai/src/openai-prepare-tools.test.ts
+++ b/packages/openai/src/openai-prepare-tools.test.ts
@@ -1,7 +1,12 @@
 import { prepareTools } from './openai-prepare-tools';
 
 it('should return undefined tools and toolChoice when tools are null', () => {
-  const result = prepareTools({ tools: undefined, structuredOutputs: false });
+  const result = prepareTools({
+    tools: undefined,
+    structuredOutputs: false,
+    strictJsonSchema: false,
+  });
+
   expect(result).toEqual({
     tools: undefined,
     toolChoice: undefined,
@@ -10,7 +15,12 @@ it('should return undefined tools and toolChoice when tools are null', () => {
 });
 
 it('should return undefined tools and toolChoice when tools are empty', () => {
-  const result = prepareTools({ tools: [], structuredOutputs: false });
+  const result = prepareTools({
+    tools: [],
+    structuredOutputs: false,
+    strictJsonSchema: false,
+  });
+
   expect(result).toEqual({
     tools: undefined,
     toolChoice: undefined,
@@ -29,7 +39,9 @@ it('should correctly prepare function tools', () => {
       },
     ],
     structuredOutputs: false,
+    strictJsonSchema: false,
   });
+
   expect(result.tools).toEqual([
     {
       type: 'function',
@@ -73,7 +85,9 @@ it('should correctly prepare provider-defined-server tools', () => {
       },
     ],
     structuredOutputs: false,
+    strictJsonSchema: false,
   });
+
   expect(result.tools).toEqual([
     {
       type: 'file_search',
@@ -106,7 +120,9 @@ it('should add warnings for unsupported tools', () => {
       },
     ],
     structuredOutputs: false,
+    strictJsonSchema: false,
   });
+
   expect(result.tools).toEqual([]);
   expect(result.toolChoice).toBeUndefined();
   expect(result.toolWarnings).toMatchInlineSnapshot(`
@@ -135,7 +151,9 @@ it('should add warnings for unsupported provider-defined tools', () => {
       } as any,
     ],
     structuredOutputs: false,
+    strictJsonSchema: false,
   });
+
   expect(result.tools).toEqual([]);
   expect(result.toolChoice).toBeUndefined();
   expect(result.toolWarnings).toEqual([
@@ -163,6 +181,7 @@ it('should handle tool choice "auto"', () => {
     ],
     toolChoice: { type: 'auto' },
     structuredOutputs: false,
+    strictJsonSchema: false,
   });
   expect(result.toolChoice).toEqual('auto');
 });
@@ -179,6 +198,7 @@ it('should handle tool choice "required"', () => {
     ],
     toolChoice: { type: 'required' },
     structuredOutputs: false,
+    strictJsonSchema: false,
   });
   expect(result.toolChoice).toEqual('required');
 });
@@ -195,6 +215,7 @@ it('should handle tool choice "none"', () => {
     ],
     toolChoice: { type: 'none' },
     structuredOutputs: false,
+    strictJsonSchema: false,
   });
   expect(result.toolChoice).toEqual('none');
 });
@@ -211,6 +232,7 @@ it('should handle tool choice "tool"', () => {
     ],
     toolChoice: { type: 'tool', toolName: 'testFunction' },
     structuredOutputs: false,
+    strictJsonSchema: false,
   });
   expect(result.toolChoice).toEqual({
     type: 'function',

--- a/packages/openai/src/openai-prepare-tools.ts
+++ b/packages/openai/src/openai-prepare-tools.ts
@@ -11,10 +11,12 @@ export function prepareTools({
   tools,
   toolChoice,
   structuredOutputs,
+  strictJsonSchema,
 }: {
   tools: LanguageModelV2CallOptions['tools'];
   toolChoice?: LanguageModelV2CallOptions['toolChoice'];
   structuredOutputs: boolean;
+  strictJsonSchema: boolean;
 }): {
   tools?: OpenAITools;
   toolChoice?: OpenAIToolChoice;
@@ -40,7 +42,7 @@ export function prepareTools({
             name: tool.name,
             description: tool.description,
             parameters: tool.inputSchema,
-            strict: structuredOutputs ? true : undefined,
+            strict: structuredOutputs ? strictJsonSchema : undefined,
           },
         });
         break;

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -342,27 +342,43 @@ describe('OpenAIResponsesLanguageModel', () => {
           },
         });
 
-        expect(await server.calls[0].requestBodyJson).toStrictEqual({
-          model: 'gpt-4o',
-          text: {
-            format: {
-              type: 'json_schema',
-              strict: true,
-              name: 'response',
-              description: 'A response',
-              schema: {
-                type: 'object',
-                properties: { value: { type: 'string' } },
-                required: ['value'],
-                additionalProperties: false,
-                $schema: 'http://json-schema.org/draft-07/schema#',
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "gpt-4o",
+            "text": {
+              "format": {
+                "description": "A response",
+                "name": "response",
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "additionalProperties": false,
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "value",
+                  ],
+                  "type": "object",
+                },
+                "strict": false,
+                "type": "json_schema",
               },
             },
-          },
-          input: [
-            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
-          ],
-        });
+          }
+        `);
 
         expect(warnings).toStrictEqual([]);
       });
@@ -573,30 +589,43 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
         });
 
-        expect(await server.calls[0].requestBodyJson).toStrictEqual({
-          model: 'gpt-4o',
-          text: {
-            format: {
-              type: 'json_schema',
-              strict: true,
-              name: 'response',
-              description: 'A response',
-              schema: {
-                type: 'object',
-                properties: { value: { type: 'string' } },
-                required: ['value'],
-                additionalProperties: false,
-                $schema: 'http://json-schema.org/draft-07/schema#',
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "gpt-4o",
+            "text": {
+              "format": {
+                "description": "A response",
+                "name": "response",
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "additionalProperties": false,
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "value",
+                  ],
+                  "type": "object",
+                },
+                "strict": false,
+                "type": "json_schema",
               },
             },
-          },
-          input: [
-            {
-              role: 'user',
-              content: [{ type: 'input_text', text: 'Hello' }],
-            },
-          ],
-        });
+          }
+        `);
 
         expect(warnings).toStrictEqual([]);
       });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -101,7 +101,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       schema: openaiResponsesProviderOptionsSchema,
     });
 
-    const isStrict = openaiOptions?.strictSchemas ?? true;
+    const strictJsonSchema = openaiOptions?.strictJsonSchema ?? false;
 
     const baseArgs = {
       model: this.modelId,
@@ -116,7 +116,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             responseFormat.schema != null
               ? {
                   type: 'json_schema',
-                  strict: isStrict,
+                  strict: strictJsonSchema,
                   name: responseFormat.name ?? 'response',
                   description: responseFormat.description,
                   schema: responseFormat.schema,
@@ -195,7 +195,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
     } = prepareResponsesTools({
       tools,
       toolChoice,
-      strict: isStrict,
+      strictJsonSchema,
     });
 
     return {
@@ -912,7 +912,7 @@ const openaiResponsesProviderOptionsSchema = z.object({
   store: z.boolean().nullish(),
   user: z.string().nullish(),
   reasoningEffort: z.string().nullish(),
-  strictSchemas: z.boolean().nullish(),
+  strictJsonSchema: z.boolean().nullish(),
   instructions: z.string().nullish(),
   reasoningSummary: z.string().nullish(),
   serviceTier: z.enum(['auto', 'flex']).nullish(),

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -8,11 +8,11 @@ import { OpenAIResponsesTool } from './openai-responses-api-types';
 export function prepareResponsesTools({
   tools,
   toolChoice,
-  strict,
+  strictJsonSchema,
 }: {
   tools: LanguageModelV2CallOptions['tools'];
   toolChoice?: LanguageModelV2CallOptions['toolChoice'];
-  strict: boolean;
+  strictJsonSchema: boolean;
 }): {
   tools?: Array<OpenAIResponsesTool>;
   toolChoice?:
@@ -42,7 +42,7 @@ export function prepareResponsesTools({
           name: tool.name,
           description: tool.description,
           parameters: tool.inputSchema,
-          strict: strict ? true : undefined,
+          strict: strictJsonSchema,
         });
         break;
       case 'provider-defined':

--- a/packages/openai/src/responses/openai-responses-settings.ts
+++ b/packages/openai/src/responses/openai-responses-settings.ts
@@ -44,5 +44,3 @@ export type OpenAIResponsesModelId =
   | 'gpt-3.5-turbo-1106'
   | 'chatgpt-4o-latest'
   | (string & {});
-
-export interface OpenAIResponsesSettings {}


### PR DESCRIPTION
## Background

In AI SDK 5, strict mode for tool calling and output generation was enabled by default for the OpenAI responses and chat language models.

However, this caused several issues, e.g. #6913 #6642 #4662

## Summary

* default strict mode to false for openai responses and chat language models (breaking change)
* introduce provider option `strictJsonSchema` for chat language models
* rename provider option `strictSchemas` to `strictJsonSchema` for responses language model (breaking change)

## Related Issues

Fixes #6913 #6642 #4662