### PR TITLE
fix hono streaming chunk type errors

### DIFF
--- a/content/cookbook/15-api-servers/30-hono.mdx
+++ b/content/cookbook/15-api-servers/30-hono.mdx
@@ -47,35 +47,6 @@ app.post('/', async c => {
 serve({ fetch: app.fetch, port: 8080 });
 ```
 
-### Data Stream
-
-You can use the `toDataStream` method to get a data stream from the result and then pipe it to the response.
-
-```ts filename='index.ts'
-import { openai } from '@ai-sdk/openai';
-import { serve } from '@hono/node-server';
-import { streamText } from 'ai';
-import { Hono } from 'hono';
-import { stream } from 'hono/streaming';
-
-const app = new Hono();
-
-app.post('/', async c => {
-  const result = streamText({
-    model: openai('gpt-4o'),
-    prompt: 'Invent a new holiday and describe its traditions.',
-  });
-
-  // Mark the response as a v1 data stream:
-  c.header('X-Vercel-AI-Data-Stream', 'v1');
-  c.header('Content-Type', 'text/plain; charset=utf-8');
-
-  return stream(c, stream => stream.pipe(result.toDataStream()));
-});
-
-serve({ fetch: app.fetch, port: 8080 });
-```
-
 ### Text Stream
 
 You can use the `textStream` property to get a text stream from the result and then pipe it to the response.

--- a/content/cookbook/15-api-servers/30-hono.mdx
+++ b/content/cookbook/15-api-servers/30-hono.mdx
@@ -23,6 +23,30 @@ curl -X POST http://localhost:8080
 
 **Full example**: [github.com/vercel/ai/examples/hono](https://github.com/vercel/ai/tree/main/examples/hono)
 
+### UI Message Stream
+
+You can use the `toUIMessageStreamResponse` method to create a properly formatted streaming response.
+
+```ts filename='index.ts'
+import { openai } from '@ai-sdk/openai';
+import { serve } from '@hono/node-server';
+import { streamText } from 'ai';
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+app.post('/', async c => {
+  const result = streamText({
+    model: openai('gpt-4o'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  return result.toUIMessageStreamResponse();
+});
+
+serve({ fetch: app.fetch, port: 8080 });
+```
+
 ### Data Stream
 
 You can use the `toDataStream` method to get a data stream from the result and then pipe it to the response.
@@ -47,6 +71,33 @@ app.post('/', async c => {
   c.header('Content-Type', 'text/plain; charset=utf-8');
 
   return stream(c, stream => stream.pipe(result.toDataStream()));
+});
+
+serve({ fetch: app.fetch, port: 8080 });
+```
+
+### Text Stream
+
+You can use the `textStream` property to get a text stream from the result and then pipe it to the response.
+
+```ts filename='index.ts' highlight="17"
+import { openai } from '@ai-sdk/openai';
+import { serve } from '@hono/node-server';
+import { streamText } from 'ai';
+import { Hono } from 'hono';
+import { stream } from 'hono/streaming';
+
+const app = new Hono();
+
+app.post('/', async c => {
+  const result = streamText({
+    model: openai('gpt-4o'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  c.header('Content-Type', 'text/plain; charset=utf-8');
+
+  return stream(c, stream => stream.pipe(result.textStream));
 });
 
 serve({ fetch: app.fetch, port: 8080 });
@@ -92,33 +143,6 @@ app.post('/stream-data', async c => {
   return stream(c, stream =>
     stream.pipe(dataStream.pipeThrough(new TextEncoderStream())),
   );
-});
-
-serve({ fetch: app.fetch, port: 8080 });
-```
-
-### Text Stream
-
-You can use the `textStream` property to get a text stream from the result and then pipe it to the response.
-
-```ts filename='index.ts' highlight="17"
-import { openai } from '@ai-sdk/openai';
-import { serve } from '@hono/node-server';
-import { streamText } from 'ai';
-import { Hono } from 'hono';
-import { stream } from 'hono/streaming';
-
-const app = new Hono();
-
-app.post('/', async c => {
-  const result = streamText({
-    model: openai('gpt-4o'),
-    prompt: 'Invent a new holiday and describe its traditions.',
-  });
-
-  c.header('Content-Type', 'text/plain; charset=utf-8');
-
-  return stream(c, stream => stream.pipe(result.textStream));
 });
 
 serve({ fetch: app.fetch, port: 8080 });

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/server.ts",
+    "dev:streaming": "tsx watch src/hono-streaming.ts",
     "curl": "curl -i -X POST http://localhost:8080",
     "type-check": "tsc --build"
   },

--- a/examples/hono/src/hono-streaming.ts
+++ b/examples/hono/src/hono-streaming.ts
@@ -1,0 +1,48 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import 'dotenv/config';
+import { Hono } from 'hono';
+import { serve } from '@hono/node-server';
+
+async function main() {
+  console.log('=== Hono Streaming Example ===');
+  
+  const app = new Hono();
+
+  // Basic UI Message Stream endpoint
+  app.post('/chat', async c => {
+    const result = streamText({
+      model: openai('gpt-4o'),
+      prompt: 'Invent a new holiday and describe its traditions.',
+    });
+
+    return result.toUIMessageStreamResponse();
+  });
+
+  // Text stream endpoint
+  app.post('/text', async c => {
+    const result = streamText({
+      model: openai('gpt-4o'),
+      prompt: 'Write a short poem about coding.',
+    });
+
+    c.header('Content-Type', 'text/plain; charset=utf-8');
+    
+    return new Response(result.textStream, {
+      headers: c.res.headers,
+    });
+  });
+
+  app.get('/health', c => c.text('Hono streaming server is running!'));
+
+  const port = 3001;
+  console.log(`Server starting on http://localhost:${port}`);
+  console.log('Test with: curl -X POST http://localhost:3001/chat');
+  
+  serve({
+    fetch: app.fetch,
+    port,
+  });
+}
+
+main().catch(console.error); 

--- a/examples/hono/src/hono-streaming.ts
+++ b/examples/hono/src/hono-streaming.ts
@@ -6,7 +6,7 @@ import { serve } from '@hono/node-server';
 
 async function main() {
   console.log('=== Hono Streaming Example ===');
-  
+
   const app = new Hono();
 
   // Basic UI Message Stream endpoint
@@ -27,7 +27,7 @@ async function main() {
     });
 
     c.header('Content-Type', 'text/plain; charset=utf-8');
-    
+
     return new Response(result.textStream, {
       headers: c.res.headers,
     });
@@ -38,11 +38,11 @@ async function main() {
   const port = 3001;
   console.log(`Server starting on http://localhost:${port}`);
   console.log('Test with: curl -X POST http://localhost:3001/chat');
-  
+
   serve({
     fetch: app.fetch,
     port,
   });
 }
 
-main().catch(console.error); 
+main().catch(console.error);


### PR DESCRIPTION
## background

Users reported streaming failures with Hono when using `result.toUIMessageStream()` with `stream.pipe()`, causing "chunk must be string or Buffer" errors that crashed servers.

## summary

- add UI Message Stream approach to hono documentation
- fix streaming examples to use `toUIMessageStreamResponse()`

## verification

- documentation updated with recommended approach first
- tested locally to ensure fixes work

## tasks

- [x] updated hono cookbook documentation with UI Message Stream
- [x] created working streaming examples 
- [x] verified fix resolves user's GitHub issue

related issue #7045