### PR TITLE
fix (ai): throw error for v1 models

### DIFF
--- a/.changeset/silver-laws-play.md
+++ b/.changeset/silver-laws-play.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): throw error for v1 models

--- a/packages/ai/src/error/index.ts
+++ b/packages/ai/src/error/index.ts
@@ -21,6 +21,7 @@ export { NoObjectGeneratedError } from './no-object-generated-error';
 export { NoOutputSpecifiedError } from './no-output-specified-error';
 export { NoSuchToolError } from './no-such-tool-error';
 export { ToolCallRepairError } from './tool-call-repair-error';
+export { UnsupportedModelVersionError } from './unsupported-model-version-error';
 
 export { InvalidDataContentError } from '../prompt/invalid-data-content-error';
 export { InvalidMessageRoleError } from '../prompt/invalid-message-role-error';

--- a/packages/ai/src/error/unsupported-model-version-error.ts
+++ b/packages/ai/src/error/unsupported-model-version-error.ts
@@ -1,0 +1,23 @@
+import { AISDKError } from '@ai-sdk/provider';
+
+/**
+Error that is thrown when a model with an unsupported version is used.
+ */
+export class UnsupportedModelVersionError extends AISDKError {
+  readonly version: string;
+  readonly provider: string;
+  readonly modelId: string;
+
+  constructor(options: { version: string; provider: string; modelId: string }) {
+    super({
+      name: 'AI_UnsupportedModelVersionError',
+      message:
+        `Unsupported model version ${options.version} for provider "${options.provider}" and model "${options.modelId}". ` +
+        `AI SDK 5 only supports models that implement specification version "v2".`,
+    });
+
+    this.version = options.version;
+    this.provider = options.provider;
+    this.modelId = options.modelId;
+  }
+}

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -1,10 +1,12 @@
 import { ImageModelV2, ImageModelV2ProviderMetadata } from '@ai-sdk/provider';
+import { ProviderOptions } from '@ai-sdk/provider-utils';
 import { NoImageGeneratedError } from '../../src/error/no-image-generated-error';
 import {
   detectMediaType,
   imageMediaTypeSignatures,
 } from '../../src/util/detect-media-type';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { UnsupportedModelVersionError } from '../error/unsupported-model-version-error';
 import {
   DefaultGeneratedFile,
   GeneratedFile,
@@ -12,7 +14,6 @@ import {
 import { ImageGenerationWarning } from '../types/image-model';
 import { ImageModelResponseMetadata } from '../types/image-model-response-metadata';
 import { GenerateImageResult } from './generate-image-result';
-import { ProviderOptions } from '@ai-sdk/provider-utils';
 
 /**
 Generates images using an image model.
@@ -113,6 +114,14 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<GenerateImageResult> {
+  if (model.specificationVersion !== 'v2') {
+    throw new UnsupportedModelVersionError({
+      version: model.specificationVersion,
+      provider: model.provider,
+      modelId: model.modelId,
+    });
+  }
+
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
   // default to 1 if the model has not specified limits on

--- a/packages/ai/src/generate-speech/generate-speech.ts
+++ b/packages/ai/src/generate-speech/generate-speech.ts
@@ -1,10 +1,12 @@
 import { JSONValue, SpeechModelV2 } from '@ai-sdk/provider';
+import { ProviderOptions } from '@ai-sdk/provider-utils';
 import { NoSpeechGeneratedError } from '../../src/error/no-speech-generated-error';
 import {
   audioMediaTypeSignatures,
   detectMediaType,
 } from '../../src/util/detect-media-type';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { UnsupportedModelVersionError } from '../error/unsupported-model-version-error';
 import { SpeechWarning } from '../types/speech-model';
 import { SpeechModelResponseMetadata } from '../types/speech-model-response-metadata';
 import { SpeechResult } from './generate-speech-result';
@@ -12,7 +14,6 @@ import {
   DefaultGeneratedAudioFile,
   GeneratedAudioFile,
 } from './generated-audio-file';
-import { ProviderOptions } from '@ai-sdk/provider-utils';
 
 /**
 Generates speech audio using a speech model.
@@ -112,6 +113,14 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<SpeechResult> {
+  if (model.specificationVersion !== 'v2') {
+    throw new UnsupportedModelVersionError({
+      version: model.specificationVersion,
+      provider: model.provider,
+      modelId: model.modelId,
+    });
+  }
+
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
   const result = await retry(() =>

--- a/packages/ai/src/prompt/resolve-language-model.ts
+++ b/packages/ai/src/prompt/resolve-language-model.ts
@@ -1,9 +1,18 @@
 import { gateway } from '@ai-sdk/gateway';
 import { LanguageModelV2 } from '@ai-sdk/provider';
+import { UnsupportedModelVersionError } from '../error';
 import { LanguageModel } from '../types/language-model';
 
 export function resolveLanguageModel(model: LanguageModel): LanguageModelV2 {
   if (typeof model !== 'string') {
+    if (model.specificationVersion !== 'v2') {
+      throw new UnsupportedModelVersionError({
+        version: model.specificationVersion,
+        provider: model.provider,
+        modelId: model.modelId,
+      });
+    }
+
     return model;
   }
 

--- a/packages/ai/src/transcribe/transcribe.ts
+++ b/packages/ai/src/transcribe/transcribe.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src/util/detect-media-type';
 import { download } from '../../src/util/download';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { UnsupportedModelVersionError } from '../error/unsupported-model-version-error';
 import { DataContent } from '../prompt';
 import { convertDataContentToUint8Array } from '../prompt/data-content';
 import { TranscriptionWarning } from '../types/transcription-model';
@@ -78,6 +79,14 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<TranscriptionResult> {
+  if (model.specificationVersion !== 'v2') {
+    throw new UnsupportedModelVersionError({
+      version: model.specificationVersion,
+      provider: model.provider,
+      modelId: model.modelId,
+    });
+  }
+
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
   const audioData =
     audio instanceof URL


### PR DESCRIPTION
## Background

People might try to use v1 models despite typescript errors, e.g. from js or by ignoring them.

## Summary

Throw an error for v1 models. AI SDK 5 requires v2 models.