### PR TITLE
feat (ai): step input message modification in prepareStep

### DIFF
--- a/.changeset/nice-dogs-flow.md
+++ b/.changeset/nice-dogs-flow.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): step input message modification in prepareStep

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -150,15 +150,16 @@ It is called with the following parameters:
 - `stopWhen`: The stopping condition that was passed into `generateText`.
 - `stepNumber`: The number of the step that is being executed.
 - `steps`: The steps that have been executed so far.
+- `messages`: The messages that will be sent to the model for the current step.
 
-You can use it to provide different settings for a step.
+You can use it to provide different settings for a step, including modifying the input messages.
 
 ```tsx highlight="5-7"
 import { generateText } from 'ai';
 
 const result = await generateText({
   // ...
-  prepareStep: async ({ model, stepNumber, steps }) => {
+  prepareStep: async ({ model, stepNumber, steps, messages }) => {
     if (stepNumber === 0) {
       return {
         // use a different model for this step:
@@ -173,6 +174,23 @@ const result = await generateText({
     // when nothing is returned, the default settings are used
   },
 });
+```
+
+#### Message Modification for Longer Agentic Loops
+
+In longer agentic loops, you can use the `messages` parameter to modify the input messages for each step. This is particularly useful for prompt compression:
+
+```tsx
+prepareStep: async ({ stepNumber, steps, messages }) => {
+  // Compress conversation history for longer loops
+  if (messages.length > 20) {
+    return {
+      messages: messages.slice(-10),
+    };
+  }
+
+  return {};
+},
 ```
 
 ## Response Messages

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -528,9 +528,7 @@ To see `generateText` in action, check out [these examples](#examples).
     {
       name: 'prepareStep',
       type: '(options: PrepareStepOptions) => PrepareStepResult<TOOLS> | Promise<PrepareStepResult<TOOLS>>',
-      isOptional: true,
-      description:
-        'Optional function that you can use to provide different settings for a step.',
+        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, system prompt, and input messages for each step.',
       properties: [
         {
           type: 'PrepareStepFunction<TOOLS>',
@@ -559,9 +557,50 @@ To see `generateText` in action, check out [these examples](#examples).
                       type: 'LanguageModel',
                       description: 'The model that is being used.',
                     },
+                    {
+                      name: 'messages',
+                      type: 'Array<ModelMessage>',
+                      description: 'The messages that will be sent to the model for the current step.',
+                    },
                   ],
                 },
               ],
+            },
+          ],
+        },
+        {
+          type: 'PrepareStepResult<TOOLS>',
+          description: 'Return value that can modify settings for the current step.',
+          parameters: [
+            {
+              name: 'model',
+              type: 'LanguageModel',
+              isOptional: true,
+              description: 'Change the model for this step.',
+            },
+            {
+              name: 'toolChoice',
+              type: 'ToolChoice<TOOLS>',
+              isOptional: true,
+              description: 'Change the tool choice strategy for this step.',
+            },
+            {
+              name: 'activeTools',
+              type: 'Array<keyof TOOLS>',
+              isOptional: true,
+              description: 'Change which tools are active for this step.',
+            },
+            {
+              name: 'system',
+              type: 'string',
+              isOptional: true,
+              description: 'Change the system prompt for this step.',
+            },
+            {
+              name: 'messages',
+              type: 'Array<ModelMessage>',
+              isOptional: true,
+              description: 'Modify the input messages for this step.',
             },
           ],
         },

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -574,7 +574,7 @@ To see `streamText` in action, check out [these examples](#examples).
       type: '(options: PrepareStepOptions) => PrepareStepResult<TOOLS> | Promise<PrepareStepResult<TOOLS>>',
       isOptional: true,
       description:
-        'Optional function that you can use to provide different settings for a step.',
+        'Optional function that you can use to provide different settings for a step. You can modify the model, tool choices, active tools, system prompt, and input messages for each step.',
       properties: [
         {
           type: 'PrepareStepFunction<TOOLS>',
@@ -603,9 +603,52 @@ To see `streamText` in action, check out [these examples](#examples).
                       type: 'LanguageModel',
                       description: 'The model that is being used.',
                     },
+                    {
+                      name: 'messages',
+                      type: 'Array<ModelMessage>',
+                      description:
+                        'The messages that will be sent to the model for the current step.',
+                    },
                   ],
                 },
               ],
