### PR TITLE
 docs: add Korean chunking regex example

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
@@ -56,8 +56,21 @@ The word based chunking **does not work well** with the following languages that
 
 For these languages we recommend using a custom regex, like the following:
 
+- Korean - `/[\uAC00-\uD7A3]|\S+\s+/`
 - Chinese - `/[\u4E00-\u9FFF]|\S+\s+/`
 - Japanese - `/[\u3040-\u309F\u30A0-\u30FF]|\S+\s+/`
+
+```tsx filename="Korean example"
+import { smoothStream, streamText } from 'ai';
+
+const result = streamText({
+  model: 'openai/gpt-4.1',
+  prompt: 'Your prompt here',
+  experimental_transform: smoothStream({
+    chunking: /[\uAC00-\uD7A3]|\S+\s+/,
+  }),
+});
+```
 
 ```tsx filename="Japanese example"
 import { smoothStream, streamText } from 'ai';


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

This PR adds a custom regex example for Korean.  
Korean text doesn’t chunk well with the default behavior of [smoothStream()](https://v5.ai-sdk.dev/docs/reference/ai-sdk-core/smooth-stream#smoothstream).

<!-- Why was this change necessary? -->

## Summary

Added a Korean chunking regex example to the docs.  
No code changes.

---

<img src="https://github.com/user-attachments/assets/29ddaad0-6eaa-48b8-9834-f8b8a2dea072" width="500" />

---

<!-- What did you change? -->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
