### PR TITLE
fix (ui): text part metadata support in ui messages

### DIFF
--- a/.changeset/smart-singers-remain.md
+++ b/.changeset/smart-singers-remain.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ui): text message metadata support in ui messages

--- a/examples/next-openai/app/use-chat-reasoning-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-reasoning-tools/page.tsx
@@ -30,8 +30,10 @@ export default function Chat() {
       },
     });
 
+  console.log(structuredClone(messages));
+
   return (
-    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
       {messages?.map(message => (
         <div key={message.id} className="whitespace-pre-wrap">
           <strong>{`${message.role}: `}</strong>
@@ -40,7 +42,7 @@ export default function Chat() {
               return (
                 <pre
                   key={index}
-                  className="max-w-full overflow-x-auto break-words whitespace-pre-wrap"
+                  className="overflow-x-auto max-w-full whitespace-pre-wrap break-words"
                 >
                   {part.text}
                 </pre>
@@ -51,7 +53,7 @@ export default function Chat() {
               return (
                 <pre
                   key={index}
-                  className="max-w-full mb-4 overflow-x-auto italic text-gray-500 break-words whitespace-pre-wrap"
+                  className="overflow-x-auto mb-4 max-w-full italic text-gray-500 whitespace-pre-wrap break-words"
                 >
                   {part.text}
                 </pre>

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -2380,19 +2380,16 @@ describe('streamText', () => {
             },
             {
               "id": "1",
-              "providerMetadata": undefined,
               "type": "reasoning-start",
             },
             {
               "delta": "I will open the conversation",
               "id": "1",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
               "delta": " with witty banter.",
               "id": "1",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
@@ -2407,7 +2404,6 @@ describe('streamText', () => {
             },
             {
               "id": "1",
-              "providerMetadata": undefined,
               "type": "reasoning-end",
             },
             {
@@ -2421,24 +2417,20 @@ describe('streamText', () => {
             },
             {
               "id": "2",
-              "providerMetadata": undefined,
               "type": "reasoning-end",
             },
             {
               "id": "3",
-              "providerMetadata": undefined,
               "type": "reasoning-start",
             },
             {
               "delta": " Once the user has relaxed,",
               "id": "3",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
               "delta": " I will pry for valuable information.",
               "id": "3",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
@@ -2462,13 +2454,11 @@ describe('streamText', () => {
             {
               "delta": " I need to think about",
               "id": "4",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
               "delta": " this problem carefully.",
               "id": "4",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
@@ -2483,19 +2473,16 @@ describe('streamText', () => {
             {
               "delta": " The best solution",
               "id": "5",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
               "delta": " requires careful",
               "id": "5",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
               "delta": " consideration of all factors.",
               "id": "5",
-              "providerMetadata": undefined,
               "type": "reasoning-delta",
             },
             {
@@ -6020,18 +6007,15 @@ describe('streamText', () => {
               },
               {
                 "id": "0",
-                "providerMetadata": undefined,
                 "type": "reasoning-start",
               },
               {
                 "delta": "thinking",
                 "id": "0",
-                "providerMetadata": undefined,
                 "type": "reasoning-delta",
               },
               {
                 "id": "0",
-                "providerMetadata": undefined,
                 "type": "reasoning-end",
               },
               {
@@ -7740,18 +7724,15 @@ describe('streamText', () => {
               },
               {
                 "id": "id-0",
-                "providerMetadata": undefined,
                 "type": "reasoning-start",
               },
               {
                 "delta": "thinking",
                 "id": "id-0",
-                "providerMetadata": undefined,
                 "type": "reasoning-delta",
               },
               {
                 "id": "id-0",
-                "providerMetadata": undefined,
                 "type": "reasoning-end",
               },
               {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -2022,7 +2022,7 @@ describe('streamText', () => {
   });
 
   describe('result.toUIMessageStream', () => {
-    it('should create a data stream', async () => {
+    it('should create a ui message stream', async () => {
       const result = streamText({
         model: createTestModel(),
         ...defaultSettings(),
@@ -2075,6 +2075,184 @@ describe('streamText', () => {
       `);
     });
 
+    it('should create a ui message stream with provider metadata', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'stream-start',
+              warnings: [],
+            },
+            {
+              type: 'reasoning-start',
+              id: 'r1',
+              providerMetadata: { testProvider: { signature: 'r1' } },
+            },
+            {
+              type: 'reasoning-delta',
+              id: 'r1',
+              delta: 'Hello',
+              providerMetadata: { testProvider: { signature: 'r2' } },
+            },
+            {
+              type: 'reasoning-delta',
+              id: 'r1',
+              delta: ', ',
+              providerMetadata: { testProvider: { signature: 'r3' } },
+            },
+            {
+              type: 'reasoning-end',
+              id: 'r1',
+              providerMetadata: { testProvider: { signature: 'r4' } },
+            },
+            {
+              type: 'text-start',
+              id: '1',
+              providerMetadata: { testProvider: { signature: '1' } },
+            },
+            {
+              type: 'text-delta',
+              id: '1',
+              delta: 'Hello',
+              providerMetadata: { testProvider: { signature: '2' } },
+            },
+            {
+              type: 'text-delta',
+              id: '1',
+              delta: ', ',
+              providerMetadata: { testProvider: { signature: '3' } },
+            },
+            {
+              type: 'text-delta',
+              id: '1',
+              delta: 'world!',
+              providerMetadata: { testProvider: { signature: '4' } },
+            },
+            {
+              type: 'text-end',
+              id: '1',
+              providerMetadata: { testProvider: { signature: '5' } },
+            },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: testUsage,
+            },
+          ]),
+        }),
+        ...defaultSettings(),
+      });
+
+      const uiMessageStream = result.toUIMessageStream();
+
+      expect(await convertReadableStreamToArray(uiMessageStream))
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "messageId": undefined,
+            "messageMetadata": undefined,
+            "type": "start",
+          },
+          {
+            "type": "start-step",
+          },
+          {
+            "id": "r1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "r1",
+              },
+            },
+            "type": "reasoning-start",
+          },
+          {
+            "delta": "Hello",
+            "id": "r1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "r2",
+              },
+            },
+            "type": "reasoning-delta",
+          },
+          {
+            "delta": ", ",
+            "id": "r1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "r3",
+              },
+            },
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "r1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "r4",
+              },
+            },
+            "type": "reasoning-end",
+          },
+          {
+            "id": "1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "1",
+              },
+            },
+            "type": "text-start",
+          },
+          {
+            "delta": "Hello",
+            "id": "1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "2",
+              },
+            },
+            "type": "text-delta",
+          },
+          {
+            "delta": ", ",
+            "id": "1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "3",
+              },
+            },
+            "type": "text-delta",
+          },
+          {
+            "delta": "world!",
+            "id": "1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "4",
+              },
+            },
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "5",
+              },
+            },
+            "type": "text-end",
+          },
+          {
+            "type": "finish-step",
+          },
+          {
+            "messageMetadata": undefined,
+            "type": "finish",
+          },
+        ]
+      `);
+    });
+
     it('should send tool call, tool call stream start, tool call deltas, and tool result stream parts', async () => {
       const result = streamText({
         model: createTestModel({
@@ -2110,7 +2288,7 @@ describe('streamText', () => {
       ).toMatchSnapshot();
     });
 
-    it('should send metadata as defined in the metadata function', async () => {
+    it('should send message metadata as defined in the metadata function', async () => {
       const result = streamText({
         model: createTestModel(),
         ...defaultSettings(),

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1613,7 +1613,13 @@ However, the LLM results are expected to be small enough to not cause issues.
           const partType = part.type;
           switch (partType) {
             case 'text-start': {
-              controller.enqueue({ type: 'text-start', id: part.id });
+              controller.enqueue({
+                type: 'text-start',
+                id: part.id,
+                ...(part.providerMetadata != null
+                  ? { providerMetadata: part.providerMetadata }
+                  : {}),
+              });
               break;
             }
 
@@ -1622,12 +1628,21 @@ However, the LLM results are expected to be small enough to not cause issues.
                 type: 'text-delta',
                 id: part.id,
                 delta: part.text,
+                ...(part.providerMetadata != null
+                  ? { providerMetadata: part.providerMetadata }
+                  : {}),
               });
               break;
             }
 
             case 'text-end': {
-              controller.enqueue({ type: 'text-end', id: part.id });
+              controller.enqueue({
+                type: 'text-end',
+                id: part.id,
+                ...(part.providerMetadata != null
+                  ? { providerMetadata: part.providerMetadata }
+                  : {}),
+              });
               break;
             }
 
@@ -1635,7 +1650,9 @@ However, the LLM results are expected to be small enough to not cause issues.
               controller.enqueue({
                 type: 'reasoning-start',
                 id: part.id,
-                providerMetadata: part.providerMetadata,
+                ...(part.providerMetadata != null
+                  ? { providerMetadata: part.providerMetadata }
+                  : {}),
               });
               break;
             }
@@ -1646,7 +1663,9 @@ However, the LLM results are expected to be small enough to not cause issues.
                   type: 'reasoning-delta',
                   id: part.id,
                   delta: part.text,
-                  providerMetadata: part.providerMetadata,
+                  ...(part.providerMetadata != null
+                    ? { providerMetadata: part.providerMetadata }
+                    : {}),
                 });
               }
               break;
@@ -1656,7 +1675,9 @@ However, the LLM results are expected to be small enough to not cause issues.
               controller.enqueue({
                 type: 'reasoning-end',
                 id: part.id,
-                providerMetadata: part.providerMetadata,
+                ...(part.providerMetadata != null
+                  ? { providerMetadata: part.providerMetadata }
+                  : {}),
               });
               break;
             }
@@ -1677,7 +1698,9 @@ However, the LLM results are expected to be small enough to not cause issues.
                   sourceId: part.id,
                   url: part.url,
                   title: part.title,
-                  providerMetadata: part.providerMetadata,
+                  ...(part.providerMetadata != null
+                    ? { providerMetadata: part.providerMetadata }
+                    : {}),
                 });
               }
 
@@ -1688,7 +1711,9 @@ However, the LLM results are expected to be small enough to not cause issues.
                   mediaType: part.mediaType,
                   title: part.title,
                   filename: part.filename,
-                  providerMetadata: part.providerMetadata,
+                  ...(part.providerMetadata != null
+                    ? { providerMetadata: part.providerMetadata }
+                    : {}),
                 });
               }
               break;

--- a/packages/ai/src/types/provider-metadata.ts
+++ b/packages/ai/src/types/provider-metadata.ts
@@ -1,7 +1,4 @@
-import {
-  SharedV2ProviderMetadata,
-  SharedV2ProviderOptions,
-} from '@ai-sdk/provider';
+import { SharedV2ProviderMetadata } from '@ai-sdk/provider';
 import { z } from 'zod/v4';
 import { jsonValueSchema } from './json-value';
 

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -403,6 +403,7 @@ describe('createUIMessageStream', () => {
               "metadata": undefined,
               "parts": [
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "1a",
                   "type": "text",
@@ -416,6 +417,7 @@ describe('createUIMessageStream', () => {
             "metadata": undefined,
             "parts": [
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "1a",
                 "type": "text",
@@ -480,6 +482,7 @@ describe('createUIMessageStream', () => {
                   "type": "text",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "1b",
                   "type": "text",
@@ -497,6 +500,7 @@ describe('createUIMessageStream', () => {
                 "type": "text",
               },
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "1b",
                 "type": "text",

--- a/packages/ai/src/ui-message-stream/read-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/read-ui-message-stream.test.ts
@@ -26,74 +26,78 @@ describe('readUIMessageStream', () => {
 
     expect(await convertAsyncIterableToArray(uiMessages))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "id": "msg-123",
-          "metadata": undefined,
-          "parts": [],
-          "role": "assistant",
-        },
-        {
-          "id": "msg-123",
-          "metadata": undefined,
-          "parts": [
-            {
-              "type": "step-start",
-            },
-            {
-              "state": "streaming",
-              "text": "",
-              "type": "text",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "id": "msg-123",
-          "metadata": undefined,
-          "parts": [
-            {
-              "type": "step-start",
-            },
-            {
-              "state": "streaming",
-              "text": "Hello, ",
-              "type": "text",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "id": "msg-123",
-          "metadata": undefined,
-          "parts": [
-            {
-              "type": "step-start",
-            },
-            {
-              "state": "streaming",
-              "text": "Hello, world!",
-              "type": "text",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "id": "msg-123",
-          "metadata": undefined,
-          "parts": [
-            {
-              "type": "step-start",
-            },
-            {
-              "state": "done",
-              "text": "Hello, world!",
-              "type": "text",
-            },
-          ],
-          "role": "assistant",
-        },
-      ]
-    `);
+        [
+          {
+            "id": "msg-123",
+            "metadata": undefined,
+            "parts": [],
+            "role": "assistant",
+          },
+          {
+            "id": "msg-123",
+            "metadata": undefined,
+            "parts": [
+              {
+                "type": "step-start",
+              },
+              {
+                "providerMetadata": undefined,
+                "state": "streaming",
+                "text": "",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "id": "msg-123",
+            "metadata": undefined,
+            "parts": [
+              {
+                "type": "step-start",
+              },
+              {
+                "providerMetadata": undefined,
+                "state": "streaming",
+                "text": "Hello, ",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "id": "msg-123",
+            "metadata": undefined,
+            "parts": [
+              {
+                "type": "step-start",
+              },
+              {
+                "providerMetadata": undefined,
+                "state": "streaming",
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "id": "msg-123",
+            "metadata": undefined,
+            "parts": [
+              {
+                "type": "step-start",
+              },
+              {
+                "providerMetadata": undefined,
+                "state": "done",
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
   });
 });

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -1,26 +1,32 @@
 import { z } from 'zod/v4';
-import { ValueOf } from '../util/value-of';
+import {
+  ProviderMetadata,
+  providerMetadataSchema,
+} from '../types/provider-metadata';
 import {
   InferUIMessageData,
   InferUIMessageMetadata,
   UIDataTypes,
   UIMessage,
 } from '../ui/ui-messages';
-import { ProviderMetadata } from '../types/provider-metadata';
+import { ValueOf } from '../util/value-of';
 
 export const uiMessageChunkSchema = z.union([
   z.strictObject({
     type: z.literal('text-start'),
     id: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('text-delta'),
     id: z.string(),
     delta: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('text-end'),
     id: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('error'),
@@ -43,6 +49,7 @@ export const uiMessageChunkSchema = z.union([
     toolName: z.string(),
     input: z.unknown(),
     providerExecuted: z.boolean().optional(),
+    callProviderMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('tool-output-available'),
@@ -59,23 +66,23 @@ export const uiMessageChunkSchema = z.union([
   z.strictObject({
     type: z.literal('reasoning'),
     text: z.string(),
-    providerMetadata: z.record(z.string(), z.any()).optional(),
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('reasoning-start'),
     id: z.string(),
-    providerMetadata: z.record(z.string(), z.any()).optional(),
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('reasoning-delta'),
     id: z.string(),
     delta: z.string(),
-    providerMetadata: z.record(z.string(), z.any()).optional(),
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('reasoning-end'),
     id: z.string(),
-    providerMetadata: z.record(z.string(), z.any()).optional(),
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('reasoning-part-finish'),
@@ -85,7 +92,7 @@ export const uiMessageChunkSchema = z.union([
     sourceId: z.string(),
     url: z.string(),
     title: z.string().optional(),
-    providerMetadata: z.any().optional(), // Use z.any() for generic metadata
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('source-document'),
@@ -93,12 +100,13 @@ export const uiMessageChunkSchema = z.union([
     mediaType: z.string(),
     title: z.string(),
     filename: z.string().optional(),
-    providerMetadata: z.any().optional(), // Use z.any() for generic metadata
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.literal('file'),
     url: z.string(),
     mediaType: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
   }),
   z.strictObject({
     type: z.string().startsWith('data-'),
@@ -140,10 +148,27 @@ export type UIMessageChunk<
   METADATA = unknown,
   DATA_TYPES extends UIDataTypes = UIDataTypes,
 > =
-  | { type: 'text-start'; id: string }
-  | { type: 'text-delta'; delta: string; id: string }
-  | { type: 'text-end'; id: string }
-  | { type: 'reasoning-start'; id: string; providerMetadata?: ProviderMetadata }
+  | {
+      type: 'text-start';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'text-delta';
+      delta: string;
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'text-end';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'reasoning-start';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
   | {
       type: 'reasoning-delta';
       id: string;

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -148,6 +148,7 @@ describe('chat', () => {
                 "type": "step-start",
               },
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "Hello, world.",
                 "type": "text",
@@ -194,6 +195,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -222,6 +224,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello",
                   "type": "text",
@@ -250,6 +253,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello,",
                   "type": "text",
@@ -278,6 +282,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, world",
                   "type": "text",
@@ -306,6 +311,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, world.",
                   "type": "text",
@@ -334,6 +340,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Hello, world.",
                   "type": "text",
@@ -429,6 +436,7 @@ describe('chat', () => {
                 "type": "step-start",
               },
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "Hello, world.",
                 "type": "text",
@@ -479,6 +487,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -509,6 +518,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, world.",
                   "type": "text",
@@ -539,6 +549,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Hello, world.",
                   "type": "text",
@@ -651,6 +662,7 @@ describe('chat', () => {
                 "type": "step-start",
               },
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "Hello, world.",
                 "type": "text",
@@ -719,6 +731,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -747,6 +760,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello",
                   "type": "text",
@@ -775,6 +789,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello,",
                   "type": "text",
@@ -803,6 +818,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, world",
                   "type": "text",
@@ -831,6 +847,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, world.",
                   "type": "text",
@@ -859,6 +876,7 @@ describe('chat', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Hello, world.",
                   "type": "text",

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -71,7 +71,7 @@ describe('convertToModelMessages', () => {
   });
 
   describe('assistant message', () => {
-    it('should convert a simple assistant message', () => {
+    it('should convert a simple assistant text message', () => {
       const result = convertToModelMessages([
         {
           role: 'assistant',
@@ -85,6 +85,41 @@ describe('convertToModelMessages', () => {
           content: [{ type: 'text', text: 'Hello, human!' }],
         },
       ]);
+    });
+
+    it('should convert a simple assistant text message with provider metadata', () => {
+      const result = convertToModelMessages([
+        {
+          role: 'assistant',
+          parts: [
+            {
+              type: 'text',
+              text: 'Hello, human!',
+              state: 'done',
+              providerMetadata: { testProvider: { signature: '1234567890' } },
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "providerOptions": {
+                  "testProvider": {
+                    "signature": "1234567890",
+                  },
+                },
+                "text": "Hello, human!",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
     });
 
     it('should convert an assistant message with reasoning', () => {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -107,6 +107,9 @@ export function convertToModelMessages(
                 content.push({
                   type: 'text' as const,
                   text: part.text,
+                  ...(part.providerMetadata != null
+                    ? { providerOptions: part.providerMetadata }
+                    : {}),
                 });
               } else if (part.type === 'file') {
                 content.push({

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -84,6 +84,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -101,6 +102,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, ",
                   "type": "text",
@@ -118,6 +120,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, world!",
                   "type": "text",
@@ -135,6 +138,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Hello, world!",
                   "type": "text",
@@ -157,6 +161,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Hello, world!",
               "type": "text",
@@ -347,6 +352,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -380,6 +386,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -413,6 +420,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -451,6 +459,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
@@ -641,6 +650,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -683,6 +693,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -725,6 +736,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -772,6 +784,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
@@ -853,6 +866,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -870,6 +884,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "I will ",
                   "type": "text",
@@ -887,6 +902,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
@@ -904,6 +920,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
@@ -921,6 +938,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
@@ -949,6 +967,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
@@ -979,6 +998,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
@@ -1000,6 +1020,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -1017,6 +1038,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
@@ -1038,6 +1060,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "The weather in London ",
                   "type": "text",
@@ -1055,6 +1078,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
@@ -1076,6 +1100,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -1093,6 +1118,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "I will use a tool to get the weather in London.",
                   "type": "text",
@@ -1114,6 +1140,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -1136,6 +1163,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "I will use a tool to get the weather in London.",
               "type": "text",
@@ -1157,6 +1185,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
@@ -1586,6 +1615,7 @@ describe('processUIMessageStream', () => {
                   "type": "reasoning",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -1639,6 +1669,7 @@ describe('processUIMessageStream', () => {
                   "type": "reasoning",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -1692,6 +1723,7 @@ describe('processUIMessageStream', () => {
                   "type": "reasoning",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -1750,6 +1782,7 @@ describe('processUIMessageStream', () => {
               "type": "reasoning",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
@@ -1886,6 +1919,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -1917,6 +1951,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -1948,6 +1983,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -1984,6 +2020,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
@@ -2081,6 +2118,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -2104,6 +2142,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "t1",
                   "type": "text",
@@ -2128,6 +2167,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "t1",
                   "type": "text",
@@ -2152,6 +2192,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "t1t2",
                   "type": "text",
@@ -2176,6 +2217,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "t1t2",
                   "type": "text",
@@ -2202,6 +2244,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "t1t2",
                   "type": "text",
@@ -2233,6 +2276,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "t1t2",
               "type": "text",
@@ -2298,6 +2342,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -2315,6 +2360,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "t1",
                   "type": "text",
@@ -2332,6 +2378,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "t1",
                   "type": "text",
@@ -2351,6 +2398,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "t1",
                   "type": "text",
@@ -2375,6 +2423,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "t1",
               "type": "text",
@@ -2457,6 +2506,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -2478,6 +2528,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "t1",
                   "type": "text",
@@ -2499,6 +2550,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "t1",
                   "type": "text",
@@ -2525,6 +2577,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "t1",
               "type": "text",
@@ -2791,6 +2844,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -2808,6 +2862,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, ",
                   "type": "text",
@@ -2825,6 +2880,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hello, world!",
                   "type": "text",
@@ -2842,6 +2898,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Hello, world!",
                   "type": "text",
@@ -2864,6 +2921,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Hello, world!",
               "type": "text",
@@ -3325,6 +3383,7 @@ describe('processUIMessageStream', () => {
                   "type": "reasoning",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -3372,6 +3431,7 @@ describe('processUIMessageStream', () => {
                   "type": "reasoning",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Hi there!",
                   "type": "text",
@@ -3419,6 +3479,7 @@ describe('processUIMessageStream', () => {
                   "type": "reasoning",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Hi there!",
                   "type": "text",
@@ -3471,6 +3532,7 @@ describe('processUIMessageStream', () => {
               "type": "reasoning",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Hi there!",
               "type": "text",
@@ -3660,6 +3722,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -3677,6 +3740,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -3694,6 +3758,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -3711,6 +3776,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "The weather in London is sunny.",
                   "type": "text",
@@ -3740,6 +3806,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "The weather in London is sunny.",
               "type": "text",
@@ -3819,6 +3886,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -3836,6 +3904,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "Here is a file:",
                   "type": "text",
@@ -3853,6 +3922,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
@@ -3870,6 +3940,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
@@ -3892,6 +3963,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
@@ -3902,6 +3974,7 @@ describe('processUIMessageStream', () => {
                   "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "",
                   "type": "text",
@@ -3919,6 +3992,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
@@ -3929,6 +4003,7 @@ describe('processUIMessageStream', () => {
                   "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "streaming",
                   "text": "And another one:",
                   "type": "text",
@@ -3946,6 +4021,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
@@ -3956,6 +4032,7 @@ describe('processUIMessageStream', () => {
                   "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "And another one:",
                   "type": "text",
@@ -3973,6 +4050,7 @@ describe('processUIMessageStream', () => {
                   "type": "step-start",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "Here is a file:",
                   "type": "text",
@@ -3983,6 +4061,7 @@ describe('processUIMessageStream', () => {
                   "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
                 },
                 {
+                  "providerMetadata": undefined,
                   "state": "done",
                   "text": "And another one:",
                   "type": "text",
@@ -4010,6 +4089,7 @@ describe('processUIMessageStream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Here is a file:",
               "type": "text",
@@ -4020,6 +4100,7 @@ describe('processUIMessageStream', () => {
               "url": "data:text/plain;base64,SGVsbG8gV29ybGQ=",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "And another one:",
               "type": "text",
@@ -4780,6 +4861,201 @@ describe('processUIMessageStream', () => {
             "state": "output-available",
             "toolCallId": "tool-call-id",
             "type": "tool-tool-name",
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('provider metadata', () => {
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        {
+          type: 'text-start',
+          id: '1',
+          providerMetadata: { testProvider: { signature: '1' } },
+        },
+        {
+          type: 'text-delta',
+          id: '1',
+          delta: 'Hello',
+        },
+        {
+          type: 'text-delta',
+          id: '1',
+          delta: ', ',
+        },
+        {
+          type: 'text-delta',
+          id: '1',
+          delta: 'world!',
+        },
+        {
+          type: 'text-end',
+          id: '1',
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('should call the update function with the correct arguments', async () => {
+      expect(writeCalls).toMatchInlineSnapshot(`
+        [
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1",
+                    },
+                  },
+                  "state": "streaming",
+                  "text": "",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1",
+                    },
+                  },
+                  "state": "streaming",
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1",
+                    },
+                  },
+                  "state": "streaming",
+                  "text": "Hello, ",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1",
+                    },
+                  },
+                  "state": "streaming",
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "providerMetadata": {
+                    "testProvider": {
+                      "signature": "1",
+                    },
+                  },
+                  "state": "done",
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+        ]
+      `);
+    });
+
+    it('should have the correct final message state', async () => {
+      expect(state!.message.parts).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "step-start",
+          },
+          {
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "1",
+              },
+            },
+            "state": "done",
+            "text": "Hello, world!",
+            "type": "text",
           },
         ]
       `);

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -179,6 +179,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               const textPart: TextUIPart = {
                 type: 'text',
                 text: '',
+                providerMetadata: part.providerMetadata,
                 state: 'streaming',
               };
               state.activeTextParts[part.id] = textPart;
@@ -188,7 +189,10 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-delta': {
-              state.activeTextParts[part.id].text += part.delta;
+              const textPart = state.activeTextParts[part.id];
+              textPart.text += part.delta;
+              textPart.providerMetadata =
+                part.providerMetadata ?? textPart.providerMetadata;
               write();
               break;
             }
@@ -196,6 +200,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             case 'text-end': {
               const textPart = state.activeTextParts[part.id];
               textPart.state = 'done';
+              textPart.providerMetadata =
+                part.providerMetadata ?? textPart.providerMetadata;
               delete state.activeTextParts[part.id];
               write();
               break;

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -1,5 +1,6 @@
 import { InferToolInput, InferToolOutput, Tool } from '@ai-sdk/provider-utils';
 import { ToolSet } from '../generate-text';
+import { ProviderMetadata } from '../types/provider-metadata';
 import { DeepPartial } from '../util/deep-partial';
 import { ValueOf } from '../util/value-of';
 
@@ -94,6 +95,11 @@ export type TextUIPart = {
    * The state of the text part.
    */
   state?: 'streaming' | 'done';
+
+  /**
+   * The provider metadata.
+   */
+  providerMetadata?: ProviderMetadata;
 };
 
 /**
@@ -115,7 +121,7 @@ export type ReasoningUIPart = {
   /**
    * The provider metadata.
    */
-  providerMetadata?: Record<string, any>;
+  providerMetadata?: ProviderMetadata;
 };
 
 /**
@@ -126,7 +132,7 @@ export type SourceUrlUIPart = {
   sourceId: string;
   url: string;
   title?: string;
-  providerMetadata?: Record<string, any>;
+  providerMetadata?: ProviderMetadata;
 };
 
 /**
@@ -138,7 +144,7 @@ export type SourceDocumentUIPart = {
   mediaType: string;
   title: string;
   filename?: string;
-  providerMetadata?: Record<string, any>;
+  providerMetadata?: ProviderMetadata;
 };
 
 /**
@@ -164,6 +170,11 @@ export type FileUIPart = {
    * It can either be a URL to a hosted file or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
    */
   url: string;
+
+  /**
+   * The provider metadata.
+   */
+  providerMetadata?: ProviderMetadata;
 };
 
 /**
@@ -199,6 +210,7 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
         providerExecuted?: boolean;
         output?: never;
         errorText?: never;
+        callProviderMetadata?: ProviderMetadata;
       }
     | {
         state: 'output-available';
@@ -206,6 +218,7 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
         output: TOOLS[NAME]['output'];
         errorText?: never;
         providerExecuted?: boolean;
+        callProviderMetadata?: ProviderMetadata;
       }
     | {
         state: 'output-error';
@@ -213,6 +226,7 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
         output?: never;
         errorText: string;
         providerExecuted?: boolean;
+        callProviderMetadata?: ProviderMetadata;
       }
   );
 }>;

--- a/packages/angular/src/lib/chat.ng.test.ts
+++ b/packages/angular/src/lib/chat.ng.test.ts
@@ -271,6 +271,7 @@ describe('text stream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Hello, world.",
               "type": "text",
@@ -842,6 +843,7 @@ describe('maxSteps', () => {
                 "type": "tool-test-tool",
               },
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "final result",
                 "type": "text",
@@ -967,6 +969,7 @@ describe('file attachments with data url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Response to message with text attachment",
               "type": "text",
@@ -1056,6 +1059,7 @@ describe('file attachments with data url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
@@ -1155,6 +1159,7 @@ describe('file attachments with url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
@@ -1249,6 +1254,7 @@ describe('file attachments with empty text content', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
@@ -1470,6 +1476,7 @@ describe('generateId function', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Hello, world.",
               "type": "text",

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -358,6 +358,7 @@ describe('data protocol stream', () => {
             },
             "parts": [
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "Hello, world.",
                 "type": "text",
@@ -518,6 +519,7 @@ describe('text stream', () => {
                 "type": "step-start",
               },
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "Hello, world.",
                 "type": "text",

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -274,6 +274,7 @@ describe('text stream', () => {
               "type": "step-start",
             },
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Hello, world.",
               "type": "text",
@@ -833,6 +834,7 @@ describe('maxSteps', () => {
                 "type": "tool-test-tool",
               },
               {
+                "providerMetadata": undefined,
                 "state": "done",
                 "text": "final result",
                 "type": "text",
@@ -958,6 +960,7 @@ describe('file attachments with data url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Response to message with text attachment",
               "type": "text",
@@ -1047,6 +1050,7 @@ describe('file attachments with data url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
@@ -1146,6 +1150,7 @@ describe('file attachments with url', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
@@ -1242,6 +1247,7 @@ describe('file attachments with empty text content', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Response to message with image attachment",
               "type": "text",
@@ -1463,6 +1469,7 @@ describe('generateId function', () => {
           "metadata": undefined,
           "parts": [
             {
+              "providerMetadata": undefined,
               "state": "done",
               "text": "Hello, world.",
               "type": "text",


### PR DESCRIPTION
## Background

Chatbot with OpenAI reasoning do not work because they lack provider metadata support (see #7099 ).

## Summary

Support provider metadata in ui message text parts.

## Verification

- [x] ui chatbot with reasoning

## Tasks

- [x] ui message and chunk types have metadata
- [x] send metadata from stream text
- [x] process metadata in process ui messages
- [x] model message conversion
- [x] fix tests
- [x] changeset

## Related Issues

#7099 