### PR TITLE
fix(ai): add support for MCP protocol version 2025-06-18

### DIFF
--- a/.changeset/swift-insects-think.md
+++ b/.changeset/swift-insects-think.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): add support for MCP protocol version 2025-06-18

--- a/packages/ai/src/tool/mcp/mock-mcp-transport.ts
+++ b/packages/ai/src/tool/mcp/mock-mcp-transport.ts
@@ -68,7 +68,7 @@ export class MockMCPTransport implements MCPTransport {
           jsonrpc: '2.0',
           id: message.id,
           result: this.initializeResult || {
-            protocolVersion: '2024-11-05',
+            protocolVersion: '2025-06-18',
             serverInfo: {
               name: 'mock-mcp-server',
               version: '1.0.0',

--- a/packages/ai/src/tool/mcp/types.ts
+++ b/packages/ai/src/tool/mcp/types.ts
@@ -2,9 +2,10 @@ import { z } from 'zod/v4';
 import { JSONObject } from '@ai-sdk/provider';
 import { FlexibleSchema, Tool } from '@ai-sdk/provider-utils';
 
-export const LATEST_PROTOCOL_VERSION = '2025-03-26';
+export const LATEST_PROTOCOL_VERSION = '2025-06-18';
 export const SUPPORTED_PROTOCOL_VERSIONS = [
   LATEST_PROTOCOL_VERSION,
+  '2025-03-26',
   '2024-11-05',
 ];
 


### PR DESCRIPTION
## background

Users with FastMCP servers (version 2.10.6+) were unable to connect because they use MCP protocol version 2025-06-18, but the AI SDK only supported versions up to 2025-03-26, causing connection failures with "Server's protocol version is not supported" errors.

## summary

- add 2025-06-18 to supported MCP protocol versions
- update mock transport to use latest protocol version

## verification

- all existing MCP tests pass
- backward compatibility maintained for 2025-03-26 and 2024-11-05 versions
- FastMCP server connections now work without errors

## tasks

- [x] updated SUPPORTED_PROTOCOL_VERSIONS array in types.ts
- [x] set LATEST_PROTOCOL_VERSION to 2025-06-18
- [x] updated mock transport default protocol version
- [x] verified all test pass

related issue #7575