### PR TITLE
feat (provider/openai-compatible): add includeUsage option

### DIFF
--- a/.changeset/neat-frogs-shop.md
+++ b/.changeset/neat-frogs-shop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Add (optional) includeUsage option to createOpenAICompatible

--- a/content/providers/02-openai-compatible-providers/index.mdx
+++ b/content/providers/02-openai-compatible-providers/index.mdx
@@ -44,6 +44,7 @@ const provider = createOpenAICompatible({
   name: 'provider-name',
   apiKey: process.env.PROVIDER_API_KEY,
   baseURL: 'https://api.provider.com/v1',
+  includeUsage: true, // Include usage information in streaming responses
 });
 ```
 
@@ -74,6 +75,10 @@ You can use the following optional settings to customize the provider instance:
   Defaults to the global `fetch` function.
   You can use it as a middleware to intercept requests,
   or to provide a custom fetch implementation for e.g. testing.
+
+- **includeUsage** _boolean_
+
+  Include usage information in streaming responses. When enabled, usage data will be included in the response metadata for streaming requests. Defaults to `undefined` (`false`).
 
 ## Language Models
 

--- a/packages/openai-compatible/src/openai-compatible-provider.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.test.ts
@@ -179,4 +179,80 @@ describe('OpenAICompatibleProvider', () => {
       );
     });
   });
+
+  describe('includeUsage setting', () => {
+    it('should pass includeUsage: true to all model types when specified in provider settings', () => {
+      const options = {
+        baseURL: 'https://api.example.com',
+        name: 'test-provider',
+        includeUsage: true,
+      };
+      const provider = createOpenAICompatible(options);
+
+      provider.chatModel('chat-model');
+      expect(
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0][1].includeUsage,
+      ).toBe(true);
+
+      provider.completionModel('completion-model');
+      expect(
+        OpenAICompatibleCompletionLanguageModelMock.mock.calls[0][1]
+          .includeUsage,
+      ).toBe(true);
+
+      provider('model-id');
+      expect(
+        OpenAICompatibleChatLanguageModelMock.mock.calls[1][1].includeUsage,
+      ).toBe(true);
+    });
+
+    it('should pass includeUsage: false to all model types when specified in provider settings', () => {
+      const options = {
+        baseURL: 'https://api.example.com',
+        name: 'test-provider',
+        includeUsage: false,
+      };
+      const provider = createOpenAICompatible(options);
+
+      provider.chatModel('chat-model');
+      expect(
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0][1].includeUsage,
+      ).toBe(false);
+
+      provider.completionModel('completion-model');
+      expect(
+        OpenAICompatibleCompletionLanguageModelMock.mock.calls[0][1]
+          .includeUsage,
+      ).toBe(false);
+
+      provider('model-id');
+      expect(
+        OpenAICompatibleChatLanguageModelMock.mock.calls[1][1].includeUsage,
+      ).toBe(false);
+    });
+
+    it('should pass includeUsage: undefined to all model types when not specified in provider settings', () => {
+      const options = {
+        baseURL: 'https://api.example.com',
+        name: 'test-provider',
+      };
+      const provider = createOpenAICompatible(options);
+
+      provider.chatModel('chat-model');
+      expect(
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0][1].includeUsage,
+      ).toBeUndefined();
+
+      provider.completionModel('completion-model');
+      expect(
+        OpenAICompatibleCompletionLanguageModelMock.mock.calls[0][1]
+          .includeUsage,
+      ).toBeUndefined();
+
+      provider('model-id');
+      expect(
+        OpenAICompatibleChatLanguageModelMock.mock.calls[1][1].includeUsage,
+      ).toBeUndefined();
+    });
+  });
 });

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -63,6 +63,11 @@ Custom fetch implementation. You can use it as a middleware to intercept request
 or to provide a custom fetch implementation for e.g. testing.
    */
   fetch?: FetchFunction;
+
+  /**
+Include usage information in streaming responses.
+   */
+  includeUsage?: boolean;
 }
 
 /**
@@ -113,16 +118,16 @@ export function createOpenAICompatible<
     createChatModel(modelId);
 
   const createChatModel = (modelId: CHAT_MODEL_IDS) =>
-    new OpenAICompatibleChatLanguageModel(
-      modelId,
-      getCommonModelConfig('chat'),
-    );
+    new OpenAICompatibleChatLanguageModel(modelId, {
+      ...getCommonModelConfig('chat'),
+      includeUsage: options.includeUsage,
+    });
 
   const createCompletionModel = (modelId: COMPLETION_MODEL_IDS) =>
-    new OpenAICompatibleCompletionLanguageModel(
-      modelId,
-      getCommonModelConfig('completion'),
-    );
+    new OpenAICompatibleCompletionLanguageModel(modelId, {
+      ...getCommonModelConfig('completion'),
+      includeUsage: options.includeUsage,
+    });
 
   const createEmbeddingModel = (modelId: EMBEDDING_MODEL_IDS) =>
     new OpenAICompatibleEmbeddingModel(modelId, {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Users of the openai-compatible provider were unable to configure usage tracking in streaming responses. When
attempting to pass `stream_options: { include_usage: true }` through `providerOptions`, the setting would be
overridden by the internal model configuration logic, which always set `stream_options` to `undefined` when `this.
config.includeUsage` was not explicitly configured. And there was no way to explicitly configure it.

## Summary

<!-- What did you change? -->

Added an `includeUsage?: boolean` option to the `OpenAICompatibleProviderSettings` interface that allows users to
configure usage tracking at the provider level. The setting is properly forwarded to both chat and completion model
configurations, enabling `stream_options: { include_usage: true }` in API requests when set to `true`.

**Changes made:**
- Added `includeUsage?: boolean` to `OpenAICompatibleProviderSettings` interface
- Updated `createChatModel` and `createCompletionModel` functions to pass the setting through to model configs
- Added tests covering all three states (`true`, `false`, `undefined`) across all model types

**Usage:**
```typescript
const provider = createOpenAICompatible({
  baseURL: 'https://api.example.com/v1',
  name: 'my-provider',
  includeUsage: true, // Now configurable!
  apiKey: 'your-key'
});
```

## Verification

1. Created a test provider with includeUsage: true and verified that the setting is passed to model constructors
3. Verified backward compatibility by testing providers without the includeUsage setting (should remain undefined)

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A patch changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the
project root)
- [x] Formatting issues have been fixed (run pnpm prettier-fix in the project root)

## Future Work

—

## Related Issues

Fixes #6774