### PR TITLE
fix(@ai-sdk/provider-utils): Use safeParseAsync for zod schemas

### DIFF
--- a/.changeset/sour-mails-clap.md
+++ b/.changeset/sour-mails-clap.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Adds support for async zod validators

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -1,4 +1,4 @@
-import { Validator, validatorSymbol } from './validator';
+import { Validator, validatorSymbol, type ValidationResult } from './validator';
 import { JSONSchema7 } from '@ai-sdk/provider';
 import * as z3 from 'zod/v3';
 import * as z4 from 'zod/v4';
@@ -49,7 +49,7 @@ export function jsonSchema<OBJECT = unknown>(
   }: {
     validate?: (
       value: unknown,
-    ) => { success: true; value: OBJECT } | { success: false; error: Error };
+    ) => ValidationResult<OBJECT> | PromiseLike<ValidationResult<OBJECT>>;
   } = {},
 ): Schema<OBJECT> {
   return {

--- a/packages/provider-utils/src/zod-schema.ts
+++ b/packages/provider-utils/src/zod-schema.ts
@@ -25,8 +25,8 @@ export function zod3Schema<OBJECT>(
       target: 'jsonSchema7', // note: openai mode breaks various gemini conversions
     }) as JSONSchema7,
     {
-      validate: value => {
-        const result = zodSchema.safeParse(value);
+      validate: async value => {
+        const result = await zodSchema.safeParseAsync(value);
         return result.success
           ? { success: true, value: result.data }
           : { success: false, error: result.error };
@@ -57,8 +57,8 @@ export function zod4Schema<OBJECT>(
   }) as JSONSchema7;
 
   return jsonSchema(z4JSONSchema, {
-    validate: value => {
-      const result = z4.safeParse(zodSchema, value);
+    validate: async value => {
+      const result = await z4.safeParseAsync(zodSchema, value);
       return result.success
         ? { success: true, value: result.data }
         : { success: false, error: result.error };


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

To support `async` `refine` calls

## Summary

<!-- What did you change? -->

Changed calls of `safeParse` to `safeParseAsync`. Calls to `validate` were already `await`ed.

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

`pnpm link`ed into another project where I added a tool with an `async` `refine` in its `inputSchema`. Without this change, it throws an error.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues


Fixes #6868 