### PR TITLE
feat (provider/vercel): update chat model ids and examples

### DIFF
--- a/.changeset/empty-schools-cheer.md
+++ b/.changeset/empty-schools-cheer.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/vercel': patch
+---
+
+feat (provider/vercel): update chat model ids and examples

--- a/examples/ai-core/src/generate-object/vercel.ts
+++ b/examples/ai-core/src/generate-object/vercel.ts
@@ -5,23 +5,28 @@ import { z } from 'zod/v4';
 
 async function main() {
   const result = await generateObject({
-    model: vercel('v0-1.0-md'),
+    model: vercel('v0-1.5-md'),
     schema: z.object({
-      recipe: z.object({
-        name: z.string(),
-        ingredients: z.array(
-          z.object({
-            name: z.string(),
-            amount: z.string(),
-          }),
-        ),
-        steps: z.array(z.string()),
+      button: z.object({
+        element: z.string(),
+        baseStyles: z.object({
+          padding: z.string(),
+          borderRadius: z.string(),
+          border: z.string(),
+          backgroundColor: z.string(),
+          color: z.string(),
+          cursor: z.string(),
+        }),
+        hoverStyles: z.object({
+          backgroundColor: z.string(),
+          transform: z.string().optional(),
+        }),
       }),
     }),
-    prompt: 'Generate a lasagna recipe.',
+    prompt: 'Generate CSS styles for a modern primary button component.',
   });
 
-  console.log(JSON.stringify(result.object.recipe, null, 2));
+  console.log(JSON.stringify(result.object.button, null, 2));
   console.log();
   console.log('Token usage:', result.usage);
   console.log('Finish reason:', result.finishReason);

--- a/examples/ai-core/src/generate-text/vercel.ts
+++ b/examples/ai-core/src/generate-text/vercel.ts
@@ -4,9 +4,8 @@ import { generateText } from 'ai';
 
 async function main() {
   const result = await generateText({
-    model: vercel('v0-1.0-md'),
-    // prompt: 'Invent a new holiday and describe its traditions.',
-    prompt: 'Create a Next.js AI chatbot',
+    model: vercel('v0-1.5-md'),
+    prompt: 'Implement Fibonacci in Lua.',
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/stream-object/vercel.ts
+++ b/examples/ai-core/src/stream-object/vercel.ts
@@ -5,20 +5,25 @@ import { z } from 'zod/v4';
 
 async function main() {
   const result = streamObject({
-    model: vercel('v0-1.0-md'),
+    model: vercel('v0-1.5-md'),
     schema: z.object({
-      characters: z.array(
-        z.object({
-          name: z.string(),
-          class: z
-            .string()
-            .describe('Character class, e.g. warrior, mage, or thief.'),
-          description: z.string(),
+      button: z.object({
+        element: z.string(),
+        baseStyles: z.object({
+          padding: z.string(),
+          borderRadius: z.string(),
+          border: z.string(),
+          backgroundColor: z.string(),
+          color: z.string(),
+          cursor: z.string(),
         }),
-      ),
+        hoverStyles: z.object({
+          backgroundColor: z.string(),
+          transform: z.string().optional(),
+        }),
+      }),
     }),
-    prompt:
-      'Generate 3 character descriptions for a fantasy role playing game.',
+    prompt: 'Generate CSS styles for a modern primary button component.',
   });
 
   for await (const partialObject of result.partialObjectStream) {

--- a/examples/ai-core/src/stream-text/vercel.ts
+++ b/examples/ai-core/src/stream-text/vercel.ts
@@ -4,14 +4,10 @@ import 'dotenv/config';
 
 async function main() {
   const result = streamText({
-    model: vercel('v0-1.0-md'),
-    prompt: 'Invent a new holiday and describe its traditions.',
-    onError: error => {
-      console.error(error);
-    },
+    model: vercel('v0-1.5-md'),
+    prompt: 'Implement Fibonacci in Lua.',
   });
 
-  console.log(result);
   for await (const textPart of result.textStream) {
     process.stdout.write(textPart);
   }

--- a/packages/vercel/src/vercel-chat-options.ts
+++ b/packages/vercel/src/vercel-chat-options.ts
@@ -1,2 +1,6 @@
-// https://vercel.com/docs/v0/api
-export type VercelChatModelId = 'v0-1.0-md' | (string & {});
+// https://v0.dev/docs/v0-model-api
+export type VercelChatModelId =
+  | 'v0-1.0-md'
+  | 'v0-1.5-md'
+  | 'v0-1.5-lg'
+  | (string & {});


### PR DESCRIPTION
## Background

v0 has updated its available model ids.

## Summary

Added new model ids and updated existing vercel examples to reflect the new non-legacy model.

## Future Work

Note the generate and stream object examples are not fully operational -- further work appears required either in the provider or model side or both.
