### PR TITLE
feat (provider/anthropic): cache control for tools

### DIFF
--- a/.changeset/wild-beans-help.md
+++ b/.changeset/wild-beans-help.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/anthropic': patch
+'ai': patch
+---
+
+feat (provider/anthropic): cache control for tools

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -139,13 +139,6 @@ on how to integrate reasoning into your chatbot.
 
 ### Cache Control
 
-<Note>
-  Anthropic cache control was originally a beta feature and required passing an
-  opt-in `cacheControl` setting when creating the model instance. It is now
-  Generally Available and enabled by default. The `cacheControl` setting is no
-  longer needed and will be removed in a future release.
-</Note>
-
 In the messages and message parts, you can use the `providerOptions` property to set cache control breakpoints.
 You need to set the `anthropic` property in the `providerOptions` object to `{ cacheControl: { type: 'ephemeral' } }` to set a cache control breakpoint.
 
@@ -203,6 +196,30 @@ const result = await generateText({
       role: 'system',
       content: 'Uncached system message part',
     },
+    {
+      role: 'user',
+      content: 'User prompt',
+    },
+  ],
+});
+```
+
+Cache control for tools:
+
+```ts
+const result = await generateText({
+  model: anthropic('claude-3-5-haiku-latest'),
+  tools: {
+    cityAttractions: tool({
+      inputSchema: z.object({ city: z.string() }),
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: 'ephemeral' },
+        },
+      },
+    }),
+  },
+  messages: [
     {
       role: 'user',
       content: 'User prompt',

--- a/examples/ai-core/src/generate-text/anthropic-tool-call-cache.ts
+++ b/examples/ai-core/src/generate-text/anthropic-tool-call-cache.ts
@@ -11,7 +11,7 @@ async function main() {
         inputSchema: z.object({ city: z.string() }),
         providerOptions: {
           anthropic: {
-            cacheControl: { type: 'ephemeral', ttl: '5m' },
+            cacheControl: { type: 'ephemeral' },
           },
         },
       }),

--- a/examples/ai-core/src/generate-text/anthropic-tool-call-cache.ts
+++ b/examples/ai-core/src/generate-text/anthropic-tool-call-cache.ts
@@ -1,0 +1,25 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod/v4';
+
+async function main() {
+  const result = await generateText({
+    model: anthropic('claude-3-5-haiku-latest'),
+    tools: {
+      cityAttractions: tool({
+        inputSchema: z.object({ city: z.string() }),
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral', ttl: '5m' },
+          },
+        },
+      }),
+    },
+    prompt: 'What attractions should I visit in San Francisco?',
+  });
+
+  console.log(JSON.stringify(result.request.body, null, 2));
+}
+
+main().catch(console.error);

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -320,6 +320,7 @@ describe('generateText', () => {
                   required: ['value'],
                   type: 'object',
                 },
+                providerOptions: undefined,
               },
               {
                 type: 'function',
@@ -332,6 +333,7 @@ describe('generateText', () => {
                   required: ['somethingElse'],
                   type: 'object',
                 },
+                providerOptions: undefined,
               },
             ]);
 
@@ -411,6 +413,7 @@ describe('generateText', () => {
                   required: ['value'],
                   type: 'object',
                 },
+                providerOptions: undefined,
               },
             ]);
 
@@ -627,6 +630,7 @@ describe('generateText', () => {
                         required: ['value'],
                         type: 'object',
                       },
+                      providerOptions: undefined,
                     },
                   ]);
 
@@ -1262,6 +1266,7 @@ describe('generateText', () => {
                     "type": "object",
                   },
                   "name": "tool1",
+                  "providerOptions": undefined,
                   "type": "function",
                 },
               ],
@@ -1769,6 +1774,7 @@ describe('generateText', () => {
             "type": "object",
           },
           "name": "tool1",
+          "providerOptions": undefined,
           "type": "function",
         },
       ]
@@ -2124,6 +2130,7 @@ describe('generateText', () => {
                   required: ['value'],
                   type: 'object',
                 },
+                providerOptions: undefined,
               },
               {
                 type: 'function',
@@ -2135,6 +2142,7 @@ describe('generateText', () => {
                   required: ['somethingElse'],
                   type: 'object',
                 },
+                providerOptions: undefined,
               },
             ]);
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1007,6 +1007,7 @@ describe('streamText', () => {
                   required: ['value'],
                   type: 'object',
                 },
+                providerOptions: undefined,
               },
             ]);
 
