### PR TITLE
docs(CONTRIBUTING): remove repetition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,4 @@ We greatly appreciate your pull requests. Here are the steps to submit them:
 
 7. **Respond to Feedback**: Stay receptive to and address any feedback or alteration requests from the project maintainers.
 
-### Fixing Prettier Issues
-
-> [!TIP]
-> Run `pnpm prettier-fix` before opening a pull request.
-
-If you encounter any prettier issues, you can fix them by running `pnpm prettier-fix`. This command will automatically fix any formatting issues in your code.
-
 Thank you for contributing to the AI SDK! Your efforts help us improve the project for everyone.


### PR DESCRIPTION
## Background

`pnpm prettier-fix` is mentioned in both step 5 and at the end of the documentation. Also pull request templates now include instructions to run the same command.

## Summary

Remove section including repetitive instructions.

## Verification

Preview at https://github.com/vercel/ai/blob/update-contributing/CONTRIBUTING.md

## Tasks

- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

In preparation to add documentation about adding codemods

## Related Issues

n/a
