### PR TITLE
fix(codemod): correct import-LanguageModelV2-from-provider-package direction and quote preservation

### DIFF
--- a/.changeset/six-shrimps-attack.md
+++ b/.changeset/six-shrimps-attack.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+fix(codemod): correct import-LanguageModelV2-from-provider-package direction and quote preservation

--- a/packages/codemod/src/codemods/v5/import-LanguageModelV2-from-provider-package.ts
+++ b/packages/codemod/src/codemods/v5/import-LanguageModelV2-from-provider-package.ts
@@ -14,8 +14,8 @@ export default createTransformer((fileInfo, api, options, context) => {
   root.find(j.ImportDeclaration).forEach(importPath => {
     const node = importPath.node;
 
-    // Check if the source value is exactly 'ai'
-    if (node.source.value !== 'ai') return;
+    // Check if the source value is exactly '@ai-sdk/provider'
+    if (node.source.value !== '@ai-sdk/provider') return;
 
     // Check if the named import includes 'LanguageModelV1' or 'LanguageModelV2'
     const specifiers =
@@ -25,8 +25,8 @@ export default createTransformer((fileInfo, api, options, context) => {
           Object.keys(ImportMappings).includes(s.imported.name),
       ) ?? [];
 
+    // Rename LanguageModelV1 to LanguageModelV2 if present
     for (const specifier of specifiers) {
-      // If the import is 'LanguageModelV1', we will change it to 'LanguageModelV2'
       if (
         specifier.type === 'ImportSpecifier' &&
         ImportMappings[specifier.imported.name]
@@ -38,11 +38,11 @@ export default createTransformer((fileInfo, api, options, context) => {
     // Set hasChanges to true since we will modify the AST
     context.hasChanges = true;
 
-    // Change the module source from 'ai' to '@ai-sdk/provider'
-    node.source = j.stringLiteral('@ai-sdk/provider');
+    // Change the module source from '@ai-sdk/provider' to 'ai'
+    node.source.value = 'ai';
 
     context.messages.push(
-      `Updated import of LanguageModelV2 from 'ai' to '@ai-sdk/provider'`,
+      `Updated import from '@ai-sdk/provider' to 'ai'`,
     );
   });
 });

--- a/packages/codemod/src/codemods/v5/import-LanguageModelV2-from-provider-package.ts
+++ b/packages/codemod/src/codemods/v5/import-LanguageModelV2-from-provider-package.ts
@@ -41,8 +41,6 @@ export default createTransformer((fileInfo, api, options, context) => {
     // Change the module source from '@ai-sdk/provider' to 'ai'
     node.source.value = 'ai';
 
-    context.messages.push(
-      `Updated import from '@ai-sdk/provider' to 'ai'`,
-    );
+    context.messages.push(`Updated import from '@ai-sdk/provider' to 'ai'`);
   });
 });


### PR DESCRIPTION
## background

The `import-LanguageModelV2-from-provider-package` codemod was incorrectly changing imports from `"ai"` to `"@ai-sdk/provider"` when it should move imports from `"@ai-sdk/provider"` to `"ai"`. It was also unnecessarily changing quote styles from double to single quotes.

## summary

- fix codemod to move imports from `@ai-sdk/provider` to `ai` (correct direction)
- preserve original quote style in import statements
- only transform imports that actually come from `@ai-sdk/provider`

## verification

- imports from `"ai"` remain unchanged
- imports from `"@ai-sdk/provider"` correctly move to `"ai"`
- quote style preserved (double quotes stay double, single stay single)
- LanguageModelV1 properly renamed to LanguageModelV2

## tasks

- [x] reverse codemod logic to check for `@ai-sdk/provider` source
- [x] update log messages to reflect correct direction