### PR TITLE
docs(getting-started/nuxt): improve getting started for nuxt

### DIFF
--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -82,7 +82,7 @@ Replace `xxxxxxxxx` with your actual OpenAI API key and configure the environmen
 export default defineNuxtConfig({
   // rest of your nuxt config
   runtimeConfig: {
-    openaiApiKey: process.env.NUXT_OPENAI_API_KEY,
+    openaiApiKey: '',
   },
 });
 ```

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -73,7 +73,7 @@ Create a `.env` file in your project root and add your OpenAI API Key. This key 
 Edit the `.env` file:
 
 ```env filename=".env"
-OPENAI_API_KEY=xxxxxxxxx
+NUXT_OPENAI_API_KEY=xxxxxxxxx
 ```
 
 Replace `xxxxxxxxx` with your actual OpenAI API key and configure the environment variable in `nuxt.config.ts`:
@@ -82,7 +82,7 @@ Replace `xxxxxxxxx` with your actual OpenAI API key and configure the environmen
 export default defineNuxtConfig({
   // rest of your nuxt config
   runtimeConfig: {
-    openaiApiKey: process.env.OPENAI_API_KEY,
+    openaiApiKey: process.env.NUXT_OPENAI_API_KEY,
   },
 });
 ```


### PR DESCRIPTION
add NUXT_ namespace to the env name


## Background
While getting intouch with mcp and ai sdk framework,
I'm stumble about the not optimal used env naming of the nuxt getting started part. 
Since the env is only available at build but not at run time,
when not NUXT_ as prefixed is used.

So I added the NUXT_* prefix to the doc,
evade other followers to stumble about the point. 

Official doc about this topic: https://nuxt.com/docs/guide/going-further/runtime-config#environment-variables

Keeping the note aboud the default env name unchanged.
In https://github.com/vercel/ai/blob/main/examples/nuxt-openai/.env.example the right name already used.
## Summary

Change env name of nuxt getting started section to NUXT_*
