### PR TITLE
feat(provider/openai): add missing reasoning models to responses API

### DIFF
--- a/.changeset/slimy-feet-fail.md
+++ b/.changeset/slimy-feet-fail.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add missing reasoning models to responses API

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -227,7 +227,8 @@ The following optional provider options are available for OpenAI chat models:
 #### Reasoning
 
 OpenAI has introduced the `o1`,`o3`, and `o4` series of [reasoning models](https://platform.openai.com/docs/guides/reasoning).
-Currently, `o4-mini`, `o3`, `o3-mini`, `o1`, `o1-mini`, and `o1-preview` are available.
+Currently, `o4-mini`, `o3`, `o3-mini`, `o1`, `o1-mini`, and `o1-preview` are available via both the chat and responses APIs. The
+models `codex-mini-latest` and `computer-use-preview` are available only via the [responses API](#responses-models).
 
 Reasoning models currently only generate text, have several limitations, and are only supported using `generateText` and `streamText`.
 

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -8,6 +8,11 @@ import {
   mockId,
 } from '@ai-sdk/provider-utils/test';
 import { OpenAIResponsesLanguageModel } from './openai-responses-language-model';
+import {
+  OpenAIResponsesModelId,
+  openaiResponsesModelIds,
+  openaiResponsesReasoningModelIds,
+} from './openai-responses-settings';
 
 const TEST_PROMPT: LanguageModelV2Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -35,6 +40,13 @@ const TEST_TOOLS: Array<LanguageModelV2FunctionTool> = [
     },
   },
 ];
+
+const nonReasoningModelIds = openaiResponsesModelIds.filter(
+  modelId =>
+    !openaiResponsesReasoningModelIds.includes(
+      modelId as (typeof openaiResponsesReasoningModelIds)[number],
+    ),
+);
 
 function createModel(modelId: string) {
   return new OpenAIResponsesLanguageModel(modelId, {
@@ -293,37 +305,71 @@ describe('OpenAIResponsesLanguageModel', () => {
         ]);
       });
 
-      it('should remove unsupported settings for o3', async () => {
-        const { warnings } = await createModel('o3').doGenerate({
-          prompt: [
-            { role: 'system', content: 'You are a helpful assistant.' },
-            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
-          ],
-          temperature: 0.5,
-          topP: 0.3,
-        });
+      it.each(openaiResponsesReasoningModelIds)(
+        'should remove and warn about unsupported settings for reasoning model %s',
+        async modelId => {
+          const { warnings } = await createModel(modelId).doGenerate({
+            prompt: [
+              { role: 'system', content: 'You are a helpful assistant.' },
+              { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+            ],
+            temperature: 0.5,
+            topP: 0.3,
+          });
 
-        expect(await server.calls[0].requestBodyJson).toStrictEqual({
-          model: 'o3',
-          input: [
-            { role: 'developer', content: 'You are a helpful assistant.' },
+          const expectedMessages = [
+            // o1 models prior to o1-2024-12-17 should remove system messages, all other models should replace
+            // them with developer messages
+            ...(![
+              'o1-mini',
+              'o1-mini-2024-09-12',
+              'o1-preview',
+              'o1-preview-2024-09-12',
+            ].includes(modelId)
+              ? [
+                  {
+                    role: 'developer',
+                    content: 'You are a helpful assistant.',
+                  },
+                ]
+              : []),
             { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
-          ],
-        });
+          ];
 
-        expect(warnings).toStrictEqual([
-          {
-            details: 'temperature is not supported for reasoning models',
-            setting: 'temperature',
-            type: 'unsupported-setting',
-          },
-          {
-            details: 'topP is not supported for reasoning models',
-            setting: 'topP',
-            type: 'unsupported-setting',
-          },
-        ]);
-      });
+          expect(await server.calls[0].requestBodyJson).toStrictEqual({
+            model: modelId,
+            input: expectedMessages,
+          });
+
+          expect(warnings).toStrictEqual([
+            // o1 models prior to o1-2024-12-17 should remove system messages, all other models should replace
+            // them with developer messages
+            ...([
+              'o1-mini',
+              'o1-mini-2024-09-12',
+              'o1-preview',
+              'o1-preview-2024-09-12',
+            ].includes(modelId)
+              ? [
+                  {
+                    message: 'system messages are removed for this model',
+                    type: 'other',
+                  },
+                ]
+              : []),
+            {
+              details: 'temperature is not supported for reasoning models',
+              setting: 'temperature',
+              type: 'unsupported-setting',
+            },
+            {
+              details: 'topP is not supported for reasoning models',
+              setting: 'topP',
+              type: 'unsupported-setting',
+            },
+          ]);
+        },
+      );
 
       it('should send response format json schema', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
@@ -511,28 +557,69 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
-      it('should send reasoningEffort provider option', async () => {
-        const { warnings } = await createModel('o3').doGenerate({
-          prompt: TEST_PROMPT,
-          providerOptions: {
-            openai: {
-              reasoningEffort: 'low',
+      it.each(openaiResponsesReasoningModelIds)(
+        'should send reasoningEffort and reasoningSummary provider options for %s',
+        async modelId => {
+          const { warnings } = await createModel(modelId).doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              openai: {
+                reasoningEffort: 'low',
+                reasoningSummary: 'auto',
+              },
             },
-          },
-        });
+          });
 
-        expect(await server.calls[0].requestBodyJson).toStrictEqual({
-          model: 'o3',
-          input: [
-            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
-          ],
-          reasoning: {
-            effort: 'low',
-          },
-        });
+          expect(await server.calls[0].requestBodyJson).toStrictEqual({
+            model: modelId,
+            input: [
+              {
+                role: 'user',
+                content: [{ type: 'input_text', text: 'Hello' }],
+              },
+            ],
+            reasoning: {
+              effort: 'low',
+              summary: 'auto',
+            },
+          });
 
-        expect(warnings).toStrictEqual([]);
-      });
+          expect(warnings).toStrictEqual([]);
+        },
+      );
+
+      it.each(nonReasoningModelIds)(
+        'should not send and warn about unsupported reasoningEffort and reasoningSummary provider options for %s',
+        async modelId => {
+          const { warnings } = await createModel(modelId).doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              openai: {
+                reasoningEffort: 'low',
+              },
+            },
+          });
+
+          expect(await server.calls[0].requestBodyJson).toStrictEqual({
+            model: modelId,
+            input: [
+              {
+                role: 'user',
+                content: [{ type: 'input_text', text: 'Hello' }],
+              },
+            ],
+          });
+
+          expect(warnings).toStrictEqual([
+            {
+              type: 'unsupported-setting',
+              setting: 'reasoningEffort',
+              details:
+                'reasoningEffort is not supported for non-reasoning models',
+            },
+          ]);
+        },
+      );
 
       it('should send instructions provider option', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -172,6 +172,22 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
           details: 'topP is not supported for reasoning models',
         });
       }
