### PR TITLE
adding Cactus as a local inference provider

### DIFF
--- a/packages/cactus/README.md
+++ b/packages/cactus/README.md
@@ -1,0 +1,115 @@
+# Cactus Provider
+
+The Vercel AI SDK Cactus Provider enables the use of on-device, local LLMs in React Native applications. It serves as a bridge between the Vercel AI SDK's streamlined API and the [Cactus](https://github.com/cactus-compute/cactus) industry-leading C++ inference engine.
+
+This provider lets you to run any GGUF-compatible model from platforms like HuggingFace directly on a user's device, ensuring privacy, offline availability, and low-latency inference.
+
+## Setup
+
+### Prerequisites
+
+The Cactus provider requires `react-native-fs` for model management.
+
+Install the required peer dependencies:
+
+```bash
+npm install react-native-fs
+npx pod-install
+```
+
+### Configuration
+
+Ensure your project's `tsconfig.json` includes `"esnext.asynciterable"` in the `lib` array to provide the necessary types for asynchronous iteration over streams.
+
+**`tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "lib": ["esnext", "esnext.asynciterable"]
+  }
+}
+```
+
+## Provider Instance
+
+Create an instance of the Cactus provider that you can use to create language model clients.
+
+```ts
+import { createCactus } from './cactus-provider'; // Adjust path accordingly
+
+const cactus = createCactus();
+```
+
+## Language Model
+
+The Cactus language model runs locally on the user's device. To use it, you must first instantiate it with a URL pointing to a GGUF model file.
+
+```ts
+const model = cactus.languageModel(
+  'https://huggingface.co/Cactus-Compute/SmolVLM2-256m-Instruct-GGUF/resolve/main/SmolVLM2-256M-Video-Instruct-Q8_0.gguf'
+);
+```
+
+Before use, the model must be downloaded and initialized. This provider includes methods to manage this lifecycle:
+
+```tsx
+import { ModelStatus } from './cactus-chat-language-model'; // Adjust path
+
+function MyComponent() {
+  const [status, setStatus] = useState(ModelStatus.IDLE);
+
+  useEffect(() => {
+    async function setupModel() {
+      setStatus(ModelStatus.DOWNLOADING);
+      await model.downloadModel();
+      setStatus(ModelStatus.INITIALIZING);
+      await model.initialize();
+      setStatus(ModelStatus.READY);
+    }
+    setupModel();
+  }, []);
+
+  // ... render UI based on status
+}
+```
+
+### Streaming
+
+You can stream text responses using the `stream` method. The provider manages the complexities of the underlying stateful model, allowing you to use it as if it were a stateless API.
+
+```ts
+import { streamText } from 'ai';
+
+//...
+
+const { textStream } = await streamText({
+  model,
+  prompt: 'Who is Roman?',
+});
+
+for await (const textPart of textStream) {
+  // ... process text part
+}
+```
+
+## Model Capabilities
+
+| Feature | `doGenerate` | `doStream` |
+| :-- | :--: | :--: |
+| **Text** | ✅ | ✅ |
+| **Images** | ❌ | ❌ |
+| **Tools** | ❌ | ❌ |
+| **Object** | ❌ | ❌ |
+
+While the underlying Cactus engine supports Vision Language Models (VLMs), this provider currently only exposes text-based chat completions.
+
+## Unsupported Methods
+
+The Cactus provider is focused on providing core text generation capabilities on-device. The following `LanguageModelV2` methods are **not supported**:
+
+-   `doEmbed`: For creating embeddings from text.
+-   `doTools`: For using tools or function calling.
+-   `doObject`: For generating structured object outputs.
+
+The `supportedUrls` property is also not applicable, as Cactus runs models locally and does not interact with remote API endpoints. 

--- a/packages/cactus/package.json
+++ b/packages/cactus/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@ai-sdk/cactus",
+    "version": "0.0.1",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "files": [
+      "dist/"
+    ],
+    "scripts": {
+      "build": "tsc",
+      "dev": "tsc -w"
+    },
+    "dependencies": {
+      "@ai-sdk/provider": "workspace:*",
+      "@ai-sdk/provider-utils": "workspace:*",
+      "cactus-react-native": "^0.2.2",
+      "react-native-fs": "^2.20.0"
+    },
+    "peerDependencies": {},
+    "devDependencies": {}
+  }

