### PR TITLE
feat (ai): make streamText toUIMessageStream async iterable

### DIFF
--- a/.changeset/small-flies-greet.md
+++ b/.changeset/small-flies-greet.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): make streamText toUIMessageStream async iterable

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -277,7 +277,7 @@ If an error occurs, it is passed to the optional `onError` callback.
      */
   toUIMessageStream<UI_MESSAGE extends UIMessage>(
     options?: UIMessageStreamOptions<UI_MESSAGE>,
-  ): ReadableStream<InferUIMessageChunk<UI_MESSAGE>>;
+  ): AsyncIterableStream<InferUIMessageChunk<UI_MESSAGE>>;
 
   /**
   Writes UI message stream output to a Node.js response-like object.

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1619,7 +1619,7 @@ However, the LLM results are expected to be small enough to not cause issues.
     sendStart = true,
     sendFinish = true,
     onError = getErrorMessage,
-  }: UIMessageStreamOptions<UI_MESSAGE> = {}): ReadableStream<
+  }: UIMessageStreamOptions<UI_MESSAGE> = {}): AsyncIterableStream<
     InferUIMessageChunk<UI_MESSAGE>
   > {
     const responseMessageId =
@@ -1879,13 +1879,15 @@ However, the LLM results are expected to be small enough to not cause issues.
       }),
     );
 
-    return handleUIMessageStreamFinish<UI_MESSAGE>({
-      stream: baseStream,
-      messageId: responseMessageId ?? generateMessageId?.(),
-      originalMessages,
-      onFinish,
-      onError,
-    });
+    return createAsyncIterableStream(
+      handleUIMessageStreamFinish<UI_MESSAGE>({
+        stream: baseStream,
+        messageId: responseMessageId ?? generateMessageId?.(),
+        originalMessages,
+        onFinish,
+        onError,
+      }),
+    );
   }
 
   pipeUIMessageStreamToResponse<UI_MESSAGE extends UIMessage>(


### PR DESCRIPTION
## Background

All stream functions should also be async iterable to make them easier to use.

## Summary

make streamText toUIMessageStream async iterable