### PR TITLE
feat(ai/v4): Record tool call errors on tool call spans in `generateText` and `streamText`

### DIFF
--- a/.changeset/serious-ravens-stare.md
+++ b/.changeset/serious-ravens-stare.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): Record tool call errors on tool call spans recorded in `generateText` and `streamText`.

--- a/packages/ai/core/generate-text/generate-text.ts
+++ b/packages/ai/core/generate-text/generate-text.ts
@@ -16,7 +16,7 @@ import { stringifyForTelemetry } from '../prompt/stringify-for-telemetry';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
 import { getTracer } from '../telemetry/get-tracer';
-import { recordSpan } from '../telemetry/record-span';
+import { recordErrorOnSpan, recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { LanguageModel, ToolChoice } from '../types';
@@ -733,6 +733,7 @@ async function executeTools<TOOLS extends ToolSet>({
 
             return result;
           } catch (error) {
+            recordErrorOnSpan(span, error);
             throw new ToolExecutionError({
               toolCallId,
               toolName,

--- a/packages/ai/core/generate-text/run-tools-transformation.ts
+++ b/packages/ai/core/generate-text/run-tools-transformation.ts
@@ -4,7 +4,7 @@ import { Tracer } from '@opentelemetry/api';
 import { ToolExecutionError } from '../../errors';
 import { CoreMessage } from '../prompt/message';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
-import { recordSpan } from '../telemetry/record-span';
+import { recordErrorOnSpan, recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import {
@@ -274,6 +274,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                       }
                     },
                     (error: any) => {
+                      recordErrorOnSpan(span, error);
                       toolResultsStreamController!.enqueue({
                         type: 'error',
                         error: new ToolExecutionError({

--- a/packages/ai/core/generate-text/stream-text.test.ts
+++ b/packages/ai/core/generate-text/stream-text.test.ts
@@ -3127,6 +3127,73 @@ describe('streamText', () => {
       expect(tracer.jsonSpans).toMatchSnapshot();
     });
 
+    it('should record error on tool call', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'tool1',
+              args: `{ "value": "value" }`,
+            },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { completionTokens: 10, promptTokens: 3 },
+            },
+          ]),
+        }),
+        tools: {
+          tool1: {
+            parameters: z.object({ value: z.string() }),
+            execute: async () => {
+              throw new Error('Tool execution failed');
+            },
+          },
+        },
+        prompt: 'test-input',
+        experimental_telemetry: { isEnabled: true, tracer },
+        _internal: { now: mockValues(0, 100, 500) },
+      });
+
+      await result.consumeStream();
+
+      expect(tracer.jsonSpans).toHaveLength(3);
+
+      // Check that we have the expected spans
+      expect(tracer.jsonSpans[0].name).toBe('ai.streamText');
+      expect(tracer.jsonSpans[1].name).toBe('ai.streamText.doStream');
+      expect(tracer.jsonSpans[2].name).toBe('ai.toolCall');
+
+      // Check that the tool call span has error status
+      const toolCallSpan = tracer.jsonSpans[2];
+      expect(toolCallSpan.status).toEqual({
+        code: 2,
+        message: 'Tool execution failed',
+      });
+
+      // Check that the tool call span has exception event
+      expect(toolCallSpan.events).toHaveLength(1);
+      const exceptionEvent = toolCallSpan.events[0];
+      expect(exceptionEvent.name).toBe('exception');
+      expect(exceptionEvent.attributes).toMatchObject({
+        'exception.message': 'Tool execution failed',
+        'exception.name': 'Error',
+      });
+      expect(exceptionEvent.attributes?.['exception.stack']).toContain(
+        'Tool execution failed',
+      );
+      expect(exceptionEvent.time).toEqual([0, 0]);
+    });
+
     it('should not record telemetry inputs / outputs when disabled', async () => {
       const result = streamText({
         model: createTestModel({

--- a/packages/ai/core/telemetry/record-span.ts
+++ b/packages/ai/core/telemetry/record-span.ts
@@ -24,19 +24,7 @@ export function recordSpan<T>({
       return result;
     } catch (error) {
       try {
-        if (error instanceof Error) {
-          span.recordException({
-            name: error.name,
-            message: error.message,
-            stack: error.stack,
-          });
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: error.message,
-          });
-        } else {
-          span.setStatus({ code: SpanStatusCode.ERROR });
-        }
+        recordErrorOnSpan(span, error);
       } finally {
         // always stop the span when there is an error:
         span.end();
@@ -45,4 +33,27 @@ export function recordSpan<T>({
       throw error;
     }
   });
+}
+
+/**
+ * Record an error on a span. If the error is an instance of Error, an exception event will be recorded on the span, otherwise
+ * the span will be set to an error status.
+ *
+ * @param span - The span to record the error on.
+ * @param error - The error to record on the span.
+ */
+export function recordErrorOnSpan(span: Span, error: unknown) {
+  if (error instanceof Error) {
+    span.recordException({
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    });
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error.message,
+    });
+  } else {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
 }

--- a/packages/ai/core/test/mock-tracer.ts
+++ b/packages/ai/core/test/mock-tracer.ts
@@ -2,9 +2,12 @@ import {
   AttributeValue,
   Attributes,
   Context,
+  Exception,
   Span,
   SpanContext,
   SpanOptions,
+  SpanStatus,
+  TimeInput,
   Tracer,
 } from '@opentelemetry/api';
 
@@ -16,6 +19,7 @@ export class MockTracer implements Tracer {
       name: span.name,
       attributes: span.attributes,
       events: span.events,
+      ...(span.status && { status: span.status }),
     }));
   }
 
@@ -67,7 +71,12 @@ class MockSpan implements Span {
   context?: Context;
   options?: SpanOptions;
   attributes: Attributes;
-  events: Array<{ name: string; attributes: Attributes | undefined }> = [];
+  events: Array<{
+    name: string;
+    attributes: Attributes | undefined;
+    time?: [number, number];
+  }> = [];
+  status?: SpanStatus;
 
   readonly _spanContext: SpanContext = new MockSpanContext();
 
@@ -111,7 +120,8 @@ class MockSpan implements Span {
   addLinks() {
     return this;
   }
-  setStatus() {
+  setStatus(status: SpanStatus) {
+    this.status = status;
     return this;
   }
   updateName() {
@@ -123,8 +133,19 @@ class MockSpan implements Span {
   isRecording() {
     return false;
   }
-  recordException() {
-    return this;
+  recordException(exception: Exception, time?: TimeInput) {
+    const error =
+      typeof exception === 'string' ? new Error(exception) : exception;
+    this.events.push({
+      name: 'exception',
+      attributes: {
+        'exception.type': error.constructor?.name || 'Error',
+        'exception.name': error.name || 'Error',
+        'exception.message': error.message || '',
+        'exception.stack': error.stack || '',
+      },
+      time: Array.isArray(time) ? time : [0, 0],
+    });
   }
 }
 


### PR DESCRIPTION
This is a backport of https://github.com/vercel/ai/pull/7033