@@ -5245,6 +5246,7 @@ describe('streamText', () => {
                     "type": "object",
                   },
                   "name": "tool1",
+                  "providerOptions": undefined,
                   "type": "function",
                 },
               ],
@@ -5319,6 +5321,7 @@ describe('streamText', () => {
                     "type": "object",
                   },
                   "name": "tool1",
+                  "providerOptions": undefined,
                   "type": "function",
                 },
               ],
@@ -6373,6 +6376,7 @@ describe('streamText', () => {
                     "type": "object",
                   },
                   "name": "tool1",
+                  "providerOptions": undefined,
                   "type": "function",
                 },
               ],
@@ -9071,6 +9075,7 @@ describe('streamText', () => {
                   required: ['value'],
                   type: 'object',
                 },
+                providerOptions: undefined,
               },
             ]);
             expect(toolChoice).toStrictEqual({ type: 'required' });
@@ -11244,6 +11249,7 @@ describe('streamText', () => {
               "type": "object",
             },
             "name": "tool1",
+            "providerOptions": undefined,
             "type": "function",
           },
         ]

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
@@ -1,10 +1,8 @@
 import { z } from 'zod/v4';
-import { ToolSet } from '../generate-text/tool-set';
 import { prepareToolsAndToolChoice } from './prepare-tools-and-tool-choice';
 import { Tool, tool } from '@ai-sdk/provider-utils';
-import { LanguageModelV2FunctionTool } from '@ai-sdk/provider';
 
