### PR TITLE
docs: remove maxSteps parameter from useChat api reference (v5)

### DIFF
--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -143,12 +143,6 @@ Allows you to easily create a conversational user interface for your chatbot app
       description: 'Initial chat messages to populate the conversation with.',
     },
     {
-      name: 'maxSteps',
-      type: 'number',
-      isOptional: true,
-      description: 'Maximum number of sequential tool execution steps per assistant message. Defaults to 1.',
-    },
-    {
       name: 'onToolCall',
       type: '({toolCall: ToolCall}) => void | Promise<void>',
       isOptional: true,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

The `useChat` API reference still included `maxSteps`, which was removed in v5 ([Migration Guide](https://v5.ai-sdk.dev/docs/migration-guides/migration-guide-5-0#maxsteps-removal)).

## Summary

<!-- What did you change? -->

Removed the `maxSteps` parameter from the `useChat` API reference.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->


Need to update related examples in the Cookbook. For now, I left them unchanged to avoid confusion until they can be revised properly.

## Related Issues

None.

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
