### PR TITLE
feat: add moonshot provider for kimi k2 model

### DIFF
--- a/.changeset/neat-pigs-end.md
+++ b/.changeset/neat-pigs-end.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshot': patch
+---
+
+feat(moonshot): add Moonshot provider with Kimi K2 model support

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -37,6 +37,7 @@ The AI SDK comes with a wide range of providers that you can use to interact wit
 - [Fireworks Provider](/providers/ai-sdk-providers/fireworks) (`@ai-sdk/fireworks`)
 - [DeepInfra Provider](/providers/ai-sdk-providers/deepinfra) (`@ai-sdk/deepinfra`)
 - [DeepSeek Provider](/providers/ai-sdk-providers/deepseek) (`@ai-sdk/deepseek`)
+- [Moonshot Provider](/providers/ai-sdk-providers/moonshot) (`@ai-sdk/moonshot`)
 - [Cerebras Provider](/providers/ai-sdk-providers/cerebras) (`@ai-sdk/cerebras`)
 - [Groq Provider](/providers/ai-sdk-providers/groq) (`@ai-sdk/groq`)
 - [Perplexity Provider](/providers/ai-sdk-providers/perplexity) (`@ai-sdk/perplexity`)
@@ -137,6 +138,8 @@ Here are the capabilities of popular models:
 | [Google Vertex](/providers/ai-sdk-providers/google-vertex)               | `gemini-1.5-pro`                            | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)                         | `deepseek-chat`                             | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)                         | `deepseek-reasoner`                         | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
+| [Moonshot](/providers/ai-sdk-providers/moonshot)                         | `kimi-k2-base`                              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| [Moonshot](/providers/ai-sdk-providers/moonshot)                         | `kimi-k2-instruct`                          | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)                         | `llama3.1-8b`                               | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)                         | `llama3.1-70b`                              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)                         | `llama3.3-70b`                              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/61-moonshot.mdx
+++ b/content/providers/01-ai-sdk-providers/61-moonshot.mdx
@@ -95,9 +95,9 @@ const model = moonshot.chat('kimi-k2-0711-preview');
 
 ## Model Capabilities
 
