### PR TITLE
fix (provider/openai): push first reasoning chunk in output item added event

### DIFF
--- a/.changeset/selfish-cups-provide.md
+++ b/.changeset/selfish-cups-provide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix (provider/openai): push first reasoning chunk in output item added event

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2558,7 +2558,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "response-metadata",
               },
               {
-                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
+                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
                     "reasoning": {
@@ -2570,7 +2570,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "reasoning-start",
               },
               {
-                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
+                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
                     "reasoning": {
@@ -2864,7 +2864,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "response-metadata",
               },
               {
-                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
+                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
                     "reasoning": {
@@ -2876,7 +2876,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "reasoning-start",
               },
               {
-                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
+                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
                     "reasoning": {


### PR DESCRIPTION
## Background

Reasoning can take longer and for reasoning without summary parts we want to push the notification immediately.

## Summary

push first reasoning chunk in output item added event

## Related Issues

#7155 #7029
