### PR TITLE
update provider documentation to use shorter method names

### DIFF
--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -412,14 +412,14 @@ console.log('Sources:', await result.sources);
 
 ## Image Models
 
-You can create xAI image models using the `.imageModel()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
+You can create xAI image models using the `.image()` factory method. For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ```ts
 import { xai } from '@ai-sdk/xai';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: xai.imageModel('grok-2-image'),
+  model: xai.image('grok-2-image'),
   prompt: 'A futuristic cityscape at sunset',
 });
 ```
@@ -438,7 +438,7 @@ import { xai } from '@ai-sdk/xai';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { images } = await generateImage({
-  model: xai.imageModel('grok-2-image'),
+  model: xai.image('grok-2-image'),
   prompt: 'A futuristic cityscape at sunset',
   maxImagesPerCall: 5, // Default is 10
   n: 2, // Generate 2 images

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -893,10 +893,10 @@ The following optional provider options are available for OpenAI completion mode
 ## Embedding Models
 
 You can create models that call the [OpenAI embeddings API](https://platform.openai.com/docs/api-reference/embeddings)
-using the `.textEmbeddingModel()` factory method.
+using the `.textEmbedding()` factory method.
 
 ```ts
-const model = openai.textEmbeddingModel('text-embedding-3-large');
+const model = openai.textEmbedding('text-embedding-3-large');
 ```
 
 OpenAI embedding models support several additional provider options.
@@ -907,7 +907,7 @@ import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: openai.textEmbeddingModel('text-embedding-3-large'),
+  model: openai.textEmbedding('text-embedding-3-large'),
   value: 'sunny day at the beach',
   providerOptions: {
     openai: {

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -422,10 +422,10 @@ The following optional provider options are available for Azure OpenAI completio
 ## Embedding Models
 
 You can create models that call the Azure OpenAI embeddings API
-using the `.textEmbeddingModel()` factory method.
+using the `.textEmbedding()` factory method.
 
 ```ts
-const model = azure.textEmbeddingModel('your-embedding-deployment');
+const model = azure.textEmbedding('your-embedding-deployment');
 ```
 
 Azure OpenAI embedding models support several additional settings.
@@ -436,7 +436,7 @@ import { azure } from '@ai-sdk/azure';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: azure.textEmbeddingModel('your-embedding-deployment'),
+  model: azure.textEmbedding('your-embedding-deployment'),
   value: 'sunny day at the beach',
   providerOptions: {
     azure: {
@@ -461,17 +461,17 @@ The following optional provider options are available for Azure OpenAI embedding
 
 ## Image Models
 
-You can create models that call the Azure OpenAI image generation API (DALL-E) using the `.imageModel()` factory method. The first argument is your deployment name for the DALL-E model.
+You can create models that call the Azure OpenAI image generation API (DALL-E) using the `.image()` factory method. The first argument is your deployment name for the DALL-E model.
 
 ```ts
