### PR TITLE
feat(amazon-bedrock): add style parameter support for image generation

### DIFF
--- a/.changeset/wild-hairs-hide.md
+++ b/.changeset/wild-hairs-hide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Add style parameter support for Amazon Bedrock Nova Canvas image generation

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -529,6 +529,7 @@ const { image } = await generateImage({
       quality: 'premium',
       negativeText: 'blurry, low quality',
       cfgScale: 7.5,
+      style: 'PHOTOREALISM',
     },
   },
 });
@@ -547,6 +548,14 @@ The following optional provider options are available for Amazon Nova Canvas:
 - **cfgScale** _number_
 
   Controls how closely the generated image adheres to the prompt. Higher values result in images that are more closely aligned to the prompt.
+
+- **style** _string_
+
+  Predefined visual style for image generation.  
+  Accepts one of:
+  `3D_ANIMATED_FAMILY_FILM` · `DESIGN_SKETCH` · `FLAT_VECTOR_ILLUSTRATION` ·  
+  `GRAPHIC_NOVEL_ILLUSTRATION` · `MAXIMALISM` · `MIDCENTURY_RETRO` ·  
+  `PHOTOREALISM` · `SOFT_DIGITAL_PAINTING`.
 
 Documentation for additional settings can be found within the [Amazon Bedrock
 User Guide for Amazon Nova

--- a/packages/amazon-bedrock/src/bedrock-image-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.test.ts
@@ -202,4 +202,57 @@ describe('doGenerate', () => {
     );
     expect(result.response.modelId).toBe('amazon.nova-canvas-v1:0');
   });
+
+  it('should pass the style parameter when provided', async () => {
+    await model.doGenerate({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: 1234,
+      providerOptions: {
+        bedrock: {
+          negativeText: 'bad',
+          quality: 'premium',
+          cfgScale: 1.2,
+          style: 'PHOTOREALISM',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      taskType: 'TEXT_IMAGE',
+      textToImageParams: {
+        text: prompt,
+        negativeText: 'bad',
+        style: 'PHOTOREALISM',
+      },
+      imageGenerationConfig: {
+        numberOfImages: 1,
+        seed: 1234,
+        quality: 'premium',
+        cfgScale: 1.2,
+        width: 1024,
+        height: 1024,
+      },
+    });
+  });
+
+  it('should not include style parameter when not provided', async () => {
+    await model.doGenerate({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      aspectRatio: undefined,
+      seed: 1234,
+      providerOptions: {
+        bedrock: {
+          quality: 'standard',
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.textToImageParams).not.toHaveProperty('style');
+  });
 });

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -65,6 +65,11 @@ export class BedrockImageModel implements ImageModelV2 {
               negativeText: providerOptions.bedrock.negativeText,
             }
           : {}),
+        ...(providerOptions?.bedrock?.style
+          ? {
+              style: providerOptions.bedrock.style,
+            }
+          : {}),
       },
       imageGenerationConfig: {
         ...(width ? { width } : {}),


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.
We suggest you read the following contributing guide we've created before submitting:
https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->
## Background
Amazon Nova Canvas now supports predefined visual styles for image generation via the style parameter. AI SDK didn’t forward this parameter, so users couldn’t take advantage of the feature.

## Summary
Adds conditional support for style in the image-generation request:

```
...(providerOptions?.bedrock?.style
  ? { style: providerOptions.bedrock.style }
  : {}),
```

### Changes:
- Inject the style field into the request body when providerOptions.bedrock.style is defined.

## Verification
1. Building the package with `pnpm build`
2. Running tests with `pnpm test` in the `packages/amazon-bedrock` directory
3. Confirmed request body contains the `style` field only when specified.

## Tasks
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work
- Add docs & examples for using providerOptions.bedrock.style.
- Consider a TypeScript enum / union for autocomplete.
- Validate style values against the supported set.

## Related Issues
N/A - This is a feature addition based on the latest AWS documentation for Amazon Nova Canvas.

### Reference
[AWS Documentation - Amazon Nova Canvas Request and Response Structure](https://docs.aws.amazon.com/nova/latest/userguide/image-gen-styles.html)