--- a/packages/cactus/src/cactus-chat-language-model.ts
+++ b/packages/cactus/src/cactus-chat-language-model.ts
@@ -1,0 +1,319 @@
+import {
+  LanguageModelV2,
+  LanguageModelV2CallOptions,
+  LanguageModelV2Content,
+  LanguageModelV2FinishReason,
+  LanguageModelV2StreamPart,
+  LanguageModelV2Usage,
+  LanguageModelV2CallWarning,
+  LanguageModelV2Prompt,
+  LanguageModelV2TextPart,
+  LanguageModelV2ResponseMetadata,
+  SharedV2Headers,
+} from '@ai-sdk/provider';
+import { CactusChatSettings } from './cactus-provider';
+import {
+  CactusLM,
+  CompletionParams,
+  NativeCompletionResult,
+  CactusOAICompatibleMessage,
+} from 'cactus-react-native';
+
+import RNFS from 'react-native-fs';
+
+
+const ModelCache = {
+  _cache: new Map<string, { localPath: string }>(),
+  getLocalPath(url: string): string {
+    const filename =
+      url.split('/').pop()?.replace(/[^a-zA-Z0-9.-]/g, '_') ?? 'model.gguf';
+    return `${RNFS.DocumentDirectoryPath}/${filename}`;
+  },
+  async isDownloaded(url: string): Promise<boolean> {
+    if (this._cache.has(url)) return true; // in-session cache
+    const localPath = this.getLocalPath(url);
+    const exists = await RNFS.exists(localPath); // check filesystem
+    if (exists) {
+      this.add(url, localPath);
+      return true;
+    }
+    return false;
+  },
+  add(url: string, localPath: string) {
+    this._cache.set(url, { localPath });
+  },
+  list(): Array<{ url: string; localPath: string }> {
+    return Array.from(ModelCache._cache.entries()).map(
+      ([url, data]: [string, { localPath: string }]) => ({
+        url,
+        ...data,
+      }),
+    );
+  },
+};
+
+export enum ModelStatus {
+  IDLE,
+  DOWNLOADING,
+  INITIALIZING,
+  READY,
+  ERROR,
+}
+
+export interface CactusChatLanguageModelConfig {
+  provider: string;
+  generateId?: () => string;
+}
+
+export class CactusChatLanguageModel implements LanguageModelV2 {
+  readonly specificationVersion = 'v2';
+  readonly provider: string;
+  readonly modelId: string;
+  readonly modelUrl: string;
+
+  private lm: CactusLM | null = null;
+  private status: ModelStatus = ModelStatus.IDLE;
+  private lastError: Error | null = null;
+  private conversationHistory: CactusOAICompatibleMessage[] = [];
+
+  constructor(
+    modelUrl: string,
+    private readonly settings: CactusChatSettings,
+    private readonly config: CactusChatLanguageModelConfig,
+  ) {
+    this.modelUrl = modelUrl;
+    // modelId is the model file path used in CactusLM.init().
+    // We use modelId because it's a required parameter in LanguageModelV2.
+    this.modelId = ModelCache.getLocalPath(this.modelUrl);
+    this.provider = config.provider; // 'cactus'
+  }
+
+  public getStatus(): ModelStatus {
+    return this.status;
+  }
+
+  public getLastError(): Error | null {
+    return this.lastError; // useful for debugging when this.status is ModelStatus.ERROR
+  }
+
+  static async listDownloadedModels() {
+    return ModelCache.list();
+  }
+
+  private async adaptMessagesToStatefulContext(
+    fullPrompt: CactusOAICompatibleMessage[],
+  ): Promise<CactusOAICompatibleMessage[]> {
+    let divergent = fullPrompt.length < this.conversationHistory.length;
+    if (!divergent) {
+      for (let i = 0; i < this.conversationHistory.length; i++) {
+        // Using JSON.stringify for a concise deep comparison.
+        if (JSON.stringify(this.conversationHistory[i]) !== JSON.stringify(fullPrompt[i])) {
+          divergent = true;
+          break;
+        }
+      }
+    }
+
+    if (divergent) {
+      await this.lm!.rewind();
+      this.conversationHistory = [];
+      return fullPrompt;
+    } else {
+      return fullPrompt.slice(this.conversationHistory.length);
+    }
+  }
+
+  async downloadModel(
+    options: { onProgress?: (p: number) => void } = {},
+  ): Promise<string> {
+    this.status = ModelStatus.DOWNLOADING;
+    try {
+      await RNFS.downloadFile({
+        fromUrl: this.modelUrl,
+        toFile: this.modelId,
+        progress: (res: { bytesWritten: number; contentLength: number }) =>
+          options.onProgress?.(res.bytesWritten / res.contentLength),
+      }).promise;
+
+      ModelCache.add(this.modelUrl, this.modelId);
+      this.status = ModelStatus.IDLE;
+      return this.modelId;
+    } catch (e) {
+      this.lastError = e as Error;
+      this.status = ModelStatus.ERROR;
+      throw e;
+    }
+  }
+
+  async initialize(): Promise<void> {
+    if (this.status === ModelStatus.READY) return;
+    if (this.status === ModelStatus.INITIALIZING) return;
+    const isDownloaded = await ModelCache.isDownloaded(this.modelUrl);
+    if (!isDownloaded) {
+      throw new Error('Model not downloaded. Call downloadModel() first.');
+    }
+
+    this.status = ModelStatus.INITIALIZING;
+    try {
+      const { lm, error } = await CactusLM.init({ model: this.modelId });
+      if (error) throw error;
+      this.lm = lm;
+      this.status = ModelStatus.READY;
+    } catch (e) {
+      this.lastError = e as Error;
+      this.status = ModelStatus.ERROR;
+      throw e;
+    }
+  }
+
+  private assertIsReady(): void {
+    if (this.status !== ModelStatus.READY || !this.lm) {
+      throw new Error(
+        `Model not ready. Status: ${
+          ModelStatus[this.status]
+        }. Error: ${this.lastError?.message}`,
+      );
+    }
+  }
+
+  private convertToCactusMessages(
+    prompt: LanguageModelV2Prompt,
+  ): CactusOAICompatibleMessage[] {
+    return prompt.map(message => {
+      if (message.role === 'system') {
+        return { role: 'system', content: message.content };
+      }
+      const content = message.content
+        .filter(part => part.type === 'text')
+        .map(part => (part as LanguageModelV2TextPart).text)
+        .join('');
+      return { role: message.role, content };
+    });
+  }
+
+  private getCactusParams(
+    options: LanguageModelV2CallOptions,
+  ): CompletionParams {
+    const params: CompletionParams = {};
+    if (options.temperature != null) params.temperature = options.temperature;
+    if (options.maxOutputTokens != null) params.n_predict = options.maxOutputTokens;
+    if (options.stopSequences != null) params.stop = options.stopSequences;
+    return params;
+  }
+
+  get supportedUrls(): Record<string, RegExp[]> {return {}} // cactus is on-device only
+
+  async doGenerate(
+    options: LanguageModelV2CallOptions,
+  ): Promise<{
+    content: Array<LanguageModelV2Content>;
+    finishReason: LanguageModelV2FinishReason;
+    usage: LanguageModelV2Usage;
+    warnings: Array<LanguageModelV2CallWarning>;
+    request?: { body?: unknown };
+    response?: LanguageModelV2ResponseMetadata & {
+      headers?: SharedV2Headers;
+      body?: unknown;
+    };
+  }> {
+    this.assertIsReady();
+    const fullPrompt = this.convertToCactusMessages(options.prompt);
+    const newMessages = await this.adaptMessagesToStatefulContext(fullPrompt);
+
+    if (newMessages.length === 0) {
+      return {
+        content: [],
+        finishReason: 'stop',
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        warnings: [],
+      };
+    }
+
+    const params = this.getCactusParams(options);
+    const result: NativeCompletionResult = await this.lm!.completion(
+      newMessages,
+      params,
+    );
+
+    this.conversationHistory.push(...newMessages, {
+      role: 'assistant',
+      content: result.content,
+    });
+
+    return {
+      content: [{ type: 'text', text: result.content }],
+      finishReason: 'stop' as const,
+      usage: {
+        inputTokens: result.tokens_evaluated,
+        outputTokens: result.tokens_predicted,
+        totalTokens: result.tokens_evaluated + result.tokens_predicted,
+      },
+      warnings: [],
+    };
+  }
+
+  async doStream(
+    options: LanguageModelV2CallOptions,
+  ): Promise<{
+    stream: ReadableStream<LanguageModelV2StreamPart>;
+    warnings: Array<LanguageModelV2CallWarning>;
+    request?: { body?: unknown };
+    response?: {
+      headers?: SharedV2Headers;
+    };
+  }> {
+    this.assertIsReady();
+    const fullPrompt = this.convertToCactusMessages(options.prompt);
+    const newMessages = await this.adaptMessagesToStatefulContext(fullPrompt);
+    const params = this.getCactusParams(options);
+
+    const stream = new ReadableStream<LanguageModelV2StreamPart>({
+      start: async controller => {
+        if (newMessages.length === 0) {
+          controller.enqueue({
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          });
+          controller.close();
+          return;
+        }
+
+        let fullResponse = '';
+        const completionPromise = this.lm!.completion(
+          newMessages,
+          params,
+          data => {
+            // This callback is invoked from the native side for each token
+            fullResponse += data.token;
+            controller.enqueue({ type: 'text', text: data.token });
+          },
+        );
+
+        completionPromise
+          .then(result => {
+            controller.enqueue({
+              type: 'finish',
+              finishReason: 'stop',
+              usage: {
+                inputTokens: result.tokens_evaluated,
+                outputTokens: result.tokens_predicted,
+                totalTokens:
+                  result.tokens_evaluated + result.tokens_predicted,
+              },
+            });
+            this.conversationHistory.push(...newMessages, {
+              role: 'assistant',
+              content: fullResponse,
+            });
+            controller.close();
+          })
+          .catch(error => {
+            controller.error(error);
+          });
+      },
+    });
+
+    return { stream, warnings: [] };
+  }
+} 

