### PR TITLE
feat(google): automatically handle system instructions for Gemma models

### DIFF
--- a/.changeset/spotty-goats-confess.md
+++ b/.changeset/spotty-goats-confess.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(google): automatically handle system instructions for Gemma models

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -172,6 +172,23 @@ const { text } = await generateText({
 Google Generative AI language models can also be used in the `streamText`, `generateObject`, and `streamObject` functions
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+### Gemma Models
+
+Gemma models don't natively support the `systemInstruction` parameter, but the provider automatically handles system instructions by prepending them to the first user message. This allows you to use system instructions with Gemma models seamlessly:
+
+```ts
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: google('gemma-3-12b-it'),
+  system: 'You are a helpful assistant that responds concisely.',
+  prompt: 'What is machine learning?',
+});
+```
+
+The system instruction is automatically formatted and included in the conversation, so Gemma models can follow the guidance without any additional configuration.
+
 ### File Inputs
 
 The Google Generative AI provider supports file inputs, e.g. PDF files.

--- a/examples/ai-core/src/generate-text/google-gemma-system-instructions.ts
+++ b/examples/ai-core/src/generate-text/google-gemma-system-instructions.ts
@@ -1,0 +1,19 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: google('gemma-3-12b-it'),
+    system:
+      'You are a helpful pirate assistant. Always respond like a friendly pirate, using "Arrr" and pirate terminology.',
+    prompt: 'What is the meaning of life?',
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/google-gemma-system-instructions.ts
+++ b/examples/ai-core/src/stream-text/google-gemma-system-instructions.ts
@@ -1,0 +1,22 @@
+import { google } from '@ai-sdk/google';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: google('gemma-3-12b-it'),
+    system:
+      'You are a helpful pirate assistant. Always respond like a friendly pirate, using "Arrr" and pirate terminology.',
+    prompt: 'Tell me a short story about finding treasure.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -24,6 +24,119 @@ describe('system messages', () => {
   });
 });
 