-const model = azure.imageModel('your-dalle-deployment-name');
+const model = azure.image('your-dalle-deployment-name');
 ```
 
 Azure OpenAI image models support several additional settings. You can pass them as `providerOptions.azure` when generating the image:
 
 ```ts
 await generateImage({
-  model: azure.imageModel('your-dalle-deployment-name'),
+  model: azure.image('your-dalle-deployment-name'),
   prompt: 'A photorealistic image of a cat astronaut floating in space',
   size: '1024x1024', // '1024x1024', '1792x1024', or '1024x1792' for DALL-E 3
   providerOptions: {
@@ -492,7 +492,7 @@ import { azure } from '@ai-sdk/azure';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: azure.imageModel('your-dalle-deployment-name'),
+  model: azure.image('your-dalle-deployment-name'),
   prompt: 'A photorealistic image of a cat astronaut floating in space',
   size: '1024x1024', // '1024x1024', '1792x1024', or '1024x1792' for DALL-E 3
 });

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -436,10 +436,10 @@ on how to integrate reasoning into your chatbot.
 ## Embedding Models
 
 You can create models that call the Bedrock API [Bedrock API](https://docs.aws.amazon.com/bedrock/latest/userguide/titan-embedding-models.html)
-using the `.textEmbeddingModel()` factory method.
+using the `.textEmbedding()` factory method.
 
 ```ts
-const model = bedrock.textEmbeddingModel('amazon.titan-embed-text-v1');
+const model = bedrock.textEmbedding('amazon.titan-embed-text-v1');
 ```
 
 Bedrock Titan embedding model amazon.titan-embed-text-v2:0 supports several additional settings.
@@ -449,7 +449,7 @@ You can pass them as an options argument:
 import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { embed } from 'ai';
 
-const model = bedrock.textEmbeddingModel('amazon.titan-embed-text-v2:0');
+const model = bedrock.textEmbedding('amazon.titan-embed-text-v2:0');
 
 const { embedding } = await embed({
   model,
@@ -506,7 +506,7 @@ import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: bedrock.imageModel('amazon.nova-canvas-v1:0'),
+  model: bedrock.image('amazon.nova-canvas-v1:0'),
   prompt: 'A beautiful sunset over a calm ocean',
   size: '512x512',
   seed: 42,
@@ -520,7 +520,7 @@ import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: bedrock.imageModel('amazon.nova-canvas-v1:0'),
+  model: bedrock.image('amazon.nova-canvas-v1:0'),
   prompt: 'A beautiful sunset over a calm ocean',
   size: '512x512',
   seed: 42,
@@ -567,7 +567,7 @@ You can customize the generation behavior with optional options:
 
 ```ts
 await generateImage({
-  model: bedrock.imageModel('amazon.nova-canvas-v1:0'),
+  model: bedrock.image('amazon.nova-canvas-v1:0'),
   prompt: 'A beautiful sunset over a calm ocean',
   size: '512x512',
   seed: 42,

--- a/content/providers/01-ai-sdk-providers/11-deepinfra.mdx
+++ b/content/providers/01-ai-sdk-providers/11-deepinfra.mdx
@@ -186,7 +186,7 @@ For more details and pricing information, see the [DeepInfra text-to-image model
 
 ## Embedding Models
 
-You can create DeepInfra embedding models using the `.textEmbeddingModel()` factory method.
+You can create DeepInfra embedding models using the `.textEmbedding()` factory method.
 For more on embedding models with the AI SDK see [embed()](/docs/reference/ai-sdk-core/embed).
 
 ```ts
@@ -194,7 +194,7 @@ import { deepinfra } from '@ai-sdk/deepinfra';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: deepinfra.textEmbeddingModel('BAAI/bge-large-en-v1.5'),
+  model: deepinfra.textEmbedding('BAAI/bge-large-en-v1.5'),
   value: 'sunny day at the beach',
 });
 ```

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -557,10 +557,10 @@ The system instruction is automatically formatted and included in the conversati
 ## Embedding Models
 
 You can create models that call the [Google Generative AI embeddings API](https://ai.google.dev/gemini-api/docs/embeddings)
-using the `.textEmbeddingModel()` factory method.
+using the `.textEmbedding()` factory method.
 
 ```ts
-const model = google.textEmbeddingModel('text-embedding-004');
+const model = google.textEmbedding('text-embedding-004');
 ```
 
 Google Generative AI embedding models support aditional settings. You can pass them as an options argument:
@@ -569,7 +569,7 @@ Google Generative AI embedding models support aditional settings. You can pass t
 import { google } from '@ai-sdk/google';
 import { embed } from 'ai';
 
-const model = google.textEmbeddingModel('text-embedding-004');
+const model = google.textEmbedding('text-embedding-004');
 
 const { embedding } = await embed({
   model,

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -638,10 +638,10 @@ The following Zod features are known to not work with Google Vertex:
 
 ### Embedding Models
 
-You can create models that call the Google Vertex AI embeddings API using the `.textEmbeddingModel()` factory method:
+You can create models that call the Google Vertex AI embeddings API using the `.textEmbedding()` factory method:
 
 ```ts
-const model = vertex.textEmbeddingModel('text-embedding-004');
+const model = vertex.textEmbedding('text-embedding-004');
 ```
 
 Google Vertex AI embedding models support additional settings. You can pass them as an options argument:
@@ -650,7 +650,7 @@ Google Vertex AI embedding models support additional settings. You can pass them
 import { vertex } from '@ai-sdk/google-vertex';
 import { embed } from 'ai';
 
-const model = vertex.textEmbeddingModel('text-embedding-004');
+const model = vertex.textEmbedding('text-embedding-004');
 
 const { embedding } = await embed({
   model,

--- a/content/providers/01-ai-sdk-providers/20-mistral.mdx
+++ b/content/providers/01-ai-sdk-providers/20-mistral.mdx
@@ -224,10 +224,10 @@ Mistral language models can also be used in the `streamText`, `generateObject`, 
 ## Embedding Models
 
 You can create models that call the [Mistral embeddings API](https://docs.mistral.ai/api/#operation/createEmbedding)
-using the `.textEmbeddingModel()` factory method.
+using the `.textEmbedding()` factory method.
 
 ```ts
-const model = mistral.textEmbeddingModel('mistral-embed');
+const model = mistral.textEmbedding('mistral-embed');
 ```
 
 You can use Mistral embedding models to generate embeddings with the `embed` function:
@@ -237,7 +237,7 @@ import { mistral } from '@ai-sdk/mistral';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: mistral.textEmbeddingModel('mistral-embed'),
+  model: mistral.textEmbedding('mistral-embed'),
   value: 'sunny day at the beach',
 });
 ```

--- a/content/providers/01-ai-sdk-providers/24-togetherai.mdx
+++ b/content/providers/01-ai-sdk-providers/24-togetherai.mdx
@@ -108,7 +108,7 @@ const { text } = await generateText({
 Together.ai language models can also be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
-The Together.ai provider also supports [completion models](https://docs.together.ai/docs/serverless-models#language-models) via (following the above example code) `togetherai.completionModel()` and [embedding models](https://docs.together.ai/docs/serverless-models#embedding-models) via `togetherai.textEmbeddingModel()`.
+The Together.ai provider also supports [completion models](https://docs.together.ai/docs/serverless-models#language-models) via (following the above example code) `togetherai.completion()` and [embedding models](https://docs.together.ai/docs/serverless-models#embedding-models) via `togetherai.textEmbedding()`.
 
 ## Model Capabilities
 
@@ -191,7 +191,7 @@ Together.ai image models support various image dimensions that vary by model. Co
 
 ## Embedding Models
 
-You can create Together.ai embedding models using the `.textEmbeddingModel()` factory method.
+You can create Together.ai embedding models using the `.textEmbedding()` factory method.
 For more on embedding models with the AI SDK see [embed()](/docs/reference/ai-sdk-core/embed).
 
 ```ts
@@ -199,7 +199,7 @@ import { togetherai } from '@ai-sdk/togetherai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: togetherai.textEmbeddingModel(
+  model: togetherai.textEmbedding(
     'togethercomputer/m2-bert-80M-2k-retrieval',
   ),
   value: 'sunny day at the beach',

--- a/content/providers/01-ai-sdk-providers/24-togetherai.mdx
+++ b/content/providers/01-ai-sdk-providers/24-togetherai.mdx
@@ -199,9 +199,7 @@ import { togetherai } from '@ai-sdk/togetherai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: togetherai.textEmbedding(
-    'togethercomputer/m2-bert-80M-2k-retrieval',
-  ),
+  model: togetherai.textEmbedding('togethercomputer/m2-bert-80M-2k-retrieval'),
   value: 'sunny day at the beach',
 });
 ```

--- a/content/providers/01-ai-sdk-providers/25-cohere.mdx
+++ b/content/providers/01-ai-sdk-providers/25-cohere.mdx
@@ -118,10 +118,10 @@ Cohere language models can also be used in the `streamText`, `generateObject`, a
 ## Embedding Models
 
 You can create models that call the [Cohere embed API](https://docs.cohere.com/v2/reference/embed)
-using the `.textEmbeddingModel()` factory method.
+using the `.textEmbedding()` factory method.
 
 ```ts
-const model = cohere.textEmbeddingModel('embed-english-v3.0');
+const model = cohere.textEmbedding('embed-english-v3.0');
 ```
 
 You can use Cohere embedding models to generate embeddings with the `embed` function:
@@ -131,7 +131,7 @@ import { cohere } from '@ai-sdk/cohere';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: cohere.textEmbeddingModel('embed-english-v3.0'),
+  model: cohere.textEmbedding('embed-english-v3.0'),
   value: 'sunny day at the beach',
   providerOptions: {
     cohere: {
@@ -148,7 +148,7 @@ import { cohere } from '@ai-sdk/cohere';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: cohere.textEmbeddingModel('embed-english-v3.0'),
+  model: cohere.textEmbedding('embed-english-v3.0'),
   value: 'sunny day at the beach',
   providerOptions: {
     cohere: {

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -110,9 +110,7 @@ Fireworks language models can also be used in the `streamText` function
 You can create models that call the Fireworks completions API using the `.completion()` factory method:
 
 ```ts
-const model = fireworks.completion(
-  'accounts/fireworks/models/firefunction-v1',
-);
+const model = fireworks.completion('accounts/fireworks/models/firefunction-v1');
 ```
 
 ### Model Capabilities

--- a/content/providers/01-ai-sdk-providers/26-fireworks.mdx
+++ b/content/providers/01-ai-sdk-providers/26-fireworks.mdx
@@ -107,10 +107,10 @@ Fireworks language models can also be used in the `streamText` function
 
 ### Completion Models
 
-You can create models that call the Fireworks completions API using the `.completionModel()` factory method:
+You can create models that call the Fireworks completions API using the `.completion()` factory method:
 
 ```ts
-const model = fireworks.completionModel(
+const model = fireworks.completion(
   'accounts/fireworks/models/firefunction-v1',
 );
 ```
@@ -144,10 +144,10 @@ const model = fireworks.completionModel(
 
 ## Embedding Models
 
-You can create models that call the Fireworks embeddings API using the `.textEmbeddingModel()` factory method:
+You can create models that call the Fireworks embeddings API using the `.textEmbedding()` factory method:
 
 ```ts
-const model = fireworks.textEmbeddingModel('nomic-ai/nomic-embed-text-v1.5');
+const model = fireworks.textEmbedding('nomic-ai/nomic-embed-text-v1.5');
 ```
 
 You can use Fireworks embedding models to generate embeddings with the `embed` function:
@@ -157,7 +157,7 @@ import { fireworks } from '@ai-sdk/fireworks';
 import { embed } from 'ai';
 
 const { embedding } = await embed({
-  model: fireworks.textEmbeddingModel('nomic-ai/nomic-embed-text-v1.5'),
+  model: fireworks.textEmbedding('nomic-ai/nomic-embed-text-v1.5'),
   value: 'sunny day at the beach',
 });
 ```
@@ -175,7 +175,7 @@ const { embedding } = await embed({
 
 ## Image Models
 
-You can create Fireworks image models using the `.imageModel()` factory method.
+You can create Fireworks image models using the `.image()` factory method.
 For more on image generation with the AI SDK see [generateImage()](/docs/reference/ai-sdk-core/generate-image).
 
 ```ts
@@ -183,7 +183,7 @@ import { fireworks } from '@ai-sdk/fireworks';
 import { experimental_generateImage as generateImage } from 'ai';
 
 const { image } = await generateImage({
-  model: fireworks.imageModel('accounts/fireworks/models/flux-1-dev-fp8'),
+  model: fireworks.image('accounts/fireworks/models/flux-1-dev-fp8'),
   prompt: 'A futuristic cityscape at sunset',
   aspectRatio: '16:9',
 });


### PR DESCRIPTION
## background

v5 updates (`.imageModel()`, `.textEmbeddingModel()`, `.completionModel()`) in favor of shorter alternatives (`.image()`, `.textEmbedding()`, `.completion()`).

## summary

- update provider docs to use `.image()` instead of `.imageModel()`
- update provider docs to use `.textEmbedding()` instead of `.textEmbeddingModel()` 
- update provider docs to use `.completion()` instead of `.completionModel()`

## verification

- all provider documentation now uses consistent shorter method names
- examples and factory method descriptions updated across 11 provider files
- both method names still work (shorter preferred, longer shows deprecation warnings)

## tasks

- [x] updated xAI provider documentation 
- [x] updated OpenAI provider documentation
- [x] updated Azure provider documentation
- [x] updated Amazon Bedrock provider documentation
- [x] updated Fireworks provider documentation
- [x] updated DeepInfra provider documentation
- [x] updated Mistral provider documentation
- [x] updated Cohere provider documentation
- [x] updated TogetherAI provider documentation
- [x] updated Google Generative AI provider documentation
- [x] updated Google Vertex provider documentation 