### PR TITLE
fix (provider/google): removes `additionalProperties` field from schema sent to Google APIs

### DIFF
--- a/.changeset/flat-taxis-cheer.md
+++ b/.changeset/flat-taxis-cheer.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+removes (unsupported) `additionalProperties` from the Schema sent in the request payloads to Google APIs

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -23,48 +23,28 @@ it('should remove additionalProperties and $schema', () => {
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
 });
 
-it('supports additionalProperties: true', () => {
+it('should remove empty additionalProperties object from nested object schemas', function () {
   const input: JSONSchema7 = {
-    $schema: 'http://json-schema.org/draft-07/schema#',
     type: 'object',
     properties: {
-      name: { type: 'string' },
-      age: { type: 'number' },
+      keys: {
+        type: 'object',
+        additionalProperties: { type: 'string' },
+        description: 'Description for the key',
+      },
     },
-    additionalProperties: true,
+    additionalProperties: false,
+    $schema: 'http://json-schema.org/draft-07/schema#',
   };
 
   const expected = {
     type: 'object',
     properties: {
-      name: { type: 'string' },
-      age: { type: 'number' },
+      keys: {
+        type: 'object',
+        description: 'Description for the key',
+      },
     },
-    additionalProperties: true,
-  };
-
-  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
-});
-
-// z.record(z.string())
-it('supports `additionalProperties` as an object', () => {
-  const input: JSONSchema7 = {
-    $schema: 'http://json-schema.org/draft-07/schema#',
-    type: 'object',
-    properties: {
-      name: { type: 'string' },
-      age: { type: 'number' },
-    },
-    additionalProperties: { type: 'string' },
-  };
-
-  const expected = {
-    type: 'object',
-    properties: {
-      name: { type: 'string' },
-      age: { type: 'number' },
-    },
-    additionalProperties: { type: 'string' },
   };
 
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -28,7 +28,6 @@ export function convertJSONSchemaToOpenAPISchema(
     const: constValue,
     minLength,
     enum: enumValues,
-    additionalProperties,
   } = jsonSchema;
 
   const result: Record<string, unknown> = {};
@@ -114,13 +113,6 @@ export function convertJSONSchemaToOpenAPISchema(
 
   if (minLength !== undefined) {
     result.minLength = minLength;
-  }
-
-  if (additionalProperties === true) {
-    result.additionalProperties = true;
-  } else if (additionalProperties) {
-    result.additionalProperties =
-      convertJSONSchemaToOpenAPISchema(additionalProperties);
   }
 
   return result;


### PR DESCRIPTION
## Background
Google APIs support only a subset of OpenAPI schema, for both [Function Declarations](https://ai.google.dev/api/caching#FunctionDeclaration) and [Structured Outputs](https://ai.google.dev/gemini-api/docs/structured-output#json-schemas).

And `additionalProperties` is not one of them. Passing this property in the request leads to 400 BAD REQUEST error from Google APIs, complaining specifically about the invalid parameter: `additionalProperties`.

In the following PRs, [for v4](https://github.com/vercel/ai/pull/5626) and [for v5](https://github.com/vercel/ai/pull/6919), there was an important fix to identify properties incorrectly getting converted to undefined because they did not have `properties` field but we those PRs introduced `additionalProperties` in the converted schema.

## Summary
This PR keeps the change in `isEmptyObjectSchema` for identifying the objects with empty or no `properties` field and reverts the introduction of `additionalProperties`.

## Verification
Verified manually that the change helps in mitigating the 400 BAD REQUEST from Google APIs.

## Related Issues
Partially reverts #5626