### PR TITLE
fix (ui): add message metadata in Chat.sendMessage

### DIFF
--- a/.changeset/sour-papayas-end.md
+++ b/.changeset/sour-papayas-end.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ui): add message metadata in Chat.sendMessage

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -130,6 +130,7 @@ describe('chat', () => {
         [
           {
             "id": "id-0",
+            "metadata": undefined,
             "parts": [
               {
                 "text": "Hello, world!",
@@ -162,6 +163,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -174,6 +176,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -201,6 +204,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -228,6 +232,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -255,6 +260,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -282,6 +288,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -309,6 +316,212 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "done",
+                  "text": "Hello, world.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+        ]
+      `);
+    });
+
+    it('should include the metadata of text message', async () => {
+      server.urls['http://localhost:3000/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatStreamPart({ type: 'start' }),
+          formatStreamPart({ type: 'start-step' }),
+          formatStreamPart({ type: 'text-start', id: 'text-1' }),
+          formatStreamPart({
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'Hello, world.',
+          }),
+          formatStreamPart({ type: 'text-end', id: 'text-1' }),
+          formatStreamPart({ type: 'finish-step' }),
+          formatStreamPart({ type: 'finish' }),
+        ],
+      };
+
+      const finishPromise = createResolvablePromise<void>();
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: new DefaultChatTransport({
+          api: 'http://localhost:3000/api/chat',
+        }),
+        onFinish: () => finishPromise.resolve(),
+      });
+
+      chat.sendMessage({
+        text: 'Hello, world!',
+        metadata: { someData: true },
+      });
+
+      await finishPromise.promise;
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(
+        `
+        {
+          "id": "123",
+          "messages": [
+            {
+              "id": "id-0",
+              "metadata": {
+                "someData": true,
+              },
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "trigger": "submit-user-message",
+        }
+      `,
+      );
+
+      expect(chat.messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "id-0",
+            "metadata": {
+              "someData": true,
+            },
+            "parts": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "id": "id-1",
+            "metadata": undefined,
+            "parts": [
+              {
+                "type": "step-start",
+              },
+              {
+                "state": "done",
+                "text": "Hello, world.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+
+      expect(chat.history).toMatchInlineSnapshot(`
+        [
+          [],
+          [
+            {
+              "id": "id-0",
+              "metadata": {
+                "someData": true,
+              },
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "metadata": {
+                "someData": true,
+              },
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "metadata": {
+                "someData": true,
+              },
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "state": "streaming",
+                  "text": "Hello, world.",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          [
+            {
+              "id": "id-0",
+              "metadata": {
+                "someData": true,
+              },
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -420,6 +633,7 @@ describe('chat', () => {
         [
           {
             "id": "id-0",
+            "metadata": undefined,
             "parts": [
               {
                 "text": "Hello, world!",
@@ -474,6 +688,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -486,6 +701,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -513,6 +729,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -540,6 +757,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -567,6 +785,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -594,6 +813,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",
@@ -621,6 +841,7 @@ describe('chat', () => {
           [
             {
               "id": "id-0",
+              "metadata": undefined,
               "parts": [
                 {
                   "text": "Hello, world!",

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -268,12 +268,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         parts: [
           ...fileParts,
           ...('text' in message && message.text != null
-            ? [
-                {
-                  type: 'text' as const,
-                  text: message.text,
-                },
-              ]
+            ? [{ type: 'text' as const, text: message.text }]
             : []),
         ],
       } as UI_MESSAGE;

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -264,8 +264,6 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         ? message.files
         : await convertFileListToFileUIParts(message.files);
 
-      console.log('MESSAGE METADATA', message.metadata);
-
       uiMessage = {
         parts: [
           ...fileParts,

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -251,7 +251,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         }
       | {
           files: FileList | FileUIPart[];
-          metadata?: InferUIMessageMetadata<UI_MESSAGE>;
+          metadata?: never;
           parts?: never;
           messageId?: string;
         },
@@ -264,11 +264,18 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         ? message.files
         : await convertFileListToFileUIParts(message.files);
 
+      console.log('MESSAGE METADATA', message.metadata);
+
       uiMessage = {
         parts: [
           ...fileParts,
           ...('text' in message && message.text != null
-            ? [{ type: 'text' as const, text: message.text }]
+            ? [
+                {
+                  type: 'text' as const,
+                  text: message.text,
+                },
+              ]
             : []),
         ],
       } as UI_MESSAGE;
@@ -299,12 +306,14 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         ...uiMessage,
         id: message.messageId,
         role: uiMessage.role ?? 'user',
+        metadata: message.metadata,
       } as UI_MESSAGE);
     } else {
       this.state.pushMessage({
         ...uiMessage,
         id: uiMessage.id ?? this.generateId(),
         role: uiMessage.role ?? 'user',
+        metadata: message.metadata,
       } as UI_MESSAGE);
     }
 

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -251,7 +251,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         }
       | {
           files: FileList | FileUIPart[];
-          metadata?: never;
+          metadata?: InferUIMessageMetadata<UI_MESSAGE>;
           parts?: never;
           messageId?: string;
         },

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -611,6 +611,7 @@ describe('prepareChatRequest', () => {
         "messages": [
           {
             "id": "id-1",
+            "metadata": undefined,
             "parts": [
               {
                 "text": "hi",

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -257,6 +257,7 @@ describe('text stream', () => {
       [
         {
           "id": "id-1",
+          "metadata": undefined,
           "parts": [
             {
               "text": "hi",
@@ -807,6 +808,7 @@ describe('maxSteps', () => {
         [
           {
             "id": "id-0",
+            "metadata": undefined,
             "parts": [
               {
                 "text": "hi",
@@ -936,6 +938,7 @@ describe('file attachments with data url', () => {
       [
         {
           "id": "id-1",
+          "metadata": undefined,
           "parts": [
             {
               "filename": "test.txt",
@@ -1024,6 +1027,7 @@ describe('file attachments with data url', () => {
       [
         {
           "id": "id-1",
+          "metadata": undefined,
           "parts": [
             {
               "filename": "test.png",
@@ -1122,6 +1126,7 @@ describe('file attachments with url', () => {
       [
         {
           "id": "id-1",
+          "metadata": undefined,
           "parts": [
             {
               "filename": "test.png",
@@ -1221,6 +1226,7 @@ describe('file attachments with empty text content', () => {
       [
         {
           "id": "id-1",
+          "metadata": undefined,
           "parts": [
             {
               "filename": "test.png",
@@ -1443,6 +1449,7 @@ describe('generateId function', () => {
       [
         {
           "id": "testid-1",
+          "metadata": undefined,
           "parts": [
             {
               "text": "hi",


### PR DESCRIPTION
## Background

Metadata was not added to the submitted message.

## Summary

Add metadata to the message that is created in Chat.sendMessage.

## Verification

Manually tested end to end with `next-openai` example.

## Related Issues

Fixes #6946 