### PR TITLE
docs: remove `newMessageId` in `streamText`

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2293,12 +2293,6 @@ To see `streamText` in action, check out [these examples](#examples).
           type: 'UIMessageStreamOptions',
           parameters: [
             {
-              name: 'newMessageId',
-              type: 'string',
-              isOptional: true,
-              description: 'Message ID that is sent to the client if a new message is created.',
-            },
-            {
               name: 'originalMessages',
               type: 'UIMessage[]',
               isOptional: true,


### PR DESCRIPTION
## Background
Documentation for `newMessageId ` within `streamText` in v5 is outdated. `newMessageId` was removed in #6726 but leftover in the documentation.

## Summary
Removed out-of-date documentation.

## Tasks
* [x]  Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)