### PR TITLE
feat(provider/groq): add structured outputs support

### DIFF
--- a/.changeset/slimy-apples-film.md
+++ b/.changeset/slimy-apples-film.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+feat(provider/groq): add structured outputs support

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -151,7 +151,7 @@ console.log(JSON.stringify(result.object, null, 2));
 
 You can disable structured outputs for models that don't support them:
 
-```ts highlight="7"
+```ts highlight="9"
 import { groq } from '@ai-sdk/groq';
 import { generateObject } from 'ai';
 import { z } from 'zod';

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -109,7 +109,7 @@ The following optional provider options are available for Groq language models:
 - **structuredOutputs** _boolean_
 
   Whether to use structured outputs.
-  
+
   Defaults to `true`.
 
   When enabled, object generation will use the `json_schema` format instead of `json_object` format, providing more reliable structured outputs.
@@ -177,9 +177,11 @@ console.log(JSON.stringify(result.object, null, 2));
 ```
 
 <Note type="warning">
-  Structured outputs are only supported by newer Groq models like `moonshotai/kimi-k2-instruct`.
-  For unsupported models, you can disable structured outputs by setting `structuredOutputs: false`.
-  When disabled, Groq uses the `json_object` format which requires the word "JSON" to be included in your messages.
+  Structured outputs are only supported by newer Groq models like
+  `moonshotai/kimi-k2-instruct`. For unsupported models, you can disable
+  structured outputs by setting `structuredOutputs: false`. When disabled, Groq
+  uses the `json_object` format which requires the word "JSON" to be included in
+  your messages.
 </Note>
 
 ### Example

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -106,6 +106,14 @@ The following optional provider options are available for Groq language models:
 
   For a complete list of reasoning models and their capabilities, see [Groq's reasoning models documentation](https://console.groq.com/docs/reasoning).
 
+- **structuredOutputs** _boolean_
+
+  Whether to use structured outputs.
+
+  Defaults to `false`.
+
+  When enabled, object generation will use the `json_schema` format instead of `json_object` format, providing more reliable structured outputs.
+
 - **parallelToolCalls** _boolean_
 
   Whether to enable parallel function calling during tool use. Defaults to `true`.
@@ -115,6 +123,43 @@ The following optional provider options are available for Groq language models:
   A unique identifier representing your end-user, which can help with monitoring and abuse detection.
 
 <Note>Only Groq reasoning models support the `reasoningFormat` option.</Note>
+
+#### Structured Outputs
+
+Groq supports structured outputs for newer models like `moonshotai/kimi-k2-instruct`.
+You can enable structured outputs by setting the `structuredOutputs` option to `true`.
+
+```ts highlight="9"
+import { groq } from '@ai-sdk/groq';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const result = await generateObject({
+  model: groq('moonshotai/kimi-k2-instruct'),
+  providerOptions: {
+    groq: {
+      structuredOutputs: true,
+    },
+  },
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(z.string()),
+      instructions: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate a simple pasta recipe.',
+});
+
+console.log(JSON.stringify(result.object, null, 2));
+```
+
+<Note type="warning">
+  Structured outputs are only supported by newer Groq models and may have
+  limitations. When structured outputs are disabled (default), Groq uses the
+  `json_object` format which requires the word "JSON" to be included in your
+  messages.
+</Note>
 
 ### Example
 

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -109,8 +109,8 @@ The following optional provider options are available for Groq language models:
 - **structuredOutputs** _boolean_
 
   Whether to use structured outputs.
-
-  Defaults to `false`.
+  
+  Defaults to `true`.
 
   When enabled, object generation will use the `json_schema` format instead of `json_object` format, providing more reliable structured outputs.
 
@@ -126,21 +126,16 @@ The following optional provider options are available for Groq language models:
 
 #### Structured Outputs
 
-Groq supports structured outputs for newer models like `moonshotai/kimi-k2-instruct`.
-You can enable structured outputs by setting the `structuredOutputs` option to `true`.
+Structured outputs are enabled by default for Groq models.
+You can disable them by setting the `structuredOutputs` option to `false`.
 
-```ts highlight="9"
+```ts
 import { groq } from '@ai-sdk/groq';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 
 const result = await generateObject({
   model: groq('moonshotai/kimi-k2-instruct'),
-  providerOptions: {
-    groq: {
-      structuredOutputs: true,
-    },
-  },
   schema: z.object({
     recipe: z.object({
       name: z.string(),
@@ -154,11 +149,37 @@ const result = await generateObject({
 console.log(JSON.stringify(result.object, null, 2));
 ```
 
