### PR TITLE
feat: locale aware chunking in smoothStream via `Intl.Segmenter`

### DIFF
--- a/.changeset/grumpy-falcons-collect.md
+++ b/.changeset/grumpy-falcons-collect.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): locale-aware segmentation for `smoothStream`

--- a/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
@@ -42,10 +42,17 @@ const result = streamText({
     },
     {
       name: 'chunking',
-      type: '"word" | "line" | RegExp | (buffer: string) => string | undefined | null',
+      type: '"word" | "line" | "grapheme" | "word-intl" | "sentence" | RegExp | (buffer: string) => string | undefined | null',
       isOptional: true,
       description:
-        'Controls how the text is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, or provide a custom callback or RegExp pattern for custom chunking.',
+        'Controls how the text is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, "grapheme" for character-level using Intl.Segmenter, "word-intl" for locale-aware word segmentation, "sentence" for sentence boundaries, or provide a custom callback or RegExp pattern for custom chunking.',
+    },
+    {
+      name: 'segmenterOptions',
+      type: '{ locale?: string | string[]; localeMatcher?: "lookup" | "best fit" }',
+      isOptional: true,
+      description:
+        'Options for Intl.Segmenter when using "grapheme", "word-intl", or "sentence" chunking. Specify locale for language-specific segmentation.',
     },
   ]}
 />
@@ -53,18 +60,21 @@ const result = streamText({
 #### Word chunking caveats with non-latin languages
 
 <Note>
-    The word based chunking **does not work well** with the following languages that do not delimit words with spaces:
+    The default "word" chunking **does not work well** with languages that do not delimit words with spaces.
 
-    For these languages we recommend using a custom regex, like the following:
+    **Recommended solution**: Use `chunking: "word-intl"` with appropriate `segmenterOptions.locale`:
+
+    ```ts
+    smoothStream({
+      chunking: 'word-intl',
+      segmenterOptions: { locale: 'ja' } // for Japanese
+    })
+    ```
+
+    Alternatively, you can use custom regex or chunking functions:
 
     - Chinese - `/[\u4E00-\u9FFF]|\S+\s+/`
     - Japanese - `/[\u3040-\u309F\u30A0-\u30FF]|\S+\s+/`
-
-    For these languages you could pass your own language aware chunking function:
-
-    - Vietnamese
-    - Thai
-    - Javanese (Aksara Jawa)
 
 </Note>
 


### PR DESCRIPTION
## Background

Currently `smoothStream` uses regex based chunking, but for many languages that doesn't use space delimiter it doesn't work well and we need to manually provide chunks. This often times performant and robust then regex based approaches and unlocks new chucking strategies (grapheme and sentence). This API is also [widely supported](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter#browser_compatibility) for sometime now.

## Summary

Added new chunking options (word-intl, grapheme and sentence) using `Intl.Segmenter` and also added locale specific options via `segmenterOptions` option.

```ts
smoothStream({
  delayInMs: 10,
  chunking: 'word-intl',
  segmenterOptions: { locale: 'ja' },
})

smoothStream({
  chunking: 'grapheme',
})
```

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

`Intl.Segmenter` can be made default chunking instead of regex based chunking and overall API can be improved targeting DX

