### PR TITLE
fix (example): fix next persistence example assistant message id generation

### DIFF
--- a/examples/next/app/api/chat/route.ts
+++ b/examples/next/app/api/chat/route.ts
@@ -63,6 +63,7 @@ export async function POST(req: Request) {
 
   return result.toUIMessageStreamResponse({
     originalMessages: messages,
+    generateMessageId: generateId,
     messageMetadata: ({ part }) => {
       if (part.type === 'start') {
         return { createdAt: Date.now() };


### PR DESCRIPTION
## Background

Without opting into generateMessageId, stored assistant messages have empty ids.