### PR TITLE
fix(elevenlabs): use camelCase fileFormat in provider options

### DIFF
--- a/.changeset/afraid-countries-crash.md
+++ b/.changeset/afraid-countries-crash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/elevenlabs': patch
+---
+
+fix(elevenlabs): use camelCase fileFormat in provider options

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -115,7 +115,7 @@ The following provider options are available:
   Whether to annotate which speaker is currently talking in the uploaded file.
   Defaults to `true`.
 
-- **fileFormat** _enum_
+- **file_format** _enum_
 
   The format of input audio.
   Defaults to `'other'`.

--- a/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
+++ b/content/providers/01-ai-sdk-providers/90-elevenlabs.mdx
@@ -115,7 +115,7 @@ The following provider options are available:
   Whether to annotate which speaker is currently talking in the uploaded file.
   Defaults to `true`.
 
-- **file_format** _enum_
+- **fileFormat** _enum_
 
   The format of input audio.
   Defaults to `'other'`.

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.test.ts
@@ -342,4 +342,40 @@ describe('doGenerate', () => {
       }
     `);
   });
+
+  it('should pass provider options correctly', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        elevenlabs: {
+          languageCode: 'en',
+          fileFormat: 'pcm_s16le_16',
+          tagAudioEvents: false,
+          numSpeakers: 2,
+          timestampsGranularity: 'character',
+          diarize: true,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyMultipart).toMatchInlineSnapshot(`
+      {
+        "diarize": "true",
+        "file": File {
+          Symbol(kHandle): Blob {},
+          Symbol(kLength): 40169,
+          Symbol(kType): "audio/wav",
+        },
+        "file_format": "pcm_s16le_16",
+        "language_code": "en",
+        "model_id": "scribe_v1",
+        "num_speakers": "2",
+        "tag_audio_events": "false",
+        "timestamps_granularity": "character",
+      }
+    `);
+  });
 });

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -26,7 +26,7 @@ const elevenLabsProviderOptionsSchema = z.object({
     .nullish()
     .default('word'),
   diarize: z.boolean().nullish().default(false),
-  file_format: z.enum(['pcm_s16le_16', 'other']).nullish().default('other'),
+  fileFormat: z.enum(['pcm_s16le_16', 'other']).nullish().default('other'),
 });
 
 export type ElevenLabsTranscriptionCallOptions = z.infer<
@@ -84,7 +84,7 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV2 {
         num_speakers: elevenlabsOptions.numSpeakers ?? undefined,
         timestamps_granularity:
           elevenlabsOptions.timestampsGranularity ?? undefined,
-        file_format: elevenlabsOptions.file_format ?? undefined,
+        file_format: elevenlabsOptions.fileFormat ?? undefined,
       };
 
       if (typeof elevenlabsOptions.diarize === 'boolean') {


### PR DESCRIPTION
## background

updated provider options to align with docs

## summary
now uses fileFormat instead of file_format