### PR TITLE
docs(provider/gladia): fix api key used

### DIFF
--- a/content/providers/01-ai-sdk-providers/120-gladia.mdx
+++ b/content/providers/01-ai-sdk-providers/120-gladia.mdx
@@ -47,7 +47,7 @@ You can use the following optional settings to customize the Gladia provider ins
 - **apiKey** _string_
 
   API key that is being sent using the `Authorization` header.
-  It defaults to the `DEEPGRAM_API_KEY` environment variable.
+  It defaults to the `GLADIA_API_KEY` environment variable.
 
 - **headers** _Record&lt;string,string&gt;_
 


### PR DESCRIPTION
fix gladia provider page docs, to show correct api key usage