### PR TITLE
chore (ai): rename text and reasoning chunks in streamText fullstream

### DIFF
--- a/.changeset/dull-rabbits-tie.md
+++ b/.changeset/dull-rabbits-tie.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore (ai): rename text and reasoning chunks in streamText fullstream

--- a/examples/ai-core/src/stream-text/amazon-bedrock-cache-point-tool-call.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-cache-point-tool-call.ts
@@ -146,7 +146,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
@@ -24,7 +24,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'reasoning': {
+      case 'reasoning-delta': {
         if (!enteredReasoning) {
           enteredReasoning = true;
           console.log('\nREASONING:\n');
@@ -33,7 +33,7 @@ async function main() {
         break;
       }
 
-      case 'text': {
+      case 'text-delta': {
         if (!enteredText) {
           enteredText = true;
           console.log('\nTEXT:\n');

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-chatbot.ts
@@ -60,9 +60,9 @@ async function main() {
 
     process.stdout.write('\nAssistant: ');
     for await (const part of result.fullStream) {
-      if (part.type === 'reasoning') {
+      if (part.type === 'reasoning-delta') {
         process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
-      } else if (part.type === 'text') {
+      } else if (part.type === 'text-delta') {
         process.stdout.write(part.text);
       }
     }

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
@@ -26,7 +26,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'reasoning': {
+      case 'reasoning-delta': {
         if (!enteredReasoning) {
           enteredReasoning = true;
           console.log('\nREASONING:\n');
@@ -35,7 +35,7 @@ async function main() {
         break;
       }
 
-      case 'text': {
+      case 'text-delta': {
         if (!enteredText) {
           enteredText = true;
           console.log('\nTEXT:\n');

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning.ts
@@ -20,9 +20,9 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }
   }

--- a/examples/ai-core/src/stream-text/amazon-bedrock-tool-call.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-tool-call.ts
@@ -25,7 +25,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/anthropic-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-fullstream.ts
@@ -18,7 +18,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/anthropic-on-chunk-raw.ts
+++ b/examples/ai-core/src/stream-text/anthropic-on-chunk-raw.ts
@@ -15,7 +15,7 @@ async function main() {
       'Write a short poem about coding. Include reasoning about your creative process.',
     includeRawChunks: true,
     onChunk({ chunk }) {
-      if (chunk.type === 'text') {
+      if (chunk.type === 'text-delta') {
         textChunkCount++;
         console.log('onChunk text:', chunk.text);
       } else if (chunk.type === 'raw') {

--- a/examples/ai-core/src/stream-text/anthropic-pdf-sources.ts
+++ b/examples/ai-core/src/stream-text/anthropic-pdf-sources.ts
@@ -34,7 +34,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         process.stdout.write(part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-chatbot.ts
@@ -60,9 +60,9 @@ async function main() {
 
     process.stdout.write('\nAssistant: ');
     for await (const part of result.fullStream) {
-      if (part.type === 'reasoning') {
+      if (part.type === 'reasoning-delta') {
         process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
-      } else if (part.type === 'text') {
+      } else if (part.type === 'text-delta') {
         process.stdout.write(part.text);
       }
     }

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
@@ -39,7 +39,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'reasoning': {
+      case 'reasoning-delta': {
         if (!enteredReasoning) {
           enteredReasoning = true;
           console.log('\nREASONING:\n');
@@ -48,7 +48,7 @@ async function main() {
         break;
       }
 
-      case 'text': {
+      case 'text-delta': {
         if (!enteredText) {
           enteredText = true;
           console.log('\nTEXT:\n');

--- a/examples/ai-core/src/stream-text/anthropic-reasoning.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning.ts
@@ -19,13 +19,13 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
 
       if (part.providerMetadata?.anthropic?.redactedData != null) {
         process.stdout.write('\x1b[31m' + '<redacted>' + '\x1b[0m');
       }
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }
   }

--- a/examples/ai-core/src/stream-text/anthropic-text-citations.ts
+++ b/examples/ai-core/src/stream-text/anthropic-text-citations.ts
@@ -33,7 +33,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text':
+      case 'text-delta':
         process.stdout.write(part.text);
         break;
 

--- a/examples/ai-core/src/stream-text/azure-fullstream-logprobs.ts
+++ b/examples/ai-core/src/stream-text/azure-fullstream-logprobs.ts
@@ -15,7 +15,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/azure-fullstream.ts
+++ b/examples/ai-core/src/stream-text/azure-fullstream.ts
@@ -18,7 +18,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/cerebras-tool-call.ts
+++ b/examples/ai-core/src/stream-text/cerebras-tool-call.ts
@@ -25,7 +25,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/cohere-tool-call-empty-params.ts
+++ b/examples/ai-core/src/stream-text/cohere-tool-call-empty-params.ts
@@ -37,7 +37,7 @@ async function main() {
     console.log(delta);
 
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/cohere-tool-call.ts
+++ b/examples/ai-core/src/stream-text/cohere-tool-call.ts
@@ -26,7 +26,7 @@ async function main() {
     console.log(delta);
 
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/deepseek-reasoning.ts
+++ b/examples/ai-core/src/stream-text/deepseek-reasoning.ts
@@ -9,9 +9,9 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }
   }

--- a/examples/ai-core/src/stream-text/deepseek-tool-call.ts
+++ b/examples/ai-core/src/stream-text/deepseek-tool-call.ts
@@ -25,7 +25,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/fireworks-kimi-k2-tool-call.ts
+++ b/examples/ai-core/src/stream-text/fireworks-kimi-k2-tool-call.ts
@@ -24,7 +24,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/fireworks-reasoning.ts
+++ b/examples/ai-core/src/stream-text/fireworks-reasoning.ts
@@ -17,13 +17,13 @@ async function main() {
   let enteredReasoning = false;
   let enteredText = false;
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;
         console.log('\nREASONING:\n');
       }
       process.stdout.write(part.text);
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       if (!enteredText) {
         enteredText = true;
         console.log('\nTEXT:\n');

--- a/examples/ai-core/src/stream-text/google-chatbot-image-output.ts
+++ b/examples/ai-core/src/stream-text/google-chatbot-image-output.ts
@@ -26,7 +26,7 @@ async function main() {
     process.stdout.write('\nAssistant: ');
     for await (const delta of result.fullStream) {
       switch (delta.type) {
-        case 'text': {
+        case 'text-delta': {
           process.stdout.write(delta.text);
           break;
         }

--- a/examples/ai-core/src/stream-text/google-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-fullstream.ts
@@ -18,7 +18,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/google-grounding.ts
+++ b/examples/ai-core/src/stream-text/google-grounding.ts
@@ -12,7 +12,7 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'text') {
+    if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }
 

--- a/examples/ai-core/src/stream-text/google-image-output.ts
+++ b/examples/ai-core/src/stream-text/google-image-output.ts
@@ -14,7 +14,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         process.stdout.write(part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/google-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-reasoning.ts
@@ -20,9 +20,9 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }
   }

--- a/examples/ai-core/src/stream-text/google-url-context.ts
+++ b/examples/ai-core/src/stream-text/google-url-context.ts
@@ -13,7 +13,7 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'text') {
+    if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }
 

--- a/examples/ai-core/src/stream-text/google-vertex-anthropic-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-anthropic-fullstream.ts
@@ -18,7 +18,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/google-vertex-anthropic-tool-call.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-anthropic-tool-call.ts
@@ -25,7 +25,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/google-vertex-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-fullstream.ts
@@ -18,7 +18,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-reasoning.ts
@@ -17,9 +17,9 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }
   }

--- a/examples/ai-core/src/stream-text/groq-kimi-k2-tool-call.ts
+++ b/examples/ai-core/src/stream-text/groq-kimi-k2-tool-call.ts
@@ -24,7 +24,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/groq-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/groq-reasoning-fullstream.ts
@@ -14,13 +14,13 @@ async function main() {
   let enteredReasoning = false;
   let enteredText = false;
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;
         console.log('\nREASONING:\n');
       }
       process.stdout.write(part.text);
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       if (!enteredText) {
         enteredText = true;
         console.log('\nTEXT:\n');

--- a/examples/ai-core/src/stream-text/mistral-fullstream.ts
+++ b/examples/ai-core/src/stream-text/mistral-fullstream.ts
@@ -18,7 +18,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/mistral-raw-chunks.ts
+++ b/examples/ai-core/src/stream-text/mistral-raw-chunks.ts
@@ -13,7 +13,7 @@ async function main() {
   let rawChunkCount = 0;
 
   for await (const chunk of result.fullStream) {
-    if (chunk.type === 'text') {
+    if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);
     } else if (chunk.type === 'raw') {

--- a/examples/ai-core/src/stream-text/mistral-reasoning-raw.ts
+++ b/examples/ai-core/src/stream-text/mistral-reasoning-raw.ts
@@ -20,13 +20,13 @@ async function main() {
   let enteredText = false;
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       if (!enteredReasoning) {
         enteredReasoning = true;
         console.log('REASONING:');
       }
       process.stdout.write(part.text);
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       if (!enteredText) {
         enteredText = true;
         console.log('\n\nTEXT:');

--- a/examples/ai-core/src/stream-text/openai-compatible-raw-chunks.ts
+++ b/examples/ai-core/src/stream-text/openai-compatible-raw-chunks.ts
@@ -24,7 +24,7 @@ async function main() {
   for await (const chunk of result.fullStream) {
     console.log('Chunk type:', chunk.type, 'Chunk:', JSON.stringify(chunk));
 
-    if (chunk.type === 'text') {
+    if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);
     } else if (chunk.type === 'raw') {

--- a/examples/ai-core/src/stream-text/openai-compatible-togetherai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-compatible-togetherai-tool-call.ts
@@ -35,7 +35,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/openai-fullstream.ts
+++ b/examples/ai-core/src/stream-text/openai-fullstream.ts
@@ -18,7 +18,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning-chatbot.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning-chatbot.ts
@@ -66,7 +66,7 @@ async function main() {
           process.stdout.write('\x1b[34m');
           break;
 
-        case 'reasoning':
+        case 'reasoning-delta':
           process.stdout.write(chunk.text);
           break;
 
@@ -105,7 +105,7 @@ async function main() {
           process.stdout.write('\x1b[32m');
           break;
 
-        case 'text':
+        case 'text-delta':
           process.stdout.write(chunk.text);
           break;
 

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts
@@ -19,9 +19,9 @@ async function main() {
   });
 
   for await (const part of result.fullStream) {
-    if (part.type === 'reasoning') {
+    if (part.type === 'reasoning-delta') {
       process.stdout.write('\x1b[34m' + part.text + '\x1b[0m');
-    } else if (part.type === 'text') {
+    } else if (part.type === 'text-delta') {
       process.stdout.write(part.text);
     }
   }

--- a/examples/ai-core/src/stream-text/openai-responses-reasoning-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-reasoning-tool-call.ts
@@ -62,7 +62,7 @@ async function main() {
         process.stdout.write('\x1b[34m');
         break;
 
-      case 'reasoning':
+      case 'reasoning-delta':
         process.stdout.write(chunk.text);
         break;
 
@@ -101,7 +101,7 @@ async function main() {
         process.stdout.write('\x1b[32m');
         break;
 
-      case 'text':
+      case 'text-delta':
         process.stdout.write(chunk.text);
         break;
 

--- a/examples/ai-core/src/stream-text/openai-responses-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-tool-call.ts
@@ -31,7 +31,7 @@ async function main() {
 
   for await (const chunk of result.fullStream) {
     switch (chunk.type) {
-      case 'text': {
+      case 'text-delta': {
         process.stdout.write(chunk.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/openai-tool-call-raw-json-schema.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call-raw-json-schema.ts
@@ -36,7 +36,7 @@ async function main() {
 
   for await (const part of result.fullStream) {
     switch (part.type) {
-      case 'text': {
+      case 'text-delta': {
         console.log('Text:', part.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/openai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call.ts
@@ -26,7 +26,7 @@ async function main() {
 
   for await (const chunk of result.fullStream) {
     switch (chunk.type) {
-      case 'text': {
+      case 'text-delta': {
         process.stdout.write(chunk.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/openai-web-search-tool.ts
+++ b/examples/ai-core/src/stream-text/openai-web-search-tool.ts
@@ -17,7 +17,7 @@ async function main() {
 
   for await (const chunk of result.fullStream) {
     switch (chunk.type) {
-      case 'text': {
+      case 'text-delta': {
         process.stdout.write(chunk.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/raw-chunks.ts
+++ b/examples/ai-core/src/stream-text/raw-chunks.ts
@@ -13,7 +13,7 @@ async function main() {
   let rawChunkCount = 0;
 
   for await (const chunk of result.fullStream) {
-    if (chunk.type === 'text') {
+    if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);
     } else if (chunk.type === 'raw') {

--- a/examples/ai-core/src/stream-text/togetherai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/togetherai-tool-call.ts
@@ -25,7 +25,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/examples/ai-core/src/stream-text/vercel-tool-call.ts
+++ b/examples/ai-core/src/stream-text/vercel-tool-call.ts
@@ -1,9 +1,9 @@
 import { vercel } from '@ai-sdk/vercel';
-import { streamText, CoreMessage, ToolCallPart, ToolResultPart } from 'ai';
+import { streamText, ToolCallPart, ToolResultPart, ModelMessage } from 'ai';
 import 'dotenv/config';
 import { weatherTool } from '../tools/weather-tool';
 
-const messages: CoreMessage[] = [];
+const messages: ModelMessage[] = [];
 
 async function main() {
   let toolResponseAvailable = false;
@@ -24,7 +24,7 @@ async function main() {
 
   for await (const chunk of result.fullStream) {
     switch (chunk.type) {
-      case 'text': {
+      case 'text-delta': {
         process.stdout.write(chunk.text);
         break;
       }

--- a/examples/ai-core/src/stream-text/xai-raw-chunks.ts
+++ b/examples/ai-core/src/stream-text/xai-raw-chunks.ts
@@ -13,7 +13,7 @@ async function main() {
   let rawChunkCount = 0;
 
   for await (const chunk of result.fullStream) {
-    if (chunk.type === 'text') {
+    if (chunk.type === 'text-delta') {
       textChunkCount++;
       console.log('Text chunk', textChunkCount, ':', chunk.text);
     } else if (chunk.type === 'raw') {

--- a/examples/ai-core/src/stream-text/xai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/xai-tool-call.ts
@@ -25,7 +25,7 @@ async function main() {
 
   for await (const delta of result.fullStream) {
     switch (delta.type) {
-      case 'text': {
+      case 'text-delta': {
         fullResponse += delta.text;
         process.stdout.write(delta.text);
         break;

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -46,9 +46,9 @@ describe('smoothStream', () => {
     it('should combine partial words', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'Hello', type: 'text', id: '1' },
-        { text: ', ', type: 'text', id: '1' },
-        { text: 'world!', type: 'text', id: '1' },
+        { text: 'Hello', type: 'text-delta', id: '1' },
+        { text: ', ', type: 'text-delta', id: '1' },
+        { text: 'world!', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -69,12 +69,12 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "Hello, ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": "world!",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -89,7 +89,7 @@ describe('smoothStream', () => {
         { type: 'text-start', id: '1' },
         {
           text: 'Hello, World! This is an example text.',
-          type: 'text',
+          type: 'text-delta',
           id: '1',
         },
         { type: 'text-end', id: '1' },
@@ -112,42 +112,42 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "Hello, ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "World! ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "This ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "is ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "an ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "example ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": "text.",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -160,11 +160,11 @@ describe('smoothStream', () => {
     it('should keep longer whitespace sequences together', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'First line', type: 'text', id: '1' },
-        { text: ' \n\n', type: 'text', id: '1' },
-        { text: '  ', type: 'text', id: '1' },
-        { text: '  Multiple spaces', type: 'text', id: '1' },
-        { text: '\n    Indented', type: 'text', id: '1' },
+        { text: 'First line', type: 'text-delta', id: '1' },
+        { text: ' \n\n', type: 'text-delta', id: '1' },
+        { text: '  ', type: 'text-delta', id: '1' },
+        { text: '  Multiple spaces', type: 'text-delta', id: '1' },
+        { text: '\n    Indented', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -181,13 +181,13 @@ describe('smoothStream', () => {
         {
           id: '1',
           text: 'First ',
-          type: 'text',
+          type: 'text-delta',
         },
         'delay 10',
         {
           id: '1',
           text: 'line \n\n',
-          type: 'text',
+          type: 'text-delta',
         },
         'delay 10',
         {
@@ -195,18 +195,18 @@ describe('smoothStream', () => {
           // because it is part of the new chunk:
           id: '1',
           text: '    Multiple ',
-          type: 'text',
+          type: 'text-delta',
         },
         'delay 10',
         {
           id: '1',
           text: 'spaces\n    ',
-          type: 'text',
+          type: 'text-delta',
         },
         {
           id: '1',
           text: 'Indented',
-          type: 'text',
+          type: 'text-delta',
         },
         { id: '1', type: 'text-end' },
       ]);
@@ -215,9 +215,9 @@ describe('smoothStream', () => {
     it('should send remaining text buffer before tool call starts', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'I will check the', type: 'text', id: '1' },
-        { text: ' weather in Lon', type: 'text', id: '1' },
-        { text: 'don.', type: 'text', id: '1' },
+        { text: 'I will check the', type: 'text-delta', id: '1' },
+        { text: ' weather in Lon', type: 'text-delta', id: '1' },
+        { text: 'don.', type: 'text-delta', id: '1' },
         {
           type: 'tool-call',
           toolCallId: '1',
@@ -244,42 +244,42 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "I ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "will ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "check ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "the ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "weather ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "in ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": "London.",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "input": {
@@ -300,9 +300,9 @@ describe('smoothStream', () => {
     it('should send remaining text buffer before tool call starts and tool call streaming is enabled', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { type: 'text', id: '1', text: 'I will check the' },
-        { type: 'text', id: '1', text: ' weather in Lon' },
-        { type: 'text', id: '1', text: 'don.' },
+        { type: 'text-delta', id: '1', text: 'I will check the' },
+        { type: 'text-delta', id: '1', text: ' weather in Lon' },
+        { type: 'text-delta', id: '1', text: 'don.' },
         {
           type: 'tool-input-start',
           toolName: 'weather',
@@ -336,42 +336,42 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "I ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "will ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "check ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "the ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "weather ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "in ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": "London.",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "2",
@@ -406,10 +406,10 @@ describe('smoothStream', () => {
     it(`doesn't return chunks with just spaces`, async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { type: 'text', id: '1', text: ' ' },
-        { type: 'text', id: '1', text: ' ' },
-        { type: 'text', id: '1', text: ' ' },
-        { type: 'text', id: '1', text: 'foo' },
+        { type: 'text-delta', id: '1', text: ' ' },
+        { type: 'text-delta', id: '1', text: ' ' },
+        { type: 'text-delta', id: '1', text: ' ' },
+        { type: 'text-delta', id: '1', text: 'foo' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -429,7 +429,7 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "   foo",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -446,11 +446,11 @@ describe('smoothStream', () => {
         { type: 'text-start', id: '1' },
         {
           text: 'First line\nSecond line\nThird line with more text\n',
-          type: 'text',
+          type: 'text-delta',
           id: '1',
         },
-        { text: 'Partial line', type: 'text', id: '1' },
-        { text: ' continues\nFinal line\n', type: 'text', id: '1' },
+        { text: 'Partial line', type: 'text-delta', id: '1' },
+        { text: ' continues\nFinal line\n', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -473,35 +473,35 @@ describe('smoothStream', () => {
             "id": "1",
             "text": "First line
         ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "Second line
         ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "Third line with more text
         ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "Partial line continues
         ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "Final line
         ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -514,9 +514,9 @@ describe('smoothStream', () => {
     it('should handle text without line endings in line chunking mode', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'Text without', type: 'text', id: '1' },
-        { text: ' any line', type: 'text', id: '1' },
-        { text: ' breaks', type: 'text', id: '1' },
+        { text: 'Text without', type: 'text-delta', id: '1' },
+        { text: ' any line', type: 'text-delta', id: '1' },
+        { text: ' breaks', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -536,7 +536,7 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "Text without any line breaks",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -551,7 +551,7 @@ describe('smoothStream', () => {
     it(`should return correct result for regexes that don't match from the exact start onwards`, async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'Hello_, world!', type: 'text', id: '1' },
+        { text: 'Hello_, world!', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -573,12 +573,12 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "Hello_",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": ", world!",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -591,7 +591,7 @@ describe('smoothStream', () => {
     it('should support custom chunking regexps (character-level)', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'Hello, world!', type: 'text', id: '1' },
+        { text: 'Hello, world!', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -613,79 +613,79 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "H",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "e",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "l",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "l",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "o",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": ",",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": " ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "w",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "o",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "r",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "l",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "d",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "!",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -700,8 +700,8 @@ describe('smoothStream', () => {
     it('should support custom chunking callback', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'He_llo, ', type: 'text', id: '1' },
-        { text: 'w_orld!', type: 'text', id: '1' },
+        { text: 'He_llo, ', type: 'text-delta', id: '1' },
+        { text: 'w_orld!', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -722,18 +722,18 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "He_",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "llo, w_",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": "orld!",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -747,7 +747,7 @@ describe('smoothStream', () => {
       it('throws empty match error', async () => {
         const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
           { type: 'text-start', id: '1' },
-          { text: 'Hello, world!', type: 'text', id: '1' },
+          { text: 'Hello, world!', type: 'text-delta', id: '1' },
           { type: 'text-end', id: '1' },
         ]).pipeThrough(
           smoothStream({ chunking: () => '', _internal: { delay } })({
@@ -765,7 +765,7 @@ describe('smoothStream', () => {
       it('throws match prefix error', async () => {
         const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
           { type: 'text-start', id: '1' },
-          { text: 'Hello, world!', type: 'text', id: '1' },
+          { text: 'Hello, world!', type: 'text-delta', id: '1' },
           { type: 'text-end', id: '1' },
         ]).pipeThrough(
           smoothStream({ chunking: () => 'world', _internal: { delay } })({
@@ -786,7 +786,7 @@ describe('smoothStream', () => {
     it('should default to 10ms', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'Hello, world!', type: 'text', id: '1' },
+        { text: 'Hello, world!', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -806,12 +806,12 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "Hello, ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": "world!",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -824,7 +824,7 @@ describe('smoothStream', () => {
     it('should support different number of milliseconds delay', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'Hello, world!', type: 'text', id: '1' },
+        { text: 'Hello, world!', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -845,12 +845,12 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "Hello, ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": "world!",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -863,7 +863,7 @@ describe('smoothStream', () => {
     it('should support null delay', async () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
-        { text: 'Hello, world!', type: 'text', id: '1' },
+        { text: 'Hello, world!', type: 'text-delta', id: '1' },
         { type: 'text-end', id: '1' },
       ]).pipeThrough(
         smoothStream({
@@ -884,12 +884,12 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "Hello, ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
             "text": "world!",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",
@@ -905,12 +905,12 @@ describe('smoothStream', () => {
       const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
         { type: 'text-start', id: '1' },
         { type: 'text-start', id: '2' },
-        { text: 'I will check the', type: 'text', id: '1' },
-        { text: ' weather in Lon', type: 'text', id: '1' },
-        { text: 'don.', type: 'text', id: '1' },
-        { text: 'I will check the', type: 'text', id: '2' },
-        { text: ' weather in Lon', type: 'text', id: '2' },
-        { text: 'don.', type: 'text', id: '2' },
+        { text: 'I will check the', type: 'text-delta', id: '1' },
+        { text: ' weather in Lon', type: 'text-delta', id: '1' },
+        { text: 'don.', type: 'text-delta', id: '1' },
+        { text: 'I will check the', type: 'text-delta', id: '2' },
+        { text: ' weather in Lon', type: 'text-delta', id: '2' },
+        { text: 'don.', type: 'text-delta', id: '2' },
         { type: 'text-end', id: '1' },
         { type: 'text-end', id: '2' },
       ]).pipeThrough(
@@ -935,83 +935,83 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "I ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "will ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "check ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "the ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "weather ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "in ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "1",
             "text": "London.",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "2",
             "text": "I ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "2",
             "text": "will ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "2",
             "text": "check ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "2",
             "text": "the ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "2",
             "text": "weather ",
-            "type": "text",
+            "type": "text-delta",
           },
           "delay 10",
           {
             "id": "2",
             "text": "in ",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "2",
             "text": "London.",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "1",

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -91,9 +91,9 @@ export function smoothStream<TOOLS extends ToolSet>({
 
     return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
       async transform(chunk, controller) {
-        if (chunk.type !== 'text') {
+        if (chunk.type !== 'text-delta') {
           if (buffer.length > 0) {
-            controller.enqueue({ type: 'text', text: buffer, id });
+            controller.enqueue({ type: 'text-delta', text: buffer, id });
             buffer = '';
           }
 
@@ -102,7 +102,7 @@ export function smoothStream<TOOLS extends ToolSet>({
         }
 
         if (chunk.id !== id && buffer.length > 0) {
-          controller.enqueue({ type: 'text', text: buffer, id });
+          controller.enqueue({ type: 'text-delta', text: buffer, id });
           buffer = '';
         }
 
@@ -112,7 +112,7 @@ export function smoothStream<TOOLS extends ToolSet>({
         let match;
 
         while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type: 'text', text: match, id });
+          controller.enqueue({ type: 'text-delta', text: match, id });
           buffer = buffer.slice(match.length);
 
           await delay(delayInMs);

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -323,7 +323,7 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       providerMetadata?: ProviderMetadata;
     }
   | {
-      type: 'text';
+      type: 'text-delta';
       id: string;
       providerMetadata?: ProviderMetadata;
       text: string;
@@ -339,7 +339,7 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       providerMetadata?: ProviderMetadata;
     }
   | {
-      type: 'reasoning';
+      type: 'reasoning-delta';
       providerMetadata?: ProviderMetadata;
       id: string;
       text: string;

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -444,72 +444,72 @@ describe('streamText', () => {
 
       expect(await convertAsyncIterableToArray(result.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "type": "start",
-          },
-          {
-            "request": {},
-            "type": "start-step",
-            "warnings": [],
-          },
-          {
-            "id": "1",
-            "type": "text-start",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": "Hello",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": ", ",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": "world!",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "type": "text-end",
-          },
-          {
-            "finishReason": "stop",
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "response-id",
-              "modelId": "response-model-id",
-              "timestamp": 1970-01-01T00:00:05.000Z,
+          [
+            {
+              "type": "start",
             },
-            "type": "finish-step",
-            "usage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
+            {
+              "request": {},
+              "type": "start-step",
+              "warnings": [],
             },
-          },
-          {
-            "finishReason": "stop",
-            "totalUsage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
+            {
+              "id": "1",
+              "type": "text-start",
             },
-            "type": "finish",
-          },
-        ]
-      `);
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "Hello",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": ", ",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "world!",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "type": "text-end",
+            },
+            {
+              "finishReason": "stop",
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "response-id",
+                "modelId": "response-model-id",
+                "timestamp": 1970-01-01T00:00:05.000Z,
+              },
+              "type": "finish-step",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+            },
+            {
+              "finishReason": "stop",
+              "totalUsage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+              "type": "finish",
+            },
+          ]
+        `);
     });
 
     it('should send reasoning deltas', async () => {
@@ -537,13 +537,13 @@ describe('streamText', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "I will open the conversation",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "1",
               "providerMetadata": undefined,
               "text": " with witty banter.",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "1",
@@ -553,7 +553,7 @@ describe('streamText', () => {
                 },
               },
               "text": "",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "1",
@@ -580,13 +580,13 @@ describe('streamText', () => {
               "id": "3",
               "providerMetadata": undefined,
               "text": " Once the user has relaxed,",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "3",
               "providerMetadata": undefined,
               "text": " I will pry for valuable information.",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "3",
@@ -610,13 +610,13 @@ describe('streamText', () => {
               "id": "4",
               "providerMetadata": undefined,
               "text": " I need to think about",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "4",
               "providerMetadata": undefined,
               "text": " this problem carefully.",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "5",
@@ -631,19 +631,19 @@ describe('streamText', () => {
               "id": "5",
               "providerMetadata": undefined,
               "text": " The best solution",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "5",
               "providerMetadata": undefined,
               "text": " requires careful",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "5",
               "providerMetadata": undefined,
               "text": " consideration of all factors.",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "4",
@@ -671,13 +671,13 @@ describe('streamText', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "Hi",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
               "providerMetadata": undefined,
               "text": " there!",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
@@ -724,84 +724,84 @@ describe('streamText', () => {
 
       expect(await convertAsyncIterableToArray(result.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "type": "start",
-          },
-          {
-            "request": {},
-            "type": "start-step",
-            "warnings": [],
-          },
-          {
-            "id": "123",
-            "providerMetadata": {
-              "provider": {
-                "custom": "value",
+          [
+            {
+              "type": "start",
+            },
+            {
+              "request": {},
+              "type": "start-step",
+              "warnings": [],
+            },
+            {
+              "id": "123",
+              "providerMetadata": {
+                "provider": {
+                  "custom": "value",
+                },
+              },
+              "sourceType": "url",
+              "title": "Example",
+              "type": "source",
+              "url": "https://example.com",
+            },
+            {
+              "id": "1",
+              "type": "text-start",
+            },
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "Hello!",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "type": "text-end",
+            },
+            {
+              "id": "456",
+              "providerMetadata": {
+                "provider": {
+                  "custom": "value2",
+                },
+              },
+              "sourceType": "url",
+              "title": "Example 2",
+              "type": "source",
+              "url": "https://example.com/2",
+            },
+            {
+              "finishReason": "stop",
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish-step",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
               },
             },
-            "sourceType": "url",
-            "title": "Example",
-            "type": "source",
-            "url": "https://example.com",
-          },
-          {
-            "id": "1",
-            "type": "text-start",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": "Hello!",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "type": "text-end",
-          },
-          {
-            "id": "456",
-            "providerMetadata": {
-              "provider": {
-                "custom": "value2",
+            {
+              "finishReason": "stop",
+              "totalUsage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
               },
+              "type": "finish",
             },
-            "sourceType": "url",
-            "title": "Example 2",
-            "type": "source",
-            "url": "https://example.com/2",
-          },
-          {
-            "finishReason": "stop",
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
-            },
-            "type": "finish-step",
-            "usage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
-            },
-          },
-          {
-            "finishReason": "stop",
-            "totalUsage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
-            },
-            "type": "finish",
-          },
-        ]
-      `);
+          ]
+        `);
     });
 
     it('should send files', async () => {
@@ -812,78 +812,78 @@ describe('streamText', () => {
 
       expect(await convertAsyncIterableToArray(result.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "type": "start",
-          },
-          {
-            "request": {},
-            "type": "start-step",
-            "warnings": [],
-          },
-          {
-            "file": DefaultGeneratedFileWithType {
-              "base64Data": "Hello World",
-              "mediaType": "text/plain",
+          [
+            {
+              "type": "start",
+            },
+            {
+              "request": {},
+              "type": "start-step",
+              "warnings": [],
+            },
+            {
+              "file": DefaultGeneratedFileWithType {
+                "base64Data": "Hello World",
+                "mediaType": "text/plain",
+                "type": "file",
+                "uint8ArrayData": undefined,
+              },
               "type": "file",
-              "uint8ArrayData": undefined,
             },
-            "type": "file",
-          },
-          {
-            "id": "1",
-            "type": "text-start",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": "Hello!",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "type": "text-end",
-          },
-          {
-            "file": DefaultGeneratedFileWithType {
-              "base64Data": "QkFVRw==",
-              "mediaType": "image/jpeg",
+            {
+              "id": "1",
+              "type": "text-start",
+            },
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "Hello!",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "type": "text-end",
+            },
+            {
+              "file": DefaultGeneratedFileWithType {
+                "base64Data": "QkFVRw==",
+                "mediaType": "image/jpeg",
+                "type": "file",
+                "uint8ArrayData": undefined,
+              },
               "type": "file",
-              "uint8ArrayData": undefined,
             },
-            "type": "file",
-          },
-          {
-            "finishReason": "stop",
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+            {
+              "finishReason": "stop",
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish-step",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
             },
-            "type": "finish-step",
-            "usage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
+            {
+              "finishReason": "stop",
+              "totalUsage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+              "type": "finish",
             },
-          },
-          {
-            "finishReason": "stop",
-            "totalUsage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
-            },
-            "type": "finish",
-          },
-        ]
-      `);
+          ]
+        `);
     });
 
     it('should use fallback response metadata when response metadata is not provided', async () => {
@@ -923,72 +923,72 @@ describe('streamText', () => {
 
       expect(await convertAsyncIterableToArray(result.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "type": "start",
-          },
-          {
-            "request": {},
-            "type": "start-step",
-            "warnings": [],
-          },
-          {
-            "id": "1",
-            "type": "text-start",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": "Hello",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": ", ",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": "world!",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "type": "text-end",
-          },
-          {
-            "finishReason": "stop",
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-2000",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:02.000Z,
+          [
+            {
+              "type": "start",
             },
-            "type": "finish-step",
-            "usage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
+            {
+              "request": {},
+              "type": "start-step",
+              "warnings": [],
             },
-          },
-          {
-            "finishReason": "stop",
-            "totalUsage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
+            {
+              "id": "1",
+              "type": "text-start",
             },
-            "type": "finish",
-          },
-        ]
-      `);
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "Hello",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": ", ",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "world!",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "type": "text-end",
+            },
+            {
+              "finishReason": "stop",
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-2000",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:02.000Z,
+              },
+              "type": "finish-step",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+            },
+            {
+              "finishReason": "stop",
+              "totalUsage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+              "type": "finish",
+            },
+          ]
+        `);
     });
 
     it('should send tool calls', async () => {
@@ -1350,72 +1350,72 @@ describe('streamText', () => {
 
       expect(await convertAsyncIterableToArray(result.fullStream))
         .toMatchInlineSnapshot(`
-        [
-          {
-            "type": "start",
-          },
-          {
-            "request": {},
-            "type": "start-step",
-            "warnings": [],
-          },
-          {
-            "id": "1",
-            "type": "text-start",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": "Hello",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": ", ",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "providerMetadata": undefined,
-            "text": "world!",
-            "type": "text",
-          },
-          {
-            "id": "1",
-            "type": "text-end",
-          },
-          {
-            "finishReason": "stop",
-            "providerMetadata": undefined,
-            "response": {
-              "headers": undefined,
-              "id": "id-0",
-              "modelId": "mock-model-id",
-              "timestamp": 1970-01-01T00:00:00.000Z,
+          [
+            {
+              "type": "start",
             },
-            "type": "finish-step",
-            "usage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
+            {
+              "request": {},
+              "type": "start-step",
+              "warnings": [],
             },
-          },
-          {
-            "finishReason": "stop",
-            "totalUsage": {
-              "cachedInputTokens": undefined,
-              "inputTokens": 3,
-              "outputTokens": 10,
-              "reasoningTokens": undefined,
-              "totalTokens": 13,
+            {
+              "id": "1",
+              "type": "text-start",
             },
-            "type": "finish",
-          },
-        ]
-      `);
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "Hello",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": ", ",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "providerMetadata": undefined,
+              "text": "world!",
+              "type": "text-delta",
+            },
+            {
+              "id": "1",
+              "type": "text-end",
+            },
+            {
+              "finishReason": "stop",
+              "providerMetadata": undefined,
+              "response": {
+                "headers": undefined,
+                "id": "id-0",
+                "modelId": "mock-model-id",
+                "timestamp": 1970-01-01T00:00:00.000Z,
+              },
+              "type": "finish-step",
+              "usage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+            },
+            {
+              "finishReason": "stop",
+              "totalUsage": {
+                "cachedInputTokens": undefined,
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "reasoningTokens": undefined,
+                "totalTokens": 13,
+              },
+              "type": "finish",
+            },
+          ]
+        `);
     });
   });
 
@@ -3328,19 +3328,19 @@ describe('streamText', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "Hello",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
               "providerMetadata": undefined,
               "text": ", ",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
               "providerMetadata": undefined,
               "text": "world!",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
@@ -4146,8 +4146,8 @@ describe('streamText', () => {
         TextStreamPart<any>,
         {
           type:
-            | 'text'
-            | 'reasoning'
+            | 'text-delta'
+            | 'reasoning-delta'
             | 'source'
             | 'tool-call'
             | 'tool-input-start'
@@ -4222,7 +4222,7 @@ describe('streamText', () => {
             "id": "1",
             "providerMetadata": undefined,
             "text": "Hello",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "2",
@@ -4238,7 +4238,7 @@ describe('streamText', () => {
             "id": "3",
             "providerMetadata": undefined,
             "text": "Feeling clever",
-            "type": "reasoning",
+            "type": "reasoning-delta",
           },
           {
             "delta": "test",
@@ -4295,7 +4295,7 @@ describe('streamText', () => {
             "id": "4",
             "providerMetadata": undefined,
             "text": " World",
-            "type": "text",
+            "type": "text-delta",
           },
         ]
       `);
@@ -5347,7 +5347,7 @@ describe('streamText', () => {
                 "id": "0",
                 "providerMetadata": undefined,
                 "text": "thinking",
-                "type": "reasoning",
+                "type": "reasoning-delta",
               },
               {
                 "id": "0",
@@ -5407,13 +5407,13 @@ describe('streamText', () => {
                 "id": "1",
                 "providerMetadata": undefined,
                 "text": "Hello, ",
-                "type": "text",
+                "type": "text-delta",
               },
               {
                 "id": "1",
                 "providerMetadata": undefined,
                 "text": "world!",
-                "type": "text",
+                "type": "text-delta",
               },
               {
                 "id": "1",
@@ -6931,7 +6931,7 @@ describe('streamText', () => {
                 "id": "id-0",
                 "providerMetadata": undefined,
                 "text": "thinking",
-                "type": "reasoning",
+                "type": "reasoning-delta",
               },
               {
                 "id": "id-0",
@@ -6991,13 +6991,13 @@ describe('streamText', () => {
                 "id": "1",
                 "providerMetadata": undefined,
                 "text": "Hello, ",
-                "type": "text",
+                "type": "text-delta",
               },
               {
                 "id": "1",
                 "providerMetadata": undefined,
                 "text": "world!",
-                "type": "text",
+                "type": "text-delta",
               },
               {
                 "id": "1",
@@ -9445,7 +9445,10 @@ describe('streamText', () => {
           TextStreamPart<{ tool1: Tool<{ value: string }> }>
         >({
           transform(chunk, controller) {
-            if (chunk.type === 'text' || chunk.type === 'reasoning') {
+            if (
+              chunk.type === 'text-delta' ||
+              chunk.type === 'reasoning-delta'
+            ) {
               chunk.text = chunk.text.toUpperCase();
             }
 
@@ -10388,8 +10391,8 @@ describe('streamText', () => {
             TextStreamPart<any>,
             {
               type:
-                | 'text'
-                | 'reasoning'
+                | 'text-delta'
+                | 'reasoning-delta'
                 | 'source'
                 | 'tool-call'
                 | 'tool-input-start'
@@ -10449,13 +10452,13 @@ describe('streamText', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "HELLO",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "2",
               "providerMetadata": undefined,
               "text": "FEELING CLEVER",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "call-1",
@@ -10502,7 +10505,7 @@ describe('streamText', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": " WORLD",
-              "type": "text",
+              "type": "text-delta",
             },
           ]
         `);
@@ -10515,7 +10518,7 @@ describe('streamText', () => {
         (options: { tools: TOOLS }) =>
           new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
             transform(chunk, controller) {
-              if (chunk.type !== 'text') {
+              if (chunk.type !== 'text-delta') {
                 controller.enqueue(chunk);
                 return;
               }
@@ -10532,7 +10535,7 @@ describe('streamText', () => {
         (options: { tools: TOOLS }) =>
           new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
             transform(chunk, controller) {
-              if (chunk.type !== 'text') {
+              if (chunk.type !== 'text-delta') {
                 controller.enqueue(chunk);
                 return;
               }
@@ -10570,7 +10573,7 @@ describe('streamText', () => {
             // stream buffering and scanning to correctly emit prior text
             // and to detect all STOP occurrences.
             transform(chunk, controller) {
-              if (chunk.type !== 'text') {
+              if (chunk.type !== 'text-delta') {
                 controller.enqueue(chunk);
                 return;
               }
@@ -10643,55 +10646,55 @@ describe('streamText', () => {
 
         expect(await convertAsyncIterableToArray(result.fullStream))
           .toMatchInlineSnapshot(`
-          [
-            {
-              "type": "start",
-            },
-            {
-              "request": {},
-              "type": "start-step",
-              "warnings": [],
-            },
-            {
-              "id": "1",
-              "type": "text-start",
-            },
-            {
-              "id": "1",
-              "providerMetadata": undefined,
-              "text": "Hello, ",
-              "type": "text",
-            },
-            {
-              "finishReason": "stop",
-              "providerMetadata": undefined,
-              "response": {
-                "id": "response-id",
-                "modelId": "mock-model-id",
-                "timestamp": 1970-01-01T00:00:00.000Z,
+            [
+              {
+                "type": "start",
               },
-              "type": "finish-step",
-              "usage": {
-                "cachedInputTokens": undefined,
-                "inputTokens": undefined,
-                "outputTokens": undefined,
-                "reasoningTokens": undefined,
-                "totalTokens": undefined,
+              {
+                "request": {},
+                "type": "start-step",
+                "warnings": [],
               },
-            },
-            {
-              "finishReason": "stop",
-              "totalUsage": {
-                "cachedInputTokens": undefined,
-                "inputTokens": undefined,
-                "outputTokens": undefined,
-                "reasoningTokens": undefined,
-                "totalTokens": undefined,
+              {
+                "id": "1",
+                "type": "text-start",
               },
-              "type": "finish",
-            },
-          ]
-        `);
+              {
+                "id": "1",
+                "providerMetadata": undefined,
+                "text": "Hello, ",
+                "type": "text-delta",
+              },
+              {
+                "finishReason": "stop",
+                "providerMetadata": undefined,
+                "response": {
+                  "id": "response-id",
+                  "modelId": "mock-model-id",
+                  "timestamp": 1970-01-01T00:00:00.000Z,
+                },
+                "type": "finish-step",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokens": undefined,
+                  "outputTokens": undefined,
+                  "reasoningTokens": undefined,
+                  "totalTokens": undefined,
+                },
+              },
+              {
+                "finishReason": "stop",
+                "totalUsage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokens": undefined,
+                  "outputTokens": undefined,
+                  "reasoningTokens": undefined,
+                  "totalTokens": undefined,
+                },
+                "type": "finish",
+              },
+            ]
+          `);
       });
 
       it('options.onStepFinish should be called', async () => {
@@ -11463,7 +11466,7 @@ describe('streamText', () => {
             "id": "1",
             "providerMetadata": undefined,
             "text": "Hello, world!",
-            "type": "text",
+            "type": "text-delta",
           },
         ]
       `);
@@ -11567,138 +11570,138 @@ describe('streamText', () => {
       it('should return the full stream with the correct parts', async () => {
         expect(await convertAsyncIterableToArray(result.fullStream))
           .toMatchInlineSnapshot(`
-          [
-            {
-              "type": "start",
-            },
-            {
-              "request": {},
-              "type": "start-step",
-              "warnings": [],
-            },
-            {
-              "id": "0",
-              "type": "reasoning-start",
-            },
-            {
-              "id": "1",
-              "type": "text-start",
-            },
-            {
-              "id": "0",
-              "providerMetadata": undefined,
-              "text": "Thinking...",
-              "type": "reasoning",
-            },
-            {
-              "id": "1",
-              "providerMetadata": undefined,
-              "text": "Hello",
-              "type": "text",
-            },
-            {
-              "id": "1",
-              "providerMetadata": undefined,
-              "text": ", ",
-              "type": "text",
-            },
-            {
-              "id": "2",
-              "type": "text-start",
-            },
-            {
-              "id": "2",
-              "providerMetadata": undefined,
-              "text": "This ",
-              "type": "text",
-            },
-            {
-              "id": "2",
-              "providerMetadata": undefined,
-              "text": "is ",
-              "type": "text",
-            },
-            {
-              "id": "3",
-              "type": "reasoning-start",
-            },
-            {
-              "id": "0",
-              "providerMetadata": undefined,
-              "text": "I'm thinking...",
-              "type": "reasoning",
-            },
-            {
-              "id": "3",
-              "providerMetadata": undefined,
-              "text": "Separate thoughts",
-              "type": "reasoning",
-            },
-            {
-              "id": "2",
-              "providerMetadata": undefined,
-              "text": "a",
-              "type": "text",
-            },
-            {
-              "id": "1",
-              "providerMetadata": undefined,
-              "text": "world!",
-              "type": "text",
-            },
-            {
-              "id": "0",
-              "type": "reasoning-end",
-            },
-            {
-              "id": "2",
-              "providerMetadata": undefined,
-              "text": " test.",
-              "type": "text",
-            },
-            {
-              "id": "2",
-              "type": "text-end",
-            },
-            {
-              "id": "3",
-              "type": "reasoning-end",
-            },
-            {
-              "id": "1",
-              "type": "text-end",
-            },
-            {
-              "finishReason": "stop",
-              "providerMetadata": undefined,
-              "response": {
-                "headers": undefined,
-                "id": "id-0",
-                "modelId": "mock-model-id",
-                "timestamp": 1970-01-01T00:00:02.000Z,
+            [
+              {
+                "type": "start",
               },
-              "type": "finish-step",
-              "usage": {
-                "cachedInputTokens": undefined,
-                "inputTokens": 3,
-                "outputTokens": 10,
-                "reasoningTokens": undefined,
-                "totalTokens": 13,
+              {
+                "request": {},
+                "type": "start-step",
+                "warnings": [],
               },
-            },
-            {
-              "finishReason": "stop",
-              "totalUsage": {
-                "cachedInputTokens": undefined,
-                "inputTokens": 3,
-                "outputTokens": 10,
-                "reasoningTokens": undefined,
-                "totalTokens": 13,
+              {
+                "id": "0",
+                "type": "reasoning-start",
               },
-              "type": "finish",
-            },
-          ]
-        `);
+              {
+                "id": "1",
+                "type": "text-start",
+              },
+              {
+                "id": "0",
+                "providerMetadata": undefined,
+                "text": "Thinking...",
+                "type": "reasoning-delta",
+              },
+              {
+                "id": "1",
+                "providerMetadata": undefined,
+                "text": "Hello",
+                "type": "text-delta",
+              },
+              {
+                "id": "1",
+                "providerMetadata": undefined,
+                "text": ", ",
+                "type": "text-delta",
+              },
+              {
+                "id": "2",
+                "type": "text-start",
+              },
+              {
+                "id": "2",
+                "providerMetadata": undefined,
+                "text": "This ",
+                "type": "text-delta",
+              },
+              {
+                "id": "2",
+                "providerMetadata": undefined,
+                "text": "is ",
+                "type": "text-delta",
+              },
+              {
+                "id": "3",
+                "type": "reasoning-start",
+              },
+              {
+                "id": "0",
+                "providerMetadata": undefined,
+                "text": "I'm thinking...",
+                "type": "reasoning-delta",
+              },
+              {
+                "id": "3",
+                "providerMetadata": undefined,
+                "text": "Separate thoughts",
+                "type": "reasoning-delta",
+              },
+              {
+                "id": "2",
+                "providerMetadata": undefined,
+                "text": "a",
+                "type": "text-delta",
+              },
+              {
+                "id": "1",
+                "providerMetadata": undefined,
+                "text": "world!",
+                "type": "text-delta",
+              },
+              {
+                "id": "0",
+                "type": "reasoning-end",
+              },
+              {
+                "id": "2",
+                "providerMetadata": undefined,
+                "text": " test.",
+                "type": "text-delta",
+              },
+              {
+                "id": "2",
+                "type": "text-end",
+              },
+              {
+                "id": "3",
+                "type": "reasoning-end",
+              },
+              {
+                "id": "1",
+                "type": "text-end",
+              },
+              {
+                "finishReason": "stop",
+                "providerMetadata": undefined,
+                "response": {
+                  "headers": undefined,
+                  "id": "id-0",
+                  "modelId": "mock-model-id",
+                  "timestamp": 1970-01-01T00:00:02.000Z,
+                },
+                "type": "finish-step",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokens": 3,
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
+              },
+              {
+                "finishReason": "stop",
+                "totalUsage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokens": 3,
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
+                "type": "finish",
+              },
+            ]
+          `);
       });
 
       it('should return the content parts in the correct order', async () => {
@@ -11908,7 +11911,7 @@ describe('streamText', () => {
                 "id": "1",
                 "providerMetadata": undefined,
                 "text": "Hello",
-                "type": "text",
+                "type": "text-delta",
               },
               {
                 "type": "abort",
@@ -12137,74 +12140,74 @@ describe('streamText', () => {
       it('should only stream initial chunks in full stream', async () => {
         expect(await convertAsyncIterableToArray(result.fullStream))
           .toMatchInlineSnapshot(`
-          [
-            {
-              "type": "start",
-            },
-            {
-              "request": {},
-              "type": "start-step",
-              "warnings": [],
-            },
-            {
-              "input": {
-                "value": "value",
+            [
+              {
+                "type": "start",
               },
-              "providerExecuted": undefined,
-              "providerMetadata": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-call",
-            },
-            {
-              "input": {
-                "value": "value",
+              {
+                "request": {},
+                "type": "start-step",
+                "warnings": [],
               },
-              "output": "result1",
-              "providerExecuted": undefined,
-              "providerMetadata": undefined,
-              "toolCallId": "call-1",
-              "toolName": "tool1",
-              "type": "tool-result",
-            },
-            {
-              "finishReason": "tool-calls",
-              "providerMetadata": undefined,
-              "response": {
-                "headers": undefined,
-                "id": "id-0",
-                "modelId": "mock-model-id",
-                "timestamp": 1970-01-01T00:00:00.000Z,
+              {
+                "input": {
+                  "value": "value",
+                },
+                "providerExecuted": undefined,
+                "providerMetadata": undefined,
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
               },
-              "type": "finish-step",
-              "usage": {
-                "cachedInputTokens": undefined,
-                "inputTokens": 3,
-                "outputTokens": 10,
-                "reasoningTokens": undefined,
-                "totalTokens": 13,
+              {
+                "input": {
+                  "value": "value",
+                },
+                "output": "result1",
+                "providerExecuted": undefined,
+                "providerMetadata": undefined,
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-result",
               },
-            },
-            {
-              "request": {},
-              "type": "start-step",
-              "warnings": [],
-            },
-            {
-              "id": "1",
-              "type": "text-start",
-            },
-            {
-              "id": "1",
-              "providerMetadata": undefined,
-              "text": "Hello",
-              "type": "text",
-            },
-            {
-              "type": "abort",
-            },
-          ]
-        `);
+              {
+                "finishReason": "tool-calls",
+                "providerMetadata": undefined,
+                "response": {
+                  "headers": undefined,
+                  "id": "id-0",
+                  "modelId": "mock-model-id",
+                  "timestamp": 1970-01-01T00:00:00.000Z,
+                },
+                "type": "finish-step",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokens": 3,
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
+              },
+              {
+                "request": {},
+                "type": "start-step",
+                "warnings": [],
+              },
+              {
+                "id": "1",
+                "type": "text-start",
+              },
+              {
+                "id": "1",
+                "providerMetadata": undefined,
+                "text": "Hello",
+                "type": "text-delta",
+              },
+              {
+                "type": "abort",
+              },
+            ]
+          `);
       });
 
       it('should sent an abort chunk in the ui message stream', async () => {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -133,8 +133,8 @@ export type StreamTextOnChunkCallback<TOOLS extends ToolSet> = (event: {
     TextStreamPart<TOOLS>,
     {
       type:
-        | 'text'
-        | 'reasoning'
+        | 'text-delta'
+        | 'reasoning-delta'
         | 'source'
         | 'tool-call'
         | 'tool-input-start'
@@ -461,7 +461,7 @@ function createOutputTransformStream<
   }) {
     controller.enqueue({
       part: {
-        type: 'text',
+        type: 'text-delta',
         id: firstTextChunkId!,
         text: textChunk,
       },
@@ -481,7 +481,7 @@ function createOutputTransformStream<
       }
 
       if (
-        chunk.type !== 'text' &&
+        chunk.type !== 'text-delta' &&
         chunk.type !== 'text-start' &&
         chunk.type !== 'text-end'
       ) {
@@ -658,8 +658,8 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
         const { part } = chunk;
 
         if (
-          part.type === 'text' ||
-          part.type === 'reasoning' ||
+          part.type === 'text-delta' ||
+          part.type === 'reasoning-delta' ||
           part.type === 'source' ||
           part.type === 'tool-call' ||
           part.type === 'tool-result' ||
@@ -684,7 +684,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
           recordedContent.push(activeTextContent[part.id]);
         }
 
-        if (part.type === 'text') {
+        if (part.type === 'text-delta') {
           const activeText = activeTextContent[part.id];
 
           if (activeText == null) {
@@ -717,7 +717,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
           recordedContent.push(activeReasoningContent[part.id]);
         }
 
-        if (part.type === 'reasoning') {
+        if (part.type === 'reasoning-delta') {
           const activeReasoning = activeReasoningContent[part.id];
 
           if (activeReasoning == null) {
@@ -1175,7 +1175,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                     case 'text-delta': {
                       if (chunk.delta.length > 0) {
                         controller.enqueue({
-                          type: 'text',
+                          type: 'text-delta',
                           id: chunk.id,
                           text: chunk.delta,
                           providerMetadata: chunk.providerMetadata,
@@ -1193,7 +1193,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
 
                     case 'reasoning-delta': {
                       controller.enqueue({
-                        type: 'reasoning',
+                        type: 'reasoning-delta',
                         id: chunk.id,
                         text: chunk.delta,
                         providerMetadata: chunk.providerMetadata,
@@ -1553,7 +1553,7 @@ However, the LLM results are expected to be small enough to not cause issues.
       this.teeStream().pipeThrough(
         new TransformStream<EnrichedStreamPart<TOOLS, PARTIAL_OUTPUT>, string>({
           transform({ part }, controller) {
-            if (part.type === 'text') {
+            if (part.type === 'text-delta') {
               controller.enqueue(part.text);
             }
           },
@@ -1654,7 +1654,7 @@ However, the LLM results are expected to be small enough to not cause issues.
               break;
             }
 
-            case 'text': {
+            case 'text-delta': {
               controller.enqueue({
                 type: 'text-delta',
                 id: part.id,
@@ -1688,7 +1688,7 @@ However, the LLM results are expected to be small enough to not cause issues.
               break;
             }
 
-            case 'reasoning': {
+            case 'reasoning-delta': {
               if (sendReasoning) {
                 controller.enqueue({
                   type: 'reasoning-delta',

--- a/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.test.ts
@@ -244,13 +244,13 @@ describe('extractReasoningMiddleware', () => {
               "id": "reasoning-0",
               "providerMetadata": undefined,
               "text": "ana",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "reasoning-0",
               "providerMetadata": undefined,
               "text": "lyzing the request",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "reasoning-0",
@@ -260,13 +260,13 @@ describe('extractReasoningMiddleware', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "Here",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
               "providerMetadata": undefined,
               "text": " is the response",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
@@ -365,7 +365,7 @@ describe('extractReasoningMiddleware', () => {
               "id": "reasoning-0",
               "providerMetadata": undefined,
               "text": "analyzing the request",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "reasoning-0",
@@ -375,7 +375,7 @@ describe('extractReasoningMiddleware', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "Here is the response",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "reasoning-1",
@@ -386,7 +386,7 @@ describe('extractReasoningMiddleware', () => {
               "providerMetadata": undefined,
               "text": "
           thinking about the response",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "reasoning-1",
@@ -397,7 +397,7 @@ describe('extractReasoningMiddleware', () => {
               "providerMetadata": undefined,
               "text": "
           more",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
@@ -494,14 +494,14 @@ describe('extractReasoningMiddleware', () => {
               "id": "reasoning-0",
               "providerMetadata": undefined,
               "text": "ana",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "reasoning-0",
               "providerMetadata": undefined,
               "text": "lyzing the request
           ",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "reasoning-0",
@@ -613,14 +613,14 @@ describe('extractReasoningMiddleware', () => {
               "id": "reasoning-0",
               "providerMetadata": undefined,
               "text": "ana",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "reasoning-0",
               "providerMetadata": undefined,
               "text": "lyzing the request
           ",
-              "type": "reasoning",
+              "type": "reasoning-delta",
             },
             {
               "id": "reasoning-0",
@@ -630,7 +630,7 @@ describe('extractReasoningMiddleware', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "this is the response",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
@@ -687,26 +687,26 @@ describe('extractReasoningMiddleware', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "ana",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
               "providerMetadata": undefined,
               "text": "lyzing the request
           ",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
               "providerMetadata": undefined,
               "text": "</think>",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
               "providerMetadata": undefined,
               "text": "this is the response",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",
@@ -796,7 +796,7 @@ describe('extractReasoningMiddleware', () => {
               "id": "1",
               "providerMetadata": undefined,
               "text": "this is the response",
-              "type": "text",
+              "type": "text-delta",
             },
             {
               "id": "1",

--- a/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
@@ -49,60 +49,60 @@ describe('simulateStreamingMiddleware', () => {
 
     expect(await convertAsyncIterableToArray(result.fullStream))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "type": "start",
-        },
-        {
-          "request": {},
-          "type": "start-step",
-          "warnings": [],
-        },
-        {
-          "id": "0",
-          "type": "text-start",
-        },
-        {
-          "id": "0",
-          "providerMetadata": undefined,
-          "text": "This is a test response",
-          "type": "text",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
-        },
-        {
-          "finishReason": "stop",
-          "providerMetadata": undefined,
-          "response": {
-            "headers": undefined,
-            "id": "id-0",
-            "modelId": "mock-model-id",
-            "timestamp": 2025-01-01T00:00:00.000Z,
+        [
+          {
+            "type": "start",
           },
-          "type": "finish-step",
-          "usage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
+          {
+            "request": {},
+            "type": "start-step",
+            "warnings": [],
           },
-        },
-        {
-          "finishReason": "stop",
-          "totalUsage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
+          {
+            "id": "0",
+            "type": "text-start",
           },
-          "type": "finish",
-        },
-      ]
-    `);
+          {
+            "id": "0",
+            "providerMetadata": undefined,
+            "text": "This is a test response",
+            "type": "text-delta",
+          },
+          {
+            "id": "0",
+            "type": "text-end",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": undefined,
+            "response": {
+              "headers": undefined,
+              "id": "id-0",
+              "modelId": "mock-model-id",
+              "timestamp": 2025-01-01T00:00:00.000Z,
+            },
+            "type": "finish-step",
+            "usage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
+            },
+          },
+          {
+            "finishReason": "stop",
+            "totalUsage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
+            },
+            "type": "finish",
+          },
+        ]
+      `);
   });
 
   it('should simulate streaming with reasoning as string', async () => {
@@ -134,75 +134,75 @@ describe('simulateStreamingMiddleware', () => {
 
     expect(await convertAsyncIterableToArray(result.fullStream))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "type": "start",
-        },
-        {
-          "request": {},
-          "type": "start-step",
-          "warnings": [],
-        },
-        {
-          "id": "0",
-          "providerMetadata": undefined,
-          "type": "reasoning-start",
-        },
-        {
-          "id": "0",
-          "providerMetadata": undefined,
-          "text": "This is the reasoning process",
-          "type": "reasoning",
-        },
-        {
-          "id": "0",
-          "type": "reasoning-end",
-        },
-        {
-          "id": "1",
-          "type": "text-start",
-        },
-        {
-          "id": "1",
-          "providerMetadata": undefined,
-          "text": "This is a test response",
-          "type": "text",
-        },
-        {
-          "id": "1",
-          "type": "text-end",
-        },
-        {
-          "finishReason": "stop",
-          "providerMetadata": undefined,
-          "response": {
-            "headers": undefined,
-            "id": "id-1",
-            "modelId": "mock-model-id",
-            "timestamp": 2025-01-01T00:00:00.000Z,
+        [
+          {
+            "type": "start",
           },
-          "type": "finish-step",
-          "usage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
+          {
+            "request": {},
+            "type": "start-step",
+            "warnings": [],
           },
-        },
-        {
-          "finishReason": "stop",
-          "totalUsage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
+          {
+            "id": "0",
+            "providerMetadata": undefined,
+            "type": "reasoning-start",
           },
-          "type": "finish",
-        },
-      ]
-    `);
+          {
+            "id": "0",
+            "providerMetadata": undefined,
+            "text": "This is the reasoning process",
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "0",
+            "type": "reasoning-end",
+          },
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          {
+            "id": "1",
+            "providerMetadata": undefined,
+            "text": "This is a test response",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "type": "text-end",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": undefined,
+            "response": {
+              "headers": undefined,
+              "id": "id-1",
+              "modelId": "mock-model-id",
+              "timestamp": 2025-01-01T00:00:00.000Z,
+            },
+            "type": "finish-step",
+            "usage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
+            },
+          },
+          {
+            "finishReason": "stop",
+            "totalUsage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
+            },
+            "type": "finish",
+          },
+        ]
+      `);
   });
 
   it('should simulate streaming with reasoning as array of text objects', async () => {
@@ -246,109 +246,109 @@ describe('simulateStreamingMiddleware', () => {
 
     expect(await convertAsyncIterableToArray(result.fullStream))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "type": "start",
-        },
-        {
-          "request": {},
-          "type": "start-step",
-          "warnings": [],
-        },
-        {
-          "id": "0",
-          "type": "text-start",
-        },
-        {
-          "id": "0",
-          "providerMetadata": undefined,
-          "text": "This is a test response",
-          "type": "text",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
-        },
-        {
-          "id": "1",
-          "providerMetadata": undefined,
-          "type": "reasoning-start",
-        },
-        {
-          "id": "1",
-          "providerMetadata": undefined,
-          "text": "First reasoning step",
-          "type": "reasoning",
-        },
-        {
-          "id": "1",
-          "type": "reasoning-end",
-        },
-        {
-          "id": "2",
-          "providerMetadata": undefined,
-          "type": "reasoning-start",
-        },
-        {
-          "id": "2",
-          "providerMetadata": undefined,
-          "text": "Second reasoning step",
-          "type": "reasoning",
-        },
-        {
-          "id": "2",
-          "type": "reasoning-end",
-        },
-        {
-          "id": "3",
-          "providerMetadata": {
-            "testProvider": {
-              "signature": "abc",
+        [
+          {
+            "type": "start",
+          },
+          {
+            "request": {},
+            "type": "start-step",
+            "warnings": [],
+          },
+          {
+            "id": "0",
+            "type": "text-start",
+          },
+          {
+            "id": "0",
+            "providerMetadata": undefined,
+            "text": "This is a test response",
+            "type": "text-delta",
+          },
+          {
+            "id": "0",
+            "type": "text-end",
+          },
+          {
+            "id": "1",
+            "providerMetadata": undefined,
+            "type": "reasoning-start",
+          },
+          {
+            "id": "1",
+            "providerMetadata": undefined,
+            "text": "First reasoning step",
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "1",
+            "type": "reasoning-end",
+          },
+          {
+            "id": "2",
+            "providerMetadata": undefined,
+            "type": "reasoning-start",
+          },
+          {
+            "id": "2",
+            "providerMetadata": undefined,
+            "text": "Second reasoning step",
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "2",
+            "type": "reasoning-end",
+          },
+          {
+            "id": "3",
+            "providerMetadata": {
+              "testProvider": {
+                "signature": "abc",
+              },
+            },
+            "type": "reasoning-start",
+          },
+          {
+            "id": "3",
+            "providerMetadata": undefined,
+            "text": "",
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "3",
+            "type": "reasoning-end",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": undefined,
+            "response": {
+              "headers": undefined,
+              "id": "id-2",
+              "modelId": "mock-model-id",
+              "timestamp": 2025-01-01T00:00:00.000Z,
+            },
+            "type": "finish-step",
+            "usage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
             },
           },
-          "type": "reasoning-start",
-        },
-        {
-          "id": "3",
-          "providerMetadata": undefined,
-          "text": "",
-          "type": "reasoning",
-        },
-        {
-          "id": "3",
-          "type": "reasoning-end",
-        },
-        {
-          "finishReason": "stop",
-          "providerMetadata": undefined,
-          "response": {
-            "headers": undefined,
-            "id": "id-2",
-            "modelId": "mock-model-id",
-            "timestamp": 2025-01-01T00:00:00.000Z,
+          {
+            "finishReason": "stop",
+            "totalUsage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
+            },
+            "type": "finish",
           },
-          "type": "finish-step",
-          "usage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
-          },
-        },
-        {
-          "finishReason": "stop",
-          "totalUsage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
-          },
-          "type": "finish",
-        },
-      ]
-    `);
+        ]
+      `);
   });
 
   it('should simulate streaming with reasoning as array of mixed objects', async () => {
@@ -389,94 +389,94 @@ describe('simulateStreamingMiddleware', () => {
 
     expect(await convertAsyncIterableToArray(result.fullStream))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "type": "start",
-        },
-        {
-          "request": {},
-          "type": "start-step",
-          "warnings": [],
-        },
-        {
-          "id": "0",
-          "providerMetadata": undefined,
-          "type": "reasoning-start",
-        },
-        {
-          "id": "0",
-          "providerMetadata": undefined,
-          "text": "First reasoning step",
-          "type": "reasoning",
-        },
-        {
-          "id": "0",
-          "type": "reasoning-end",
-        },
-        {
-          "id": "1",
-          "providerMetadata": {
-            "testProvider": {
-              "isRedacted": true,
+        [
+          {
+            "type": "start",
+          },
+          {
+            "request": {},
+            "type": "start-step",
+            "warnings": [],
+          },
+          {
+            "id": "0",
+            "providerMetadata": undefined,
+            "type": "reasoning-start",
+          },
+          {
+            "id": "0",
+            "providerMetadata": undefined,
+            "text": "First reasoning step",
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "0",
+            "type": "reasoning-end",
+          },
+          {
+            "id": "1",
+            "providerMetadata": {
+              "testProvider": {
+                "isRedacted": true,
+              },
+            },
+            "type": "reasoning-start",
+          },
+          {
+            "id": "1",
+            "providerMetadata": undefined,
+            "text": "data",
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "1",
+            "type": "reasoning-end",
+          },
+          {
+            "id": "2",
+            "type": "text-start",
+          },
+          {
+            "id": "2",
+            "providerMetadata": undefined,
+            "text": "This is a test response",
+            "type": "text-delta",
+          },
+          {
+            "id": "2",
+            "type": "text-end",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": undefined,
+            "response": {
+              "headers": undefined,
+              "id": "id-3",
+              "modelId": "mock-model-id",
+              "timestamp": 2025-01-01T00:00:00.000Z,
+            },
+            "type": "finish-step",
+            "usage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
             },
           },
-          "type": "reasoning-start",
-        },
-        {
-          "id": "1",
-          "providerMetadata": undefined,
-          "text": "data",
-          "type": "reasoning",
-        },
-        {
-          "id": "1",
-          "type": "reasoning-end",
-        },
-        {
-          "id": "2",
-          "type": "text-start",
-        },
-        {
-          "id": "2",
-          "providerMetadata": undefined,
-          "text": "This is a test response",
-          "type": "text",
-        },
-        {
-          "id": "2",
-          "type": "text-end",
-        },
-        {
-          "finishReason": "stop",
-          "providerMetadata": undefined,
-          "response": {
-            "headers": undefined,
-            "id": "id-3",
-            "modelId": "mock-model-id",
-            "timestamp": 2025-01-01T00:00:00.000Z,
+          {
+            "finishReason": "stop",
+            "totalUsage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
+            },
+            "type": "finish",
           },
-          "type": "finish-step",
-          "usage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
-          },
-        },
-        {
-          "finishReason": "stop",
-          "totalUsage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
-          },
-          "type": "finish",
-        },
-      ]
-    `);
+        ]
+      `);
   });
 
   it('should simulate streaming with tool calls', async () => {
@@ -549,7 +549,7 @@ describe('simulateStreamingMiddleware', () => {
             "id": "0",
             "providerMetadata": undefined,
             "text": "This is a test response",
-            "type": "text",
+            "type": "text-delta",
           },
           {
             "id": "0",
@@ -631,64 +631,64 @@ describe('simulateStreamingMiddleware', () => {
 
     expect(await convertAsyncIterableToArray(result.fullStream))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "type": "start",
-        },
-        {
-          "request": {},
-          "type": "start-step",
-          "warnings": [],
-        },
-        {
-          "id": "0",
-          "type": "text-start",
-        },
-        {
-          "id": "0",
-          "providerMetadata": undefined,
-          "text": "This is a test response",
-          "type": "text",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
-        },
-        {
-          "finishReason": "stop",
-          "providerMetadata": {
-            "custom": {
-              "key": "value",
+        [
+          {
+            "type": "start",
+          },
+          {
+            "request": {},
+            "type": "start-step",
+            "warnings": [],
+          },
+          {
+            "id": "0",
+            "type": "text-start",
+          },
+          {
+            "id": "0",
+            "providerMetadata": undefined,
+            "text": "This is a test response",
+            "type": "text-delta",
+          },
+          {
+            "id": "0",
+            "type": "text-end",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "custom": {
+                "key": "value",
+              },
+            },
+            "response": {
+              "headers": undefined,
+              "id": "id-5",
+              "modelId": "mock-model-id",
+              "timestamp": 2025-01-01T00:00:00.000Z,
+            },
+            "type": "finish-step",
+            "usage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
             },
           },
-          "response": {
-            "headers": undefined,
-            "id": "id-5",
-            "modelId": "mock-model-id",
-            "timestamp": 2025-01-01T00:00:00.000Z,
+          {
+            "finishReason": "stop",
+            "totalUsage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 5,
+              "outputTokens": 10,
+              "reasoningTokens": 3,
+              "totalTokens": 18,
+            },
+            "type": "finish",
           },
-          "type": "finish-step",
-          "usage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
-          },
-        },
-        {
-          "finishReason": "stop",
-          "totalUsage": {
-            "cachedInputTokens": undefined,
-            "inputTokens": 5,
-            "outputTokens": 10,
-            "reasoningTokens": 3,
-            "totalTokens": 18,
-          },
-          "type": "finish",
-        },
-      ]
-    `);
+        ]
+      `);
   });
 
   it('should handle empty text response', async () => {


### PR DESCRIPTION
## Background

In ui streams and language model stream the parts are called `text-delta` and `reasoning-delta`. The full stream from `streamText` is inconsistent.

## Summary

* rename `text` part to `text-delta`
* rename `reasoning` part to `reasoning-delta`

## Related Issues

Fixes #7452