### PR TITLE
feat (ai): export mock image, speech, and transcription models

### DIFF
--- a/.changeset/flat-ants-draw.md
+++ b/.changeset/flat-ants-draw.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): export mock image, speech, and transcription models

--- a/packages/ai/test/index.ts
+++ b/packages/ai/test/index.ts
@@ -5,7 +5,10 @@ export {
   mockId,
 } from '@ai-sdk/provider-utils/test';
 export { MockEmbeddingModelV2 } from '../src/test/mock-embedding-model-v2';
+export { MockImageModelV2 } from '../src/test/mock-image-model-v2';
 export { MockLanguageModelV2 } from '../src/test/mock-language-model-v2';
+export { MockSpeechModelV2 } from '../src/test/mock-speech-model-v2';
+export { MockTranscriptionModelV2 } from '../src/test/mock-transcription-model-v2';
 export { mockValues } from '../src/test/mock-values';
 
 import { simulateReadableStream as originalSimulateReadableStream } from '../src/util/simulate-readable-stream';


### PR DESCRIPTION
## Background

Only mock language and embedding models were exported.

## Summary

export mock image, speech, and transcription models

## Related Issues

#6747 