### PR TITLE
fix(ai): Unexpected reasoning-start event in extract reasoning middleware

### DIFF
--- a/.changeset/spotty-apples-call.md
+++ b/.changeset/spotty-apples-call.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): Unexpected reasoning-start event in extract reasoning middleware

--- a/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.test.ts
@@ -684,18 +684,10 @@ describe('extractReasoningMiddleware', () => {
               "type": "text-start",
             },
             {
-              "id": "reasoning-0",
-              "type": "reasoning-start",
-            },
-            {
               "id": "1",
               "providerMetadata": undefined,
               "text": "ana",
               "type": "text",
-            },
-            {
-              "id": "reasoning-0",
-              "type": "reasoning-start",
             },
             {
               "id": "1",
@@ -705,18 +697,100 @@ describe('extractReasoningMiddleware', () => {
               "type": "text",
             },
             {
-              "id": "reasoning-0",
-              "type": "reasoning-start",
-            },
-            {
               "id": "1",
               "providerMetadata": undefined,
               "text": "</think>",
               "type": "text",
             },
             {
-              "id": "reasoning-0",
-              "type": "reasoning-start",
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "this is the response",
+              "type": "text",
+            },
+            {
+              "id": "1",
+              "type": "text-end",
+            },
+            {
+              "finishReason": "stop",
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish-step",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 5,
+                "outputTokens": 10,
+                "reasoningTokens": 3,
+                "totalTokens": 18,
+              },
+            },
+            {
+              "finishReason": "stop",
+              "totalUsage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 5,
+                "outputTokens": 10,
+                "reasoningTokens": 3,
+                "totalTokens": 18,
+              },
+              "type": "finish",
+            },
+          ]
+        `);
+    });
+
+    it('should keep original text when <think> tag is not present', async () => {
+      const mockModel = new MockLanguageModelV2({
+        async doStream() {
+          return {
+            stream: convertArrayToReadableStream([
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: 'this is the response' },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: testUsage,
+              },
+            ]),
+          };
+        },
+      });
+
+      const result = streamText({
+        model: wrapLanguageModel({
+          model: mockModel,
+          middleware: extractReasoningMiddleware({ tagName: 'think' }),
+        }),
+        prompt: 'Hello, how can I help?',
+      });
+
+      expect(await convertAsyncIterableToArray(result.fullStream))
+        .toMatchInlineSnapshot(`
+          [
+            {
+              "type": "start",
+            },
+            {
+              "request": {},
+              "type": "start-step",
+              "warnings": [],
+            },
+            {
+              "id": "1",
+              "type": "text-start",
             },
             {
               "id": "1",

--- a/packages/ai/core/middleware/extract-reasoning-middleware.ts
+++ b/packages/ai/core/middleware/extract-reasoning-middleware.ts
@@ -133,9 +133,9 @@ export function extractReasoningMiddleware({
                       : '';
 
                   if (
-                    (activeExtraction.afterSwitch &&
-                      activeExtraction.isReasoning) ||
-                    activeExtraction.isFirstReasoning
+                    activeExtraction.isReasoning &&
+                    (activeExtraction.afterSwitch ||
+                      activeExtraction.isFirstReasoning)
                   ) {
                     controller.enqueue({
                       type: 'reasoning-start',


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

If the extract reasoning middleware is used when making a request but the model's response does not include `<think></think>` tags, the middleware will generate an unexpected reasoning-start event. 

## Summary

<!-- What did you change? -->

Ensure that the reasoning-start event is only emitted in real reasoning mode.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
