### PR TITLE
feat (ui): transient data parts

### DIFF
--- a/.changeset/quiet-peas-end.md
+++ b/.changeset/quiet-peas-end.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ui): transient data parts

--- a/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-parts.ts
@@ -104,6 +104,7 @@ export const uiMessageStreamPartSchema = z.union([
     type: z.string().startsWith('data-'),
     id: z.string().optional(),
     data: z.unknown(),
+    transient: z.boolean().optional(),
   }),
   z.strictObject({
     type: z.literal('start-step'),
@@ -131,6 +132,7 @@ export type DataUIMessageStreamPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
     type: `data-${NAME}`;
     id?: string;
     data: DATA_TYPES[NAME];
+    transient?: boolean;
   };
 }>;
 

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -477,6 +477,12 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                   InferUIMessageData<UI_MESSAGE>
                 >;
 
+                // transient parts are not added to the message state
+                if (dataPart.transient) {
+                  onData?.(dataPart);
+                  break;
+                }
+
                 // TODO improve type safety
                 const existingPart: any =
                   dataPart.id != null


### PR DESCRIPTION
## Background

In some cases, the data sent to the client is ephemeral and should not be added to the message history.

## Summary

Add a flag on data part chunks that prevents them from being added to the message parts.

## Related Issues

https://github.com/vercel/ai/discussions/6975