### PR TITLE
feat(anthropic): add text editor tool support for Claude 4 models

### DIFF
--- a/.changeset/shy-plants-serve.md
+++ b/.changeset/shy-plants-serve.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(anthropic): add text_editor_20250429 tool for Claude 4 models

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -300,7 +300,7 @@ const textEditorTool = anthropic.tools.textEditor_20241022({
 
 Parameters:
 
-- `command` ('view' | 'create' | 'str_replace' | 'insert' | 'undo_edit'): The command to run. Note: `undo_edit` is not available in Claude 4 models.
+- `command` ('view' | 'create' | 'str_replace' | 'insert' | 'undo_edit'): The command to run. Note: `undo_edit` is only available in Claude 3.5 Sonnet and earlier models.
 - `path` (string): Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.
 - `file_text` (string, optional): Required for `create` command, with the content of the file to be created.
 - `insert_line` (number, optional): Required for `insert` command. The line number after which to insert the new string.

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -258,7 +258,28 @@ Parameters:
 
 #### Text Editor Tool
 
-The Text Editor Tool provides functionality for viewing and editing text files:
+The Text Editor Tool provides functionality for viewing and editing text files.
+
+**For Claude 4 models (Opus & Sonnet):**
+
+```ts
+const textEditorTool = anthropic.tools.textEditor_20250429({
+  execute: async ({
+    command,
+    path,
+    file_text,
+    insert_line,
+    new_str,
+    old_str,
+    view_range,
+  }) => {
+    // Implement your text editing logic here
+    // Return the result of the text editing operation
+  },
+});
+```
+
+**For Claude 3.5 Sonnet and earlier models:**
 
 ```ts
 const textEditorTool = anthropic.tools.textEditor_20241022({
@@ -279,7 +300,7 @@ const textEditorTool = anthropic.tools.textEditor_20241022({
 
 Parameters:
 
-- `command` ('view' | 'create' | 'str_replace' | 'insert' | 'undo_edit'): The command to run.
+- `command` ('view' | 'create' | 'str_replace' | 'insert' | 'undo_edit'): The command to run. Note: `undo_edit` is not available in Claude 4 models.
 - `path` (string): Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.
 - `file_text` (string, optional): Required for `create` command, with the content of the file to be created.
 - `insert_line` (number, optional): Required for `insert` command. The line number after which to insert the new string.
@@ -287,15 +308,28 @@ Parameters:
 - `old_str` (string, optional): Required for `str_replace` command, containing the string to replace.
 - `view_range` (number[], optional): Optional for `view` command to specify line range to show.
 
-When using the Text Editor Tool, make sure to name the key in the tools object `str_replace_editor`.
+When using the Text Editor Tool, make sure to name the key in the tools object correctly:
+- **Claude 4 models**: Use `str_replace_based_edit_tool`
+- **Claude 3.5 Sonnet and earlier**: Use `str_replace_editor`
 
 ```ts
+// For Claude 4 models
+const response = await generateText({
+  model: anthropic('claude-opus-4-20250514'),
+  prompt:
+    "Create a new file called example.txt, write 'Hello World' to it, and run 'cat example.txt' in the terminal",
+  tools: {
+    str_replace_based_edit_tool: textEditorTool, // Claude 4 tool name
+  },
+});
+
+// For Claude 3.5 Sonnet and earlier
 const response = await generateText({
   model: anthropic('claude-3-5-sonnet-20241022'),
   prompt:
     "Create a new file called example.txt, write 'Hello World' to it, and run 'cat example.txt' in the terminal",
   tools: {
-    str_replace_editor: textEditorTool,
+    str_replace_editor: textEditorTool, // Earlier models tool name
   },
 });
 ```

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -309,6 +309,7 @@ Parameters:
 - `view_range` (number[], optional): Optional for `view` command to specify line range to show.
 
 When using the Text Editor Tool, make sure to name the key in the tools object correctly:
+
 - **Claude 4 models**: Use `str_replace_based_edit_tool`
 - **Claude 3.5 Sonnet and earlier**: Use `str_replace_editor`
 

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -133,7 +133,7 @@ export type AnthropicTool =
     }
   | {
       name: string;
-      type: 'text_editor_20250124' | 'text_editor_20241022';
+      type: 'text_editor_20250124' | 'text_editor_20241022' | 'text_editor_20250429';
     }
   | {
       name: string;

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -133,7 +133,10 @@ export type AnthropicTool =
     }
   | {
       name: string;
-      type: 'text_editor_20250124' | 'text_editor_20241022' | 'text_editor_20250429';
+      type:
+        | 'text_editor_20250124'
+        | 'text_editor_20241022'
+        | 'text_editor_20250429';
     }
   | {
       name: string;

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -92,6 +92,13 @@ export function prepareTools({
               type: 'text_editor_20241022',
             });
             break;
+          case 'anthropic.text_editor_20250429':
+            betas.add('computer-use-2025-01-24');
+            anthropicTools.push({
+              name: 'str_replace_based_edit_tool',
+              type: 'text_editor_20250429',
+            });
+            break;
           case 'anthropic.bash_20250124':
             betas.add('computer-use-2025-01-24');
             anthropicTools.push({

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -4,6 +4,7 @@ import { computer_20241022 } from './tool/computer_20241022';
 import { computer_20250124 } from './tool/computer_20250124';
 import { textEditor_20241022 } from './tool/text-editor_20241022';
 import { textEditor_20250124 } from './tool/text-editor_20250124';
+import { textEditor_20250429 } from './tool/text-editor_20250429';
 import { webSearch_20250305 } from './tool/web-search_20250305';
 
 export const anthropicTools = {
@@ -34,6 +35,12 @@ export const anthropicTools = {
    * Creates a tool for editing text. Must have name "str_replace_editor".
    */
   textEditor_20250124,
+
+  /**
+   * Creates a tool for editing text. Must have name "str_replace_based_edit_tool".
+   * Note: This version does not support the "undo_edit" command.
+   */
+  textEditor_20250429,
 
   /**
    * Creates a tool for executing actions on a computer. Must have name "computer".

--- a/packages/anthropic/src/tool/text-editor_20250429.ts
+++ b/packages/anthropic/src/tool/text-editor_20250429.ts
@@ -1,0 +1,55 @@
+import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const textEditor_20250429 = createProviderDefinedToolFactory<
+  {
+    /**
+     * The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`.
+     * Note: `undo_edit` is not supported in Claude 4 models.
+     */
+    command: 'view' | 'create' | 'str_replace' | 'insert';
+
+    /**
+     * Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.
+     */
+    path: string;
+
+    /**
+     * Required parameter of `create` command, with the content of the file to be created.
+     */
+    file_text?: string;
+
+    /**
+     * Required parameter of `insert` command. The `new_str` will be inserted AFTER the line `insert_line` of `path`.
+     */
+    insert_line?: number;
+
+    /**
+     * Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
+     */
+    new_str?: string;
+
+    /**
+     * Required parameter of `str_replace` command containing the string in `path` to replace.
+     */
+    old_str?: string;
+
+    /**
+     * Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.
+     */
+    view_range?: number[];
+  },
+  {}
+>({
+  id: 'anthropic.text_editor_20250429',
+  name: 'str_replace_based_edit_tool',
+  inputSchema: z.object({
+    command: z.enum(['view', 'create', 'str_replace', 'insert']),
+    path: z.string(),
+    file_text: z.string().optional(),
+    insert_line: z.number().int().optional(),
+    new_str: z.string().optional(),
+    old_str: z.string().optional(),
+    view_range: z.array(z.number().int()).optional(),
+  }),
+});


### PR DESCRIPTION
## background

Anthropic released Claude 4 models with an updated text editor tool (`text_editor_20250429`) that uses a new naming convention and removes the `undo_edit` command functionality.

## summary

- add `text_editor_20250429` tool for Claude 4 Opus & Sonnet
- use `str_replace_based_edit_tool` name (vs `str_replace_editor` for older versions)
- remove `undo_edit` command support as per Claude 4 specifications
- use `computer-use-2025-01-24` beta flag

## verification

- tool properly integrated into anthropic provider
- correct beta flag and tool name mapping

## tasks

- [x] created text-editor_20250429.ts with correct tool schema
- [x] updated anthropic-tools.ts exports and documentation
- [x] added tool mapping in anthropic-prepare-tools.ts
- [x] added tool type to anthropic-api-types.ts
- [x] removed undo_edit command for Claude 4 compatibility

## future work
* monitor for additional Claude 4 tool updates and capabilities 

related issue #6471 #6752