### PR TITLE
fix (provider/openai): handle responses api errors

### DIFF
--- a/.changeset/sweet-flowers-smash.md
+++ b/.changeset/sweet-flowers-smash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix (provider/openai): handle responses api errors

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1637,6 +1637,66 @@ describe('OpenAIResponsesLanguageModel', () => {
         `);
       });
     });
+
+    describe('errors', () => {
+      it('should throw an API call error when the response contains an error part', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_67c97c0203188190a025beb4a75242bc',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: {
+              code: 'ERR_SOMETHING',
+              message: 'Something went wrong',
+            },
+            incomplete_details: null,
+            input: [],
+            instructions: null,
+            max_output_tokens: null,
+            model: 'gpt-4o-2024-07-18',
+            output: [],
+            parallel_tool_calls: true,
+            previous_response_id: null,
+            reasoning: {
+              effort: null,
+              summary: null,
+            },
+            store: true,
+            temperature: 1,
+            text: {
+              format: {
+                type: 'text',
+              },
+            },
+            tool_choice: 'auto',
+            tools: [],
+            top_p: 1,
+            truncation: 'disabled',
+            usage: {
+              input_tokens: 345,
+              input_tokens_details: {
+                cached_tokens: 234,
+              },
+              output_tokens: 538,
+              output_tokens_details: {
+                reasoning_tokens: 123,
+              },
+              total_tokens: 572,
+            },
+            user: null,
+            metadata: {},
+          },
+        };
+
+        expect(
+          createModel('gpt-4o').doGenerate({
+            prompt: TEST_PROMPT,
+          }),
+        ).rejects.toThrow('Something went wrong');
+      });
+    });
   });
 
   describe('doStream', () => {
@@ -2050,9 +2110,8 @@ describe('OpenAIResponsesLanguageModel', () => {
           includeRawChunks: false,
         });
 
-        expect(
-          await convertReadableStreamToArray(stream),
-        ).toMatchInlineSnapshot(`
+        expect(await convertReadableStreamToArray(stream))
+          .toMatchInlineSnapshot(`
           [
             {
               "type": "stream-start",

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2034,6 +2034,65 @@ describe('OpenAIResponsesLanguageModel', () => {
         ]
       `);
     });
+
+    describe('errors', () => {
+      it('should stream error parts', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'stream-chunks',
+          chunks: [
+            `data:{"type":"response.created","response":{"id":"resp_67cf3390786881908b27489d7e8cfb6b","object":"response","created_at":1741632400,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"web_search_preview","search_context_size":"medium","user_location":{"type":"approximate","city":null,"country":"US","region":null,"timezone":null}}],"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+            `data:{"type":"error","code":"ERR_SOMETHING","message":"Something went wrong","param":null,"sequence_number":1}\n\n`,
+          ],
+        };
+
+        const { stream } = await createModel('gpt-4o-mini').doStream({
+          prompt: TEST_PROMPT,
+          includeRawChunks: false,
+        });
+
+        expect(
+          await convertReadableStreamToArray(stream),
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "type": "stream-start",
+              "warnings": [],
+            },
+            {
+              "id": "resp_67cf3390786881908b27489d7e8cfb6b",
+              "modelId": "gpt-4o-mini-2024-07-18",
+              "timestamp": 2025-03-10T18:46:40.000Z,
+              "type": "response-metadata",
+            },
+            {
+              "error": {
+                "code": "ERR_SOMETHING",
+                "message": "Something went wrong",
+                "param": null,
+                "sequence_number": 1,
+                "type": "error",
+              },
+              "type": "error",
+            },
+            {
+              "finishReason": "unknown",
+              "providerMetadata": {
+                "openai": {
+                  "responseId": "resp_67cf3390786881908b27489d7e8cfb6b",
+                },
+              },
+              "type": "finish",
+              "usage": {
+                "inputTokens": undefined,
+                "outputTokens": undefined,
+                "totalTokens": undefined,
+              },
+            },
+          ]
+        `);
+      });
+    });
+
     describe('reasoning', () => {
       it('should handle reasoning with summary', async () => {
         server.urls['https://api.openai.com/v1/responses'].response = {


### PR DESCRIPTION
## Background

The OpenAI responses API exposes errors as part of its regular responses via error chunks and an error property.

## Summary

Handle error property and error stream parts.