### PR TITLE
fix(amazon bedrock): reasoning configuration support

### DIFF
--- a/.changeset/sixty-pillows-boil.md
+++ b/.changeset/sixty-pillows-boil.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Fixes "Extra inputs are not permitted" error when using reasoning with Bedrock

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -996,10 +996,10 @@ describe('doStream', () => {
           budget_tokens: 2000,
         },
       },
-          // Should have adjusted maxTokens (100 + 2000)
-    inferenceConfig: {
-      maxTokens: 2100,
-    },
+      // Should have adjusted maxTokens (100 + 2000)
+      inferenceConfig: {
+        maxTokens: 2100,
+      },
     });
 
     // Should NOT contain reasoningConfig at the top level
@@ -1227,7 +1227,6 @@ function prepareJsonResponse({
 }
 
 describe('doGenerate', () => {
-
   it('should extract text response', async () => {
     prepareJsonResponse({ content: [{ type: 'text', text: 'Hello, World!' }] });
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -167,17 +167,21 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
       });
     }
 
-    const { thinking: _, reasoningConfig: __, ...filteredBedrockOptions } =
-      providerMetadata?.bedrock || {};
+    const {
+      thinking: _,
+      reasoningConfig: __,
+      ...filteredBedrockOptions
+    } = providerMetadata?.bedrock || {};
 
     const additionalModelRequestFields = {
       ...this.settings.additionalModelRequestFields,
-      ...(isThinking && thinkingBudget != null && {
-        thinking: {
-          type: reasoningConfigOptions.data?.type,
-          budget_tokens: thinkingBudget,
-        },
-      }),
+      ...(isThinking &&
+        thinkingBudget != null && {
+          thinking: {
+            type: reasoningConfigOptions.data?.type,
+            budget_tokens: thinkingBudget,
+          },
+        }),
     };
 
     const baseArgs: BedrockConverseInput = {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -145,15 +145,6 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
       } else {
         inferenceConfig.maxTokens = thinkingBudget + 4096; // Default + thinking budget maxTokens = 4096, TODO update default in v5
       }
-      // Add them to additional model request fields
-      // Add reasoning config to additionalModelRequestFields
-      this.settings.additionalModelRequestFields = {
-        ...this.settings.additionalModelRequestFields,
-        reasoningConfig: {
-          type: reasoningConfigOptions.data?.type,
-          budget_tokens: thinkingBudget,
-        },
-      };
     }
 
     // Remove temperature if thinking is enabled
@@ -176,14 +167,29 @@ export class BedrockChatLanguageModel implements LanguageModelV1 {
       });
     }
 
+    const { thinking: _, reasoningConfig: __, ...filteredBedrockOptions } =
+      providerMetadata?.bedrock || {};
+
+    const additionalModelRequestFields = {
+      ...this.settings.additionalModelRequestFields,
+      ...(isThinking && thinkingBudget != null && {
+        thinking: {
+          type: reasoningConfigOptions.data?.type,
+          budget_tokens: thinkingBudget,
+        },
+      }),
+    };
+
     const baseArgs: BedrockConverseInput = {
       system,
-      additionalModelRequestFields: this.settings.additionalModelRequestFields,
+      ...(Object.keys(additionalModelRequestFields).length > 0 && {
+        additionalModelRequestFields,
+      }),
       ...(Object.keys(inferenceConfig).length > 0 && {
         inferenceConfig,
       }),
       messages,
-      ...providerMetadata?.bedrock,
+      ...filteredBedrockOptions,
     };
 
     switch (type) {


### PR DESCRIPTION
## background

Amazon Bedrock models support reasoning/thinking functionality through the `reasoningConfig` parameter

## summary

- fix reasoning config transformation from `reasoningConfig` to `thinking` in request body

## verification

- proper parameter transformation and filtering works in both generate and stream modes

## tasks

- [x] fix `prepareJsonResponse` function scope for test compatibility
- [x] correct reasoning config parameter names in tests (`thinking` → `reasoningConfig`)
- [x] filter reasoningConfig from final request body 