### PR TITLE
fix(provider/bedrock): include toolConfig when conversation contains tool content

### DIFF
--- a/.changeset/three-fishes-applaud.md
+++ b/.changeset/three-fishes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/bedrock): include toolConfig when conversation contains tool content

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -166,7 +166,11 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
       });
     }
 
-    const { toolConfig, toolWarnings } = prepareTools({ tools, toolChoice });
+    const { toolConfig, toolWarnings } = prepareTools({
+      tools,
+      toolChoice,
+      prompt,
+    });
 
     // Filter out reasoningConfig from providerOptions.bedrock to prevent sending it to Bedrock API
     const { reasoningConfig: _, ...filteredBedrockOptions } =
@@ -182,7 +186,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
           inferenceConfig,
         }),
         ...filteredBedrockOptions,
-        ...(toolConfig.tools?.length ? { toolConfig } : {}),
+        ...(toolConfig.tools !== undefined ? { toolConfig } : {}),
       },
       warnings: [...warnings, ...toolWarnings],
     };

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -2,24 +2,50 @@ import {
   JSONObject,
   LanguageModelV2CallOptions,
   LanguageModelV2CallWarning,
+  LanguageModelV2Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { BedrockTool, BedrockToolConfiguration } from './bedrock-api-types';
 
+/**
+ * Check if the conversation contains any tool calls or tool results.
+ * Bedrock requires toolConfig to be present when messages contain toolUse or toolResult blocks.
+ */
+function promptContainsToolContent(prompt: LanguageModelV2Prompt): boolean {
+  return prompt.some(message => {
+    if ('content' in message && Array.isArray(message.content)) {
+      return message.content.some(
+        part => part.type === 'tool-call' || part.type === 'tool-result',
+      );
+    }
+    return false;
+  });
+}
+
 export function prepareTools({
   tools,
   toolChoice,
+  prompt,
 }: {
   tools: LanguageModelV2CallOptions['tools'];
   toolChoice?: LanguageModelV2CallOptions['toolChoice'];
+  prompt: LanguageModelV2Prompt;
 }): {
-  toolConfig: BedrockToolConfiguration; // note: do not rename, name required by Bedrock
+  toolConfig: BedrockToolConfiguration;
   toolWarnings: LanguageModelV2CallWarning[];
 } {
-  // when the tools array is empty, change it to undefined to prevent errors:
   tools = tools?.length ? tools : undefined;
 
+  const hasToolContent = promptContainsToolContent(prompt);
+
   if (tools == null) {
+    if (hasToolContent) {
+      return {
+        toolConfig: { tools: [], toolChoice: undefined },
+        toolWarnings: [],
+      };
+    }
+
     return {
       toolConfig: { tools: undefined, toolChoice: undefined },
       toolWarnings: [],
@@ -66,7 +92,14 @@ export function prepareTools({
         toolWarnings,
       };
     case 'none':
-      // Bedrock does not support 'none' tool choice, so we remove the tools:
+      // Bedrock does not support 'none' tool choice, so we remove the tools.
+      // However, if conversation contains tool content, we need empty tools array for API.
+      if (hasToolContent) {
+        return {
+          toolConfig: { tools: [], toolChoice: undefined },
+          toolWarnings,
+        };
+      }
       return {
         toolConfig: { tools: undefined, toolChoice: undefined },
         toolWarnings,

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -39,15 +39,8 @@ export function prepareTools({
   const hasToolContent = promptContainsToolContent(prompt);
 
   if (tools == null) {
-    if (hasToolContent) {
-      return {
-        toolConfig: { tools: [], toolChoice: undefined },
-        toolWarnings: [],
-      };
-    }
-
     return {
-      toolConfig: { tools: undefined, toolChoice: undefined },
+      toolConfig: { tools: hasToolContent ? [] : undefined, toolChoice: undefined },
       toolWarnings: [],
     };
   }
@@ -94,14 +87,8 @@ export function prepareTools({
     case 'none':
       // Bedrock does not support 'none' tool choice, so we remove the tools.
       // However, if conversation contains tool content, we need empty tools array for API.
-      if (hasToolContent) {
-        return {
-          toolConfig: { tools: [], toolChoice: undefined },
-          toolWarnings,
-        };
-      }
       return {
-        toolConfig: { tools: undefined, toolChoice: undefined },
+        toolConfig: { tools: hasToolContent ? [] : undefined, toolChoice: undefined },
         toolWarnings,
       };
     case 'tool':

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -40,7 +40,10 @@ export function prepareTools({
 
   if (tools == null) {
     return {
-      toolConfig: { tools: hasToolContent ? [] : undefined, toolChoice: undefined },
+      toolConfig: {
+        tools: hasToolContent ? [] : undefined,
+        toolChoice: undefined,
+      },
       toolWarnings: [],
     };
   }
@@ -88,7 +91,10 @@ export function prepareTools({
       // Bedrock does not support 'none' tool choice, so we remove the tools.
       // However, if conversation contains tool content, we need empty tools array for API.
       return {
-        toolConfig: { tools: hasToolContent ? [] : undefined, toolChoice: undefined },
+        toolConfig: {
+          tools: hasToolContent ? [] : undefined,
+          toolChoice: undefined,
+        },
         toolWarnings,
       };
     case 'tool':

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -31,7 +31,7 @@ export function prepareTools({
   toolChoice?: LanguageModelV2CallOptions['toolChoice'];
   prompt: LanguageModelV2Prompt;
 }): {
-  toolConfig: BedrockToolConfiguration;
+  toolConfig: BedrockToolConfiguration; // note: do not rename, name required by Bedrock
   toolWarnings: LanguageModelV2CallWarning[];
 } {
   tools = tools?.length ? tools : undefined;


### PR DESCRIPTION
## background

Amazon Bedrock API requires the `toolConfig` field when messages contain `toolUse` or `toolResult` blocks, even if no tools are available for the current step. Previously, conversations with prior tool calls would fail when using `activeTools: []` or `toolChoice: 'none'` because the provider omitted `toolConfig` entirely.

## summary

- detect tool content in conversation history
- include empty toolConfig when needed for API compatibility

## verification

- all tests pass including new toolConfig-specific tests
- fix works for both `activeTools: []` and `toolChoice: 'none'` scenarios

## tasks

- [x] modify prepareTools to handle tool content scenarios
- [x] update conditional logic for toolConfig inclusion
- [x] tests for fix scenarios

related issue #7528