### PR TITLE
docs: clarify `sendStart` usage in `streamText`

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2342,7 +2342,7 @@ To see `streamText` in action, check out [these examples](#examples).
               type: 'boolean',
               isOptional: true,
               description:
-                'Send the message start event to the client. Set to false if you are using additional streamText calls and the message start event has already been sent. Defaults to true. Note: this setting is currently not used, but you should already set it to false if you are using additional streamText calls that send additional data to prevent the message start event from being sent multiple times.',
+                'Send the message start event to the client. Set to false if you are using additional streamText calls and the message start event has already been sent. Defaults to true.',
             },
             {
               name: 'onError',


### PR DESCRIPTION
## Background
Documentation for `sendStart` within `streamText` in v5 is outdated. As of #6499 `sendStart` is used to control whether the start message is sent or not.

https://github.com/vercel/ai/blob/1ed028703999fe3a897f5a3dc240c452791e3555/packages/ai/core/generate-text/stream-text.ts#L1541-L1550

## Summary
Removed out-of-date documentation.

## Tasks
* [x]  Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)