### PR TITLE
feat: export fixJson from ai

### DIFF
--- a/packages/ai/src/util/index.ts
+++ b/packages/ai/src/util/index.ts
@@ -8,3 +8,4 @@ export { isDeepEqualData } from './is-deep-equal-data';
 export { parsePartialJson } from './parse-partial-json';
 export { SerialJobExecutor } from './serial-job-executor';
 export { simulateReadableStream } from './simulate-readable-stream';
+export { fixJson } from './fix-json';


### PR DESCRIPTION
Exports `fixJSON` util. 

For context, I'm trying to only use the `fixJSON` method to repair a custom tool call. `parsePartialJson` is async so I didn't opt for that.