### PR TITLE
update: docs for codemod

### DIFF
--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -56,74 +56,74 @@ npx @ai-sdk/codemod v5/rename-format-stream-part .
 
 ### v4 Codemods (v3 → v4 Migration)
 
-| Codemod | Description |
-| ------- | ----------- |
+| Codemod                                               | Description                                                    |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
 | `v4/remove-ai-stream-methods-from-stream-text-result` | Transforms v4/remove ai stream methods from stream text result |
-| `v4/remove-anthropic-facade` | Transforms v4/remove anthropic facade |
-| `v4/remove-await-streamobject` | Transforms v4/remove await streamobject |
-| `v4/remove-await-streamtext` | Transforms v4/remove await streamtext |
-| `v4/remove-deprecated-provider-registry-exports` | Transforms v4/remove deprecated provider registry exports |
-| `v4/remove-experimental-ai-fn-exports` | Transforms v4/remove experimental ai fn exports |
-| `v4/remove-experimental-message-types` | Transforms v4/remove experimental message types |
-| `v4/remove-experimental-streamdata` | Transforms v4/remove experimental streamdata |
-| `v4/remove-experimental-tool` | Transforms v4/remove experimental tool |
-| `v4/remove-experimental-useassistant` | Transforms v4/remove experimental useassistant |
-| `v4/remove-google-facade` | Transforms v4/remove google facade |
-| `v4/remove-isxxxerror` | Transforms v4/remove isxxxerror |
-| `v4/remove-metadata-with-headers` | Transforms v4/remove metadata with headers |
-| `v4/remove-mistral-facade` | Transforms v4/remove mistral facade |
-| `v4/remove-openai-facade` | Transforms v4/remove openai facade |
-| `v4/rename-format-stream-part` | Transforms v4/rename format stream part |
-| `v4/rename-parse-stream-part` | Transforms v4/rename parse stream part |
-| `v4/replace-baseurl` | Transforms v4/replace baseurl |
-| `v4/replace-continuation-steps` | Transforms v4/replace continuation steps |
-| `v4/replace-langchain-toaistream` | Transforms v4/replace langchain toaistream |
-| `v4/replace-nanoid` | Transforms v4/replace nanoid |
-| `v4/replace-roundtrips-with-maxsteps` | Transforms v4/replace roundtrips with maxsteps |
-| `v4/replace-token-usage-types` | Transforms v4/replace token usage types |
-| `v4/rewrite-framework-imports` | Transforms v4/rewrite framework imports |
+| `v4/remove-anthropic-facade`                          | Transforms v4/remove anthropic facade                          |
+| `v4/remove-await-streamobject`                        | Transforms v4/remove await streamobject                        |
+| `v4/remove-await-streamtext`                          | Transforms v4/remove await streamtext                          |
+| `v4/remove-deprecated-provider-registry-exports`      | Transforms v4/remove deprecated provider registry exports      |
+| `v4/remove-experimental-ai-fn-exports`                | Transforms v4/remove experimental ai fn exports                |
+| `v4/remove-experimental-message-types`                | Transforms v4/remove experimental message types                |
+| `v4/remove-experimental-streamdata`                   | Transforms v4/remove experimental streamdata                   |
+| `v4/remove-experimental-tool`                         | Transforms v4/remove experimental tool                         |
+| `v4/remove-experimental-useassistant`                 | Transforms v4/remove experimental useassistant                 |
+| `v4/remove-google-facade`                             | Transforms v4/remove google facade                             |
+| `v4/remove-isxxxerror`                                | Transforms v4/remove isxxxerror                                |
+| `v4/remove-metadata-with-headers`                     | Transforms v4/remove metadata with headers                     |
+| `v4/remove-mistral-facade`                            | Transforms v4/remove mistral facade                            |
+| `v4/remove-openai-facade`                             | Transforms v4/remove openai facade                             |
+| `v4/rename-format-stream-part`                        | Transforms v4/rename format stream part                        |
+| `v4/rename-parse-stream-part`                         | Transforms v4/rename parse stream part                         |
+| `v4/replace-baseurl`                                  | Transforms v4/replace baseurl                                  |
+| `v4/replace-continuation-steps`                       | Transforms v4/replace continuation steps                       |
+| `v4/replace-langchain-toaistream`                     | Transforms v4/replace langchain toaistream                     |
+| `v4/replace-nanoid`                                   | Transforms v4/replace nanoid                                   |
+| `v4/replace-roundtrips-with-maxsteps`                 | Transforms v4/replace roundtrips with maxsteps                 |
+| `v4/replace-token-usage-types`                        | Transforms v4/replace token usage types                        |
+| `v4/rewrite-framework-imports`                        | Transforms v4/rewrite framework imports                        |
 
 ### v5 Codemods (v4 → v5 Migration)
 