-const mockTools: ToolSet = {
+const mockTools = {
   tool1: tool({
     description: 'Tool 1 description',
     inputSchema: z.object({}),
@@ -23,93 +21,352 @@ const mockProviderDefinedTool: Tool = {
   inputSchema: z.object({}),
 };
 
-const mockToolsWithProviderDefined: ToolSet = {
+const mockToolsWithProviderDefined = {
   ...mockTools,
   providerTool: mockProviderDefinedTool,
 };
 
-it('should return undefined for both tools and toolChoice when tools is not provided', () => {
-  const result = prepareToolsAndToolChoice({
-    tools: undefined,
-    toolChoice: undefined,
-    activeTools: undefined,
-  });
-  expect(result).toEqual({ tools: undefined, toolChoice: undefined });
-});
+describe('prepareToolsAndToolChoice', () => {
+  it('should return undefined for both tools and toolChoice when tools is not provided', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: undefined,
+      toolChoice: undefined,
+      activeTools: undefined,
+    });
 
-it('should return all tools when activeTools is not provided', () => {
-  const result = prepareToolsAndToolChoice({
-    tools: mockTools,
-    toolChoice: undefined,
-    activeTools: undefined,
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": undefined,
+        "tools": undefined,
+      }
+    `);
   });
-  expect(result.tools).toHaveLength(2);
-  expect((result.tools?.[0] as LanguageModelV2FunctionTool).name).toBe('tool1');
-  expect((result.tools?.[1] as LanguageModelV2FunctionTool).name).toBe('tool2');
-  expect(result.toolChoice).toEqual({ type: 'auto' });
-});
 
-it('should filter tools based on activeTools', () => {
-  const result = prepareToolsAndToolChoice({
-    tools: mockTools,
-    toolChoice: undefined,
-    activeTools: ['tool1'],
-  });
-  expect(result.tools).toHaveLength(1);
-  expect((result.tools?.[0] as LanguageModelV2FunctionTool).name).toBe('tool1');
-  expect(result.toolChoice).toEqual({ type: 'auto' });
-});
+  it('should return all tools when activeTools is not provided', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: mockTools,
+      toolChoice: undefined,
+      activeTools: undefined,
+    });
 
-it('should handle string toolChoice', () => {
-  const result = prepareToolsAndToolChoice({
-    tools: mockTools,
-    toolChoice: 'none',
-    activeTools: undefined,
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "type": "auto",
+        },
+        "tools": [
+          {
+            "description": "Tool 1 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {},
+              "type": "object",
+            },
+            "name": "tool1",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+          {
+            "description": "Tool 2 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "city": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "city",
+              ],
+              "type": "object",
+            },
+            "name": "tool2",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+        ],
+      }
+    `);
   });
-  expect(result.tools).toHaveLength(2);
-  expect(result.toolChoice).toEqual({ type: 'none' });
-});
 
-it('should handle object toolChoice', () => {
-  const result = prepareToolsAndToolChoice({
-    tools: mockTools,
-    toolChoice: { type: 'tool', toolName: 'tool2' },
-    activeTools: undefined,
-  });
-  expect(result.tools).toHaveLength(2);
-  expect(result.toolChoice).toEqual({ type: 'tool', toolName: 'tool2' });
-});
+  it('should filter tools based on activeTools', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: mockTools,
+      toolChoice: undefined,
+      activeTools: ['tool1'],
+    });
 
-it('should correctly map tool properties', () => {
-  const result = prepareToolsAndToolChoice({
-    tools: mockTools,
-    toolChoice: undefined,
-    activeTools: undefined,
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "type": "auto",
+        },
+        "tools": [
+          {
+            "description": "Tool 1 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {},
+              "type": "object",
+            },
+            "name": "tool1",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+        ],
+      }
+    `);
   });
-  expect(result.tools?.[0]).toEqual({
-    type: 'function',
-    name: 'tool1',
-    description: 'Tool 1 description',
-    inputSchema: {
-      $schema: 'http://json-schema.org/draft-07/schema#',
-      additionalProperties: false,
-      type: 'object',
-      properties: {},
-    },
-  });
-});
 
-it('should handle provider-defined tool type', () => {
-  const result = prepareToolsAndToolChoice({
-    tools: mockToolsWithProviderDefined,
-    toolChoice: undefined,
-    activeTools: undefined,
+  it('should handle string toolChoice', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: mockTools,
+      toolChoice: 'none',
+      activeTools: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "type": "none",
+        },
+        "tools": [
+          {
+            "description": "Tool 1 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {},
+              "type": "object",
+            },
+            "name": "tool1",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+          {
+            "description": "Tool 2 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "city": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "city",
+              ],
+              "type": "object",
+            },
+            "name": "tool2",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+        ],
+      }
+    `);
   });
-  expect(result.tools).toHaveLength(3);
-  expect(result.tools?.[2]).toEqual({
-    type: 'provider-defined',
-    name: 'providerTool',
-    id: 'provider.tool-id',
-    args: { key: 'value' },
+
+  it('should handle object toolChoice', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: mockTools,
+      toolChoice: { type: 'tool', toolName: 'tool2' },
+      activeTools: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "toolName": "tool2",
+          "type": "tool",
+        },
+        "tools": [
+          {
+            "description": "Tool 1 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {},
+              "type": "object",
+            },
+            "name": "tool1",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+          {
+            "description": "Tool 2 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "city": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "city",
+              ],
+              "type": "object",
+            },
+            "name": "tool2",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should correctly map tool properties', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: mockTools,
+      toolChoice: undefined,
+      activeTools: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "type": "auto",
+        },
+        "tools": [
+          {
+            "description": "Tool 1 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {},
+              "type": "object",
+            },
+            "name": "tool1",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+          {
+            "description": "Tool 2 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "city": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "city",
+              ],
+              "type": "object",
+            },
+            "name": "tool2",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should handle provider-defined tool type', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: mockToolsWithProviderDefined,
+      toolChoice: undefined,
+      activeTools: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "type": "auto",
+        },
+        "tools": [
+          {
+            "description": "Tool 1 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {},
+              "type": "object",
+            },
+            "name": "tool1",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+          {
+            "description": "Tool 2 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "city": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "city",
+              ],
+              "type": "object",
+            },
+            "name": "tool2",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+          {
+            "args": {
+              "key": "value",
+            },
+            "id": "provider.tool-id",
+            "name": "providerTool",
+            "type": "provider-defined",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('should pass through provider options', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: {
+        tool1: tool({
+          description: 'Tool 1 description',
+          inputSchema: z.object({}),
+          providerOptions: {
+            aProvider: {
+              aSetting: 'aValue',
+            },
+          },
+        }),
+      },
+      toolChoice: undefined,
+      activeTools: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "type": "auto",
+        },
+        "tools": [
+          {
+            "description": "Tool 1 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {},
+              "type": "object",
+            },
+            "name": "tool1",
+            "providerOptions": {
+              "aProvider": {
+                "aSetting": "aValue",
+              },
+            },
+            "type": "function",
+          },
+        ],
+      }
+    `);
   });
 });

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
@@ -48,6 +48,7 @@ export function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
             name,
             description: tool.description,
             inputSchema: asSchema(tool.inputSchema).jsonSchema,
+            providerOptions: tool.providerOptions,
           };
         case 'provider-defined':
           return {

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -7,7 +7,10 @@ export type AnthropicMessagesPrompt = {
 
 export type AnthropicMessage = AnthropicUserMessage | AnthropicAssistantMessage;
 
-export type AnthropicCacheControl = { type: 'ephemeral' };
+export type AnthropicCacheControl = {
+  type: 'ephemeral';
+  ttl?: '5m' | '1h';
+};
 
 export interface AnthropicUserMessage {
   role: 'user';

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -126,6 +126,7 @@ export type AnthropicTool =
       name: string;
       description: string | undefined;
       input_schema: JSONSchema7;
+      cache_control: AnthropicCacheControl | undefined;
     }
   | {
       name: string;

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -9,7 +9,6 @@ export type AnthropicMessage = AnthropicUserMessage | AnthropicAssistantMessage;
 
 export type AnthropicCacheControl = {
   type: 'ephemeral';
-  ttl?: '5m' | '1h';
 };
 
 export interface AnthropicUserMessage {

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -186,7 +186,7 @@ describe('prepareTools', () => {
           inputSchema: {},
           providerOptions: {
             anthropic: {
-              cacheControl: { type: 'ephemeral', ttl: '5m' },
+              cacheControl: { type: 'ephemeral' },
             },
           },
         },
@@ -197,7 +197,6 @@ describe('prepareTools', () => {
       [
         {
           "cache_control": {
-            "ttl": "5m",
             "type": "ephemeral",
           },
           "description": "Test",

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -1,105 +1,106 @@
 import { prepareTools } from './anthropic-prepare-tools';
 
-it('should return undefined tools and tool_choice when tools are null', () => {
-  const result = prepareTools({ tools: undefined });
-  expect(result).toEqual({
-    tools: undefined,
-    tool_choice: undefined,
-    toolWarnings: [],
-    betas: new Set(),
+describe('prepareTools', () => {
+  it('should return undefined tools and tool_choice when tools are null', () => {
+    const result = prepareTools({ tools: undefined });
+    expect(result).toEqual({
+      tools: undefined,
+      tool_choice: undefined,
+      toolWarnings: [],
+      betas: new Set(),
+    });
   });
-});
 
-it('should return undefined tools and tool_choice when tools are empty', () => {
-  const result = prepareTools({ tools: [] });
-  expect(result).toEqual({
-    tools: undefined,
-    tool_choice: undefined,
-    toolWarnings: [],
-    betas: new Set(),
+  it('should return undefined tools and tool_choice when tools are empty', () => {
+    const result = prepareTools({ tools: [] });
+    expect(result).toEqual({
+      tools: undefined,
+      tool_choice: undefined,
+      toolWarnings: [],
+      betas: new Set(),
+    });
   });
-});
 
-it('should correctly prepare function tools', () => {
-  const result = prepareTools({
-    tools: [
+  it('should correctly prepare function tools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'A test function',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    });
+    expect(result.tools).toEqual([
       {
-        type: 'function',
         name: 'testFunction',
         description: 'A test function',
-        inputSchema: { type: 'object', properties: {} },
+        input_schema: { type: 'object', properties: {} },
       },
-    ],
+    ]);
+    expect(result.toolChoice).toBeUndefined();
+    expect(result.toolWarnings).toEqual([]);
   });
-  expect(result.tools).toEqual([
-    {
-      name: 'testFunction',
-      description: 'A test function',
-      input_schema: { type: 'object', properties: {} },
-    },
-  ]);
-  expect(result.toolChoice).toBeUndefined();
-  expect(result.toolWarnings).toEqual([]);
-});
 
-it('should correctly prepare provider-defined tools', () => {
-  const result = prepareTools({
-    tools: [
+  it('should correctly prepare provider-defined tools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'provider-defined',
+          id: 'anthropic.computer_20241022',
+          name: 'computer',
+          args: { displayWidthPx: 800, displayHeightPx: 600, displayNumber: 1 },
+        },
+        {
+          type: 'provider-defined',
+          id: 'anthropic.text_editor_20241022',
+          name: 'text_editor',
+          args: {},
+        },
+        {
+          type: 'provider-defined',
+          id: 'anthropic.bash_20241022',
+          name: 'bash',
+          args: {},
+        },
+      ],
+    });
+    expect(result.tools).toEqual([
       {
-        type: 'provider-defined',
-        id: 'anthropic.computer_20241022',
         name: 'computer',
-        args: { displayWidthPx: 800, displayHeightPx: 600, displayNumber: 1 },
+        type: 'computer_20241022',
+        display_width_px: 800,
+        display_height_px: 600,
+        display_number: 1,
       },
       {
-        type: 'provider-defined',
-        id: 'anthropic.text_editor_20241022',
-        name: 'text_editor',
-        args: {},
+        name: 'str_replace_editor',
+        type: 'text_editor_20241022',
       },
       {
-        type: 'provider-defined',
-        id: 'anthropic.bash_20241022',
         name: 'bash',
-        args: {},
+        type: 'bash_20241022',
       },
-    ],
+    ]);
+    expect(result.toolChoice).toBeUndefined();
+    expect(result.toolWarnings).toEqual([]);
   });
-  expect(result.tools).toEqual([
-    {
-      name: 'computer',
-      type: 'computer_20241022',
-      display_width_px: 800,
-      display_height_px: 600,
-      display_number: 1,
-    },
-    {
-      name: 'str_replace_editor',
-      type: 'text_editor_20241022',
-    },
-    {
-      name: 'bash',
-      type: 'bash_20241022',
-    },
-  ]);
-  expect(result.toolChoice).toBeUndefined();
-  expect(result.toolWarnings).toEqual([]);
-});
 
-it('should add warnings for unsupported tools', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'provider-defined',
-        id: 'unsupported.tool',
-        name: 'unsupported_tool',
-        args: {},
-      },
-    ],
-  });
-  expect(result.tools).toEqual([]);
-  expect(result.toolChoice).toBeUndefined();
-  expect(result.toolWarnings).toMatchInlineSnapshot(`
+  it('should add warnings for unsupported tools', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'provider-defined',
+          id: 'unsupported.tool',
+          name: 'unsupported_tool',
+          args: {},
+        },
+      ],
+    });
+    expect(result.tools).toEqual([]);
+    expect(result.toolChoice).toBeUndefined();
+    expect(result.toolWarnings).toMatchInlineSnapshot(`
     [
       {
         "tool": {
@@ -112,65 +113,98 @@ it('should add warnings for unsupported tools', () => {
       },
     ]
   `);
