### PR TITLE
fix(amazon-bedrock): add structured output support for claude models

### DIFF
--- a/.changeset/healthy-snakes-glow.md
+++ b/.changeset/healthy-snakes-glow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): add structured output support for claude models

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -1441,7 +1441,9 @@ describe('doStream', () => {
     };
 
     const { stream } = await model.doStream({
-      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Generate JSON' }] }],
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'Generate JSON' }] },
+      ],
       responseFormat: {
         type: 'json',
         schema: {
@@ -2149,13 +2151,20 @@ describe('doGenerate', () => {
           type: 'tool_use',
           id: 'json-tool-id',
           name: 'json',
-          input: { recipe: { name: 'Lasagna', ingredients: ['pasta', 'cheese'] } },
+          input: {
+            recipe: { name: 'Lasagna', ingredients: ['pasta', 'cheese'] },
+          },
         },
       ],
     });
 
     const result = await model.doGenerate({
-      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Generate a recipe' }] }],
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Generate a recipe' }],
+        },
+      ],
       responseFormat: {
         type: 'json',
         schema: {
@@ -2182,8 +2191,12 @@ describe('doGenerate', () => {
     const requestBody = await server.calls[0].requestBodyJson;
     expect(requestBody.toolConfig.tools).toHaveLength(1);
     expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
-    expect(requestBody.toolConfig.tools[0].toolSpec.description).toBe('Respond with a JSON object.');
-    expect(requestBody.toolConfig.toolChoice).toEqual({ tool: { name: 'json' } });
+    expect(requestBody.toolConfig.tools[0].toolSpec.description).toBe(
+      'Respond with a JSON object.',
+    );
+    expect(requestBody.toolConfig.toolChoice).toEqual({
+      tool: { name: 'json' },
+    });
   });
 
   it('should warn when tools are provided with JSON response format', async () => {
@@ -2220,7 +2233,8 @@ describe('doGenerate', () => {
     expect(result.warnings).toEqual([
       {
         type: 'other',
-        message: 'JSON response format does not support tools. The provided tools are ignored.',
+        message:
+          'JSON response format does not support tools. The provided tools are ignored.',
       },
     ]);
   });

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -8,6 +8,7 @@ import {
   LanguageModelV2StreamPart,
   LanguageModelV2Usage,
   SharedV2ProviderMetadata,
+  LanguageModelV2FunctionTool,
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
@@ -69,6 +70,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
   }: Parameters<LanguageModelV2['doGenerate']>[0]): Promise<{
     command: BedrockConverseInput;
     warnings: LanguageModelV2CallWarning[];
+    usesJsonResponseTool: boolean;
   }> {
     // Parse provider options
     const bedrockOptions =
@@ -108,13 +110,34 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
       });
     }
 
-    if (responseFormat != null && responseFormat.type !== 'text') {
+    if (responseFormat != null && responseFormat.type !== 'text' && responseFormat.type !== 'json') {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'responseFormat',
-        details: 'JSON response format is not supported.',
+        details: 'Only text and json response formats are supported.',
       });
     }
+
+    if (tools != null && responseFormat?.type === 'json') {
+      if (tools.length > 0) {
+        warnings.push({
+          type: 'other',
+          message:
+            'JSON response format does not support tools. ' +
+            'The provided tools are ignored.',
+        });
+      }
+    }
+
+    const jsonResponseTool: LanguageModelV2FunctionTool | undefined =
+      responseFormat?.type === 'json' && responseFormat.schema != null
+        ? {
+            type: 'function',
+            name: 'json',
+            description: 'Respond with a JSON object.',
+            inputSchema: responseFormat.schema,
+          }
+        : undefined;
 
     const { system, messages } = await convertToBedrockChatMessages(prompt);
 
@@ -167,8 +190,12 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
     }
 
     const { toolConfig, toolWarnings } = prepareTools({
-      tools,
-      toolChoice,
+      tools: jsonResponseTool != null
+        ? [jsonResponseTool]
+        : tools ?? [],
+      toolChoice: jsonResponseTool != null
+        ? { type: 'tool', toolName: jsonResponseTool.name }
+        : toolChoice,
       prompt,
     });
 
@@ -189,6 +216,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
         ...(toolConfig.tools !== undefined ? { toolConfig } : {}),
       },
       warnings: [...warnings, ...toolWarnings],
+      usesJsonResponseTool: jsonResponseTool != null,
     };
   }
 
