### PR TITLE
docs: fix frontmatter format

### DIFF
--- a/content/docs/07-reference/04-stream-helpers/16-langchain-adapter.mdx
+++ b/content/docs/07-reference/04-stream-helpers/16-langchain-adapter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@ai-sdk/langchain Adapter"
+title: '@ai-sdk/langchain Adapter'
 description: API Reference for the LangChain Adapter.
 ---
 

--- a/content/docs/07-reference/04-stream-helpers/16-langchain-adapter.mdx
+++ b/content/docs/07-reference/04-stream-helpers/16-langchain-adapter.mdx
@@ -1,5 +1,5 @@
 ---
-title: @ai-sdk/langchain Adapter
+title: "@ai-sdk/langchain Adapter"
 description: API Reference for the LangChain Adapter.
 ---
 

--- a/content/docs/07-reference/04-stream-helpers/16-llamaindex-adapter.mdx
+++ b/content/docs/07-reference/04-stream-helpers/16-llamaindex-adapter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@ai-sdk/llamaindex Adapter"
+title: '@ai-sdk/llamaindex Adapter'
 description: API Reference for the LlamaIndex Adapter.
 ---
 

--- a/content/docs/07-reference/04-stream-helpers/16-llamaindex-adapter.mdx
+++ b/content/docs/07-reference/04-stream-helpers/16-llamaindex-adapter.mdx
@@ -1,5 +1,5 @@
 ---
-title: @ai-sdk/llamaindex Adapter
+title: "@ai-sdk/llamaindex Adapter"
 description: API Reference for the LlamaIndex Adapter.
 ---
 


### PR DESCRIPTION
## Background

This pull request fixes the yaml formatting in the following two docs pages:
- content/docs/07-reference/04-stream-helpers/16-langchain-adapter.mdx
- content/docs/07-reference/04-stream-helpers/16-llamaindex-adapter.mdx

The incorrect formatting was crashing the docs search on https://ai-sdk.dev.

Fixes #6852 

## Summary

Surround the title in quotes.

## Tasks

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
