### PR TITLE
fix (react): chat instance recreation in `useChat`

### DIFF
--- a/.changeset/fresh-jeans-occur.md
+++ b/.changeset/fresh-jeans-occur.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix (ai/react): chat instance recreation in useChat

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -57,7 +57,17 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   resume = false,
   ...options
 }: UseChatOptions<UI_MESSAGE> = {}): UseChatHelpers<UI_MESSAGE> {
-  const chatRef = useRef('chat' in options ? options.chat : new Chat(options));
+  const chatRef = useRef<Chat<UI_MESSAGE>>(
+    'chat' in options ? options.chat : new Chat(options),
+  );
+
+  const shouldRecreateChat =
+    ('chat' in options && options.chat !== chatRef.current) ||
+    ('id' in options && chatRef.current.id !== options.id);
+
+  if (shouldRecreateChat) {
+    chatRef.current = 'chat' in options ? options.chat : new Chat(options);
+  }
 
   const subscribeToMessages = useCallback(
     (update: () => void) =>

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -16,6 +16,7 @@ import {
   UIMessageChunk,
 } from 'ai';
 import React, { act, useRef, useState } from 'react';
+import { Chat } from './chat.react';
 import { setupTestComponent } from './setup-test-component';
 import { useChat } from './use-chat';
 
@@ -344,53 +345,6 @@ describe('data protocol stream', () => {
           "trigger": "submit-user-message",
         }
       `);
-    });
-
-    it('should clear out messages when the id changes', async () => {
-      server.urls['/api/chat'].response = {
-        type: 'stream-chunks',
-        chunks: [
-          formatChunk({ type: 'text-start', id: '0' }),
-          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
-          formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
-          formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
-          formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
-          formatChunk({ type: 'text-end', id: '0' }),
-        ],
-      };
-
-      await userEvent.click(screen.getByTestId('do-send'));
-
-      await waitFor(() => {
-        expect(
-          JSON.parse(screen.getByTestId('messages').textContent ?? ''),
-        ).toStrictEqual([
-          {
-            id: expect.any(String),
-            parts: [
-              {
-                text: 'hi',
-                type: 'text',
-              },
-            ],
-            role: 'user',
-          },
-          {
-            id: 'id-1',
-            parts: [
-              {
-                text: 'Hello, world.',
-                type: 'text',
-                state: 'done',
-              },
-            ],
-            role: 'assistant',
-          },
-        ]);
-      });
-      await userEvent.click(screen.getByTestId('do-change-id'));
-
-      expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
     });
   });
 });
@@ -2331,5 +2285,194 @@ describe('experimental_throttle', () => {
     );
 
     vi.useRealTimers();
+  });
+});
+
+describe('id changes', () => {
+  setupTestComponent(
+    () => {
+      const [id, setId] = React.useState<string>('initial-id');
+
+      const {
+        messages,
+        sendMessage,
+        error,
+        status,
+        id: idKey,
+      } = useChat({
+        id,
+        generateId: mockId(),
+      });
+
+      return (
+        <div>
+          <div data-testid="id">{idKey}</div>
+          <div data-testid="status">{status.toString()}</div>
+          {error && <div data-testid="error">{error.toString()}</div>}
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+            }}
+          />
+          <button
+            data-testid="do-change-id"
+            onClick={() => {
+              setId('second-id');
+            }}
+          />
+        </div>
+      );
+    },
+    {
+      init: TestComponent => <TestComponent />,
+    },
+  );
+
+  it('should update chat instance when the id changes', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
+      ],
+    };
+
+    await userEvent.click(screen.getByTestId('do-send'));
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+      ).toStrictEqual([
+        {
+          id: expect.any(String),
+          parts: [
+            {
+              text: 'hi',
+              type: 'text',
+            },
+          ],
+          role: 'user',
+        },
+        {
+          id: 'id-1',
+          parts: [
+            {
+              text: 'Hello, world.',
+              type: 'text',
+              state: 'done',
+            },
+          ],
+          role: 'assistant',
+        },
+      ]);
+    });
+    await userEvent.click(screen.getByTestId('do-change-id'));
+
+    expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+  });
+});
+
+describe('chat instance changes', () => {
+  setupTestComponent(
+    () => {
+      const [chat, setChat] = React.useState<Chat<UIMessage>>(
+        new Chat({
+          id: 'initial-id',
+          generateId: mockId(),
+        }),
+      );
+
+      const {
+        messages,
+        sendMessage,
+        error,
+        status,
+        id: idKey,
+      } = useChat({
+        chat,
+      });
+
+      return (
+        <div>
+          <div data-testid="id">{idKey}</div>
+          <div data-testid="status">{status.toString()}</div>
+          {error && <div data-testid="error">{error.toString()}</div>}
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+            }}
+          />
+          <button
+            data-testid="do-change-chat"
+            onClick={() => {
+              setChat(
+                new Chat({
+                  id: 'second-id',
+                  generateId: mockId(),
+                }),
+              );
+            }}
+          />
+        </div>
+      );
+    },
+    {
+      init: TestComponent => <TestComponent />,
+    },
+  );
+
+  it('should update chat instance when the id changes', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ',' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: '.' }),
+        formatChunk({ type: 'text-end', id: '0' }),
+      ],
+    };
+
+    await userEvent.click(screen.getByTestId('do-send'));
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+      ).toStrictEqual([
+        {
+          id: expect.any(String),
+          parts: [
+            {
+              text: 'hi',
+              type: 'text',
+            },
+          ],
+          role: 'user',
+        },
+        {
+          id: 'id-1',
+          parts: [
+            {
+              text: 'Hello, world.',
+              type: 'text',
+              state: 'done',
+            },
+          ],
+          role: 'assistant',
+        },
+      ]);
+    });
+    await userEvent.click(screen.getByTestId('do-change-chat'));
+
+    expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

This PR updates the React `useChat` hook to ensure the internal Chat instance is correctly recreated when either the `id` or a custom `Chat` instance changes. This addresses issues where chat state (such as messages and status) was not resetting as expected when switching updating `id` from a parent component.

Previously, the `Chat` instance was stored in a `useRef` and only initialized on the **first** render. When the parent changed the id, the same `Chat` instance was reused, causing state from the previous session to persist and preventing the UI from updating as expected.

## Summary

- The hook checks if the `id` or a custom `Chat` instance has changed between renders. If so, it recreates the internal Chat instance, ensuring state is reset appropriately.
- Only recreates the `Chat` ref when necessary, avoiding unnecessary resets and ensuring performance

Alternatives/additional changes considered but not implemented:

- Exporting a `setId` from within the hook
- Recreating `Chat` instance when any of the options changed

## Verification

Added tests for:
- Changing hook's `id` parameter
- Changing hook's `chat` parameter

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

The heuristics for re-creating the chat instance can easily be expanded to include other chat options like: `messages` or `transport` but not initially added.

## Related Issues

Addresses https://github.com/vercel/ai/issues/6992
