### PR TITLE
 docs(provider/vercel): updated docs for provider page

### DIFF
--- a/content/providers/01-ai-sdk-providers/02-vercel.mdx
+++ b/content/providers/01-ai-sdk-providers/02-vercel.mdx
@@ -5,7 +5,7 @@ description: Learn how to use Vercel's v0 models with the AI SDK.
 
 # Vercel Provider
 
-The [Vercel](https://vercel.com) provider gives you access to the [v0 API](https://vercel.com/docs/v0/api), designed for building modern web applications. The `v0-1.0-md` model supports text and image inputs and provides fast streaming responses.
+The [Vercel](https://vercel.com) provider gives you access to the [v0 API](https://vercel.com/docs/v0/api), designed for building modern web applications. The v0 models support text and image inputs and provide fast streaming responses.
 
 You can create your Vercel API key at [v0.dev](https://v0.dev/chat/settings/keys).
 
@@ -97,11 +97,19 @@ Vercel language models can also be used in the `streamText` function (see [AI SD
 
 ## Models
 
-### v0-1.0-md
+### v0-1.5-md
 
-The `v0-1.0-md` model is the default model served by the v0 API.
+The `v0-1.5-md` model is for everyday tasks and UI generation.
 
-Capabilities:
+### v0-1.5-lg
+
+The `v0-1.5-lg` model is for advanced thinking or reasoning.
+
+### v0-1.0-md (legacy)
+
+The `v0-1.0-md` model is the legacy model served by the v0 API.
+
+All v0 models have the following capabilities:
 
 - Supports text and image inputs (multimodal)
 - Supports function/tool calls
@@ -112,4 +120,6 @@ Capabilities:
 
 | Model       | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | ----------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `v0-1.5-md` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `v0-1.5-lg` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `v0-1.0-md` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |


### PR DESCRIPTION
# Background

updated vercel provider page docs, to follow the newly update v5 version