### PR TITLE
docs: update community provider pages support

### DIFF
--- a/content/providers/03-community-providers/02-qwen.mdx
+++ b/content/providers/03-community-providers/02-qwen.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the Qwen provider.
 
 # Qwen Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [younis-ahmed/qwen-ai-provider](https://github.com/younis-ahmed/qwen-ai-provider) is a community provider that uses [Qwen](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) to provide language model support for the AI SDK.
 
 ## Setup

--- a/content/providers/03-community-providers/02-qwen.mdx
+++ b/content/providers/03-community-providers/02-qwen.mdx
@@ -6,7 +6,9 @@ description: Learn how to use the Qwen provider.
 # Qwen Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 [younis-ahmed/qwen-ai-provider](https://github.com/younis-ahmed/qwen-ai-provider) is a community provider that uses [Qwen](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) to provide language model support for the AI SDK.

--- a/content/providers/03-community-providers/04-chrome-ai.mdx
+++ b/content/providers/03-community-providers/04-chrome-ai.mdx
@@ -13,7 +13,9 @@ description: Learn how to use the Chrome AI provider for the AI SDK.
 </Note>
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 ## Setup

--- a/content/providers/03-community-providers/04-chrome-ai.mdx
+++ b/content/providers/03-community-providers/04-chrome-ai.mdx
@@ -12,6 +12,10 @@ description: Learn how to use the Chrome AI provider for the AI SDK.
   incompatible changes.
 </Note>
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 ## Setup
 
 The ChromeAI provider is available in the `chrome-ai` module. You can install it with:

