### PR TITLE
fix (provider/gateway): remove unnecessary `x-` prefix on auth method header

### DIFF
--- a/.changeset/tough-pugs-drive.md
+++ b/.changeset/tough-pugs-drive.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix (provider/gateway): remove unnecessary 'x-' prefix on auth method header

--- a/packages/gateway/src/errors/parse-auth-method.test.ts
+++ b/packages/gateway/src/errors/parse-auth-method.test.ts
@@ -6,7 +6,7 @@ import {
 
 describe('GATEWAY_AUTH_METHOD_HEADER', () => {
   it('should export the correct header name', () => {
-    expect(GATEWAY_AUTH_METHOD_HEADER).toBe('x-ai-gateway-auth-method');
+    expect(GATEWAY_AUTH_METHOD_HEADER).toBe('ai-gateway-auth-method');
   });
 });
 

--- a/packages/gateway/src/errors/parse-auth-method.ts
+++ b/packages/gateway/src/errors/parse-auth-method.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod/v4';
 
-export const GATEWAY_AUTH_METHOD_HEADER = 'x-ai-gateway-auth-method' as const;
+export const GATEWAY_AUTH_METHOD_HEADER = 'ai-gateway-auth-method' as const;
 
 export function parseAuthMethod(headers: Record<string, string | undefined>) {
   const result = gatewayAuthMethodSchema.safeParse(

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -31,7 +31,7 @@ const createTestModel = (
     baseURL: 'https://api.test.com',
     headers: () => ({
       Authorization: 'Bearer test-token',
-      'x-ai-gateway-auth-method': 'api-key',
+      'ai-gateway-auth-method': 'api-key',
     }),
     fetch: globalThis.fetch,
     o11yHeaders: config.o11yHeaders || {},

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -81,7 +81,7 @@ describe('GatewayProvider', () => {
         Authorization: 'Bearer test-api-key',
         'Custom-Header': 'value',
         'ai-gateway-protocol-version': expect.any(String),
-        'x-ai-gateway-auth-method': 'api-key',
+        'ai-gateway-auth-method': 'api-key',
       });
     });
 
@@ -102,7 +102,7 @@ describe('GatewayProvider', () => {
         Authorization: 'Bearer mock-oidc-token',
         'Custom-Header': 'value',
         'ai-gateway-protocol-version': expect.any(String),
-        'x-ai-gateway-auth-method': 'oidc',
+        'ai-gateway-auth-method': 'oidc',
       });
     });
 
@@ -378,7 +378,7 @@ describe('GatewayProvider', () => {
 
       // Verify that the API key was used in the Authorization header
       expect(headers.Authorization).toBe(`Bearer ${testApiKey}`);
-      expect(headers['x-ai-gateway-auth-method']).toBe('api-key');
+      expect(headers['ai-gateway-auth-method']).toBe('api-key');
 
       // Verify getVercelOidcToken was never called
       expect(getVercelOidcToken).not.toHaveBeenCalled();


### PR DESCRIPTION
## Background

The Gateway provider added a header to report the auth method used to the server. We included an `x-` prefix but this is unnecessary and makes the header different from our other existing `ai-` headers.

## Summary

Standardize on `ai-` as a prefix and remove the `x-` prefix from the auth method header.
