### PR TITLE
fix (ui): support tool names with dash

### DIFF
--- a/.changeset/ten-windows-serve.md
+++ b/.changeset/ten-windows-serve.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ui): support tool names with dash

--- a/packages/ai/src/ui/ui-messages.test.ts
+++ b/packages/ai/src/ui/ui-messages.test.ts
@@ -1,0 +1,27 @@
+import { getToolName } from './ui-messages';
+
+describe('getToolName', () => {
+  it('should return the tool name after the "tool-" prefix', () => {
+    expect(
+      getToolName({
+        type: 'tool-getLocation',
+        toolCallId: 'tool1',
+        state: 'output-available',
+        input: {},
+        output: 'some result',
+      }),
+    ).toBe('getLocation');
+  });
+
+  it('should return the tool name for tools that contains a dash', () => {
+    expect(
+      getToolName({
+        type: 'tool-get-location',
+        toolCallId: 'tool1',
+        state: 'output-available',
+        input: {},
+        output: 'some result',
+      }),
+    ).toBe('get-location');
+  });
+});

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -240,7 +240,7 @@ export function isToolUIPart<TOOLS extends UITools>(
 export function getToolName<TOOLS extends UITools>(
   part: ToolUIPart<TOOLS>,
 ): keyof TOOLS {
-  return part.type.split('-')[1] as keyof TOOLS;
+  return part.type.split('-').slice(1).join('-') as keyof TOOLS;
 }
 
 export type InferUIMessageMetadata<T extends UIMessage> =


### PR DESCRIPTION
## Background

Only the fragment after the first hyphen was return as tool name (see #7374 ).

## Summary

Add support for tool names with dashes.

## Related Issues

Fixes #7374 