### PR TITLE
feat (provider/gateway): add qwen3 coder model id

### DIFF
--- a/.changeset/new-rats-fly.md
+++ b/.changeset/new-rats-fly.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add qwen3 coder model id

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -3,6 +3,7 @@ export type GatewayModelId =
   | 'alibaba/qwen-3-235b'
   | 'alibaba/qwen-3-30b'
   | 'alibaba/qwen-3-32b'
+  | 'alibaba/qwen3-coder'
   | 'amazon/nova-lite'
   | 'amazon/nova-micro'
   | 'amazon/nova-pro'


### PR DESCRIPTION
## Background

Qwen released the new Qwen3 Coder model and we've added it to AI Gateway.

## Summary

Add the new Qwen3 model id to Gateway settings.
