### PR TITLE
fix (provider/openai): multi-step reasoning with text

### DIFF
--- a/.changeset/gorgeous-gifts-drop.md
+++ b/.changeset/gorgeous-gifts-drop.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai': patch
+'ai': patch
+---
+
+fix (provider/openai): multi-step reasoning with text

--- a/examples/next-openai/app/api/use-chat-reasoning-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-reasoning-tools/route.ts
@@ -1,28 +1,13 @@
-import { createAnthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { fireworks } from '@ai-sdk/fireworks';
+import { openai } from '@ai-sdk/openai';
 import {
   convertToModelMessages,
-  extractReasoningMiddleware,
   stepCountIs,
   streamText,
   tool,
   UIDataTypes,
   UIMessage,
-  wrapLanguageModel,
 } from 'ai';
 import { z } from 'zod/v4';
-
-const anthropic = createAnthropic({
-  // example fetch wrapper that logs the input to the API call:
-  fetch: async (url, options) => {
-    console.log('URL', url);
-    console.log('Headers', JSON.stringify(options!.headers, null, 2));
-    console.log(
-      `Body ${JSON.stringify(JSON.parse(options!.body! as string), null, 2)}`,
-    );
-    return await fetch(url, options);
-  },
-});
 
 export type ReasoningToolsMessage = UIMessage<
   never, // could define metadata here
@@ -52,10 +37,7 @@ export async function POST(req: Request) {
   console.log(JSON.stringify(messages, null, 2));
 
   const result = streamText({
-    model: wrapLanguageModel({
-      model: fireworks('accounts/fireworks/models/qwen3-30b-a3b'),
-      middleware: extractReasoningMiddleware({ tagName: 'think' }),
-    }),
+    model: openai('o3'),
     messages: convertToModelMessages(messages),
     stopWhen: stepCountIs(5), // multi-steps for server-side tools
     tools: {

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -123,6 +123,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > onSte
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
             },
@@ -179,6 +180,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
   {
     "content": [
       {
+        "providerOptions": undefined,
         "text": "Hello, world!",
         "type": "text",
       },
@@ -311,6 +313,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
             },
@@ -456,6 +459,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
             },
@@ -512,6 +516,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
   {
     "content": [
       {
+        "providerOptions": undefined,
         "text": "Hello, world!",
         "type": "text",
       },
@@ -644,6 +649,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
             },
@@ -696,6 +702,7 @@ exports[`generateText > result.response > should contain response body and heade
     {
       "content": [
         {
+          "providerOptions": undefined,
           "text": "Hello, world!",
           "type": "text",
         },
@@ -719,6 +726,7 @@ exports[`generateText > result.response > should contain response body and heade
     {
       "content": [
         {
+          "providerOptions": undefined,
           "text": "Hello, world!",
           "type": "text",
         },
@@ -736,6 +744,7 @@ exports[`generateText > result.response.messages > should contain assistant resp
   {
     "content": [
       {
+        "providerOptions": undefined,
         "text": "Hello, world!",
         "type": "text",
       },
@@ -774,6 +783,7 @@ exports[`generateText > result.response.messages > should contain assistant resp
   {
     "content": [
       {
+        "providerOptions": undefined,
         "text": "Hello, world!",
         "type": "text",
       },
@@ -806,6 +816,7 @@ exports[`generateText > result.response.messages > should contain reasoning 1`] 
         "type": "reasoning",
       },
       {
+        "providerOptions": undefined,
         "text": "Hello, world!",
         "type": "text",
       },
@@ -900,6 +911,7 @@ exports[`generateText > result.steps > should add the reasoning from the model r
               "type": "reasoning",
             },
             {
+              "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
             },
@@ -962,6 +974,7 @@ exports[`generateText > result.steps > should contain files 1`] = `
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
             },
@@ -1040,6 +1053,7 @@ exports[`generateText > result.steps > should contain sources 1`] = `
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Hello, world!",
               "type": "text",
             },

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1014,6 +1014,7 @@ describe('generateText', () => {
                       {
                         "content": [
                           {
+                            "providerOptions": undefined,
                             "text": "Hello, world!",
                             "type": "text",
                           },
@@ -1194,6 +1195,7 @@ describe('generateText', () => {
                       {
                         "content": [
                           {
+                            "providerOptions": undefined,
                             "text": "Hello, world!",
                             "type": "text",
                           },

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -3,19 +3,19 @@ import {
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider';
 import { generateId, ModelMessage } from '@ai-sdk/provider-utils';
-import { SpanStatusCode, Tracer } from '@opentelemetry/api';
+import { Tracer } from '@opentelemetry/api';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { recordErrorOnSpan, recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { FinishReason, LanguageModelUsage, ProviderMetadata } from '../types';
+import { Source } from '../types/language-model';
 import { DefaultGeneratedFileWithType, GeneratedFile } from './generated-file';
 import { parseToolCall } from './parse-tool-call';
+import { ToolCallUnion } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { ToolErrorUnion, ToolResultUnion } from './tool-output';
 import { ToolSet } from './tool-set';
-import { Source } from '../types/language-model';
-import { ToolCallUnion } from './tool-call';
 
 export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
   // Text blocks:

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -3450,7 +3450,7 @@ describe('streamText', () => {
                 "type": "reasoning",
               },
               {
-                "providerMetadata": undefined,
+                "providerOptions": undefined,
                 "text": "Hi there!",
                 "type": "text",
               },
@@ -3532,7 +3532,7 @@ describe('streamText', () => {
             {
               "content": [
                 {
-                  "providerMetadata": undefined,
+                  "providerOptions": undefined,
                   "text": "Hello",
                   "type": "text",
                 },
@@ -3731,7 +3731,7 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
-                      "providerMetadata": undefined,
+                      "providerOptions": undefined,
                       "text": "Hi there!",
                       "type": "text",
                     },
@@ -3807,7 +3807,7 @@ describe('streamText', () => {
                 {
                   "content": [
                     {
-                      "providerMetadata": undefined,
+                      "providerOptions": undefined,
                       "text": "Hello!",
                       "type": "text",
                     },
@@ -3883,7 +3883,7 @@ describe('streamText', () => {
                       "type": "file",
                     },
                     {
-                      "providerMetadata": undefined,
+                      "providerOptions": undefined,
                       "text": "Hello!",
                       "type": "text",
                     },
@@ -4290,7 +4290,7 @@ describe('streamText', () => {
               {
                 "content": [
                   {
-                    "providerMetadata": undefined,
+                    "providerOptions": undefined,
                     "text": "Hello, world!",
                     "type": "text",
                   },
@@ -4372,7 +4372,7 @@ describe('streamText', () => {
                   {
                     "content": [
                       {
-                        "providerMetadata": undefined,
+                        "providerOptions": undefined,
                         "text": "Hello, world!",
                         "type": "text",
                       },
@@ -4523,7 +4523,7 @@ describe('streamText', () => {
               {
                 "content": [
                   {
-                    "providerMetadata": undefined,
+                    "providerOptions": undefined,
                     "text": "Hello!",
                     "type": "text",
                   },
@@ -4603,7 +4603,7 @@ describe('streamText', () => {
                   {
                     "content": [
                       {
-                        "providerMetadata": undefined,
+                        "providerOptions": undefined,
                         "text": "Hello!",
                         "type": "text",
                       },
@@ -4720,7 +4720,7 @@ describe('streamText', () => {
                     "type": "file",
                   },
                   {
-                    "providerMetadata": undefined,
+                    "providerOptions": undefined,
                     "text": "Hello!",
                     "type": "text",
                   },
@@ -4781,7 +4781,7 @@ describe('streamText', () => {
                         "type": "file",
                       },
                       {
-                        "providerMetadata": undefined,
+                        "providerOptions": undefined,
                         "text": "Hello!",
                         "type": "text",
                       },
@@ -4882,7 +4882,7 @@ describe('streamText', () => {
           {
             "content": [
               {
-                "providerMetadata": undefined,
+                "providerOptions": undefined,
                 "text": "Hello, world!",
                 "type": "text",
               },
@@ -4930,7 +4930,7 @@ describe('streamText', () => {
           {
             "content": [
               {
-                "providerMetadata": undefined,
+                "providerOptions": undefined,
                 "text": "Hello, world!",
                 "type": "text",
               },
@@ -5384,7 +5384,7 @@ describe('streamText', () => {
                   {
                     "content": [
                       {
-                        "providerMetadata": undefined,
+                        "providerOptions": undefined,
                         "text": "Hello, world!",
                         "type": "text",
                       },
@@ -5536,7 +5536,7 @@ describe('streamText', () => {
                       {
                         "content": [
                           {
-                            "providerMetadata": undefined,
+                            "providerOptions": undefined,
                             "text": "Hello, world!",
                             "type": "text",
                           },
@@ -5721,7 +5721,7 @@ describe('streamText', () => {
                     {
                       "content": [
                         {
-                          "providerMetadata": undefined,
+                          "providerOptions": undefined,
                           "text": "Hello, world!",
                           "type": "text",
                         },
@@ -5925,7 +5925,7 @@ describe('streamText', () => {
                     {
                       "content": [
                         {
-                          "providerMetadata": undefined,
+                          "providerOptions": undefined,
                           "text": "Hello, world!",
                           "type": "text",
                         },
@@ -5989,7 +5989,7 @@ describe('streamText', () => {
               {
                 "content": [
                   {
-                    "providerMetadata": undefined,
+                    "providerOptions": undefined,
                     "text": "Hello, world!",
                     "type": "text",
                   },
@@ -6458,7 +6458,7 @@ describe('streamText', () => {
                       {
                         "content": [
                           {
-                            "providerMetadata": undefined,
+                            "providerOptions": undefined,
                             "text": "Hello, world!",
                             "type": "text",
                           },
@@ -6642,7 +6642,7 @@ describe('streamText', () => {
                       {
                         "content": [
                           {
-                            "providerMetadata": undefined,
+                            "providerOptions": undefined,
                             "text": "Hello, world!",
                             "type": "text",
                           },
@@ -6973,7 +6973,7 @@ describe('streamText', () => {
                   {
                     "content": [
                       {
-                        "providerMetadata": undefined,
+                        "providerOptions": undefined,
                         "text": "Hello, world!",
                         "type": "text",
                       },
@@ -7125,7 +7125,7 @@ describe('streamText', () => {
                       {
                         "content": [
                           {
-                            "providerMetadata": undefined,
+                            "providerOptions": undefined,
                             "text": "Hello, world!",
                             "type": "text",
                           },
@@ -7310,7 +7310,7 @@ describe('streamText', () => {
                     {
                       "content": [
                         {
-                          "providerMetadata": undefined,
+                          "providerOptions": undefined,
                           "text": "Hello, world!",
                           "type": "text",
                         },
@@ -7514,7 +7514,7 @@ describe('streamText', () => {
                     {
                       "content": [
                         {
-                          "providerMetadata": undefined,
+                          "providerOptions": undefined,
                           "text": "Hello, world!",
                           "type": "text",
                         },
@@ -7578,7 +7578,7 @@ describe('streamText', () => {
               {
                 "content": [
                   {
-                    "providerMetadata": undefined,
+                    "providerOptions": undefined,
                     "text": "Hello, world!",
                     "type": "text",
                   },
@@ -9411,7 +9411,7 @@ describe('streamText', () => {
               role: 'assistant',
               content: [
                 {
-                  providerMetadata: undefined,
+                  providerOptions: undefined,
                   text: 'HELLO, WORLD!',
                   type: 'text',
                 },
@@ -9674,7 +9674,7 @@ describe('streamText', () => {
                   {
                     "content": [
                       {
-                        "providerMetadata": undefined,
+                        "providerOptions": undefined,
                         "text": "HELLO, WORLD!",
                         "type": "text",
                       },
@@ -9895,7 +9895,7 @@ describe('streamText', () => {
                 {
                   "content": [
                     {
-                      "providerMetadata": undefined,
+                      "providerOptions": undefined,
                       "text": "HELLO, WORLD!",
                       "type": "text",
                     },
@@ -9977,7 +9977,7 @@ describe('streamText', () => {
                     {
                       "content": [
                         {
-                          "providerMetadata": undefined,
+                          "providerOptions": undefined,
                           "text": "HELLO, WORLD!",
                           "type": "text",
                         },
@@ -10164,7 +10164,7 @@ describe('streamText', () => {
                 {
                   "content": [
                     {
-                      "providerMetadata": undefined,
+                      "providerOptions": undefined,
                       "text": "HELLO, WORLD!",
                       "type": "text",
                     },
@@ -10620,7 +10620,7 @@ describe('streamText', () => {
                 {
                   "content": [
                     {
-                      "providerMetadata": undefined,
+                      "providerOptions": undefined,
                       "text": "Hello, ",
                       "type": "text",
                     },
@@ -10983,7 +10983,7 @@ describe('streamText', () => {
                 {
                   "content": [
                     {
-                      "providerMetadata": undefined,
+                      "providerOptions": undefined,
                       "text": "{ "value": "Hello, world!" }",
                       "type": "text",
                     },
@@ -11014,7 +11014,7 @@ describe('streamText', () => {
                     {
                       "content": [
                         {
-                          "providerMetadata": undefined,
+                          "providerOptions": undefined,
                           "text": "{ "value": "Hello, world!" }",
                           "type": "text",
                         },
@@ -11652,12 +11652,12 @@ describe('streamText', () => {
                         "type": "reasoning",
                       },
                       {
-                        "providerMetadata": undefined,
+                        "providerOptions": undefined,
                         "text": "Hello, world!",
                         "type": "text",
                       },
                       {
-                        "providerMetadata": undefined,
+                        "providerOptions": undefined,
                         "text": "This is a test.",
                         "type": "text",
                       },

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -682,7 +682,8 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
           }
 
           activeText.text += part.text;
-          activeText.providerMetadata = part.providerMetadata;
+          activeText.providerMetadata =
+            part.providerMetadata ?? activeText.providerMetadata;
         }
 
         if (part.type === 'text-end') {

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -770,4 +770,36 @@ describe('toResponseMessages', () => {
       `);
     });
   });
+
+  it('should include provider metadata in the text parts', () => {
+    const result = toResponseMessages({
+      content: [
+        {
+          type: 'text',
+          text: 'Here is a text',
+          providerMetadata: { testProvider: { signature: 'sig' } },
+        },
+      ],
+      tools: {},
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "providerOptions": {
+                "testProvider": {
+                  "signature": "sig",
+                },
+              },
+              "text": "Here is a text",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ]
+    `);
+  });
 });

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -98,6 +98,7 @@ describe('toResponseMessages', () => {
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Using a tool",
               "type": "text",
             },
@@ -154,6 +155,7 @@ describe('toResponseMessages', () => {
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Tool used",
               "type": "text",
             },
@@ -220,6 +222,7 @@ describe('toResponseMessages', () => {
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "Tool used",
               "type": "text",
             },
@@ -336,6 +339,7 @@ describe('toResponseMessages', () => {
               "type": "reasoning",
             },
             {
+              "providerOptions": undefined,
               "text": "Final text",
               "type": "text",
             },
@@ -386,6 +390,7 @@ describe('toResponseMessages', () => {
         {
           "content": [
             {
+              "providerOptions": undefined,
               "text": "multipart tool result",
               "type": "text",
             },
@@ -441,7 +446,11 @@ describe('toResponseMessages', () => {
       {
         role: 'assistant',
         content: [
-          { type: 'text', text: 'Here is an image' },
+          {
+            type: 'text',
+            text: 'Here is an image',
+            providerOptions: undefined,
+          },
           {
             type: 'file',
             data: pngFile.base64,
@@ -479,7 +488,11 @@ describe('toResponseMessages', () => {
       {
         role: 'assistant',
         content: [
-          { type: 'text', text: 'Here are multiple images' },
+          {
+            type: 'text',
+            text: 'Here are multiple images',
+            providerOptions: undefined,
+          },
           {
             type: 'file',
             data: pngFile.base64,
@@ -518,7 +531,11 @@ describe('toResponseMessages', () => {
       {
         role: 'assistant',
         content: [
-          { type: 'text', text: 'Here is a binary image' },
+          {
+            type: 'text',
+            text: 'Here is a binary image',
+            providerOptions: undefined,
+          },
           {
             type: 'file',
             data: pngFile.base64,
@@ -583,6 +600,7 @@ describe('toResponseMessages', () => {
               "type": "file",
             },
             {
+              "providerOptions": undefined,
               "text": "Combined response",
               "type": "text",
             },
@@ -708,6 +726,7 @@ describe('toResponseMessages', () => {
           {
             "content": [
               {
+                "providerOptions": undefined,
                 "text": "Let me search for recent news from San Francisco.",
                 "type": "text",
               },
@@ -737,6 +756,7 @@ describe('toResponseMessages', () => {
                 "type": "tool-result",
               },
               {
+                "providerOptions": undefined,
                 "text": "Based on the search results, several significant events took place in San Francisco yesterday (June 22, 2025). Here are the main highlights:
 
         1. Juneteenth Celebration:

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -31,7 +31,11 @@ export function toResponseMessages<TOOLS extends ToolSet>({
     .map(part => {
       switch (part.type) {
         case 'text':
-          return part;
+          return {
+            type: 'text',
+            text: part.text,
+            providerOptions: part.providerMetadata,
+          };
         case 'reasoning':
           return {
             type: 'reasoning',

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
@@ -348,7 +348,15 @@ describe('convertToOpenAIResponsesMessages', () => {
           {
             role: 'assistant',
             content: [
-              { type: 'text', text: 'I will search for that information.' },
+              {
+                type: 'text',
+                text: 'I will search for that information.',
+                providerOptions: {
+                  openai: {
+                    itemId: 'id_123',
+                  },
+                },
+              },
               {
                 type: 'tool-call',
                 toolCallId: 'call_123',
@@ -356,7 +364,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                 input: { query: 'weather in San Francisco' },
                 providerOptions: {
                   openai: {
-                    itemId: 'id_123',
+                    itemId: 'id_456',
                   },
                 },
               },
@@ -375,12 +383,13 @@ describe('convertToOpenAIResponsesMessages', () => {
                 "type": "output_text",
               },
             ],
+            "id": "id_123",
             "role": "assistant",
           },
           {
             "arguments": "{"query":"weather in San Francisco"}",
             "call_id": "call_123",
-            "id": "id_123",
+            "id": "id_456",
             "name": "search",
             "type": "function_call",
           },
@@ -1315,6 +1324,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                   "type": "output_text",
                 },
               ],
+              "id": undefined,
               "role": "assistant",
             },
             {
@@ -1324,6 +1334,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                   "type": "output_text",
                 },
               ],
+              "id": undefined,
               "role": "assistant",
             },
           ],

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.ts
@@ -1,5 +1,4 @@
 import {
-  InvalidArgumentError,
   LanguageModelV2CallWarning,
   LanguageModelV2Prompt,
   UnsupportedFunctionalityError,
@@ -113,6 +112,8 @@ export async function convertToOpenAIResponsesMessages({
               messages.push({
                 role: 'assistant',
                 content: [{ type: 'output_text', text: part.text }],
+                id:
+                  (part.providerOptions?.openai?.itemId as string) ?? undefined,
               });
               break;
             }

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -33,6 +33,7 @@ export type OpenAIResponsesAssistantMessage = {
     | OpenAIWebSearchCall
     | OpenAIComputerCall
   >;
+  id?: string;
 };
 
 export type OpenAIResponsesFunctionCall = {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -134,6 +134,11 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(result.content).toMatchInlineSnapshot(`
           [
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                },
+              },
               "text": "answer text",
               "type": "text",
             },
@@ -1063,6 +1068,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "reasoning",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                },
+              },
               "text": "answer text",
               "type": "text",
             },
@@ -1170,6 +1180,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "reasoning",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                },
+              },
               "text": "answer text",
               "type": "text",
             },