-| Codemod | Description |
-| ------- | ----------- |
-| `v5/flatten-streamtext-file-properties` | Transforms v5/flatten streamtext file properties |
-| `v5/import-LanguageModelV2-from-provider-package` | Transforms v5/import LanguageModelV2 from provider package |
-| `v5/migrate-to-data-stream-protocol-v2` | Transforms v5/migrate to data stream protocol v2 |
-| `v5/move-image-model-maxImagesPerCall` | Transforms v5/move image model maxImagesPerCall |
-| `v5/move-langchain-adapter` | Transforms v5/move langchain adapter |
-| `v5/move-provider-options` | Transforms v5/move provider options |
-| `v5/move-react-to-ai-sdk` | Transforms v5/move react to ai sdk |
-| `v5/move-ui-utils-to-ai` | Transforms v5/move ui utils to ai |
-| `v5/remove-experimental-wrap-language-model` | Transforms v5/remove experimental wrap language model |
-| `v5/remove-get-ui-text` | Transforms v5/remove get ui text |
-| `v5/remove-openai-compatibility` | Transforms v5/remove openai compatibility |
-| `v5/remove-sendExtraMessageFields` | Transforms v5/remove sendExtraMessageFields |
-| `v5/rename-core-message-to-model-message` | Transforms v5/rename core message to model message |
-| `v5/rename-datastream-transform-stream` | Transforms v5/rename datastream transform stream |
-| `v5/rename-languagemodelv1providermetadata` | Transforms v5/rename languagemodelv1providermetadata |
-| `v5/rename-max-tokens-to-max-output-tokens` | Transforms v5/rename max tokens to max output tokens |
-| `v5/rename-message-to-ui-message` | Transforms v5/rename message to ui message |
-| `v5/rename-mime-type-to-media-type` | Transforms v5/rename mime type to media type |
-| `v5/rename-reasoning-properties` | Transforms v5/rename reasoning properties |
-| `v5/rename-reasoning-to-reasoningText` | Transforms v5/rename reasoning to reasoningText |
-| `v5/rename-request-options` | Transforms v5/rename request options |
-| `v5/replace-bedrock-snake-case` | Transforms v5/replace bedrock snake case |
-| `v5/replace-content-with-parts` | Transforms v5/replace content with parts |
-| `v5/replace-experimental-provider-metadata` | Transforms v5/replace experimental provider metadata |
-| `v5/replace-generatetext-text-property` | Transforms v5/replace generatetext text property |
-| `v5/replace-image-type-with-file-type` | Transforms v5/replace image type with file type |
-| `v5/replace-llamaindex-adapter` | Transforms v5/replace llamaindex adapter |
-| `v5/replace-oncompletion-with-onfinal` | Transforms v5/replace oncompletion with onfinal |
+| Codemod                                              | Description                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------------- |
+| `v5/flatten-streamtext-file-properties`              | Transforms v5/flatten streamtext file properties              |
+| `v5/import-LanguageModelV2-from-provider-package`    | Transforms v5/import LanguageModelV2 from provider package    |
+| `v5/migrate-to-data-stream-protocol-v2`              | Transforms v5/migrate to data stream protocol v2              |
+| `v5/move-image-model-maxImagesPerCall`               | Transforms v5/move image model maxImagesPerCall               |
+| `v5/move-langchain-adapter`                          | Transforms v5/move langchain adapter                          |
+| `v5/move-provider-options`                           | Transforms v5/move provider options                           |
+| `v5/move-react-to-ai-sdk`                            | Transforms v5/move react to ai sdk                            |
+| `v5/move-ui-utils-to-ai`                             | Transforms v5/move ui utils to ai                             |
+| `v5/remove-experimental-wrap-language-model`         | Transforms v5/remove experimental wrap language model         |
+| `v5/remove-get-ui-text`                              | Transforms v5/remove get ui text                              |
+| `v5/remove-openai-compatibility`                     | Transforms v5/remove openai compatibility                     |
+| `v5/remove-sendExtraMessageFields`                   | Transforms v5/remove sendExtraMessageFields                   |
+| `v5/rename-core-message-to-model-message`            | Transforms v5/rename core message to model message            |
+| `v5/rename-datastream-transform-stream`              | Transforms v5/rename datastream transform stream              |
+| `v5/rename-languagemodelv1providermetadata`          | Transforms v5/rename languagemodelv1providermetadata          |
+| `v5/rename-max-tokens-to-max-output-tokens`          | Transforms v5/rename max tokens to max output tokens          |
+| `v5/rename-message-to-ui-message`                    | Transforms v5/rename message to ui message                    |
+| `v5/rename-mime-type-to-media-type`                  | Transforms v5/rename mime type to media type                  |
+| `v5/rename-reasoning-properties`                     | Transforms v5/rename reasoning properties                     |
+| `v5/rename-reasoning-to-reasoningText`               | Transforms v5/rename reasoning to reasoningText               |
+| `v5/rename-request-options`                          | Transforms v5/rename request options                          |
+| `v5/replace-bedrock-snake-case`                      | Transforms v5/replace bedrock snake case                      |
+| `v5/replace-content-with-parts`                      | Transforms v5/replace content with parts                      |
+| `v5/replace-experimental-provider-metadata`          | Transforms v5/replace experimental provider metadata          |
+| `v5/replace-generatetext-text-property`              | Transforms v5/replace generatetext text property              |
+| `v5/replace-image-type-with-file-type`               | Transforms v5/replace image type with file type               |
+| `v5/replace-llamaindex-adapter`                      | Transforms v5/replace llamaindex adapter                      |
+| `v5/replace-oncompletion-with-onfinal`               | Transforms v5/replace oncompletion with onfinal               |
 | `v5/replace-provider-metadata-with-provider-options` | Transforms v5/replace provider metadata with provider options |
