### PR TITLE
chore (provider/openai): standardize on itemId in provider metadata

### DIFF
--- a/.changeset/soft-forks-poke.md
+++ b/.changeset/soft-forks-poke.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+chore (provider/openai): standardize on itemId in provider metadata

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
@@ -489,9 +489,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_001',
-                        reasoning: {
-                          encryptedContent: 'encrypted_content_001',
-                        },
+                        reasoningEncryptedContent: 'encrypted_content_001',
                       },
                     },
                   },
@@ -530,9 +528,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_001',
-                        reasoning: {
-                          encryptedContent: null,
-                        },
+                        reasoningEncryptedContent: null,
                       },
                     },
                   },
@@ -606,9 +602,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_001',
-                        reasoning: {
-                          encryptedContent: 'encrypted_content_001',
-                        },
+                        reasoningEncryptedContent: 'encrypted_content_001',
                       },
                     },
                   },
@@ -910,9 +904,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_001',
-                        reasoning: {
-                          encryptedContent: 'encrypted_content_001',
-                        },
+                        reasoningEncryptedContent: 'encrypted_content_001',
                       },
                     },
                   },
@@ -922,9 +914,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_001',
-                        reasoning: {
-                          encryptedContent: 'encrypted_content_001',
-                        },
+                        reasoningEncryptedContent: 'encrypted_content_001',
                       },
                     },
                   },
@@ -962,9 +952,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_002',
-                        reasoning: {
-                          encryptedContent: 'encrypted_content_002',
-                        },
+                        reasoningEncryptedContent: 'encrypted_content_002',
                       },
                     },
                   },
@@ -974,9 +962,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_002',
-                        reasoning: {
-                          encryptedContent: 'encrypted_content_002',
-                        },
+                        reasoningEncryptedContent: 'encrypted_content_002',
                       },
                     },
                   },
