### PR TITLE
feat (ui): allow asynchronous onFinish in createUIMessageStream

### DIFF
--- a/.changeset/tiny-seals-flash.md
+++ b/.changeset/tiny-seals-flash.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ui): allow asynchronous onFinish in createUIMessageStream

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -43,7 +43,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
      * (including the original message if it was extended).
      */
     responseMessage: UI_MESSAGE;
-  }) => void;
+  }) => void | PromiseLike<void>;
 
   generateId?: IdGenerator;
 }): ReadableStream<InferUIMessageChunk<UI_MESSAGE>> {

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -46,7 +46,7 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
      * (including the original message if it was extended).
      */
     responseMessage: UI_MESSAGE;
-  }) => void;
+  }) => void | PromiseLike<void>;
 }): ReadableStream<InferUIMessageChunk<UI_MESSAGE>> {
   // last message is only relevant for assistant messages
   let lastMessage: UI_MESSAGE | undefined =
@@ -112,9 +112,9 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
         controller.enqueue(chunk);
       },
 
-      flush() {
+      async flush() {
         const isContinuation = state.message.id === lastMessage?.id;
-        onFinish({
+        await onFinish({
           isContinuation,
           responseMessage: state.message as UI_MESSAGE,
           messages: [


### PR DESCRIPTION
## Background

Users want to use async functions as callback without getting ESLint errors (see #7384 ).

## Summary

Allow promise-like return values and await.

## Related Issues

Fixes #7384 