### PR TITLE
feat (ai): add isAborted to onFinish callback for ui message streams

### DIFF
--- a/.changeset/wild-tables-enjoy.md
+++ b/.changeset/wild-tables-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+feat (ai): add isAborted to onFinish callback for ui message streams

--- a/content/docs/06-advanced/02-stopping-streams.mdx
+++ b/content/docs/06-advanced/02-stopping-streams.mdx
@@ -75,6 +75,13 @@ When streams are aborted, you may need to perform cleanup operations such as per
 
 Unlike `onFinish`, which is called when a stream completes normally, `onAbort` is specifically called when a stream is aborted via `AbortSignal`. This distinction allows you to handle normal completion and aborted streams differently.
 
+<Note>
+  For UI message streams (`toUIMessageStreamResponse`), the `onFinish` callback
+  also receives an `isAborted` parameter that indicates whether the stream was
+  aborted. This allows you to handle both completion and abort scenarios in a
+  single callback.
+</Note>
+
 ```tsx highlight="8-12"
 import { streamText } from 'ai';
 
@@ -121,6 +128,45 @@ for await (const part of result.fullStream) {
   }
 }
 ```
+
+## UI Message Streams
+
+When using `toUIMessageStreamResponse`, you need to handle stream abortion slightly differently. The `onFinish` callback receives an `isAborted` parameter, and you should pass the `consumeStream` function to ensure proper abort handling:
+
+```tsx highlight="5,19,20-24,26"
+import { openai } from '@ai-sdk/openai';
+import {
+  consumeStream,
+  convertToModelMessages,
+  streamText,
+  UIMessage,
+} from 'ai';
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    messages: convertToModelMessages(messages),
+    abortSignal: req.signal,
+  });
+
+  return result.toUIMessageStreamResponse({
+    onFinish: async ({ isAborted }) => {
+      if (isAborted) {
+        console.log('Stream was aborted');
+        // Handle abort-specific cleanup
+      } else {
+        console.log('Stream completed normally');
+        // Handle normal completion
+      }
+    },
+    consumeSseStream: consumeStream,
+  });
+}
+```
+
+The `consumeStream` function is necessary for proper abort handling in UI message streams. It ensures that the stream is properly consumed even when aborted, preventing potential memory leaks or hanging connections.
 
 ## AI SDK RSC
 

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2350,9 +2350,9 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'toUIMessageStream',
-      type: '(options?: UIMessageStreamOptions) => ReadableStream<UIMessageChunk>',
+      type: '(options?: UIMessageStreamOptions) => AsyncIterableStream<UIMessageChunk>',
       description:
-        'Converts the result to a UI message stream.',
+        'Converts the result to a UI message stream. Returns an AsyncIterableStream that can be used as both an AsyncIterable and a ReadableStream.',
       properties: [
         {
           type: 'UIMessageStreamOptions',
@@ -2365,9 +2365,9 @@ To see `streamText` in action, check out [these examples](#examples).
             },
             {
               name: 'onFinish',
-              type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; }) => void',
+              type: '(options: { messages: UIMessage[]; isContinuation: boolean; responseMessage: UIMessage; isAborted: boolean; }) => void',
               isOptional: true,
-              description: 'Callback function called when the stream finishes. Provides the updated list of UI messages, whether the response is a continuation, and the response message.',
+              description: 'Callback function called when the stream finishes. Provides the updated list of UI messages, whether the response is a continuation, the response message, and whether the stream was aborted.',
             },
             {
               name: 'messageMetadata',
@@ -2409,6 +2409,13 @@ To see `streamText` in action, check out [these examples](#examples).
               isOptional: true,
               description:
                 'Process an error, e.g. to log it. Returns error message to include in the data stream. Defaults to () => "An error occurred."',
+            },
+            {
+              name: 'consumeSseStream',
+              type: '(stream: ReadableStream) => Promise<void>',
+              isOptional: true,
+              description:
+                'Function to consume the SSE stream. Required for proper abort handling in UI message streams. Use the `consumeStream` function from the AI SDK.',
             },
           ],
         },

