### PR TITLE
chore(ai): bundle dependencies in CLI binary

### DIFF
--- a/.changeset/perfect-bottles-ring.md
+++ b/.changeset/perfect-bottles-ring.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(ai): bundle dependencies in CLI binary

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -33,28 +33,16 @@ export default defineConfig([
     dts: true,
     sourcemap: true,
   },
-  // CLI binary
-  {
-    entry: ['src/bin/ai.ts'],
-    outDir: 'dist/bin',
-    format: ['cjs'],
-    bundle: true,
-    sourcemap: true,
-    banner: {
-      js: '#!/usr/bin/env node',
-    },
-  },
   // CLI binary minified
   {
     entry: ['src/bin/ai.ts'],
     outDir: 'dist/bin',
     outExtension: () => ({ js: '.min.js' }),
-    format: ['cjs'],
+    format: 'cjs',
     bundle: true,
     minify: true,
+    banner: { js: '#!/usr/bin/env node' },
     sourcemap: false,
-    banner: {
-      js: '#!/usr/bin/env node',
-    },
+    noExternal: [/.*/],
   },
 ]);

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -38,7 +38,7 @@ export default defineConfig([
     entry: ['src/bin/ai.ts'],
     outDir: 'dist/bin',
     outExtension: () => ({ js: '.min.js' }),
-    format: 'cjs',
+    format: ['cjs'],
     bundle: true,
     minify: true,
     banner: { js: '#!/usr/bin/env node' },


### PR DESCRIPTION
## background

users installing the AI CLI globally were experiencing dependency resolution issues and peer dependency warnings when `zod` wasn't available in their environment, making the CLI unreliable across different setups.

## summary

- bundle all dependencies in CLI binary for standalone operation
- remove non-minified CLI build to reduce package size

## verification

- CLI binary is self-contained (416KB vs 65KB, includes bundled zod)
- no external dependency requires remain in output
- all existing tests pass

## tasks

- [x] configure tsup to bundle dependencies with `noExternal`
- [x] remove non-minified CLI build configuration
- [x] verify zod and other deps are properly bundled 