### PR TITLE
fix(hume): updated README to use default provider hume

### DIFF
--- a/packages/hume/README.md
+++ b/packages/hume/README.md
@@ -13,7 +13,7 @@ npm i @ai-sdk/hume
 
 ## Provider Instance
 
-You can import the default provider instance `lmnt` from `@ai-sdk/lmnt`:
+You can import the default provider instance `hume` from `@ai-sdk/hume`:
 
 ```ts
 import { hume } from '@ai-sdk/hume';


### PR DESCRIPTION
## background

fixed default provider instance

## summary

changed ```
You can import the default provider instance `lmnt` from `@ai-sdk/
lmnt`:
``` to `You can import the default provider instance `hume` from `@ai-sdk/hume`:`