### PR TITLE
docs: fix refs to the language model spec

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -54,7 +54,7 @@ You can also use the [OpenAI Compatible provider](/providers/openai-compatible-p
 - [LM Studio](/providers/openai-compatible-providers/lmstudio)
 - [Baseten](/providers/openai-compatible-providers/baseten)
 
-Our [language model specification](https://github.com/vercel/ai/tree/main/packages/provider/src/language-model/v1) is published as an open-source package, which you can use to create [custom providers](/providers/community-providers/custom-providers).
+Our [language model specification](https://github.com/vercel/ai/tree/main/packages/provider/src/language-model/v2) is published as an open-source package, which you can use to create [custom providers](/providers/community-providers/custom-providers).
 
 The open-source community has created the following providers:
 

--- a/content/providers/03-community-providers/index.mdx
+++ b/content/providers/03-community-providers/index.mdx
@@ -5,7 +5,7 @@ description: Learn how to use Language Model Specification.
 
 # Community Providers
 
-The AI SDK provides a [Language Model Specification](https://github.com/vercel/ai/tree/main/packages/provider/src/language-model/v1).
+The AI SDK provides a [Language Model Specification](https://github.com/vercel/ai/tree/main/packages/provider/src/language-model/v2).
 You can [write your own provider](./community-providers/custom-providers) that adheres to the specification and it will be compatible with the AI SDK.
 
 Here are the community providers that implement the Language Model Specification:


### PR DESCRIPTION
## Background

Some docs still refer to the language mode spec v1 (code no longer exists in the branch).
https://ai-sdk.dev/providers/community-providers/custom-providers#writing-a-custom-provider

## Summary

Updated refs to v1 to v2.

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