--- a/packages/cactus/src/cactus-provider.ts
+++ b/packages/cactus/src/cactus-provider.ts
@@ -1,0 +1,48 @@
+import { generateId } from '@ai-sdk/provider-utils';
+import { ProviderV2 } from '@ai-sdk/provider';
+import { CactusChatLanguageModel } from './cactus-chat-language-model';
+
+export interface CactusChatSettings {}
+
+export interface CactusProvider extends ProviderV2 {
+  (modelUrl: string, settings?: CactusChatSettings): CactusChatLanguageModel;
+
+  languageModel(
+    modelUrl: string,
+    settings?: CactusChatSettings,
+  ): CactusChatLanguageModel;
+}
+
+export interface CactusProviderSettings {
+  model?: any;
+  generateId?: () => string;
+}
+
+export function createCactus(
+  options: CactusProviderSettings = {},
+): CactusProvider {
+  const createChatModel = (
+    modelUrl: string,
+    settings: CactusChatSettings = {},
+  ) =>
+    new CactusChatLanguageModel(modelUrl, settings, {
+      provider: 'cactus',
+      generateId: options.generateId ?? generateId,
+    });
+
+  const provider = function (modelUrl: string, settings?: CactusChatSettings) {
+    if (new.target) {
+      throw new Error(
+        'The model factory function cannot be called with the new keyword.',
+      );
+    }
+
+    return createChatModel(modelUrl, settings);
+  };
+
+  provider.languageModel = createChatModel;
+
+  return provider as CactusProvider;
+}
+
+export const cactus = createCactus();

