### PR TITLE
test (provider/anthropic): test that overloaded errors can be parsed

### DIFF
--- a/packages/anthropic/src/anthropic-error.test.ts
+++ b/packages/anthropic/src/anthropic-error.test.ts
@@ -1,0 +1,29 @@
+import { anthropicErrorDataSchema } from './anthropic-error';
+
+describe('anthropicError', () => {
+  describe('anthropicErrorDataSchema', () => {
+    it('should parse overloaded error', async () => {
+      const result = anthropicErrorDataSchema.safeParse({
+        type: 'error',
+        error: {
+          details: null,
+          type: 'overloaded_error',
+          message: 'Overloaded',
+        },
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "error": {
+              "message": "Overloaded",
+              "type": "overloaded_error",
+            },
+            "type": "error",
+          },
+          "success": true,
+        }
+      `);
+    });
+  });
+});

--- a/packages/anthropic/src/anthropic-error.ts
+++ b/packages/anthropic/src/anthropic-error.ts
@@ -1,12 +1,11 @@
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
-const anthropicErrorDataSchema = z.object({
+export const anthropicErrorDataSchema = z.object({
   type: z.literal('error'),
   error: z.object({
     type: z.string(),
     message: z.string(),
-    details: z.any().optional(),
   }),
 });
 

--- a/packages/anthropic/src/anthropic-error.ts
+++ b/packages/anthropic/src/anthropic-error.ts
@@ -6,6 +6,7 @@ const anthropicErrorDataSchema = z.object({
   error: z.object({
     type: z.string(),
     message: z.string(),
+    details: z.any().optional(),
   }),
 });
 


### PR DESCRIPTION
## Background

#7317 indicated that certain errors cannot be parsed.

## Summary

Add test that shows overloaded errors can be parsed.
