### PR TITLE
feat (provider/xai): export XaiProviderOptions

### DIFF
--- a/.changeset/poor-walls-arrive.md
+++ b/.changeset/poor-walls-arrive.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat (provider/xai): export XaiProviderOptions

--- a/packages/xai/src/index.ts
+++ b/packages/xai/src/index.ts
@@ -1,3 +1,4 @@
+export type { XaiProviderOptions } from './xai-chat-options';
+export type { XaiErrorData } from './xai-error';
 export { createXai, xai } from './xai-provider';
 export type { XaiProvider, XaiProviderSettings } from './xai-provider';
-export type { XaiErrorData } from './xai-error';


### PR DESCRIPTION
## Background

Provider option types are needed for satisfies checks.

## Summary

Export `XaiProviderOptions`.

## Related Issues

Fixes #7233