@@ -1303,6 +1318,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "reasoning",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                },
+              },
               "text": "answer text",
               "type": "text",
             },
@@ -1413,6 +1433,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "reasoning",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                },
+              },
               "text": "answer text",
               "type": "text",
             },
@@ -1568,6 +1593,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "reasoning",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                },
+              },
               "text": "Let me think about this step by step.",
               "type": "text",
             },
@@ -1584,6 +1614,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "reasoning",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_final_78d08d03767d92908f25523f5ge51e77",
+                },
+              },
               "text": "Based on my analysis, here is the solution.",
               "type": "text",
             },
@@ -1888,6 +1923,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               "type": "tool-result",
             },
             {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67cf2b35467481908f24412e4fd40d66",
+                },
+              },
               "text": "Last week in San Francisco, several notable events and developments took place:
 
           **Bruce Lee Statue in Chinatown**
@@ -2055,6 +2095,11 @@ describe('OpenAIResponsesLanguageModel', () => {
           },
           {
             "id": "msg_67c9a81dea8c8190b79651a2b3adf91e",
+            "providerMetadata": {
+              "openai": {
+                "itemId": "msg_67c9a81dea8c8190b79651a2b3adf91e",
+              },
+            },
             "type": "text-start",
           },
           {
@@ -2126,6 +2171,11 @@ describe('OpenAIResponsesLanguageModel', () => {
           },
           {
             "id": "msg_67c9a81dea8c8190b79651a2b3adf91e",
+            "providerMetadata": {
+              "openai": {
+                "itemId": "msg_67c9a81dea8c8190b79651a2b3adf91e",
+              },
+            },
             "type": "text-start",
           },
           {
@@ -2359,6 +2409,11 @@ describe('OpenAIResponsesLanguageModel', () => {
           },
           {
             "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+            "providerMetadata": {
+              "openai": {
+                "itemId": "msg_67cf33924ea88190b8c12bf68c1f6416",
+              },
+            },
             "type": "text-start",
           },
           {
@@ -2631,6 +2686,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               },
               {
                 "id": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                  },
+                },
                 "type": "text-start",
               },
               {
@@ -2741,6 +2801,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               },
               {
                 "id": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                  },
+                },
                 "type": "text-start",
               },
               {
@@ -2935,6 +3000,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               },
               {
                 "id": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                  },