--- a/packages/cactus/src/index.ts
+++ b/packages/cactus/src/index.ts
@@ -1,0 +1,2 @@
+export * from './cactus-provider';
+export * from './cactus-chat-language-model';


### PR DESCRIPTION
## Background

This change introduces a new community provider, `@ai-sdk/cactus`, to the Vercel AI SDK (**v5**). [Cactus](https://github.com/cactus-compute/cactus) is a cross-platform framework for running GGUF-compatible LLMs and VLMs locally in mobile applications.

🌵 Cactus 🌵 enables developers to build privacy-first, offline-capable AI features in their React Native apps by using on-device inference. It acts as a bridge connecting the Vercel AI SDK with Cactus' market-leading C++ inference engine.
## Summary

This PR adds the complete `@ai-sdk/cactus` provider package. The key changes include:

*   `cactus-provider.ts`: The main provider factory (`createCactus`) that conforms to the AI SDK provider interface.
*   `cactus-chat-language-model.ts`: The core implementation that manages the model lifecycle (downloading, initializing), bridges the stateless/stateful conversation context, and handles `doGenerate` and `doStream` calls.
* other standard files (package, readme, index)

## Verification

Wrote, built, and thoroughly tested React Native applications (in and out of the Expo lifecycle), both on iOS and Android.

## Tasks

- [x] Documentation has been added / updated (for bug fixes / features)

## Future Work

-   **Embedding Support**: Implement the `doEmbed` method to expose the text embedding capabilities of the underlying Cactus engine.
-   **Vision (VLM) Support**: Extend the provider to support multi-modal inputs (text and images) for Vision Language Models, a core feature of Cactus.
-   **Structured Output**: Investigate implementing `doTools` and `doObject` if future versions of the native Cactus engine add support for function calling or constrained JSON output.