@@ -199,7 +227,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
   async doGenerate(
     options: Parameters<LanguageModelV2['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2['doGenerate']>>> {
-    const { command: args, warnings } = await this.getArgs(options);
+    const { command: args, warnings, usesJsonResponseTool } = await this.getArgs(options);
 
     const url = `${this.getUrl(this.modelId)}/converse`;
     const { value: response, responseHeaders } = await postJsonToApi({
@@ -226,7 +254,11 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
     for (const part of response.output.message.content) {
       // text
       if (part.text) {
-        content.push({ type: 'text', text: part.text });
+        // when a json response tool is used, the tool call is returned as text,
+        // so we ignore the text content:
+        if (!usesJsonResponseTool) {
+          content.push({ type: 'text', text: part.text });
+        }
       }
 
       // reasoning
@@ -262,18 +294,26 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
 
       // tool calls
       if (part.toolUse) {
-        content.push({
-          type: 'tool-call' as const,
-          toolCallId: part.toolUse?.toolUseId ?? this.config.generateId(),
-          toolName: part.toolUse?.name ?? `tool-${this.config.generateId()}`,
-          input: JSON.stringify(part.toolUse?.input ?? ''),
-        });
+        content.push(
+          // when a json response tool is used, the tool call becomes the text:
+          usesJsonResponseTool
+            ? {
+                type: 'text',
+                text: JSON.stringify(part.toolUse.input),
+              }
+            : {
+                type: 'tool-call' as const,
+                toolCallId: part.toolUse?.toolUseId ?? this.config.generateId(),
+                toolName: part.toolUse?.name ?? `tool-${this.config.generateId()}`,
+                input: JSON.stringify(part.toolUse?.input ?? ''),
+              },
+        );
       }
     }
 
     // provider metadata:
     const providerMetadata =
-      response.trace || response.usage
+      response.trace || response.usage || usesJsonResponseTool
         ? {
             bedrock: {
               ...(response.trace && typeof response.trace === 'object'
@@ -284,6 +324,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
                   cacheWriteInputTokens: response.usage.cacheWriteInputTokens,
                 },
               }),
+              ...(usesJsonResponseTool && { isJsonResponseFromTool: true }),
             },
           }
         : undefined;
@@ -311,7 +352,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
   async doStream(
     options: Parameters<LanguageModelV2['doStream']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2['doStream']>>> {
-    const { command: args, warnings } = await this.getArgs(options);
+    const { command: args, warnings, usesJsonResponseTool } = await this.getArgs(options);
     const url = `${this.getUrl(this.modelId)}/converse-stream`;
 
     const { value: response, responseHeaders } = await postJsonToApi({
@@ -430,11 +471,12 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
                   }
                 : undefined;
 
-              if (cacheUsage || trace) {
+              if (cacheUsage || trace || usesJsonResponseTool) {
                 providerMetadata = {
                   bedrock: {
                     ...cacheUsage,
                     ...trace,
+                    ...(usesJsonResponseTool && { isJsonResponseFromTool: true }),
                   },
                 };
               }
@@ -461,17 +503,24 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
 
               if (contentBlocks[blockIndex] == null) {
                 contentBlocks[blockIndex] = { type: 'text' };
-                controller.enqueue({
-                  type: 'text-start',
-                  id: String(blockIndex),
-                });
+                
+                // when a json response tool is used, we don't emit text events
+                if (!usesJsonResponseTool) {
+                  controller.enqueue({
+                    type: 'text-start',
+                    id: String(blockIndex),
+                  });
+                }
               }
 
-              controller.enqueue({
-                type: 'text-delta',
-                id: String(blockIndex),
-                delta: value.contentBlockDelta.delta.text,
-              });
+              // when a json response tool is used, we don't emit text events
+              if (!usesJsonResponseTool) {
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: String(blockIndex),
+                  delta: value.contentBlockDelta.delta.text,
+                });
+              }
             }
 
             if (value.contentBlockStop?.contentBlockIndex != null) {
@@ -485,21 +534,41 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
                     id: String(blockIndex),
                   });
                 } else if (contentBlock.type === 'text') {
-                  controller.enqueue({
-                    type: 'text-end',
-                    id: String(blockIndex),
-                  });
+                  // when a json response tool is used, we don't emit text events
+                  if (!usesJsonResponseTool) {
+                    controller.enqueue({
+                      type: 'text-end',
+                      id: String(blockIndex),
+                    });
+                  }
                 } else if (contentBlock.type === 'tool-call') {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: contentBlock.toolCallId,
-                  });
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: contentBlock.toolCallId,
-                    toolName: contentBlock.toolName,
-                    input: contentBlock.jsonText,
-                  });
+                  if (usesJsonResponseTool) {
+                    // when a json response tool is used, emit the tool input as text
+                    controller.enqueue({
+                      type: 'text-start',
+                      id: String(blockIndex),
+                    });
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: String(blockIndex),
+                      delta: contentBlock.jsonText,
+                    });
+                    controller.enqueue({
+                      type: 'text-end',
+                      id: String(blockIndex),
+                    });
+                  } else {
+                    controller.enqueue({
+                      type: 'tool-input-end',
+                      id: contentBlock.toolCallId,
+                    });
+                    controller.enqueue({
+                      type: 'tool-call',
+                      toolCallId: contentBlock.toolCallId,
+                      toolName: contentBlock.toolName,
+                      input: contentBlock.jsonText,
+                    });
+                  }
                 }
 
                 delete contentBlocks[blockIndex];