+You can disable structured outputs for models that don't support them:
+
+```ts highlight="7"
+import { groq } from '@ai-sdk/groq';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const result = await generateObject({
+  model: groq('gemma2-9b-it'),
+  providerOptions: {
+    groq: {
+      structuredOutputs: false,
+    },
+  },
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(z.string()),
+      instructions: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate a simple pasta recipe in JSON format.',
+});
+
+console.log(JSON.stringify(result.object, null, 2));
+```
+
 <Note type="warning">
-  Structured outputs are only supported by newer Groq models and may have
-  limitations. When structured outputs are disabled (default), Groq uses the
-  `json_object` format which requires the word "JSON" to be included in your
-  messages.
+  Structured outputs are only supported by newer Groq models like `moonshotai/kimi-k2-instruct`.
+  For unsupported models, you can disable structured outputs by setting `structuredOutputs: false`.
+  When disabled, Groq uses the `json_object` format which requires the word "JSON" to be included in your messages.
 </Note>
 
 ### Example

--- a/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
@@ -7,7 +7,7 @@ async function main() {
   const result = await generateObject({
     model: groq('moonshotai/kimi-k2-instruct'),
     schema: z.record(z.unknown()),
-    prompt: 'Create a simple pasta recipe. Please return the following in JSON format.',
+    prompt: 'Create a simple pasta recipe.',
     providerOptions: {
       groq: {
         structuredOutputs: true,

--- a/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
@@ -20,4 +20,4 @@ async function main() {
   console.log('Token usage:', result.usage);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
@@ -6,11 +6,6 @@ import 'dotenv/config';
 async function main() {
   const result = await generateObject({
     model: groq('moonshotai/kimi-k2-instruct'),
-    providerOptions: {
-      groq: {
-        structuredOutputs: true,
-      },
-    },
     schema: z.object({
       recipe: z.object({
         name: z.string(),

--- a/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
@@ -1,0 +1,23 @@
+import { groq } from '@ai-sdk/groq';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateObject({
+    model: groq('moonshotai/kimi-k2-instruct'),
+    schema: z.record(z.unknown()),
+    prompt: 'Create a simple pasta recipe. Please return the following in JSON format.',
+    providerOptions: {
+      groq: {
+        structuredOutputs: true,
+      },
+    },
+  });
+
+  console.log(JSON.stringify(result.object, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+}
+
+main().catch(console.error); 

--- a/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
+++ b/examples/ai-core/src/generate-object/groq-kimi-k2-structured-outputs.ts
@@ -6,18 +6,22 @@ import 'dotenv/config';
 async function main() {
   const result = await generateObject({
     model: groq('moonshotai/kimi-k2-instruct'),
-    schema: z.record(z.unknown()),
-    prompt: 'Create a simple pasta recipe.',
     providerOptions: {
       groq: {
         structuredOutputs: true,
       },
     },
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(z.string()),
+        instructions: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Generate a simple pasta recipe.',
   });
 
   console.log(JSON.stringify(result.object, null, 2));
-  console.log();
-  console.log('Token usage:', result.usage);
 }
 
 main().catch(console.error);

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -411,7 +411,8 @@ describe('doGenerate', () => {
 
     expect(warnings).toEqual([
       {
-        details: 'JSON response format schema is only supported with structuredOutputs',
+        details:
+          'JSON response format schema is only supported with structuredOutputs',
         setting: 'responseFormat',
         type: 'unsupported-setting',
       },

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -508,6 +508,136 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should handle structured outputs with Kimi K2 model', async () => {
+    prepareJsonResponse({ 
+      content: '{"recipe":{"name":"Spaghetti Aglio e Olio","ingredients":["spaghetti","garlic","olive oil","parmesan"],"instructions":["Boil pasta","Sauté garlic","Combine"]}}' 
+    });
+
+    const kimiModel = provider('moonshotai/kimi-k2-instruct');
+
+    const result = await kimiModel.doGenerate({
+      providerOptions: {
+        groq: {
+          structuredOutputs: true,
+        },
+      },
+      responseFormat: {
+        type: 'json',
+        name: 'recipe_response',
+        description: 'A recipe with ingredients and instructions',
+        schema: {
+          type: 'object',
+          properties: {
+            recipe: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                ingredients: { type: 'array', items: { type: 'string' } },
+                instructions: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['name', 'ingredients', 'instructions'],
+            },
+          },
+          required: ['recipe'],
+          additionalProperties: false,
+          $schema: 'http://json-schema.org/draft-07/schema#',
+        },
+      },
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Generate a simple pasta recipe' }] }],
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Generate a simple pasta recipe",
+            "role": "user",
+          },
+        ],
+        "model": "moonshotai/kimi-k2-instruct",
+        "response_format": {
+          "json_schema": {
+            "description": "A recipe with ingredients and instructions",
+            "name": "recipe_response",
+            "schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "recipe": {
+                  "properties": {
+                    "ingredients": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "instructions": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "ingredients",
+                    "instructions",
+                  ],
+                  "type": "object",
+                },
+              },
+              "required": [
+                "recipe",
+              ],
+              "type": "object",
+            },
+          },
+          "type": "json_schema",
+        },
+      }
+    `);
+
+    expect(result.content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "{"recipe":{"name":"Spaghetti Aglio e Olio","ingredients":["spaghetti","garlic","olive oil","parmesan"],"instructions":["Boil pasta","Sauté garlic","Combine"]}}",
+          "type": "text",
+        },
+      ]
+    `);
+  });
+
+  it('should include warnings when structured outputs disabled but schema provided', async () => {
+    prepareJsonResponse({ content: '{"value":"test"}' });
+
+    const { warnings } = await model.doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+          $schema: 'http://json-schema.org/draft-07/schema#',
+        },
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(warnings).toMatchInlineSnapshot(`
+      [
+        {
+          "details": "JSON response format schema is only supported with structuredOutputs",
+          "setting": "responseFormat",
+          "type": "unsupported-setting",
+        },
+      ]
+    `);
+  });
+
   it('should send request body', async () => {
     prepareJsonResponse({ content: '' });
 

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -509,8 +509,9 @@ describe('doGenerate', () => {
   });
 
   it('should handle structured outputs with Kimi K2 model', async () => {
-    prepareJsonResponse({ 
-      content: '{"recipe":{"name":"Spaghetti Aglio e Olio","ingredients":["spaghetti","garlic","olive oil","parmesan"],"instructions":["Boil pasta","Sauté garlic","Combine"]}}' 
+    prepareJsonResponse({
+      content:
+        '{"recipe":{"name":"Spaghetti Aglio e Olio","ingredients":["spaghetti","garlic","olive oil","parmesan"],"instructions":["Boil pasta","Sauté garlic","Combine"]}}',
     });
 
     const kimiModel = provider('moonshotai/kimi-k2-instruct');
@@ -543,7 +544,12 @@ describe('doGenerate', () => {
           $schema: 'http://json-schema.org/draft-07/schema#',
         },
       },
-      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Generate a simple pasta recipe' }] }],
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Generate a simple pasta recipe' }],
+        },
+      ],
     });
 
     expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -28,8 +28,6 @@ import { groqErrorDataSchema, groqFailedResponseHandler } from './groq-error';
 import { prepareTools } from './groq-prepare-tools';
 import { mapGroqFinishReason } from './map-groq-finish-reason';
 
-
-
 type GroqChatConfig = {
   provider: string;
   headers: () => Record<string, string | undefined>;
@@ -100,7 +98,8 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'responseFormat',
-        details: 'JSON response format schema is only supported with structuredOutputs',
+        details:
+          'JSON response format schema is only supported with structuredOutputs',
       });
     }
 

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -4,6 +4,7 @@ import {
   LanguageModelV2CallWarning,
   LanguageModelV2Content,
   LanguageModelV2FinishReason,
+  LanguageModelV2Prompt,
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
   SharedV2ProviderMetadata,
@@ -26,6 +27,8 @@ import { GroqChatModelId, groqProviderOptions } from './groq-chat-options';
 import { groqErrorDataSchema, groqFailedResponseHandler } from './groq-error';
 import { prepareTools } from './groq-prepare-tools';
 import { mapGroqFinishReason } from './map-groq-finish-reason';
+
+
 
 type GroqChatConfig = {
   provider: string;
@@ -74,6 +77,14 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
   }) {
     const warnings: LanguageModelV2CallWarning[] = [];
 
+    const groqOptions = await parseProviderOptions({
+      provider: 'groq',
+      providerOptions,
+      schema: groqProviderOptions,
+    });
+
+    const structuredOutputs = groqOptions?.structuredOutputs ?? false;
+
     if (topK != null) {
       warnings.push({
         type: 'unsupported-setting',
@@ -82,22 +93,16 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
     }
 
     if (
-      responseFormat != null &&
-      responseFormat.type === 'json' &&
-      responseFormat.schema != null
+      responseFormat?.type === 'json' &&
+      responseFormat.schema != null &&
+      !structuredOutputs
     ) {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'responseFormat',
-        details: 'JSON response format schema is not supported',
+        details: 'JSON response format schema is only supported with structuredOutputs',
       });
     }
-
-    const groqOptions = await parseProviderOptions({
-      provider: 'groq',
-      providerOptions,
-      schema: groqProviderOptions,
-    });
 
     const {
       tools: groqTools,
@@ -125,9 +130,17 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
 
         // response format:
         response_format:
-          // json object response format is not supported for streaming:
-          stream === false && responseFormat?.type === 'json'
-            ? { type: 'json_object' }
+          responseFormat?.type === 'json'
+            ? structuredOutputs && responseFormat.schema != null
+              ? {
+                  type: 'json_schema',
+                  json_schema: {
+                    schema: responseFormat.schema,
+                    name: responseFormat.name ?? 'response',
+                    description: responseFormat.description,
+                  },
+                }
+              : { type: 'json_object' }
             : undefined,
 
         // provider options:

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -81,7 +81,7 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
       schema: groqProviderOptions,
     });
 
-    const structuredOutputs = groqOptions?.structuredOutputs ?? false;
+    const structuredOutputs = groqOptions?.structuredOutputs ?? true;
 
     if (topK != null) {
       warnings.push({

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -42,7 +42,7 @@ export const groqProviderOptions = z.object({
   /**
    * Whether to use structured outputs.
    *
-   * @default false
+   * @default true
    */
   structuredOutputs: z.boolean().optional(),
 });

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -38,6 +38,13 @@ export const groqProviderOptions = z.object({
    * monitor and detect abuse. Learn more.
    */
   user: z.string().optional(),
+
+  /**
+   * Whether to use structured outputs.
+   *
+   * @default false
+   */
+  structuredOutputs: z.boolean().optional(),
 });
 
 export type GroqProviderOptions = z.infer<typeof groqProviderOptions>;


### PR DESCRIPTION
## background

Users reported errors when using `generateObject` with Groq models, specifically the "'messages' must contain the word 'json' in some form" error. Groq has added structured outputs support with `json_schema` format for newer models like Kimi K2, but the AI SDK provider wasn't using it.

## summary

- add structured outputs support with `json_schema` format
- add `structuredOutputs` provider option
- maintain backward compatibility with `json_object` format

## verification

- all tests pass including new structured outputs tests
- `generateObject` works with Groq models when `structuredOutputs: true`
- example demonstrates working structured outputs with Kimi K2
- falls back gracefully to `json_object` when structured outputs disabled

## tasks

- [x] add `structuredOutputs` option to groq provider options
- [x] implement `json_schema` format when structured outputs enabled
- [x] add warning when schema used without structured outputs
- [x] add tests for both formats
- [x] add working example with Kimi K2 model