### PR TITLE
fix (ui): call sendAutomaticallyWhen with updated messages

### DIFF
--- a/.changeset/tall-sheep-hammer.md
+++ b/.changeset/tall-sheep-hammer.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ui): call sendAutomaticallyWhen with updated messages

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -432,7 +432,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       if (
         this.status !== 'streaming' &&
         this.status !== 'submitted' &&
-        this.sendAutomaticallyWhen?.({ messages })
+        this.sendAutomaticallyWhen?.({ messages: this.state.messages })
       ) {
         await this.makeRequest({
           trigger: 'submit-message',


### PR DESCRIPTION
## Background

`sendAutomaticallyWhen` was added in #7536 but passed in the old `messages` before the tool result was applied. 

## Summary

- Fixes call of `sendAutomaticallyWhen` to pass in updated message state

## Tasks

- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

#7536 
