### PR TITLE
docs: update embeddings to v5 beta

### DIFF
--- a/content/docs/03-ai-sdk-core/30-embeddings.mdx
+++ b/content/docs/03-ai-sdk-core/30-embeddings.mdx
@@ -89,6 +89,44 @@ console.log(usage); // { tokens: 10 }
 
 ## Settings
 
+### Provider Options
+
+Embedding model settings can be configured using `providerOptions` for provider-specific parameters:
+
+```ts highlight={"5-9"}
+import { openai } from '@ai-sdk/openai';
+import { embed } from 'ai';
+
+const { embedding } = await embed({
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
+  value: 'sunny day at the beach',
+  providerOptions: {
+    openai: {
+      dimensions: 512, // Reduce embedding dimensions
+    },
+  },
+});
+```
+
+### Parallel Requests
+
+The `embedMany` function now supports parallel processing with configurable `maxParallelCalls` to optimize performance:
+
+```ts highlight={"4"}
+import { openai } from '@ai-sdk/openai';
+import { embedMany } from 'ai';
+
+const { embeddings, usage } = await embedMany({
+  maxParallelCalls: 2, // Limit parallel requests
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
+  values: [
+    'sunny day at the beach',
+    'rainy afternoon in the city',
+    'snowy night in the mountains',
+  ],
+});
+```
+
 ### Retries
 
 Both `embed` and `embedMany` accept an optional `maxRetries` parameter of type `number`
@@ -137,6 +175,22 @@ const { embedding } = await embed({
   value: 'sunny day at the beach',
   headers: { 'X-Custom-Header': 'custom-value' },
 });
+```
+
+## Response Information
+
+Both `embed` and `embedMany` return response information that includes the raw provider response:
+
+```ts highlight={"4,9"}
+import { openai } from '@ai-sdk/openai';
+import { embed } from 'ai';
+
+const { embedding, response } = await embed({
+  model: openai.textEmbeddingModel('text-embedding-3-small'),
+  value: 'sunny day at the beach',
+});
+
+console.log(response); // Raw provider response
 ```
 
 ## Embedding Providers & Models


### PR DESCRIPTION
## Background

Updating docs pages for v5

## Tasks

- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)