### PR TITLE
feat (docs): add built-in-ai custom provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -76,6 +76,7 @@ The open-source community has created the following providers:
 - [Dify Provider](/providers/community-providers/dify) (`dify-ai-provider`)
 - [Sarvam Provider](/providers/community-providers/sarvam) (`sarvam-ai-provider`)
 - [Claude Code Provider](/providers/community-providers/claude-code) (`ai-sdk-provider-claude-code`)
+- [Built-in AI Provider](/providers/community-providers/built-in-ai) (`built-in-ai`)
 
 ## Self-Hosted Models
 

--- a/content/providers/03-community-providers/100-built-in-ai.mdx
+++ b/content/providers/03-community-providers/100-built-in-ai.mdx
@@ -11,7 +11,7 @@ description: Learn how to use the Built-in AI provider (browser models) for the 
 
 # Built-in AI
 
-[jakobhoeg/built-in-ai](https://github.com/jakobhoeg/built-in-ai) is a community provider that serves as the base AI SDK provider for client side in-browser AI models. 
+[jakobhoeg/built-in-ai](https://github.com/jakobhoeg/built-in-ai) is a community provider that serves as the base AI SDK provider for client side in-browser AI models.
 It currently supports Chrome & Edge's native browser AI models via the JavaScript [Prompt API](https://github.com/webmachinelearning/prompt-api), with ongoing development to include other browser-based AI providers and frameworks such as [web-llm](https://github.com/mlc-ai/web-llm) and [transformers.js](https://huggingface.co/docs/transformers.js/en/index).
 
 <Note type="warning">

--- a/content/providers/03-community-providers/100-built-in-ai.mdx
+++ b/content/providers/03-community-providers/100-built-in-ai.mdx
@@ -4,8 +4,9 @@ description: Learn how to use the Built-in AI provider (Chrome & Edge models) fo
 ---
 
 <Note type="secondary">
-  Since this package relies on `ChatTransform` and `useChat()` from AI SDK v5 to work properly, it is ONLY compatible with that version and higher. 
-  It will not work with versions below v5.
+  Since this package relies on `ChatTransform` and `useChat()` from AI SDK v5 to
+  work properly, it is ONLY compatible with that version and higher. It will not
+  work with versions below v5.
 </Note>
 
 # Built-in AI
@@ -13,7 +14,9 @@ description: Learn how to use the Built-in AI provider (Chrome & Edge models) fo
 [jakobhoeg/built-in-ai](https://github.com/jakobhoeg/built-in-ai) is a community provider that utilizes the browser's native JavaScript [Prompt API](https://github.com/webmachinelearning/prompt-api) to provide access to native browser AI models in Chrome & Edge and use these in conjunction with the AI SDK.
 
 <Note type="warning">
-  This package is under constant development as the Prompt API matures, and may contain errors and breaking changes. However, this module will also mature with it as new implementations arise.
+  This package is under constant development as the Prompt API matures, and may
+  contain errors and breaking changes. However, this module will also mature
+  with it as new implementations arise.
 </Note>
 
 ## Setup
@@ -37,18 +40,20 @@ The Built-in AI provider is available in the `built-in-ai` module. You can insta
 ### Browser-specific setup (Chrome or Edge)
 
 <Note type="warning">
-  The Prompt API (built-in AI) is currently experimental and might change as it matures. The following enablement guide for the API might also change in the future.
+  The Prompt API (built-in AI) is currently experimental and might change as it
+  matures. The following enablement guide for the API might also change in the
+  future.
 </Note>
 
 1. You need Chrome (v128 or higher) or Edge Dev/Canary (v138.0.3309.2 or higher)
 
 2. Enable these experimental flags:
-    - If you're using Chrome:
-      1. Go to chrome://flags/#prompt-api-for-gemini-nano and set it to Enabled
-      2. Go to chrome://flags/#optimization-guide-on-device-model and set it to Enabled BypassPrefRequirement
-      3. Go to chrome://components and click Check for Update on Optimization Guide On Device Model
-    - If you're using Edge:
-      1. Go to edge://flags/#prompt-api-for-phi-mini and set it to Enabled
+   - If you're using Chrome:
+     1. Go to chrome://flags/#prompt-api-for-gemini-nano and set it to Enabled
+     2. Go to chrome://flags/#optimization-guide-on-device-model and set it to Enabled BypassPrefRequirement
+     3. Go to chrome://components and click Check for Update on Optimization Guide On Device Model
+   - If you're using Edge:
+     1. Go to edge://flags/#prompt-api-for-phi-mini and set it to Enabled
 
 For more information, check out [this guide](https://developer.chrome.com/docs/extensions/ai/prompt-api)
 
@@ -86,7 +91,7 @@ You can use the following optional settings to customize the model:
 
 ## Language Models
 
-The provider will automatically work in all browsers that support the Prompt API since the browser handles model orchestration. 
+The provider will automatically work in all browsers that support the Prompt API since the browser handles model orchestration.
 For instance, if your user uses Edge, it will use [Phi4-mini](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api#the-phi-4-mini-model), and for Chrome, it will use [Gemini Nano](https://developer.chrome.com/docs/ai/prompt-api#model_download).
 
 ### Example usage

--- a/content/providers/03-community-providers/100-built-in-ai.mdx
+++ b/content/providers/03-community-providers/100-built-in-ai.mdx
@@ -1,0 +1,108 @@
+---
+title: Built-in AI
+description: Learn how to use the Built-in AI provider (Chrome & Edge models) for the AI SDK.
+---
+
+<Note type="secondary">
+  Since this package relies on `ChatTransform` and `useChat()` from AI SDK v5 to work properly, it is ONLY compatible with that version and higher. 
+  It will not work with versions below v5.
+</Note>
+
+# Built-in AI
+
+[jakobhoeg/built-in-ai](https://github.com/jakobhoeg/built-in-ai) is a community provider that utilizes the browser's native JavaScript [Prompt API](https://github.com/webmachinelearning/prompt-api) to provide access to native browser AI models in Chrome & Edge and use these in conjunction with the AI SDK.
+
+<Note type="warning">
+  This package is under constant development as the Prompt API matures, and may contain errors and breaking changes. However, this module will also mature with it as new implementations arise.
+</Note>
+
+## Setup
+
+### Installation
+
+The Built-in AI provider is available in the `built-in-ai` module. You can install it with:
+
+<Tabs items={['pnpm', 'npm', 'yarn']}>
+  <Tab>
+    <Snippet text="pnpm add built-in-ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install built-in-ai" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add built-in-ai" dark />
+  </Tab>
+</Tabs>
+
+### Browser-specific setup (Chrome or Edge)
+
+<Note type="warning">
+  The Prompt API (built-in AI) is currently experimental and might change as it matures. The following enablement guide for the API might also change in the future.
+</Note>
+
+1. You need Chrome (v128 or higher) or Edge Dev/Canary (v138.0.3309.2 or higher)
+
+2. Enable these experimental flags:
+    - If you're using Chrome:
+      1. Go to chrome://flags/#prompt-api-for-gemini-nano and set it to Enabled
+      2. Go to chrome://flags/#optimization-guide-on-device-model and set it to Enabled BypassPrefRequirement
+      3. Go to chrome://components and click Check for Update on Optimization Guide On Device Model
+    - If you're using Edge:
+      1. Go to edge://flags/#prompt-api-for-phi-mini and set it to Enabled
+
+For more information, check out [this guide](https://developer.chrome.com/docs/extensions/ai/prompt-api)
+
+## Provider Instance
+
+You can import the default provider instance `builtInAI` from `built-in-ai`:
+
+```ts
+import { builtInAI } from 'built-in-ai';
+
+const model = builtInAI();
+```
+
+If you need a customized setup, you can import `builtInAI` from `built-in-ai` and create a provider instance with your settings:
+
+```ts
+import { builtInAI } from 'built-in-ai';
+
+const model = builtInAI({
+  // optional settings, e.g.
+  temperature: 0.7,
+  topK: 5,
+});
+```
+
+You can use the following optional settings to customize the model:
+
+- **temperature** _number_
+
+  Controls randomness in the model's responses. For most models, `0` means almost deterministic results, and higher values mean more randomness.
+
+- **topK** _number_
+
+  Control the diversity and coherence of generated text by limiting the selection of the next token.
+
+## Language Models
+
+The provider will automatically work in all browsers that support the Prompt API since the browser handles model orchestration. 
+For instance, if your user uses Edge, it will use [Phi4-mini](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api#the-phi-4-mini-model), and for Chrome, it will use [Gemini Nano](https://developer.chrome.com/docs/ai/prompt-api#model_download).
+
+### Example usage
+
+```ts
+import { streamText } from 'ai';
+import { builtInAI } from 'built-in-ai';
+
+const result = streamText({
+  model: builtInAI(), // will default to the specific browser model
+  prompt: 'Hello, how are you',
+});
+
+for await (const chunk of result.textStream) {
+  console.log(chunk);
+}
+```
+
+For more examples, check out the [documentation](https://github.com/jakobhoeg/built-in-ai)

--- a/content/providers/03-community-providers/100-built-in-ai.mdx
+++ b/content/providers/03-community-providers/100-built-in-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: Built-in AI
-description: Learn how to use the Built-in AI provider (Chrome & Edge models) for the AI SDK.
+description: Learn how to use the Built-in AI provider (browser models) for the AI SDK.
 ---
 
 <Note type="secondary">
@@ -11,7 +11,8 @@ description: Learn how to use the Built-in AI provider (Chrome & Edge models) fo
 
 # Built-in AI
 
-[jakobhoeg/built-in-ai](https://github.com/jakobhoeg/built-in-ai) is a community provider that utilizes the browser's native JavaScript [Prompt API](https://github.com/webmachinelearning/prompt-api) to provide access to native browser AI models in Chrome & Edge with support for the Vercel AI SDK.
+[jakobhoeg/built-in-ai](https://github.com/jakobhoeg/built-in-ai) is a community provider that serves as the base AI SDK provider for client side in-browser AI models. 
+It currently supports Chrome & Edge's native browser AI models via the JavaScript [Prompt API](https://github.com/webmachinelearning/prompt-api), with ongoing development to include other browser-based AI providers and frameworks such as [web-llm](https://github.com/mlc-ai/web-llm) and [transformers.js](https://huggingface.co/docs/transformers.js/en/index).
 
 <Note type="warning">
   This package is under constant development as the Prompt API matures, and may
@@ -23,17 +24,17 @@ description: Learn how to use the Built-in AI provider (Chrome & Edge models) fo
 
 ### Installation
 
-The Built-in AI provider is available in the `built-in-ai` module. You can install it with:
+The `@built-in-ai/core` package is the AI SDK provider for Chrome and Edge browser's built-in AI models. You can install it with:
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm add built-in-ai" dark />
+    <Snippet text="pnpm add @built-in-ai/core" dark />
   </Tab>
   <Tab>
-    <Snippet text="npm install built-in-ai" dark />
+    <Snippet text="npm install @built-in-ai/core" dark />
   </Tab>
   <Tab>
-    <Snippet text="yarn add built-in-ai" dark />
+    <Snippet text="yarn add @built-in-ai/core" dark />
   </Tab>
 </Tabs>
 
@@ -59,18 +60,18 @@ For more information, check out [this guide](https://developer.chrome.com/docs/e
 
 ## Provider Instance
 
-You can import the default provider instance `builtInAI` from `built-in-ai`:
+You can import the default provider instance `builtInAI` from `@built-in-ai/core`:
 
 ```ts
-import { builtInAI } from 'built-in-ai';
+import { builtInAI } from '@built-in-ai/core';
 
 const model = builtInAI();
 ```
 
-If you need a customized setup, you can import `builtInAI` from `built-in-ai` and create a provider instance with your settings:
+If you need a customized setup, you can import `builtInAI` from `@built-in-ai/core` and create a provider instance with your settings:
 
 ```ts
-import { builtInAI } from 'built-in-ai';
+import { builtInAI } from '@built-in-ai/core';
 
 const model = builtInAI({
   // optional settings, e.g.
@@ -98,7 +99,7 @@ For instance, if your user uses Edge, it will use [Phi4-mini](https://learn.micr
 
 ```ts
 import { streamText } from 'ai';
-import { builtInAI } from 'built-in-ai';
+import { builtInAI } from '@built-in-ai/core';
 
 const result = streamText({
   model: builtInAI(), // will default to the specific browser model

--- a/content/providers/03-community-providers/100-built-in-ai.mdx
+++ b/content/providers/03-community-providers/100-built-in-ai.mdx
@@ -11,7 +11,7 @@ description: Learn how to use the Built-in AI provider (Chrome & Edge models) fo
 
 # Built-in AI
 
-[jakobhoeg/built-in-ai](https://github.com/jakobhoeg/built-in-ai) is a community provider that utilizes the browser's native JavaScript [Prompt API](https://github.com/webmachinelearning/prompt-api) to provide access to native browser AI models in Chrome & Edge and use these in conjunction with the AI SDK.
+[jakobhoeg/built-in-ai](https://github.com/jakobhoeg/built-in-ai) is a community provider that utilizes the browser's native JavaScript [Prompt API](https://github.com/webmachinelearning/prompt-api) to provide access to native browser AI models in Chrome & Edge with support for the Vercel AI SDK.
 
 <Note type="warning">
   This package is under constant development as the Prompt API matures, and may


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

This PR adds `built-in-ai` as a community provider that utilizes the browser's native JavaScript [Prompt API](https://github.com/webmachinelearning/prompt-api) to provide access to native browser AI models in Chrome & Edge with support for the Vercel AI SDK.

It will also serves as the AI SDK provider for other client side in-browser AI models (libraries), meaning we'll aim to add support for 'web-llm' and 'transformers.js' under the @built-in-ai org.

<!-- Why was this change necessary? -->
While there is an [existing package](https://github.com/jeasonstudio/chrome-ai) that attempted to provide similar functionality for Chrome, it has been inactive for the past year with no maintenance or updates. It's not updated to work with the Prompt API nor the AI SDK.

There is [an issue](https://github.com/jeasonstudio/chrome-ai/issues/32) created in December last year, asking about the status of the repository that received no response.
The open issue with no responses and a year of inactivity, suggests that the package will not be maintained.

## Summary

<!-- What did you change? -->
I added the Built-in AI custom provider to the `content/providers/03-community-providers` and updated the `content\docs\02-foundations\02-providers-and-models.mdx`.

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

When the Vercel AI SDK v5 is released to stable, the '<Note>' components with warnings should be removed from the documentation .mdx
