### PR TITLE
docs(migrationV5/vue): fix @ai-sdk/vue migration

### DIFF
--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1032,7 +1032,8 @@ const chat = new Chat({
   transport: new DefaultChatTransport({ api: '/api/chat' }),
 });
 
-const handleSubmit = () => {
+const handleSubmit = (e: Event) => {
+  e.preventDefault();
   chat.sendMessage({ text: input.value });
   input.value = '';
 };


### PR DESCRIPTION
copy the code from "wire up the ui"

## Background

Since the change from useChat to Chat is happening the message handling did change,
in the "wire up th ui" a working code already mention: https://v5.ai-sdk.dev/docs/getting-started/nuxt#wire-up-the-ui
copy the logic to the migration doc.

Subject: https://v5.ai-sdk.dev/docs/migration-guides/migration-guide-5-0#usechat-replaced-with-chat-class
## Summary

Add e.preventDefault(); to the handleSubmit methode
