### PR TITLE
bugfix(openai-compatible): set choices[].tool_calls[].index to be optional for parameter for SambaNova model support

### DIFF
--- a/.changeset/heavy-balloons-enjoy.md
+++ b/.changeset/heavy-balloons-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': minor
+---
+
+Allow choices[].tool_calls[].index to be optional for extra compatibility

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -724,7 +724,7 @@ const createOpenAICompatibleChatChunkSchema = <ERROR_SCHEMA extends z.ZodType>(
               tool_calls: z
                 .array(
                   z.object({
-                    index: z.number(),
+                    index: z.number().optional(),
                     id: z.string().nullish(),
                     function: z.object({
                       name: z.string().nullish(),


### PR DESCRIPTION
## Background

Sambanova models do not return an index for `choices[].delta.tool_calls[].index`. This PR sets it to be optional.

## Summary

Updating for ai-sdk `main` branch.

## Verification

- [X] Tests have been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

#7238 