### PR TITLE
feat(ai): Record tool call errors on tool call spans in `generateText` and `streamText`

### DIFF
--- a/.changeset/serious-ravens-stare.md
+++ b/.changeset/serious-ravens-stare.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-feat(ai): Record tool call errors on tool call spans
+feat(ai): Record tool call errors on tool call spans recorded in `generateText` and `streamText`.

--- a/.changeset/serious-ravens-stare.md
+++ b/.changeset/serious-ravens-stare.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): Record tool call errors on tool call spans

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -24,7 +24,7 @@ import { wrapGatewayError } from '../prompt/wrap-gateway-error';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
 import { getTracer } from '../telemetry/get-tracer';
-import { recordSpan } from '../telemetry/record-span';
+import { recordErrorOnSpan, recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { stringifyForTelemetry } from '../telemetry/stringify-for-telemetry';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
@@ -620,6 +620,7 @@ async function executeTools<TOOLS extends ToolSet>({
               output: result,
             } as ToolResultUnion<TOOLS>;
           } catch (error) {
+            recordErrorOnSpan(span, error);
             return {
               type: 'tool-error',
               toolCallId,

--- a/packages/ai/core/generate-text/run-tools-transformation.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.ts
@@ -3,9 +3,9 @@ import {
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider';
 import { generateId, ModelMessage } from '@ai-sdk/provider-utils';
-import { Tracer } from '@opentelemetry/api';
+import { SpanStatusCode, Tracer } from '@opentelemetry/api';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
-import { recordSpan } from '../telemetry/record-span';
+import { recordErrorOnSpan, recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { FinishReason, LanguageModelUsage, ProviderMetadata } from '../types';
@@ -265,6 +265,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                       abortSignal,
                     });
                   } catch (error) {
+                    recordErrorOnSpan(span, error);
                     toolResultsStreamController!.enqueue({
                       ...toolCall,
                       type: 'tool-error',

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -7997,6 +7997,72 @@ describe('streamText', () => {
       expect(tracer.jsonSpans).toMatchSnapshot();
     });
 
+    it('should record error on tool call', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'tool1',
+              input: `{ "value": "value" }`,
+            },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: testUsage,
+            },
+          ]),
+        }),
+        tools: {
+          tool1: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => {
+              throw new Error('Tool execution failed');
+            },
+          },
+        },
+        prompt: 'test-input',
+        experimental_telemetry: { isEnabled: true, tracer },
+        _internal: { now: mockValues(0, 100, 500) },
+      });
+
+      await result.consumeStream();
+
+      expect(tracer.jsonSpans).toHaveLength(3);
+
+      // Check that we have the expected spans
+      expect(tracer.jsonSpans[0].name).toBe('ai.streamText');
+      expect(tracer.jsonSpans[1].name).toBe('ai.streamText.doStream');
+      expect(tracer.jsonSpans[2].name).toBe('ai.toolCall');
+
+      // Check that the tool call span has error status
+      const toolCallSpan = tracer.jsonSpans[2];
+      expect(toolCallSpan.status).toEqual({
+        code: 2,
+        message: 'Tool execution failed',
+      });
+
+      // Check that the tool call span has exception event
+      expect(toolCallSpan.events).toHaveLength(1);
+      const exceptionEvent = toolCallSpan.events[0];
+      expect(exceptionEvent.name).toBe('exception');
+      expect(exceptionEvent.attributes).toMatchObject({
+        'exception.message': 'Tool execution failed',
+        'exception.name': 'Error',
+      });
+      expect(exceptionEvent.attributes?.['exception.stack']).toContain(
+        'Tool execution failed',
+      );
+      expect(exceptionEvent.time).toEqual([0, 0]);
+    });
+
     it('should not record telemetry inputs / outputs when disabled', async () => {
       const result = streamText({
         model: createTestModel({

--- a/packages/ai/core/telemetry/record-span.ts
+++ b/packages/ai/core/telemetry/record-span.ts
@@ -24,19 +24,7 @@ export function recordSpan<T>({
       return result;
     } catch (error) {
       try {
-        if (error instanceof Error) {
-          span.recordException({
-            name: error.name,
-            message: error.message,
-            stack: error.stack,
-          });
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: error.message,
-          });
-        } else {
-          span.setStatus({ code: SpanStatusCode.ERROR });
-        }
+        recordErrorOnSpan(span, error);
       } finally {
         // always stop the span when there is an error:
         span.end();
@@ -45,4 +33,27 @@ export function recordSpan<T>({
       throw error;
     }
   });
+}
+
+/**
+ * Record an error on a span. If the error is an instance of Error, an exception event will be recorded on the span, otherwise
+ * the span will be set to an error status.
+ *
+ * @param span - The span to record the error on.
+ * @param error - The error to record on the span.
+ */
+export function recordErrorOnSpan(span: Span, error: unknown) {
+  if (error instanceof Error) {
+    span.recordException({
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    });
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error.message,
+    });
+  } else {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
 }

--- a/packages/ai/core/test/mock-tracer.ts
+++ b/packages/ai/core/test/mock-tracer.ts
@@ -134,15 +134,15 @@ class MockSpan implements Span {
     return false;
   }
   recordException(exception: Exception, time?: TimeInput) {
-    const errorObj =
+    const error =
       typeof exception === 'string' ? new Error(exception) : exception;
     this.events.push({
       name: 'exception',
       attributes: {
-        'exception.type': errorObj.constructor?.name || 'Error',
-        'exception.name': errorObj.name || 'Error',
-        'exception.message': errorObj.message || '',
-        'exception.stack': errorObj.stack || '',
+        'exception.type': error.constructor?.name || 'Error',
+        'exception.name': error.name || 'Error',
+        'exception.message': error.message || '',
+        'exception.stack': error.stack || '',
       },
       time: Array.isArray(time) ? time : [0, 0],
     });


### PR DESCRIPTION
## Background

Although the `recordSpan` helper does record errors on recorded spans, in the case of tool call spans it was not being triggered. This was causing confusion from users who depended on this status change to get insights about tool call usage error rates. This change was done for tool calls used by both `generateText` and `streamText`.

## Summary

This PR updates these spans so that they get error statuses accordingly by updating the places where `name: 'ai.toolCall'` spans are called.

## Verification

This was manually verified in an example app.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

ref https://github.com/vercel/ai/issues/6673
resolves https://github.com/getsentry/sentry-javascript/issues/16748
