### PR TITLE
fix(openai): update file_search fields to match API changes

### DIFF
--- a/.changeset/lovely-boxes-scream.md
+++ b/.changeset/lovely-boxes-scream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): update file_search fields to match API changes

--- a/content/docs/10-cli/index.mdx
+++ b/content/docs/10-cli/index.mdx
@@ -18,7 +18,7 @@ To start using the AI SDK CLI, you'll need to set up authentication and learn th
     {
       title: 'Authentication',
       description: 'Learn how to set up authentication for the AI SDK CLI.',
-      href: '/docs/ai-sdk-cli/authentication',
+      href: '/docs/cli/authentication',
     },
   ]}
 />

--- a/content/docs/10-cli/index.mdx
+++ b/content/docs/10-cli/index.mdx
@@ -18,7 +18,7 @@ To start using the AI SDK CLI, you'll need to set up authentication and learn th
     {
       title: 'Authentication',
       description: 'Learn how to set up authentication for the AI SDK CLI.',
-      href: '/docs/cli/authentication',
+      href: '/docs/ai-sdk-cli/authentication',
     },
   ]}
 />

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -687,8 +687,10 @@ const result = await generateText({
     file_search: openai.tools.fileSearch({
       // optional configuration:
       vectorStoreIds: ['vs_123', 'vs_456'],
-      maxResults: 10,
-      searchType: 'auto',
+      maxNumResults: 10,
+      ranking: {
+        ranker: 'auto',
+      },
     }),
   },
   // Force file search tool:

--- a/examples/ai-core/src/generate-text/openai-provider-defined-tools.ts
+++ b/examples/ai-core/src/generate-text/openai-provider-defined-tools.ts
@@ -18,8 +18,10 @@ async function main() {
       }),
 
       fileSearch: openai.tools.fileSearch({
-        maxResults: 5,
-        searchType: 'semantic',
+        maxNumResults: 5,
+        ranking: {
+          ranker: 'semantic',
+        },
       }),
     },
   });

--- a/examples/ai-core/src/generate-text/provider-defined-tools-working.ts
+++ b/examples/ai-core/src/generate-text/provider-defined-tools-working.ts
@@ -18,8 +18,10 @@ async function main() {
   });
 
   const openaiFileSearch = openai.tools.fileSearch({
-    maxResults: 5,
-    searchType: 'semantic',
+    maxNumResults: 5,
+    ranking: {
+      ranker: 'semantic',
+    },
   });
 
   console.log('OpenAI Web Search Tool created successfully');

