### PR TITLE
docs: updated docs for embed deprecated

### DIFF
--- a/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
+++ b/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
@@ -30,7 +30,7 @@ async function main() {
     .filter(chunk => chunk.length > 0 && chunk !== '\n');
 
   const { embeddings } = await embedMany({
-    model: openai.embedding('text-embedding-3-small'),
+    model: openai.textEmbeddingModel('text-embedding-3-small'),
     values: chunks,
   });
   embeddings.forEach((e, i) => {
@@ -44,7 +44,7 @@ async function main() {
     'What were the two main things the author worked on before college?';
 
   const { embedding } = await embed({
-    model: openai.embedding('text-embedding-3-small'),
+    model: openai.textEmbeddingModel('text-embedding-3-small'),
     value: input,
   });
   const context = db

--- a/content/cookbook/05-node/60-embed-text.mdx
+++ b/content/cookbook/05-node/60-embed-text.mdx
@@ -17,7 +17,7 @@ import 'dotenv/config';
 
 async function main() {
   const { embedding, usage } = await embed({
-    model: openai.embedding('text-embedding-3-small'),
+    model: openai.textEmbeddingModel('text-embedding-3-small'),
     value: 'sunny day at the beach',
   });
 

--- a/content/cookbook/05-node/61-embed-text-batch.mdx
+++ b/content/cookbook/05-node/61-embed-text-batch.mdx
@@ -17,7 +17,7 @@ import 'dotenv/config';
 
 async function main() {
   const { embeddings, usage } = await embedMany({
-    model: openai.embedding('text-embedding-3-small'),
+    model: openai.textEmbeddingModel('text-embedding-3-small'),
     values: [
       'sunny day at the beach',
       'rainy afternoon in the city',

--- a/content/docs/02-guides/01-rag-chatbot.mdx
+++ b/content/docs/02-guides/01-rag-chatbot.mdx
@@ -272,7 +272,7 @@ Let’s add a function to generate embeddings. Copy the following code into your
 import { embedMany } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
-const embeddingModel = openai.embedding('text-embedding-ada-002');
+const embeddingModel = openai.textEmbeddingModel('text-embedding-ada-002');
 
 const generateChunks = (input: string): string[] => {
   return input
@@ -643,7 +643,7 @@ import { db } from '../db';
 import { cosineDistance, desc, gt, sql } from 'drizzle-orm';
 import { embeddings } from '../db/schema/embeddings';
 
-const embeddingModel = openai.embedding('text-embedding-ada-002');
+const embeddingModel = openai.textEmbeddingModel('text-embedding-ada-002');
 
 const generateChunks = (input: string): string[] => {
   return input

--- a/content/docs/03-ai-sdk-core/30-embeddings.mdx
+++ b/content/docs/03-ai-sdk-core/30-embeddings.mdx
@@ -12,7 +12,7 @@ In this space, similar words are close to each other, and the distance between w
 
 The AI SDK provides the [`embed`](/docs/reference/ai-sdk-core/embed) function to embed single values, which is useful for tasks such as finding similar words
 or phrases or clustering text.
-You can use it with embeddings models, e.g. `openai.embedding('text-embedding-3-large')` or `mistral.embedding('mistral-embed')`.
+You can use it with embeddings models, e.g. `openai.textEmbeddingModel('text-embedding-3-large')` or `mistral.textEmbeddingModel('mistral-embed')`.
 
 ```tsx
 import { embed } from 'ai';
@@ -20,7 +20,7 @@ import { openai } from '@ai-sdk/openai';
 
 // 'embedding' is a single embedding object (number[])
 const { embedding } = await embed({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   value: 'sunny day at the beach',
 });
 ```
@@ -32,7 +32,7 @@ it is often useful to embed many values at once (batch embedding).
 
 The AI SDK provides the [`embedMany`](/docs/reference/ai-sdk-core/embed-many) function for this purpose.
 Similar to `embed`, you can use it with embeddings models,
-e.g. `openai.embedding('text-embedding-3-large')` or `mistral.embedding('mistral-embed')`.
+e.g. `openai.textEmbeddingModel('text-embedding-3-large')` or `mistral.textEmbeddingModel('mistral-embed')`.
 
 ```tsx
 import { openai } from '@ai-sdk/openai';
@@ -41,7 +41,7 @@ import { embedMany } from 'ai';
 // 'embeddings' is an array of embedding objects (number[][]).
 // It is sorted in the same order as the input values.
 const { embeddings } = await embedMany({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   values: [
     'sunny day at the beach',
     'rainy afternoon in the city',
@@ -61,7 +61,7 @@ import { openai } from '@ai-sdk/openai';
 import { cosineSimilarity, embedMany } from 'ai';
 
 const { embeddings } = await embedMany({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   values: ['sunny day at the beach', 'rainy afternoon in the city'],
 });
 
@@ -80,7 +80,7 @@ import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
 const { embedding, usage } = await embed({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   value: 'sunny day at the beach',
 });
 
@@ -100,7 +100,7 @@ import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   value: 'sunny day at the beach',
   maxRetries: 0, // Disable retries
 });
@@ -117,7 +117,7 @@ import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   value: 'sunny day at the beach',
   abortSignal: AbortSignal.timeout(1000), // Abort after 1 second
 });
@@ -133,7 +133,7 @@ import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   value: 'sunny day at the beach',
   headers: { 'X-Custom-Header': 'custom-value' },
 });

--- a/content/docs/03-ai-sdk-core/45-provider-management.mdx
+++ b/content/docs/03-ai-sdk-core/45-provider-management.mdx
@@ -122,7 +122,7 @@ export const myProvider = customProvider({
     }),
   },
   embeddingModels: {
-    emdedding: openai.textEmbeddingModel('text-embedding-3-small'),
+    embedding: openai.textEmbeddingModel('text-embedding-3-small'),
   },
   // no fallback provider
 });

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -14,7 +14,7 @@ import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   value: 'sunny day at the beach',
 });
 ```
@@ -33,7 +33,7 @@ const { embedding } = await embed({
       name: 'model',
       type: 'EmbeddingModel',
       description:
-        "The embedding model to use. Example: openai.embedding('text-embedding-3-small')",
+        "The embedding model to use. Example: openai.textEmbeddingModel('text-embedding-3-small')",
     },
     {
       name: 'value',

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -16,7 +16,7 @@ import { openai } from '@ai-sdk/openai';
 import { embedMany } from 'ai';
 
 const { embeddings } = await embedMany({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   values: [
     'sunny day at the beach',
     'rainy afternoon in the city',
@@ -39,7 +39,7 @@ const { embeddings } = await embedMany({
       name: 'model',
       type: 'EmbeddingModel',
       description:
-        "The embedding model to use. Example: openai.embedding('text-embedding-3-small')",
+        "The embedding model to use. Example: openai.textEmbeddingModel('text-embedding-3-small')",
     },
     {
       name: 'values',

--- a/content/docs/07-reference/01-ai-sdk-core/50-cosine-similarity.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/50-cosine-similarity.mdx
@@ -16,7 +16,7 @@ import { openai } from '@ai-sdk/openai';
 import { cosineSimilarity, embedMany } from 'ai';
 
 const { embeddings } = await embedMany({
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   values: ['sunny day at the beach', 'rainy afternoon in the city'],
 });
 

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1204,7 +1204,7 @@ const { response } = await embed(/* */);
 ```tsx filename="AI SDK 5.0"
 const { embeddings, usage } = await embedMany({
   maxParallelCalls: 2, // Limit parallel requests
-  model: openai.embedding('text-embedding-3-small'),
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
   values: [
     'sunny day at the beach',
     'rainy afternoon in the city',

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -893,10 +893,10 @@ The following optional provider options are available for OpenAI completion mode
 ## Embedding Models
 
 You can create models that call the [OpenAI embeddings API](https://platform.openai.com/docs/api-reference/embeddings)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
-const model = openai.embedding('text-embedding-3-large');
+const model = openai.textEmbeddingModel('text-embedding-3-large');
 ```
 
 OpenAI embedding models support several additional provider options.
@@ -907,7 +907,7 @@ import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: openai.embedding('text-embedding-3-large'),
+  model: openai.textEmbeddingModel('text-embedding-3-large'),
   value: 'sunny day at the beach',
   providerOptions: {
     openai: {

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -422,10 +422,10 @@ The following optional provider options are available for Azure OpenAI completio
 ## Embedding Models
 
 You can create models that call the Azure OpenAI embeddings API
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
-const model = azure.embedding('your-embedding-deployment');
+const model = azure.textEmbeddingModel('your-embedding-deployment');
 ```
 
 Azure OpenAI embedding models support several additional settings.
@@ -436,7 +436,7 @@ import { azure } from '@ai-sdk/azure';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: azure.embedding('your-embedding-deployment'),
+  model: azure.textEmbeddingModel('your-embedding-deployment'),
   value: 'sunny day at the beach',
   providerOptions: {
     azure: {

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -436,10 +436,10 @@ on how to integrate reasoning into your chatbot.
 ## Embedding Models
 
 You can create models that call the Bedrock API [Bedrock API](https://docs.aws.amazon.com/bedrock/latest/userguide/titan-embedding-models.html)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
-const model = bedrock.embedding('amazon.titan-embed-text-v1');
+const model = bedrock.textEmbeddingModel('amazon.titan-embed-text-v1');
 ```
 
 Bedrock Titan embedding model amazon.titan-embed-text-v2:0 supports several additional settings.
@@ -449,7 +449,7 @@ You can pass them as an options argument:
 import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { embed } from 'ai';
 
-const model = bedrock.embedding('amazon.titan-embed-text-v2:0');
+const model = bedrock.textEmbeddingModel('amazon.titan-embed-text-v2:0');
 
 const { embedding } = await embed({
   model,

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -219,10 +219,10 @@ Mistral language models can also be used in the `streamText`, `generateObject`, 
 ## Embedding Models
 
 You can create models that call the [Mistral embeddings API](https://docs.mistral.ai/api/#operation/createEmbedding)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
-const model = mistral.embedding('mistral-embed');
+const model = mistral.textEmbeddingModel('mistral-embed');
 ```
 
 ### Model Capabilities

--- a/content/providers/01-ai-sdk-providers/25-cohere.mdx
+++ b/content/providers/01-ai-sdk-providers/25-cohere.mdx
@@ -113,16 +113,16 @@ Cohere language models can also be used in the `streamText`, `generateObject`, a
 ## Embedding Models
 
 You can create models that call the [Cohere embed API](https://docs.cohere.com/v2/reference/embed)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
-const model = cohere.embedding('embed-english-v3.0');
+const model = cohere.textEmbeddingModel('embed-english-v3.0');
 ```
 
 Cohere embedding models support provider options. You can pass them as an options argument:
 
 ```ts
-const model = cohere.embedding('embed-english-v3.0');
+const model = cohere.textEmbeddingModel('embed-english-v3.0');
 
 await embed({
   model,

--- a/content/providers/02-openai-compatible-providers/30-lmstudio.mdx
+++ b/content/providers/02-openai-compatible-providers/30-lmstudio.mdx
@@ -117,7 +117,7 @@ Similar to `embed`, you can use it with embeddings models,
 e.g. `lmstudio.textEmbeddingModel('text-embedding-nomic-embed-text-v1.5')` or `lmstudio.textEmbeddingModel('text-embedding-bge-small-en-v1.5')`.
 
 ```tsx
-import { createOpenAICompatible } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { embedMany } from 'ai';
 
 const lmstudio = createOpenAICompatible({

--- a/content/providers/02-openai-compatible-providers/30-lmstudio.mdx
+++ b/content/providers/02-openai-compatible-providers/30-lmstudio.mdx
@@ -81,10 +81,10 @@ LM Studio language models can also be used with `streamText`.
 ## Embedding Models
 
 You can create models that call the [LM Studio embeddings API](https://lmstudio.ai/docs/basics/server#endpoints-overview)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
-const model = lmstudio.embedding('text-embedding-nomic-embed-text-v1.5');
+const model = lmstudio.textEmbeddingModel('text-embedding-nomic-embed-text-v1.5');
 ```
 
 ### Example - Embedding a Single Value

--- a/content/providers/02-openai-compatible-providers/30-lmstudio.mdx
+++ b/content/providers/02-openai-compatible-providers/30-lmstudio.mdx
@@ -84,7 +84,9 @@ You can create models that call the [LM Studio embeddings API](https://lmstudio.
 using the `.textEmbeddingModel()` factory method.
 
 ```ts
-const model = lmstudio.textEmbeddingModel('text-embedding-nomic-embed-text-v1.5');
+const model = lmstudio.textEmbeddingModel(
+  'text-embedding-nomic-embed-text-v1.5',
+);
 ```
 
 ### Example - Embedding a Single Value

--- a/content/providers/03-community-providers/03-ollama.mdx
+++ b/content/providers/03-community-providers/03-ollama.mdx
@@ -79,8 +79,8 @@ The following models have been tested with image inputs:
 ## Embedding Models
 
 You can create models that call the [Ollama embeddings API](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings)
-using the `.textEmbeddingModel()` factory method.
+using the `.embedding()` factory method.
 
 ```ts
-const model = ollama.textEmbeddingModel('nomic-embed-text');
+const model = ollama.embedding('nomic-embed-text');
 ```

--- a/content/providers/03-community-providers/03-ollama.mdx
+++ b/content/providers/03-community-providers/03-ollama.mdx
@@ -6,7 +6,10 @@ description: Learn how to use the Ollama provider.
 # Ollama Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. It uses the deprecated `.embedding()` method instead of the standard `.textEmbeddingModel()` method. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. It uses the
+  deprecated `.embedding()` method instead of the standard
+  `.textEmbeddingModel()` method. Please wait for the provider to be updated or
+  consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
 </Note>
 
 [sgomez/ollama-ai-provider](https://github.com/sgomez/ollama-ai-provider) is a community provider that uses [Ollama](https://ollama.com/) to provide language model support for the AI SDK.

--- a/content/providers/03-community-providers/03-ollama.mdx
+++ b/content/providers/03-community-providers/03-ollama.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the Ollama provider.
 
 # Ollama Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. It uses the deprecated `.embedding()` method instead of the standard `.textEmbeddingModel()` method. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [sgomez/ollama-ai-provider](https://github.com/sgomez/ollama-ai-provider) is a community provider that uses [Ollama](https://ollama.com/) to provide language model support for the AI SDK.
 
 ## Setup
@@ -79,8 +83,8 @@ The following models have been tested with image inputs:
 ## Embedding Models
 
 You can create models that call the [Ollama embeddings API](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings)
-using the `.textEmbeddingModel()` factory method.
+using the `.embedding()` factory method.
 
 ```ts
-const model = ollama.textEmbeddingModel('nomic-embed-text');
+const model = ollama.embedding('nomic-embed-text');
 ```

--- a/content/providers/03-community-providers/03-ollama.mdx
+++ b/content/providers/03-community-providers/03-ollama.mdx
@@ -79,8 +79,8 @@ The following models have been tested with image inputs:
 ## Embedding Models
 
 You can create models that call the [Ollama embeddings API](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
-const model = ollama.embedding('nomic-embed-text');
+const model = ollama.textEmbeddingModel('nomic-embed-text');
 ```

--- a/content/providers/03-community-providers/60-mixedbread.mdx
+++ b/content/providers/03-community-providers/60-mixedbread.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the Mixedbread provider.
 
 # Mixedbread Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. It uses the deprecated `.embedding()` method instead of the standard `.textEmbeddingModel()` method. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [patelvivekdev/mixedbread-ai-provider](https://github.com/patelvivekdev/mixedbread-ai-provider) is a community provider that uses [Mixedbread](https://www.mixedbread.ai/) to provide Embedding support for the AI SDK.
 
 ## Setup
@@ -55,12 +59,12 @@ You can use the following optional settings to customize the Mixedbread provider
 ## Embedding Models
 
 You can create models that call the [Mixedbread embeddings API](https://www.mixedbread.ai/api-reference/endpoints/embeddings)
-using the `.textEmbeddingModel()` factory method.
+using the `.embedding()` factory method.
 
 ```ts
 import { mixedbread } from 'mixedbread-ai-provider';
 
-const embeddingModel = mixedbread.textEmbeddingModel(
+const embeddingModel = mixedbread.embedding(
   'mixedbread-ai/mxbai-embed-large-v1',
 );
 ```
@@ -85,7 +89,7 @@ The settings object should contain the settings you want to add to the model.
 ```ts
 import { mixedbread } from 'mixedbread-ai-provider';
 
-const embeddingModel = mixedbread.textEmbeddingModel(
+const embeddingModel = mixedbread.embedding(
   'mixedbread-ai/mxbai-embed-large-v1',
   {
     prompt: 'Generate embeddings for text', // Max 256 characters

--- a/content/providers/03-community-providers/60-mixedbread.mdx
+++ b/content/providers/03-community-providers/60-mixedbread.mdx
@@ -55,12 +55,12 @@ You can use the following optional settings to customize the Mixedbread provider
 ## Embedding Models
 
 You can create models that call the [Mixedbread embeddings API](https://www.mixedbread.ai/api-reference/endpoints/embeddings)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
 import { mixedbread } from 'mixedbread-ai-provider';
 
-const embeddingModel = mixedbread.embedding(
+const embeddingModel = mixedbread.textEmbeddingModel(
   'mixedbread-ai/mxbai-embed-large-v1',
 );
 ```
@@ -85,7 +85,7 @@ The settings object should contain the settings you want to add to the model.
 ```ts
 import { mixedbread } from 'mixedbread-ai-provider';
 
-const embeddingModel = mixedbread.embedding(
+const embeddingModel = mixedbread.textEmbeddingModel(
   'mixedbread-ai/mxbai-embed-large-v1',
   {
     prompt: 'Generate embeddings for text', // Max 256 characters

--- a/content/providers/03-community-providers/60-mixedbread.mdx
+++ b/content/providers/03-community-providers/60-mixedbread.mdx
@@ -55,12 +55,12 @@ You can use the following optional settings to customize the Mixedbread provider
 ## Embedding Models
 
 You can create models that call the [Mixedbread embeddings API](https://www.mixedbread.ai/api-reference/endpoints/embeddings)
-using the `.textEmbeddingModel()` factory method.
+using the `.embedding()` factory method.
 
 ```ts
 import { mixedbread } from 'mixedbread-ai-provider';
 
-const embeddingModel = mixedbread.textEmbeddingModel(
+const embeddingModel = mixedbread.embedding(
   'mixedbread-ai/mxbai-embed-large-v1',
 );
 ```
@@ -85,7 +85,7 @@ The settings object should contain the settings you want to add to the model.
 ```ts
 import { mixedbread } from 'mixedbread-ai-provider';
 
-const embeddingModel = mixedbread.textEmbeddingModel(
+const embeddingModel = mixedbread.embedding(
   'mixedbread-ai/mxbai-embed-large-v1',
   {
     prompt: 'Generate embeddings for text', // Max 256 characters

--- a/content/providers/03-community-providers/60-mixedbread.mdx
+++ b/content/providers/03-community-providers/60-mixedbread.mdx
@@ -6,7 +6,10 @@ description: Learn how to use the Mixedbread provider.
 # Mixedbread Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. It uses the deprecated `.embedding()` method instead of the standard `.textEmbeddingModel()` method. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. It uses the
+  deprecated `.embedding()` method instead of the standard
+  `.textEmbeddingModel()` method. Please wait for the provider to be updated or
+  consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
 </Note>
 
 [patelvivekdev/mixedbread-ai-provider](https://github.com/patelvivekdev/mixedbread-ai-provider) is a community provider that uses [Mixedbread](https://www.mixedbread.ai/) to provide Embedding support for the AI SDK.

--- a/content/providers/03-community-providers/60-mixedbread.mdx
+++ b/content/providers/03-community-providers/60-mixedbread.mdx
@@ -55,7 +55,7 @@ You can use the following optional settings to customize the Mixedbread provider
 ## Embedding Models
 
 You can create models that call the [Mixedbread embeddings API](https://www.mixedbread.ai/api-reference/endpoints/embeddings)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
 import { mixedbread } from 'mixedbread-ai-provider';

--- a/content/providers/03-community-providers/61-voyage-ai.mdx
+++ b/content/providers/03-community-providers/61-voyage-ai.mdx
@@ -6,7 +6,10 @@ description: Learn how to use the Voyage AI provider.
 # Voyage AI Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. It uses the deprecated `.embedding()` method instead of the standard `.textEmbeddingModel()` method. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. It uses the
+  deprecated `.embedding()` method instead of the standard
+  `.textEmbeddingModel()` method. Please wait for the provider to be updated or
+  consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
 </Note>
 
 [patelvivekdev/voyage-ai-provider](https://github.com/patelvivekdev/voyageai-ai-provider) is a community provider that uses [Voyage AI](https://www.voyageai.com) to provide Embedding support for the AI SDK.

--- a/content/providers/03-community-providers/61-voyage-ai.mdx
+++ b/content/providers/03-community-providers/61-voyage-ai.mdx
@@ -55,12 +55,12 @@ You can use the following optional settings to customize the Voyage provider ins
 ## Embedding Models
 
 You can create models that call the [Voyage embeddings API](https://docs.voyageai.com/reference/embeddings-api)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
 import { voyage } from 'voyage-ai-provider';
 
-const embeddingModel = voyage.embedding('voyage-3');
+const embeddingModel = voyage.textEmbeddingModel('voyage-3');
 ```
 
 You can find more models on the [Voyage Library](https://docs.voyageai.com/docs/embeddings) homepage.
@@ -91,7 +91,7 @@ The settings object should contain the settings you want to add to the model.
 ```ts
 import { voyage } from 'voyage-ai-provider';
 
-const embeddingModel = voyage.embedding('voyage-3', {
+const embeddingModel = voyage.textEmbeddingModel('voyage-3', {
   inputType: 'document', // 'document' or 'query'
   truncation: false,
   outputDimension: 1024, // the new model voyage-code-3, voyage-3-large has 4 different output dimensions: 256, 512, 1024 (default), 2048

--- a/content/providers/03-community-providers/61-voyage-ai.mdx
+++ b/content/providers/03-community-providers/61-voyage-ai.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the Voyage AI provider.
 
 # Voyage AI Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. It uses the deprecated `.embedding()` method instead of the standard `.textEmbeddingModel()` method. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [patelvivekdev/voyage-ai-provider](https://github.com/patelvivekdev/voyageai-ai-provider) is a community provider that uses [Voyage AI](https://www.voyageai.com) to provide Embedding support for the AI SDK.
 
 ## Setup
@@ -55,12 +59,12 @@ You can use the following optional settings to customize the Voyage provider ins
 ## Embedding Models
 
 You can create models that call the [Voyage embeddings API](https://docs.voyageai.com/reference/embeddings-api)
-using the `.textEmbeddingModel()` factory method.
+using the `.embedding()` factory method.
 
 ```ts
 import { voyage } from 'voyage-ai-provider';
 
-const embeddingModel = voyage.textEmbeddingModel('voyage-3');
+const embeddingModel = voyage.embedding('voyage-3');
 ```
 
 You can find more models on the [Voyage Library](https://docs.voyageai.com/docs/embeddings) homepage.
@@ -91,7 +95,7 @@ The settings object should contain the settings you want to add to the model.
 ```ts
 import { voyage } from 'voyage-ai-provider';
 
-const embeddingModel = voyage.textEmbeddingModel('voyage-3', {
+const embeddingModel = voyage.embedding('voyage-3', {
   inputType: 'document', // 'document' or 'query'
   truncation: false,
   outputDimension: 1024, // the new model voyage-code-3, voyage-3-large has 4 different output dimensions: 256, 512, 1024 (default), 2048

--- a/content/providers/03-community-providers/61-voyage-ai.mdx
+++ b/content/providers/03-community-providers/61-voyage-ai.mdx
@@ -55,12 +55,12 @@ You can use the following optional settings to customize the Voyage provider ins
 ## Embedding Models
 
 You can create models that call the [Voyage embeddings API](https://docs.voyageai.com/reference/embeddings-api)
-using the `.textEmbeddingModel()` factory method.
+using the `.embedding()` factory method.
 
 ```ts
 import { voyage } from 'voyage-ai-provider';
 
-const embeddingModel = voyage.textEmbeddingModel('voyage-3');
+const embeddingModel = voyage.embedding('voyage-3');
 ```
 
 You can find more models on the [Voyage Library](https://docs.voyageai.com/docs/embeddings) homepage.
@@ -91,7 +91,7 @@ The settings object should contain the settings you want to add to the model.
 ```ts
 import { voyage } from 'voyage-ai-provider';
 
-const embeddingModel = voyage.textEmbeddingModel('voyage-3', {
+const embeddingModel = voyage.embedding('voyage-3', {
   inputType: 'document', // 'document' or 'query'
   truncation: false,
   outputDimension: 1024, // the new model voyage-code-3, voyage-3-large has 4 different output dimensions: 256, 512, 1024 (default), 2048

--- a/content/providers/03-community-providers/61-voyage-ai.mdx
+++ b/content/providers/03-community-providers/61-voyage-ai.mdx
@@ -55,7 +55,7 @@ You can use the following optional settings to customize the Voyage provider ins
 ## Embedding Models
 
 You can create models that call the [Voyage embeddings API](https://docs.voyageai.com/reference/embeddings-api)
-using the `.embedding()` factory method.
+using the `.textEmbeddingModel()` factory method.
 
 ```ts
 import { voyage } from 'voyage-ai-provider';


### PR DESCRIPTION
## background

updated docs, to follow the newly update v5 version, switching from .embedding(deprecated) to the new .textEmbeddingModel
