### PR TITLE
fix(docs): replace language model specification url with v2

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -9,7 +9,7 @@ Companies such as OpenAI and Anthropic (providers) offer access to a range of la
 
 Each provider typically has its own unique method for interfacing with their models, complicating the process of switching providers and increasing the risk of vendor lock-in.
 
-To solve these challenges, AI SDK Core offers a standardized approach to interacting with LLMs through a [language model specification](https://github.com/vercel/ai/tree/main/packages/provider/src/language-model/v1) that abstracts differences between providers. This unified interface allows you to switch between providers with ease while using the same API for all providers.
+To solve these challenges, AI SDK Core offers a standardized approach to interacting with LLMs through a [language model specification](https://github.com/vercel/ai/tree/main/packages/provider/src/language-model/v2) that abstracts differences between providers. This unified interface allows you to switch between providers with ease while using the same API for all providers.
 
 Here is an overview of the AI SDK Provider Architecture:
 


### PR DESCRIPTION
## Background

The "language model specification" link in the [Providers and Models](https://v5.ai-sdk.dev/docs/foundations/providers-and-models#providers-and-models) section of the documentation was outdated and pointed to an incorrect repository path.

## Summary

This PR updates the link to point to the correct and current location of the language model specification.