--- a/content/providers/03-community-providers/14-azure-ai.mdx
+++ b/content/providers/03-community-providers/14-azure-ai.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the @quail-ai/azure-ai-provider for the AI SDK.
 
 # Azure Custom Provider for AI SDK
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 The **[Quail-AI/azure-ai-provider](https://github.com/QuailAI/azure-ai-provider)** enables unofficial integration with Azure-hosted language models that use Azure's native APIs instead of the standard OpenAI API format.
 
 ## Language Models

--- a/content/providers/03-community-providers/14-azure-ai.mdx
+++ b/content/providers/03-community-providers/14-azure-ai.mdx
@@ -6,7 +6,9 @@ description: Learn how to use the @quail-ai/azure-ai-provider for the AI SDK.
 # Azure Custom Provider for AI SDK
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 The **[Quail-AI/azure-ai-provider](https://github.com/QuailAI/azure-ai-provider)** enables unofficial integration with Azure-hosted language models that use Azure's native APIs instead of the standard OpenAI API format.

--- a/content/providers/03-community-providers/21-crosshatch.mdx
+++ b/content/providers/03-community-providers/21-crosshatch.mdx
@@ -6,7 +6,9 @@ description: Learn how to use the Crosshatch provider for the AI SDK.
 # Crosshatch Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 The [Crosshatch](https://crosshatch.io) provider supports secure inference from popular language models with permissioned access to data users share, giving responses personalized with complete user context.

--- a/content/providers/03-community-providers/21-crosshatch.mdx
+++ b/content/providers/03-community-providers/21-crosshatch.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the Crosshatch provider for the AI SDK.
 
 # Crosshatch Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 The [Crosshatch](https://crosshatch.io) provider supports secure inference from popular language models with permissioned access to data users share, giving responses personalized with complete user context.
 
 It creates language model objects that can be used with the `generateText`, `streamText`, `generateObject` and `streamObject` functions.

--- a/content/providers/03-community-providers/5-requesty.mdx
+++ b/content/providers/03-community-providers/5-requesty.mdx
@@ -6,7 +6,9 @@ description: Requesty Provider for the AI SDK
 # Requesty
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 [Requesty](https://requesty.ai/) is a unified LLM gateway that provides access to over 300 large language models from leading providers like OpenAI, Anthropic, Google, Mistral, AWS, and more. The Requesty provider for the AI SDK enables seamless integration with all these models while offering enterprise-grade advantages:

--- a/content/providers/03-community-providers/5-requesty.mdx
+++ b/content/providers/03-community-providers/5-requesty.mdx
@@ -5,6 +5,10 @@ description: Requesty Provider for the AI SDK
 
 # Requesty
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [Requesty](https://requesty.ai/) is a unified LLM gateway that provides access to over 300 large language models from leading providers like OpenAI, Anthropic, Google, Mistral, AWS, and more. The Requesty provider for the AI SDK enables seamless integration with all these models while offering enterprise-grade advantages:
 
 - **Universal Model Access**: One API key for 300+ models from multiple providers

--- a/content/providers/03-community-providers/70-mem0.mdx
+++ b/content/providers/03-community-providers/70-mem0.mdx
@@ -6,7 +6,9 @@ description: 'Learn how to use the Mem0 AI SDK provider for the AI SDK.'
 # Mem0 Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 The [Mem0 Provider](https://github.com/mem0ai/mem0/tree/main/vercel-ai-sdk) is a library developed by [**Mem0**](https://mem0.ai)

--- a/content/providers/03-community-providers/70-mem0.mdx
+++ b/content/providers/03-community-providers/70-mem0.mdx
@@ -5,6 +5,10 @@ description: 'Learn how to use the Mem0 AI SDK provider for the AI SDK.'
 
 # Mem0 Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 The [Mem0 Provider](https://github.com/mem0ai/mem0/tree/main/vercel-ai-sdk) is a library developed by [**Mem0**](https://mem0.ai)
 to integrate with the AI SDK.
 This library brings enhanced AI interaction capabilities to your applications by introducing persistent memory functionality.

--- a/content/providers/03-community-providers/71-letta.mdx
+++ b/content/providers/03-community-providers/71-letta.mdx
@@ -5,6 +5,10 @@ description: 'Learn how to use the Letta AI SDK provider for the AI SDK.'
 
 # Letta Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 The [Letta AI-SDK provider](https://github.com/letta-ai/vercel-ai-sdk-provider) is the official provider for the [Letta](https://docs.letta.com) platform. It allows you to integrate Letta's AI capabilities into your applications using the Vercel AI SDK.
 
 ## Setup

--- a/content/providers/03-community-providers/71-letta.mdx
+++ b/content/providers/03-community-providers/71-letta.mdx
@@ -6,7 +6,9 @@ description: 'Learn how to use the Letta AI SDK provider for the AI SDK.'
 # Letta Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 The [Letta AI-SDK provider](https://github.com/letta-ai/vercel-ai-sdk-provider) is the official provider for the [Letta](https://docs.letta.com) platform. It allows you to integrate Letta's AI capabilities into your applications using the Vercel AI SDK.

--- a/content/providers/03-community-providers/90-llama-cpp.mdx
+++ b/content/providers/03-community-providers/90-llama-cpp.mdx
@@ -9,4 +9,8 @@ description: Learn how to use Llama CPP.
   The LlamaCpp provider is a prototype that is currently unmaintained.
 </Note>
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [nnance/llamacpp-ai-provider](https://github.com/nnance/llamacpp-ai-provider) is a community provider that uses [Llama.cpp](https://github.com/ggerganov/llama.cpp) to provide language model support for the AI SDK.

--- a/content/providers/03-community-providers/90-llama-cpp.mdx
+++ b/content/providers/03-community-providers/90-llama-cpp.mdx
@@ -10,7 +10,9 @@ description: Learn how to use Llama CPP.
 </Note>
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 [nnance/llamacpp-ai-provider](https://github.com/nnance/llamacpp-ai-provider) is a community provider that uses [Llama.cpp](https://github.com/ggerganov/llama.cpp) to provide language model support for the AI SDK.

--- a/content/providers/03-community-providers/91-anthropic-vertex-ai.mdx
+++ b/content/providers/03-community-providers/91-anthropic-vertex-ai.mdx
@@ -10,6 +10,10 @@ description: Learn how to use the Anthropic Vertex provider for the AI SDK.
   provider](/providers/ai-sdk-providers/google-vertex).
 </Note>
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [nalaso/anthropic-vertex-ai](https://github.com/nalaso/anthropic-vertex-ai) is a community provider that uses Anthropic models through Vertex AI to provide language model support for the AI SDK.
 
 ## Setup

--- a/content/providers/03-community-providers/91-anthropic-vertex-ai.mdx
+++ b/content/providers/03-community-providers/91-anthropic-vertex-ai.mdx
@@ -11,7 +11,9 @@ description: Learn how to use the Anthropic Vertex provider for the AI SDK.
 </Note>
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 [nalaso/anthropic-vertex-ai](https://github.com/nalaso/anthropic-vertex-ai) is a community provider that uses Anthropic models through Vertex AI to provide language model support for the AI SDK.

--- a/content/providers/03-community-providers/92-spark.mdx
+++ b/content/providers/03-community-providers/92-spark.mdx
@@ -6,7 +6,9 @@ description: Learn how to use the Spark provider for the AI SDK.
 # Spark Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 The **[Spark provider](https://github.com/klren0312/spark-ai-provider)** contains language model support for the Spark API, giving you access to models like lite, generalv3, pro-128k, generalv3.5, max-32k and 4.0Ultra.

--- a/content/providers/03-community-providers/92-spark.mdx
+++ b/content/providers/03-community-providers/92-spark.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the Spark provider for the AI SDK.
 
 # Spark Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 The **[Spark provider](https://github.com/klren0312/spark-ai-provider)** contains language model support for the Spark API, giving you access to models like lite, generalv3, pro-128k, generalv3.5, max-32k and 4.0Ultra.
 
 ## Setup

--- a/content/providers/03-community-providers/93-inflection-ai.mdx
+++ b/content/providers/03-community-providers/93-inflection-ai.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the unofficial Inflection AI provider for the AI S
 
 # Unofficial Community Provider for AI SDK - Inflection AI
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 The **[unofficial Inflection AI provider](https://www.npmjs.com/package/inflection-ai-sdk-provider)** for the [AI SDK](/docs) contains language model support for the [Inflection AI API](https://developers.inflection.ai/).
 
 ## Setup

--- a/content/providers/03-community-providers/93-inflection-ai.mdx
+++ b/content/providers/03-community-providers/93-inflection-ai.mdx
@@ -6,7 +6,9 @@ description: Learn how to use the unofficial Inflection AI provider for the AI S
 # Unofficial Community Provider for AI SDK - Inflection AI
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 The **[unofficial Inflection AI provider](https://www.npmjs.com/package/inflection-ai-sdk-provider)** for the [AI SDK](/docs) contains language model support for the [Inflection AI API](https://developers.inflection.ai/).

--- a/content/providers/03-community-providers/94-langdb.mdx
+++ b/content/providers/03-community-providers/94-langdb.mdx
@@ -6,7 +6,9 @@ description: Learn how to use LangDB with the AI SDK
 # LangDB
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 [LangDB](https://langdb.ai) is a high-performance enterprise AI gateway built in Rust, designed to govern, secure, and optimize AI traffic.

--- a/content/providers/03-community-providers/94-langdb.mdx
+++ b/content/providers/03-community-providers/94-langdb.mdx
@@ -5,6 +5,10 @@ description: Learn how to use LangDB with the AI SDK
 
 # LangDB
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [LangDB](https://langdb.ai) is a high-performance enterprise AI gateway built in Rust, designed to govern, secure, and optimize AI traffic.
 
 LangDB provides OpenAI-compatible APIs, enabling developers to connect with multiple LLMs by changing just two lines of code. With LangDB, you can:

--- a/content/providers/03-community-providers/95-zhipu.mdx
+++ b/content/providers/03-community-providers/95-zhipu.mdx
@@ -6,7 +6,9 @@ description: Learn how to use the Zhipu provider.
 # Zhipu AI Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 [Zhipu AI Provider](https://github.com/Xiang-CH/zhipu-ai-provider) is a community provider for the [AI SDK](/). It enables seamless integration with **GLM** and Embedding Models provided on [bigmodel.cn](https://bigmodel.cn/) by [ZhipuAI](https://www.zhipuai.cn/).

--- a/content/providers/03-community-providers/95-zhipu.mdx
+++ b/content/providers/03-community-providers/95-zhipu.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the Zhipu provider.
 
 # Zhipu AI Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 [Zhipu AI Provider](https://github.com/Xiang-CH/zhipu-ai-provider) is a community provider for the [AI SDK](/). It enables seamless integration with **GLM** and Embedding Models provided on [bigmodel.cn](https://bigmodel.cn/) by [ZhipuAI](https://www.zhipuai.cn/).
 
 ## Setup

--- a/content/providers/03-community-providers/99-claude-code.mdx
+++ b/content/providers/03-community-providers/99-claude-code.mdx
@@ -6,7 +6,9 @@ description: Learn how to use the Claude Code community provider to access Claud
 # Claude Code Provider
 
 <Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+  This community provider is not yet compatible with AI SDK 5. Please wait for
+  the provider to be updated or consider using an [AI SDK 5 compatible
+  provider](/providers/ai-sdk-providers).
 </Note>
 
 The [ai-sdk-provider-claude-code](https://github.com/ben-vargas/ai-sdk-provider-claude-code) community provider allows you to access Claude models through the official Claude Code SDK/CLI. While it works with both Claude Pro/Max subscriptions and API key authentication, it's particularly useful for developers who want to use their existing Claude subscription without managing API keys.

--- a/content/providers/03-community-providers/99-claude-code.mdx
+++ b/content/providers/03-community-providers/99-claude-code.mdx
@@ -5,6 +5,10 @@ description: Learn how to use the Claude Code community provider to access Claud
 
 # Claude Code Provider
 
+<Note type="warning">
+  This community provider is not yet compatible with AI SDK 5. Please wait for the provider to be updated or consider using an [AI SDK 5 compatible provider](/providers/ai-sdk-providers).
+</Note>
+
 The [ai-sdk-provider-claude-code](https://github.com/ben-vargas/ai-sdk-provider-claude-code) community provider allows you to access Claude models through the official Claude Code SDK/CLI. While it works with both Claude Pro/Max subscriptions and API key authentication, it's particularly useful for developers who want to use their existing Claude subscription without managing API keys.
 
 ## Setup


### PR DESCRIPTION
Update supported models as community providers are still in the process of being updated to v5