### PR TITLE
feat (ai): add InferUITools helper

### DIFF
--- a/.changeset/silly-brooms-thank.md
+++ b/.changeset/silly-brooms-thank.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): add InferUITools helper

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -993,3 +993,110 @@ export default function Page() {
   );
 }
 ```
+
+## Type Inference for Tools
+
+When working with tools in TypeScript, AI SDK UI provides type inference helpers to ensure type safety for your tool inputs and outputs.
+
+### InferUITool
+
+The `InferUITool` type helper infers the input and output types of a single tool for use in UI messages:
+
+```tsx
+import { InferUITool } from 'ai';
+import { z } from 'zod';
+
+const weatherTool = {
+  description: 'Get the current weather',
+  parameters: z.object({
+    location: z.string().describe('The city and state'),
+  }),
+  execute: async ({ location }) => {
+    return `The weather in ${location} is sunny.`;
+  },
+};
+
+// Infer the types from the tool
+type WeatherUITool = InferUITool<typeof weatherTool>;
+// This creates a type with:
+// {
+//   input: { location: string };
+//   output: string;
+// }
+```
+
+### InferUITools
+
+The `InferUITools` type helper infers the input and output types of a `ToolSet`:
+
+```tsx
+import { InferUITools, ToolSet } from 'ai';
+import { z } from 'zod';
+
+const tools: ToolSet = {
+  weather: {
+    description: 'Get the current weather',
+    parameters: z.object({
+      location: z.string().describe('The city and state'),
+    }),
+    execute: async ({ location }) => {
+      return `The weather in ${location} is sunny.`;
+    },
+  },
+  calculator: {
+    description: 'Perform basic arithmetic',
+    parameters: z.object({
+      operation: z.enum(['add', 'subtract', 'multiply', 'divide']),
+      a: z.number(),
+      b: z.number(),
+    }),
+    execute: async ({ operation, a, b }) => {
+      switch (operation) {
+        case 'add':
+          return a + b;
+        case 'subtract':
+          return a - b;
+        case 'multiply':
+          return a * b;
+        case 'divide':
+          return a / b;
+      }
+    },
+  },
+};
+
+// Infer the types from the tool set
+type MyUITools = InferUITools<typeof tools>;
+// This creates a type with:
+// {
+//   weather: { input: { location: string }; output: string };
+//   calculator: { input: { operation: 'add' | 'subtract' | 'multiply' | 'divide'; a: number; b: number }; output: number };
+// }
+```
+
+### Using Inferred Types
+
+You can use these inferred types to create a custom UIMessage type and pass it to various AI SDK UI functions:
+
+```tsx
+import { InferUITools, UIMessage, UIDataTypes } from 'ai';
+
+type MyUITools = InferUITools<typeof tools>;
+type MyUIMessage = UIMessage<never, UIDataTypes, MyUITools>;
+```
+
+Pass the custom type to `useChat` or `createUIMessageStream`:
+
+```tsx
+import { useChat } from '@ai-sdk/react';
+import { createUIMessageStream } from 'ai';
+import { MyUIMessage } from './types';
+
+// With useChat
+const { messages } = useChat<MyUIMessage>();
+
+// With createUIMessageStream
+const stream = createUIMessageStream<MyUIMessage>(/* ... */);
+```
+
+This provides full type safety for tool inputs and outputs on the client and server.

--- a/content/docs/07-reference/02-ai-sdk-ui/46-infer-ui-tools.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/46-infer-ui-tools.mdx
@@ -1,0 +1,94 @@
+---
+title: InferUITools
+description: API Reference for InferUITools.
+---
+
+# InferUITools
+
+Infers the input and output types of a `ToolSet`.
+
+This type helper is useful when working with tools in TypeScript to ensure type safety for your tool inputs and outputs in `UIMessage`s.
+
+## Import
+
+```tsx
+import { InferUITools } from 'ai';
+```
+
+## API Signature
+
+### Type Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'TOOLS',
+      type: 'ToolSet',
+      description: 'The tool set to infer types from.',
+    },
+  ]}
+/>
+
+### Returns
+
+A type that maps each tool in the tool set to its inferred input and output types.
+
+The resulting type has the shape:
+```typescript
+{
+  [NAME in keyof TOOLS & string]: {
+    input: InferToolInput<TOOLS[NAME]>;
+    output: InferToolOutput<TOOLS[NAME]>;
+  };
+}
+```
+
+## Examples
+
+### Basic Usage
+
+```tsx
+import { InferUITools } from 'ai';
+import { z } from 'zod';
+
+const tools = {
+  weather: {
+    description: 'Get the current weather',
+    parameters: z.object({
+      location: z.string().describe('The city and state'),
+    }),
+    execute: async ({ location }) => {
+      return `The weather in ${location} is sunny.`;
+    },
+  },
+  calculator: {
+    description: 'Perform basic arithmetic',
+    parameters: z.object({
+      operation: z.enum(['add', 'subtract', 'multiply', 'divide']),
+      a: z.number(),
+      b: z.number(),
+    }),
+    execute: async ({ operation, a, b }) => {
+      switch (operation) {
+        case 'add': return a + b;
+        case 'subtract': return a - b;
+        case 'multiply': return a * b;
+        case 'divide': return a / b;
+      }
+    },
+  },
+};
+
+// Infer the types from the tool set
+type MyUITools = InferUITools<typeof tools>;
+// This creates a type with:
+// {
+//   weather: { input: { location: string }; output: string };
+//   calculator: { input: { operation: 'add' | 'subtract' | 'multiply' | 'divide'; a: number; b: number }; output: number };
+// }
+```
+
+## Related
+
+- [`InferUITool`](/docs/reference/ai-sdk-ui/infer-ui-tool) - Infer types for a single tool
+- [`useChat`](/docs/reference/ai-sdk-ui/use-chat) - Chat hook that supports typed tools

--- a/content/docs/07-reference/02-ai-sdk-ui/46-infer-ui-tools.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/46-infer-ui-tools.mdx
@@ -34,6 +34,7 @@ import { InferUITools } from 'ai';
 A type that maps each tool in the tool set to its inferred input and output types.
 
 The resulting type has the shape:
+
 ```typescript
 {
   [NAME in keyof TOOLS & string]: {
@@ -70,10 +71,14 @@ const tools = {
     }),
     execute: async ({ operation, a, b }) => {
       switch (operation) {
-        case 'add': return a + b;
-        case 'subtract': return a - b;
-        case 'multiply': return a * b;
-        case 'divide': return a / b;
+        case 'add':
+          return a + b;
+        case 'subtract':
+          return a - b;
+        case 'multiply':
+          return a * b;
+        case 'divide':
+          return a / b;
       }
     },
   },

