### PR TITLE
feat (provider/gateway): Add providerMetadata to embeddings response

### DIFF
--- a/.changeset/wise-bees-listen.md
+++ b/.changeset/wise-bees-listen.md
@@ -1,0 +1,7 @@
+---
+'@example/ai-core': patch
+'@ai-sdk/gateway': patch
+'ai': patch
+---
+
+feat (provider/gateway): Add providerMetadata to embeddings response

--- a/.changeset/wise-bees-listen.md
+++ b/.changeset/wise-bees-listen.md
@@ -1,5 +1,6 @@
 ---
 '@ai-sdk/gateway': patch
+'@ai-sdk/provider': patch
 'ai': patch
 ---
 

--- a/.changeset/wise-bees-listen.md
+++ b/.changeset/wise-bees-listen.md
@@ -1,5 +1,4 @@
 ---
-'@example/ai-core': patch
 '@ai-sdk/gateway': patch
 'ai': patch
 ---

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -174,5 +174,11 @@ const { embedding } = await embed({
         },
       ],
     },
+    {
+      name: 'providerMetadata',
+      type: 'ProviderMetadata | undefined',
+      isOptional: true,
+      description: 'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
   ]}
 />

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -178,7 +178,8 @@ const { embedding } = await embed({
       name: 'providerMetadata',
       type: 'ProviderMetadata | undefined',
       isOptional: true,
-      description: 'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
   ]}
 />

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -161,6 +161,11 @@ const { embeddings } = await embedMany({
         },
       ],
     },
-
+    {
+      name: 'providerMetadata',
+      type: 'ProviderMetadata | undefined',
+      isOptional: true,
+      description: 'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
 ]}
 />

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -165,7 +165,8 @@ const { embeddings } = await embedMany({
       name: 'providerMetadata',
       type: 'ProviderMetadata | undefined',
       isOptional: true,
-      description: 'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+      description:
+        'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
-]}
+  ]}
 />

--- a/examples/ai-core/src/embed-many/gateway.ts
+++ b/examples/ai-core/src/embed-many/gateway.ts
@@ -1,10 +1,6 @@
-import { createGatewayProvider } from '@ai-sdk/gateway';
+import { gateway } from '@ai-sdk/gateway';
 import { embedMany } from 'ai';
 import 'dotenv/config';