+            },
+          ],
+        },
+        {
+          type: 'PrepareStepResult<TOOLS>',
+          description:
+            'Return value that can modify settings for the current step.',
+          parameters: [
+            {
+              name: 'model',
+              type: 'LanguageModel',
+              isOptional: true,
+              description: 'Change the model for this step.',
+            },
+            {
+              name: 'toolChoice',
+              type: 'ToolChoice<TOOLS>',
+              isOptional: true,
+              description: 'Change the tool choice strategy for this step.',
+            },
+            {
+              name: 'activeTools',
+              type: 'Array<keyof TOOLS>',
+              isOptional: true,
+              description: 'Change which tools are active for this step.',
+            },
+            {
+              name: 'system',
+              type: 'string',
+              isOptional: true,
+              description: 'Change the system prompt for this step.',
+            },
+            {
+              name: 'messages',
+              type: 'Array<ModelMessage>',
+              isOptional: true,
+              description: 'Modify the input messages for this step.',
             },
           ],
         },

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1,19 +1,21 @@
 import {
   LanguageModelV2CallOptions,
   LanguageModelV2FunctionTool,
+  LanguageModelV2Prompt,
   LanguageModelV2ProviderDefinedTool,
+  LanguageModelV2ToolChoice,
 } from '@ai-sdk/provider';
-import { jsonSchema } from '@ai-sdk/provider-utils';
+import { jsonSchema, tool } from '@ai-sdk/provider-utils';
 import { mockId } from '@ai-sdk/provider-utils/test';
 import assert from 'node:assert';
 import { z } from 'zod/v4';
-import { Output, stepCountIs } from '.';
+import { Output } from '.';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
 import { MockTracer } from '../test/mock-tracer';
-import { tool } from '@ai-sdk/provider-utils';
 import { generateText } from './generate-text';
 import { GenerateTextResult } from './generate-text-result';
 import { StepResult } from './step-result';
