### PR TITLE
feat(openai): add file_search tool support to Responses API

### DIFF
--- a/.changeset/good-cycles-matter.md
+++ b/.changeset/good-cycles-matter.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add missing file_search tool support to OpenAI Responses API

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -696,6 +696,12 @@ const result = await generateText({
 });
 ```
 
+<Note>
+  The tool must be named `file_search` when using OpenAI's file search
+  functionality. This name is required by OpenAI's API specification and cannot
+  be customized.
+</Note>
+
 #### Reasoning Summaries
 
 For reasoning models like `o3-mini`, `o3`, and `o4-mini`, you can enable reasoning summaries to see the model's thought process. Different models support different summarizers—for example, `o4-mini` supports detailed summaries. Set `reasoningSummary: "auto"` to automatically receive the richest level available.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -673,6 +673,29 @@ const result = await generateText({
 const sources = result.sources;
 ```
 
+#### File Search
+
+The OpenAI responses provider supports file search through the `openai.tools.fileSearch` tool.
+
+You can force the use of the file search tool by setting the `toolChoice` parameter to `{ type: 'tool', toolName: 'file_search' }`.
+
+```ts
+const result = await generateText({
+  model: openai.responses('gpt-4o-mini'),
+  prompt: 'What does the document say about user authentication?',
+  tools: {
+    file_search: openai.tools.fileSearch({
+      // optional configuration:
+      vectorStoreIds: ['vs_123', 'vs_456'],
+      maxResults: 10,
+      searchType: 'auto',
+    }),
+  },
+  // Force file search tool:
+  toolChoice: { type: 'tool', toolName: 'file_search' },
+});
+```
+
 #### Reasoning Summaries
 
 For reasoning models like `o3-mini`, `o3`, and `o4-mini`, you can enable reasoning summaries to see the model's thought process. Different models support different summarizers—for example, `o4-mini` supports detailed summaries. Set `reasoningSummary: "auto"` to automatically receive the richest level available.

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -76,6 +76,12 @@ export type OpenAIResponsesTool =
         city: string;
         region: string;
       };
+    }
+  | {
+      type: 'file_search';
+      vector_store_ids?: string[];
+      max_results?: number;
+      search_type?: 'auto' | 'keyword' | 'semantic';
     };
 
 export type OpenAIResponsesReasoning = {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -787,6 +787,144 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send file_search tool', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.file_search',
+              name: 'file_search',
+              args: {
+                vectorStoreIds: ['vs_123', 'vs_456'],
+                maxResults: 10,
+                searchType: 'auto',
+              },
+            },
+          ],
+          prompt: TEST_PROMPT,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "gpt-4o",
+            "tools": [
+              {
+                "max_results": 10,
+                "search_type": "auto",
+                "type": "file_search",
+                "vector_store_ids": [
+                  "vs_123",
+                  "vs_456",
+                ],
+              },
+            ],
+          }
+        `);
+
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should send file_search tool as tool_choice', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          toolChoice: {
+            type: 'tool',
+            toolName: 'file_search',
+          },
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.file_search',
+              name: 'file_search',
+              args: {
+                vectorStoreIds: ['vs_789'],
+                maxResults: 5,
+              },
+            },
+          ],
+          prompt: TEST_PROMPT,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "gpt-4o",
+            "tool_choice": {
+              "type": "file_search",
+            },
+            "tools": [
+              {
+                "max_results": 5,
+                "type": "file_search",
+                "vector_store_ids": [
+                  "vs_789",
+                ],
+              },
+            ],
+          }
+        `);
+
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should send file_search tool with minimal args', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.file_search',
+              name: 'file_search',
+              args: {},
+            },
+          ],
+          prompt: TEST_PROMPT,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "gpt-4o",
+            "tools": [
+              {
+                "type": "file_search",
+              },
+            ],
+          }
+        `);
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should warn about unsupported settings', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -4,6 +4,7 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { OpenAIResponsesTool } from './openai-responses-api-types';
+import { fileSearchArgsSchema } from '../tool/file-search';
 
 export function prepareResponsesTools({
   tools,
@@ -19,6 +20,7 @@ export function prepareResponsesTools({
     | 'auto'
     | 'none'
     | 'required'
+    | { type: 'file_search' }
     | { type: 'web_search_preview' }
     | { type: 'function'; name: string };
   toolWarnings: LanguageModelV2CallWarning[];
@@ -47,6 +49,16 @@ export function prepareResponsesTools({
         break;
       case 'provider-defined':
         switch (tool.id) {
+          case 'openai.file_search': {
+            const args = fileSearchArgsSchema.parse(tool.args);
+            openaiTools.push({
+              type: 'file_search',
+              vector_store_ids: args.vectorStoreIds,
+              max_results: args.maxResults,
+              search_type: args.searchType,
+            });
+            break;
+          }
           case 'openai.web_search_preview':
             openaiTools.push({
               type: 'web_search_preview',
@@ -87,7 +99,9 @@ export function prepareResponsesTools({
       return {
         tools: openaiTools,
         toolChoice:
-          toolChoice.toolName === 'web_search_preview'
+          toolChoice.toolName === 'file_search'
+            ? { type: 'file_search' }
+            : toolChoice.toolName === 'web_search_preview'
             ? { type: 'web_search_preview' }
             : { type: 'function', name: toolChoice.toolName },
         toolWarnings,

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -102,8 +102,8 @@ export function prepareResponsesTools({
           toolChoice.toolName === 'file_search'
             ? { type: 'file_search' }
             : toolChoice.toolName === 'web_search_preview'
-            ? { type: 'web_search_preview' }
-            : { type: 'function', name: toolChoice.toolName },
+              ? { type: 'web_search_preview' }
+              : { type: 'function', name: toolChoice.toolName },
         toolWarnings,
       };
     default: {


### PR DESCRIPTION
## background

OpenAI Responses API was missing support for the `file_search` tool that was already available in the regular OpenAI API, causing file search tools to be treated as unsupported and fall through to error handling.

## summary

- add file_search tool support to OpenAI Responses API
- add test for file_search functionality
- updated docs 

## verification

- all tests pass including new file_search-specific tests
- file_search tools are properly processed instead of being marked unsupported
- tool choice selection works with file_search tools

## tasks

- [x] add file_search case to openai-responses-prepare-tools.ts
- [x] add file_search tool type to openai-responses-api-types.ts  
- [x] add tool choice support for file_search