+                },
                 "type": "text-start",
               },
               {
@@ -3047,6 +3117,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               },
               {
                 "id": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                  },
+                },
                 "type": "text-start",
               },
               {
@@ -3255,6 +3330,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               },
               {
                 "id": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                  },
+                },
                 "type": "text-start",
               },
               {
@@ -3321,6 +3401,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               },
               {
                 "id": "msg_final_78d08d03767d92908f25523f5ge51e77",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "msg_final_78d08d03767d92908f25523f5ge51e77",
+                  },
+                },
                 "type": "text-start",
               },
               {
@@ -3458,43 +3543,48 @@ describe('OpenAIResponsesLanguageModel', () => {
         });
 
         expect(result.content).toMatchInlineSnapshot(`
-        [
-          {
-            "input": "",
-            "providerExecuted": true,
-            "toolCallId": "ws_67cf2b3051e88190b006770db6fdb13d",
-            "toolName": "web_search_preview",
-            "type": "tool-call",
-          },
-          {
-            "providerExecuted": true,
-            "result": {
-              "status": "completed",
+          [
+            {
+              "input": "",
+              "providerExecuted": true,
+              "toolCallId": "ws_67cf2b3051e88190b006770db6fdb13d",
+              "toolName": "web_search_preview",
+              "type": "tool-call",
             },
-            "toolCallId": "ws_67cf2b3051e88190b006770db6fdb13d",
-            "toolName": "web_search_preview",
-            "type": "tool-result",
-          },
-          {
-            "text": "As of June 23, 2025, here are some recent developments in San Francisco's tech scene:",
-            "type": "text",
-          },
-          {
-            "id": "id-0",
-            "sourceType": "url",
-            "title": "Discover Tech Events & Activities in San Francisco, CA | Eventbrite",
-            "type": "source",
-            "url": "https://www.eventbrite.sg/d/ca--san-francisco/tech-events/?utm_source=openai",
-          },
-          {
-            "id": "id-1",
-            "sourceType": "url",
-            "title": "AI+ SF Summit: AI agents are the next big thing",
-            "type": "source",
-            "url": "https://www.axios.com/2024/12/10/ai-sf-summit-2024-roundup?utm_source=openai",
-          },
-        ]
-      `);
+            {
+              "providerExecuted": true,
+              "result": {
+                "status": "completed",
+              },
+              "toolCallId": "ws_67cf2b3051e88190b006770db6fdb13d",
+              "toolName": "web_search_preview",
+              "type": "tool-result",
+            },
+            {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67cf2b35467481908f24412e4fd40d66",
+                },
+              },
+              "text": "As of June 23, 2025, here are some recent developments in San Francisco's tech scene:",
+              "type": "text",
+            },
+            {
+              "id": "id-0",
+              "sourceType": "url",
+              "title": "Discover Tech Events & Activities in San Francisco, CA | Eventbrite",
+              "type": "source",
+              "url": "https://www.eventbrite.sg/d/ca--san-francisco/tech-events/?utm_source=openai",
+            },
+            {
+              "id": "id-1",
+              "sourceType": "url",
+              "title": "AI+ SF Summit: AI agents are the next big thing",
+              "type": "source",
+              "url": "https://www.axios.com/2024/12/10/ai-sf-summit-2024-roundup?utm_source=openai",
+            },
+          ]
+        `);
       });
 
       it('should handle computer use tool calls', async () => {
@@ -3554,30 +3644,35 @@ describe('OpenAIResponsesLanguageModel', () => {
         });
 
         expect(result.content).toMatchInlineSnapshot(`
