### PR TITLE
fix(@ai-sdk/google): Use single embeddings endpoint when using embed()

### DIFF
--- a/.changeset/good-trains-breathe.md
+++ b/.changeset/good-trains-breathe.md
@@ -13,9 +13,9 @@ Before, AI SDK would always use the batch endpoint, even for embed() calls, whic
 
 This does not have any breaking functionality and is fully tested :)
 if (values.length > 1) {
-  const batchResult = await this.doEmbedBatch({
-    values,
-    options,
-  });
-  return batchResult;
+const batchResult = await this.doEmbedBatch({
+values,
+options,
+});
+return batchResult;
 }

--- a/.changeset/good-trains-breathe.md
+++ b/.changeset/good-trains-breathe.md
@@ -1,0 +1,21 @@
+---
+'@ai-sdk/google': patch
+---
+
+embed() now uses the single embeddings endpoint
+No code updates are needed.
+
+This is to make sure that users are not ratelimited when using the batch endpoint, since many models have different limits for batch and single embeddings.
+
+Eg: Google has a limit of 150 RPM for batch requests, and 1500 RPM for single requests.
+
+Before, AI SDK would always use the batch endpoint, even for embed() calls, which led to ratelimits.
+
+This does not have any breaking functionality and is fully tested :)
+if (values.length > 1) {
+  const batchResult = await this.doEmbedBatch({
+    values,
+    options,
+  });
+  return batchResult;
+}

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -687,6 +687,11 @@ using the `.textEmbedding()` factory method.
 const model = google.textEmbedding('text-embedding-004');
 ```
 
+The Google Generative AI provider sends API calls to the right endpoint based on the type of embedding:
+
+- **Single embeddings**: When embedding a single value with `embed()`, the provider uses the single `:embedContent` endpoint, which typically has higher rate limits compared to the batch endpoint.
+- **Batch embeddings**: When embedding multiple values with `embedMany()` or multiple values in `embed()`, the provider uses the `:batchEmbedContents` endpoint.
+
 Google Generative AI embedding models support aditional settings. You can pass them as an options argument:
 
 ```ts

--- a/packages/google/src/google-generative-ai-embedding-model.test.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.test.ts
@@ -12,20 +12,13 @@ const testValues = ['sunny day at the beach', 'rainy day in the city'];
 const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
 const model = provider.textEmbeddingModel('text-embedding-004');
 
-const BATCH_URL = 'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContents';
-const SINGLE_URL = 'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent';
+const BATCH_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContents';
+const SINGLE_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent';
 const server = createTestServer({
-  [BATCH_URL]:
-    {},
-  [SINGLE_URL]:
-    {
-      response: {
-        type: 'json-value',
-        body: {
-          embedding: { values: dummyEmbeddings[0] },
-        },
-      }
-    },
+  [BATCH_URL]: {},
+  [SINGLE_URL]: {},
 });
 
 describe('GoogleGenerativeAIEmbeddingModel', () => {
@@ -36,9 +29,7 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
     embeddings?: EmbeddingModelV2Embedding[];
     headers?: Record<string, string>;
   } = {}) {
-    server.urls[
-      BATCH_URL
-    ].response = {
+    server.urls[BATCH_URL].response = {
       type: 'json-value',
       headers,
       body: {
@@ -52,7 +43,7 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
       body: {
         embedding: { values: embeddings[0] },
       },
-    }
+    };
   }
 
   it('should extract embedding', async () => {
@@ -172,23 +163,22 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
   });
 
   it('should use the batch embeddings endpoint', async () => {
-    prepareJsonResponse()
-    const model = provider.textEmbeddingModel("text-embedding-004")
+    prepareJsonResponse();
+    const model = provider.textEmbeddingModel('text-embedding-004');
     await model.doEmbed({
       values: testValues,
     });
 
     expect(server.calls[0].requestUrl).toBe(BATCH_URL);
-  })
+  });
 
   it('should use the single embeddings endpoint', async () => {
-
-    const model = provider.textEmbeddingModel("text-embedding-004")
+    const model = provider.textEmbeddingModel('text-embedding-004');
 
     await model.doEmbed({
       values: [testValues[0]],
     });
 
     expect(server.calls[0].requestUrl).toBe(SINGLE_URL);
-  })
+  });
 });

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -83,7 +83,7 @@ export class GoogleGenerativeAIEmbeddingModel
       body: {
         model: `models/${this.modelId}`,
         content: {
-          parts: [{ text: value }]
+          parts: [{ text: value }],
         },
         outputDimensionality: googleOptions?.outputDimensionality,
         taskType: googleOptions?.taskType,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

We use the `@ai-sdk/google` package at supermemory, and many times, use the `embed()` functionality to generate embeddings for single queries etc. 

However, I noticed that the AI sdk was _always_ calling the batch embed content, and we frequently ran into ratelimits because that endpoint has a limit of 150, as opposed to 1500 for the single `:embedContent` endpoint. The ratelimit is measured by number of requests, not number of items in the batch for google. 

This PR makes sure that when there's `embed` (a single embedding), the request goes through the `embedContent` endpoint, ensuring that the right type of ratelimit is enforced. It also reads the result and formats it in the same output format as expected.

## Summary

<!-- What did you change? -->

I added a function `doEmbedSingle` that uses the single `embedContent` URL `${this.config.baseURL}/models/${this.modelId}:embedContent`

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

I temporarily added a console.log in the doEmbedSingle, ran it, and also verified that it does not break by running the batch one again. 

I ran the `pnpm tsx src/embed/google.ts` with my `GOOGLE_GENERATIVE_AI_API_KEY` and confirmed that it works.

<img width="1024" height="532" alt="image" src="https://github.com/user-attachments/assets/f3b3f859-fb8f-4db4-891c-1b8b922a093f" />


## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->
This functionality should (and could be) added to other embedding providers as well, I added a readonly `readonly supportsSingleEmbed = true;` to check for availability of that function. 

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