-
-const gateway = createGatewayProvider({
-  baseURL: 'http://localhost:3000/v1/ai',
-});
 
 async function main() {
   const result = await embedMany({

--- a/examples/ai-core/src/embed-many/gateway.ts
+++ b/examples/ai-core/src/embed-many/gateway.ts
@@ -1,6 +1,10 @@
-import { gateway } from '@ai-sdk/gateway';
+import { createGatewayProvider } from '@ai-sdk/gateway';
 import { embedMany } from 'ai';
 import 'dotenv/config';
+
+const gateway = createGatewayProvider({
+  baseURL: 'http://localhost:3000/v1/ai',
+});
 
 async function main() {
   const result = await embedMany({
@@ -14,7 +18,7 @@ async function main() {
 
   console.log('Embeddings:', result.embeddings);
   console.log('Usage:', result.usage);
-  
+
   if (result.providerMetadata) {
     console.log('\nProvider Metadata:');
     console.log(JSON.stringify(result.providerMetadata, null, 2));

--- a/examples/ai-core/src/embed-many/gateway.ts
+++ b/examples/ai-core/src/embed-many/gateway.ts
@@ -3,7 +3,7 @@ import { embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embeddings, usage } = await embedMany({
+  const result = await embedMany({
     model: gateway.textEmbeddingModel('openai/text-embedding-3-small'),
     values: [
       'sunny day at the beach',
@@ -12,8 +12,13 @@ async function main() {
     ],
   });
 
-  console.log(embeddings);
-  console.log(usage);
+  console.log('Embeddings:', result.embeddings);
+  console.log('Usage:', result.usage);
+  
+  if (result.providerMetadata) {
+    console.log('\nProvider Metadata:');
+    console.log(JSON.stringify(result.providerMetadata, null, 2));
+  }
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/gateway.ts
+++ b/examples/ai-core/src/embed/gateway.ts
@@ -1,6 +1,10 @@
-import { gateway } from '@ai-sdk/gateway';
+import { createGatewayProvider } from '@ai-sdk/gateway';
 import { embed } from 'ai';
 import 'dotenv/config';
+
+const gateway = createGatewayProvider({
+  baseURL: 'http://localhost:3000/v1/ai',
+});
 
 async function main() {
   const result = await embed({
@@ -10,7 +14,7 @@ async function main() {
 
   console.log('Embedding:', result.embedding);
   console.log('Usage:', result.usage);
-  
+
   if (result.providerMetadata) {
     console.log('\nProvider Metadata:');
     console.log(JSON.stringify(result.providerMetadata, null, 2));

--- a/examples/ai-core/src/embed/gateway.ts
+++ b/examples/ai-core/src/embed/gateway.ts
@@ -1,10 +1,6 @@
-import { createGatewayProvider } from '@ai-sdk/gateway';
+import { gateway } from '@ai-sdk/gateway';
 import { embed } from 'ai';
 import 'dotenv/config';
-
-const gateway = createGatewayProvider({
-  baseURL: 'http://localhost:3000/v1/ai',
-});
 
 async function main() {
   const result = await embed({

--- a/examples/ai-core/src/embed/gateway.ts
+++ b/examples/ai-core/src/embed/gateway.ts
@@ -3,13 +3,18 @@ import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embedding, usage } = await embed({
+  const result = await embed({
     model: gateway.textEmbeddingModel('openai/text-embedding-3-small'),
     value: 'sunny day at the beach',
   });
 
-  console.log(embedding);
-  console.log(usage);
+  console.log('Embedding:', result.embedding);
+  console.log('Usage:', result.usage);
+  
+  if (result.providerMetadata) {
+    console.log('\nProvider Metadata:');
+    console.log(JSON.stringify(result.providerMetadata, null, 2));
+  }
 }
 
 main().catch(console.error);

--- a/packages/ai/src/embed/embed-many-result.ts
+++ b/packages/ai/src/embed/embed-many-result.ts
@@ -1,5 +1,6 @@
 import { Embedding } from '../types';
 import { EmbeddingModelUsage } from '../types/usage';
+import { ProviderMetadata } from '../types';
 
 /**
 The result of a `embedMany` call.
@@ -20,6 +21,11 @@ export interface EmbedManyResult<VALUE> {
   The embedding token usage.
     */
   readonly usage: EmbeddingModelUsage;
+
+  /**
+  Optional provider-specific metadata.
+     */
+  readonly providerMetadata?: ProviderMetadata;
 
   /**
   Optional raw response data.

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -443,3 +443,25 @@ describe('telemetry', () => {
     expect(tracer.jsonSpans).toMatchSnapshot();
   });
 });
+
+describe('result.providerMetadata', () => {
+  it('should include provider metadata when returned in response bodies', async () => {
+    const providerMetadata = {
+      gateway: { routing: { resolvedProvider: 'test-provider' } },
+    };
+
+    const result = await embedMany({
+      model: new MockEmbeddingModelV2({
+        supportsParallelCalls: false,
+        maxEmbeddingsPerCall: 3,
+        doEmbed: mockEmbed(testValues, dummyEmbeddings, undefined, {
+          headers: {},
+          body: { providerMetadata },
+        }),
+      }),
+      values: testValues,
+    });
+
+    expect(result.providerMetadata).toStrictEqual(providerMetadata);
+  });
+});

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -454,10 +454,16 @@ describe('result.providerMetadata', () => {
       model: new MockEmbeddingModelV2({
         supportsParallelCalls: false,
         maxEmbeddingsPerCall: 3,
-        doEmbed: mockEmbed(testValues, dummyEmbeddings, undefined, {
-          headers: {},
-          body: {},
-        }, providerMetadata),
+        doEmbed: mockEmbed(
+          testValues,
+          dummyEmbeddings,
+          undefined,
+          {
+            headers: {},
+            body: {},
+          },
+          providerMetadata,
+        ),
       }),
       values: testValues,
     });

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -445,7 +445,7 @@ describe('telemetry', () => {
 });
 
 describe('result.providerMetadata', () => {
-  it('should include provider metadata when returned in response bodies', async () => {
+  it('should include provider metadata when returned by the model', async () => {
     const providerMetadata = {
       gateway: { routing: { resolvedProvider: 'test-provider' } },
     };
@@ -456,8 +456,8 @@ describe('result.providerMetadata', () => {
         maxEmbeddingsPerCall: 3,
         doEmbed: mockEmbed(testValues, dummyEmbeddings, undefined, {
           headers: {},
-          body: { providerMetadata },
-        }),
+          body: {},
+        }, providerMetadata),
       }),
       values: testValues,
     });

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -10,6 +10,7 @@ import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attribu
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { Embedding, EmbeddingModel } from '../types';
 import { EmbedManyResult } from './embed-many-result';
+import { EmbeddingResponseBody } from './embed';
 
 /**
 Embed several values using an embedding model. The type of the value is defined
@@ -195,6 +196,7 @@ Only applicable for HTTP-based providers.
           values,
           embeddings,
           usage,
+          providerMetadata: (response?.body as EmbeddingResponseBody)?.providerMetadata,
           responses: [response],
         });
       }
@@ -297,10 +299,15 @@ Only applicable for HTTP-based providers.
         }),
       );
 
+      const providerMetadata = responses?.find(
+        r => (r?.body as EmbeddingResponseBody)?.providerMetadata
+      )?.body as EmbeddingResponseBody;
+
       return new DefaultEmbedManyResult({
         values,
         embeddings,
         usage: { tokens },
+        providerMetadata: providerMetadata?.providerMetadata,
         responses,
       });
     },
@@ -311,17 +318,20 @@ class DefaultEmbedManyResult<VALUE> implements EmbedManyResult<VALUE> {
   readonly values: EmbedManyResult<VALUE>['values'];
   readonly embeddings: EmbedManyResult<VALUE>['embeddings'];
   readonly usage: EmbedManyResult<VALUE>['usage'];
+  readonly providerMetadata: EmbedManyResult<VALUE>['providerMetadata'];
   readonly responses: EmbedManyResult<VALUE>['responses'];
 
   constructor(options: {
     values: EmbedManyResult<VALUE>['values'];
     embeddings: EmbedManyResult<VALUE>['embeddings'];
     usage: EmbedManyResult<VALUE>['usage'];
+    providerMetadata?: EmbedManyResult<VALUE>['providerMetadata'];
     responses?: EmbedManyResult<VALUE>['responses'];
   }) {
     this.values = options.values;
     this.embeddings = options.embeddings;
     this.usage = options.usage;
+    this.providerMetadata = options.providerMetadata;
     this.responses = options.responses;
   }
 }

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -289,8 +289,19 @@ Only applicable for HTTP-based providers.
           embeddings.push(...result.embeddings);
           responses.push(result.response);
           tokens += result.usage.tokens;
-          if (!providerMetadata && result.providerMetadata) {
-            providerMetadata = result.providerMetadata;
+          if (result.providerMetadata) {
+            if (!providerMetadata) {
+              providerMetadata = { ...result.providerMetadata };
+            } else {
+              for (const [providerName, metadata] of Object.entries(
+                result.providerMetadata,
+              )) {
+                providerMetadata[providerName] = {
+                  ...(providerMetadata[providerName] ?? {}),
+                  ...metadata,
+                };
+              }
+            }
           }
         }
       }

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -196,7 +196,8 @@ Only applicable for HTTP-based providers.
           values,
           embeddings,
           usage,
-          providerMetadata: (response?.body as EmbeddingResponseBody)?.providerMetadata,
+          providerMetadata: (response?.body as EmbeddingResponseBody)
+            ?.providerMetadata,
           responses: [response],
         });
       }
@@ -300,7 +301,7 @@ Only applicable for HTTP-based providers.
       );
 
       const providerMetadata = responses?.find(
-        r => (r?.body as EmbeddingResponseBody)?.providerMetadata
+        r => (r?.body as EmbeddingResponseBody)?.providerMetadata,
       )?.body as EmbeddingResponseBody;
 
       return new DefaultEmbedManyResult({

--- a/packages/ai/src/embed/embed-result.ts
+++ b/packages/ai/src/embed/embed-result.ts
@@ -1,5 +1,6 @@
 import { Embedding } from '../types';
 import { EmbeddingModelUsage } from '../types/usage';
+import { ProviderMetadata } from '../types';
 
 /**
 The result of an `embed` call.
@@ -20,6 +21,11 @@ export interface EmbedResult<VALUE> {
   The embedding token usage.
     */
   readonly usage: EmbeddingModelUsage;
+
+  /**
+  Optional provider-specific metadata.
+     */
+  readonly providerMetadata?: ProviderMetadata;
 
   /**
   Optional response data.

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -85,9 +85,7 @@ describe('result.providerMetadata', () => {
 
     const result = await embed({
       model: new MockEmbeddingModelV2({
-        doEmbed: mockEmbed([
-          testValue,
-        ], [dummyEmbedding], undefined, {
+        doEmbed: mockEmbed([testValue], [dummyEmbedding], undefined, {
           headers: {},
           body: { providerMetadata },
         }),

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -87,8 +87,8 @@ describe('result.providerMetadata', () => {
       model: new MockEmbeddingModelV2({
         doEmbed: mockEmbed([testValue], [dummyEmbedding], undefined, {
           headers: {},
-          body: { providerMetadata },
-        }),
+          body: {},
+        }, providerMetadata),
       }),
       value: testValue,
     });

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -85,10 +85,16 @@ describe('result.providerMetadata', () => {
 
     const result = await embed({
       model: new MockEmbeddingModelV2({
-        doEmbed: mockEmbed([testValue], [dummyEmbedding], undefined, {
-          headers: {},
-          body: {},
-        }, providerMetadata),
+        doEmbed: mockEmbed(
+          [testValue],
+          [dummyEmbedding],
+          undefined,
+          {
+            headers: {},
+            body: {},
+          },
+          providerMetadata,
+        ),
       }),
       value: testValue,
     });

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -73,6 +73,32 @@ describe('result.usage', () => {
   });
 });
 
+describe('result.providerMetadata', () => {
+  it('should include provider metadata when returned by the model', async () => {
+    const providerMetadata = {
+      gateway: {
+        routing: {
+          resolvedProvider: 'test-provider',
+        },
+      },
+    };
+
+    const result = await embed({
+      model: new MockEmbeddingModelV2({
+        doEmbed: mockEmbed([
+          testValue,
+        ], [dummyEmbedding], undefined, {
+          headers: {},
+          body: { providerMetadata },
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(result.providerMetadata).toStrictEqual(providerMetadata);
+  });
+});
+
 describe('options.headers', () => {
   it('should set headers', async () => {
     const result = await embed({

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -173,7 +173,8 @@ Only applicable for HTTP-based providers.
         value,
         embedding,
         usage,
-        providerMetadata: (response?.body as EmbeddingResponseBody)?.providerMetadata,
+        providerMetadata: (response?.body as EmbeddingResponseBody)
+          ?.providerMetadata,
         response,
       });
     },

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -7,8 +7,13 @@ import { getTracer } from '../telemetry/get-tracer';
 import { recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
-import { EmbeddingModel } from '../types';
+import { EmbeddingModel, ProviderMetadata } from '../types';
 import { EmbedResult } from './embed-result';
+
+export type EmbeddingResponseBody = {
+  providerMetadata?: ProviderMetadata;
+  [key: string]: unknown;
+};
 
 /**
 Embed a value using an embedding model. The type of the value is defined by the embedding model.
@@ -168,6 +173,7 @@ Only applicable for HTTP-based providers.
         value,
         embedding,
         usage,
+        providerMetadata: (response?.body as EmbeddingResponseBody)?.providerMetadata,
         response,
       });
     },
@@ -178,17 +184,20 @@ class DefaultEmbedResult<VALUE> implements EmbedResult<VALUE> {
   readonly value: EmbedResult<VALUE>['value'];
   readonly embedding: EmbedResult<VALUE>['embedding'];
   readonly usage: EmbedResult<VALUE>['usage'];
+  readonly providerMetadata: EmbedResult<VALUE>['providerMetadata'];
   readonly response: EmbedResult<VALUE>['response'];
 
   constructor(options: {
     value: EmbedResult<VALUE>['value'];
     embedding: EmbedResult<VALUE>['embedding'];
     usage: EmbedResult<VALUE>['usage'];
+    providerMetadata?: EmbedResult<VALUE>['providerMetadata'];
     response?: EmbedResult<VALUE>['response'];
   }) {
     this.value = options.value;
     this.embedding = options.embedding;
     this.usage = options.usage;
+    this.providerMetadata = options.providerMetadata;
     this.response = options.response;
   }
 }

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -10,11 +10,6 @@ import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { EmbeddingModel, ProviderMetadata } from '../types';
 import { EmbedResult } from './embed-result';
 
-export type EmbeddingResponseBody = {
-  providerMetadata?: ProviderMetadata;
-  [key: string]: unknown;
-};
-
 /**
 Embed a value using an embedding model. The type of the value is defined by the embedding model.
 
@@ -107,7 +102,7 @@ Only applicable for HTTP-based providers.
     }),
     tracer,
     fn: async span => {
-      const { embedding, usage, response } = await retry(() =>
+      const { embedding, usage, response, providerMetadata } = await retry(() =>
         // nested spans to align with the embedMany telemetry data:
         recordSpan({
           name: 'ai.embed.doEmbed',
@@ -153,6 +148,7 @@ Only applicable for HTTP-based providers.
             return {
               embedding,
               usage,
+              providerMetadata: modelResponse.providerMetadata,
               response: modelResponse.response,
             };
           },
@@ -173,8 +169,7 @@ Only applicable for HTTP-based providers.
         value,
         embedding,
         usage,
-        providerMetadata: (response?.body as EmbeddingResponseBody)
-          ?.providerMetadata,
+        providerMetadata,
         response,
       });
     },

--- a/packages/ai/src/test/mock-embedding-model-v2.ts
+++ b/packages/ai/src/test/mock-embedding-model-v2.ts
@@ -43,9 +43,12 @@ export function mockEmbed<VALUE>(
   response: Awaited<
     ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>
   >['response'] = { headers: {}, body: {} },
+  providerMetadata?: Awaited<
+    ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>
+  >['providerMetadata'],
 ): EmbeddingModelV2<VALUE>['doEmbed'] {
   return async ({ values }) => {
     assert.deepStrictEqual(expectedValues, values);
-    return { embeddings, usage, response };
+    return { embeddings, usage, response, providerMetadata };
   };
 }

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -166,5 +166,22 @@ describe('GatewayEmbeddingModel', () => {
           GatewayInternalServerError.isInstance(err) && err.statusCode === 500,
       );
     });
+
+    it('should include providerMetadata in response body', async () => {
+      server.urls['https://api.test.com/embedding-model'].response = {
+        type: 'json-value',
+        body: {
+          embeddings: dummyEmbeddings,
+          usage: { tokens: 5 },
+          providerMetadata: { gateway: { routing: { test: true } } },
+        },
+      };
+
+      const { response } = await createTestModel().doEmbed({ values: testValues });
+
+      expect(response?.body).toMatchObject({
+        providerMetadata: { gateway: { routing: { test: true } } },
+      });
+    });
   });
 });

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -200,8 +200,8 @@ describe('GatewayEmbeddingModel', () => {
         values: testValues,
       });
 
-      expect(result.providerMetadata).toStrictEqual({ 
-        gateway: { routing: { test: true } } 
+      expect(result.providerMetadata).toStrictEqual({
+        gateway: { routing: { test: true } },
       });
     });
   });

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -185,5 +185,24 @@ describe('GatewayEmbeddingModel', () => {
         providerMetadata: { gateway: { routing: { test: true } } },
       });
     });
+
+    it('should extract providerMetadata to top level', async () => {
+      server.urls['https://api.test.com/embedding-model'].response = {
+        type: 'json-value',
+        body: {
+          embeddings: dummyEmbeddings,
+          usage: { tokens: 5 },
+          providerMetadata: { gateway: { routing: { test: true } } },
+        },
+      };
+
+      const result = await createTestModel().doEmbed({
+        values: testValues,
+      });
+
+      expect(result.providerMetadata).toStrictEqual({ 
+        gateway: { routing: { test: true } } 
+      });
+    });
   });
 });

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -177,7 +177,9 @@ describe('GatewayEmbeddingModel', () => {
         },
       };
 
-      const { response } = await createTestModel().doEmbed({ values: testValues });
+      const { response } = await createTestModel().doEmbed({
+        values: testValues,
+      });
 
       expect(response?.body).toMatchObject({
         providerMetadata: { gateway: { routing: { test: true } } },

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -11,6 +11,7 @@ import { z } from 'zod/v4';
 import type { GatewayConfig } from './gateway-config';
 import { asGatewayError } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
+import type { SharedV2ProviderMetadata } from '@ai-sdk/provider';
 
 export class GatewayEmbeddingModel implements EmbeddingModelV2<string> {
   readonly specificationVersion = 'v2';
@@ -69,7 +70,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV2<string> {
       return {
         embeddings: responseBody.embeddings,
         usage: responseBody.usage ?? undefined,
-        providerMetadata: responseBody.providerMetadata,
+        providerMetadata: responseBody.providerMetadata as unknown as SharedV2ProviderMetadata,
         response: { headers: responseHeaders, body: rawValue },
       };
     } catch (error) {
@@ -92,5 +93,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV2<string> {
 const gatewayEmbeddingResponseSchema = z.object({
   embeddings: z.array(z.array(z.number())),
   usage: z.object({ tokens: z.number() }).nullish(),
-  providerMetadata: z.any().optional(),
+  providerMetadata: z
+    .record(z.string(), z.record(z.string(), z.unknown()))
+    .optional(),
 });

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -69,7 +69,8 @@ export class GatewayEmbeddingModel implements EmbeddingModelV2<string> {
       return {
         embeddings: responseBody.embeddings,
         usage: responseBody.usage ?? undefined,
-        response: { headers: responseHeaders, body: responseBody },
+        providerMetadata: responseBody.providerMetadata,
+        response: { headers: responseHeaders, body: rawValue },
       };
     } catch (error) {
       throw asGatewayError(error, parseAuthMethod(resolvedHeaders));

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -69,7 +69,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV2<string> {
       return {
         embeddings: responseBody.embeddings,
         usage: responseBody.usage ?? undefined,
-        response: { headers: responseHeaders, body: rawValue },
+        response: { headers: responseHeaders, body: responseBody },
       };
     } catch (error) {
       throw asGatewayError(error, parseAuthMethod(resolvedHeaders));
@@ -91,4 +91,5 @@ export class GatewayEmbeddingModel implements EmbeddingModelV2<string> {
 const gatewayEmbeddingResponseSchema = z.object({
   embeddings: z.array(z.array(z.number())),
   usage: z.object({ tokens: z.number() }).nullish(),
+  providerMetadata: z.any().optional(),
 });

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -70,7 +70,8 @@ export class GatewayEmbeddingModel implements EmbeddingModelV2<string> {
       return {
         embeddings: responseBody.embeddings,
         usage: responseBody.usage ?? undefined,
-        providerMetadata: responseBody.providerMetadata as unknown as SharedV2ProviderMetadata,
+        providerMetadata:
+          responseBody.providerMetadata as unknown as SharedV2ProviderMetadata,
         response: { headers: responseHeaders, body: rawValue },
       };
     } catch (error) {

--- a/packages/gateway/src/gateway-embedding-options.ts
+++ b/packages/gateway/src/gateway-embedding-options.ts
@@ -2,4 +2,5 @@ export type GatewayEmbeddingModelId =
   | 'openai/text-embedding-3-small'
   | 'openai/text-embedding-3-large'
   | 'openai/text-embedding-ada-002'
+  | 'amazon/titan-embed-text-v2:0'
   | (string & {});

--- a/packages/provider/src/embedding-model/v2/embedding-model-v2.ts
+++ b/packages/provider/src/embedding-model/v2/embedding-model-v2.ts
@@ -1,4 +1,4 @@
-import { SharedV2Headers, SharedV2ProviderOptions } from '../../shared';
+import { SharedV2Headers, SharedV2ProviderOptions, SharedV2ProviderMetadata } from '../../shared';
 import { EmbeddingModelV2Embedding } from './embedding-model-v2-embedding';
 
 /**
@@ -83,6 +83,13 @@ Generated embeddings. They are in the same order as the input values.
 Token usage. We only have input tokens for embeddings.
     */
     usage?: { tokens: number };
+
+    /**
+Additional provider-specific metadata. They are passed through
+from the provider to the AI SDK and enable provider-specific
+results that can be fully encapsulated in the provider.
+     */
+    providerMetadata?: SharedV2ProviderMetadata;
 
     /**
 Optional response information for debugging purposes.

--- a/packages/provider/src/embedding-model/v2/embedding-model-v2.ts
+++ b/packages/provider/src/embedding-model/v2/embedding-model-v2.ts
@@ -1,4 +1,8 @@
-import { SharedV2Headers, SharedV2ProviderOptions, SharedV2ProviderMetadata } from '../../shared';
+import {
+  SharedV2Headers,
+  SharedV2ProviderOptions,
+  SharedV2ProviderMetadata,
+} from '../../shared';
 import { EmbeddingModelV2Embedding } from './embedding-model-v2-embedding';
 
 /**


### PR DESCRIPTION
## Background

Provider metadata (Gateway routing) wasn't being returned in embedding responses

## Summary

Returned it in the embed route and printed it in 2 example Gateway scripts

## Verification

`pnpm test`
Manual verification using 2 example Gateway embeddings scripts

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues
https://linear.app/vercel/issue/AI-4010/add-providermetadata-to-embed-responses