### PR TITLE
feat (ai): add ignoreIncompleteToolCalls option to convertToModelMessages

### DIFF
--- a/.changeset/curvy-cats-kneel.md
+++ b/.changeset/curvy-cats-kneel.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): add ignoreIncompleteToolCalls option to convertToModelMessages

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -35,21 +35,15 @@ export function convertToModelMessages(
   const modelMessages: ModelMessage[] = [];
 
   if (options?.ignoreIncompleteToolCalls) {
-    messages = messages.map(message => {
-      if (message.role !== 'assistant' || message.parts == null) {
-        return message;
-      }
-
-      return {
-        ...message,
-        parts: message.parts.filter(
-          part =>
-            !isToolUIPart(part) ||
-            (part.state !== 'input-streaming' &&
-              part.state !== 'input-available'),
-        ),
-      };
-    });
+    messages = messages.map(message => ({
+      ...message,
+      parts: message.parts.filter(
+        part =>
+          !isToolUIPart(part) ||
+          (part.state !== 'input-streaming' &&
+            part.state !== 'input-available'),
+      ),
+    }));
   }
 
   for (const message of messages) {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -33,9 +33,8 @@ export function convertToModelMessages(
   },
 ): ModelMessage[] {
   const modelMessages: ModelMessage[] = [];
-  const ignoreIncompleteToolCalls = options?.ignoreIncompleteToolCalls ?? false;
 
-  if (ignoreIncompleteToolCalls) {
+  if (options?.ignoreIncompleteToolCalls) {
     messages = messages.map(message => {
       if (message.role !== 'assistant' || message.parts == null) {
         return message;


### PR DESCRIPTION
## Background

Converting UI to model messages currently throws an error for incomplete tool calls.

## Summary

Add an option to ignore incomplete tool calls.

## Related Issues

Fixes #7097