### PR TITLE
change useChat from useRef to useMemo

### DIFF
--- a/.changeset/slimy-shrimps-clap.md
+++ b/.changeset/slimy-shrimps-clap.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+switch useChat Chat from ref to memo

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -4,13 +4,7 @@ import {
   type CreateUIMessage,
   type UIMessage,
 } from 'ai';
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useSyncExternalStore,
-} from 'react';
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
 import { Chat } from './chat.react';
 
 export type { CreateUIMessage, UIMessage };


### PR DESCRIPTION
## Summary

the useChat hook in react now 
this means that the sendMessage function will send user message with the new id if it changes.

```typescript
const {
    sendMessage,
    ...props
} = useChat({
    id,
},[id]);
```

## Tasks

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)


## Related Issues
"Fixes" #6992
