### PR TITLE
fix (provider/openai): correct default for chat model strict mode

### DIFF
--- a/.changeset/perfect-deers-work.md
+++ b/.changeset/perfect-deers-work.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix (provider/openai): correct default for chat model strict mode

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -783,10 +783,6 @@ function isReasoningModel(modelId: string) {
   return modelId.startsWith('o');
 }
 
-function isAudioModel(modelId: string) {
-  return modelId.startsWith('gpt-4o-audio-preview');
-}
-
 function supportsFlexProcessing(modelId: string) {
   return modelId.startsWith('o3') || modelId.startsWith('o4-mini');
 }

--- a/packages/openai/src/openai-chat-options.ts
+++ b/packages/openai/src/openai-chat-options.ts
@@ -122,7 +122,7 @@ export const openaiProviderOptions = z.object({
   /**
    * Whether to use strict JSON schema validation.
    *
-   * @default true
+   * @default false
    */
   strictJsonSchema: z.boolean().optional(),
 });


### PR DESCRIPTION
## Background

Default value in jsdoc was incorrect.

## Summary

Updated default value.