### PR TITLE
fix (ui): handle empty messages array in shouldResubmitMessages

### DIFF
--- a/.changeset/mighty-spies-warn.md
+++ b/.changeset/mighty-spies-warn.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix error thrown when emptying messages in onError or onFinish

--- a/packages/ai/src/ui/should-resubmit-messages.test.ts
+++ b/packages/ai/src/ui/should-resubmit-messages.test.ts
@@ -26,6 +26,17 @@ describe('shouldResubmitMessages', () => {
     ).toBe(false);
   });
 
+  it('should return false when there is no last message (empty messages array)', () => {
+    expect(
+      shouldResubmitMessages({
+        originalMaxToolInvocationStep: undefined,
+        originalMessageCount: 0,
+        maxSteps: 3,
+        messages: [],
+      }),
+    ).toBe(false);
+  });
+
   it('should allow resubmission when maxSteps > 1 and there are tool invocations with results', () => {
     expect(
       shouldResubmitMessages({

--- a/packages/ai/src/ui/should-resubmit-messages.ts
+++ b/packages/ai/src/ui/should-resubmit-messages.ts
@@ -12,6 +12,9 @@ export function shouldResubmitMessages({
   messages: UIMessage[];
 }) {
   const lastMessage = messages[messages.length - 1];
+  if (!lastMessage) {
+    return false;
+  }
 
   // count the number of step-start parts in the last message:
   const lastMessageStepStartCount = lastMessage.parts.filter(
@@ -21,8 +24,6 @@ export function shouldResubmitMessages({
   return (
     // check if the feature is enabled:
     maxSteps > 1 &&
-    // ensure there is a last message:
-    lastMessage != null &&
     // ensure we actually have new steps (to prevent infinite loops in case of errors):
     (messages.length > originalMessageCount ||
       lastMessageStepStartCount !== originalMaxToolInvocationStep) &&


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

This prevents #7473 when `messages` is an empty array, which can happen if the user mutates `messages` during `onError` or `onFinish` callbacks. Example use case: reverting last sent message when an error has occurred.

## Summary

<!-- What did you change? -->
Catch the condition early where `lastMessage` is undefined.

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->
1. Added failing test for empty array
2. Fix implementation
3. Re-run test

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
Fixes #7473 