-});
-
-it('should handle tool choice "auto"', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'function',
-        name: 'testFunction',
-        description: 'Test',
-        inputSchema: {},
-      },
-    ],
-    toolChoice: { type: 'auto' },
   });
-  expect(result.toolChoice).toEqual({ type: 'auto' });
-});
 
-it('should handle tool choice "required"', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'function',
-        name: 'testFunction',
-        description: 'Test',
-        inputSchema: {},
-      },
-    ],
-    toolChoice: { type: 'required' },
+  it('should handle tool choice "auto"', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'auto' },
+    });
+    expect(result.toolChoice).toEqual({ type: 'auto' });
   });
-  expect(result.toolChoice).toEqual({ type: 'any' });
-});
 
-it('should handle tool choice "none"', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'function',
-        name: 'testFunction',
-        description: 'Test',
-        inputSchema: {},
-      },
-    ],
-    toolChoice: { type: 'none' },
+  it('should handle tool choice "required"', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'required' },
+    });
+    expect(result.toolChoice).toEqual({ type: 'any' });
   });
-  expect(result.tools).toBeUndefined();
-  expect(result.toolChoice).toBeUndefined();
-});
 
-it('should handle tool choice "tool"', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'function',
-        name: 'testFunction',
-        description: 'Test',
-        inputSchema: {},
-      },
-    ],
-    toolChoice: { type: 'tool', toolName: 'testFunction' },
+  it('should handle tool choice "none"', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'none' },
+    });
+    expect(result.tools).toBeUndefined();
+    expect(result.toolChoice).toBeUndefined();
   });
