### PR TITLE
Allow destructuring `output` and `errorText` on `ToolUIPart`

### DIFF
--- a/.changeset/cuddly-phones-smell.md
+++ b/.changeset/cuddly-phones-smell.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-Allow destructuring `ToolUIPart` type
+Allow destructuring output and errorText on `ToolUIPart` type

--- a/.changeset/cuddly-phones-smell.md
+++ b/.changeset/cuddly-phones-smell.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Allow destrucuting `ToolUIPart` type

--- a/.changeset/cuddly-phones-smell.md
+++ b/.changeset/cuddly-phones-smell.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-Allow destrucuting `ToolUIPart` type
+Allow destructuring `ToolUIPart` type

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -179,21 +179,27 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
         state: 'input-streaming';
         input: DeepPartial<TOOLS[NAME]['input']>;
         providerExecuted?: boolean;
+        output: undefined;
+        errorText: undefined;
       }
     | {
         state: 'input-available';
         input: TOOLS[NAME]['input'];
         providerExecuted?: boolean;
+        output: undefined;
+        errorText: undefined;
       }
     | {
         state: 'output-available';
         input: TOOLS[NAME]['input'];
         output: TOOLS[NAME]['output'];
+        errorText: undefined;
         providerExecuted?: boolean;
       }
     | {
         state: 'output-error';
         input: TOOLS[NAME]['input'];
+        output: undefined;
         errorText: string;
         providerExecuted?: boolean;
       }

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -169,7 +169,6 @@ export type DataUIPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
     data: DATA_TYPES[NAME];
   };
 }>;
-
 export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
   [NAME in keyof TOOLS & string]: {
     type: `tool-${NAME}`;
@@ -179,27 +178,27 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
         state: 'input-streaming';
         input: DeepPartial<TOOLS[NAME]['input']>;
         providerExecuted?: boolean;
-        output: undefined;
-        errorText: undefined;
+        output?: never;
+        errorText?: never;
       }
     | {
         state: 'input-available';
         input: TOOLS[NAME]['input'];
         providerExecuted?: boolean;
-        output: undefined;
-        errorText: undefined;
+        output?: never;
+        errorText?: never;
       }
     | {
         state: 'output-available';
         input: TOOLS[NAME]['input'];
         output: TOOLS[NAME]['output'];
-        errorText: undefined;
+        errorText?: never;
         providerExecuted?: boolean;
       }
     | {
         state: 'output-error';
         input: TOOLS[NAME]['input'];
-        output: undefined;
+        output?: never;
         errorText: string;
         providerExecuted?: boolean;
       }


### PR DESCRIPTION
This way you can accomplish the following use case, rendering a component for a tool type safely:

```tsx

export function EditorToolPreview({
  input,
  state,
  toolCallId,
  output,
}: Extract<MyToolPart, { type: 'tool-str_replace_editor' }>) {
  return <pre>{JSON.stringify(output, null, 2)}</pre>;
}

function ChatMessage({ message }: { message: MyUIMessage }) {
  return (
    <ChatAssistantMessage className="">
      {message.parts.map((part: any, index: number) => {
        if (part.type === 'text') {
          return <Markdown key={index} markdown={part.text} />;
        }

        if (part.type === 'tool-str_replace_editor') {
          return <EditorToolPreview key={index} {...part} />;
        }

        return null;
      })}
    </ChatAssistantMessage>
  );
}

```

Without this PR you can't destructure output directly in the component props because you would need to discriminate on `state` first:

```tsx
export function EditorToolPreview(
  props: Extract<MyToolPart, { type: 'tool-str_replace_editor' }>,
) {
  if (props.state === 'output-available') {
    return <pre>{JSON.stringify(props.output, null, 2)}</pre>;
  }
  return null;
}
```

This means changing a lot of code to migrate to v5 to use props instead of destructuring