-| `v5/replace-rawresponse-with-response` | Transforms v5/replace rawresponse with response |
-| `v5/replace-redacted-reasoning-type` | Transforms v5/replace redacted reasoning type |
-| `v5/replace-simulate-streaming` | Transforms v5/replace simulate streaming |
-| `v5/replace-textdelta-with-text` | Transforms v5/replace textdelta with text |
-| `v5/replace-usage-token-properties` | Transforms v5/replace usage token properties |
-| `v5/restructure-file-stream-parts` | Transforms v5/restructure file stream parts |
-| `v5/restructure-source-stream-parts` | Transforms v5/restructure source stream parts |
-| `v5/rsc-package` | Transforms v5/rsc package |
+| `v5/replace-rawresponse-with-response`               | Transforms v5/replace rawresponse with response               |
+| `v5/replace-redacted-reasoning-type`                 | Transforms v5/replace redacted reasoning type                 |
+| `v5/replace-simulate-streaming`                      | Transforms v5/replace simulate streaming                      |
+| `v5/replace-textdelta-with-text`                     | Transforms v5/replace textdelta with text                     |
+| `v5/replace-usage-token-properties`                  | Transforms v5/replace usage token properties                  |
+| `v5/restructure-file-stream-parts`                   | Transforms v5/restructure file stream parts                   |
+| `v5/restructure-source-stream-parts`                 | Transforms v5/restructure source stream parts                 |
+| `v5/rsc-package`                                     | Transforms v5/rsc package                                     |
 
 ## CLI Options
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -21,10 +21,10 @@ This will automatically detect and transform all applicable code patterns in you
 To run codemods for a specific version:
 
 ```sh
-# Run v4 codemods (v4 → v5 migration) - 24 codemods
+# Run v4 codemods (v3 → v4 migration) - 24 codemods
 npx @ai-sdk/codemod v4
 
-# Run v5 codemods (v5 breaking changes) - 38 codemods
+# Run v5 codemods (v4 → v5 migration) - 38 codemods
 npx @ai-sdk/codemod v5
 
 # Run all codemods (both v4 and v5) - 62 codemods
@@ -54,76 +54,76 @@ npx @ai-sdk/codemod v5/rename-format-stream-part .
 
 ## Available Codemods
 
-### v4 Codemods (v4 → v5 Migration)
+### v4 Codemods (v3 → v4 Migration)
 
-| Codemod                                               | Description                                                    |
-| ----------------------------------------------------- | -------------------------------------------------------------- |
+| Codemod | Description |
+| ------- | ----------- |
 | `v4/remove-ai-stream-methods-from-stream-text-result` | Transforms v4/remove ai stream methods from stream text result |
-| `v4/remove-anthropic-facade`                          | Transforms v4/remove anthropic facade                          |
-| `v4/remove-await-streamobject`                        | Transforms v4/remove await streamobject                        |
-| `v4/remove-await-streamtext`                          | Transforms v4/remove await streamtext                          |
-| `v4/remove-deprecated-provider-registry-exports`      | Transforms v4/remove deprecated provider registry exports      |
-| `v4/remove-experimental-ai-fn-exports`                | Transforms v4/remove experimental ai fn exports                |
-| `v4/remove-experimental-message-types`                | Transforms v4/remove experimental message types                |
-| `v4/remove-experimental-streamdata`                   | Transforms v4/remove experimental streamdata                   |
-| `v4/remove-experimental-tool`                         | Transforms v4/remove experimental tool                         |
-| `v4/remove-experimental-useassistant`                 | Transforms v4/remove experimental useassistant                 |
-| `v4/remove-google-facade`                             | Transforms v4/remove google facade                             |
-| `v4/remove-isxxxerror`                                | Transforms v4/remove isxxxerror                                |
-| `v4/remove-metadata-with-headers`                     | Transforms v4/remove metadata with headers                     |
-| `v4/remove-mistral-facade`                            | Transforms v4/remove mistral facade                            |
-| `v4/remove-openai-facade`                             | Transforms v4/remove openai facade                             |
-| `v4/rename-format-stream-part`                        | Transforms v4/rename format stream part                        |
-| `v4/rename-parse-stream-part`                         | Transforms v4/rename parse stream part                         |
-| `v4/replace-baseurl`                                  | Transforms v4/replace baseurl                                  |
-| `v4/replace-continuation-steps`                       | Transforms v4/replace continuation steps                       |
-| `v4/replace-langchain-toaistream`                     | Transforms v4/replace langchain toaistream                     |
-| `v4/replace-nanoid`                                   | Transforms v4/replace nanoid                                   |
-| `v4/replace-roundtrips-with-maxsteps`                 | Transforms v4/replace roundtrips with maxsteps                 |
-| `v4/replace-token-usage-types`                        | Transforms v4/replace token usage types                        |
-| `v4/rewrite-framework-imports`                        | Transforms v4/rewrite framework imports                        |
+| `v4/remove-anthropic-facade` | Transforms v4/remove anthropic facade |
+| `v4/remove-await-streamobject` | Transforms v4/remove await streamobject |
+| `v4/remove-await-streamtext` | Transforms v4/remove await streamtext |
+| `v4/remove-deprecated-provider-registry-exports` | Transforms v4/remove deprecated provider registry exports |
+| `v4/remove-experimental-ai-fn-exports` | Transforms v4/remove experimental ai fn exports |
+| `v4/remove-experimental-message-types` | Transforms v4/remove experimental message types |
+| `v4/remove-experimental-streamdata` | Transforms v4/remove experimental streamdata |
+| `v4/remove-experimental-tool` | Transforms v4/remove experimental tool |
+| `v4/remove-experimental-useassistant` | Transforms v4/remove experimental useassistant |
+| `v4/remove-google-facade` | Transforms v4/remove google facade |
+| `v4/remove-isxxxerror` | Transforms v4/remove isxxxerror |
+| `v4/remove-metadata-with-headers` | Transforms v4/remove metadata with headers |
+| `v4/remove-mistral-facade` | Transforms v4/remove mistral facade |
+| `v4/remove-openai-facade` | Transforms v4/remove openai facade |
+| `v4/rename-format-stream-part` | Transforms v4/rename format stream part |
+| `v4/rename-parse-stream-part` | Transforms v4/rename parse stream part |
+| `v4/replace-baseurl` | Transforms v4/replace baseurl |
+| `v4/replace-continuation-steps` | Transforms v4/replace continuation steps |
+| `v4/replace-langchain-toaistream` | Transforms v4/replace langchain toaistream |
+| `v4/replace-nanoid` | Transforms v4/replace nanoid |
+| `v4/replace-roundtrips-with-maxsteps` | Transforms v4/replace roundtrips with maxsteps |
+| `v4/replace-token-usage-types` | Transforms v4/replace token usage types |
+| `v4/rewrite-framework-imports` | Transforms v4/rewrite framework imports |
 
-### v5 Codemods (v5 Breaking Changes)
+### v5 Codemods (v4 → v5 Migration)
 
-| Codemod                                              | Description                                                   |
-| ---------------------------------------------------- | ------------------------------------------------------------- |
-| `v5/flatten-streamtext-file-properties`              | Transforms v5/flatten streamtext file properties              |
-| `v5/import-LanguageModelV2-from-provider-package`    | Transforms v5/import LanguageModelV2 from provider package    |
-| `v5/migrate-to-data-stream-protocol-v2`              | Transforms v5/migrate to data stream protocol v2              |
-| `v5/move-image-model-maxImagesPerCall`               | Transforms v5/move image model maxImagesPerCall               |
-| `v5/move-langchain-adapter`                          | Transforms v5/move langchain adapter                          |
-| `v5/move-provider-options`                           | Transforms v5/move provider options                           |
-| `v5/move-react-to-ai-sdk`                            | Transforms v5/move react to ai sdk                            |
-| `v5/move-ui-utils-to-ai`                             | Transforms v5/move ui utils to ai                             |
-| `v5/remove-experimental-wrap-language-model`         | Transforms v5/remove experimental wrap language model         |
-| `v5/remove-get-ui-text`                              | Transforms v5/remove get ui text                              |
-| `v5/remove-openai-compatibility`                     | Transforms v5/remove openai compatibility                     |
-| `v5/remove-sendExtraMessageFields`                   | Transforms v5/remove sendExtraMessageFields                   |
-| `v5/rename-core-message-to-model-message`            | Transforms v5/rename core message to model message            |
-| `v5/rename-datastream-transform-stream`              | Transforms v5/rename datastream transform stream              |
-| `v5/rename-languagemodelv1providermetadata`          | Transforms v5/rename languagemodelv1providermetadata          |
-| `v5/rename-max-tokens-to-max-output-tokens`          | Transforms v5/rename max tokens to max output tokens          |
-| `v5/rename-message-to-ui-message`                    | Transforms v5/rename message to ui message                    |
-| `v5/rename-mime-type-to-media-type`                  | Transforms v5/rename mime type to media type                  |
-| `v5/rename-reasoning-properties`                     | Transforms v5/rename reasoning properties                     |
-| `v5/rename-reasoning-to-reasoningText`               | Transforms v5/rename reasoning to reasoningText               |
-| `v5/rename-request-options`                          | Transforms v5/rename request options                          |
-| `v5/replace-bedrock-snake-case`                      | Transforms v5/replace bedrock snake case                      |
-| `v5/replace-content-with-parts`                      | Transforms v5/replace content with parts                      |
-| `v5/replace-experimental-provider-metadata`          | Transforms v5/replace experimental provider metadata          |
-| `v5/replace-generatetext-text-property`              | Transforms v5/replace generatetext text property              |
-| `v5/replace-image-type-with-file-type`               | Transforms v5/replace image type with file type               |
-| `v5/replace-llamaindex-adapter`                      | Transforms v5/replace llamaindex adapter                      |
-| `v5/replace-oncompletion-with-onfinal`               | Transforms v5/replace oncompletion with onfinal               |
+| Codemod | Description |
+| ------- | ----------- |
+| `v5/flatten-streamtext-file-properties` | Transforms v5/flatten streamtext file properties |
+| `v5/import-LanguageModelV2-from-provider-package` | Transforms v5/import LanguageModelV2 from provider package |
+| `v5/migrate-to-data-stream-protocol-v2` | Transforms v5/migrate to data stream protocol v2 |
+| `v5/move-image-model-maxImagesPerCall` | Transforms v5/move image model maxImagesPerCall |
+| `v5/move-langchain-adapter` | Transforms v5/move langchain adapter |
+| `v5/move-provider-options` | Transforms v5/move provider options |
+| `v5/move-react-to-ai-sdk` | Transforms v5/move react to ai sdk |
+| `v5/move-ui-utils-to-ai` | Transforms v5/move ui utils to ai |
+| `v5/remove-experimental-wrap-language-model` | Transforms v5/remove experimental wrap language model |
+| `v5/remove-get-ui-text` | Transforms v5/remove get ui text |
+| `v5/remove-openai-compatibility` | Transforms v5/remove openai compatibility |
+| `v5/remove-sendExtraMessageFields` | Transforms v5/remove sendExtraMessageFields |
+| `v5/rename-core-message-to-model-message` | Transforms v5/rename core message to model message |
+| `v5/rename-datastream-transform-stream` | Transforms v5/rename datastream transform stream |
+| `v5/rename-languagemodelv1providermetadata` | Transforms v5/rename languagemodelv1providermetadata |
+| `v5/rename-max-tokens-to-max-output-tokens` | Transforms v5/rename max tokens to max output tokens |
+| `v5/rename-message-to-ui-message` | Transforms v5/rename message to ui message |
+| `v5/rename-mime-type-to-media-type` | Transforms v5/rename mime type to media type |
+| `v5/rename-reasoning-properties` | Transforms v5/rename reasoning properties |
+| `v5/rename-reasoning-to-reasoningText` | Transforms v5/rename reasoning to reasoningText |
+| `v5/rename-request-options` | Transforms v5/rename request options |
+| `v5/replace-bedrock-snake-case` | Transforms v5/replace bedrock snake case |
+| `v5/replace-content-with-parts` | Transforms v5/replace content with parts |
+| `v5/replace-experimental-provider-metadata` | Transforms v5/replace experimental provider metadata |
+| `v5/replace-generatetext-text-property` | Transforms v5/replace generatetext text property |
+| `v5/replace-image-type-with-file-type` | Transforms v5/replace image type with file type |
+| `v5/replace-llamaindex-adapter` | Transforms v5/replace llamaindex adapter |
+| `v5/replace-oncompletion-with-onfinal` | Transforms v5/replace oncompletion with onfinal |
 | `v5/replace-provider-metadata-with-provider-options` | Transforms v5/replace provider metadata with provider options |
-| `v5/replace-rawresponse-with-response`               | Transforms v5/replace rawresponse with response               |
-| `v5/replace-redacted-reasoning-type`                 | Transforms v5/replace redacted reasoning type                 |
-| `v5/replace-simulate-streaming`                      | Transforms v5/replace simulate streaming                      |
-| `v5/replace-textdelta-with-text`                     | Transforms v5/replace textdelta with text                     |
-| `v5/replace-usage-token-properties`                  | Transforms v5/replace usage token properties                  |
-| `v5/restructure-file-stream-parts`                   | Transforms v5/restructure file stream parts                   |
-| `v5/restructure-source-stream-parts`                 | Transforms v5/restructure source stream parts                 |
-| `v5/rsc-package`                                     | Transforms v5/rsc package                                     |
+| `v5/replace-rawresponse-with-response` | Transforms v5/replace rawresponse with response |
+| `v5/replace-redacted-reasoning-type` | Transforms v5/replace redacted reasoning type |
+| `v5/replace-simulate-streaming` | Transforms v5/replace simulate streaming |
+| `v5/replace-textdelta-with-text` | Transforms v5/replace textdelta with text |
+| `v5/replace-usage-token-properties` | Transforms v5/replace usage token properties |
+| `v5/restructure-file-stream-parts` | Transforms v5/restructure file stream parts |
+| `v5/restructure-source-stream-parts` | Transforms v5/restructure source stream parts |
+| `v5/rsc-package` | Transforms v5/rsc package |
 
 ## CLI Options
 
@@ -136,8 +136,8 @@ npx @ai-sdk/codemod <command> [options]
 **Available Commands:**
 
 - `upgrade` - Apply all codemods (v4 + v5)
-- `v4` - Apply v4 codemods (v4 → v5 migration)
-- `v5` - Apply v5 codemods (v5 breaking changes)
+- `v4` - Apply v4 codemods (v3 → v4 migration)
+- `v5` - Apply v5 codemods (v4 → v5 migration)
 - `<codemod-name> <path>` - Apply specific codemod
 
 ### Global Options

--- a/packages/codemod/scripts/generate-readme.ts
+++ b/packages/codemod/scripts/generate-readme.ts
@@ -56,11 +56,11 @@ function generateDescription(name: string): string {
 
 function categorizeCodemod(name: string): string {
   if (name.startsWith('v4/')) {
-    return 'v4 Codemods (v4 → v5 Migration)';
+    return 'v4 Codemods (v3 → v4 Migration)';
   }
 
   if (name.startsWith('v5/')) {
-    return 'v5 Codemods (v5 Breaking Changes)';
+    return 'v5 Codemods (v4 → v5 Migration)';
   }
 
   return 'General Codemods';
@@ -83,8 +83,8 @@ codemodFiles.forEach(codemod => {
 });
 
 const categoryOrder = [
-  'v4 Codemods (v4 → v5 Migration)',
-  'v5 Codemods (v5 Breaking Changes)',
+  'v4 Codemods (v3 → v4 Migration)',
+  'v5 Codemods (v4 → v5 Migration)',
   'General Codemods',
 ];
 

--- a/packages/codemod/src/bin/codemod.ts
+++ b/packages/codemod/src/bin/codemod.ts
@@ -52,7 +52,7 @@ addTransformOptions(
 });
 
 addTransformOptions(
-  program.command('v4').description('Apply v4 codemods (v4 → v5 migration)'),
+  program.command('v4').description('Apply v4 codemods (v3 → v4 migration)'),
 ).action((options: TransformOptions) => {
   try {
     upgradeV4(options);
@@ -63,7 +63,7 @@ addTransformOptions(
 });
 
 addTransformOptions(
-  program.command('v5').description('Apply v5 codemods (v5 breaking changes)'),
+  program.command('v5').description('Apply v5 codemods (v4 → v5 migration)'),
 ).action((options: TransformOptions) => {
   try {
     upgradeV5(options);


### PR DESCRIPTION
## background

codemod command descriptions that incorrectly suggested `v4` runs v4→v5 migrations when it actually runs v3→v4 migrations.

## summary

- fix codemod command descriptions to correctly indicate migration direction
- update documentation to reflect actual command behavior

## verification

- CLI help shows correct migration directions for v4 and v5 commands
- README documentation matches actual command functionality
- auto-generated content uses corrected category names

## tasks

- [x] fix CLI command descriptions in codemod.ts
- [x] update README with correct migration directions
- [x] fix README generation script category names