### PR TITLE
fix (ai): throw error for v2 models or string model ids

### DIFF
--- a/.changeset/afraid-readers-bow.md
+++ b/.changeset/afraid-readers-bow.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): throw error for v2 models or string model ids

--- a/packages/ai/core/embed/embed-many.ts
+++ b/packages/ai/core/embed/embed-many.ts
@@ -8,6 +8,7 @@ import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { Embedding, EmbeddingModel } from '../types';
 import { splitArray } from '../util/split-array';
 import { EmbedManyResult } from './embed-many-result';
+import { UnsupportedModelVersionError } from '../../errors/unsupported-model-version-error';
 
 /**
 Embed several values using an embedding model. The type of the value is defined
@@ -66,6 +67,10 @@ Only applicable for HTTP-based providers.
    */
   experimental_telemetry?: TelemetrySettings;
 }): Promise<EmbedManyResult<VALUE>> {
+  if (typeof model === 'string' || model.specificationVersion !== 'v1') {
+    throw new UnsupportedModelVersionError();
+  }
+
   const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
   const baseTelemetryAttributes = getBaseTelemetryAttributes({

--- a/packages/ai/core/embed/embed.ts
+++ b/packages/ai/core/embed/embed.ts
@@ -1,3 +1,4 @@
+import { UnsupportedModelVersionError } from '../../errors/unsupported-model-version-error';
 import { prepareRetries } from '../prompt/prepare-retries';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
@@ -61,6 +62,10 @@ Only applicable for HTTP-based providers.
    */
   experimental_telemetry?: TelemetrySettings;
 }): Promise<EmbedResult<VALUE>> {
+  if (typeof model === 'string' || model.specificationVersion !== 'v1') {
+    throw new UnsupportedModelVersionError();
+  }
+
   const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
   const baseTelemetryAttributes = getBaseTelemetryAttributes({

--- a/packages/ai/core/generate-image/generate-image.ts
+++ b/packages/ai/core/generate-image/generate-image.ts
@@ -12,6 +12,7 @@ import {
   detectMimeType,
   imageMimeTypeSignatures,
 } from '../util/detect-mimetype';
+import { UnsupportedModelVersionError } from '../../errors/unsupported-model-version-error';
 
 /**
 Generates images using an image model.
@@ -106,6 +107,10 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<GenerateImageResult> {
+  if (typeof model === 'string' || model.specificationVersion !== 'v1') {
+    throw new UnsupportedModelVersionError();
+  }
+
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
   // default to 1 if the model has not specified limits on

--- a/packages/ai/core/generate-object/generate-object.ts
+++ b/packages/ai/core/generate-object/generate-object.ts
@@ -36,6 +36,7 @@ import { injectJsonInstruction } from './inject-json-instruction';
 import { getOutputStrategy } from './output-strategy';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
 import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
+import { UnsupportedModelVersionError } from '../../errors/unsupported-model-version-error';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -399,6 +400,10 @@ export async function generateObject<SCHEMA, RESULT>({
       currentDate?: () => Date;
     };
   }): Promise<GenerateObjectResult<RESULT>> {
+  if (typeof model === 'string' || model.specificationVersion !== 'v1') {
+    throw new UnsupportedModelVersionError();
+  }
+
   validateObjectGenerationInput({
     output,
     mode,

--- a/packages/ai/core/generate-object/stream-object.ts
+++ b/packages/ai/core/generate-object/stream-object.ts
@@ -54,6 +54,7 @@ import { OutputStrategy, getOutputStrategy } from './output-strategy';
 import { ObjectStreamPart, StreamObjectResult } from './stream-object-result';
 import { validateObjectGenerationInput } from './validate-object-generation-input';
 import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
+import { UnsupportedModelVersionError } from '../../errors/unsupported-model-version-error';
 
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
@@ -411,6 +412,10 @@ export function streamObject<SCHEMA, PARTIAL, RESULT, ELEMENT_STREAM>({
       now?: () => number;
     };
   }): StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM> {
+  if (typeof model === 'string' || model.specificationVersion !== 'v1') {
+    throw new UnsupportedModelVersionError();
+  }
+
   validateObjectGenerationInput({
     output,
     mode,

--- a/packages/ai/core/generate-speech/generate-speech.ts
+++ b/packages/ai/core/generate-speech/generate-speech.ts
@@ -13,6 +13,7 @@ import {
   DefaultGeneratedAudioFile,
   GeneratedAudioFile,
 } from './generated-audio-file';
+import { UnsupportedModelVersionError } from '../../errors/unsupported-model-version-error';
 
 /**
 Generates speech audio using a speech model.
@@ -105,6 +106,10 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<SpeechResult> {
+  if (typeof model === 'string' || model.specificationVersion !== 'v1') {
+    throw new UnsupportedModelVersionError();
+  }
+
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
 
   const result = await retry(() =>

--- a/packages/ai/core/transcribe/transcribe.ts
+++ b/packages/ai/core/transcribe/transcribe.ts
@@ -12,6 +12,7 @@ import {
   detectMimeType,
 } from '../util/detect-mimetype';
 import { TranscriptionResult } from './transcribe-result';
+import { UnsupportedModelVersionError } from '../../errors/unsupported-model-version-error';
 
 /**
 Generates transcripts using a transcription model.
@@ -78,6 +79,10 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<TranscriptionResult> {
+  if (typeof model === 'string' || model.specificationVersion !== 'v1') {
+    throw new UnsupportedModelVersionError();
+  }
+
   const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
   const audioData =
     audio instanceof URL

--- a/packages/ai/errors/index.ts
+++ b/packages/ai/errors/index.ts
@@ -22,6 +22,7 @@ export { NoSuchToolError } from './no-such-tool-error';
 export { ToolCallRepairError } from './tool-call-repair-error';
 export { ToolExecutionError } from './tool-execution-error';
 export { MCPClientError } from './mcp-client-error';
+export { UnsupportedModelVersionError } from './unsupported-model-version-error';
 
 export { InvalidDataContentError } from '../core/prompt/invalid-data-content-error';
 export { InvalidMessageRoleError } from '../core/prompt/invalid-message-role-error';

--- a/packages/ai/errors/unsupported-model-version-error.ts
+++ b/packages/ai/errors/unsupported-model-version-error.ts
@@ -1,0 +1,16 @@
+import { AISDKError } from '@ai-sdk/provider';
+
+/**
+Error that is thrown when a model with an unsupported version is used.
+ */
+export class UnsupportedModelVersionError extends AISDKError {
+  constructor() {
+    super({
+      name: 'AI_UnsupportedModelVersionError',
+      message:
+        `Unsupported model version. ` +
+        `AI SDK 4 only supports models that implement specification version "v1". ` +
+        `Please upgrade to AI SDK 5 to use this model.`,
+    });
+  }
+}


### PR DESCRIPTION
## Background

People might try to use v2 models or string model ids despite typescript errors, e.g. from js or by ignoring them.

## Summary

Throw an error for v2 models or string model ids. AI SDK 4 requires v1 models.