### PR TITLE
feat(provider/perplexity): support image input

### DIFF
--- a/.changeset/modern-trains-reflect.md
+++ b/.changeset/modern-trains-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/perplexity': major
+---
+
+feat(provider/perplexity): support image input

--- a/packages/perplexity/src/__snapshots__/convert-to-perplexity-messages.test.ts.snap
+++ b/packages/perplexity/src/__snapshots__/convert-to-perplexity-messages.test.ts.snap
@@ -18,6 +18,26 @@ exports[`convertToPerplexityMessages > system messages > should convert a system
 ]
 `;
 
+exports[`convertToPerplexityMessages > user messages > should convert a user message with image parts 1`] = `
+[
+  {
+    "content": [
+      {
+        "text": "Hello ",
+        "type": "text",
+      },
+      {
+        "image_url": {
+          "url": "data:image/png;base64,AAECAw==",
+        },
+        "type": "image_url",
+      },
+    ],
+    "role": "user",
+  },
+]
+`;
+
 exports[`convertToPerplexityMessages > user messages > should convert a user message with text parts 1`] = `
 [
   {

--- a/packages/perplexity/src/convert-to-perplexity-messages.test.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.test.ts
@@ -29,6 +29,24 @@ describe('convertToPerplexityMessages', () => {
         ]),
       ).toMatchSnapshot();
     });
+
+    it('should convert a user message with image parts', () => {
+      expect(
+        convertToPerplexityMessages([
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Hello ' },
+              {
+                type: 'file',
+                data: new Uint8Array([0, 1, 2, 3]),
+                mediaType: 'image/png',
+              },
+            ],
+          },
+        ]),
+      ).toMatchSnapshot();
+    });
   });
 
   describe('assistant messages', () => {

--- a/packages/perplexity/src/convert-to-perplexity-messages.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.ts
@@ -2,7 +2,11 @@ import {
   LanguageModelV2Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
-import { PerplexityPrompt } from './perplexity-language-model-prompt';
+import {
+  PerplexityMessageContent,
+  PerplexityPrompt,
+} from './perplexity-language-model-prompt';
+import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 
 export function convertToPerplexityMessages(
   prompt: LanguageModelV2Prompt,
@@ -18,18 +22,49 @@ export function convertToPerplexityMessages(
 
       case 'user':
       case 'assistant': {
+        const hasImage = content.some(
+          part => part.type === 'file' && part.mediaType.startsWith('image/'),
+        );
+
+        const messageContent = content
+          .map(part => {
+            switch (part.type) {
+              case 'text': {
+                return {
+                  type: 'text',
+                  text: part.text,
+                };
+              }
+              case 'file': {
+                return part.data instanceof URL
+                  ? {
+                      type: 'image_url',
+                      image_url: {
+                        url: part.data.toString(),
+                      },
+                    }
+                  : {
+                      type: 'image_url',
+                      image_url: {
+                        url: `data:${part.mediaType ?? 'image/jpeg'};base64,${
+                          typeof part.data === 'string'
+                            ? part.data
+                            : convertUint8ArrayToBase64(part.data)
+                        }`,
+                      },
+                    };
+              }
+            }
+          })
+          .filter(Boolean) as PerplexityMessageContent[];
         messages.push({
           role,
-          content: content
-            .map(part => {
-              switch (part.type) {
-                case 'text': {
-                  return part.text;
-                }
-              }
-            })
-            .filter(Boolean)
-            .join(''),
+          content: hasImage
+            ? messageContent
+            : messageContent
+                .filter(part => part.type === 'text')
+                .map(part => part.text)
+                .join(''),
         });
         break;
       }

--- a/packages/perplexity/src/perplexity-language-model-prompt.ts
+++ b/packages/perplexity/src/perplexity-language-model-prompt.ts
@@ -2,5 +2,17 @@ export type PerplexityPrompt = Array<PerplexityMessage>;
 
 export type PerplexityMessage = {
   role: 'system' | 'user' | 'assistant';
-  content: string;
+  content: string | PerplexityMessageContent[];
 };
+
+export type PerplexityMessageContent =
+  | {
+      type: 'text';
+      text: string;
+    }
+  | {
+      type: 'image_url';
+      image_url: {
+        url: string;
+      };
+    };


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

While Perplexity's core API (excluding `sonar-deep-research`) allows image input as documented here: [https://docs.perplexity.ai/guides/image-guide](https://docs.perplexity.ai/guides/image-guide), this functionality is not yet available in the `@ai-sdk/perplexity` package.

## Summary

<!-- What did you change? -->
I change function `convertToPerplexityMessages` to support image as input. I also create new type for message content: `PerplexityMessageContent`

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

Fixed #6250
Related PR #6416