-| Model                  | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
-| ---------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `kimi-k2-0711-preview` | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| Model                  | Text Generation     | Object Generation   | Image Input         | Tool Usage          | Tool Streaming      |
+| ---------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `kimi-k2-0711-preview` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   Please see the [Moonshot docs](https://platform.moonshot.ai/docs) for more

--- a/content/providers/01-ai-sdk-providers/61-moonshot.mdx
+++ b/content/providers/01-ai-sdk-providers/61-moonshot.mdx
@@ -1,0 +1,106 @@
+---
+title: Moonshot
+description: Learn how to use Moonshot's models with the AI SDK.
+---
+
+# Moonshot Provider
+
+The [Moonshot](https://moonshot.ai) provider offers access to powerful language models through the Moonshot API, including their Kimi K2 model with advanced reasoning and coding capabilities.
+
+API keys can be obtained from the [Moonshot Platform](https://platform.moonshot.ai).
+
+## Setup
+
+The Moonshot provider is available via the `@ai-sdk/moonshot` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn']}>
+  <Tab>
+    <Snippet text="pnpm add @ai-sdk/moonshot" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install @ai-sdk/moonshot" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add @ai-sdk/moonshot" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+You can import the default provider instance `moonshot` from `@ai-sdk/moonshot`:
+
+```ts
+import { moonshot } from '@ai-sdk/moonshot';
+```
+
+For custom configuration, you can import `createMoonshot` and create a provider instance with your settings:
+
+```ts
+import { createMoonshot } from '@ai-sdk/moonshot';
+
+const moonshot = createMoonshot({
+  apiKey: process.env.MOONSHOT_API_KEY ?? '',
+});
+```
+
+You can use the following optional settings to customize the Moonshot provider instance:
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls.
+  The default prefix is `https://api.moonshot.ai/v1`.
+
+- **apiKey** _string_
+
+  API key that is being sent using the `Authorization` header. It defaults to
+  the `MOONSHOT_API_KEY` environment variable.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+
+## Language Models
+
+You can create language models using a provider instance:
+
+```ts
+import { moonshot } from '@ai-sdk/moonshot';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: moonshot('kimi-k2-0711-preview'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+```
+
+Moonshot language models can be used in the `streamText` function
+(see [AI SDK Core](/docs/ai-sdk-core)).
+
+You can create Moonshot language models using a provider instance. The first argument is the model ID, e.g. `kimi-k2-0711-preview`:
+
+```ts
+const model = moonshot('kimi-k2-0711-preview');
+```
+
+You can also use the `.languageModel()` and `.chat()` methods:
+
+```ts
+const model = moonshot.languageModel('kimi-k2-0711-preview');
+const model = moonshot.chat('kimi-k2-0711-preview');
+```
+
+## Model Capabilities
+
+| Model                  | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
+| ---------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `kimi-k2-0711-preview` | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+
+<Note>
+  Please see the [Moonshot docs](https://platform.moonshot.ai/docs) for more
+  details about the available models. You can also pass any available provider
+  model ID as a string if needed.
+</Note>

--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -24,6 +24,7 @@
     "@ai-sdk/luma": "workspace:*",
     "@ai-sdk/hume": "workspace:*",
     "@ai-sdk/mistral": "workspace:*",
+    "@ai-sdk/moonshot": "workspace:*",
     "@ai-sdk/openai": "workspace:*",
     "@ai-sdk/openai-compatible": "workspace:*",
     "@ai-sdk/perplexity": "workspace:*",

--- a/examples/ai-core/src/generate-text/moonshot-chatbot.ts
+++ b/examples/ai-core/src/generate-text/moonshot-chatbot.ts
@@ -1,5 +1,5 @@
 import { moonshot } from '@ai-sdk/moonshot';
-import { generateText, tool } from 'ai';
+import { generateText, tool, ModelMessage } from 'ai';
 import 'dotenv/config';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod/v4';
@@ -10,7 +10,7 @@ const terminal = readline.createInterface({
 });
 
 async function main() {
-  const messages = [];
+  const messages: ModelMessage[] = [];
 
   while (true) {
     const userInput = await terminal.question('You: ');

--- a/examples/ai-core/src/generate-text/moonshot-chatbot.ts
+++ b/examples/ai-core/src/generate-text/moonshot-chatbot.ts
@@ -1,0 +1,43 @@
+import { moonshot } from '@ai-sdk/moonshot';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import * as readline from 'node:readline/promises';
+import { z } from 'zod/v4';
+
+const terminal = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+async function main() {
+  const messages = [];
+
+  while (true) {
+    const userInput = await terminal.question('You: ');
+    messages.push({ role: 'user', content: userInput });
+
+    const { text } = await generateText({
+      model: moonshot('kimi-k2-0711-preview'),
+      tools: {
+        weather: tool({
+          description: 'Get the weather in a location',
+          inputSchema: z.object({
+            location: z
+              .string()
+              .describe('The location to get the weather for'),
+          }),
+          execute: async ({ location }) => ({
+            location,
+            temperature: 72 + Math.floor(Math.random() * 21) - 10,
+          }),
+        }),
+      },
+      messages,
+    });
+
+    console.log(`Assistant: ${text}`);
+    messages.push({ role: 'assistant', content: text });
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/moonshot-tool-call.ts
+++ b/examples/ai-core/src/generate-text/moonshot-tool-call.ts
@@ -1,0 +1,27 @@
+import { moonshot } from '@ai-sdk/moonshot';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod/v4';
+
+async function main() {
+  const { text } = await generateText({
+    model: moonshot('kimi-k2-0711-preview'),
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location',
+        inputSchema: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+        }),
+      }),
+    },
+    prompt: 'What is the weather in Tokyo?',
+  });
+
+  console.log(text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/moonshot.ts
+++ b/examples/ai-core/src/generate-text/moonshot.ts
@@ -1,0 +1,15 @@
+import { moonshot } from '@ai-sdk/moonshot';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const { text } = await generateText({
+    model: moonshot('kimi-k2-0711-preview'),
+    prompt: 'Count from 1 to 3 and say hello.',
+    temperature: 0.6, // Recommended temperature for Kimi K2
+  });
+
+  console.log(text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/moonshot-tool-call.ts
+++ b/examples/ai-core/src/stream-text/moonshot-tool-call.ts
@@ -1,0 +1,73 @@
+import { moonshot } from '@ai-sdk/moonshot';
+import { streamText, ModelMessage, ToolCallPart, ToolResultPart } from 'ai';
+import 'dotenv/config';
+import { weatherTool } from '../tools/weather-tool';
+
+const messages: ModelMessage[] = [];
+
+async function main() {
+  let toolResponseAvailable = false;
+
+  const result = streamText({
+    model: moonshot('kimi-k2-0711-preview'),
+    maxOutputTokens: 512,
+    tools: {
+      weather: weatherTool,
+    },
+    toolChoice: 'auto',
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  let fullResponse = '';
+  const toolCalls: ToolCallPart[] = [];
+  const toolResponses: ToolResultPart[] = [];
+
+  for await (const delta of result.fullStream) {
+    switch (delta.type) {
+      case 'text': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
+        break;
+      }
+
+      case 'tool-call': {
+        toolCalls.push(delta);
+
+        process.stdout.write(
+          `\nTool call: '${delta.toolName}' ${JSON.stringify(delta.input)}`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        const transformedDelta: ToolResultPart = {
+          ...delta,
+          output: { type: 'json', value: delta.output },
+        };
+        toolResponses.push(transformedDelta);
+
+        process.stdout.write(
+          `\nTool response: '${delta.toolName}' ${JSON.stringify(
+            delta.output,
+          )}`,
+        );
+        break;
+      }
+    }
+  }
+  process.stdout.write('\n\n');
+
+  messages.push({
+    role: 'assistant',
+    content: [{ type: 'text', text: fullResponse }, ...toolCalls],
+  });
+
+  if (toolResponses.length > 0) {
+    messages.push({ role: 'tool', content: toolResponses });
+  }
+
+  toolResponseAvailable = toolCalls.length > 0;
+  console.log('Messages:', messages[0].content);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/moonshot.ts
+++ b/examples/ai-core/src/stream-text/moonshot.ts
@@ -1,0 +1,17 @@
+import { moonshot } from '@ai-sdk/moonshot';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: moonshot('kimi-k2-0711-preview'),
+    prompt: "How many r's is there in strawberry?",
+    temperature: 0.6, // Recommended temperature for Kimi K2
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+}
+
+main().catch(console.error);

--- a/packages/moonshot/CHANGELOG.md
+++ b/packages/moonshot/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @ai-sdk/moonshot
 
-## 1.0.0-beta.1
+## 0.0.1
 
-### Major Changes
+### Patch Changes
 
 - Initial release of the Moonshot provider for AI SDK
-- Support for Kimi K2 models (kimi-k2-base and kimi-k2-instruct)
+- Support for Kimi K2 model (kimi-k2-0711-preview)
 - OpenAI-compatible API integration
 - Tool calling support for agentic capabilities

--- a/packages/moonshot/CHANGELOG.md
+++ b/packages/moonshot/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @ai-sdk/moonshot
+
+## 1.0.0-beta.1
+
+### Major Changes
+
+- Initial release of the Moonshot provider for AI SDK
+- Support for Kimi K2 models (kimi-k2-base and kimi-k2-instruct)
+- OpenAI-compatible API integration
+- Tool calling support for agentic capabilities

--- a/packages/moonshot/README.md
+++ b/packages/moonshot/README.md
@@ -1,0 +1,57 @@
+# AI SDK - Moonshot Provider
+
+The **[Moonshot provider](https://ai-sdk.dev/providers/ai-sdk-providers/moonshot)** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for the [Moonshot AI](https://api.moonshot.ai) platform.
+
+## Setup
+
+The Moonshot provider is available in the `@ai-sdk/moonshot` module. You can install it with
+
+```bash
+npm i @ai-sdk/moonshot
+```
+
+## Provider Instance
+
+You can import the default provider instance `moonshot` from `@ai-sdk/moonshot`:
+
+```ts
+import { moonshot } from '@ai-sdk/moonshot';
+```
+
+## Example
+
+```ts
+import { moonshot } from '@ai-sdk/moonshot';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: moonshot('kimi-k2-0711-preview'),
+  prompt: 'Write a JavaScript function that sorts a list:',
+  temperature: 0.6, // Recommended temperature for Kimi K2
+});
+```
+
+## Models
+
+The Moonshot provider supports the following models:
+
+### Generation Models
+
+- `kimi-k2-0711-preview`: Mixture-of-Experts model with exceptional coding and agent capabilities
+
+## Configuration
+
+You can configure the Moonshot provider with your API key and other settings:
+
+```ts
+import { createMoonshot } from '@ai-sdk/moonshot';
+
+const moonshot = createMoonshot({
+  apiKey: 'your-moonshot-api-key', // defaults to process.env.MOONSHOT_API_KEY
+  baseURL: 'https://api.moonshot.ai/v1', // optional, defaults to Moonshot's API
+});
+```
+
+## Documentation
+
+Please check out the **[Moonshot provider](https://ai-sdk.dev/providers/ai-sdk-providers/moonshot)** for more information.

--- a/packages/moonshot/package.json
+++ b/packages/moonshot/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@ai-sdk/moonshot",
+  "version": "1.0.0-beta.1",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "lint": "eslint \"./**/*.ts*\"",
+    "type-check": "tsc --build",
+    "prettier-check": "prettier --check \"./**/*.ts*\"",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/openai-compatible": "workspace:*",
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8",
+    "typescript": "5.8.3",
+    "zod": "3.25.49"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.49"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/ai.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai",
+    "moonshot",
+    "kimi"
+  ]
+} 

--- a/packages/moonshot/src/index.ts
+++ b/packages/moonshot/src/index.ts
@@ -1,0 +1,6 @@
+export { createMoonshot, moonshot } from './moonshot-provider';
+export type {
+  MoonshotProvider,
+  MoonshotProviderSettings,
+} from './moonshot-provider';
+export type { OpenAICompatibleErrorData as MoonshotErrorData } from '@ai-sdk/openai-compatible';

--- a/packages/moonshot/src/moonshot-chat-options.ts
+++ b/packages/moonshot/src/moonshot-chat-options.ts
@@ -1,0 +1,4 @@
+// https://platform.moonshot.ai/docs/introduction#text-generation-model
+export type MoonshotChatModelId =
+  // Generation Model kimi-k2
+  'kimi-k2-0711-preview' | (string & {});

--- a/packages/moonshot/src/moonshot-provider.test.ts
+++ b/packages/moonshot/src/moonshot-provider.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { createMoonshot } from './moonshot-provider';
+import { loadApiKey } from '@ai-sdk/provider-utils';
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+
+const OpenAICompatibleChatLanguageModelMock =
+  OpenAICompatibleChatLanguageModel as unknown as Mock;
+
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  OpenAICompatibleChatLanguageModel: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/provider-utils', () => ({
+  loadApiKey: vi.fn().mockReturnValue('mock-api-key'),
+  withoutTrailingSlash: vi.fn(url => url),
+}));
+
+describe('MoonshotProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createMoonshot', () => {
+    it('should create a MoonshotProvider instance with default options', () => {
+      const provider = createMoonshot();
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+
+      expect(constructorCall[0]).toBe('model-id');
+      expect(config.provider).toBe('moonshot.chat');
+      expect(config.url({ path: '/chat/completions' })).toBe(
+        'https://api.moonshot.ai/v1/chat/completions',
+      );
+
+      const headers = config.headers();
+      expect(headers).toMatchInlineSnapshot(`
+        {
+          "Authorization": "Bearer mock-api-key",
+        }
+      `);
+
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: undefined,
+        environmentVariableName: 'MOONSHOT_API_KEY',
+        description: 'Moonshot API key',
+      });
+    });
+
+    it('should create a MoonshotProvider instance with custom options', () => {
+      const options = {
+        apiKey: 'custom-key',
+        baseURL: 'https://custom.url',
+        headers: { 'Custom-Header': 'value' },
+      };
+      const provider = createMoonshot(options);
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+
+      expect(constructorCall[0]).toBe('model-id');
+      expect(config.provider).toBe('moonshot.chat');
+      expect(config.url({ path: '/chat/completions' })).toBe(
+        'https://custom.url/chat/completions',
+      );
+
+      const headers = config.headers();
+      expect(headers).toMatchInlineSnapshot(`
+        {
+          "Authorization": "Bearer mock-api-key",
+          "Custom-Header": "value",
+        }
+      `);
+
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: 'custom-key',
+        environmentVariableName: 'MOONSHOT_API_KEY',
+        description: 'Moonshot API key',
+      });
+    });
+
+    it('should return a chat model when called as a function', () => {
+      const provider = createMoonshot();
+      const modelId = 'kimi-k2-0711-preview';
+
+      const model = provider(modelId);
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+    });
+  });
+
+  describe('languageModel', () => {
+    it('should construct a language model with correct configuration', () => {
+      const provider = createMoonshot();
+      const modelId = 'kimi-k2-0711-preview';
+
+      const model = provider.languageModel(modelId);
+
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+      expect(OpenAICompatibleChatLanguageModelMock).toHaveBeenCalledWith(
+        modelId,
+        expect.objectContaining({
+          provider: 'moonshot.chat',
+        }),
+      );
+    });
+  });
+
+  describe('chat', () => {
+    it('should construct a chat model with correct configuration', () => {
+      const provider = createMoonshot();
+      const modelId = 'kimi-k2-0711-preview';
+
+      const model = provider.chat(modelId);
+
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+      expect(OpenAICompatibleChatLanguageModelMock).toHaveBeenCalledWith(
+        modelId,
+        expect.objectContaining({
+          provider: 'moonshot.chat',
+        }),
+      );
+    });
+  });
+
+  describe('textEmbeddingModel', () => {
+    it('should throw NoSuchModelError when attempting to create embedding model', () => {
+      const provider = createMoonshot();
+
+      expect(() => provider.textEmbeddingModel('any-model')).toThrow(
+        'No such textEmbeddingModel: any-model',
+      );
+    });
+  });
+
+  describe('imageModel', () => {
+    it('should throw NoSuchModelError when attempting to create image model', () => {
+      const provider = createMoonshot();
+
+      expect(() => provider.imageModel('any-model')).toThrow(
+        'No such imageModel: any-model',
+      );
+    });
+  });
+});