--- a/examples/next-openai/app/api/chat-openai-file-search/route.ts
+++ b/examples/next-openai/app/api/chat-openai-file-search/route.ts
@@ -24,8 +24,10 @@ export async function POST(req: Request) {
     model: openai.responses('gpt-4o-mini'),
     tools: {
       file_search: openai.tools.fileSearch({
-        maxResults: 10,
-        searchType: 'semantic',
+        maxNumResults: 10,
+        ranking: {
+          ranker: 'semantic',
+        },
         // vectorStoreIds: ['vs_123'], // optional: specify vector store IDs
       }),
     },

--- a/packages/openai/src/openai-prepare-tools.test.ts
+++ b/packages/openai/src/openai-prepare-tools.test.ts
@@ -66,8 +66,10 @@ it('should correctly prepare provider-defined-server tools', () => {
         name: 'file_search',
         args: {
           vectorStoreIds: ['vs_123'],
-          maxResults: 10,
-          searchType: 'semantic',
+          maxNumResults: 10,
+          ranking: {
+            ranker: 'semantic',
+          },
         },
       },
       {
@@ -92,8 +94,10 @@ it('should correctly prepare provider-defined-server tools', () => {
     {
       type: 'file_search',
       vector_store_ids: ['vs_123'],
-      max_results: 10,
-      search_type: 'semantic',
+      max_num_results: 10,
+      ranking_options: {
+        ranker: 'semantic',
+      },
     },
     {
       type: 'web_search_preview',

--- a/packages/openai/src/openai-prepare-tools.ts
+++ b/packages/openai/src/openai-prepare-tools.ts
@@ -53,8 +53,10 @@ export function prepareTools({
             openaiTools.push({
               type: 'file_search',
               vector_store_ids: args.vectorStoreIds,
-              max_results: args.maxResults,
-              search_type: args.searchType,
+              max_num_results: args.maxNumResults,
+              ranking_options: args.ranking
+                ? { ranker: args.ranking.ranker }
+                : undefined,
             });
             break;
           }

--- a/packages/openai/src/openai-types.ts
+++ b/packages/openai/src/openai-types.ts
@@ -19,8 +19,10 @@ export interface OpenAIFunctionTool {
 export interface OpenAIFileSearchTool {
   type: 'file_search';
   vector_store_ids?: string[];
-  max_results?: number;
-  search_type?: 'auto' | 'keyword' | 'semantic';
+  max_num_results?: number;
+  ranking_options?: {
+    ranker?: 'auto' | 'keyword' | 'semantic';
+  };
 }
 
 /**

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -82,8 +82,10 @@ export type OpenAIResponsesTool =
   | {
       type: 'file_search';
       vector_store_ids?: string[];
-      max_results?: number;
-      search_type?: 'auto' | 'keyword' | 'semantic';
+      max_num_results?: number;
+      ranking_options?: {
+        ranker?: 'auto' | 'keyword' | 'semantic';
+      };
     };
 
 export type OpenAIResponsesReasoning = {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -801,8 +801,10 @@ describe('OpenAIResponsesLanguageModel', () => {
               name: 'file_search',
               args: {
                 vectorStoreIds: ['vs_123', 'vs_456'],
-                maxResults: 10,
-                searchType: 'auto',
+                maxNumResults: 10,
+                ranking: {
+                  ranker: 'auto',
+                },
               },
             },
           ],
@@ -825,8 +827,10 @@ describe('OpenAIResponsesLanguageModel', () => {
             "model": "gpt-4o",
             "tools": [
               {
-                "max_results": 10,
-                "search_type": "auto",
+                "max_num_results": 10,
+                "ranking_options": {
+                  "ranker": "auto",
+                },
                 "type": "file_search",
                 "vector_store_ids": [
                   "vs_123",
@@ -853,7 +857,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               name: 'file_search',
               args: {
                 vectorStoreIds: ['vs_789'],
-                maxResults: 5,
+                maxNumResults: 5,
               },
             },
           ],
@@ -879,7 +883,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             },
             "tools": [
               {
-                "max_results": 5,
+                "max_num_results": 5,
                 "type": "file_search",
                 "vector_store_ids": [
                   "vs_789",

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -54,8 +54,10 @@ export function prepareResponsesTools({
             openaiTools.push({
               type: 'file_search',
               vector_store_ids: args.vectorStoreIds,
-              max_results: args.maxResults,
-              search_type: args.searchType,
+              max_num_results: args.maxNumResults,
+              ranking_options: args.ranking
+                ? { ranker: args.ranking.ranker }
+                : undefined,
             });
             break;
           }

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -11,12 +11,16 @@ export const fileSearchArgsSchema = z.object({
   /**
    * Maximum number of search results to return. Defaults to 10.
    */
-  maxResults: z.number().optional(),
+  maxNumResults: z.number().optional(),
 
   /**
-   * Type of search to perform. Defaults to 'auto'.
+   * Ranking options for the search.
    */
-  searchType: z.enum(['auto', 'keyword', 'semantic']).optional(),
+  ranking: z
+    .object({
+      ranker: z.enum(['auto', 'keyword', 'semantic']).optional(),
+    })
+    .optional(),
 });
 
 export const fileSearch = createProviderDefinedToolFactory<
@@ -35,12 +39,14 @@ export const fileSearch = createProviderDefinedToolFactory<
     /**
      * Maximum number of search results to return. Defaults to 10.
      */
-    maxResults?: number;
+    maxNumResults?: number;
 
     /**
-     * Type of search to perform. Defaults to 'auto'.
+     * Ranking options for the search.
      */
-    searchType?: 'auto' | 'keyword' | 'semantic';
+    ranking?: {
+      ranker?: 'auto' | 'keyword' | 'semantic';
+    };
   }
 >({
   id: 'openai.file_search',


### PR DESCRIPTION
## background

OpenAI updated their Responses API documentation, changing field names for the file_search tool. The SDK needs to match the API to prevent runtime errors.

## summary

- update file_search fields: `max_results` → `max_num_results`, `search_type` → `ranking.ranker`

## verification

- all tests pass
- examples updated and working
- documentation reflects new field structure

## tasks

- [x] update type definitions
- [x] update tool preparation logic
- [x] update tests
- [x] update examples
- [x] update documentation 

related issue #7437