### PR TITLE
feat(openai): add file_search filters and update field names

### DIFF
--- a/.changeset/lazy-beans-marry.md
+++ b/.changeset/lazy-beans-marry.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add file_search filters and update field names

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -691,6 +691,13 @@ const result = await generateText({
       ranking: {
         ranker: 'auto',
       },
+      filters: {
+        type: 'and',
+        filters: [
+          { key: 'author', type: 'eq', value: 'John Doe' },
+          { key: 'date', type: 'gte', value: '2023-01-01' },
+        ],
+      },
     }),
   },
   // Force file search tool:

--- a/examples/next-openai/app/api/chat-openai-file-search/route.ts
+++ b/examples/next-openai/app/api/chat-openai-file-search/route.ts
@@ -29,6 +29,7 @@ export async function POST(req: Request) {
           ranker: 'semantic',
         },
         // vectorStoreIds: ['vs_123'], // optional: specify vector store IDs
+        // filters: { key: 'category', type: 'eq', value: 'technical' }, // optional: filter results
       }),
     },
     messages: convertToModelMessages(messages),

--- a/packages/openai/src/openai-prepare-tools.test.ts
+++ b/packages/openai/src/openai-prepare-tools.test.ts
@@ -113,6 +113,47 @@ it('should correctly prepare provider-defined-server tools', () => {
   expect(result.toolWarnings).toEqual([]);
 });
 
