### PR TITLE
feat (ui): add sendAutomaticallyWhen to Chat

### DIFF
--- a/.changeset/giant-eyes-relax.md
+++ b/.changeset/giant-eyes-relax.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ui): add sendAutomaticallyWhen to Chat

--- a/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
+++ b/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
@@ -2,37 +2,33 @@
 
 import { useChat } from '@ai-sdk/react';
 import ChatInput from '@component/chat-input';
-import { DefaultChatTransport } from 'ai';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from 'ai';
 import { StreamingToolCallsMessage } from '../api/use-chat-streaming-tool-calls/route';
 
 export default function Chat() {
-  const {
-    messages,
-    status,
-    sendMessage,
-    addToolResult,
-    canAssistantMessageBeSubmitted,
-  } = useChat<StreamingToolCallsMessage>({
-    transport: new DefaultChatTransport({
-      api: '/api/use-chat-streaming-tool-calls',
-    }),
+  const { messages, status, sendMessage, addToolResult } =
+    useChat<StreamingToolCallsMessage>({
+      transport: new DefaultChatTransport({
+        api: '/api/use-chat-streaming-tool-calls',
+      }),
 
-    // run client-side tools that are automatically executed:
-    async onToolCall({ toolCall }) {
-      if (toolCall.toolName === 'showWeatherInformation') {
-        // display tool. add tool result that informs the llm that the tool was executed.
-        await addToolResult({
-          tool: 'showWeatherInformation',
-          toolCallId: toolCall.toolCallId,
-          output: 'Weather information was shown to the user.',
-        });
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
-        if (canAssistantMessageBeSubmitted()) {
-          sendMessage();
+      // run client-side tools that are automatically executed:
+      async onToolCall({ toolCall }) {
+        if (toolCall.toolName === 'showWeatherInformation') {
+          // display tool. add tool result that informs the llm that the tool was executed.
+          await addToolResult({
+            tool: 'showWeatherInformation',
+            toolCallId: toolCall.toolCallId,
+            output: 'Weather information was shown to the user.',
+          });
         }
-      }
-    },
-  });
+      },
+    });
 
   // used to only render the role when it changes:
   let lastRole: string | undefined = undefined;

--- a/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
+++ b/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
@@ -21,7 +21,7 @@ export default function Chat() {
       async onToolCall({ toolCall }) {
         if (toolCall.toolName === 'showWeatherInformation') {
           // display tool. add tool result that informs the llm that the tool was executed.
-          await addToolResult({
+          addToolResult({
             tool: 'showWeatherInformation',
             toolCallId: toolCall.toolCallId,
             output: 'Weather information was shown to the user.',

--- a/examples/next-openai/app/use-chat-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-tools/page.tsx
@@ -27,7 +27,7 @@ export default function Chat() {
             'San Francisco',
           ];
 
-          await addToolResult({
+          addToolResult({
             tool: 'getLocation',
             toolCallId: toolCall.toolCallId,
             output: cities[Math.floor(Math.random() * cities.length)],
@@ -63,7 +63,7 @@ export default function Chat() {
                           <button
                             className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700"
                             onClick={async () => {
-                              await addToolResult({
+                              addToolResult({
                                 tool: 'askForConfirmation',
                                 toolCallId: part.toolCallId,
                                 output: 'Yes, confirmed.',
@@ -75,7 +75,7 @@ export default function Chat() {
                           <button
                             className="px-4 py-2 font-bold text-white bg-red-500 rounded hover:bg-red-700"
                             onClick={async () => {
-                              await addToolResult({
+                              addToolResult({
                                 tool: 'askForConfirmation',
                                 toolCallId: part.toolCallId,
                                 output: 'No, denied',

--- a/examples/next-openai/app/use-chat-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-tools/page.tsx
@@ -2,45 +2,39 @@
 
 import ChatInput from '@/component/chat-input';
 import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport } from 'ai';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from 'ai';
 import { UseChatToolsMessage } from '../api/use-chat-tools/route';
 
 export default function Chat() {
-  const {
-    messages,
-    sendMessage,
-    addToolResult,
-    status,
-    canAssistantMessageBeSubmitted,
-  } = useChat<UseChatToolsMessage>({
-    transport: new DefaultChatTransport({ api: '/api/use-chat-tools' }),
+  const { messages, sendMessage, addToolResult, status } =
+    useChat<UseChatToolsMessage>({
+      transport: new DefaultChatTransport({ api: '/api/use-chat-tools' }),
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
-    // run client-side tools that are automatically executed:
-    async onToolCall({ toolCall }) {
-      // artificial 2 second delay
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      // run client-side tools that are automatically executed:
+      async onToolCall({ toolCall }) {
+        // artificial 2 second delay
+        await new Promise(resolve => setTimeout(resolve, 2000));
 
-      if (toolCall.toolName === 'getLocation') {
-        const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
+        if (toolCall.toolName === 'getLocation') {
+          const cities = [
+            'New York',
+            'Los Angeles',
+            'Chicago',
+            'San Francisco',
+          ];
 
-        await addToolResult({
-          tool: 'getLocation',
-          toolCallId: toolCall.toolCallId,
-          output: cities[Math.floor(Math.random() * cities.length)],
-        });
-
-        if (canAssistantMessageBeSubmitted()) {
-          sendMessage();
+          await addToolResult({
+            tool: 'getLocation',
+            toolCallId: toolCall.toolCallId,
+            output: cities[Math.floor(Math.random() * cities.length)],
+          });
         }
-      }
-    },
-
-    onFinish() {
-      if (canAssistantMessageBeSubmitted()) {
-        sendMessage();
-      }
-    },
-  });
+      },
+    });
 
   return (
     <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
@@ -74,10 +68,6 @@ export default function Chat() {
                                 toolCallId: part.toolCallId,
                                 output: 'Yes, confirmed.',
                               });
-
-                              if (canAssistantMessageBeSubmitted()) {
-                                sendMessage();
-                              }
                             }}
                           >
                             Yes
@@ -90,10 +80,6 @@ export default function Chat() {
                                 toolCallId: part.toolCallId,
                                 output: 'No, denied',
                               });
-
-                              if (canAssistantMessageBeSubmitted()) {
-                                sendMessage();
-                              }
                             }}
                           >
                             No

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1,12 +1,6 @@
 import { createTestServer, mockId } from '@ai-sdk/provider-utils/test';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
-import {
-  AbstractChat,
-  ChatInit,
-  ChatState,
-  ChatStatus,
-  isAssistantMessageWithCompletedToolCalls,
-} from './chat';
+import { AbstractChat, ChatInit, ChatState, ChatStatus } from './chat';
 import { UIMessage } from './ui-messages';
 import { UIMessageChunk } from '../ui-message-stream/ui-message-chunks';
 import { DefaultChatTransport } from './default-chat-transport';
@@ -894,58 +888,5 @@ describe('chat', () => {
         ]
       `);
     });
-  });
-});
-
-describe('isAssistantMessageWithCompletedToolCalls', () => {
-  it('should return false if the last step of a multi-step sequency only has text', () => {
-    expect(
-      isAssistantMessageWithCompletedToolCalls({
-        id: '1',
-        role: 'assistant',
-        parts: [
-          { type: 'step-start' },
-          {
-            type: 'tool-getLocation',
-            toolCallId: 'call_CuEdmzpx4ZldCkg5SVr3ikLz',
-            state: 'output-available',
-            input: {},
-            output: 'New York',
-          },
-          { type: 'step-start' },
-          {
-            type: 'text',
-            text: 'The current weather in New York is windy.',
-            state: 'done',
-          },
-        ],
-      }),
-    ).toBe(false);
-  });
-
-  it('should return true when there is a text part after the last tool result in the last step', () => {
-    expect(
-      isAssistantMessageWithCompletedToolCalls({
-        id: '1',
-        role: 'assistant',
-        parts: [
-          { type: 'step-start' },
-          {
-            type: 'tool-getWeatherInformation',
-            toolCallId: 'call_6iy0GxZ9R4VDI5MKohXxV48y',
-            state: 'output-available',
-            input: {
-              city: 'New York',
-            },
-            output: 'windy',
-          },
-          {
-            type: 'text',
-            text: 'The current weather in New York is windy.',
-            state: 'done',
-          },
-        ],
-      }),
-    ).toBe(true);
   });
 });

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -396,7 +396,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     tool: TOOL;
     toolCallId: string;
     output: InferUIMessageTools<UI_MESSAGE>[TOOL]['output'];
-  }) => {
+  }) =>
     this.jobExecutor.run(async () => {
       const messages = this.state.messages;
       const lastMessage = messages[messages.length - 1];
@@ -425,7 +425,6 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           );
       }
     });
-  };
 
   /**
    * Abort the current request immediately, keep the generated tokens if any.

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -1,7 +1,6 @@
 import {
   generateId as generateIdFunc,
   IdGenerator,
-  Resolvable,
   StandardSchemaV1,
   Validator,
 } from '@ai-sdk/provider-utils';
@@ -158,7 +157,7 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
    */
   sendAutomaticallyWhen?: (options: {
     messages: UI_MESSAGE[];
-  }) => Resolvable<boolean>;
+  }) => boolean | PromiseLike<boolean>;
 }
 
 export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
@@ -557,36 +556,4 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       this.activeResponse = undefined;
     }
   }
-}
-
-/**
-Check if the message is an assistant message with completed tool calls.
-The last step of the message must have at least one tool invocation and
-all tool invocations must have a result.
- */
-export function isAssistantMessageWithCompletedToolCalls(
-  message: UIMessage | undefined,
-): message is UIMessage & {
-  role: 'assistant';
-} {
-  if (!message) {
-    return false;
-  }
-
-  if (message.role !== 'assistant') {
-    return false;
-  }
-
-  const lastStepStartIndex = message.parts.reduce((lastIndex, part, index) => {
-    return part.type === 'step-start' ? index : lastIndex;
-  }, -1);
-
-  const lastStepToolInvocations = message.parts
-    .slice(lastStepStartIndex + 1)
-    .filter(isToolUIPart);
-
-  return (
-    lastStepToolInvocations.length > 0 &&
-    lastStepToolInvocations.every(part => part.state === 'output-available')
-  );
 }

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -1,6 +1,7 @@
 import {
   generateId as generateIdFunc,
   IdGenerator,
+  Resolvable,
   StandardSchemaV1,
   Validator,
 } from '@ai-sdk/provider-utils';
@@ -150,6 +151,14 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
    * @param data The data part that was received.
    */
   onData?: ChatOnDataCallback<UI_MESSAGE>;
+
+  /**
+   * When provided, this function will be called when the stream is finished or a tool call is added
+   * to determine if the current messages should be resubmitted.
+   */
+  sendAutomaticallyWhen?: (options: {
+    messages: UI_MESSAGE[];
+  }) => Resolvable<boolean>;
 }
 
 export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
@@ -418,15 +427,6 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       }
     });
   };
-
-  /**
-   * Checks if the assistant message can be submitted, i.e. if it
-   * has tool calls and all tool calls have results.
-   *
-   * @returns {boolean} True if the assistant message can be submitted, false otherwise.
-   */
-  canAssistantMessageBeSubmitted = (): boolean =>
-    isAssistantMessageWithCompletedToolCalls(this.lastMessage);
 
   /**
    * Abort the current request immediately, keep the generated tokens if any.

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -26,6 +26,7 @@ export {
   type PrepareReconnectToStreamRequest,
   type PrepareSendMessagesRequest,
 } from './http-chat-transport';
+export { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-message-is-complete-with-tool-calls';
 export { TextStreamChatTransport } from './text-stream-chat-transport';
 export {
   getToolName,
@@ -35,8 +36,8 @@ export {
   type InferUITool,
   type InferUITools,
   type ReasoningUIPart,
-  type SourceUrlUIPart,
   type SourceDocumentUIPart,
+  type SourceUrlUIPart,
   type StepStartUIPart,
   type TextUIPart,
   type ToolUIPart,

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.test.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.test.ts
@@ -1,0 +1,62 @@
+import { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-message-is-complete-with-tool-calls';
+
+describe('lastAssistantMessageIsCompleteWithToolCalls', () => {
+  it('should return false if the last step of a multi-step sequency only has text', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getLocation',
+                toolCallId: 'call_CuEdmzpx4ZldCkg5SVr3ikLz',
+                state: 'output-available',
+                input: {},
+                output: 'New York',
+              },
+              { type: 'step-start' },
+              {
+                type: 'text',
+                text: 'The current weather in New York is windy.',
+                state: 'done',
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return true when there is a text part after the last tool result in the last step', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeatherInformation',
+                toolCallId: 'call_6iy0GxZ9R4VDI5MKohXxV48y',
+                state: 'output-available',
+                input: {
+                  city: 'New York',
+                },
+                output: 'windy',
+              },
+              {
+                type: 'text',
+                text: 'The current weather in New York is windy.',
+                state: 'done',
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.ts
@@ -1,0 +1,35 @@
+import { isToolUIPart, UIMessage } from './ui-messages';
+
+/**
+Check if the message is an assistant message with completed tool calls.
+The last step of the message must have at least one tool invocation and
+all tool invocations must have a result.
+ */
+export function lastAssistantMessageIsCompleteWithToolCalls({
+  messages,
+}: {
+  messages: UIMessage[];
+}): boolean {
+  const message = messages[messages.length - 1];
+
+  if (!message) {
+    return false;
+  }
+
+  if (message.role !== 'assistant') {
+    return false;
+  }
+
+  const lastStepStartIndex = message.parts.reduce((lastIndex, part, index) => {
+    return part.type === 'step-start' ? index : lastIndex;
+  }, -1);
+
+  const lastStepToolInvocations = message.parts
+    .slice(lastStepStartIndex + 1)
+    .filter(isToolUIPart);
+
+  return (
+    lastStepToolInvocations.length > 0 &&
+    lastStepToolInvocations.every(part => part.state === 'output-available')
+  );
+}

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -34,7 +34,6 @@ export type UseChatHelpers<UI_MESSAGE extends UIMessage> = {
   | 'addToolResult'
   | 'status'
   | 'messages'
-  | 'canAssistantMessageBeSubmitted'
 >;
 
 export type UseChatOptions<UI_MESSAGE extends UIMessage> = (
@@ -123,8 +122,6 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     sendMessage: chatRef.current.sendMessage,
     regenerate: chatRef.current.regenerate,
     stop: chatRef.current.stop,
-    canAssistantMessageBeSubmitted:
-      chatRef.current.canAssistantMessageBeSubmitted,
     error,
     resumeStream: chatRef.current.resumeStream,
     status,


### PR DESCRIPTION
## Background

#7511 removed automatic resubmit from `Chat`. However, it complicated the code needed on the client side and led to flickering due to status changes.

## Summary

- remove `canAssistantMessageBeSubmitted` helper from `Chat`
- add `sendAutomaticallyWhen` to `Chat`
- add `lastAssistantMessageIsCompleteWithToolCalls` helper

## Verification

- [x] Manually executed updated use chat with tool calls 

## Tasks

- [x] add resubmit test for chat
- [x] implement
- [x] update example
- [x] changeset
- [x] fix resubmit issue

## Related Issues

Follow up on #7511