### PR TITLE
fix (build): set release mode back to pre

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "exit",
+  "mode": "pre",
   "tag": "beta",
   "initialVersions": {
     "@example/ai-core": "0.0.0",


### PR DESCRIPTION
## Background

Build mode was accidentally switched to `exit` in #7516 

## Summary

set release mode back to pre

## Related Issues

#7516 