--- a/examples/next-openai/app/api/chat/route.ts
+++ b/examples/next-openai/app/api/chat/route.ts
@@ -11,7 +11,14 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai('gpt-4o'),
     prompt,
+    abortSignal: req.signal,
   });
 
-  return result.toUIMessageStreamResponse();
+  return result.toUIMessageStreamResponse({
+    onFinish: async ({ isAborted }) => {
+      if (isAborted) {
+        console.log('Aborted');
+      }
+    },
+  });
 }

--- a/examples/next-openai/app/api/chat/route.ts
+++ b/examples/next-openai/app/api/chat/route.ts
@@ -25,6 +25,6 @@ export async function POST(req: Request) {
         console.log('Aborted');
       }
     },
-    consumeSseStream: consumeStream,
+    consumeSseStream: consumeStream, // needed for correct abort handling
   });
 }

--- a/examples/next-openai/app/api/chat/route.ts
+++ b/examples/next-openai/app/api/chat/route.ts
@@ -1,5 +1,10 @@
 import { openai } from '@ai-sdk/openai';
-import { convertToModelMessages, streamText, UIMessage } from 'ai';
+import {
+  consumeStream,
+  convertToModelMessages,
+  streamText,
+  UIMessage,
+} from 'ai';
 
 export const maxDuration = 30;
 
@@ -20,5 +25,6 @@ export async function POST(req: Request) {
         console.log('Aborted');
       }
     },
+    consumeSseStream: consumeStream,
   });
 }

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -4,6 +4,7 @@ import { InferUIMessageChunk } from '../../src/ui-message-stream/ui-message-chun
 import { UIMessageStreamResponseInit } from '../../src/ui-message-stream/ui-message-stream-response-init';
 import { InferUIMessageMetadata, UIMessage } from '../../src/ui/ui-messages';
 import { AsyncIterableStream } from '../../src/util/async-iterable-stream';
