### PR TITLE
feat (ai): export Chat callback types

### DIFF
--- a/.changeset/modern-grapes-glow.md
+++ b/.changeset/modern-grapes-glow.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): export Chat callback types

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -91,6 +91,22 @@ export interface ChatState<UI_MESSAGE extends UIMessage> {
   snapshot: <T>(thing: T) => T;
 }
 
+export type ChatErrorCallback = (error: Error) => void;
+
+export type ChatToolCallCallback = ({
+  toolCall,
+}: {
+  toolCall: ToolCall<string, unknown>;
+}) => void | Promise<unknown> | unknown;
+
+export type ChatDataCallback<UI_MESSAGE extends UIMessage> = (
+  dataPart: DataUIPart<InferUIMessageData<UI_MESSAGE>>,
+) => void;
+
+export type ChatFinishCallback<UI_MESSAGE extends UIMessage> = (options: {
+  message: UI_MESSAGE;
+}) => void;
+
 export interface ChatInit<UI_MESSAGE extends UIMessage> {
   /**
    * A unique identifier for the chat. If not provided, a random one will be
@@ -118,7 +134,7 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
   /**
    * Callback function to be called when an error is encountered.
    */
-  onError?: (error: Error) => void;
+  onError?: ChatErrorCallback;
 
   /**
   Optional callback function that is invoked when a tool call is received.
@@ -127,25 +143,21 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
   You can optionally return a result for the tool call,
   either synchronously or asynchronously.
      */
-  onToolCall?: ({
-    toolCall,
-  }: {
-    toolCall: ToolCall<string, unknown>;
-  }) => void | Promise<unknown> | unknown;
+  onToolCall?: ChatToolCallCallback;
 
   /**
    * Optional callback function that is called when the assistant message is finished streaming.
    *
    * @param message The message that was streamed.
    */
-  onFinish?: (options: { message: UI_MESSAGE }) => void;
+  onFinish?: ChatFinishCallback<UI_MESSAGE>;
 
   /**
    * Optional callback function that is called when a data part is received.
    *
    * @param data The data part that was received.
    */
-  onData?: (dataPart: DataUIPart<InferUIMessageData<UI_MESSAGE>>) => void;
+  onData?: ChatDataCallback<UI_MESSAGE>;
 }
 
 export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -91,19 +91,19 @@ export interface ChatState<UI_MESSAGE extends UIMessage> {
   snapshot: <T>(thing: T) => T;
 }
 
-export type ChatErrorCallback = (error: Error) => void;
+export type ChatOnErrorCallback = (error: Error) => void;
 
-export type ChatToolCallCallback = ({
+export type ChatOnToolCallCallback = ({
   toolCall,
 }: {
   toolCall: ToolCall<string, unknown>;
 }) => void | Promise<unknown> | unknown;
 
-export type ChatDataCallback<UI_MESSAGE extends UIMessage> = (
+export type ChatOnDataCallback<UI_MESSAGE extends UIMessage> = (
   dataPart: DataUIPart<InferUIMessageData<UI_MESSAGE>>,
 ) => void;
 
-export type ChatFinishCallback<UI_MESSAGE extends UIMessage> = (options: {
+export type ChatOnFinishCallback<UI_MESSAGE extends UIMessage> = (options: {
   message: UI_MESSAGE;
 }) => void;
 
@@ -134,7 +134,7 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
   /**
    * Callback function to be called when an error is encountered.
    */
-  onError?: ChatErrorCallback;
+  onError?: ChatOnErrorCallback;
 
   /**
   Optional callback function that is invoked when a tool call is received.
@@ -143,21 +143,21 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
   You can optionally return a result for the tool call,
   either synchronously or asynchronously.
      */
-  onToolCall?: ChatToolCallCallback;
+  onToolCall?: ChatOnToolCallCallback;
 
   /**
    * Optional callback function that is called when the assistant message is finished streaming.
    *
    * @param message The message that was streamed.
    */
-  onFinish?: ChatFinishCallback<UI_MESSAGE>;
+  onFinish?: ChatOnFinishCallback<UI_MESSAGE>;
 
   /**
    * Optional callback function that is called when a data part is received.
    *
    * @param data The data part that was received.
    */
-  onData?: ChatDataCallback<UI_MESSAGE>;
+  onData?: ChatOnDataCallback<UI_MESSAGE>;
 }
 
 export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -2,16 +2,16 @@ export { callCompletionApi } from './call-completion-api';
 export {
   AbstractChat,
   type ChatInit,
+  type ChatOnDataCallback,
+  type ChatOnErrorCallback,
+  type ChatOnFinishCallback,
+  type ChatOnToolCallCallback,
   type ChatRequestOptions,
   type ChatState,
   type ChatStatus,
   type CreateUIMessage,
   type InferUIDataParts,
   type UIDataPartSchemas,
-  type ChatErrorCallback,
-  type ChatToolCallCallback,
-  type ChatDataCallback,
-  type ChatFinishCallback,
 } from './chat';
 export { type ChatTransport } from './chat-transport';
 export { convertFileListToFileUIParts } from './convert-file-list-to-file-ui-parts';

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -8,6 +8,10 @@ export {
   type CreateUIMessage,
   type InferUIDataParts,
   type UIDataPartSchemas,
+  type ChatErrorCallback,
+  type ChatToolCallCallback,
+  type ChatDataCallback,
+  type ChatFinishCallback,
 } from './chat';
 export { type ChatTransport } from './chat-transport';
 export { convertFileListToFileUIParts } from './convert-file-list-to-file-ui-parts';


### PR DESCRIPTION
## Background

Users may want to extract callback handlers and need type safety.

## Summary

Extract and export callback types for `Chat` callbacks.