### PR TITLE
fix (ui): do not send changing assistant message ids when onFinish is provided

### DIFF
--- a/.changeset/tough-mirrors-peel.md
+++ b/.changeset/tough-mirrors-peel.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ui): do not send changing assistant message ids when onFinish is provided

--- a/examples/next-openai/app/api/use-chat-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-tools/route.ts
@@ -84,5 +84,10 @@ export async function POST(req: Request) {
     tools,
   });
 
-  return result.toUIMessageStreamResponse();
+  return result.toUIMessageStreamResponse({
+    //  originalMessages: messages, //add if you want to have correct ids
+    onFinish: options => {
+      console.log('onFinish', options);
+    },
+  });
 }

--- a/examples/next/app/api/chat/route.ts
+++ b/examples/next/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { MyUIMessage } from '@/util/chat-schema';
+import { openai } from '@ai-sdk/openai';
 import { readChat, saveChat } from '@util/chat-store';
 import { convertToModelMessages, generateId, streamText } from 'ai';
 import { after } from 'next/server';
@@ -56,7 +57,7 @@ export async function POST(req: Request) {
   saveChat({ id, messages, activeStreamId: null });
 
   const result = streamText({
-    model: 'openai/gpt-4o-mini',
+    model: openai('gpt-4o-mini'),
     messages: convertToModelMessages(messages),
   });
 

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@ai-sdk/openai": "workspace:*",
     "@ai-sdk/react": "workspace:*",
     "@vercel/blob": "^0.26.0",
     "ai": "workspace:*",

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -3,7 +3,6 @@ import {
   LanguageModelV2CallOptions,
   LanguageModelV2CallWarning,
   LanguageModelV2FunctionTool,
-  LanguageModelV2Message,
   LanguageModelV2ProviderDefinedTool,
   LanguageModelV2StreamPart,
   SharedV2ProviderMetadata,
@@ -2425,6 +2424,61 @@ describe('streamText', () => {
             "mediaType": "image/jpeg",
             "type": "file",
             "url": "data:image/jpeg;base64,QkFVRw==",
+          },
+          {
+            "type": "finish-step",
+          },
+          {
+            "messageMetadata": undefined,
+            "type": "finish",
+          },
+        ]
+      `);
+    });
+
+    it('should not generate a new message id when onFinish is provided', async () => {
+      const result = streamText({
+        model: createTestModel(),
+        ...defaultSettings(),
+      });
+
+      const uiMessageStream = result.toUIMessageStream({
+        onFinish: () => {}, // provided onFinish should trigger a new message id
+      });
+
+      expect(await convertReadableStreamToArray(uiMessageStream))
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "messageId": undefined,
+            "messageMetadata": undefined,
+            "type": "start",
+          },
+          {
+            "type": "start-step",
+          },
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          {
+            "delta": "Hello",
+            "id": "1",
+            "type": "text-delta",
+          },
+          {
+            "delta": ", ",
+            "id": "1",
+            "type": "text-delta",
+          },
+          {
+            "delta": "world!",
+            "id": "1",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "type": "text-end",
           },
           {
             "type": "finish-step",

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1806,7 +1806,7 @@ However, the LLM results are expected to be small enough to not cause issues.
 
     return handleUIMessageStreamFinish<UI_MESSAGE>({
       stream: baseStream,
-      messageId: responseMessageId ?? this.generateId(),
+      messageId: responseMessageId,
       originalMessages,
       onFinish,
       onError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,9 @@ importers:
 
   examples/next:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: workspace:*
+        version: link:../../packages/openai
       '@ai-sdk/react':
         specifier: workspace:*
         version: link:../../packages/react


### PR DESCRIPTION
## Background

#7169 uncovered an issue where the onFinish callback on toUIMessageStream triggered the sending of different assistant message ids.

## Summary

Ensure no id is generated in this situation.

## Verification

Tested against next and next-openai examples.

## Related Issues

Fixes #7169