+import { ErrorHandler } from '../../src/util/error-handler';
 import {
   CallWarning,
   FinishReason,
@@ -13,6 +14,7 @@ import {
 import { Source } from '../types/language-model';
 import { LanguageModelResponseMetadata } from '../types/language-model-response-metadata';
 import { LanguageModelUsage } from '../types/usage';
+import { UIMessageStreamOnFinishCallback } from '../ui-message-stream/ui-message-stream-on-finish-callback';
 import { ContentPart } from './content-part';
 import { GeneratedFile } from './generated-file';
 import { ResponseMessage } from './response-message';
@@ -20,7 +22,6 @@ import { StepResult } from './step-result';
 import { ToolCallUnion } from './tool-call';
 import { ToolErrorUnion, ToolResultUnion } from './tool-output';
 import { ToolSet } from './tool-set';
-import { ErrorHandler } from '../../src/util/error-handler';
 
 export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
   /**
@@ -37,24 +38,7 @@ export type UIMessageStreamOptions<UI_MESSAGE extends UIMessage> = {
    */
   generateMessageId?: IdGenerator;
 
-  onFinish?: (options: {
-    /**
-     * The updates list of UI messages.
-     */
-    messages: UI_MESSAGE[];
-
-    /**
-     * Indicates whether the response message is a continuation of the last original message,
-     * or if a new message was created.
-     */
-    isContinuation: boolean;
-
-    /**
-     * The message that was sent to the client as a response
-     * (including the original message if it was extended).
-     */
-    responseMessage: UI_MESSAGE;
-  }) => PromiseLike<void> | void;
+  onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
 
   /**
    * Extracts message metadata that will be send to the client.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -11920,7 +11920,25 @@ describe('streamText', () => {
       it('should sent an abort chunk in the ui message stream', async () => {
         expect(
           await convertAsyncIterableToArray(result.toUIMessageStream()),
-        ).toMatchInlineSnapshot();
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "type": "start",
+            },
+            {
+              "type": "start-step",
+            },
+            {
+              "id": "1",
+              "type": "text-start",
+            },
+            {
+              "delta": "Hello",
+              "id": "1",
+              "type": "text-delta",
+            },
+          ]
+        `);
       });
     });
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -11918,9 +11918,8 @@ describe('streamText', () => {
       });
 
       it('should sent an abort chunk in the ui message stream', async () => {
-        expect(
-          await convertAsyncIterableToArray(result.toUIMessageStream()),
-        ).toMatchInlineSnapshot(`
+        expect(await convertAsyncIterableToArray(result.toUIMessageStream()))
+          .toMatchInlineSnapshot(`
           [
             {
               "type": "start",
@@ -11936,6 +11935,9 @@ describe('streamText', () => {
               "delta": "Hello",
               "id": "1",
               "type": "text-delta",
+            },
+            {
+              "type": "abort",
             },
           ]
         `);
@@ -12197,6 +12199,55 @@ describe('streamText', () => {
               "providerMetadata": undefined,
               "text": "Hello",
               "type": "text",
+            },
+            {
+              "type": "abort",
+            },
+          ]
+        `);
+      });
+
+      it('should sent an abort chunk in the ui message stream', async () => {
+        expect(
+          await convertAsyncIterableToArray(result.toUIMessageStream()),
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "type": "start",
+            },
+            {
+              "type": "start-step",
+            },
+            {
+              "input": {
+                "value": "value",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-input-available",
+            },
+            {
+              "output": "result1",
+              "providerExecuted": undefined,
+              "toolCallId": "call-1",
+              "type": "tool-output-available",
+            },
+            {
+              "type": "finish-step",
+            },
+            {
+              "type": "start-step",
+            },
+            {
+              "id": "1",
+              "type": "text-start",
+            },
+            {
+              "delta": "Hello",
+              "id": "1",
+              "type": "text-delta",
             },
             {
               "type": "abort",

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -11916,6 +11916,12 @@ describe('streamText', () => {
             ]
           `);
       });
+
+      it('should sent an abort chunk in the ui message stream', async () => {
+        expect(
+          await convertAsyncIterableToArray(result.toUIMessageStream()),
+        ).toMatchInlineSnapshot();
+      });
     });
 
     describe('abort in 2nd step', () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -12208,9 +12208,8 @@ describe('streamText', () => {
       });
 
       it('should sent an abort chunk in the ui message stream', async () => {
-        expect(
-          await convertAsyncIterableToArray(result.toUIMessageStream()),
-        ).toMatchInlineSnapshot(`
+        expect(await convertAsyncIterableToArray(result.toUIMessageStream()))
+          .toMatchInlineSnapshot(`
           [
             {
               "type": "start",

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1846,7 +1846,11 @@ However, the LLM results are expected to be small enough to not cause issues.
               break;
             }
 
-            case 'abort':
+            case 'abort': {
+              controller.enqueue({ type: 'abort' });
+              break;
+            }
+
             case 'tool-input-end': {
               break;
             }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1847,7 +1847,7 @@ However, the LLM results are expected to be small enough to not cause issues.
             }
 
             case 'abort': {
-              controller.enqueue({ type: 'abort' });
+              controller.enqueue(part);
               break;
             }
 

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -396,6 +396,7 @@ describe('createUIMessageStream', () => {
     expect(recordedOptions).toMatchInlineSnapshot(`
       [
         {
+          "isAborted": false,
           "isContinuation": false,
           "messages": [
             {
@@ -461,6 +462,7 @@ describe('createUIMessageStream', () => {
     expect(recordedOptions).toMatchInlineSnapshot(`
       [
         {
+          "isAborted": false,
           "isContinuation": true,
           "messages": [
             {
@@ -541,6 +543,7 @@ describe('createUIMessageStream', () => {
     expect(recordedOptions).toMatchInlineSnapshot(`
       [
         {
+          "isAborted": false,
           "isContinuation": false,
           "messages": [
             {
@@ -599,6 +602,7 @@ describe('createUIMessageStream', () => {
     expect(recordedOptions).toMatchInlineSnapshot(`
       [
         {
+          "isAborted": false,
           "isContinuation": false,
           "messages": [
             {

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.ts
@@ -6,6 +6,7 @@ import {
 import { UIMessage } from '../ui/ui-messages';
 import { handleUIMessageStreamFinish } from './handle-ui-message-stream-finish';
 import { InferUIMessageChunk } from './ui-message-chunks';
+import { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
 import { UIMessageStreamWriter } from './ui-message-stream-writer';
 
 export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
@@ -26,24 +27,7 @@ export function createUIMessageStream<UI_MESSAGE extends UIMessage>({
    */
   originalMessages?: UI_MESSAGE[];
 
-  onFinish?: (options: {
-    /**
-     * The updates list of UI messages.
-     */
-    messages: UI_MESSAGE[];
-
-    /**
-     * Indicates whether the response message is a continuation of the last original message,
-     * or if a new message was created.
-     */
-    isContinuation: boolean;
-
-    /**
-     * The message that was sent to the client as a response
-     * (including the original message if it was extended).
-     */
-    responseMessage: UI_MESSAGE;
-  }) => void | PromiseLike<void>;
+  onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
 
   generateId?: IdGenerator;
 }): ReadableStream<InferUIMessageChunk<UI_MESSAGE>> {

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
@@ -1,0 +1,237 @@
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
+import { describe, expect, it, vi } from 'vitest';
+import { UIMessage } from '../ui/ui-messages';
+import { UIMessageChunk } from './ui-message-chunks';
+import { handleUIMessageStreamFinish } from './handle-ui-message-stream-finish';
+
+function createUIMessageStream(parts: UIMessageChunk[]) {
+  return convertArrayToReadableStream(parts);
+}
+
+describe('handleUIMessageStreamFinish', () => {
+  const mockErrorHandler = vi.fn();
+
+  beforeEach(() => {
+    mockErrorHandler.mockClear();
+  });
+
+  describe('stream pass-through without onFinish', () => {
+    it('should pass through stream chunks without processing when onFinish is not provided', async () => {
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-delta', id: 'text-1', delta: ' World' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-123',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        // onFinish is not provided
+      });
+
+      const result = await convertReadableStreamToArray(resultStream);
+
+      expect(result).toEqual(inputChunks);
+      expect(mockErrorHandler).not.toHaveBeenCalled();
+    });
+
+    it('should inject messageId when not present in start chunk', async () => {
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start' }, // no messageId
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Test' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'injected-123',
+        originalMessages: [],
+        onError: mockErrorHandler,
+      });
+
+      const result = await convertReadableStreamToArray(resultStream);
+
+      expect(result[0]).toEqual({ type: 'start', messageId: 'injected-123' });
+      expect(result.slice(1)).toEqual(inputChunks.slice(1));
+    });
+  });
+
+  describe('stream processing with onFinish callback', () => {
+    it('should process stream and call onFinish with correct parameters', async () => {
+      const onFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-456' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+        { type: 'text-delta', id: 'text-1', delta: ' World' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish' },
+      ];
+
+      const originalMessages: UIMessage[] = [
+        {
+          id: 'user-msg-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-456',
+        originalMessages,
+        onError: mockErrorHandler,
+        onFinish: onFinishCallback,
+      });
+
+      const result = await convertReadableStreamToArray(resultStream);
+
+      expect(result).toEqual(inputChunks);
+      expect(onFinishCallback).toHaveBeenCalledTimes(1);
+
+      const callArgs = onFinishCallback.mock.calls[0][0];
+      expect(callArgs.isContinuation).toBe(false);
+      expect(callArgs.responseMessage.id).toBe('msg-456');
+      expect(callArgs.responseMessage.role).toBe('assistant');
+      expect(callArgs.messages).toHaveLength(2);
+      expect(callArgs.messages[0]).toEqual(originalMessages[0]);
+      expect(callArgs.messages[1]).toEqual(callArgs.responseMessage);
+    });
+
+    it('should handle empty original messages array', async () => {
+      const onFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-789' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Response' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish' },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-789',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onFinish: onFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onFinishCallback).toHaveBeenCalledTimes(1);
+
+      const callArgs = onFinishCallback.mock.calls[0][0];
+      expect(callArgs.isContinuation).toBe(false);
+      expect(callArgs.messages).toHaveLength(1);
+      expect(callArgs.messages[0]).toEqual(callArgs.responseMessage);
+    });
+  });
+
+  describe('stream processing with continuation scenario', () => {
+    it('should handle continuation when last message is assistant', async () => {
+      const onFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'assistant-msg-1' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: ' continued' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish' },
+      ];
+
+      const originalMessages: UIMessage[] = [
+        {
+          id: 'user-msg-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Continue this' }],
+        },
+        {
+          id: 'assistant-msg-1',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'This is' }],
+        },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-999', // this should be ignored since we're continuing
+        originalMessages,
+        onError: mockErrorHandler,
+        onFinish: onFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onFinishCallback).toHaveBeenCalledTimes(1);
+
+      const callArgs = onFinishCallback.mock.calls[0][0];
+      expect(callArgs.isContinuation).toBe(true);
+      expect(callArgs.responseMessage.id).toBe('assistant-msg-1'); // uses the existing assistant message id
+      expect(callArgs.messages).toHaveLength(2); // original user message + updated assistant message
+      expect(callArgs.messages[0]).toEqual(originalMessages[0]);
+      expect(callArgs.messages[1]).toEqual(callArgs.responseMessage);
+    });
+
+    it('should not treat user message as continuation', async () => {
+      const onFinishCallback = vi.fn();
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-001' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'New response' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish' },
+      ];
+
+      const originalMessages: UIMessage[] = [
+        {
+          id: 'user-msg-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Question' }],
+        },
+        {
+          id: 'user-msg-2',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Another question' }],
+        },
+      ];
+
+      const stream = createUIMessageStream(inputChunks);
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream,
+        messageId: 'msg-001',
+        originalMessages,
+        onError: mockErrorHandler,
+        onFinish: onFinishCallback,
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(onFinishCallback).toHaveBeenCalledTimes(1);
+
+      const callArgs = onFinishCallback.mock.calls[0][0];
+      expect(callArgs.isContinuation).toBe(false);
+      expect(callArgs.responseMessage.id).toBe('msg-001');
+      expect(callArgs.messages).toHaveLength(3); // 2 user messages + 1 new assistant message
+    });
+  });
+});

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -42,6 +42,8 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
     messageId = lastMessage.id;
   }
 