--- a/packages/moonshot/src/moonshot-provider.ts
+++ b/packages/moonshot/src/moonshot-provider.ts
@@ -1,0 +1,91 @@
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+import {
+  LanguageModelV2,
+  NoSuchModelError,
+  ProviderV2,
+} from '@ai-sdk/provider';
+import {
+  FetchFunction,
+  loadApiKey,
+  withoutTrailingSlash,
+} from '@ai-sdk/provider-utils';
+import { MoonshotChatModelId } from './moonshot-chat-options';
+
+export interface MoonshotProviderSettings {
+  /**
+   * Moonshot API key.
+   */
+  apiKey?: string;
+  /**
+   * Base URL for the API calls.
+   */
+  baseURL?: string;
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface MoonshotProvider extends ProviderV2 {
+  /**
+   * Creates a Moonshot model for text generation.
+   */
+  (modelId: MoonshotChatModelId): LanguageModelV2;
+
+  /**
+   * Creates a Moonshot model for text generation.
+   */
+  languageModel(modelId: MoonshotChatModelId): LanguageModelV2;
+
+  /**
+   * Creates a Moonshot chat model for text generation.
+   */
+  chat(modelId: MoonshotChatModelId): LanguageModelV2;
+}
+
+export function createMoonshot(
+  options: MoonshotProviderSettings = {},
+): MoonshotProvider {
+  const baseURL = withoutTrailingSlash(
+    options.baseURL ?? 'https://api.moonshot.ai/v1',
+  );
+  const getHeaders = () => ({
+    Authorization: `Bearer ${loadApiKey({
+      apiKey: options.apiKey,
+      environmentVariableName: 'MOONSHOT_API_KEY',
+      description: 'Moonshot API key',
+    })}`,
+    ...options.headers,
+  });
+
+  const createLanguageModel = (modelId: MoonshotChatModelId) => {
+    return new OpenAICompatibleChatLanguageModel(modelId, {
+      provider: `moonshot.chat`,
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  const provider = (modelId: MoonshotChatModelId) =>
+    createLanguageModel(modelId);
+
+  provider.languageModel = createLanguageModel;
+  provider.chat = createLanguageModel;
+
+  provider.textEmbeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'textEmbeddingModel' });
+  };
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  return provider;
+}
+
+export const moonshot = createMoonshot();

--- a/packages/moonshot/tsconfig.build.json
+++ b/packages/moonshot/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "dist/**/*"]
+} 