+import { stepCountIs } from './stop-condition';
 
 const dummyResponseValues = {
   finishReason: 'stop' as const,
@@ -753,47 +755,27 @@ describe('generateText', () => {
     describe('2 steps: initial, tool-result with prepareStep', () => {
       let result: GenerateTextResult<any, any>;
       let onStepFinishResults: StepResult<any>[];
+      let doGenerateCalls: Array<{
+        prompt: LanguageModelV2Prompt;
+        tools?: (
+          | LanguageModelV2FunctionTool
+          | LanguageModelV2ProviderDefinedTool
+        )[];
+        toolChoice?: LanguageModelV2ToolChoice;
+      }>;
 
       beforeEach(async () => {
         onStepFinishResults = [];
+        doGenerateCalls = [];
 
         let responseCount = 0;
 
         const trueModel = new MockLanguageModelV2({
           doGenerate: async ({ prompt, tools, toolChoice }) => {
+            doGenerateCalls.push({ prompt, tools, toolChoice });
+
             switch (responseCount++) {
               case 0:
-                expect(toolChoice).toStrictEqual({
-                  type: 'tool',
-                  toolName: 'tool1',
-                });
-                expect(tools).toStrictEqual([
-                  {
-                    type: 'function',
-                    name: 'tool1',
-                    description: undefined,
-                    inputSchema: {
-                      $schema: 'http://json-schema.org/draft-07/schema#',
-                      additionalProperties: false,
-                      properties: { value: { type: 'string' } },
-                      required: ['value'],
-                      type: 'object',
-                    },
-                  },
-                ]);
-
-                expect(prompt).toStrictEqual([
-                  {
-                    role: 'system',
-                    content: 'system-message-0',
-                  },
-                  {
-                    role: 'user',
-                    content: [{ type: 'text', text: 'test-input' }],
-                    providerOptions: undefined,
-                  },
-                ]);
-
                 return {
                   ...dummyResponseValues,
                   content: [
@@ -877,6 +859,12 @@ describe('generateText', () => {
                   toolName: 'tool1' as const,
                 },
                 system: 'system-message-0',
+                messages: [
+                  {
+                    role: 'user',
+                    content: 'new input from prepareStep',
+                  },
+                ],
               };
             }
 
@@ -892,16 +880,119 @@ describe('generateText', () => {
         });
       });
 
+      it('doGenerate should be called with the correct arguments', () => {
+        expect(doGenerateCalls).toMatchInlineSnapshot(`
+          [
+            {
+              "prompt": [
+                {
+                  "content": "system-message-0",
+                  "role": "system",
+                },
+                {
+                  "content": [
+                    {
+                      "text": "new input from prepareStep",
+                      "type": "text",
+                    },
+                  ],
+                  "providerOptions": undefined,
+                  "role": "user",
+                },
+              ],
+              "toolChoice": {
+                "toolName": "tool1",
+                "type": "tool",
+              },
+              "tools": [
+                {
+                  "description": undefined,
+                  "inputSchema": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "additionalProperties": false,
+                    "properties": {
+                      "value": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "value",
+                    ],
+                    "type": "object",
+                  },
+                  "name": "tool1",
+                  "type": "function",
+                },
+              ],
+            },
+            {
+              "prompt": [
+                {
+                  "content": "system-message-1",
+                  "role": "system",
+                },
+                {
+                  "content": [
+                    {
+                      "text": "test-input",
+                      "type": "text",
+                    },
+                  ],
+                  "providerOptions": undefined,
+                  "role": "user",
+                },
+                {
+                  "content": [
+                    {
+                      "input": {
+                        "value": "value",
+                      },
+                      "providerExecuted": undefined,
+                      "providerOptions": undefined,
+                      "toolCallId": "call-1",
+                      "toolName": "tool1",
+                      "type": "tool-call",
+                    },
+                  ],
+                  "providerOptions": undefined,
+                  "role": "assistant",
+                },
+                {
+                  "content": [
+                    {
+                      "output": {
+                        "type": "text",
+                        "value": "result1",
+                      },
+                      "providerOptions": undefined,
+                      "toolCallId": "call-1",
+                      "toolName": "tool1",
+                      "type": "tool-result",
+                    },
+                  ],
+                  "providerOptions": undefined,
+                  "role": "tool",
+                },
+              ],
+              "toolChoice": {
+                "type": "auto",
+              },
+              "tools": [],
+            },
+          ]
+        `);
+      });
+
       it('result.text should return text from last step', async () => {
-        assert.deepStrictEqual(result.text, 'Hello, world!');
+        expect(result.text).toStrictEqual('Hello, world!');
       });
 
       it('result.toolCalls should return empty tool calls from last step', async () => {
-        assert.deepStrictEqual(result.toolCalls, []);
+        expect(result.toolCalls).toStrictEqual([]);
       });
 
       it('result.toolResults should return empty tool results from last step', async () => {
-        assert.deepStrictEqual(result.toolResults, []);
+        expect(result.toolResults).toStrictEqual([]);
       });
 
       it('result.response.messages should contain response messages from all steps', () => {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -285,12 +285,13 @@ A function that attempts to repair a tool call that failed to parse.
             model,
             steps,
             stepNumber: steps.length,
+            messages: stepInputMessages,
           });
 
           const promptMessages = await convertToLanguageModelPrompt({
             prompt: {
               system: prepareStepResult?.system ?? initialPrompt.system,
-              messages: stepInputMessages,
+              messages: prepareStepResult?.messages ?? stepInputMessages,
             },
             supportedUrls: await model.supportedUrls,
           });

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -1,4 +1,4 @@
-import { Tool } from '@ai-sdk/provider-utils';
+import { ModelMessage, Tool } from '@ai-sdk/provider-utils';
 import { LanguageModel, ToolChoice } from '../types/language-model';
 import { StepResult } from './step-result';
 
@@ -19,6 +19,7 @@ export type PrepareStepFunction<
   steps: Array<StepResult<NoInfer<TOOLS>>>;
   stepNumber: number;
   model: LanguageModel;
+  messages: Array<ModelMessage>;
 }) => PromiseLike<PrepareStepResult<TOOLS>> | PrepareStepResult<TOOLS>;
 
 export type PrepareStepResult<
@@ -29,5 +30,6 @@ export type PrepareStepResult<
       toolChoice?: ToolChoice<NoInfer<TOOLS>>;
       activeTools?: Array<keyof NoInfer<TOOLS>>;
       system?: string;
+      messages?: Array<ModelMessage>;
     }
   | undefined;

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -5672,6 +5672,12 @@ describe('streamText', () => {
                   toolName: 'tool1' as const,
                 },
                 system: 'system-message-0',
+                messages: [
+                  {
+                    role: 'user',
+                    content: 'new input from prepareStep',
+                  },
+                ],
               };
             }
 
@@ -5704,7 +5710,7 @@ describe('streamText', () => {
                 {
                   "content": [
                     {
-                      "text": "test-input",
+                      "text": "new input from prepareStep",
                       "type": "text",
                     },
                   ],

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -3,11 +3,18 @@ import {
   LanguageModelV2CallOptions,
   LanguageModelV2CallWarning,
   LanguageModelV2FunctionTool,
+  LanguageModelV2Message,
   LanguageModelV2ProviderDefinedTool,
   LanguageModelV2StreamPart,
   SharedV2ProviderMetadata,
 } from '@ai-sdk/provider';
-import { delay, jsonSchema, tool, Tool } from '@ai-sdk/provider-utils';
+import {
+  delay,
+  jsonSchema,
+  ModelMessage,
+  tool,
+  Tool,
+} from '@ai-sdk/provider-utils';
 import {
   convertArrayToReadableStream,
   convertAsyncIterableToArray,
@@ -5584,6 +5591,7 @@ describe('streamText', () => {
       let prepareStepCalls: Array<{
         stepNumber: number;
         steps: Array<StepResult<any>>;
+        messages: Array<ModelMessage>;
       }>;
 
       beforeEach(async () => {
@@ -5654,8 +5662,8 @@ describe('streamText', () => {
           },
           prompt: 'test-input',
           stopWhen: stepCountIs(3),
-          prepareStep: async ({ model, stepNumber, steps }) => {
-            prepareStepCalls.push({ stepNumber, steps });
+          prepareStep: async ({ model, stepNumber, steps, messages }) => {
+            prepareStepCalls.push({ stepNumber, steps, messages });
 
             if (stepNumber === 0) {
               return {
@@ -5812,6 +5820,12 @@ describe('streamText', () => {
         expect(prepareStepCalls).toMatchInlineSnapshot(`
           [
             {
+              "messages": [
+                {
+                  "content": "test-input",
+                  "role": "user",
+                },
+              ],
               "stepNumber": 0,
               "steps": [
                 DefaultStepResult {
@@ -5957,6 +5971,40 @@ describe('streamText', () => {
               ],
             },
             {
+              "messages": [
+                {
+                  "content": "test-input",
+                  "role": "user",
+                },
+                {
+                  "content": [
+                    {
+                      "input": {
+                        "value": "value",
+                      },
+                      "providerExecuted": undefined,
+                      "toolCallId": "call-1",
+                      "toolName": "tool1",
+                      "type": "tool-call",
+                    },
+                  ],
+                  "role": "assistant",
+                },
+                {
+                  "content": [
+                    {
+                      "output": {
+                        "type": "text",
+                        "value": "result1",
+                      },
+                      "toolCallId": "call-1",
+                      "toolName": "tool1",
+                      "type": "tool-result",
+                    },
+                  ],
+                  "role": "tool",
+                },
+              ],
               "stepNumber": 1,
               "steps": [
                 DefaultStepResult {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -975,12 +975,13 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
             model,
             steps: recordedSteps,
             stepNumber: recordedSteps.length,
+            messages: stepInputMessages,
           });
 
           const promptMessages = await convertToLanguageModelPrompt({
             prompt: {
               system: prepareStepResult?.system ?? initialPrompt.system,
-              messages: stepInputMessages,
+              messages: prepareStepResult?.messages ?? stepInputMessages,
             },
             supportedUrls: await model.supportedUrls,
           });


### PR DESCRIPTION
## Background

In longer agentic loop, it can be helpful to modify step input messages for e.g. prompt compression or to enable caching.

## Summary

Add message as input and output to `prepareStep`.

## Tasks

- [x] streamText test case
- [x] generateText test case
- [ ] docs
- [x] changeset

## Related Issues

Fixes #7151 