### PR TITLE
bugfix(openai): Zod  schema validation for `choices[].delta.tool_calls[].index` to be an optional parameter to support

### DIFF
--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -740,7 +740,7 @@ const openaiChatChunkSchema = z.union([
             tool_calls: z
               .array(
                 z.object({
-                  index: z.number().nullish(),
+                  index: z.number().optional(),
                   id: z.string().nullish(),
                   type: z.literal('function').nullish(),
                   function: z.object({

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -740,7 +740,7 @@ const openaiChatChunkSchema = z.union([
             tool_calls: z
               .array(
                 z.object({
-                  index: z.number(),
+                  index: z.number().nullish(),
                   id: z.string().nullish(),
                   type: z.literal('function').nullish(),
                   function: z.object({


### PR DESCRIPTION
## Background

Sambanova models do not return `choices[].delta.tool_calls[].index`  (larger example of the error is in #7238)

## Summary

Modified the validation logic for tool_calls for the `index` parameter to be optional.

## Verification

- [ ] Missing testing currently

## Tasks
- [ ] Add test validating that `choices[].delta.tool_calls[].index` is not required for validation to work

## Related Issues

Fixes #7238