-  expect(result.toolChoice).toEqual({ type: 'tool', name: 'testFunction' });
+
+  it('should handle tool choice "tool"', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'tool', toolName: 'testFunction' },
+    });
+    expect(result.toolChoice).toEqual({ type: 'tool', name: 'testFunction' });
+  });
+
+  it('should set cache control', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+          providerOptions: {
+            anthropic: {
+              cacheControl: { type: 'ephemeral', ttl: '5m' },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result.tools).toMatchInlineSnapshot(`
+      [
+        {
+          "cache_control": {
+            "ttl": "5m",
+            "type": "ephemeral",
+          },
+          "description": "Test",
+          "input_schema": {},
+          "name": "testFunction",
+        },
+      ]
+    `);
+  });
 });

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -4,6 +4,7 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { AnthropicTool, AnthropicToolChoice } from './anthropic-api-types';
+import { getCacheControl } from './get-cache-control';
 import { webSearch_20250305ArgsSchema } from './tool/web-search_20250305';
 
 function isWebSearchTool(
@@ -52,10 +53,13 @@ export function prepareTools({
 
     switch (tool.type) {
       case 'function':
+        const cacheControl = getCacheControl(tool.providerOptions);
+
         anthropicTools.push({
           name: tool.name,
           description: tool.description,
           input_schema: tool.inputSchema,
+          cache_control: cacheControl,
         });
         break;
       case 'provider-defined':

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -6,16 +6,16 @@ import {
   SharedV2ProviderMetadata,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
+import { convertToBase64, parseProviderOptions } from '@ai-sdk/provider-utils';
 import {
   AnthropicAssistantMessage,
-  AnthropicCacheControl,
   AnthropicMessagesPrompt,
   AnthropicToolResultContent,
   AnthropicUserMessage,
 } from './anthropic-api-types';
-import { convertToBase64, parseProviderOptions } from '@ai-sdk/provider-utils';
 import { anthropicReasoningMetadataSchema } from './anthropic-messages-language-model';
 import { anthropicFilePartProviderOptions } from './anthropic-messages-options';
+import { getCacheControl } from './get-cache-control';
 import { webSearch_20250305OutputSchema } from './tool/web-search_20250305';
 
 function convertToString(data: LanguageModelV2DataContent): string {
@@ -55,20 +55,6 @@ export async function convertToAnthropicMessagesPrompt({
 
   let system: AnthropicMessagesPrompt['system'] = undefined;
   const messages: AnthropicMessagesPrompt['messages'] = [];
-
-  function getCacheControl(
-    providerMetadata: SharedV2ProviderMetadata | undefined,
-  ): AnthropicCacheControl | undefined {
-    const anthropic = providerMetadata?.anthropic;
-
-    // allow both cacheControl and cache_control:
-    const cacheControlValue =
-      anthropic?.cacheControl ?? anthropic?.cache_control;
-
-    // Pass through value assuming it is of the correct type.
-    // The Anthropic API will validate the value.
-    return cacheControlValue as AnthropicCacheControl | undefined;
-  }
 
   async function shouldEnableCitations(
     providerMetadata: SharedV2ProviderMetadata | undefined,

--- a/packages/anthropic/src/get-cache-control.ts
+++ b/packages/anthropic/src/get-cache-control.ts
@@ -1,0 +1,15 @@
+import { SharedV2ProviderMetadata } from '@ai-sdk/provider';
+import { AnthropicCacheControl } from './anthropic-api-types';
+
+export function getCacheControl(
+  providerMetadata: SharedV2ProviderMetadata | undefined,
+): AnthropicCacheControl | undefined {
+  const anthropic = providerMetadata?.anthropic;
+
+  // allow both cacheControl and cache_control:
+  const cacheControlValue = anthropic?.cacheControl ?? anthropic?.cache_control;
+
+  // Pass through value assuming it is of the correct type.
+  // The Anthropic API will validate the value.
+  return cacheControlValue as AnthropicCacheControl | undefined;
+}


### PR DESCRIPTION
## Background

Caching a subset of tools is currently not possible, see #3820.

## Summary

Support cache control for anthropic tools:

```ts
const result = await generateText({
  model: anthropic('claude-3-5-haiku-latest'),
  tools: {
    cityAttractions: tool({
      inputSchema: z.object({ city: z.string() }),
      providerOptions: {
        anthropic: {
          cacheControl: { type: 'ephemeral' },
        },
      },
    }),
  },
  messages: [
    {
      role: 'user',
      content: 'User prompt',
    },
  ],
});
```

## Verification

- [x] Check manually that option is set on the request.

## Tasks

- [x] changeset
- [x] docs
- [x] prepare tools
- [x] example
- [x] passthrough
- [x] debug

## Related Issues

Fixes #3820