### PR TITLE
chore (ai): rename UIMessageStreamPart to UIMessageChunk

### DIFF
--- a/.changeset/young-dolls-yell.md
+++ b/.changeset/young-dolls-yell.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+chore (ai): rename UIMessageStreamPart to UIMessageChunk

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2285,7 +2285,7 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'toUIMessageStream',
-      type: '(options?: UIMessageStreamOptions) => ReadableStream<UIMessageStreamPart>',
+      type: '(options?: UIMessageStreamOptions) => ReadableStream<UIMessageChunk>',
       description:
         'Converts the result to a UI message stream.',
       properties: [

--- a/packages/ai/core/generate-text/stream-text-result.ts
+++ b/packages/ai/core/generate-text/stream-text-result.ts
@@ -1,6 +1,6 @@
 import { ReasoningPart } from '@ai-sdk/provider-utils';
 import { ServerResponse } from 'node:http';
-import { InferUIMessageStreamPart } from '../../src/ui-message-stream/ui-message-stream-parts';
+import { InferUIMessageChunk } from '../../src/ui-message-stream/ui-message-chunks';
 import { UIMessageStreamResponseInit } from '../../src/ui-message-stream/ui-message-stream-response-init';
 import { InferUIMessageMetadata, UIMessage } from '../../src/ui/ui-messages';
 import { AsyncIterableStream } from '../../src/util/async-iterable-stream';
@@ -269,7 +269,7 @@ If an error occurs, it is passed to the optional `onError` callback.
      */
   toUIMessageStream<UI_MESSAGE extends UIMessage>(
     options?: UIMessageStreamOptions<UI_MESSAGE>,
-  ): ReadableStream<InferUIMessageStreamPart<UI_MESSAGE>>;
+  ): ReadableStream<InferUIMessageChunk<UI_MESSAGE>>;
 
   /**
   Writes UI message stream output to a Node.js response-like object.

--- a/packages/ai/core/generate-text/stream-text.ts
+++ b/packages/ai/core/generate-text/stream-text.ts
@@ -19,9 +19,9 @@ import { getResponseUIMessageId } from '../../src/ui-message-stream/get-response
 import { handleUIMessageStreamFinish } from '../../src/ui-message-stream/handle-ui-message-stream-finish';
 import { pipeUIMessageStreamToResponse } from '../../src/ui-message-stream/pipe-ui-message-stream-to-response';
 import {
-  InferUIMessageStreamPart,
-  UIMessageStreamPart,
-} from '../../src/ui-message-stream/ui-message-stream-parts';
+  InferUIMessageChunk,
+  UIMessageChunk,
+} from '../../src/ui-message-stream/ui-message-chunks';
 import { UIMessageStreamResponseInit } from '../../src/ui-message-stream/ui-message-stream-response-init';
 import {
   InferUIMessageData,
@@ -1580,7 +1580,7 @@ However, the LLM results are expected to be small enough to not cause issues.
     sendFinish = true,
     onError = getErrorMessage,
   }: UIMessageStreamOptions<UI_MESSAGE> = {}): ReadableStream<
-    InferUIMessageStreamPart<UI_MESSAGE>
+    InferUIMessageChunk<UI_MESSAGE>
   > {
     const responseMessageId = getResponseUIMessageId({
       originalMessages,
@@ -1590,7 +1590,7 @@ However, the LLM results are expected to be small enough to not cause issues.
     const baseStream = this.fullStream.pipeThrough(
       new TransformStream<
         TextStreamPart<TOOLS>,
-        UIMessageStreamPart<
+        UIMessageChunk<
           InferUIMessageMetadata<UI_MESSAGE>,
           InferUIMessageData<UI_MESSAGE>
         >

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream-response.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream-response.ts
@@ -1,7 +1,7 @@
 import { prepareHeaders } from '../util/prepare-headers';
 import { JsonToSseTransformStream } from './json-to-sse-transform-stream';
 import { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
-import { UIMessageStreamPart } from './ui-message-stream-parts';
+import { UIMessageChunk } from './ui-message-chunks';
 import { UIMessageStreamResponseInit } from './ui-message-stream-response-init';
 
 export function createUIMessageStreamResponse({
@@ -11,7 +11,7 @@ export function createUIMessageStreamResponse({
   stream,
   consumeSseStream,
 }: UIMessageStreamResponseInit & {
-  stream: ReadableStream<UIMessageStreamPart>;
+  stream: ReadableStream<UIMessageChunk>;
 }): Response {
   let sseStream = stream.pipeThrough(new JsonToSseTransformStream());
 

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -2,7 +2,7 @@ import { delay } from '@ai-sdk/provider-utils';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { DelayedPromise } from '../util/delayed-promise';
 import { createUIMessageStream } from './create-ui-message-stream';
-import { UIMessageStreamPart } from './ui-message-stream-parts';
+import { UIMessageChunk } from './ui-message-chunks';
 import { UIMessageStreamWriter } from './ui-message-stream-writer';
 import { consumeStream } from '../util/consume-stream';
 import { UIMessage } from '../ui/ui-messages';
@@ -91,8 +91,8 @@ describe('createUIMessageStream', () => {
   });
 
   it('should forward elements from multiple streams and data parts', async () => {
-    let controller1: ReadableStreamDefaultController<UIMessageStreamPart>;
-    let controller2: ReadableStreamDefaultController<UIMessageStreamPart>;
+    let controller1: ReadableStreamDefaultController<UIMessageChunk>;
+    let controller2: ReadableStreamDefaultController<UIMessageChunk>;
 
     const stream = createUIMessageStream({
       execute: ({ writer }) => {
@@ -187,8 +187,8 @@ describe('createUIMessageStream', () => {
   });
 
   it('should add error parts when stream errors', async () => {
-    let controller1: ReadableStreamDefaultController<UIMessageStreamPart>;
-    let controller2: ReadableStreamDefaultController<UIMessageStreamPart>;
+    let controller1: ReadableStreamDefaultController<UIMessageChunk>;
+    let controller2: ReadableStreamDefaultController<UIMessageChunk>;
 
     const stream = createUIMessageStream({
       execute: ({ writer }) => {
@@ -308,8 +308,8 @@ describe('createUIMessageStream', () => {
 
   it('should support writing from delayed merged streams', async () => {
     let uiMessageStreamWriter: UIMessageStreamWriter<UIMessage>;
-    let controller1: ReadableStreamDefaultController<UIMessageStreamPart>;
-    let controller2: ReadableStreamDefaultController<UIMessageStreamPart>;
+    let controller1: ReadableStreamDefaultController<UIMessageChunk>;
+    let controller2: ReadableStreamDefaultController<UIMessageChunk>;
     let done = false;
 
     const stream = createUIMessageStream({
@@ -327,7 +327,7 @@ describe('createUIMessageStream', () => {
       },
     });
 
-    const result: UIMessageStreamPart[] = [];
+    const result: UIMessageChunk[] = [];
     const reader = stream.getReader();
     async function pull() {
       const { value, done } = await reader.read();

--- a/packages/ai/src/ui-message-stream/index.ts
+++ b/packages/ai/src/ui-message-stream/index.ts
@@ -3,5 +3,5 @@ export { createUIMessageStreamResponse } from './create-ui-message-stream-respon
 export { JsonToSseTransformStream } from './json-to-sse-transform-stream';
 export { pipeUIMessageStreamToResponse } from './pipe-ui-message-stream-to-response';
 export { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
-export type { UIMessageStreamPart } from './ui-message-stream-parts';
+export type { UIMessageChunk } from './ui-message-chunks';
 export type { UIMessageStreamWriter } from './ui-message-stream-writer';

--- a/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
+++ b/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
@@ -3,7 +3,7 @@ import { prepareHeaders } from '../util/prepare-headers';
 import { writeToServerResponse } from '../util/write-to-server-response';
 import { JsonToSseTransformStream } from './json-to-sse-transform-stream';
 import { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
-import { UIMessageStreamPart } from './ui-message-stream-parts';
+import { UIMessageChunk } from './ui-message-chunks';
 import { UIMessageStreamResponseInit } from './ui-message-stream-response-init';
 
 export function pipeUIMessageStreamToResponse({
@@ -15,7 +15,7 @@ export function pipeUIMessageStreamToResponse({
   consumeSseStream,
 }: {
   response: ServerResponse;
-  stream: ReadableStream<UIMessageStreamPart>;
+  stream: ReadableStream<UIMessageChunk>;
 } & UIMessageStreamResponseInit): void {
   let sseStream = stream.pipeThrough(new JsonToSseTransformStream());
 

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -8,7 +8,7 @@ import {
 } from '../ui/ui-messages';
 import { ProviderMetadata } from '../../core/types/provider-metadata';
 
-export const uiMessageStreamPartSchema = z.union([
+export const uiMessageChunkSchema = z.union([
   z.strictObject({
     type: z.literal('text-start'),
     id: z.string(),
@@ -127,7 +127,7 @@ export const uiMessageStreamPartSchema = z.union([
   }),
 ]);
 
-export type DataUIMessageStreamPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
+export type DataUIMessageChunk<DATA_TYPES extends UIDataTypes> = ValueOf<{
   [NAME in keyof DATA_TYPES & string]: {
     type: `data-${NAME}`;
     id?: string;
@@ -136,7 +136,7 @@ export type DataUIMessageStreamPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
   };
 }>;
 
-export type UIMessageStreamPart<
+export type UIMessageChunk<
   METADATA = unknown,
   DATA_TYPES extends UIDataTypes = UIDataTypes,
 > =
@@ -209,7 +209,7 @@ export type UIMessageStreamPart<
       url: string;
       mediaType: string;
     }
-  | DataUIMessageStreamPart<DATA_TYPES>
+  | DataUIMessageChunk<DATA_TYPES>
   | {
       type: 'start-step';
     }
@@ -230,13 +230,13 @@ export type UIMessageStreamPart<
       messageMetadata: METADATA;
     };
 
-export function isDataUIMessageStreamPart(
-  part: UIMessageStreamPart,
-): part is DataUIMessageStreamPart<UIDataTypes> {
-  return part.type.startsWith('data-');
+export function isDataUIMessageChunk(
+  chunk: UIMessageChunk,
+): chunk is DataUIMessageChunk<UIDataTypes> {
+  return chunk.type.startsWith('data-');
 }
 
-export type InferUIMessageStreamPart<T extends UIMessage> = UIMessageStreamPart<
+export type InferUIMessageChunk<T extends UIMessage> = UIMessageChunk<
   InferUIMessageMetadata<T>,
   InferUIMessageData<T>
 >;

--- a/packages/ai/src/ui-message-stream/ui-message-stream-writer.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-writer.ts
@@ -1,6 +1,6 @@
 import { UIMessage } from '../ui';
 import { ErrorHandler } from '../util/error-handler';
-import { InferUIMessageStreamPart } from './ui-message-stream-parts';
+import { InferUIMessageChunk } from './ui-message-chunks';
 
 export interface UIMessageStreamWriter<
   UI_MESSAGE extends UIMessage = UIMessage,
@@ -8,12 +8,12 @@ export interface UIMessageStreamWriter<
   /**
    * Appends a data stream part to the stream.
    */