+it('should correctly prepare file_search with filters', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'openai.file_search',
+        name: 'file_search',
+        args: {
+          vectorStoreIds: ['vs_123'],
+          maxNumResults: 5,
+          filters: {
+            type: 'and',
+            filters: [
+              { key: 'author', type: 'eq', value: 'John Doe' },
+              { key: 'date', type: 'gte', value: '2023-01-01' },
+            ],
+          },
+        },
+      },
+    ],
+    structuredOutputs: false,
+    strictJsonSchema: false,
+  });
+
+  expect(result.tools).toEqual([
+    {
+      type: 'file_search',
+      vector_store_ids: ['vs_123'],
+      max_num_results: 5,
+      ranking_options: undefined,
+      filters: {
+        type: 'and',
+        filters: [
+          { key: 'author', type: 'eq', value: 'John Doe' },
+          { key: 'date', type: 'gte', value: '2023-01-01' },
+        ],
+      },
+    },
+  ]);
+});
+
 it('should add warnings for unsupported tools', () => {
   const result = prepareTools({
     tools: [

--- a/packages/openai/src/openai-prepare-tools.ts
+++ b/packages/openai/src/openai-prepare-tools.ts
@@ -57,6 +57,7 @@ export function prepareTools({
               ranking_options: args.ranking
                 ? { ranker: args.ranking.ranker }
                 : undefined,
+              filters: args.filters,
             });
             break;
           }

--- a/packages/openai/src/openai-types.ts
+++ b/packages/openai/src/openai-types.ts
@@ -23,6 +23,16 @@ export interface OpenAIFileSearchTool {
   ranking_options?: {
     ranker?: 'auto' | 'keyword' | 'semantic';
   };
+  filters?: 
+    | {
+        key: string;
+        type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
+        value: string | number | boolean;
+      }
+    | {
+        type: 'and' | 'or';
+        filters: any[];
+      };
 }
 
 /**

--- a/packages/openai/src/openai-types.ts
+++ b/packages/openai/src/openai-types.ts
@@ -23,7 +23,7 @@ export interface OpenAIFileSearchTool {
   ranking_options?: {
     ranker?: 'auto' | 'keyword' | 'semantic';
   };
-  filters?: 
+  filters?:
     | {
         key: string;
         type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -86,7 +86,7 @@ export type OpenAIResponsesTool =
       ranking_options?: {
         ranker?: 'auto' | 'keyword' | 'semantic';
       };
-      filters?: 
+      filters?:
         | {
             key: string;
             type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -86,6 +86,16 @@ export type OpenAIResponsesTool =
       ranking_options?: {
         ranker?: 'auto' | 'keyword' | 'semantic';
       };
+      filters?: 
+        | {
+            key: string;
+            type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
+            value: string | number | boolean;
+          }
+        | {
+            type: 'and' | 'or';
+            filters: any[];
+          };
     };
 
 export type OpenAIResponsesReasoning = {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -896,6 +896,61 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send file_search tool with filters', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.file_search',
+              name: 'file_search',
+              args: {
+                vectorStoreIds: ['vs_123'],
+                maxNumResults: 5,
+                filters: {
+                  key: 'author',
+                  type: 'eq',
+                  value: 'Jane Smith',
+                },
+              },
+            },
+          ],
+          prompt: TEST_PROMPT,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "gpt-4o",
+            "tools": [
+              {
+                "filters": {
+                  "key": "author",
+                  "type": "eq",
+                  "value": "Jane Smith",
+                },
+                "max_num_results": 5,
+                "type": "file_search",
+                "vector_store_ids": [
+                  "vs_123",
+                ],
+              },
+            ],
+          }
+        `);
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send file_search tool with minimal args', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           tools: [

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -58,6 +58,7 @@ export function prepareResponsesTools({
               ranking_options: args.ranking
                 ? { ranker: args.ranking.ranker }
                 : undefined,
+              filters: args.filters,
             });
             break;
           }

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -10,7 +10,9 @@ const comparisonFilterSchema = z.object({
 
 const compoundFilterSchema: z.ZodType<any> = z.object({
   type: z.enum(['and', 'or']),
-  filters: z.array(z.union([comparisonFilterSchema, z.lazy(() => compoundFilterSchema)])),
+  filters: z.array(
+    z.union([comparisonFilterSchema, z.lazy(() => compoundFilterSchema)]),
+  ),
 });
 
 const filtersSchema = z.union([comparisonFilterSchema, compoundFilterSchema]);
@@ -70,7 +72,7 @@ export const fileSearch = createProviderDefinedToolFactory<
     /**
      * A filter to apply based on file attributes.
      */
-    filters?: 
+    filters?:
       | {
           key: string;
           type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -1,6 +1,20 @@
 import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
+// Filter schemas
+const comparisonFilterSchema = z.object({
+  key: z.string(),
+  type: z.enum(['eq', 'ne', 'gt', 'gte', 'lt', 'lte']),
+  value: z.union([z.string(), z.number(), z.boolean()]),
+});
+
+const compoundFilterSchema: z.ZodType<any> = z.object({
+  type: z.enum(['and', 'or']),
+  filters: z.array(z.union([comparisonFilterSchema, z.lazy(() => compoundFilterSchema)])),
+});
+
+const filtersSchema = z.union([comparisonFilterSchema, compoundFilterSchema]);
+
 // Args validation schema
 export const fileSearchArgsSchema = z.object({
   /**
@@ -21,6 +35,11 @@ export const fileSearchArgsSchema = z.object({
       ranker: z.enum(['auto', 'keyword', 'semantic']).optional(),
     })
     .optional(),
+
+  /**
+   * A filter to apply based on file attributes.
+   */
+  filters: filtersSchema.optional(),
 });
 
 export const fileSearch = createProviderDefinedToolFactory<
@@ -47,6 +66,20 @@ export const fileSearch = createProviderDefinedToolFactory<
     ranking?: {
       ranker?: 'auto' | 'keyword' | 'semantic';
     };
+
+    /**
+     * A filter to apply based on file attributes.
+     */
+    filters?: 
+      | {
+          key: string;
+          type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
+          value: string | number | boolean;
+        }
+      | {
+          type: 'and' | 'or';
+          filters: any[];
+        };
   }
 >({
   id: 'openai.file_search',


### PR DESCRIPTION
## background

OpenAI updated their Responses API documentation, changing field names for the file_search tool and adding support for filtering search results. The SDK needs to match the API to prevent runtime errors and support new functionality.

## summary

- add filters support for file_search tool (comparison and compound filters)

## verification

- all tests pass including new filter tests
- examples updated and working
- documentation reflects new filters

## tasks

- [x] add filter schemas (comparison and compound)
- [x] update tests
- [x] update examples
- [x] update documentation 