+describe('Gemma model system instructions', () => {
+  it('should prepend system instruction to first user message for Gemma models', async () => {
+    const result = convertToGoogleGenerativeAIMessages(
+      [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      ],
+      { isGemmaModel: true },
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "You are a helpful assistant.
+
+      ",
+              },
+              {
+                "text": "Hello",
+              },
+            ],
+            "role": "user",
+          },
+        ],
+        "systemInstruction": undefined,
+      }
+    `);
+  });
+
+  it('should handle multiple system messages for Gemma models', async () => {
+    const result = convertToGoogleGenerativeAIMessages(
+      [
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'system', content: 'Be concise.' },
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+      ],
+      { isGemmaModel: true },
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "You are helpful.
+
+      Be concise.
+
+      ",
+              },
+              {
+                "text": "Hi",
+              },
+            ],
+            "role": "user",
+          },
+        ],
+        "systemInstruction": undefined,
+      }
+    `);
+  });
+
+  it('should not affect non-Gemma models', async () => {
+    const result = convertToGoogleGenerativeAIMessages(
+      [
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      ],
+      { isGemmaModel: false },
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hello",
+              },
+            ],
+            "role": "user",
+          },
+        ],
+        "systemInstruction": {
+          "parts": [
+            {
+              "text": "You are helpful.",
+            },
+          ],
+        },
+      }
+    `);
+  });
+
+  it('should handle Gemma model with system instruction but no user messages', async () => {
+    const result = convertToGoogleGenerativeAIMessages(
+      [{ role: 'system', content: 'You are helpful.' }],
+      { isGemmaModel: true },
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "contents": [],
+        "systemInstruction": undefined,
+      }
+    `);
+  });
+});
+
 describe('user messages', () => {
   it('should add image parts', async () => {
     const result = convertToGoogleGenerativeAIMessages([

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -37,17 +37,6 @@ export function convertToGoogleGenerativeAIMessages(
 
         const parts: GoogleGenerativeAIContentPart[] = [];
 
-        if (
-          isGemmaModel &&
-          systemInstructionParts.length > 0 &&
-          contents.length === 0
-        ) {
-          const systemText = systemInstructionParts
-            .map(part => part.text)
-            .join('\n\n');
-          parts.push({ text: systemText + '\n\n' });
-        }
-
         for (const part of content) {
           switch (part.type) {
             case 'text': {
@@ -155,6 +144,19 @@ export function convertToGoogleGenerativeAIMessages(
         break;
       }
     }
+  }
+
+  if (
+    isGemmaModel &&
+    systemInstructionParts.length > 0 &&
+    contents.length > 0 &&
+    contents[0].role === 'user'
+  ) {
+    const systemText = systemInstructionParts
+      .map(part => part.text)
+      .join('\n\n');
+
+    contents[0].parts.unshift({ text: systemText + '\n\n' });
   }
 
   return {

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2373,7 +2373,7 @@ describe('GEMMA Model System Instruction Fix', () => {
     });
   });
 
-  it('should generate warning when GEMMA model is used with system instructions', async () => {
+  it('should NOT generate warning when GEMMA model is used with system instructions (now automatically handled)', async () => {
     server.urls[TEST_URL_GEMMA_3_12B_IT].response = {
       type: 'json-value',
       body: {
@@ -2398,14 +2398,7 @@ describe('GEMMA Model System Instruction Fix', () => {
       prompt: TEST_PROMPT_WITH_SYSTEM,
     });
 
-    expect(warnings).toMatchInlineSnapshot(`
-      [
-        {
-          "message": "GEMMA models do not support system instructions. System messages will be ignored. Consider including instructions in the first user message instead.",
-          "type": "other",
-        },
-      ]
-    `);
+    expect(warnings).toMatchInlineSnapshot(`[]`);
   });
 
   it('should NOT generate warning when GEMMA model is used without system instructions', async () => {
@@ -2466,5 +2459,55 @@ describe('GEMMA Model System Instruction Fix', () => {
     });
 
     expect(warnings).toHaveLength(0);
+  });
+
+  it('should prepend system instruction to first user message for GEMMA models', async () => {
+    server.urls[TEST_URL_GEMMA_3_12B_IT].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: { parts: [{ text: 'Hello!' }], role: 'model' },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      },
+    };
+
+    const model = new GoogleGenerativeAILanguageModel('gemma-3-12b-it', {
+      provider: 'google.generative-ai',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT_WITH_SYSTEM,
+    });
+
+    const lastCall = server.calls[server.calls.length - 1];
+    const requestBody = await lastCall.requestBodyJson;
+
+    expect(requestBody).toMatchInlineSnapshot(`
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "You are a helpful assistant.
+
+      ",
+              },
+              {
+                "text": "Hello",
+              },
+            ],
+            "role": "user",
+          },
+        ],
+        "generationConfig": {},
+      }
+    `);
   });
 });

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -2373,34 +2373,6 @@ describe('GEMMA Model System Instruction Fix', () => {
     });
   });
 
-  it('should NOT generate warning when GEMMA model is used with system instructions (now automatically handled)', async () => {
-    server.urls[TEST_URL_GEMMA_3_12B_IT].response = {
-      type: 'json-value',
-      body: {
-        candidates: [
-          {
-            content: { parts: [{ text: 'Hello!' }], role: 'model' },
-            finishReason: 'STOP',
-            index: 0,
-          },
-        ],
-      },
-    };
-
-    const model = new GoogleGenerativeAILanguageModel('gemma-3-12b-it', {
-      provider: 'google.generative-ai',
-      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
-      headers: { 'x-goog-api-key': 'test-api-key' },
-      generateId: () => 'test-id',
-    });
-
-    const { warnings } = await model.doGenerate({
-      prompt: TEST_PROMPT_WITH_SYSTEM,
-    });
-
-    expect(warnings).toMatchInlineSnapshot(`[]`);
-  });
-
   it('should NOT generate warning when GEMMA model is used without system instructions', async () => {
     server.urls[TEST_URL_GEMMA_3_12B_IT].response = {
       type: 'json-value',

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -111,8 +111,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
       prompt,
       { isGemmaModel },
     );
-    // note: for gemma models, system instructions are now automatically
-    // prepended to the first user message in convertToGoogleGenerativeAIMessages
 
     const {
       tools: googleTools,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -105,22 +105,14 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
       });
     }
 
-    const { contents, systemInstruction } =
-      convertToGoogleGenerativeAIMessages(prompt);
-
     const isGemmaModel = this.modelId.toLowerCase().startsWith('gemma-');
-    if (
-      isGemmaModel &&
-      systemInstruction &&
-      systemInstruction.parts.length > 0
-    ) {
-      warnings.push({
-        type: 'other',
-        message:
-          `GEMMA models do not support system instructions. System messages will be ignored. ` +
-          `Consider including instructions in the first user message instead.`,
-      });
-    }
+
+    const { contents, systemInstruction } = convertToGoogleGenerativeAIMessages(
+      prompt,
+      { isGemmaModel },
+    );
+    // note: for gemma models, system instructions are now automatically
+    // prepended to the first user message in convertToGoogleGenerativeAIMessages
 
     const {
       tools: googleTools,


### PR DESCRIPTION
## background

Gemma models don't support the `systemInstruction` parameter but can follow system instructions when prepended to user messages. Users were getting warnings when trying to use system instructions with Gemma models.

## summary

- automatically prepend system instructions to first user message for Gemma models
- remove warnings for Gemma model system instruction usage

## verification

- all tests pass (61/61)
- Gemma models correctly follow system instructions without warnings
- non-Gemma models unchanged

## tasks

- [x] detect Gemma models in google provider
- [x] prepend system instructions to first user message for Gemma models
- [x] remove warning generation for Gemma models
- [x] test coverage with inline snapshots 

related issue #6854 