### PR TITLE
docs: add Amazon Nova Canvas availability regions

### DIFF
--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -484,7 +484,8 @@ For more on the Amazon Nova Canvas image model, see the [Nova Canvas
 Overview](https://docs.aws.amazon.com/ai/responsible-ai/nova-canvas/overview.html).
 
 <Note>
-  The `amazon.nova-canvas-v1:0` model is available in the `us-east-1` region.
+  The `amazon.nova-canvas-v1:0` model is available in the `us-east-1`,
+  `eu-west-1`, and `ap-northeast-1` regions.
 </Note>
 
 ```ts


### PR DESCRIPTION
## Background
The documentation for Amazon Bedrock's `amazon.nova-canvas-v1:0` image model was outdated. It only listed `us-east-1` as the available region, but the model is now available in additional regions.

## Summary
Updated the region availability for the `amazon.nova-canvas-v1:0` image model:
* Added `eu-west-1` region
* Added `ap-northeast-1` region

The model is now documented as available in: `us-east-1`, `eu-west-1`, and `ap-northeast-1`.

## Tasks
* ~Tests have been added / updated (for bug fixes / features)~ - *N/A for docs*
* Documentation has been added / updated ✅
* ~A *patch* changeset for relevant packages has been added~ - *Not required for docs changes*
* Formatting issues have been fixed ✅