### PR TITLE
chore: add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .cache
 .env
+.envrc
 .next
 .turbo
 dist


### PR DESCRIPTION
## Background

`.envrc` files are commonly used with [direnv](https://direnv.net/) to automatically set environment variables when entering a directory. These files often contain sensitive information, local development settings, or personal configuration that should not be committed to version control.

## Summary

Added `.envrc` to `.gitignore` to prevent direnv environment files from being accidentally committed to the repository.

## Verification

This change can be verified by:
1. Creating a `.envrc` file in the project root
2. Running `git status` to confirm the file is ignored
3. Checking that the file doesn't appear in git tracking

## Tasks

- [x] Tests have been added / updated (for bug fixes / features) - *N/A for gitignore change*
- [x] Documentation has been added / updated (for bug fixes / features) - *N/A for gitignore change*