### PR TITLE
fix (ui): tool input can be undefined during input-streaming

### DIFF
--- a/.changeset/cyan-rockets-beg.md
+++ b/.changeset/cyan-rockets-beg.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ui): tool input can be undefined during input-streaming

--- a/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
+++ b/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
@@ -25,7 +25,7 @@ export default function Chat() {
   let lastRole: string | undefined = undefined;
 
   return (
-    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
       {messages?.map(m => {
         const isNewRole = m.role !== lastRole;
         lastRole = m.role;
@@ -42,17 +42,17 @@ export default function Chat() {
                 return (
                   <div
                     key={part.toolCallId}
-                    className="p-4 my-2 text-gray-500 border border-gray-300 rounded"
+                    className="p-4 my-2 text-gray-500 rounded border border-gray-300"
                   >
-                    <h4 className="mb-2">{part.input.city ?? ''}</h4>
+                    <h4 className="mb-2">{part.input?.city ?? ''}</h4>
                     <div className="flex flex-col gap-2">
                       <div className="flex gap-2">
-                        {part.input.weather && <b>{part.input.weather}</b>}
-                        {part.input.temperature && (
+                        {part.input?.weather && <b>{part.input.weather}</b>}
+                        {part.input?.temperature && (
                           <b>{part.input.temperature} &deg;C</b>
                         )}
                       </div>
-                      {part.input.typicalWeather && (
+                      {part.input?.typicalWeather && (
                         <div>{part.input.typicalWeather}</div>
                       )}
                     </div>

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -180,6 +180,7 @@ export type DataUIPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
     data: DATA_TYPES[NAME];
   };
 }>;
+
 export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
   [NAME in keyof TOOLS & string]: {
     type: `tool-${NAME}`;
@@ -187,7 +188,7 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
   } & (
     | {
         state: 'input-streaming';
-        input: DeepPartial<TOOLS[NAME]['input']>;
+        input: DeepPartial<TOOLS[NAME]['input']> | undefined;
         providerExecuted?: boolean;
         output?: never;
         errorText?: never;


### PR DESCRIPTION
## Background

Tool inputs could be undefined during streaming, leading to breakages ( #7184 ).

## Summary

Add `undefined` as possible value for input during tool call streaming.

## Related Issues

Fixes #7184