### PR TITLE
Fix parsing anthropic overloaded error

### DIFF
--- a/packages/anthropic/src/anthropic-error.ts
+++ b/packages/anthropic/src/anthropic-error.ts
@@ -6,6 +6,7 @@ const anthropicErrorDataSchema = z.object({
   error: z.object({
     type: z.string(),
     message: z.string(),
+    details: z.any().optional(),
   }),
 });
 


### PR DESCRIPTION
addresses #2453

it seems that for some reason the anthropic api is returning "details: null" in the error response for overloaded

```
{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}
```

this allows for parsing that properly and fixes retries being broken