### PR TITLE
feat(provider/anthropic): add disable parallel tool use option

### DIFF
--- a/.changeset/good-masks-itch.md
+++ b/.changeset/good-masks-itch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(provider/anthropic): add disable parallel tool use option

--- a/examples/ai-core/src/stream-text/anthropic-disable-parallel-tools.ts
+++ b/examples/ai-core/src/stream-text/anthropic-disable-parallel-tools.ts
@@ -11,7 +11,9 @@ async function main() {
       getWeather: tool({
         description: 'Get the current weather for a location',
         inputSchema: z.object({
-          location: z.string().describe('The city and state, e.g. San Francisco, CA'),
+          location: z
+            .string()
+            .describe('The city and state, e.g. San Francisco, CA'),
         }),
         execute: async ({ location }: { location: string }) => {
           return `Weather in ${location}: 72°F, sunny`;
@@ -32,7 +34,9 @@ async function main() {
         break;
       }
       case 'tool-call': {
-        console.log(`\nTOOL CALL: ${chunk.toolName}(${JSON.stringify(chunk.input)})`);
+        console.log(
+          `\nTOOL CALL: ${chunk.toolName}(${JSON.stringify(chunk.input)})`,
+        );
         break;
       }
       case 'tool-result': {
@@ -47,4 +51,4 @@ async function main() {
   console.log('Finish reason:', await result.finishReason);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/anthropic-disable-parallel-tools.ts
+++ b/examples/ai-core/src/stream-text/anthropic-disable-parallel-tools.ts
@@ -1,0 +1,50 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: anthropic('claude-3-5-sonnet-20241022'),
+    prompt: 'What is the weather in Paris, France and London, UK?',
+    tools: {
+      getWeather: tool({
+        description: 'Get the current weather for a location',
+        inputSchema: z.object({
+          location: z.string().describe('The city and state, e.g. San Francisco, CA'),
+        }),
+        execute: async ({ location }: { location: string }) => {
+          return `Weather in ${location}: 72°F, sunny`;
+        },
+      }),
+    },
+    providerOptions: {
+      anthropic: {
+        disableParallelToolUse: true,
+      },
+    },
+  });
+
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta': {
+        process.stdout.write(chunk.text);
+        break;
+      }
+      case 'tool-call': {
+        console.log(`\nTOOL CALL: ${chunk.toolName}(${JSON.stringify(chunk.input)})`);
+        break;
+      }
+      case 'tool-result': {
+        console.log(`TOOL RESULT: ${JSON.stringify(chunk.output)}`);
+        break;
+      }
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error); 

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -158,5 +158,5 @@ export type AnthropicTool =
     };
 
 export type AnthropicToolChoice =
-  | { type: 'auto' | 'any' }
-  | { type: 'tool'; name: string };
+  | { type: 'auto' | 'any'; disable_parallel_tool_use?: boolean }
+  | { type: 'tool'; name: string; disable_parallel_tool_use?: boolean };

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -470,6 +470,39 @@ describe('AnthropicMessagesLanguageModel', () => {
       });
     });
 
