### PR TITLE
feat: allow zod 4.x as peer dependency

### DIFF
--- a/.changeset/metal-masks-wonder.md
+++ b/.changeset/metal-masks-wonder.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+feat: allow zod 4.x as peer dependency

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -71,7 +71,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -46,7 +46,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">=16.0.0",
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -50,7 +50,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/assemblyai/package.json
+++ b/packages/assemblyai/package.json
@@ -42,7 +42,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/cerebras/package.json
+++ b/packages/cerebras/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/cohere/package.json
+++ b/packages/cohere/package.json
@@ -43,7 +43,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/deepgram/package.json
+++ b/packages/deepgram/package.json
@@ -42,7 +42,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/deepinfra/package.json
+++ b/packages/deepinfra/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/deepseek/package.json
+++ b/packages/deepseek/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/elevenlabs/package.json
+++ b/packages/elevenlabs/package.json
@@ -43,7 +43,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/fal/package.json
+++ b/packages/fal/package.json
@@ -43,7 +43,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/fireworks/package.json
+++ b/packages/fireworks/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/gladia/package.json
+++ b/packages/gladia/package.json
@@ -42,7 +42,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/google-vertex/package.json
+++ b/packages/google-vertex/package.json
@@ -64,7 +64,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -50,7 +50,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -43,7 +43,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/hume/package.json
+++ b/packages/hume/package.json
@@ -42,7 +42,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/lmnt/package.json
+++ b/packages/lmnt/package.json
@@ -42,7 +42,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/luma/package.json
+++ b/packages/luma/package.json
@@ -43,7 +43,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/mistral/package.json
+++ b/packages/mistral/package.json
@@ -43,7 +43,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/openai-compatible/package.json
+++ b/packages/openai-compatible/package.json
@@ -50,7 +50,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -50,7 +50,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/perplexity/package.json
+++ b/packages/perplexity/package.json
@@ -43,7 +43,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -53,7 +53,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19 || ^19.0.0-rc",
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "peerDependenciesMeta": {
     "zod": {

--- a/packages/replicate/package.json
+++ b/packages/replicate/package.json
@@ -43,7 +43,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/revai/package.json
+++ b/packages/revai/package.json
@@ -42,7 +42,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19 || ^19.0.0-rc",
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "peerDependenciesMeta": {
     "zod": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "svelte": "^5.31.0",
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "peerDependenciesMeta": {
     "zod": {

--- a/packages/togetherai/package.json
+++ b/packages/togetherai/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -44,7 +44,7 @@
     "zod": "3.25.49"
   },
   "peerDependencies": {
-    "zod": "^3.25.49"
+    "zod": "^3.25.49 || ^4"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1413,7 +1413,7 @@ importers:
         specifier: workspace:*
         version: link:../ai
       zod:
-        specifier: ^3.25.49
+        specifier: ^3.25.49 || ^4
         version: 3.25.49
     devDependencies:
       '@types/node':
@@ -17824,7 +17824,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1902.15(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.1902.15(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.98.0))(webpack@5.98.0(esbuild@0.25.4))
+      '@angular-devkit/build-webpack': 0.1902.15(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.98.0))(webpack@5.98.0)
       '@angular-devkit/core': 19.2.15(chokidar@4.0.3)
       '@angular/build': 19.2.15(@angular/compiler-cli@19.2.14(@angular/compiler@19.2.14)(typescript@5.8.3))(@angular/compiler@19.2.14)(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.4.0)(less@4.2.2)(postcss@8.5.2)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.3)))(terser@5.39.0)(tsx@4.19.2)(typescript@5.8.3)(yaml@2.7.0)
       '@angular/compiler-cli': 19.2.14(@angular/compiler@19.2.14)(typescript@5.8.3)
@@ -17838,14 +17838,14 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/runtime': 7.26.10
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 19.2.15(@angular/compiler-cli@19.2.14(@angular/compiler@19.2.14)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.98.0(esbuild@0.25.4))
+      '@ngtools/webpack': 19.2.15(@angular/compiler-cli@19.2.14(@angular/compiler@19.2.14)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.98.0)
       '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.2.7(@types/node@20.17.24)(jiti@2.4.0)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.5.2)
-      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.98.0(esbuild@0.25.4))
+      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.98.0)
       browserslist: 4.24.0
