### PR TITLE
feat (ai): support system parameter in Agent constructor

### DIFF
--- a/.changeset/curly-bats-build.md
+++ b/.changeset/curly-bats-build.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): support system parameter in Agent constructor

--- a/examples/ai-core/src/agent/openai-generate.ts
+++ b/examples/ai-core/src/agent/openai-generate.ts
@@ -5,6 +5,7 @@ import 'dotenv/config';
 async function main() {
   const agent = new Agent({
     model: openai('gpt-4o'),
+    system: 'You are a helpful assistant.',
   });
 
   const { text, usage } = await agent.generate({

--- a/examples/ai-core/src/agent/openai-stream.ts
+++ b/examples/ai-core/src/agent/openai-stream.ts
@@ -5,9 +5,7 @@ import 'dotenv/config';
 async function main() {
   const agent = new Agent({
     model: openai('gpt-3.5-turbo'),
-    maxOutputTokens: 512,
-    temperature: 0.3,
-    maxRetries: 5,
+    system: 'You are a helpful assistant.',
   });
 
   const result = agent.stream({

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -23,6 +23,11 @@ export type AgentSettings<
   OUTPUT_PARTIAL = never,
 > = CallSettings & {
   /**
+   * The system prompt to use.
+   */
+  system?: string;
+
+  /**
 The language model to use.
    */
   model: LanguageModel;


### PR DESCRIPTION
## Background

The system prompt is expected to be reused in multiple agent calls.

## Summary

Add system option to agent constructor.