@@ -568,11 +637,14 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
                 jsonText: '',
               };
 
-              controller.enqueue({
-                type: 'tool-input-start',
-                id: toolUse.toolUseId!,
-                toolName: toolUse.name!,
-              });
+              // when a json response tool is used, we don't emit tool events
+              if (!usesJsonResponseTool) {
+                controller.enqueue({
+                  type: 'tool-input-start',
+                  id: toolUse.toolUseId!,
+                  toolName: toolUse.name!,
+                });
+              }
             }
 
             const contentBlockDelta = value.contentBlockDelta;
@@ -587,11 +659,14 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
               if (contentBlock?.type === 'tool-call') {
                 const delta = contentBlockDelta.delta.toolUse.input ?? '';
 
-                controller.enqueue({
-                  type: 'tool-input-delta',
-                  id: contentBlock.toolCallId,
-                  delta: delta,
-                });
+                // when a json response tool is used, we don't emit tool events
+                if (!usesJsonResponseTool) {
+                  controller.enqueue({
+                    type: 'tool-input-delta',
+                    id: contentBlock.toolCallId,
+                    delta: delta,
+                  });
+                }
 
                 contentBlock.jsonText += delta;
               }

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -110,7 +110,11 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
       });
     }
 
-    if (responseFormat != null && responseFormat.type !== 'text' && responseFormat.type !== 'json') {
+    if (
+      responseFormat != null &&
+      responseFormat.type !== 'text' &&
+      responseFormat.type !== 'json'
+    ) {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'responseFormat',
@@ -190,12 +194,11 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
     }
 
     const { toolConfig, toolWarnings } = prepareTools({
-      tools: jsonResponseTool != null
-        ? [jsonResponseTool]
-        : tools ?? [],
-      toolChoice: jsonResponseTool != null
-        ? { type: 'tool', toolName: jsonResponseTool.name }
-        : toolChoice,
+      tools: jsonResponseTool != null ? [jsonResponseTool] : (tools ?? []),
+      toolChoice:
+        jsonResponseTool != null
+          ? { type: 'tool', toolName: jsonResponseTool.name }
+          : toolChoice,
       prompt,
     });
 
@@ -227,7 +230,11 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
   async doGenerate(
     options: Parameters<LanguageModelV2['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2['doGenerate']>>> {
-    const { command: args, warnings, usesJsonResponseTool } = await this.getArgs(options);
+    const {
+      command: args,
+      warnings,
+      usesJsonResponseTool,
+    } = await this.getArgs(options);
 
     const url = `${this.getUrl(this.modelId)}/converse`;
     const { value: response, responseHeaders } = await postJsonToApi({
@@ -304,7 +311,8 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
             : {
                 type: 'tool-call' as const,
                 toolCallId: part.toolUse?.toolUseId ?? this.config.generateId(),
-                toolName: part.toolUse?.name ?? `tool-${this.config.generateId()}`,
+                toolName:
+                  part.toolUse?.name ?? `tool-${this.config.generateId()}`,
                 input: JSON.stringify(part.toolUse?.input ?? ''),
               },
         );
@@ -352,7 +360,11 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
   async doStream(
     options: Parameters<LanguageModelV2['doStream']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2['doStream']>>> {
-    const { command: args, warnings, usesJsonResponseTool } = await this.getArgs(options);
+    const {
+      command: args,
+      warnings,
+      usesJsonResponseTool,
+    } = await this.getArgs(options);
     const url = `${this.getUrl(this.modelId)}/converse-stream`;
 
     const { value: response, responseHeaders } = await postJsonToApi({
@@ -476,7 +488,9 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
                   bedrock: {
                     ...cacheUsage,
                     ...trace,
-                    ...(usesJsonResponseTool && { isJsonResponseFromTool: true }),
+                    ...(usesJsonResponseTool && {
+                      isJsonResponseFromTool: true,
+                    }),
                   },
                 };
               }
@@ -503,7 +517,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
 
               if (contentBlocks[blockIndex] == null) {
                 contentBlocks[blockIndex] = { type: 'text' };
-                
+
                 // when a json response tool is used, we don't emit text events
                 if (!usesJsonResponseTool) {
                   controller.enqueue({


### PR DESCRIPTION
## background

aws bedrock's converse api doesn't expose anthropic's native structured output support, causing generateObject calls to fail with bedrock claude models. the sdk needs to implement the same json response tool pattern used by the direct anthropic provider.

## summary

- add json response tool support to bedrock claude models  
- remove json response format warning for bedrock
- implement tool-to-text conversion for structured outputs
- add streaming support for json response tool

## verification

- generateObject example works with bedrock claude
- streamObject example works with bedrock claude  
- all existing tests pass
- structured outputs return valid json instead of markdown

## tasks

- [x] implement json response tool creation
- [x] update tool preparation logic
- [x] modify content processing for both streaming and non-streaming
- [x] add provider metadata flag
- [x] fix test snapshots
- [x] verify examples work 