### PR TITLE
Filter out tools with input-available state from tool message conversion

### DIFF
--- a/.changeset/hip-waves-occur.md
+++ b/.changeset/hip-waves-occur.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Filter out tools with input-available state from tool message conversion

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -172,8 +172,12 @@ export function convertToModelMessages(
             // check if there are tool invocations with results in the block
             const toolParts = block
               .filter(isToolUIPart)
-              .filter(part => part.providerExecuted !== true);
-
+              .filter(part => part.providerExecuted !== true)
+              .filter(
+                (part): part is ToolUIPart<UITools> =>
+                  part.state === 'output-available' ||
+                  part.state === 'output-error',
+              );
             // tool message with tool results
             if (toolParts.length > 0) {
               modelMessages.push({


### PR DESCRIPTION
## Summary

Fix "Unsupported tool part state: input-available" error in convertToModelMessages

Previously, when tools were in the `input-available` state (ready for execution but no results yet), the `convertToModelMessages` function would throw an "Unsupported tool part state: input-available" error when trying to create tool messages. This occurred because the function attempted to process all tool parts for message conversion, but only handled `output-available` and `output-error` states in its switch statement.

The fix adds proper state-based filtering to only create tool messages for tools that have actual results (`output-available` or `output-error` states). Tools in `input-available` state are correctly excluded from tool message creation since they don't have outputs to convert yet.

This resolves runtime errors in useChat and other UI components when tools are awaiting execution.

## Verification
It was a small fix so added a failing test for this case

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues
Fixes #7258 