-      copy-webpack-plugin: 12.0.2(webpack@5.98.0(esbuild@0.25.4))
-      css-loader: 7.1.2(webpack@5.98.0(esbuild@0.25.4))
+      copy-webpack-plugin: 12.0.2(webpack@5.98.0)
+      css-loader: 7.1.2(webpack@5.98.0)
       esbuild-wasm: 0.25.4
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -17853,22 +17853,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.2.2
-      less-loader: 12.2.0(less@4.2.2)(webpack@5.98.0(esbuild@0.25.4))
-      license-webpack-plugin: 4.0.2(webpack@5.98.0(esbuild@0.25.4))
+      less-loader: 12.2.0(less@4.2.2)(webpack@5.98.0)
+      license-webpack-plugin: 4.0.2(webpack@5.98.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.2(webpack@5.98.0(esbuild@0.25.4))
+      mini-css-extract-plugin: 2.9.2(webpack@5.98.0)
       open: 10.1.0
       ora: 5.4.1
       picomatch: 4.0.2
       piscina: 4.8.0
       postcss: 8.5.2
-      postcss-loader: 8.1.1(postcss@8.5.2)(typescript@5.8.3)(webpack@5.98.0(esbuild@0.25.4))
+      postcss-loader: 8.1.1(postcss@8.5.2)(typescript@5.8.3)(webpack@5.98.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.85.0
-      sass-loader: 16.0.5(sass@1.85.0)(webpack@5.98.0(esbuild@0.25.4))
+      sass-loader: 16.0.5(sass@1.85.0)(webpack@5.98.0)
       semver: 7.7.1
-      source-map-loader: 5.0.0(webpack@5.98.0(esbuild@0.25.4))
+      source-map-loader: 5.0.0(webpack@5.98.0)
       source-map-support: 0.5.21
       terser: 5.39.0
       tree-kill: 1.2.2
@@ -17878,7 +17878,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.98.0)
       webpack-dev-server: 5.2.2(webpack@5.98.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.98.0(esbuild@0.25.4))
+      webpack-subresource-integrity: 5.1.0(webpack@5.98.0)
     optionalDependencies:
       esbuild: 0.25.4
       jest: 29.7.0(@types/node@20.17.24)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.3))
@@ -17906,7 +17906,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.1902.15(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.98.0))(webpack@5.98.0(esbuild@0.25.4))':
+  '@angular-devkit/build-webpack@0.1902.15(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.98.0))(webpack@5.98.0)':
     dependencies:
       '@angular-devkit/architect': 0.1902.15(chokidar@4.0.3)
       rxjs: 7.8.1
@@ -22898,7 +22898,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.3.3':
     optional: true
 
-  '@ngtools/webpack@19.2.15(@angular/compiler-cli@19.2.14(@angular/compiler@19.2.14)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.98.0(esbuild@0.25.4))':
+  '@ngtools/webpack@19.2.15(@angular/compiler-cli@19.2.14(@angular/compiler@19.2.14)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.98.0)':
     dependencies:
       '@angular/compiler-cli': 19.2.14(@angular/compiler@19.2.14)(typescript@5.8.3)
       typescript: 5.8.3
@@ -27305,7 +27305,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(esbuild@0.25.4)):
+  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0):
     dependencies:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
@@ -28043,7 +28043,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@12.0.2(webpack@5.98.0(esbuild@0.25.4)):
+  copy-webpack-plugin@12.0.2(webpack@5.98.0):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -28144,7 +28144,7 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
-  css-loader@7.1.2(webpack@5.98.0(esbuild@0.25.4)):
+  css-loader@7.1.2(webpack@5.98.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
@@ -31941,7 +31941,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.2.0(less@4.2.2)(webpack@5.98.0(esbuild@0.25.4)):
+  less-loader@12.2.0(less@4.2.2)(webpack@5.98.0):
     dependencies:
       less: 4.2.2
     optionalDependencies:
@@ -31968,7 +31968,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.98.0(esbuild@0.25.4)):
+  license-webpack-plugin@4.0.2(webpack@5.98.0):
     dependencies:
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -32550,7 +32550,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.98.0(esbuild@0.25.4)):
+  mini-css-extract-plugin@2.9.2(webpack@5.98.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -34022,7 +34022,7 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.2)(typescript@5.8.3)(webpack@5.98.0(esbuild@0.25.4)):
+  postcss-loader@8.1.1(postcss@8.5.2)(typescript@5.8.3)(webpack@5.98.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.6
@@ -34886,7 +34886,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.85.0)(webpack@5.98.0(esbuild@0.25.4)):
+  sass-loader@16.0.5(sass@1.85.0)(webpack@5.98.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -35228,7 +35228,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.98.0(esbuild@0.25.4)):
+  source-map-loader@5.0.0(webpack@5.98.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -37313,7 +37313,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.98.0(esbuild@0.25.4)):
+  webpack-subresource-integrity@5.1.0(webpack@5.98.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.98.0(esbuild@0.25.4)


### PR DESCRIPTION
## Background

Zod 4.x was not allowed as peer.

## Summary

Change version ranges to include zod 4.x

## Related Issues

#7289 