### PR TITLE
fix (ui): avoid caching globalThis.fetch in case it is patched by other libraries

### DIFF
--- a/.changeset/eighty-planets-drum.md
+++ b/.changeset/eighty-planets-drum.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ui): avoid caching globalThis.fetch in case it is patched by other libraries


### PR DESCRIPTION
## Background

Libraries might patch `globalThis.fetch`, but we are storing a potentially stale instance in `HttpChatTransport`.

## Summary

Fallback to `globalThis.fetch` at runtime when no custom fetch function is provided.

## Verification

Test `examples/next-openai`.