+    it('should pass disableParallelToolUse', async () => {
+      prepareJsonResponse({});
+
+      await model.doGenerate({
+        tools: [
+          {
+            type: 'function',
+            name: 'test-tool',
+            inputSchema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            disableParallelToolUse: true,
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        tool_choice: {
+          type: 'auto',
+          disable_parallel_tool_use: true,
+        },
+      });
+    });
+
     it('should pass headers', async () => {
       prepareJsonResponse({ content: [] });
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -330,8 +330,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
             toolChoice: { type: 'tool', toolName: jsonResponseTool.name },
             disableParallelToolUse: anthropicOptions?.disableParallelToolUse,
           }
-        : { 
-            tools: tools ?? [], 
+        : {
+            tools: tools ?? [],
             toolChoice,
             disableParallelToolUse: anthropicOptions?.disableParallelToolUse,
           },

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -328,8 +328,13 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         ? {
             tools: [jsonResponseTool],
             toolChoice: { type: 'tool', toolName: jsonResponseTool.name },
+            disableParallelToolUse: anthropicOptions?.disableParallelToolUse,
           }
-        : { tools: tools ?? [], toolChoice },
+        : { 
+            tools: tools ?? [], 
+            toolChoice,
+            disableParallelToolUse: anthropicOptions?.disableParallelToolUse,
+          },
     );
 
     return {

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -61,6 +61,12 @@ export const anthropicProviderOptions = z.object({
       budgetTokens: z.number().optional(),
     })
     .optional(),
+
+  /**
+   * Whether to disable parallel function calling during tool use. Default is false.
+   * When set to true, Claude will use at most one tool per response.
+   */
+  disableParallelToolUse: z.boolean().optional(),
 });
 
 export type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -141,7 +141,10 @@ export function prepareTools({
   if (toolChoice == null) {
     return {
       tools: anthropicTools,
-      toolChoice: undefined,
+      toolChoice:
+        disableParallelToolUse === true
+          ? { type: 'auto', disable_parallel_tool_use: true }
+          : undefined,
       toolWarnings,
       betas,
     };

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -153,18 +153,20 @@ export function prepareTools({
     case 'auto':
       return {
         tools: anthropicTools,
-        toolChoice: disableParallelToolUse === true 
-          ? { type: 'auto', disable_parallel_tool_use: true }
-          : { type: 'auto' },
+        toolChoice:
+          disableParallelToolUse === true
+            ? { type: 'auto', disable_parallel_tool_use: true }
+            : { type: 'auto' },
         toolWarnings,
         betas,
       };
     case 'required':
       return {
         tools: anthropicTools,
-        toolChoice: disableParallelToolUse === true
-          ? { type: 'any', disable_parallel_tool_use: true }
-          : { type: 'any' },
+        toolChoice:
+          disableParallelToolUse === true
+            ? { type: 'any', disable_parallel_tool_use: true }
+            : { type: 'any' },
         toolWarnings,
         betas,
       };
@@ -174,9 +176,14 @@ export function prepareTools({
     case 'tool':
       return {
         tools: anthropicTools,
-        toolChoice: disableParallelToolUse === true
-          ? { type: 'tool', name: toolChoice.toolName, disable_parallel_tool_use: true }
-          : { type: 'tool', name: toolChoice.toolName },
+        toolChoice:
+          disableParallelToolUse === true
+            ? {
+                type: 'tool',
+                name: toolChoice.toolName,
+                disable_parallel_tool_use: true,
+              }
+            : { type: 'tool', name: toolChoice.toolName },
         toolWarnings,
         betas,
       };

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -141,10 +141,9 @@ export function prepareTools({
   if (toolChoice == null) {
     return {
       tools: anthropicTools,
-      toolChoice:
-        disableParallelToolUse === true
-          ? { type: 'auto', disable_parallel_tool_use: true }
-          : undefined,
+      toolChoice: disableParallelToolUse
+        ? { type: 'auto', disable_parallel_tool_use: disableParallelToolUse }
+        : undefined,
       toolWarnings,
       betas,
     };
@@ -156,20 +155,20 @@ export function prepareTools({
     case 'auto':
       return {
         tools: anthropicTools,
-        toolChoice:
-          disableParallelToolUse === true
-            ? { type: 'auto', disable_parallel_tool_use: true }
-            : { type: 'auto' },
+        toolChoice: {
+          type: 'auto',
+          disable_parallel_tool_use: disableParallelToolUse,
+        },
         toolWarnings,
         betas,
       };
     case 'required':
       return {
         tools: anthropicTools,
-        toolChoice:
-          disableParallelToolUse === true
-            ? { type: 'any', disable_parallel_tool_use: true }
-            : { type: 'any' },
+        toolChoice: {
+          type: 'any',
+          disable_parallel_tool_use: disableParallelToolUse,
+        },
         toolWarnings,
         betas,
       };
@@ -179,14 +178,11 @@ export function prepareTools({
     case 'tool':
       return {
         tools: anthropicTools,
-        toolChoice:
-          disableParallelToolUse === true
-            ? {
-                type: 'tool',
-                name: toolChoice.toolName,
-                disable_parallel_tool_use: true,
-              }
-            : { type: 'tool', name: toolChoice.toolName },
+        toolChoice: {
+          type: 'tool',
+          name: toolChoice.toolName,
+          disable_parallel_tool_use: disableParallelToolUse,
+        },
         toolWarnings,
         betas,
       };

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -20,9 +20,11 @@ function isWebSearchTool(
 export function prepareTools({
   tools,
   toolChoice,
+  disableParallelToolUse,
 }: {
   tools: LanguageModelV2CallOptions['tools'];
   toolChoice?: LanguageModelV2CallOptions['toolChoice'];
+  disableParallelToolUse?: boolean;
 }): {
   tools: Array<AnthropicTool> | undefined;
   toolChoice: AnthropicToolChoice | undefined;
@@ -151,14 +153,18 @@ export function prepareTools({
     case 'auto':
       return {
         tools: anthropicTools,
-        toolChoice: { type: 'auto' },
+        toolChoice: disableParallelToolUse === true 
+          ? { type: 'auto', disable_parallel_tool_use: true }
+          : { type: 'auto' },
         toolWarnings,
         betas,
       };
     case 'required':
       return {
         tools: anthropicTools,
-        toolChoice: { type: 'any' },
+        toolChoice: disableParallelToolUse === true
+          ? { type: 'any', disable_parallel_tool_use: true }
+          : { type: 'any' },
         toolWarnings,
         betas,
       };
@@ -168,7 +174,9 @@ export function prepareTools({
     case 'tool':
       return {
         tools: anthropicTools,
-        toolChoice: { type: 'tool', name: toolChoice.toolName },
+        toolChoice: disableParallelToolUse === true
+          ? { type: 'tool', name: toolChoice.toolName, disable_parallel_tool_use: true }
+          : { type: 'tool', name: toolChoice.toolName },
         toolWarnings,
         betas,
       };


### PR DESCRIPTION
## background

Users reported needing to force Claude to use tools sequentially instead of in parallel for specific use cases where tool order matters or rate limits require controlled execution.

## summary

- add `disableParallelToolUse` option to Anthropic provider options
- pass `disable_parallel_tool_use` parameter to Anthropic API when enabled

## verification

- all tests pass including new disable parallel tool use test
- example demonstrates sequential tool execution when option is enabled

## tasks

- [x] option added to anthropic-messages-options.ts schema
- [x] API types updated with disable_parallel_tool_use parameter
- [x] prepareTools function handles the new parameter
- [x] language model passes option to API calls
- [x] test pass and working example added 

related issue - #7517