### PR TITLE
fix (provider/grok): filter duplicated reasoning chunks

### DIFF
--- a/.changeset/nasty-queens-play.md
+++ b/.changeset/nasty-queens-play.md
@@ -2,4 +2,4 @@
 '@ai-sdk/xai': patch
 ---
 
-fix(grok): reasoning fix
+fix (provider/grok): filter duplicated reasoning chunks

--- a/.changeset/nasty-queens-play.md
+++ b/.changeset/nasty-queens-play.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(grok): reasoning fix

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -1285,6 +1285,96 @@ describe('XaiChatLanguageModel', () => {
         ]
       `);
     });
+
+    it('should deduplicate repetitive reasoning deltas', async () => {
+      server.urls['https://api.x.ai/v1/chat/completions'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"id":"grok-4-test","object":"chat.completion.chunk","created":1750538120,"model":"grok-4-0709",` +
+            `"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"system_fingerprint":"fp_reasoning_v1"}\n\n`,
+          // Multiple identical "Thinking..." deltas (simulating Grok 4 issue)
+          `data: {"id":"grok-4-test","object":"chat.completion.chunk","created":1750538120,"model":"grok-4-0709",` +
+            `"choices":[{"index":0,"delta":{"reasoning_content":"Thinking... "},"finish_reason":null}],"system_fingerprint":"fp_reasoning_v1"}\n\n`,
+          `data: {"id":"grok-4-test","object":"chat.completion.chunk","created":1750538120,"model":"grok-4-0709",` +
+            `"choices":[{"index":0,"delta":{"reasoning_content":"Thinking... "},"finish_reason":null}],"system_fingerprint":"fp_reasoning_v1"}\n\n`,
+          `data: {"id":"grok-4-test","object":"chat.completion.chunk","created":1750538120,"model":"grok-4-0709",` +
+            `"choices":[{"index":0,"delta":{"reasoning_content":"Thinking... "},"finish_reason":null}],"system_fingerprint":"fp_reasoning_v1"}\n\n`,
+          // Different reasoning content should still come through
+          `data: {"id":"grok-4-test","object":"chat.completion.chunk","created":1750538120,"model":"grok-4-0709",` +
+            `"choices":[{"index":0,"delta":{"reasoning_content":"Actually calculating now..."},"finish_reason":null}],"system_fingerprint":"fp_reasoning_v1"}\n\n`,
+          `data: {"id":"grok-4-test","object":"chat.completion.chunk","created":1750538120,"model":"grok-4-0709",` +
+            `"choices":[{"index":0,"delta":{"content":"The answer is 42."},"finish_reason":null}],"system_fingerprint":"fp_reasoning_v1"}\n\n`,
+          `data: {"id":"grok-4-test","object":"chat.completion.chunk","created":1750538120,"model":"grok-4-0709",` +
+            `"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],` +
+            `"usage":{"prompt_tokens":15,"total_tokens":35,"completion_tokens":20,"completion_tokens_details":{"reasoning_tokens":10}},"system_fingerprint":"fp_reasoning_v1"}\n\n`,
+          `data: [DONE]\n\n`,
+        ],
+      };
+
+      const { stream } = await reasoningModel.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+        providerOptions: {
+          xai: { reasoningEffort: 'low' },
+        },
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "id": "grok-4-test",
+            "modelId": "grok-4-0709",
+            "timestamp": 2025-06-21T20:35:20.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "id": "reasoning-grok-4-test",
+            "type": "reasoning-start",
+          },
+          {
+            "delta": "Thinking... ",
+            "id": "reasoning-grok-4-test",
+            "type": "reasoning-delta",
+          },
+          {
+            "delta": "Actually calculating now...",
+            "id": "reasoning-grok-4-test",
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "text-grok-4-test",
+            "type": "text-start",
+          },
+          {
+            "delta": "The answer is 42.",
+            "id": "text-grok-4-test",
+            "type": "text-delta",
+          },
+          {
+            "id": "reasoning-grok-4-test",
+            "type": "reasoning-end",
+          },
+          {
+            "id": "text-grok-4-test",
+            "type": "text-end",
+          },
+          {
+            "finishReason": "stop",
+            "type": "finish",
+            "usage": {
+              "inputTokens": 15,
+              "outputTokens": 20,
+              "reasoningTokens": 10,
+              "totalTokens": 35,
+            },
+          },
+        ]
+      `);
+    });
   });
 });
 

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -330,6 +330,7 @@ export class XaiChatLanguageModel implements LanguageModelV2 {
     };
     let isFirstChunk = true;
     const contentBlocks: Record<string, { type: 'text' | 'reasoning' }> = {};
+    const lastReasoningDeltas: Record<string, string> = {};
 
     const self = this;
 
@@ -438,6 +439,12 @@ export class XaiChatLanguageModel implements LanguageModelV2 {
               delta.reasoning_content.length > 0
             ) {
               const blockId = `reasoning-${value.id || choiceIndex}`;
+
+              // skip if this reasoning content duplicates the last delta
+              if (lastReasoningDeltas[blockId] === delta.reasoning_content) {
+                return;
+              }
+              lastReasoningDeltas[blockId] = delta.reasoning_content;
 
               if (contentBlocks[blockId] == null) {
                 contentBlocks[blockId] = { type: 'reasoning' };


### PR DESCRIPTION
## background

XAI's Grok reasoning API was sending repetitive "Thinking... " placeholder text in each reasoning delta, causing reasoning output to show "Thinking... Thinking... Thinking..." instead of meaningful reasoning content.

## summary

- add reasoning delta deduplication to XAI provider

## verification

- all tests pass including new reasoning deduplication test

## tasks

- [x] reasoning deduplication logic in XAI streaming transform
- [x] tested reasoning via examples + e2e

## future work

* monitor XAI API for native reasoning deduplication support 

related issue #7311 