### PR TITLE
fix (provider/perplexity): fix generateObject with reasoning models

### DIFF
--- a/.changeset/strange-toys-clean.md
+++ b/.changeset/strange-toys-clean.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/perplexity': patch
+---
+
+fix (provider/perplexity): fix generateObject with reasoning models

--- a/packages/perplexity/src/extract-json-from-reasoning-response.test.ts
+++ b/packages/perplexity/src/extract-json-from-reasoning-response.test.ts
@@ -1,0 +1,27 @@
+import { extractJSONFromReasoningResponse } from './extract-json-from-reasoning-response';
+
+describe('extractJSONFromReasoningResponse', () => {
+  it('should extract JSON after </think> tag', () => {
+    const text = '<think>Some thinking process</think>{"result": "success"}';
+    const result = extractJSONFromReasoningResponse(text);
+    expect(result).toBe('{"result": "success"}');
+  });
+
+  it('should handle markdown code fences', () => {
+    const text = '<think>Thinking</think>```json\n{"data": "value"}\n```';
+    const result = extractJSONFromReasoningResponse(text);
+    expect(result).toBe('{"data": "value"}');
+  });
+
+  it('should handle generic code fences', () => {
+    const text = '<think>Thinking</think>```\n{"data": "value"}\n```';
+    const result = extractJSONFromReasoningResponse(text);
+    expect(result).toBe('{"data": "value"}');
+  });
+
+  it('should return original text when no </think> tag is found', () => {
+    const text = '{"direct": "response"}';
+    const result = extractJSONFromReasoningResponse(text);
+    expect(result).toBe('{"direct": "response"}');
+  });
+});

--- a/packages/perplexity/src/extract-json-from-reasoning-response.ts
+++ b/packages/perplexity/src/extract-json-from-reasoning-response.ts
@@ -1,0 +1,32 @@
+/**
+ * Extracts JSON content from reasoning model responses by finding content after </think> tag
+ * More robust implementation that handles markdown code fences and multiple think sections
+ *
+ * @see https://docs.perplexity.ai/guides/structured-outputs#structured-outputs-for-reasoning-models
+ */
+export function extractJSONFromReasoningResponse(text: string): string {
+  // Find the index of the closing </think> tag.
+  const marker = '</think>';
+  const idx = text.lastIndexOf(marker);
+
+  if (idx === -1) {
+    // No </think> tag found, return original text as-is
+    return text.trim();
+  }
+
+  // Extract the substring after the marker.
+  let jsonStr = text.substring(idx + marker.length).trim();
+
+  // Remove markdown code fence markers if present.
+  if (jsonStr.startsWith('```json')) {
+    jsonStr = jsonStr.substring('```json'.length).trim();
+  }
+  if (jsonStr.startsWith('```')) {
+    jsonStr = jsonStr.substring(3).trim();
+  }
+  if (jsonStr.endsWith('```')) {
+    jsonStr = jsonStr.substring(0, jsonStr.length - 3).trim();
+  }
+
+  return jsonStr;
+}

--- a/packages/perplexity/src/is-reasoning-model.ts
+++ b/packages/perplexity/src/is-reasoning-model.ts
@@ -1,0 +1,11 @@
+/**
+ * Checks if the model is a reasoning model that outputs <think> sections
+ */
+export function isReasoningModel(modelId: string): boolean {
+  const reasoningModels = [
+    'sonar-deep-research',
+    'sonar-reasoning-pro',
+    'sonar-reasoning',
+  ];
+  return reasoningModels.includes(modelId);
+}


### PR DESCRIPTION
## Background

Perplexity reasoning models (`sonar-deep-research`, `sonar-reasoning-pro`, `sonar-reasoning`) include `<think>` sections in their responses that contain reasoning tokens. When using `generateObject` with structured output, these sections cause `AI_NoObjectGeneratedError` because the response cannot be parsed as valid JSON.

Fixes #6887 

## Summary

- Added automatic extraction of JSON content from Perplexity reasoning model responses
- Only applies when using `responseFormat: { type: 'json' }` for structured output
- Preserves `<think>` sections for plain text generation (no `responseFormat`)

## Verification

Installed @ai-sdk/perplexity from local repo, and ran generateObject with reasoning model. 

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

https://github.com/vercel/ai/issues/6887