--- a/packages/moonshot/tsconfig.build.json
+++ b/packages/moonshot/tsconfig.build.json
@@ -1,9 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
-    "declaration": true,
-    "declarationMap": true
-  },
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "dist/**/*"]
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
 } 

--- a/packages/moonshot/tsconfig.json
+++ b/packages/moonshot/tsconfig.json
@@ -1,8 +1,25 @@
 {
-    "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
   },
-  "include": ["src/**/*"],
-  "exclude": ["dist/**/*", "**/*.test.ts"]
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "tsup.config.ts"
+  ],
+  "references": [
+    {
+      "path": "../openai-compatible"
+    },
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    }
+  ]
 } 

--- a/packages/moonshot/tsconfig.json
+++ b/packages/moonshot/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist/**/*", "**/*.test.ts"]
+} 

--- a/packages/moonshot/tsup.config.ts
+++ b/packages/moonshot/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    external: [
+      '@ai-sdk/provider',
+      '@ai-sdk/provider-utils',
+      '@ai-sdk/openai-compatible',
+    ],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+  },
+]);

--- a/packages/moonshot/tsup.config.ts
+++ b/packages/moonshot/tsup.config.ts
@@ -4,13 +4,7 @@ export default defineConfig([
   {
     entry: ['src/index.ts'],
     format: ['cjs', 'esm'],
-    external: [
-      '@ai-sdk/provider',
-      '@ai-sdk/provider-utils',
-      '@ai-sdk/openai-compatible',
-    ],
     dts: true,
     sourcemap: true,
-    clean: true,
   },
 ]);

--- a/packages/moonshot/vitest.edge.config.js
+++ b/packages/moonshot/vitest.edge.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+  },
+});

--- a/packages/moonshot/vitest.node.config.js
+++ b/packages/moonshot/vitest.node.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1936,6 +1936,34 @@ importers:
         specifier: 3.25.49
         version: 3.25.49
 
+  packages/moonshot:
+    dependencies:
+      '@ai-sdk/openai-compatible':
+        specifier: workspace:*
+        version: link:../openai-compatible
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8
+        version: 8.3.0(jiti@2.4.0)(postcss@8.5.3)(tsx@4.19.2)(typescript@5.8.3)(yaml@2.7.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.49
+        version: 3.25.49
+
   packages/openai:
     dependencies:
       '@ai-sdk/provider':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@ai-sdk/mistral':
         specifier: workspace:*
         version: link:../../packages/mistral
+      '@ai-sdk/moonshot':
+        specifier: workspace:*
+        version: link:../../packages/moonshot
       '@ai-sdk/openai':
         specifier: workspace:*
         version: link:../../packages/openai

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     { "path": "packages/lmnt" },
     { "path": "packages/luma" },
     { "path": "packages/mistral" },
+    { "path": "packages/moonshot" },
     { "path": "packages/openai" },
     { "path": "packages/openai-compatible" },
     { "path": "packages/perplexity" },


### PR DESCRIPTION
## background

Moonshot released the Kimi K2 model with advanced reasoning and coding capabilities. Users need access to this model through the AI SDK for building applications with strong tool calling and agentic features.

## summary

- add moonshot provider with kimi k2 model support
- openai-compatible for implementation 

## verification

- all tests pass
- tool calling works with proper streaming
- added examples 

## tasks

- [x] moonshot provider implementation
- [x] kimi-k2-0711-preview model support  
- [x] test coverage
- [x] documentation and examples