### PR TITLE
fix(examples): extract text content in getLastUserMessageText example

### DIFF
--- a/examples/ai-core/src/middleware/get-last-user-message-text.ts
+++ b/examples/ai-core/src/middleware/get-last-user-message-text.ts
@@ -13,5 +13,5 @@ export function getLastUserMessageText({
 
   return lastMessage.content.length === 0
     ? undefined
-    : lastMessage.content.filter(c => c.type === 'text').join('\n');
+    : lastMessage.content.filter(c => c.type === 'text').map(c => c.text).join('\n');
 }

--- a/examples/ai-core/src/middleware/get-last-user-message-text.ts
+++ b/examples/ai-core/src/middleware/get-last-user-message-text.ts
@@ -13,5 +13,8 @@ export function getLastUserMessageText({
 
   return lastMessage.content.length === 0
     ? undefined
-    : lastMessage.content.filter(c => c.type === 'text').map(c => c.text).join('\n');
+    : lastMessage.content
+        .filter(c => c.type === 'text')
+        .map(c => c.text)
+        .join('\n');
 }


### PR DESCRIPTION
`getLastUserMessageText` needs to extract the text of a message from the `content.text` property.

## Background

Existing behaviour is for text to be extracted as "[object Object]".

## Summary

Extract the `content.text` property.

## Verification

Logged and observed the payload before and after the change.

## Tasks
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
