### PR TITLE
docs: update useChat reference to match actual behavior

### DIFF
--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -84,7 +84,7 @@ Allows you to easily create a conversational user interface for your chatbot app
               name: 'prepareSendMessagesRequest',
               type: 'PrepareSendMessagesRequest',
               isOptional: true,
-              description: 'Function to prepare the request body for chat API calls.',
+              description: 'A function to customize the request before chat API calls.',
               properties: [
                 {
                   type: 'PrepareSendMessagesRequest',
@@ -108,6 +108,31 @@ Allows you to easily create a conversational user interface for your chatbot app
                               description: 'Current messages in the chat',
                             },
                             {
+                              name: 'requestMetadata',
+                              type: 'unknown',
+                              description: 'The request metadata',
+                            }
+                            {
+                              name: 'body',
+                              type: 'Record<string, any> | undefined',
+                              description: 'The request body',
+                            }
+                            {
+                              name: 'credentials',
+                              type: 'RequestCredentials | undefined',
+                              description: 'The request credentials',
+                            }
+                            {
+                              name: 'headers',
+                              type: 'HeadersInit | undefined',
+                              description: 'The request headers',
+                            },
+                            {
+                              name: 'api',
+                              type: 'string',
+                              description: `The API endpoint to use for the request. If not specified, it defaults to the transport’s API endpoint: /api/chat.`,
+                            },
+                            {
                               name: 'trigger',
                               type: "'submit-user-message' | 'submit-tool-result' | 'regenerate-assistant-message'",
                               description: 'The trigger for the request',
@@ -116,6 +141,61 @@ Allows you to easily create a conversational user interface for your chatbot app
                               name: 'messageId',
                               type: 'string | undefined',
                               description: 'The message ID if applicable',
+                            },
+                          ]
+                        }
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'prepareReconnectToStreamRequest',
+              type: 'PrepareReconnectToStreamRequest',
+              isOptional: true,
+              description: 'A function to customize the request before reconnect API call.',
+              properties: [
+                {
+                  type: 'PrepareReconnectToStreamRequest',
+                  parameters: [
+                    {
+                      name: 'options',
+                      type: 'PrepareReconnectToStreamRequestOptions',
+                      description: 'Options for preparing the reconnect request',
+                      properties: [
+                        {
+                          type: 'PrepareReconnectToStreamRequestOptions',
+                          parameters: [
+                            {
+                              name: 'id',
+                              type: 'string',
+                              description: 'The chat ID',
+                            },
+                            {
+                              name: 'requestMetadata',
+                              type: 'unknown',
+                              description: 'The request metadata',
+                            },
+                            {
+                              name: 'body',
+                              type: 'Record<string, any> | undefined',
+                              description: 'The request body',
+                            },
+                            {
+                              name: 'credentials',
+                              type: 'RequestCredentials | undefined',
+                              description: 'The request credentials',
+                            },
+                            {
+                              name: 'headers',
+                              type: 'HeadersInit | undefined',
+                              description: 'The request headers',
+                            },
+                            {
+                              name: 'api',
+                              type: 'string',
+                              description: `The API endpoint to use for the request. If not specified, it defaults to the transport’s API endpoint combined with the chat ID: /api/chat/{chatId}/stream.`,
                             },
                           ]
                         }


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Important reference for `useChat` in v5 is missing.
Without the `prepareReconnectToStreamRequest` option,
resumeStream doesn't work when it doesn't match the default setups.

<!-- Why was this change necessary? -->

## Summary

Fixed prepareSendMessagesRequest reference and added prepareReconnectToStreamRequest reference.
No changes other than documentation.

<!-- What did you change? -->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

I noticed that many parts of the actual behavior didn’t match the documentation.
Let me know specifically which parts need documentation updates, and I’ll be happy to help.
Feel free to leave a comment if needed.

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->
