### PR TITLE
chore(docs): patch Letta AI community providers doc

### DIFF
--- a/content/providers/03-community-providers/71-letta.mdx
+++ b/content/providers/03-community-providers/71-letta.mdx
@@ -93,9 +93,15 @@ const { text } = await generateText({
 The `vercel-ai-sdk-provider` extends the [@letta-ai/letta-client](https://www.npmjs.com/package/@letta-ai/letta-client), you can access the operations directly by using `lettaCloud.client` or `lettaLocal.client` or your custom generated `letta.client`
 
 ```ts
+// with Letta Cloud
 import { lettaCloud } from '@letta-ai/vercel-ai-sdk-provider';
 
 lettaCloud.client.agents.list();
+
+// with Letta Local
+import { lettaLocal } from '@letta-ai/vercel-ai-sdk-provider';
+
+lettaLocal.client.agents.list();
 ```
 
 ### More Information

--- a/content/providers/03-community-providers/71-letta.mdx
+++ b/content/providers/03-community-providers/71-letta.mdx
@@ -46,7 +46,7 @@ import { letta } from '@letta-ai/vercel-ai-sdk-provider';
 Create a file called `.env.local` and add your [API Key](https://app.letta.com/api-keys)
 
 ```text
-LETTA_API_KEY=<your api key>
+LETTA_API_KEY=<your_api_key>
 
 ```
 

--- a/content/providers/03-community-providers/71-letta.mdx
+++ b/content/providers/03-community-providers/71-letta.mdx
@@ -31,14 +31,6 @@ The Letta provider is available in the `@letta-ai/vercel-ai-sdk-provider` module
   </Tab>
 </Tabs>
 
-## Setup
-
-The Letta provider is available in the `@letta-ai/vercel-ai-sdk-provider` module. You can install it with
-
-```bash
-npm i @letta-ai/vercel-ai-sdk-provider a
-```
-
 ## Provider Instance
 
 You can import the default provider instance `letta` from `@letta-ai/vercel-ai-sdk-provider`:
@@ -63,7 +55,7 @@ import { lettaCloud } from '@letta-ai/vercel-ai-sdk-provider';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: lettaCloud('your-agent-id'),
+  model: lettaCloud('your_agent_id'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
@@ -75,7 +67,7 @@ import { lettaLocal } from '@letta-ai/vercel-ai-sdk-provider';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: lettaLocal('your-agent-id'),
+  model: lettaLocal('your_agent_id'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
@@ -87,12 +79,12 @@ import { createLetta } from '@letta-ai/vercel-ai-sdk-provider';
 import { generateText } from 'ai';
 
 const letta = createLetta({
-  baseUrl: '<your-base-url>',
-  token: '<your-access-token>',
+  baseUrl: '<your_base_url>',
+  token: '<your_access_token>',
 });
 
 const { text } = await generateText({
-  model: letta('your-agent-id'),
+  model: letta('your_agent_id'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
@@ -104,7 +96,7 @@ The `vercel-ai-sdk-provider` extends the [@letta-ai/letta-client](https://www.np
 ```ts
 import { lettaCloud } from '@letta-ai/vercel-ai-sdk-provider';
 
-lettaCloud.agents.list();
+lettaCloud.client.agents.list();
 ```
 
 ### More Information

--- a/content/providers/03-community-providers/71-letta.mdx
+++ b/content/providers/03-community-providers/71-letta.mdx
@@ -47,7 +47,6 @@ Create a file called `.env.local` and add your [API Key](https://app.letta.com/a
 
 ```text
 LETTA_API_KEY=<your_api_key>
-
 ```
 
 ```ts


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

We request changes on this page: https://ai-sdk.dev/providers/community-providers/letta

The Setup instructions previously contained duplicate npm install commands (including a typo), used environment‑variable placeholders with hyphens and spaces that hindered straightforward copy–pasting, referenced an outdated example function for Letta’s SDK, and omitted some guidance for running the letta client functions locally. 

In this PR, we removed the redundant install steps, corrected the typo, standardized all placeholders to snake_case for consistency, updated the example function to match the latest SDK, and added a snippet demonstrating how to configure and launch the setup on a local machine.

## Summary

* Removed `setup` redundancy.
* For env vars placeholders, replaced hyphens and spaces for underscores for easier copy-paste.
* Updated `letta cloud` example function.
* Added an example function for local setup.

## Verification

N/A

## Tasks

N/A

## Related Issues

https://github.com/vercel/ai/pull/6273/files