-        [
-          {
-            "input": "",
-            "providerExecuted": true,
-            "toolCallId": "computer_67cf2b3051e88190b006770db6fdb13d",
-            "toolName": "computer_use",
-            "type": "tool-call",
-          },
-          {
-            "providerExecuted": true,
-            "result": {
-              "status": "completed",
-              "type": "computer_use_tool_result",
+          [
+            {
+              "input": "",
+              "providerExecuted": true,
+              "toolCallId": "computer_67cf2b3051e88190b006770db6fdb13d",
+              "toolName": "computer_use",
+              "type": "tool-call",
             },
-            "toolCallId": "computer_67cf2b3051e88190b006770db6fdb13d",
-            "toolName": "computer_use",
-            "type": "tool-result",
-          },
-          {
-            "text": "I've completed the computer task.",
-            "type": "text",
-          },
-        ]
-      `);
+            {
+              "providerExecuted": true,
+              "result": {
+                "status": "completed",
+                "type": "computer_use_tool_result",
+              },
+              "toolCallId": "computer_67cf2b3051e88190b006770db6fdb13d",
+              "toolName": "computer_use",
+              "type": "tool-result",
+            },
+            {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_computer_test",
+                },
+              },
+              "text": "I've completed the computer task.",
+              "type": "text",
+            },
+          ]
+        `);
       });
     });
   });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -572,6 +572,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 controller.enqueue({
                   type: 'text-start',
                   id: value.item.id,
+                  providerMetadata: {
+                    openai: {
+                      itemId: value.item.id,
+                    },
+                  },
                 });
               } else if (isResponseOutputItemAddedReasoningChunk(value)) {
                 activeReasoning[value.item.id] = {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -260,6 +260,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               z.object({
                 type: z.literal('message'),
                 role: z.literal('assistant'),
+                id: z.string(),
                 content: z.array(
                   z.object({
                     type: z.literal('output_text'),
@@ -359,6 +360,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             content.push({
               type: 'text',
               text: contentPart.text,
+              providerMetadata: {
+                openai: {
+                  itemId: part.id,
+                },
+              },
             });
 
             for (const annotation of contentPart.annotations) {


### PR DESCRIPTION
## Background

Using OpenAI reasoning models with the responses API and text leads to error responses from the OpenAI API (see #7099).

## Summary

Send the item id as openai provider metadata, convert it to tex provider options, and use it in the next model call.

## Verification

Manually run streaming and generate o3 chatbot in the terminal.

## Related Issues

Fixes #7099