### PR TITLE
chore(docs): explain ai gateway oidc auth api key override

### DIFF
--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -134,8 +134,8 @@ const gateway = createGateway({
 
 ### OIDC Authentication (Vercel Deployments)
 
-When deployed to Vercel, the AI Gateway provider supports authenticating using OIDC (OpenID Connect)
-tokens without API Keys.
+When deployed to Vercel, the AI Gateway provider supports authenticating using [OIDC (OpenID Connect)
+tokens](https://vercel.com/docs/oidc) without API Keys.
 
 #### How OIDC Authentication Works
 
@@ -146,13 +146,14 @@ tokens without API Keys.
    - Tokens are automatically obtained and refreshed every 12 hours
 
 2. **In Local Development**:
-   - Use the [Vercel CLI](https://vercel.com/docs/cli) to run `vercel env pull` which fetches the token
-   - Since OIDC tokens expire after 12 hours, you'll need to run `vercel env pull` again to refresh them
+   - Run `vercel env pull` using the [Vercel CLI](https://vercel.com/docs/cli) to fetch the OIDC token
+   - If you use `vercel env` to start your dev server, token refresh happens automatically
+   - Since tokens expire after 12 hours, you'll need to run `vercel env pull` again if you're developing for extended periods
 
-Important notes:
-
-- If an API Key is present (either passed directly or via environment), it will always be used, even if invalid
-- OIDC tokens are only used if no API Key is present
+<Note>
+  If an API Key is present (either passed directly or via environment), it will
+  always be used, even if invalid.
+</Note>
 
 Read more about using OIDC tokens in the [Vercel AI Gateway docs](https://vercel.com/docs/ai-gateway#using-the-ai-gateway-with-a-vercel-oidc-token).
 

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -146,9 +146,13 @@ tokens](https://vercel.com/docs/oidc) without API Keys.
    - Tokens are automatically obtained and refreshed
 
 2. **In Local Development**:
-   - Run `vercel env pull` using the [Vercel CLI](https://vercel.com/docs/cli) to fetch the OIDC token
-   - When using `vercel dev` to start your dev server, token refreshing happens automatically
-   - If not using `vercel dev`, local Vercel OIDC tokens are only valid for 12 hours so you'll need to run `vercel env pull` periodically
+   - First, install and authenticate with the [Vercel CLI](https://vercel.com/docs/cli)
+   - Run `vercel env pull` to download your project's OIDC token locally
+   - For automatic token management:
+     - Use `vercel dev` to start your development server - this will handle token refreshing automatically
+   - For manual token management:
+     - If not using `vercel dev`, note that OIDC tokens expire after 12 hours
+     - You'll need to run `vercel env pull` again to refresh the token before it expires
 
 <Note>
   If an API Key is present (either passed directly or via environment), it will

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -143,12 +143,12 @@ tokens](https://vercel.com/docs/oidc) without API Keys.
 
    - OIDC authentication is automatically handled
    - No manual configuration needed
-   - Tokens are automatically obtained and refreshed every 12 hours
+   - Tokens are automatically obtained and refreshed
 
 2. **In Local Development**:
    - Run `vercel env pull` using the [Vercel CLI](https://vercel.com/docs/cli) to fetch the OIDC token
-   - If you use `vercel env` to start your dev server, token refresh happens automatically
-   - Since tokens expire after 12 hours, you'll need to run `vercel env pull` again if you're developing for extended periods
+   - If you use `vercel dev` to start your dev server, token refresh happens automatically
+   - You'll need to run `vercel env pull` periodically if you're NOT using `vercel dev` since local Vercel OIDC tokens are only valid for 12 hours.
 
 <Note>
   If an API Key is present (either passed directly or via environment), it will

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -147,7 +147,7 @@ tokens](https://vercel.com/docs/oidc) without API Keys.
 
 2. **In Local Development**:
    - Run `vercel env pull` using the [Vercel CLI](https://vercel.com/docs/cli) to fetch the OIDC token
-   - Token refresh happens automatically when using `vercel dev` to start your dev server
+   - When using `vercel dev` to start your dev server, token refreshing happens automatically
    - If not using `vercel dev`, local Vercel OIDC tokens are only valid for 12 hours so you'll need to run `vercel env pull` periodically
 
 <Note>

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -147,8 +147,8 @@ tokens](https://vercel.com/docs/oidc) without API Keys.
 
 2. **In Local Development**:
    - Run `vercel env pull` using the [Vercel CLI](https://vercel.com/docs/cli) to fetch the OIDC token
-   - If you use `vercel dev` to start your dev server, token refresh happens automatically
-   - You'll need to run `vercel env pull` periodically if you're NOT using `vercel dev` since local Vercel OIDC tokens are only valid for 12 hours.
+   - Token refresh happens automatically when using `vercel dev` to start your dev server
+   - If not using `vercel dev`, local Vercel OIDC tokens are only valid for 12 hours so you'll need to run `vercel env pull` periodically
 
 <Note>
   If an API Key is present (either passed directly or via environment), it will

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -136,7 +136,7 @@ const gateway = createGateway({
 
 The AI Gateway provider supports authenticating using OIDC (OpenID Connect) 
 tokens when deployed on Vercel. This provides a seamless authentication experience 
-without requiring manual API key management.
+without requiring API keys.
 
 #### How OIDC Authentication Works
 

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -134,13 +134,14 @@ const gateway = createGateway({
 
 ### OIDC Authentication (Vercel Deployments)
 
-The AI Gateway provider supports authenticating using OIDC (OpenID Connect) 
-tokens when deployed on Vercel. This provides a seamless authentication experience 
+The AI Gateway provider supports authenticating using OIDC (OpenID Connect)
+tokens when deployed on Vercel. This provides a seamless authentication experience
 without requiring API keys.
 
 #### How OIDC Authentication Works
 
 1. **In Production/Preview Deployments**:
+
    - OIDC authentication is automatically handled
    - No manual configuration needed
    - Tokens are automatically obtained and refreshed every 12 hours
@@ -150,6 +151,7 @@ without requiring API keys.
    - Since OIDC tokens expire after 12 hours, you'll need to run `vercel env pull` again to refresh them
 
 Important notes:
+
 - If an API Key is present (either passed directly or via environment), it will always be used, even if invalid
 - OIDC tokens are only used if no API Key is present
 

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -134,9 +134,8 @@ const gateway = createGateway({
 
 ### OIDC Authentication (Vercel Deployments)
 
-The AI Gateway provider supports authenticating using OIDC (OpenID Connect)
-tokens when deployed on Vercel. This provides a seamless authentication experience
-without requiring API keys.
+When deployed to Vercel, the AI Gateway provider supports authenticating using OIDC (OpenID Connect)
+tokens without API Keys.
 
 #### How OIDC Authentication Works
 

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -134,7 +134,26 @@ const gateway = createGateway({
 
 ### OIDC Authentication (Vercel Deployments)
 
-When deployed on Vercel, the AI Gateway provider automatically uses OIDC tokens for authentication without requiring an API key.
+The AI Gateway provider supports authenticating using OIDC (OpenID Connect) 
+tokens when deployed on Vercel. This provides a seamless authentication experience 
+without requiring manual API key management.
+
+#### How OIDC Authentication Works
+
+1. **In Production/Preview Deployments**:
+   - OIDC authentication is automatically handled
+   - No manual configuration needed
+   - Tokens are automatically obtained and refreshed every 12 hours
+
+2. **In Local Development**:
+   - Use the [Vercel CLI](https://vercel.com/docs/cli) to run `vercel env pull` which fetches the token
+   - Since OIDC tokens expire after 12 hours, you'll need to run `vercel env pull` again to refresh them
+
+Important notes:
+- If an API Key is present (either passed directly or via environment), it will always be used, even if invalid
+- OIDC tokens are only used if no API Key is present
+
+Read more about using OIDC tokens in the [Vercel AI Gateway docs](https://vercel.com/docs/ai-gateway#using-the-ai-gateway-with-a-vercel-oidc-token).
 
 ## Language Models
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->
When an API Key is used with the AI Gateway, it will always take precedence over OIDC tokens. This PR clarifies this aspect.

## Summary

<!-- What did you change? -->

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
