### PR TITLE
update: Azure OpenAI provider to v1 API format

### DIFF
--- a/.changeset/old-yaks-pull.md
+++ b/.changeset/old-yaks-pull.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/azure': patch
+---
+
+update: Azure OpenAI provider to v1 API format

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -49,7 +49,7 @@ You can use the following optional settings to customize the OpenAI provider ins
   Azure resource name.
   It defaults to the `AZURE_RESOURCE_NAME` environment variable.
 
-  The resource name is used in the assembled URL: `https://{resourceName}.openai.azure.com/openai/deployments/{modelId}{path}`.
+  The resource name is used in the assembled URL: `https://{resourceName}.openai.azure.com/openai/v1{path}`.
   You can use `baseURL` instead to specify the URL prefix.
 
 - **apiKey** _string_

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -60,7 +60,7 @@ You can use the following optional settings to customize the OpenAI provider ins
 - **apiVersion** _string_
 
   Sets a custom [api version](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation).
-  Defaults to `2025-03-01-preview`.
+  Defaults to `preview`.
 
 - **baseURL** _string_
 
@@ -69,7 +69,7 @@ You can use the following optional settings to customize the OpenAI provider ins
   Either this or `resourceName` can be used.
   When a baseURL is provided, the resourceName is ignored.
 
-  With a baseURL, the resolved URL is `{baseURL}/{modelId}{path}`.
+  With a baseURL, the resolved URL is `{baseURL}/v1{path}`.
 
 - **headers** _Record&lt;string,string&gt;_
 
