### PR TITLE
fix(ai-sdk/react) Add options.id to subscribeToMessages callback dependency array

### DIFF
--- a/.changeset/hip-paws-fly.md
+++ b/.changeset/hip-paws-fly.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix message subscription out of sync when chat id changes after mount

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -70,7 +70,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   }
 
   const optionsId = 'id' in options ? options.id : null;
-  
+
   const subscribeToMessages = useCallback(
     (update: () => void) =>
       chatRef.current['~registerMessagesCallback'](update, throttleWaitMs),

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -69,10 +69,14 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     chatRef.current = 'chat' in options ? options.chat : new Chat(options);
   }
 
+  const optionsId = 'id' in options ? options.id : null;
+  
   const subscribeToMessages = useCallback(
     (update: () => void) =>
       chatRef.current['~registerMessagesCallback'](update, throttleWaitMs),
-    [throttleWaitMs, 'id' in options ? options.id : null],
+    // optionsId is required to trigger re-subscription when the chat ID changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [throttleWaitMs, optionsId],
   );
 
   const messages = useSyncExternalStore(

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -72,7 +72,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   const subscribeToMessages = useCallback(
     (update: () => void) =>
       chatRef.current['~registerMessagesCallback'](update, throttleWaitMs),
-    [throttleWaitMs],
+    [throttleWaitMs, 'id' in options ? options.id : null],
   );
 
   const messages = useSyncExternalStore(

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2537,3 +2537,106 @@ describe('chat instance changes', () => {
     expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
   });
 });
+
+describe('streaming with id change from undefined to defined', () => {
+  setupTestComponent(
+    () => {
+      const [id, setId] = React.useState<string | undefined>(undefined);
+      const {
+        messages,
+        sendMessage,
+        status,
+      } = useChat({
+        id,
+        generateId: mockId(),
+      });
+
+      return (
+        <div>
+          <div data-testid="status">{status.toString()}</div>
+          <div data-testid="messages">{JSON.stringify(messages, null, 2)}</div>
+          <button
+            data-testid="change-id"
+            onClick={() => {
+              setId('chat-123');
+            }}
+          />
+          <button
+            data-testid="send-message"
+            onClick={() => {
+              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+            }}
+          />
+        </div>
+      );
+    },
+    {
+      init: TestComponent => <TestComponent />,
+    },
+  );
+
+  it('should handle streaming correctly when id changes from undefined to defined', async () => {
+    const controller = new TestResponseController();
+    server.urls['/api/chat'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    // First, change the ID from undefined to 'chat-123'
+    await userEvent.click(screen.getByTestId('change-id'));
+    
+    // Then send a message
+    await userEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('submitted');
+    });
+
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
+    controller.write(
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+    );
+
+    // Verify streaming is working - text should appear immediately
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+      ).toContainEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          parts: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'text',
+              text: 'Hello',
+            }),
+          ]),
+        }),
+      );
+    });
+
+    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: ',' }));
+    controller.write(
+      formatChunk({ type: 'text-delta', id: '0', delta: ' world' }),
+    );
+    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: '.' }));
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
+    controller.close();
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId('messages').textContent ?? ''),
+      ).toContainEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          parts: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'text',
+              text: 'Hello, world.',
+              state: 'done',
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+});

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2542,11 +2542,7 @@ describe('streaming with id change from undefined to defined', () => {
   setupTestComponent(
     () => {
       const [id, setId] = React.useState<string | undefined>(undefined);
-      const {
-        messages,
-        sendMessage,
-        status,
-      } = useChat({
+      const { messages, sendMessage, status } = useChat({
         id,
         generateId: mockId(),
       });
@@ -2584,7 +2580,7 @@ describe('streaming with id change from undefined to defined', () => {
 
     // First, change the ID from undefined to 'chat-123'
     await userEvent.click(screen.getByTestId('change-id'));
-    
+
     // Then send a message
     await userEvent.click(screen.getByTestId('send-message'));
 


### PR DESCRIPTION
## Background

When useChat is mounted with id=undefined and the ID is updated later (e.g., from a backend fetch), streaming responses fail to display in real-time. The UI only updates after the entire response is received, even though the network shows chunks arriving correctly.

## Summary

Fixed stale subscription callbacks in useChat hook by adding the chat ID (if available) to the dependency array of the messages subscription callback.

## Verification

Built and tested locally in my app

## Tasks

- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)


## Related Issues

Fixes #7378