--- a/content/docs/07-reference/02-ai-sdk-ui/47-infer-ui-tool.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/47-infer-ui-tool.mdx
@@ -1,0 +1,74 @@
+---
+title: InferUITool
+description: API Reference for InferUITool.
+---
+
+# InferUITool
+
+Infers the input and output types of a tool.
+
+This type helper is useful when working with individual tools to ensure type safety for your tool inputs and outputs in `UIMessage`s.
+
+## Import
+
+```tsx
+import { InferUITool } from 'ai';
+```
+
+## API Signature
+
+### Type Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'TOOL',
+      type: 'Tool',
+      description: 'The tool to infer types from.',
+    },
+  ]}
+/>
+
+### Returns
+
+A type that contains the inferred input and output types of the tool.
+
+The resulting type has the shape:
+```typescript
+{
+  input: InferToolInput<TOOL>;
+  output: InferToolOutput<TOOL>;
+}
+```
+
+## Examples
+
+### Basic Usage
+
+```tsx
+import { InferUITool } from 'ai';
+import { z } from 'zod';
+
+const weatherTool = {
+  description: 'Get the current weather',
+  parameters: z.object({
+    location: z.string().describe('The city and state'),
+  }),
+  execute: async ({ location }) => {
+    return `The weather in ${location} is sunny.`;
+  },
+};
+
+// Infer the types from the tool
+type WeatherUITool = InferUITool<typeof weatherTool>;
+// This creates a type with:
+// {
+//   input: { location: string };
+//   output: string;
+// }
+```
+
+## Related
+
+- [`InferUITools`](/docs/reference/ai-sdk-ui/infer-ui-tools) - Infer types for a tool set
+- [`ToolUIPart`](/docs/reference/ai-sdk-ui/tool-ui-part) - Tool part type for UI messages

--- a/content/docs/07-reference/02-ai-sdk-ui/47-infer-ui-tool.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/47-infer-ui-tool.mdx
@@ -34,6 +34,7 @@ import { InferUITool } from 'ai';
 A type that contains the inferred input and output types of the tool.
 
 The resulting type has the shape:
+
 ```typescript
 {
   input: InferToolInput<TOOL>;

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -33,6 +33,7 @@ export {
   type DataUIPart,
   type FileUIPart,
   type InferUITool,
+  type InferUITools,
   type ReasoningUIPart,
   type SourceUrlUIPart,
   type StepStartUIPart,

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -1,4 +1,5 @@
 import { InferToolInput, InferToolOutput, Tool } from '@ai-sdk/provider-utils';
+import { ToolSet } from '../generate-text';
 import { DeepPartial } from '../util/deep-partial';
 import { ValueOf } from '../util/value-of';
 
@@ -12,9 +13,19 @@ export type UITool = {
   output: unknown | undefined;
 };
 
+/**
+ * Infer the input and output types of a tool so it can be used as a UI tool.
+ */
 export type InferUITool<TOOL extends Tool> = {
   input: InferToolInput<TOOL>;
   output: InferToolOutput<TOOL>;
+};
+
+/**
+ * Infer the input and output types of a tool set so it can be used as a UI tool set.
+ */
+export type InferUITools<TOOLS extends ToolSet> = {
+  [NAME in keyof TOOLS & string]: InferUITool<TOOLS[NAME]>;
 };
 
 export type UITools = Record<string, UITool>;


### PR DESCRIPTION
## Background

Many applications have defined toolsets that need to be used in the UI. The `InferUITool` helper only works on a single tool.

## Summary

Introduce `InferUITools` helper.