### PR TITLE
docs: update v5 migration guide for persistence

### DIFF
--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1959,6 +1959,89 @@ await generateText({
 });
 ```
 
+## Message Persistence Changes
+
+In v4, you would typically use helper functions like `appendResponseMessages` or `appendClientMessage` to format messages in the `onFinish` callback of `streamText`:
+
+```tsx filename="AI SDK 4.0"
+import { streamText, convertToModelMessages, appendClientMessage, appendResponseMessages } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const result = streamText({
+  model: openai('gpt-4o'),
+  messages: convertToModelMessages(messages),
+  onFinish: async ({ responseMessages, usage }) => {
+    // Use helper functions to format messages
+    const updatedMessages = appendClientMessage({ messages, message: lastUserMessage });
+    const finalMessages = appendResponseMessages({ messages: updatedMessages, responseMessages });
+
+    // Save formatted messages to database
+    await saveMessages(finalMessages);
+  },
+});
+```
+
+In v5, message persistence is now handled through the `toUIMessageStreamResponse` method, which automatically formats response messages in the `UIMessage` format:
+
+```tsx filename="AI SDK 5.0"
+import { streamText, convertToModelMessages, UIMessage } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const result = streamText({
+  model: openai('gpt-4o'),
+  messages: convertToModelMessages(messages),
+});
+
+return result.toUIMessageStreamResponse({
+  originalMessages: messages, // Pass original messages for context
+  onFinish: ({ messages }) => {
+    // messages contains all messages (original + response) in UIMessage format
+    saveChat({ chatId, messages });
+  },
+});
+```
+
+### Alternative: Using createUIMessageStream
+
+For more complex scenarios, especially when working with data parts, you can use `createUIMessageStream`:
+
+```tsx filename="AI SDK 5.0 - Advanced"
+import { createUIMessageStream, createUIMessageStreamResponse, streamText, convertToModelMessages, UIMessage } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const stream = createUIMessageStream({
+  originalMessages: messages,
+  execute: ({ writer }) => {
+    // Write custom data parts
+    writer.write({
+      type: 'data',
+      data: { status: 'processing', timestamp: Date.now() }
+    });
+
+    // Stream the AI response
+    const result = streamText({
+      model: openai('gpt-4o'),
+      messages: convertToModelMessages(messages),
+    });
+
+    writer.merge(result.toUIMessageStream());
+  },
+  onFinish: ({ messages }) => {
+    // messages contains all messages (original + response + data parts) in UIMessage format
+    saveChat({ chatId, messages });
+  },
+});
+
+return createUIMessageStreamResponse({ stream });
+```
+
+### Suggested Changes
+
+1. Move `onFinish` from `streamText` to `toUIMessageStreamResponse`
+2. Pass `originalMessages` to `toUIMessageStreamResponse` for full message context
+3. Remove manual message formatting with helper functions
+4. Update storage logic to handle the complete `messages` array directly
+
 ## Provider & Model Changes
 
 ### OpenAI

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1987,6 +1987,10 @@ In v5, message persistence is now handled through the `toUIMessageStreamResponse
 import { streamText, convertToModelMessages, UIMessage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
+const messages: UIMessage[] = [
+  // Your existing messages in UIMessage format
+];
+
 const result = streamText({
   model: openai('gpt-4o'),
   messages: convertToModelMessages(messages),

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1964,7 +1964,12 @@ await generateText({
 In v4, you would typically use helper functions like `appendResponseMessages` or `appendClientMessage` to format messages in the `onFinish` callback of `streamText`:
 
 ```tsx filename="AI SDK 4.0"
-import { streamText, convertToModelMessages, appendClientMessage, appendResponseMessages } from 'ai';
+import {
+  streamText,
+  convertToModelMessages,
+  appendClientMessage,
+  appendResponseMessages,
+} from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const result = streamText({
@@ -1972,8 +1977,14 @@ const result = streamText({
   messages: convertToModelMessages(messages),
   onFinish: async ({ responseMessages, usage }) => {
     // Use helper functions to format messages
-    const updatedMessages = appendClientMessage({ messages, message: lastUserMessage });
-    const finalMessages = appendResponseMessages({ messages: updatedMessages, responseMessages });
+    const updatedMessages = appendClientMessage({
+      messages,
+      message: lastUserMessage,
+    });
+    const finalMessages = appendResponseMessages({
+      messages: updatedMessages,
+      responseMessages,
+    });
 
     // Save formatted messages to database
     await saveMessages(finalMessages);
@@ -2010,7 +2021,13 @@ return result.toUIMessageStreamResponse({
 For more complex scenarios, especially when working with data parts, you can use `createUIMessageStream`:
 
 ```tsx filename="AI SDK 5.0 - Advanced"
-import { createUIMessageStream, createUIMessageStreamResponse, streamText, convertToModelMessages, UIMessage } from 'ai';
+import {
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  streamText,
+  convertToModelMessages,
+  UIMessage,
+} from 'ai';
 import { openai } from '@ai-sdk/openai';
 
 const stream = createUIMessageStream({
@@ -2019,7 +2036,7 @@ const stream = createUIMessageStream({
     // Write custom data parts
     writer.write({
       type: 'data',
-      data: { status: 'processing', timestamp: Date.now() }
+      data: { status: 'processing', timestamp: Date.now() },
     });
 
     // Stream the AI response

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -2056,13 +2056,6 @@ const stream = createUIMessageStream({
 return createUIMessageStreamResponse({ stream });
 ```
 
-### Suggested Changes
-
-1. Move `onFinish` from `streamText` to `toUIMessageStreamResponse`
-2. Pass `originalMessages` to `toUIMessageStreamResponse` for full message context
-3. Remove manual message formatting with helper functions
-4. Update storage logic to handle the complete `messages` array directly
-
 ## Provider & Model Changes
 
 ### OpenAI


### PR DESCRIPTION
## Background

Updating docs pages for v5

## Tasks

- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)