+  let isAborted = false;
+
   const idInjectedStream = stream.pipeThrough(
     new TransformStream<
       InferUIMessageChunk<UI_MESSAGE>,
@@ -56,6 +58,10 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
           if (startChunk.messageId == null && messageId != null) {
             startChunk.messageId = messageId;
           }
+        }
+
+        if (chunk.type === 'abort') {
+          isAborted = true;
         }
 
         controller.enqueue(chunk);
@@ -99,6 +105,7 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
       async flush() {
         const isContinuation = state.message.id === lastMessage?.id;
         await onFinish({
+          isAborted,
           isContinuation,
           responseMessage: state.message as UI_MESSAGE,
           messages: [

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -6,6 +6,7 @@ import {
 import { UIMessage } from '../ui/ui-messages';
 import { ErrorHandler } from '../util/error-handler';
 import { InferUIMessageChunk, UIMessageChunk } from './ui-message-chunks';
+import { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
 
 export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   messageId,
@@ -29,24 +30,7 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
 
   onError: ErrorHandler;
 
-  onFinish?: (options: {
-    /**
-     * The updates list of UI messages.
-     */
-    messages: UI_MESSAGE[];
-
-    /**
-     * Indicates whether the response message is a continuation of the last original message,
-     * or if a new message was created.
-     */
-    isContinuation: boolean;
-
-    /**
-     * The message that was sent to the client as a response
-     * (including the original message if it was extended).
-     */
-    responseMessage: UI_MESSAGE;
-  }) => void | PromiseLike<void>;
+  onFinish?: UIMessageStreamOnFinishCallback<UI_MESSAGE>;
 }): ReadableStream<InferUIMessageChunk<UI_MESSAGE>> {
   // last message is only relevant for assistant messages
   let lastMessage: UI_MESSAGE | undefined =

--- a/packages/ai/src/ui-message-stream/index.ts
+++ b/packages/ai/src/ui-message-stream/index.ts
@@ -5,4 +5,5 @@ export { pipeUIMessageStreamToResponse } from './pipe-ui-message-stream-to-respo
 export { readUIMessageStream } from './read-ui-message-stream';
 export type { InferUIMessageChunk, UIMessageChunk } from './ui-message-chunks';
 export { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
+export type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
 export type { UIMessageStreamWriter } from './ui-message-stream-writer';

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -130,6 +130,9 @@ export const uiMessageChunkSchema = z.union([
     messageMetadata: z.unknown().optional(),
   }),
   z.strictObject({
+    type: z.literal('abort'),
+  }),
+  z.strictObject({
     type: z.literal('message-metadata'),
     messageMetadata: z.unknown(),
   }),
@@ -250,6 +253,9 @@ export type UIMessageChunk<
   | {
       type: 'finish';
       messageMetadata?: METADATA;
+    }
+  | {
+      type: 'abort';
     }
   | {
       type: 'message-metadata';

--- a/packages/ai/src/ui-message-stream/ui-message-stream-on-finish-callback.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-on-finish-callback.ts
@@ -3,7 +3,7 @@ import { UIMessage } from '../ui/ui-messages';
 export type UIMessageStreamOnFinishCallback<UI_MESSAGE extends UIMessage> =
   (event: {
     /**
-     * The updates list of UI messages.
+     * The updated list of UI messages.
      */
     messages: UI_MESSAGE[];
 
@@ -12,6 +12,11 @@ export type UIMessageStreamOnFinishCallback<UI_MESSAGE extends UIMessage> =
      * or if a new message was created.
      */
     isContinuation: boolean;
+
+    /**
+     * Indicates whether the stream was aborted.
+     */
+    isAborted: boolean;
 
     /**
      * The message that was sent to the client as a response

--- a/packages/ai/src/ui-message-stream/ui-message-stream-on-finish-callback.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-on-finish-callback.ts
@@ -1,0 +1,21 @@
+import { UIMessage } from '../ui/ui-messages';
+
+export type UIMessageStreamOnFinishCallback<UI_MESSAGE extends UIMessage> =
+  (event: {
+    /**
+     * The updates list of UI messages.
+     */
+    messages: UI_MESSAGE[];
+
+    /**
+     * Indicates whether the response message is a continuation of the last original message,
+     * or if a new message was created.
+     */
+    isContinuation: boolean;
+
+    /**
+     * The message that was sent to the client as a response
+     * (including the original message if it was extended).
+     */
+    responseMessage: UI_MESSAGE;
+  }) => PromiseLike<void> | void;

--- a/packages/ai/src/util/index.ts
+++ b/packages/ai/src/util/index.ts
@@ -1,4 +1,5 @@
 export type { AsyncIterableStream } from './async-iterable-stream';
+export { consumeStream } from './consume-stream';
 export { cosineSimilarity } from './cosine-similarity';
 export { getTextFromDataUrl } from './data-url';
 export type { DeepPartial } from './deep-partial';

--- a/packages/provider-utils/src/is-abort-error.ts
+++ b/packages/provider-utils/src/is-abort-error.ts
@@ -1,6 +1,8 @@
 export function isAbortError(error: unknown): error is Error {
   return (
     error instanceof Error &&
-    (error.name === 'AbortError' || error.name === 'TimeoutError')
+    (error.name === 'AbortError' ||
+      error.name === 'ResponseAborted' || // Next.js
+      error.name === 'TimeoutError')
   );
 }


### PR DESCRIPTION
## Background

We recommend persisting UI messages. However, the `streamText.onAbort` callback works on the model message level.

## Summary

* send abort chunks in the ui message stream
* introduce `UIMessageStreamOnFinishCallback` type
* add `isAborted` flag to `UIMessageStreamOnFinishCallback`
* add response aborted error type for nextjs
* expose consumeStream

## Note

Consuming the UI message stream is necessary because the client/server connection is gone when the fetch is aborted from the client, and because of the backpressure we need a separate ui message stream consumer.

## Verification

- [x] Check next-openai abort scenario manually

## Tasks

- [x] add abort chunk to ui message chunks
- [x] extract ui message stream onfinish callback type
- [x] add callback mechanism / extend on finish handler
- [x] evaluate processUIMessageStream impact
- [x] changeset

## Related Issues

Continues work from #7394