@@ -986,9 +972,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_002',
-                        reasoning: {
-                          encryptedContent: 'encrypted_content_002',
-                        },
+                        reasoningEncryptedContent: 'encrypted_content_002',
                       },
                     },
                   },

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
@@ -450,9 +450,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Analyzing the problem step by step',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -490,8 +488,8 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Analyzing the problem step by step',
                     providerOptions: {
                       openai: {
+                        itemId: 'reasoning_001',
                         reasoning: {
-                          id: 'reasoning_001',
                           encryptedContent: 'encrypted_content_001',
                         },
                       },
@@ -531,8 +529,8 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Analyzing the problem step by step',
                     providerOptions: {
                       openai: {
+                        itemId: 'reasoning_001',
                         reasoning: {
-                          id: 'reasoning_001',
                           encryptedContent: null,
                         },
                       },
@@ -574,9 +572,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: '', // Empty text should NOT generate warning when it's the first reasoning part
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -609,8 +605,8 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: '', // Empty text should NOT generate warning when it's the first reasoning part
                     providerOptions: {
                       openai: {
+                        itemId: 'reasoning_001',
                         reasoning: {
-                          id: 'reasoning_001',
                           encryptedContent: 'encrypted_content_001',
                         },
                       },
@@ -645,9 +641,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'First reasoning step',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -656,9 +650,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: '', // Empty text should generate warning when appending to existing reasoning sequence
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -685,7 +677,7 @@ describe('convertToOpenAIResponsesMessages', () => {
           expect(result.warnings).toMatchInlineSnapshot(`
             [
               {
-                "message": "Cannot append empty reasoning part to existing reasoning sequence. Skipping reasoning part: {"type":"reasoning","text":"","providerOptions":{"openai":{"reasoning":{"id":"reasoning_001"}}}}.",
+                "message": "Cannot append empty reasoning part to existing reasoning sequence. Skipping reasoning part: {"type":"reasoning","text":"","providerOptions":{"openai":{"itemId":"reasoning_001"}}}.",
                 "type": "other",
               },
             ]
@@ -705,9 +697,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'First reasoning step',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -716,9 +706,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Second reasoning step',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -760,9 +748,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'First reasoning block',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -771,9 +757,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Second reasoning block',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_002',
-                        },
+                        itemId: 'reasoning_002',
                       },
                     },
                   },
@@ -826,9 +810,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'First reasoning step (message 1)',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -837,9 +819,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Second reasoning step (message 1)',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_001',
-                        },
+                        itemId: 'reasoning_001',
                       },
                     },
                   },
@@ -858,9 +838,7 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'First reasoning step (message 2)',
                     providerOptions: {
                       openai: {
-                        reasoning: {
-                          id: 'reasoning_002',
-                        },
+                        itemId: 'reasoning_002',
                       },
                     },
                   },
@@ -931,8 +909,8 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Initial analysis step 1',
                     providerOptions: {
                       openai: {
+                        itemId: 'reasoning_001',
                         reasoning: {
-                          id: 'reasoning_001',
                           encryptedContent: 'encrypted_content_001',
                         },
                       },
@@ -943,8 +921,8 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Initial analysis step 2',
                     providerOptions: {
                       openai: {
+                        itemId: 'reasoning_001',
                         reasoning: {
-                          id: 'reasoning_001',
                           encryptedContent: 'encrypted_content_001',
                         },
                       },
@@ -983,8 +961,8 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Processing results step 1',
                     providerOptions: {
                       openai: {
+                        itemId: 'reasoning_002',
                         reasoning: {
-                          id: 'reasoning_002',
                           encryptedContent: 'encrypted_content_002',
                         },
                       },
@@ -995,8 +973,8 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Processing results step 2',
                     providerOptions: {
                       openai: {
+                        itemId: 'reasoning_002',
                         reasoning: {
-                          id: 'reasoning_002',
                           encryptedContent: 'encrypted_content_002',
                         },
                       },
@@ -1007,8 +985,8 @@ describe('convertToOpenAIResponsesMessages', () => {
                     text: 'Processing results step 3',
                     providerOptions: {
                       openai: {
+                        itemId: 'reasoning_002',
                         reasoning: {
-                          id: 'reasoning_002',
                           encryptedContent: 'encrypted_content_002',
                         },
                       },

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.ts
@@ -172,7 +172,7 @@ export async function convertToOpenAIResponsesMessages({
                     type: 'reasoning',
                     id: reasoningId,
                     encrypted_content:
-                      providerOptions?.reasoning?.encryptedContent,
+                      providerOptions?.reasoningEncryptedContent,
                     summary: summaryParts,
                   };
                   messages.push(reasoningMessages[reasoningId]);
@@ -232,11 +232,7 @@ export async function convertToOpenAIResponsesMessages({
 
 const openaiResponsesReasoningProviderOptionsSchema = z.object({
   itemId: z.string().nullish(),
-  reasoning: z
-    .object({
-      encryptedContent: z.string().nullish(),
-    })
-    .nullish(),
+  reasoningEncryptedContent: z.string().nullish(),
 });
 
 export type OpenAIResponsesReasoningProviderOptions = z.infer<

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.ts
@@ -148,7 +148,7 @@ export async function convertToOpenAIResponsesMessages({
                 schema: openaiResponsesReasoningProviderOptionsSchema,
               });
 
-              const reasoningId = providerOptions?.reasoning?.id;
+              const reasoningId = providerOptions?.itemId;
 
               if (reasoningId != null) {
                 const existingReasoningMessage = reasoningMessages[reasoningId];
@@ -231,9 +231,9 @@ export async function convertToOpenAIResponsesMessages({
 }
 
 const openaiResponsesReasoningProviderOptionsSchema = z.object({
+  itemId: z.string().nullish(),
   reasoning: z
     .object({
-      id: z.string().nullish(),
       encryptedContent: z.string().nullish(),
     })
     .nullish(),

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1043,9 +1043,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                  "reasoning": {
-                    "encryptedContent": null,
-                  },
+                  "reasoningEncryptedContent": null,
                 },
               },
               "text": "**Exploring burrito origins**
@@ -1057,9 +1055,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                  "reasoning": {
-                    "encryptedContent": null,
-                  },
+                  "reasoningEncryptedContent": null,
                 },
               },
               "text": "**Investigating burrito origins**
@@ -1171,9 +1167,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                  "reasoning": {
-                    "encryptedContent": null,
-                  },
+                  "reasoningEncryptedContent": null,
                 },
               },
               "text": "",
@@ -1293,9 +1287,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                  "reasoning": {
-                    "encryptedContent": "encrypted_reasoning_data_abc123",
-                  },
+                  "reasoningEncryptedContent": "encrypted_reasoning_data_abc123",
                 },
               },
               "text": "**Exploring burrito origins**
@@ -1307,9 +1299,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                  "reasoning": {
-                    "encryptedContent": "encrypted_reasoning_data_abc123",
-                  },
+                  "reasoningEncryptedContent": "encrypted_reasoning_data_abc123",
                 },
               },
               "text": "**Investigating burrito origins**
@@ -1424,9 +1414,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                  "reasoning": {
-                    "encryptedContent": "encrypted_reasoning_data_abc123",
-                  },
+                  "reasoningEncryptedContent": "encrypted_reasoning_data_abc123",
                 },
               },
               "text": "",
@@ -1568,9 +1556,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                  "reasoning": {
-                    "encryptedContent": null,
-                  },
+                  "reasoningEncryptedContent": null,
                 },
               },
               "text": "**Initial analysis**
@@ -1582,9 +1568,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                  "reasoning": {
-                    "encryptedContent": null,
-                  },
+                  "reasoningEncryptedContent": null,
                 },
               },
               "text": "**Deeper consideration**
@@ -1605,9 +1589,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "providerMetadata": {
                 "openai": {
                   "itemId": "rs_second_7908809g7gcc9291be3e3fee895028c4",
-                  "reasoning": {
-                    "encryptedContent": null,
-                  },
+                  "reasoningEncryptedContent": null,
                 },
               },
               "text": "Second reasoning block: considering alternative approaches.",
@@ -2589,9 +2571,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-start",
@@ -2623,9 +2603,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-start",
@@ -2657,9 +2635,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-end",
@@ -2669,9 +2645,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-end",
@@ -2772,9 +2746,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-start",
@@ -2784,9 +2756,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-end",
@@ -2895,9 +2865,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": "encrypted_reasoning_data_abc123",
-                    },
+                    "reasoningEncryptedContent": "encrypted_reasoning_data_abc123",
                   },
                 },
                 "type": "reasoning-start",
@@ -2929,9 +2897,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": "encrypted_reasoning_data_abc123",
-                    },
+                    "reasoningEncryptedContent": "encrypted_reasoning_data_abc123",
                   },
                 },
                 "type": "reasoning-start",
@@ -2963,9 +2929,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": "encrypted_reasoning_data_final_def456",
-                    },
+                    "reasoningEncryptedContent": "encrypted_reasoning_data_final_def456",
                   },
                 },
                 "type": "reasoning-end",
@@ -2975,9 +2939,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": "encrypted_reasoning_data_final_def456",
-                    },
+                    "reasoningEncryptedContent": "encrypted_reasoning_data_final_def456",
                   },
                 },
                 "type": "reasoning-end",
@@ -3080,9 +3042,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": "encrypted_reasoning_data_abc123",
-                    },
+                    "reasoningEncryptedContent": "encrypted_reasoning_data_abc123",
                   },
                 },
                 "type": "reasoning-start",
@@ -3092,9 +3052,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": "encrypted_reasoning_data_final_def456",
-                    },
+                    "reasoningEncryptedContent": "encrypted_reasoning_data_final_def456",
                   },
                 },
                 "type": "reasoning-end",
@@ -3217,9 +3175,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-start",
@@ -3251,9 +3207,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-start",
@@ -3285,9 +3239,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-end",
@@ -3297,9 +3249,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-end",
@@ -3332,9 +3282,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_second_7908809g7gcc9291be3e3fee895028c4",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-start",
@@ -3364,9 +3312,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "providerMetadata": {
                   "openai": {
                     "itemId": "rs_second_7908809g7gcc9291be3e3fee895028c4",
-                    "reasoning": {
-                      "encryptedContent": null,
-                    },
+                    "reasoningEncryptedContent": null,
                   },
                 },
                 "type": "reasoning-end",

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1042,9 +1042,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   "reasoning": {
                     "encryptedContent": null,
-                    "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
               },
@@ -1056,9 +1056,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   "reasoning": {
                     "encryptedContent": null,
-                    "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
               },
@@ -1170,9 +1170,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   "reasoning": {
                     "encryptedContent": null,
-                    "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
               },
@@ -1292,9 +1292,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   "reasoning": {
                     "encryptedContent": "encrypted_reasoning_data_abc123",
-                    "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
               },
@@ -1306,9 +1306,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   "reasoning": {
                     "encryptedContent": "encrypted_reasoning_data_abc123",
-                    "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
               },
@@ -1423,9 +1423,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   "reasoning": {
                     "encryptedContent": "encrypted_reasoning_data_abc123",
-                    "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
               },
@@ -1567,9 +1567,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                   "reasoning": {
                     "encryptedContent": null,
-                    "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
               },
@@ -1581,9 +1581,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                   "reasoning": {
                     "encryptedContent": null,
-                    "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
               },
@@ -1604,9 +1604,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             {
               "providerMetadata": {
                 "openai": {
+                  "itemId": "rs_second_7908809g7gcc9291be3e3fee895028c4",
                   "reasoning": {
                     "encryptedContent": null,
-                    "id": "rs_second_7908809g7gcc9291be3e3fee895028c4",
                   },
                 },
               },
@@ -2588,9 +2588,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2603,9 +2603,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -2615,9 +2613,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -2626,9 +2622,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2641,9 +2637,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -2653,9 +2647,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -2664,9 +2656,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2676,9 +2668,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2779,9 +2771,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2791,9 +2783,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2902,9 +2894,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": "encrypted_reasoning_data_abc123",
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2917,9 +2909,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -2929,9 +2919,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -2940,9 +2928,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": "encrypted_reasoning_data_abc123",
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2955,9 +2943,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -2967,9 +2953,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -2978,9 +2962,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": "encrypted_reasoning_data_final_def456",
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -2990,9 +2974,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": "encrypted_reasoning_data_final_def456",
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -3095,9 +3079,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": "encrypted_reasoning_data_abc123",
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -3107,9 +3091,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": "encrypted_reasoning_data_final_def456",
-                      "id": "rs_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -3232,9 +3216,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -3247,9 +3231,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -3259,9 +3241,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -3270,9 +3250,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -3285,9 +3265,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -3297,9 +3275,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    },
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                   },
                 },
                 "type": "reasoning-delta",
@@ -3308,9 +3284,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -3320,9 +3296,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
                     },
                   },
                 },
@@ -3355,9 +3331,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_second_7908809g7gcc9291be3e3fee895028c4:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_second_7908809g7gcc9291be3e3fee895028c4",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_second_7908809g7gcc9291be3e3fee895028c4",
                     },
                   },
                 },
@@ -3368,9 +3344,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_second_7908809g7gcc9291be3e3fee895028c4:0",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_second_7908809g7gcc9291be3e3fee895028c4",
-                    },
+                    "itemId": "rs_second_7908809g7gcc9291be3e3fee895028c4",
                   },
                 },
                 "type": "reasoning-delta",
@@ -3380,9 +3354,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_second_7908809g7gcc9291be3e3fee895028c4:0",
                 "providerMetadata": {
                   "openai": {
-                    "reasoning": {
-                      "id": "rs_second_7908809g7gcc9291be3e3fee895028c4",
-                    },
+                    "itemId": "rs_second_7908809g7gcc9291be3e3fee895028c4",
                   },
                 },
                 "type": "reasoning-delta",
@@ -3391,9 +3363,9 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "id": "rs_second_7908809g7gcc9291be3e3fee895028c4:0",
                 "providerMetadata": {
                   "openai": {
+                    "itemId": "rs_second_7908809g7gcc9291be3e3fee895028c4",
                     "reasoning": {
                       "encryptedContent": null,
-                      "id": "rs_second_7908809g7gcc9291be3e3fee895028c4",
                     },
                   },
                 },

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -345,9 +345,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               providerMetadata: {
                 openai: {
                   itemId: part.id,
-                  reasoning: {
-                    encryptedContent: part.encrypted_content ?? null,
-                  },
+                  reasoningEncryptedContent: part.encrypted_content ?? null,
                 },
               },
             });
@@ -596,9 +594,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   providerMetadata: {
                     openai: {
                       itemId: value.item.id,
-                      reasoning: {
-                        encryptedContent: value.item.encrypted_content ?? null,
-                      },
+                      reasoningEncryptedContent:
+                        value.item.encrypted_content ?? null,
                     },
                   },
                 });
@@ -693,10 +690,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                     providerMetadata: {
                       openai: {
                         itemId: value.item.id,
-                        reasoning: {
-                          encryptedContent:
-                            value.item.encrypted_content ?? null,
-                        },
+                        reasoningEncryptedContent:
+                          value.item.encrypted_content ?? null,
                       },
                     },
                   });
@@ -741,11 +736,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   providerMetadata: {
                     openai: {
                       itemId: value.item_id,
-                      reasoning: {
-                        encryptedContent:
-                          activeReasoning[value.item_id]?.encryptedContent ??
-                          null,
-                      },
+                      reasoningEncryptedContent:
+                        activeReasoning[value.item_id]?.encryptedContent ??
+                        null,
                     },
                   },
                 });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -344,8 +344,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               text: summary.text,
               providerMetadata: {
                 openai: {
+                  itemId: part.id,
                   reasoning: {
-                    id: part.id,
                     encryptedContent: part.encrypted_content ?? null,
                   },
                 },
@@ -595,8 +595,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   id: `${value.item.id}:0`,
                   providerMetadata: {
                     openai: {
+                      itemId: value.item.id,
                       reasoning: {
-                        id: value.item.id,
                         encryptedContent: value.item.encrypted_content ?? null,
                       },
                     },
@@ -692,8 +692,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                     id: `${value.item.id}:${summaryIndex}`,
                     providerMetadata: {
                       openai: {
+                        itemId: value.item.id,
                         reasoning: {
-                          id: value.item.id,
                           encryptedContent:
                             value.item.encrypted_content ?? null,
                         },
@@ -740,8 +740,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   id: `${value.item_id}:${value.summary_index}`,
                   providerMetadata: {
                     openai: {
+                      itemId: value.item_id,
                       reasoning: {
-                        id: value.item_id,
                         encryptedContent:
                           activeReasoning[value.item_id]?.encryptedContent ??
                           null,
@@ -757,9 +757,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 delta: value.delta,
                 providerMetadata: {
                   openai: {
-                    reasoning: {
-                      id: value.item_id,
-                    },
+                    itemId: value.item_id,
                   },
                 },
               });


### PR DESCRIPTION
## Background

We have `itemId` on tool and text parts. However, reasoning parts use `reasoning.id`. We need to standardize now to avoid confusion and larger migrations in the future.

## Summary

* Change `reasoning.id` to `itemId` in the provider metadata to standardize on `itemId`
* Change `reasoning.encryptedContent` to `reasoningEncryptedContent` to flatten object

## Verification

Ran `examples/ai-core/src/stream-text/openai-responses-reasoning-zero-data-retention.ts`