@@ -170,7 +170,7 @@ const { text } = await generateText({
 
 <Note>
   The URL for calling Azure chat models will be constructed as follows:
-  `https://RESOURCE_NAME.openai.azure.com/openai/deployments/DEPLOYMENT_NAME/chat/completions?api-version=API_VERSION`
+  `https://RESOURCE_NAME.openai.azure.com/openai/v1/chat/completions?api-version=preview`
 </Note>
 
 Azure OpenAI chat models support also some model specific settings that are not part of the [standard call settings](/docs/ai-sdk-core/settings).

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -222,9 +222,9 @@ describe('embedding', () => {
     }: {
       embeddings?: EmbeddingModelV2Embedding[];
     } = {}) {
-              server.urls[
-          'https://test-resource.openai.azure.com/openai/v1/embeddings'
-        ].response = {
+      server.urls[
+        'https://test-resource.openai.azure.com/openai/v1/embeddings'
+      ].response = {
         type: 'json-value',
         body: {
           object: 'list',

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -21,22 +21,18 @@ const providerApiVersionChanged = createAzure({
 });
 
 const server = createTestServer({
-  'https://test-resource.openai.azure.com/openai/deployments/test-deployment/chat/completions':
-    {},
-  'https://test-resource.openai.azure.com/openai/deployments/gpt-35-turbo-instruct/completions':
-    {},
-  'https://test-resource.openai.azure.com/openai/deployments/my-embedding/embeddings':
-    {},
-  'https://test-resource.openai.azure.com/openai/deployments/dalle-deployment/images/generations':
-    {},
-  'https://test-resource.openai.azure.com/openai/responses': {},
+  'https://test-resource.openai.azure.com/openai/v1/chat/completions': {},
+  'https://test-resource.openai.azure.com/openai/v1/completions': {},
+  'https://test-resource.openai.azure.com/openai/v1/embeddings': {},
+  'https://test-resource.openai.azure.com/openai/v1/images/generations': {},
+  'https://test-resource.openai.azure.com/openai/v1/responses': {},
 });
 
 describe('chat', () => {
   describe('doGenerate', () => {
     function prepareJsonResponse({ content = '' }: { content?: string } = {}) {
       server.urls[
-        'https://test-resource.openai.azure.com/openai/deployments/test-deployment/chat/completions'
+        'https://test-resource.openai.azure.com/openai/v1/chat/completions'
       ].response = {
         type: 'json-value',
         body: {
@@ -73,7 +69,7 @@ describe('chat', () => {
 
       expect(
         server.calls[0].requestUrlSearchParams.get('api-version'),
-      ).toStrictEqual('2025-03-01-preview');
+      ).toStrictEqual('preview');
     });
 
     it('should set the correct modified api version', async () => {
@@ -118,7 +114,7 @@ describe('chat', () => {
       prepareJsonResponse();
 
       const provider = createAzure({
-        baseURL: 'https://test-resource.openai.azure.com/openai/deployments',
+        baseURL: 'https://test-resource.openai.azure.com/openai',
         apiKey: 'test-api-key',
       });
 
@@ -126,7 +122,7 @@ describe('chat', () => {
         prompt: TEST_PROMPT,
       });
       expect(server.calls[0].requestUrl).toStrictEqual(
-        'https://test-resource.openai.azure.com/openai/deployments/test-deployment/chat/completions?api-version=2025-03-01-preview',
+        'https://test-resource.openai.azure.com/openai/v1/chat/completions?api-version=preview',
       );
     });
   });
@@ -152,7 +148,7 @@ describe('completion', () => {
       finish_reason?: string;
     }) {
       server.urls[
-        'https://test-resource.openai.azure.com/openai/deployments/gpt-35-turbo-instruct/completions'
+        'https://test-resource.openai.azure.com/openai/v1/completions'
       ].response = {
         type: 'json-value',
         body: {
@@ -180,7 +176,7 @@ describe('completion', () => {
       });
       expect(
         server.calls[0].requestUrlSearchParams.get('api-version'),
-      ).toStrictEqual('2025-03-01-preview');
+      ).toStrictEqual('preview');
     });
 
     it('should pass headers', async () => {
@@ -226,9 +222,9 @@ describe('embedding', () => {
     }: {
       embeddings?: EmbeddingModelV2Embedding[];
     } = {}) {
-      server.urls[
-        'https://test-resource.openai.azure.com/openai/deployments/my-embedding/embeddings'
-      ].response = {
+              server.urls[
+          'https://test-resource.openai.azure.com/openai/v1/embeddings'
+        ].response = {
         type: 'json-value',
         body: {
           object: 'list',
@@ -251,7 +247,7 @@ describe('embedding', () => {
       });
       expect(
         server.calls[0].requestUrlSearchParams.get('api-version'),
-      ).toStrictEqual('2025-03-01-preview');
+      ).toStrictEqual('preview');
     });
 
     it('should pass headers', async () => {
@@ -288,7 +284,7 @@ describe('image', () => {
   describe('doGenerate', () => {
     function prepareJsonResponse() {
       server.urls[
-        'https://test-resource.openai.azure.com/openai/deployments/dalle-deployment/images/generations'
+        'https://test-resource.openai.azure.com/openai/v1/images/generations'
       ].response = {
         type: 'json-value',
         body: {
@@ -321,7 +317,7 @@ describe('image', () => {
 
       expect(
         server.calls[0].requestUrlSearchParams.get('api-version'),
-      ).toStrictEqual('2025-03-01-preview');
+      ).toStrictEqual('preview');
     });
 
     it('should set the correct modified api version', async () => {
@@ -378,7 +374,7 @@ describe('image', () => {
       prepareJsonResponse();
 
       const provider = createAzure({
-        baseURL: 'https://test-resource.openai.azure.com/openai/deployments',
+        baseURL: 'https://test-resource.openai.azure.com/openai',
         apiKey: 'test-api-key',
       });
 
@@ -392,7 +388,7 @@ describe('image', () => {
       });
 
       expect(server.calls[0].requestUrl).toStrictEqual(
-        'https://test-resource.openai.azure.com/openai/deployments/dalle-deployment/images/generations?api-version=2025-03-01-preview',
+        'https://test-resource.openai.azure.com/openai/v1/images/generations?api-version=preview',
       );
     });
 
@@ -456,7 +452,7 @@ describe('responses', () => {
       },
     } = {}) {
       server.urls[
-        'https://test-resource.openai.azure.com/openai/responses'
+        'https://test-resource.openai.azure.com/openai/v1/responses'
       ].response = {
         type: 'json-value',
         body: {
@@ -495,7 +491,7 @@ describe('responses', () => {
 
       expect(
         server.calls[0].requestUrlSearchParams.get('api-version'),
-      ).toStrictEqual('2025-03-01-preview');
+      ).toStrictEqual('preview');
     });
 
     it('should pass headers', async () => {
@@ -537,7 +533,7 @@ describe('responses', () => {
       });
 
       expect(server.calls[0].requestUrl).toStrictEqual(
-        'https://test-resource.openai.azure.com/openai/responses?api-version=2025-03-01-preview',
+        'https://test-resource.openai.azure.com/openai/v1/responses?api-version=preview',
       );
     });
   });

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -132,9 +132,10 @@ export function createAzure(
     });
 
   const apiVersion = options.apiVersion ?? 'preview';
-  
+
   const url = ({ path, modelId }: { path: string; modelId: string }) => {
-    const baseUrlPrefix = options.baseURL ?? `https://${getResourceName()}.openai.azure.com/openai`;
+    const baseUrlPrefix =
+      options.baseURL ?? `https://${getResourceName()}.openai.azure.com/openai`;
     // Use v1 API format - no deployment ID in URL
     const fullUrl = new URL(`${baseUrlPrefix}/v1${path}`);
     fullUrl.searchParams.set('api-version', apiVersion);


### PR DESCRIPTION
## background

updated azure openai urls, for newer support as updated v1 now supports input PDF files streamTest on Responses API

## summary

- update Azure OpenAI URLs to v1 format
- change default API version to preview

## verification

- all tests pass with new v1 endpoint format
- deployment IDs still work via request body model field
- baseURL configuration works with v1 format

## tasks

- [x] update URL construction from deployments/{id} to v1 format
- [x] change default API version to preview
- [x] update test expectations for new URLs
- [x] update documentation with v1 format

## future work

* monitor Azure API for any additional v1 format requirements 

related issue #7372