+    } else {
+      if (openaiOptions?.reasoningEffort != null) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'reasoningEffort',
+          details: 'reasoningEffort is not supported for non-reasoning models',
+        });
+      }
+
+      if (openaiOptions?.reasoningSummary != null) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'reasoningSummary',
+          details: 'reasoningSummary is not supported for non-reasoning models',
+        });
+      }
     }
 
     // Validate flex processing support
@@ -877,7 +893,11 @@ type ResponsesModelConfig = {
 
 function getResponsesModelConfig(modelId: string): ResponsesModelConfig {
   // o series reasoning models:
-  if (modelId.startsWith('o')) {
+  if (
+    modelId.startsWith('o') ||
+    modelId.startsWith('codex-') ||
+    modelId.startsWith('computer-use')
+  ) {
     if (modelId.startsWith('o1-mini') || modelId.startsWith('o1-preview')) {
       return {
         isReasoningModel: true,

--- a/packages/openai/src/responses/openai-responses-settings.ts
+++ b/packages/openai/src/responses/openai-responses-settings.ts
@@ -1,46 +1,56 @@
+export const openaiResponsesReasoningModelIds = [
+  'o1',
+  'o1-2024-12-17',
+  'o1-mini',
+  'o1-mini-2024-09-12',
+  'o1-preview',
+  'o1-preview-2024-09-12',
+  'o3-mini',
+  'o3-mini-2025-01-31',
+  'o3',
+  'o3-2025-04-16',
+  'o4-mini',
+  'o4-mini-2025-04-16',
+  'codex-mini-latest',
+  'computer-use-preview',
+] as const;
+
+export const openaiResponsesModelIds = [
+  'gpt-4.1',
+  'gpt-4.1-2025-04-14',
+  'gpt-4.1-mini',
+  'gpt-4.1-mini-2025-04-14',
+  'gpt-4.1-nano',
+  'gpt-4.1-nano-2025-04-14',
+  'gpt-4o',
+  'gpt-4o-2024-05-13',
+  'gpt-4o-2024-08-06',
+  'gpt-4o-2024-11-20',
+  'gpt-4o-audio-preview',
+  'gpt-4o-audio-preview-2024-10-01',
+  'gpt-4o-audio-preview-2024-12-17',
+  'gpt-4o-search-preview',
+  'gpt-4o-search-preview-2025-03-11',
+  'gpt-4o-mini-search-preview',
+  'gpt-4o-mini-search-preview-2025-03-11',
+  'gpt-4o-mini',
+  'gpt-4o-mini-2024-07-18',
+  'gpt-4-turbo',
+  'gpt-4-turbo-2024-04-09',
+  'gpt-4-turbo-preview',
+  'gpt-4-0125-preview',
+  'gpt-4-1106-preview',
+  'gpt-4',
+  'gpt-4-0613',
+  'gpt-4.5-preview',
+  'gpt-4.5-preview-2025-02-27',
+  'gpt-3.5-turbo-0125',
+  'gpt-3.5-turbo',
+  'gpt-3.5-turbo-1106',
+  'chatgpt-4o-latest',
+  ...openaiResponsesReasoningModelIds,
+] as const;
+
 export type OpenAIResponsesModelId =
-  | 'o1'
-  | 'o1-2024-12-17'
-  | 'o1-mini'
-  | 'o1-mini-2024-09-12'
-  | 'o1-preview'
-  | 'o1-preview-2024-09-12'
-  | 'o3-mini'
-  | 'o3-mini-2025-01-31'
-  | 'o3'
-  | 'o3-2025-04-16'
-  | 'o4-mini'
-  | 'o4-mini-2025-04-16'
-  | 'gpt-4.1'
-  | 'gpt-4.1-2025-04-14'
-  | 'gpt-4.1-mini'
-  | 'gpt-4.1-mini-2025-04-14'
-  | 'gpt-4.1-nano'
-  | 'gpt-4.1-nano-2025-04-14'
-  | 'gpt-4o'
-  | 'gpt-4o-2024-05-13'
-  | 'gpt-4o-2024-08-06'
-  | 'gpt-4o-2024-11-20'
-  | 'gpt-4o-audio-preview'
-  | 'gpt-4o-audio-preview-2024-10-01'
-  | 'gpt-4o-audio-preview-2024-12-17'
-  | 'gpt-4o-search-preview'
-  | 'gpt-4o-search-preview-2025-03-11'
-  | 'gpt-4o-mini-search-preview'
-  | 'gpt-4o-mini-search-preview-2025-03-11'
-  | 'gpt-4o-mini'
-  | 'gpt-4o-mini-2024-07-18'
-  | 'gpt-4-turbo'
-  | 'gpt-4-turbo-2024-04-09'
-  | 'gpt-4-turbo-preview'
-  | 'gpt-4-0125-preview'
-  | 'gpt-4-1106-preview'
-  | 'gpt-4'
-  | 'gpt-4-0613'
-  | 'gpt-4.5-preview'
-  | 'gpt-4.5-preview-2025-02-27'
-  | 'gpt-3.5-turbo-0125'
-  | 'gpt-3.5-turbo'
-  | 'gpt-3.5-turbo-1106'
-  | 'chatgpt-4o-latest'
+  | (typeof openaiResponsesModelIds)[number]
   | (string & {});


### PR DESCRIPTION
## Background

This change was necessary to correctly use the new `codex-mini-latest` and `computer-use-preview` models. Without this change, reasoning settings for these models are dropped, and the reasoning model system -> developer message replacement logic isn't triggered.

## Summary

- Added `codex-mini-latest` and `computer-use-preview` to the list of responses model IDs
- Updated `modelConfig` checks so they'd be treated as reasoning models
- Updated the `OpenAIResponsesModelId` to be derived from a const array of model IDs, and broke out reasoning model IDs into their own const lists
- Used the new model ID const arrays to modify Responses API tests that exercised system message replacement and reasoning arg logic to work as combinatorial tests rather than as spot checks
- Added a negative test case to ensure that reasoning parameters weren't being sent for non-reasoning models
- updated `getArgs` to emit a warning when reasoning options are set for non-reasoning models
  - these args were silently dropped before this change

## Verification

Ran in local application using `pnpm link` to verify reasoning works with the new models.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

Would be nice to make it so the user can override the `modelConfig` logic when they're using a model ID that isn't yet recognized by the provider. That way users could consume new reasoning models on the day of release instead of being blocked by the need for a very trivial model ID list update.

## Related Issues

Fixes #6789 

I think this is a more complete/correct fix to #6789 than #6790, as the issue reported in that issue is ultimately due to `codex-mini-latest` being a reasoning model. Further, the `codex-mini-latest` models is only officially supported via the responses API (see the "Endpoints" section on [its model card](https://platform.openai.com/docs/models/codex-mini-latest)), and #6790 only modifies the chat completion API support, and only for the temperature flag.