-  write(part: InferUIMessageStreamPart<UI_MESSAGE>): void;
+  write(part: InferUIMessageChunk<UI_MESSAGE>): void;
 
   /**
    * Merges the contents of another stream to this stream.
    */
-  merge(stream: ReadableStream<InferUIMessageStreamPart<UI_MESSAGE>>): void;
+  merge(stream: ReadableStream<InferUIMessageChunk<UI_MESSAGE>>): void;
 
   /**
    * Error handler that is used by the data stream writer.

--- a/packages/ai/src/ui/call-completion-api.ts
+++ b/packages/ai/src/ui/call-completion-api.ts
@@ -1,11 +1,10 @@
 import { parseJsonEventStream, ParseResult } from '@ai-sdk/provider-utils';
 import {
-  UIMessageStreamPart,
-  uiMessageStreamPartSchema,
-} from '../ui-message-stream/ui-message-stream-parts';
+  UIMessageChunk,
+  uiMessageChunkSchema,
+} from '../ui-message-stream/ui-message-chunks';
 import { consumeStream } from '../util/consume-stream';
 import { processTextStream } from './process-text-stream';
-import { UIDataTypes } from './ui-messages';
 
 // use function to allow for mocking in tests:
 const getOriginalFetch = () => fetch;
@@ -92,12 +91,9 @@ export async function callCompletionApi({
         await consumeStream({
           stream: parseJsonEventStream({
             stream: response.body,
-            schema: uiMessageStreamPartSchema,
+            schema: uiMessageChunkSchema,
           }).pipeThrough(
-            new TransformStream<
-              ParseResult<UIMessageStreamPart>,
-              UIMessageStreamPart
-            >({
+            new TransformStream<ParseResult<UIMessageChunk>, UIMessageChunk>({
               async transform(part) {
                 if (!part.success) {
                   throw part.error;

--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -1,4 +1,4 @@
-import { UIMessageStreamPart } from '../ui-message-stream';
+import { UIMessageChunk } from '../ui-message-stream';
 import { ChatRequestOptions } from './chat';
 import { UIMessage } from './ui-messages';
 
@@ -15,11 +15,11 @@ export interface ChatTransport<UI_MESSAGE extends UIMessage> {
         | 'regenerate-assistant-message';
       messageId: string | undefined;
     } & ChatRequestOptions,
-  ) => Promise<ReadableStream<UIMessageStreamPart>>;
+  ) => Promise<ReadableStream<UIMessageChunk>>;
 
   reconnectToStream: (
     options: {
       chatId: string;
     } & ChatRequestOptions,
-  ) => Promise<ReadableStream<UIMessageStreamPart> | null>;
+  ) => Promise<ReadableStream<UIMessageChunk> | null>;
 }

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1,8 +1,9 @@
 import { createTestServer, mockId } from '@ai-sdk/provider-utils/test';
-import { DefaultChatTransport, UIMessageStreamPart } from '..';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { AbstractChat, ChatInit, ChatState, ChatStatus } from './chat';
 import { UIMessage } from './ui-messages';
+import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
+import { DefaultChatTransport } from './default-chat-transport';
 
 class TestChatState<UI_MESSAGE extends UIMessage>
   implements ChatState<UI_MESSAGE>
@@ -53,7 +54,7 @@ class TestChat extends AbstractChat<UIMessage> {
   }
 }
 
-function formatStreamPart(part: UIMessageStreamPart) {
+function formatStreamPart(part: UIMessageChunk) {
   return `data: ${JSON.stringify(part)}\n\n`;
 }
 

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -30,7 +30,7 @@ import {
   type UIDataTypes,
   type UIMessage,
 } from './ui-messages';
-import { UIMessageStreamPart } from '../ui-message-stream/ui-message-stream-parts';
+import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 
 export type CreateUIMessage<UI_MESSAGE extends UIMessage> = Omit<
   UI_MESSAGE,
@@ -457,7 +457,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
       this.activeResponse = activeResponse;
 
-      let stream: ReadableStream<UIMessageStreamPart>;
+      let stream: ReadableStream<UIMessageChunk>;
 
       if (trigger === 'resume-stream') {
         const reconnect = await this.transport.reconnectToStream({

--- a/packages/ai/src/ui/default-chat-transport.ts
+++ b/packages/ai/src/ui/default-chat-transport.ts
@@ -1,8 +1,8 @@
 import { parseJsonEventStream, ParseResult } from '@ai-sdk/provider-utils';
 import {
-  UIMessageStreamPart,
-  uiMessageStreamPartSchema,
-} from '../ui-message-stream/ui-message-stream-parts';
+  UIMessageChunk,
+  uiMessageChunkSchema,
+} from '../ui-message-stream/ui-message-chunks';
 import {
   HttpChatTransport,
   HttpChatTransportInitOptions,
@@ -18,20 +18,17 @@ export class DefaultChatTransport<
 
   protected processResponseStream(
     stream: ReadableStream<Uint8Array<ArrayBufferLike>>,
-  ): ReadableStream<UIMessageStreamPart> {
+  ): ReadableStream<UIMessageChunk> {
     return parseJsonEventStream({
       stream,
-      schema: uiMessageStreamPartSchema,
+      schema: uiMessageChunkSchema,
     }).pipeThrough(
-      new TransformStream<
-        ParseResult<UIMessageStreamPart>,
-        UIMessageStreamPart
-      >({
-        async transform(part, controller) {
-          if (!part.success) {
-            throw part.error;
+      new TransformStream<ParseResult<UIMessageChunk>, UIMessageChunk>({
+        async transform(chunk, controller) {
+          if (!chunk.success) {
+            throw chunk.error;
           }
-          controller.enqueue(part.value);
+          controller.enqueue(chunk.value);
         },
       }),
     );

--- a/packages/ai/src/ui/http-chat-transport.test.ts
+++ b/packages/ai/src/ui/http-chat-transport.test.ts
@@ -1,5 +1,5 @@
 import { createTestServer } from '@ai-sdk/provider-utils/test';
-import { UIMessageStreamPart } from '../ui-message-stream/ui-message-stream-parts';
+import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import {
   HttpChatTransport,
   HttpChatTransportInitOptions,
@@ -12,7 +12,7 @@ class MockHttpChatTransport extends HttpChatTransport<UIMessage> {
   }
   protected processResponseStream(
     stream: ReadableStream<Uint8Array<ArrayBufferLike>>,
-  ): ReadableStream<UIMessageStreamPart> {
+  ): ReadableStream<UIMessageChunk> {
     return new ReadableStream();
   }
 }

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -1,5 +1,5 @@
 import { FetchFunction } from '@ai-sdk/provider-utils';
-import { UIMessageStreamPart } from '../ui-message-stream/ui-message-stream-parts';
+import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import { ChatTransport } from './chat-transport';
 import { UIMessage } from './ui-messages';
 
@@ -193,7 +193,7 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
 
   async reconnectToStream(
     options: Parameters<ChatTransport<UI_MESSAGE>['reconnectToStream']>[0],
-  ): Promise<ReadableStream<UIMessageStreamPart> | null> {
+  ): Promise<ReadableStream<UIMessageChunk> | null> {
     const preparedRequest = await this.prepareReconnectToStreamRequest?.({
       api: this.api,
       id: options.chatId,
@@ -239,5 +239,5 @@ export abstract class HttpChatTransport<UI_MESSAGE extends UIMessage>
 
   protected abstract processResponseStream(
     stream: ReadableStream<Uint8Array<ArrayBufferLike>>,
-  ): ReadableStream<UIMessageStreamPart>;
+  ): ReadableStream<UIMessageChunk>;
 }

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -1,5 +1,5 @@
 import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
-import { UIMessageStreamPart } from '../../src/ui-message-stream/ui-message-stream-parts';
+import { UIMessageChunk } from '../../src/ui-message-stream/ui-message-chunks';
 import { consumeStream } from '../util/consume-stream';
 import {
   createStreamingUIMessageState,
@@ -8,7 +8,7 @@ import {
 } from './process-ui-message-stream';
 import { InferUIMessageData, UIMessage } from './ui-messages';
 
-function createUIMessageStream(parts: UIMessageStreamPart[]) {
+function createUIMessageStream(parts: UIMessageChunk[]) {
   return convertArrayToReadableStream(parts);
 }
 

--- a/packages/ai/src/ui/text-stream-chat-transport.ts
+++ b/packages/ai/src/ui/text-stream-chat-transport.ts
@@ -1,4 +1,4 @@
-import { UIMessageStreamPart } from '../ui-message-stream/ui-message-stream-parts';
+import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import {
   HttpChatTransport,
   HttpChatTransportInitOptions,
@@ -15,7 +15,7 @@ export class TextStreamChatTransport<
 
   protected processResponseStream(
     stream: ReadableStream<Uint8Array<ArrayBufferLike>>,
-  ): ReadableStream<UIMessageStreamPart> {
+  ): ReadableStream<UIMessageChunk> {
     return transformTextToUiMessageStream({
       stream: stream.pipeThrough(new TextDecoderStream()),
     });

--- a/packages/ai/src/ui/transform-text-to-ui-message-stream.ts
+++ b/packages/ai/src/ui/transform-text-to-ui-message-stream.ts
@@ -1,4 +1,4 @@
-import { UIMessageStreamPart } from '../ui-message-stream';
+import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 
 export function transformTextToUiMessageStream({
   stream,
@@ -6,7 +6,7 @@ export function transformTextToUiMessageStream({
   stream: ReadableStream<string>;
 }) {
   return stream.pipeThrough(
-    new TransformStream<string, UIMessageStreamPart<never, never>>({
+    new TransformStream<string, UIMessageChunk>({
       start(controller) {
         controller.enqueue({ type: 'start' });
         controller.enqueue({ type: 'start-step' });

--- a/packages/langchain/src/langchain-adapter.ts
+++ b/packages/langchain/src/langchain-adapter.ts
@@ -1,4 +1,4 @@
-import { UIMessageStreamPart } from 'ai';
+import { UIMessageChunk } from 'ai';
 import {
   createCallbacksTransformer,
   StreamCallbacks,
@@ -88,7 +88,7 @@ export function toUIMessageStream(
     )
     .pipeThrough(createCallbacksTransformer(callbacks))
     .pipeThrough(
-      new TransformStream<string, UIMessageStreamPart>({
+      new TransformStream<string, UIMessageChunk>({
         start: async controller => {
           controller.enqueue({ type: 'text-start', id: '1' });
         },

--- a/packages/llamaindex/src/llamaindex-adapter.ts
+++ b/packages/llamaindex/src/llamaindex-adapter.ts
@@ -1,4 +1,4 @@
-import { UIMessageStreamPart } from 'ai';
+import { UIMessageChunk } from 'ai';
 import { convertAsyncIteratorToReadableStream } from 'ai/internal';
 import {
   createCallbacksTransformer,
@@ -25,7 +25,7 @@ export function toUIMessageStream(
     )
     .pipeThrough(createCallbacksTransformer(callbacks))
     .pipeThrough(
-      new TransformStream<string, UIMessageStreamPart>({
+      new TransformStream<string, UIMessageChunk>({
         start: async controller => {
           controller.enqueue({ type: 'text-start', id: '1' });
         },

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -13,13 +13,13 @@ import {
   isToolUIPart,
   TextStreamChatTransport,
   UIMessage,
-  UIMessageStreamPart,
+  UIMessageChunk,
 } from 'ai';
 import React, { act, useRef, useState } from 'react';
 import { setupTestComponent } from './setup-test-component';
 import { useChat } from './use-chat';
 
-function formatStreamPart(part: UIMessageStreamPart) {
+function formatChunk(part: UIMessageChunk) {
   return `data: ${JSON.stringify(part)}\n\n`;
 }
 
@@ -83,12 +83,12 @@ describe('data protocol stream', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -167,7 +167,7 @@ describe('data protocol stream', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'error', errorText: 'custom error message' }),
+        formatChunk({ type: 'error', errorText: 'custom error message' }),
       ],
     };
 
@@ -194,11 +194,11 @@ describe('data protocol stream', () => {
         expect(screen.getByTestId('status')).toHaveTextContent('submitted');
       });
 
-      controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
       controller.write(
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
       );
-      controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
 
       await waitFor(() => {
         expect(screen.getByTestId('status')).toHaveTextContent('streaming');
@@ -236,22 +236,18 @@ describe('data protocol stream', () => {
 
     await userEvent.click(screen.getByTestId('do-send'));
 
-    controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
     );
+    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: ',' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
     );
+    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: '.' }));
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-    );
-    controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-    );
-    controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
-    controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'finish',
         messageMetadata: {
           example: 'metadata',
@@ -319,12 +315,12 @@ describe('data protocol stream', () => {
       server.urls['/api/chat'].response = {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       };
 
@@ -354,12 +350,12 @@ describe('data protocol stream', () => {
       server.urls['/api/chat'].response = {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       };
 
@@ -580,12 +576,12 @@ describe('prepareChatRequest', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -695,7 +691,7 @@ describe('onToolCall', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'tool-input-available',
           toolCallId: 'tool-call-0',
           toolName: 'test-tool',
@@ -799,7 +795,7 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-send'));
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-start',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -817,7 +813,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-delta',
         toolCallId: 'tool-call-0',
         inputTextDelta: '{"testArg":"t',
@@ -836,7 +832,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-delta',
         toolCallId: 'tool-call-0',
         inputTextDelta: 'est-value"}}',
@@ -855,7 +851,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -875,7 +871,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-output-available',
         toolCallId: 'tool-call-0',
         output: 'test-result',
@@ -906,7 +902,7 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-send'));
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -926,7 +922,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-output-available',
         toolCallId: 'tool-call-0',
         output: 'test-result',
@@ -956,10 +952,10 @@ describe('tool invocations', () => {
 
     await userEvent.click(screen.getByTestId('do-send'));
 
-    controller.write(formatStreamPart({ type: 'start' }));
-    controller.write(formatStreamPart({ type: 'start-step' }));
+    controller.write(formatChunk({ type: 'start' }));
+    controller.write(formatChunk({ type: 'start-step' }));
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -992,15 +988,15 @@ describe('tool invocations', () => {
       });
     });
 
-    controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'text-delta',
         id: '0',
         delta: 'more text',
       }),
     );
-    controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
     controller.close();
 
     await waitFor(() => {
@@ -1052,12 +1048,12 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-send'));
 
     // start stream
-    controller1.write(formatStreamPart({ type: 'start' }));
-    controller1.write(formatStreamPart({ type: 'start-step' }));
+    controller1.write(formatChunk({ type: 'start' }));
+    controller1.write(formatChunk({ type: 'start-step' }));
 
     // tool call
     controller1.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -1096,8 +1092,8 @@ describe('tool invocations', () => {
     expect(server.calls.length).toBe(1);
 
     // finish stream
-    controller1.write(formatStreamPart({ type: 'finish-step' }));
-    controller1.write(formatStreamPart({ type: 'finish' }));
+    controller1.write(formatChunk({ type: 'finish-step' }));
+    controller1.write(formatChunk({ type: 'finish' }));
 
     await controller1.close();
 
@@ -1119,12 +1115,12 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-send'));
 
     // start stream
-    controller1.write(formatStreamPart({ type: 'start' }));
-    controller1.write(formatStreamPart({ type: 'start-step' }));
+    controller1.write(formatChunk({ type: 'start' }));
+    controller1.write(formatChunk({ type: 'start-step' }));
 
     // tool call
     controller1.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -1133,8 +1129,8 @@ describe('tool invocations', () => {
     );
 
     // finish stream
-    controller1.write(formatStreamPart({ type: 'finish-step' }));
-    controller1.write(formatStreamPart({ type: 'finish' }));
+    controller1.write(formatChunk({ type: 'finish-step' }));
+    controller1.write(formatChunk({ type: 'finish' }));
     await controller1.close();
 
     await waitFor(() => {
@@ -1167,17 +1163,17 @@ describe('tool invocations', () => {
     // should trigger second request w/ tool result
     expect(server.calls.length).toBe(2);
 
-    controller2.write(formatStreamPart({ type: 'start' }));
-    controller2.write(formatStreamPart({ type: 'start-step' }));
+    controller2.write(formatChunk({ type: 'start' }));
+    controller2.write(formatChunk({ type: 'start-step' }));
 
-    controller2.write(formatStreamPart({ type: 'text-start', id: '0' }));
+    controller2.write(formatChunk({ type: 'text-start', id: '0' }));
     controller2.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: 'final result' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: 'final result' }),
     );
-    controller2.write(formatStreamPart({ type: 'text-end', id: '0' }));
+    controller2.write(formatChunk({ type: 'text-end', id: '0' }));
 
-    controller2.write(formatStreamPart({ type: 'finish-step' }));
-    controller2.write(formatStreamPart({ type: 'finish' }));
+    controller2.write(formatChunk({ type: 'finish-step' }));
+    controller2.write(formatChunk({ type: 'finish' }));
 
     await controller2.close();
 
@@ -1236,7 +1232,7 @@ describe('maxSteps', () => {
         {
           type: 'stream-chunks',
           chunks: [
-            formatStreamPart({
+            formatChunk({
               type: 'tool-input-available',
               toolCallId: 'tool-call-0',
               toolName: 'test-tool',
@@ -1247,13 +1243,13 @@ describe('maxSteps', () => {
         {
           type: 'stream-chunks',
           chunks: [
-            formatStreamPart({ type: 'text-start', id: '0' }),
-            formatStreamPart({
+            formatChunk({ type: 'text-start', id: '0' }),
+            formatChunk({
               type: 'text-delta',
               id: '0',
               delta: 'final result',
             }),
-            formatStreamPart({ type: 'text-end', id: '0' }),
+            formatChunk({ type: 'text-end', id: '0' }),
           ],
         },
       ];
@@ -1317,7 +1313,7 @@ describe('maxSteps', () => {
         {
           type: 'stream-chunks',
           chunks: [
-            formatStreamPart({
+            formatChunk({
               type: 'tool-input-available',
               toolCallId: 'tool-call-0',
               toolName: 'test-tool',
@@ -1398,16 +1394,16 @@ describe('file attachments with data url', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'text-start',
           id: '0',
         }),
-        formatStreamPart({
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with text attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -1488,16 +1484,16 @@ describe('file attachments with data url', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'text-start',
           id: '0',
         }),
-        formatStreamPart({
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with image attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -1620,16 +1616,16 @@ describe('file attachments with url', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'text-start',
           id: '0',
         }),
-        formatStreamPart({
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with image attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -1735,13 +1731,13 @@ describe('attachments with empty submit', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with image attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -1843,13 +1839,13 @@ describe('should send message with attachments', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with image attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -1957,25 +1953,25 @@ describe('regenerate', () => {
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
             type: 'text-delta',
             id: '0',
             delta: 'first response',
           }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
             type: 'text-delta',
             id: '0',
             delta: 'second response',
           }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
     ];
@@ -2059,13 +2055,13 @@ describe('test sending additional fields during message submission', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'first response',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -2151,25 +2147,21 @@ describe('resume ongoing stream and return assistant message', () => {
       expect(screen.getByTestId('status')).toHaveTextContent('submitted');
     });
 
-    controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
     );
 
     await waitFor(() => {
       expect(screen.getByTestId('status')).toHaveTextContent('streaming');
     });
 
+    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: ',' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
     );
-    controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-    );
-    controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-    );
-    controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: '.' }));
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
 
     controller.close();
 
@@ -2235,9 +2227,9 @@ describe('stop', () => {
 
     await userEvent.click(screen.getByTestId('do-send'));
 
-    controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
     );
 
     await waitFor(() => {
@@ -2253,7 +2245,7 @@ describe('stop', () => {
 
     await expect(
       controller.write(
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ', world!' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ', world!' }),
       ),
     ).rejects.toThrow();
 
@@ -2307,9 +2299,9 @@ describe('experimental_throttle', () => {
 
     vi.useFakeTimers();
 
-    controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hel' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hel' }),
     );
     await act(async () => {
       await vi.advanceTimersByTimeAsync(throttleMs + 10);
@@ -2317,16 +2309,14 @@ describe('experimental_throttle', () => {
 
     expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
 
+    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: 'lo' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: 'lo' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: ' Th' }),
     );
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: ' Th' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: 'ere' }),
     );
-    controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: 'ere' }),
-    );
-    controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
 
     expect(screen.getByTestId('message-1')).not.toHaveTextContent(
       'AI: Hello There',

--- a/packages/react/src/use-completion.ui.test.tsx
+++ b/packages/react/src/use-completion.ui.test.tsx
@@ -5,11 +5,11 @@ import {
 import '@testing-library/jest-dom/vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { UIMessageStreamPart } from 'ai';
+import { UIMessageChunk } from 'ai';
 import { setupTestComponent } from './setup-test-component';
 import { useCompletion } from './use-completion';
 
-function formatStreamPart(part: UIMessageStreamPart) {
+function formatChunk(part: UIMessageChunk) {
   return `data: ${JSON.stringify(part)}\n\n`;
 }
 
@@ -60,10 +60,10 @@ describe('stream data stream', () => {
       server.urls['/api/completion'].response = {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
         ],
       };
       await userEvent.type(screen.getByTestId('input'), 'hi{enter}');
@@ -99,7 +99,7 @@ describe('stream data stream', () => {
       await userEvent.type(screen.getByTestId('input'), 'hi{enter}');
 
       controller.write(
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
       );
 
       await waitFor(() => {

--- a/packages/svelte/src/completion.svelte.test.ts
+++ b/packages/svelte/src/completion.svelte.test.ts
@@ -3,11 +3,11 @@ import {
   TestResponseController,
 } from '@ai-sdk/provider-utils/test';
 import { render } from '@testing-library/svelte';
-import type { UIMessageStreamPart } from 'ai';
+import type { UIMessageChunk } from 'ai';
 import { Completion } from './completion.svelte.js';
 import CompletionSynchronization from './tests/completion-synchronization.svelte';
 
-function formatStreamPart(part: UIMessageStreamPart) {
+function formatChunk(part: UIMessageChunk) {
   return `data: ${JSON.stringify(part)}\n\n`;
 }
 
@@ -20,12 +20,12 @@ describe('Completion', () => {
     server.urls['/api/completion'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -49,12 +49,12 @@ describe('Completion', () => {
     server.urls['/api/completion'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -103,12 +103,12 @@ describe('Completion', () => {
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-          formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
     ];
@@ -128,12 +128,12 @@ describe('synchronization', () => {
     server.urls['/api/completion'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -165,11 +165,11 @@ describe('synchronization', () => {
       expect(completion2.loading).toBe(true);
     });
 
-    controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
-      formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
     );
-    controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
     await vi.waitFor(() => {
       expect(completion1.completion).toBe('Hello');
       expect(completion2.completion).toBe('Hello');

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -5,7 +5,7 @@ import {
 import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/vue';
-import { UIMessageStreamPart } from 'ai';
+import { UIMessageChunk } from 'ai';
 import { setupTestComponent } from './setup-test-component';
 import TestChatAppendAttachmentsComponent from './TestChatAppendAttachmentsComponent.vue';
 import TestChatAttachmentsComponent from './TestChatAttachmentsComponent.vue';
@@ -17,7 +17,7 @@ import TestChatTextStreamComponent from './TestChatTextStreamComponent.vue';
 import TestChatToolInvocationsComponent from './TestChatToolInvocationsComponent.vue';
 import TestChatUrlAttachmentsComponent from './TestChatUrlAttachmentsComponent.vue';
 
-function formatStreamPart(part: UIMessageStreamPart) {
+function formatChunk(part: UIMessageChunk) {
   return `data: ${JSON.stringify(part)}\n\n`;
 }
 
@@ -32,12 +32,12 @@ describe('prepareSubmitMessagesRequest', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -92,12 +92,12 @@ describe('data protocol stream', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -143,11 +143,11 @@ describe('data protocol stream', () => {
         expect(screen.getByTestId('status')).toHaveTextContent('submitted');
       });
 
-      controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
       controller.write(
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
       );
-      controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
 
       await waitFor(() => {
         expect(screen.getByTestId('status')).toHaveTextContent('streaming');
@@ -175,9 +175,9 @@ describe('data protocol stream', () => {
           expect(screen.getByTestId('status')).toHaveTextContent('submitted'),
         );
 
-        controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+        controller.write(formatChunk({ type: 'text-start', id: '0' }));
         controller.write(
-          formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
         );
 
         await waitFor(() =>
@@ -191,9 +191,9 @@ describe('data protocol stream', () => {
         document.dispatchEvent(new Event('visibilitychange'));
 
         controller.write(
-          formatStreamPart({ type: 'text-delta', id: '0', delta: ' world.' }),
+          formatChunk({ type: 'text-delta', id: '0', delta: ' world.' }),
         );
-        controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+        controller.write(formatChunk({ type: 'text-end', id: '0' }));
         controller.close();
 
         await waitFor(() =>
@@ -227,13 +227,13 @@ describe('data protocol stream', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
-        formatStreamPart({ type: 'finish' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'finish' }),
       ],
     };
 
@@ -320,25 +320,25 @@ describe('regenerate', () => {
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
             type: 'text-delta',
             id: '0',
             delta: 'first response',
           }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
             type: 'text-delta',
             id: '0',
             delta: 'second response',
           }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
     ];
@@ -397,13 +397,13 @@ describe('tool invocations', () => {
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
             type: 'text-delta',
             id: '0',
             delta: 'extra text',
           }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
     ];
@@ -411,7 +411,7 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-append'));
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-start',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -425,7 +425,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-delta',
         toolCallId: 'tool-call-0',
         inputTextDelta: '{"testArg":"t',
@@ -439,7 +439,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-delta',
         toolCallId: 'tool-call-0',
         inputTextDelta: 'est-value"}}',
@@ -453,7 +453,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -473,7 +473,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-output-available',
         toolCallId: 'tool-call-0',
         output: 'test-result',
@@ -510,13 +510,13 @@ describe('tool invocations', () => {
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
             type: 'text-delta',
             id: '0',
             delta: 'extra text',
           }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
     ];
@@ -524,7 +524,7 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-append'));
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -544,7 +544,7 @@ describe('tool invocations', () => {
     });
 
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-output-available',
         toolCallId: 'tool-call-0',
         output: 'test-result',
@@ -573,23 +573,23 @@ describe('tool invocations', () => {
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
             type: 'text-delta',
             id: '0',
             delta: 'extra text',
           }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
     ];
 
     await userEvent.click(screen.getByTestId('do-append'));
 
-    controller.write(formatStreamPart({ type: 'start' }));
-    controller.write(formatStreamPart({ type: 'start-step' }));
+    controller.write(formatChunk({ type: 'start' }));
+    controller.write(formatChunk({ type: 'start-step' }));
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -611,15 +611,15 @@ describe('tool invocations', () => {
       );
     });
 
-    controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
-      formatStreamPart({
+      formatChunk({
         type: 'text-delta',
         id: '0',
         delta: 'more text',
       }),
     );
-    controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
     controller.close();
 
     // DO NOT REMOVE: used to ensure test does not have side-effects
@@ -637,13 +637,13 @@ describe('tool invocations', () => {
       {
         type: 'stream-chunks',
         chunks: [
-          formatStreamPart({ type: 'text-start', id: '0' }),
-          formatStreamPart({
+          formatChunk({ type: 'text-start', id: '0' }),
+          formatChunk({
             type: 'text-delta',
             id: '0',
             delta: 'extra text',
           }),
-          formatStreamPart({ type: 'text-end', id: '0' }),
+          formatChunk({ type: 'text-end', id: '0' }),
         ],
       },
     ];
@@ -651,12 +651,12 @@ describe('tool invocations', () => {
     await userEvent.click(screen.getByTestId('do-append'));
 
     // start stream
-    controller1.write(formatStreamPart({ type: 'start' }));
-    controller1.write(formatStreamPart({ type: 'start-step' }));
+    controller1.write(formatChunk({ type: 'start' }));
+    controller1.write(formatChunk({ type: 'start-step' }));
 
     // tool call
     controller1.write(
-      formatStreamPart({
+      formatChunk({
         type: 'tool-input-available',
         toolCallId: 'tool-call-0',
         toolName: 'test-tool',
@@ -684,8 +684,8 @@ describe('tool invocations', () => {
     expect(server.calls.length).toBe(1);
 
     // finish stream
-    controller1.write(formatStreamPart({ type: 'finish-step' }));
-    controller1.write(formatStreamPart({ type: 'finish' }));
+    controller1.write(formatChunk({ type: 'finish-step' }));
+    controller1.write(formatChunk({ type: 'finish' }));
 
     await controller1.close();
 
@@ -708,16 +708,16 @@ describe('file attachments with data url', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'text-start',
           id: '0',
         }),
-        formatStreamPart({
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with text attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -773,16 +773,16 @@ describe('file attachments with data url', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'text-start',
           id: '0',
         }),
-        formatStreamPart({
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with image attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -842,16 +842,16 @@ describe('file attachments with url', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'text-start',
           id: '0',
         }),
-        formatStreamPart({
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with image attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -903,16 +903,16 @@ describe('attachments with empty submit', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'text-start',
           id: '0',
         }),
-        formatStreamPart({
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to empty message with attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -969,16 +969,16 @@ describe('should append message with attachments', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({
+        formatChunk({
           type: 'text-start',
           id: '0',
         }),
-        formatStreamPart({
+        formatChunk({
           type: 'text-delta',
           id: '0',
           delta: 'Response to message with image attachment',
         }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -1027,12 +1027,12 @@ describe('init messages', () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 

--- a/packages/vue/src/use-completion.ui.test.ts
+++ b/packages/vue/src/use-completion.ui.test.ts
@@ -5,12 +5,12 @@ import {
 import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import { findByText, screen } from '@testing-library/vue';
-import { UIMessageStreamPart } from 'ai';
+import { UIMessageChunk } from 'ai';
 import TestCompletionComponent from './TestCompletionComponent.vue';
 import TestCompletionTextStreamComponent from './TestCompletionTextStreamComponent.vue';
 import { setupTestComponent } from './setup-test-component';
 
-function formatStreamPart(part: UIMessageStreamPart) {
+function formatChunk(part: UIMessageChunk) {
   return `data: ${JSON.stringify(part)}\n\n`;
 }
 
@@ -25,12 +25,12 @@ describe('stream data stream', () => {
     server.urls['/api/completion'].response = {
       type: 'stream-chunks',
       chunks: [
-        formatStreamPart({ type: 'text-start', id: '0' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ',' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: ' world' }),
-        formatStreamPart({ type: 'text-delta', id: '0', delta: '.' }),
-        formatStreamPart({ type: 'text-end', id: '0' }),
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
       ],
     };
 
@@ -53,11 +53,11 @@ describe('stream data stream', () => {
       await screen.findByTestId('loading');
       expect(screen.getByTestId('loading')).toHaveTextContent('true');
 
-      controller.write(formatStreamPart({ type: 'text-start', id: '0' }));
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
       controller.write(
-        formatStreamPart({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
       );
-      controller.write(formatStreamPart({ type: 'text-end', id: '0' }));
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
       controller.close();
 
       await findByText(await screen.findByTestId('loading'), 'false');


### PR DESCRIPTION
## Background

The name `UIMessageStreamParts` is confusing since `UIMessage` objects also have a `parts` property.

## Summary

Rename `UIMessageStreamPart` to `UIMessageChunk`.