### PR TITLE
feat (ai): introduce dynamic tools

### DIFF
--- a/.changeset/bright-dodos-smash.md
+++ b/.changeset/bright-dodos-smash.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+feat (ai): introduce dynamic tools

--- a/examples/ai-core/src/generate-text/amazon-bedrock-cache-point-tool-call.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-cache-point-tool-call.ts
@@ -140,6 +140,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'weather': {
         toolCall.input.location; // string

--- a/examples/ai-core/src/generate-text/amazon-bedrock-cache-point-tool-call.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-cache-point-tool-call.ts
@@ -154,6 +154,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       case 'weather': {
         toolResult.input.location; // string

--- a/examples/ai-core/src/generate-text/amazon-bedrock-tool-call.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-tool-call.ts
@@ -19,6 +19,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/amazon-bedrock-tool-call.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-tool-call.ts
@@ -38,6 +38,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/anthropic-tool-call.ts
+++ b/examples/ai-core/src/generate-text/anthropic-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/anthropic-tool-call.ts
+++ b/examples/ai-core/src/generate-text/anthropic-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/anthropic-web-search.ts
+++ b/examples/ai-core/src/generate-text/anthropic-web-search.ts
@@ -29,6 +29,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       case 'web_search': {
         toolResult.input.query; // string

--- a/examples/ai-core/src/generate-text/cerebras-tool-call.ts
+++ b/examples/ai-core/src/generate-text/cerebras-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/cerebras-tool-call.ts
+++ b/examples/ai-core/src/generate-text/cerebras-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/cohere-tool-call.ts
+++ b/examples/ai-core/src/generate-text/cohere-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/cohere-tool-call.ts
+++ b/examples/ai-core/src/generate-text/cohere-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/deepinfra-tool-call.ts
+++ b/examples/ai-core/src/generate-text/deepinfra-tool-call.ts
@@ -41,6 +41,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/deepinfra-tool-call.ts
+++ b/examples/ai-core/src/generate-text/deepinfra-tool-call.ts
@@ -22,6 +22,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/gateway-tool-call.ts
+++ b/examples/ai-core/src/generate-text/gateway-tool-call.ts
@@ -19,6 +19,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/gateway-tool-call.ts
+++ b/examples/ai-core/src/generate-text/gateway-tool-call.ts
@@ -38,6 +38,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/google-tool-call.ts
+++ b/examples/ai-core/src/generate-text/google-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/google-tool-call.ts
+++ b/examples/ai-core/src/generate-text/google-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-tool-call.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/google-vertex-anthropic-tool-call.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-anthropic-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/mistral-tool-call.ts
+++ b/examples/ai-core/src/generate-text/mistral-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/mistral-tool-call.ts
+++ b/examples/ai-core/src/generate-text/mistral-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/openai-compatible-togetherai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-compatible-togetherai-tool-call.ts
@@ -30,6 +30,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/openai-compatible-togetherai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-compatible-togetherai-tool-call.ts
@@ -49,6 +49,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/openai-dynamic-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-dynamic-tool-call.ts
@@ -1,0 +1,65 @@
+import { openai } from '@ai-sdk/openai';
+import { dynamicTool, generateText, stepCountIs } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod/v4';
+import { weatherTool } from '../tools/weather-tool';
+
+async function main() {
+  const result = await generateText({
+    model: openai('gpt-4o'),
+    stopWhen: stepCountIs(5),
+    tools: {
+      currentLocation: dynamicTool({
+        description: 'Get the current location.',
+        inputSchema: z.object({}),
+        execute: async () => {
+          const locations = ['New York', 'London', 'Paris'];
+          return {
+            location: locations[Math.floor(Math.random() * locations.length)],
+          };
+        },
+      }),
+      weather: weatherTool,
+    },
+    prompt: 'What is the weather in my current location?',
+    onStepFinish: step => {
+      // typed tool calls:
+      for (const toolCall of step.toolCalls) {
+        if (toolCall.dynamic) {
+          console.log('DYNAMIC CALL', JSON.stringify(toolCall, null, 2));
+          continue;
+        }
+
+        switch (toolCall.toolName) {
+          case 'weather': {
+            console.log('STATIC CALL', JSON.stringify(toolCall, null, 2));
+            toolCall.input.location; // string
+            break;
+          }
+        }
+      }
+
+      // typed tool results for tools with execute method:
+      for (const toolResult of step.toolResults) {
+        if (toolResult.dynamic) {
+          console.log('DYNAMIC RESULT', JSON.stringify(toolResult, null, 2));
+          continue;
+        }
+
+        switch (toolResult.toolName) {
+          case 'weather': {
+            console.log('STATIC RESULT', JSON.stringify(toolResult, null, 2));
+            toolResult.input.location; // string
+            toolResult.output.location; // string
+            toolResult.output.temperature; // number
+            break;
+          }
+        }
+      }
+    },
+  });
+
+  console.log(JSON.stringify(result.content, null, 2));
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-dynamic-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-dynamic-tool-call.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod/v4';
 import { weatherTool } from '../tools/weather-tool';
 
-function dynamicToolSet(): ToolSet {
+function dynamicTools(): ToolSet {
   return {
     currentLocation: dynamicTool({
       description: 'Get the current location.',
@@ -24,7 +24,7 @@ async function main() {
     model: openai('gpt-4o'),
     stopWhen: stepCountIs(5),
     tools: {
-      ...dynamicToolSet(),
+      ...dynamicTools(),
       weather: weatherTool,
     },
     prompt: 'What is the weather in my current location?',

--- a/examples/ai-core/src/generate-text/openai-dynamic-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-dynamic-tool-call.ts
@@ -1,24 +1,30 @@
 import { openai } from '@ai-sdk/openai';
-import { dynamicTool, generateText, stepCountIs } from 'ai';
+import { dynamicTool, generateText, stepCountIs, ToolSet } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod/v4';
 import { weatherTool } from '../tools/weather-tool';
+
+function dynamicToolSet(): ToolSet {
+  return {
+    currentLocation: dynamicTool({
+      description: 'Get the current location.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const locations = ['New York', 'London', 'Paris'];
+        return {
+          location: locations[Math.floor(Math.random() * locations.length)],
+        };
+      },
+    }),
+  };
+}
 
 async function main() {
   const result = await generateText({
     model: openai('gpt-4o'),
     stopWhen: stepCountIs(5),
     tools: {
-      currentLocation: dynamicTool({
-        description: 'Get the current location.',
-        inputSchema: z.object({}),
-        execute: async () => {
-          const locations = ['New York', 'London', 'Paris'];
-          return {
-            location: locations[Math.floor(Math.random() * locations.length)],
-          };
-        },
-      }),
+      ...dynamicToolSet(),
       weather: weatherTool,
     },
     prompt: 'What is the weather in my current location?',

--- a/examples/ai-core/src/generate-text/openai-responses-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-tool-call.ts
@@ -19,6 +19,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/openai-responses-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-tool-call.ts
@@ -38,6 +38,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/openai-tool-call-raw-json-schema.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-call-raw-json-schema.ts
@@ -38,6 +38,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/openai-tool-call-raw-json-schema.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-call-raw-json-schema.ts
@@ -57,6 +57,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/openai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/openai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       case 'cityAttractions': {
         toolResult.input.city; // string

--- a/examples/ai-core/src/generate-text/togetherai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/togetherai-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/togetherai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/togetherai-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/generate-text/xai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/xai-tool-call.ts
@@ -20,6 +20,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string

--- a/examples/ai-core/src/generate-text/xai-tool-call.ts
+++ b/examples/ai-core/src/generate-text/xai-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       // NOT AVAILABLE (NO EXECUTE METHOD)
       // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-fullstream.ts
@@ -52,6 +52,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         const transformedPart: ToolResultPart = {
           ...part,
           output: { type: 'json', value: part.output },

--- a/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-reasoning-fullstream.ts
@@ -54,6 +54,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         const transformedPart: ToolResultPart = {
           ...part,
           output: { type: 'json', value: part.output },

--- a/examples/ai-core/src/stream-text/amazon-bedrock-tool-call.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-tool-call.ts
@@ -41,6 +41,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         // Transform to new format
         const transformedDelta: ToolResultPart = {
           ...delta,

--- a/examples/ai-core/src/stream-text/anthropic-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-fullstream.ts
@@ -24,6 +24,10 @@ async function main() {
       }
 
       case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           case 'cityAttractions': {
             console.log('TOOL CALL cityAttractions');

--- a/examples/ai-core/src/stream-text/anthropic-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-fullstream.ts
@@ -46,6 +46,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           // NOT AVAILABLE (NO EXECUTE METHOD)
           // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
+++ b/examples/ai-core/src/stream-text/anthropic-reasoning-fullstream.ts
@@ -67,6 +67,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         const transformedPart: ToolResultPart = {
           ...part,
           output: { type: 'json', value: part.output },

--- a/examples/ai-core/src/stream-text/azure-fullstream.ts
+++ b/examples/ai-core/src/stream-text/azure-fullstream.ts
@@ -24,6 +24,10 @@ async function main() {
       }
 
       case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           case 'cityAttractions': {
             console.log('TOOL CALL cityAttractions');

--- a/examples/ai-core/src/stream-text/azure-fullstream.ts
+++ b/examples/ai-core/src/stream-text/azure-fullstream.ts
@@ -46,6 +46,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           // NOT AVAILABLE (NO EXECUTE METHOD)
           // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/cerebras-tool-call.ts
+++ b/examples/ai-core/src/stream-text/cerebras-tool-call.ts
@@ -41,6 +41,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/ai-core/src/stream-text/cohere-tool-call-empty-params.ts
+++ b/examples/ai-core/src/stream-text/cohere-tool-call-empty-params.ts
@@ -53,6 +53,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/ai-core/src/stream-text/cohere-tool-call.ts
+++ b/examples/ai-core/src/stream-text/cohere-tool-call.ts
@@ -42,6 +42,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         // Transform to new format
         const transformedDelta: ToolResultPart = {
           ...delta,

--- a/examples/ai-core/src/stream-text/deepseek-tool-call.ts
+++ b/examples/ai-core/src/stream-text/deepseek-tool-call.ts
@@ -41,6 +41,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/ai-core/src/stream-text/fireworks-kimi-k2-tool-call.ts
+++ b/examples/ai-core/src/stream-text/fireworks-kimi-k2-tool-call.ts
@@ -39,6 +39,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/ai-core/src/stream-text/google-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-fullstream.ts
@@ -24,6 +24,10 @@ async function main() {
       }
 
       case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           case 'cityAttractions': {
             console.log('TOOL CALL cityAttractions');

--- a/examples/ai-core/src/stream-text/google-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-fullstream.ts
@@ -46,6 +46,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           // NOT AVAILABLE (NO EXECUTE METHOD)
           // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/google-vertex-anthropic-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-anthropic-fullstream.ts
@@ -24,6 +24,10 @@ async function main() {
       }
 
       case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           case 'cityAttractions': {
             console.log('TOOL CALL cityAttractions');

--- a/examples/ai-core/src/stream-text/google-vertex-anthropic-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-anthropic-fullstream.ts
@@ -46,6 +46,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           // NOT AVAILABLE (NO EXECUTE METHOD)
           // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/google-vertex-anthropic-tool-call.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-anthropic-tool-call.ts
@@ -41,6 +41,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/ai-core/src/stream-text/google-vertex-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-fullstream.ts
@@ -24,6 +24,10 @@ async function main() {
       }
 
       case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           case 'cityAttractions': {
             console.log('TOOL CALL cityAttractions');

--- a/examples/ai-core/src/stream-text/google-vertex-fullstream.ts
+++ b/examples/ai-core/src/stream-text/google-vertex-fullstream.ts
@@ -46,6 +46,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           // NOT AVAILABLE (NO EXECUTE METHOD)
           // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/groq-kimi-k2-tool-call.ts
+++ b/examples/ai-core/src/stream-text/groq-kimi-k2-tool-call.ts
@@ -40,6 +40,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/ai-core/src/stream-text/mistral-fullstream.ts
+++ b/examples/ai-core/src/stream-text/mistral-fullstream.ts
@@ -24,6 +24,10 @@ async function main() {
       }
 
       case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           case 'cityAttractions': {
             console.log('TOOL CALL cityAttractions');

--- a/examples/ai-core/src/stream-text/mistral-fullstream.ts
+++ b/examples/ai-core/src/stream-text/mistral-fullstream.ts
@@ -46,6 +46,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           // NOT AVAILABLE (NO EXECUTE METHOD)
           // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/openai-compatible-togetherai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-compatible-togetherai-tool-call.ts
@@ -51,6 +51,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/ai-core/src/stream-text/openai-dynamic-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-dynamic-tool-call.ts
@@ -4,7 +4,7 @@ import { weatherTool } from '../tools/weather-tool';
 import { stepCountIs, streamText, dynamicTool, ToolSet } from 'ai';
 import { z } from 'zod/v4';
 
-function dynamicToolSet(): ToolSet {
+function dynamicTools(): ToolSet {
   return {
     currentLocation: dynamicTool({
       description: 'Get the current location.',
@@ -24,7 +24,7 @@ async function main() {
     model: openai('gpt-4o'),
     stopWhen: stepCountIs(5),
     tools: {
-      ...dynamicToolSet(),
+      ...dynamicTools(),
       weather: weatherTool,
     },
     prompt: 'What is the weather in my current location?',

--- a/examples/ai-core/src/stream-text/openai-dynamic-tool-call.ts
+++ b/examples/ai-core/src/stream-text/openai-dynamic-tool-call.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import 'dotenv/config';
 import { weatherTool } from '../tools/weather-tool';
-import { stepCountIs, streamText, tool } from 'ai';
+import { stepCountIs, streamText, dynamicTool } from 'ai';
 import { z } from 'zod/v4';
 
 async function main() {
@@ -9,7 +9,7 @@ async function main() {
     model: openai('gpt-4-turbo'),
     stopWhen: stepCountIs(5),
     tools: {
-      currentLocation: tool({
+      currentLocation: dynamicTool({
         description: 'Get the current location.',
         inputSchema: z.object({}),
         execute: async () => {
@@ -21,7 +21,7 @@ async function main() {
       }),
       weather: weatherTool,
     },
-    prompt: 'What is the weather in my current location?',
+    prompt: 'What is the weather in my current location and in Rome?',
   });
 
   for await (const chunk of result.fullStream) {
@@ -42,23 +42,6 @@ async function main() {
         console.log(
           `TOOL RESULT ${chunk.toolName} ${JSON.stringify(chunk.output)}`,
         );
-        break;
-      }
-
-      case 'finish-step': {
-        console.log();
-        console.log();
-        console.log('STEP FINISH');
-        console.log('Finish reason:', chunk.finishReason);
-        console.log('Usage:', chunk.usage);
-        console.log();
-        break;
-      }
-
-      case 'finish': {
-        console.log('FINISH');
-        console.log('Finish reason:', chunk.finishReason);
-        console.log('Total Usage:', chunk.totalUsage);
         break;
       }
 

--- a/examples/ai-core/src/stream-text/openai-fullstream.ts
+++ b/examples/ai-core/src/stream-text/openai-fullstream.ts
@@ -24,6 +24,10 @@ async function main() {
       }
 
       case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           case 'cityAttractions': {
             console.log('TOOL CALL cityAttractions');

--- a/examples/ai-core/src/stream-text/openai-fullstream.ts
+++ b/examples/ai-core/src/stream-text/openai-fullstream.ts
@@ -46,6 +46,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           // NOT AVAILABLE (NO EXECUTE METHOD)
           // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/openai-tool-call-raw-json-schema.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call-raw-json-schema.ts
@@ -42,6 +42,10 @@ async function main() {
       }
 
       case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           case 'cityAttractions': {
             console.log('TOOL CALL cityAttractions');

--- a/examples/ai-core/src/stream-text/openai-tool-call-raw-json-schema.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-call-raw-json-schema.ts
@@ -64,6 +64,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
         switch (part.toolName) {
           // NOT AVAILABLE (NO EXECUTE METHOD)
           // case 'cityAttractions': {

--- a/examples/ai-core/src/stream-text/togetherai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/togetherai-tool-call.ts
@@ -41,6 +41,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/ai-core/src/stream-text/xai-tool-call.ts
+++ b/examples/ai-core/src/stream-text/xai-tool-call.ts
@@ -41,6 +41,10 @@ async function main() {
       }
 
       case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
         const transformedDelta: ToolResultPart = {
           ...delta,
           output: { type: 'json', value: delta.output },

--- a/examples/next-openai/app/api/dynamic-tools/route.ts
+++ b/examples/next-openai/app/api/dynamic-tools/route.ts
@@ -1,0 +1,84 @@
+import { openai } from '@ai-sdk/openai';
+import {
+  convertToModelMessages,
+  dynamicTool,
+  InferUITools,
+  stepCountIs,
+  streamText,
+  tool,
+  ToolSet,
+  UIDataTypes,
+  UIMessage,
+} from 'ai';
+import { z } from 'zod/v4';
+
+// Allow streaming responses up to 30 seconds
+export const maxDuration = 30;
+
+const getWeatherInformationTool = tool({
+  description: 'show the weather in a given city to the user',
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }: { city: string }, { messages }) => {
+    // count the number of assistant messages. throw error if 2 or less
+    const assistantMessageCount = messages.filter(
+      message => message.role === 'assistant',
+    ).length;
+
+    if (assistantMessageCount <= 2) {
+      throw new Error('could not get weather information');
+    }
+
+    // Add artificial delay of 5 seconds
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
+    return weatherOptions[Math.floor(Math.random() * weatherOptions.length)];
+  },
+});
+
+const staticTools = {
+  // server-side tool with execute function:
+  getWeatherInformation: getWeatherInformationTool,
+} as const;
+
+export type ToolsMessage = UIMessage<
+  never,
+  UIDataTypes,
+  InferUITools<typeof staticTools>
+>;
+
+function dynamicTools(): ToolSet {
+  return {
+    currentLocation: dynamicTool({
+      description: 'Get the current location.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const locations = ['New York', 'London', 'Paris'];
+        return {
+          location: locations[Math.floor(Math.random() * locations.length)],
+        };
+      },
+    }),
+  };
+}
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    messages: convertToModelMessages(messages),
+    stopWhen: stepCountIs(5), // multi-steps for server-side tools
+    tools: {
+      ...staticTools,
+      ...dynamicTools(),
+    },
+  });
+
+  return result.toUIMessageStreamResponse({
+    //  originalMessages: messages, //add if you want to have correct ids
+    onFinish: options => {
+      console.log('onFinish', options);
+    },
+  });
+}

--- a/examples/next-openai/app/dynamic-tools/page.tsx
+++ b/examples/next-openai/app/dynamic-tools/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import ChatInput from '@/component/chat-input';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { ToolsMessage } from '../api/dynamic-tools/route';
+
+export default function Chat() {
+  const { messages, sendMessage, status } = useChat<ToolsMessage>({
+    transport: new DefaultChatTransport({ api: '/api/dynamic-tools' }),
+  });
+
+  return (
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
+      {messages?.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap">
+          <strong>{`${message.role}: `}</strong>
+          {message.parts.map((part, index) => {
+            switch (part.type) {
+              case 'text':
+                return <div key={index}>{part.text}</div>;
+
+              case 'step-start':
+                return index > 0 ? (
+                  <div key={index} className="text-gray-500">
+                    <hr className="my-2 border-gray-300" />
+                  </div>
+                ) : null;
+
+              case 'dynamic-tool': {
+                switch (part.state) {
+                  case 'input-streaming':
+                  case 'input-available':
+                  case 'output-available':
+                    return (
+                      <pre key={index}>{JSON.stringify(part, null, 2)}</pre>
+                    );
+                  case 'output-error':
+                    return (
+                      <div key={index} className="text-red-500">
+                        Error: {part.errorText}
+                      </div>
+                    );
+                }
+              }
+
+              case 'tool-getWeatherInformation': {
+                switch (part.state) {
+                  // example of pre-rendering streaming tool calls:
+                  case 'input-streaming':
+                    return (
+                      <pre key={index}>
+                        {JSON.stringify(part.input, null, 2)}
+                      </pre>
+                    );
+                  case 'input-available':
+                    return (
+                      <div key={index} className="text-gray-500">
+                        Getting weather information for {part.input.city}...
+                      </div>
+                    );
+                  case 'output-available':
+                    return (
+                      <div key={index} className="text-gray-500">
+                        Weather in {part.input.city}: {part.output}
+                      </div>
+                    );
+                  case 'output-error':
+                    return (
+                      <div key={index} className="text-red-500">
+                        Error: {part.errorText}
+                      </div>
+                    );
+                }
+              }
+            }
+          })}
+          <br />
+        </div>
+      ))}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -5,7 +5,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > onSte
   DefaultStepResult {
     "content": [
       {
-        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -197,7 +196,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
   DefaultStepResult {
     "content": [
       {
-        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -345,7 +343,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
   DefaultStepResult {
     "content": [
       {
-        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -537,7 +534,6 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
   DefaultStepResult {
     "content": [
       {
-        "dynamic": false,
         "input": {
           "value": "value",
         },

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -5,6 +5,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > onSte
   DefaultStepResult {
     "content": [
       {
+        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -15,6 +16,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > onSte
         "type": "tool-call",
       },
       {
+        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -195,6 +197,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
   DefaultStepResult {
     "content": [
       {
+        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -205,6 +208,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > resul
         "type": "tool-call",
       },
       {
+        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -341,6 +345,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
   DefaultStepResult {
     "content": [
       {
+        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -351,6 +356,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
         "type": "tool-call",
       },
       {
+        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -531,6 +537,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
   DefaultStepResult {
     "content": [
       {
+        "dynamic": false,
         "input": {
           "value": "value",
         },
@@ -541,6 +548,7 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result with pr
         "type": "tool-call",
       },
       {
+        "dynamic": false,
         "input": {
           "value": "value",
         },

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -39,7 +39,7 @@ exports[`streamText > options.stopWhen > 2 steps: initial, tool-result > should 
       "ai.response.msToFirstChunk": 100,
       "ai.response.text": "",
       "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"},"dynamic":false}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -144,7 +144,7 @@ exports[`streamText > options.transform > with base transformation > telemetry s
       "ai.response.finishReason": "stop",
       "ai.response.providerMetadata": "{"testProvider":{"testKey":"TEST VALUE"}}",
       "ai.response.text": "HELLO, WORLD!",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"VALUE"},"dynamic":false}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"VALUE"}}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -173,7 +173,7 @@ exports[`streamText > options.transform > with base transformation > telemetry s
       "ai.response.providerMetadata": "{"testProvider":{"testKey":"testValue"}}",
       "ai.response.text": "Hello, world!",
       "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"VALUE"},"dynamic":false}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"VALUE"}}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -246,7 +246,6 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
     "warnings": [],
   },
   {
-    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -257,7 +256,6 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
     "type": "tool-call",
   },
   {
-    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -311,7 +309,6 @@ exports[`streamText > result.fullStream > should send tool calls 1`] = `
     "warnings": [],
   },
   {
-    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -368,7 +365,6 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
     "warnings": [],
   },
   {
-    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -379,7 +375,6 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
     "type": "tool-call",
   },
   {
-    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -788,7 +783,7 @@ exports[`streamText > telemetry > should record successful tool call 1`] = `
       "ai.prompt": "{"prompt":"test-input"}",
       "ai.response.finishReason": "stop",
       "ai.response.text": "",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"},"dynamic":false}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -816,7 +811,7 @@ exports[`streamText > telemetry > should record successful tool call 1`] = `
       "ai.response.msToFirstChunk": 100,
       "ai.response.text": "",
       "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"},"dynamic":false}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -975,7 +970,6 @@ exports[`streamText > tools with custom schema > should send tool calls 1`] = `
     "warnings": [],
   },
   {
-    "dynamic": false,
     "input": {
       "value": "value",
     },

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -593,7 +593,7 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
     "type": "start-step",
   },
   {
-    "providerExecuted": undefined,
+    "dynamic": false,
     "toolCallId": "call-1",
     "toolName": "tool1",
     "type": "tool-input-start",
@@ -612,15 +612,12 @@ exports[`streamText > result.toUIMessageStream > should send tool call, tool cal
     "input": {
       "value": "value",
     },
-    "providerExecuted": undefined,
-    "providerMetadata": undefined,
     "toolCallId": "call-1",
     "toolName": "tool1",
     "type": "tool-input-available",
   },
   {
     "output": "value-result",
-    "providerExecuted": undefined,
     "toolCallId": "call-1",
     "type": "tool-output-available",
   },

--- a/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/stream-text.test.ts.snap
@@ -39,7 +39,7 @@ exports[`streamText > options.stopWhen > 2 steps: initial, tool-result > should 
       "ai.response.msToFirstChunk": 100,
       "ai.response.text": "",
       "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"},"dynamic":false}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -144,7 +144,7 @@ exports[`streamText > options.transform > with base transformation > telemetry s
       "ai.response.finishReason": "stop",
       "ai.response.providerMetadata": "{"testProvider":{"testKey":"TEST VALUE"}}",
       "ai.response.text": "HELLO, WORLD!",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"VALUE"}}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"VALUE"},"dynamic":false}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -173,7 +173,7 @@ exports[`streamText > options.transform > with base transformation > telemetry s
       "ai.response.providerMetadata": "{"testProvider":{"testKey":"testValue"}}",
       "ai.response.text": "Hello, world!",
       "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"VALUE"}}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"VALUE"},"dynamic":false}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -246,6 +246,7 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
     "warnings": [],
   },
   {
+    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -256,6 +257,7 @@ exports[`streamText > result.fullStream > should send delayed asynchronous tool 
     "type": "tool-call",
   },
   {
+    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -309,6 +311,7 @@ exports[`streamText > result.fullStream > should send tool calls 1`] = `
     "warnings": [],
   },
   {
+    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -365,6 +368,7 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
     "warnings": [],
   },
   {
+    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -375,6 +379,7 @@ exports[`streamText > result.fullStream > should send tool results 1`] = `
     "type": "tool-call",
   },
   {
+    "dynamic": false,
     "input": {
       "value": "value",
     },
@@ -783,7 +788,7 @@ exports[`streamText > telemetry > should record successful tool call 1`] = `
       "ai.prompt": "{"prompt":"test-input"}",
       "ai.response.finishReason": "stop",
       "ai.response.text": "",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"},"dynamic":false}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -811,7 +816,7 @@ exports[`streamText > telemetry > should record successful tool call 1`] = `
       "ai.response.msToFirstChunk": 100,
       "ai.response.text": "",
       "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
-      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",
+      "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"},"dynamic":false}]",
       "ai.settings.maxRetries": 2,
       "ai.usage.inputTokens": 3,
       "ai.usage.outputTokens": 10,
@@ -970,6 +975,7 @@ exports[`streamText > tools with custom schema > should send tool calls 1`] = `
     "warnings": [],
   },
   {
+    "dynamic": false,
     "input": {
       "value": "value",
     },

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -377,7 +377,10 @@ describe('generateText', () => {
       });
 
       // test type inference
-      if (result.toolCalls[0].toolName === 'tool1') {
+      if (
+        result.toolCalls[0].toolName === 'tool1' &&
+        !result.toolCalls[0].dynamic
+      ) {
         assertType<string>(result.toolCalls[0].input.value);
       }
 
@@ -2214,7 +2217,10 @@ describe('generateText', () => {
       });
 
       // test type inference
-      if (result.toolCalls[0].toolName === 'tool1') {
+      if (
+        result.toolCalls[0].toolName === 'tool1' &&
+        !result.toolCalls[0].dynamic
+      ) {
         assertType<string>(result.toolCalls[0].input.value);
       }
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -460,7 +460,10 @@ describe('generateText', () => {
       });
 
       // test type inference
-      if (result.toolResults[0].toolName === 'tool1') {
+      if (
+        result.toolResults[0].toolName === 'tool1' &&
+        !result.toolResults[0].dynamic
+      ) {
         assertType<string>(result.toolResults[0].output);
       }
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -183,6 +183,7 @@ describe('generateText', () => {
             "type": "reasoning",
           },
           {
+            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -197,6 +198,7 @@ describe('generateText', () => {
             "type": "text",
           },
           {
+            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -382,6 +384,7 @@ describe('generateText', () => {
       expect(result.toolCalls).toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -458,15 +461,20 @@ describe('generateText', () => {
         assertType<string>(result.toolResults[0].output);
       }
 
-      expect(result.toolResults).toStrictEqual([
-        {
-          type: 'tool-result',
-          toolCallId: 'call-1',
-          toolName: 'tool1',
-          input: { value: 'value' },
-          output: 'result1',
-        },
-      ]);
+      expect(result.toolResults).toMatchInlineSnapshot(`
+        [
+          {
+            "dynamic": false,
+            "input": {
+              "value": "value",
+            },
+            "output": "result1",
+            "toolCallId": "call-1",
+            "toolName": "tool1",
+            "type": "tool-result",
+          },
+        ]
+      `);
     });
   });
 
@@ -900,6 +908,7 @@ describe('generateText', () => {
                 DefaultStepResult {
                   "content": [
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -910,6 +919,7 @@ describe('generateText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1081,6 +1091,7 @@ describe('generateText', () => {
                 DefaultStepResult {
                   "content": [
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1091,6 +1102,7 @@ describe('generateText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1476,6 +1488,7 @@ describe('generateText', () => {
                 DefaultStepResult {
                   "content": [
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1486,6 +1499,7 @@ describe('generateText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1553,6 +1567,7 @@ describe('generateText', () => {
                 DefaultStepResult {
                   "content": [
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1563,6 +1578,7 @@ describe('generateText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -2205,6 +2221,7 @@ describe('generateText', () => {
       expect(result.toolCalls).toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -2279,6 +2296,7 @@ describe('generateText', () => {
         expect(result.content).toMatchInlineSnapshot(`
           [
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -2289,6 +2307,7 @@ describe('generateText', () => {
               "type": "tool-call",
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -2299,6 +2318,7 @@ describe('generateText', () => {
               "type": "tool-result",
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -2309,6 +2329,7 @@ describe('generateText', () => {
               "type": "tool-call",
             },
             {
+              "dynamic": false,
               "error": "ERROR",
               "input": {
                 "value": "value",
@@ -2577,6 +2598,7 @@ describe('generateText', () => {
       expect(result.content).toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -2587,6 +2609,7 @@ describe('generateText', () => {
             "type": "tool-call",
           },
           {
+            "dynamic": false,
             "error": [Error: test error],
             "input": {
               "value": "value",
@@ -2683,6 +2706,7 @@ describe('generateText', () => {
       expect(result.content).toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -2693,6 +2717,7 @@ describe('generateText', () => {
             "type": "tool-call",
           },
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -2711,6 +2736,7 @@ describe('generateText', () => {
       expect(result.toolResults).toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -183,7 +183,6 @@ describe('generateText', () => {
             "type": "reasoning",
           },
           {
-            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -387,7 +386,6 @@ describe('generateText', () => {
       expect(result.toolCalls).toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -914,7 +912,6 @@ describe('generateText', () => {
                 DefaultStepResult {
                   "content": [
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1097,7 +1094,6 @@ describe('generateText', () => {
                 DefaultStepResult {
                   "content": [
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1494,7 +1490,6 @@ describe('generateText', () => {
                 DefaultStepResult {
                   "content": [
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -1573,7 +1568,6 @@ describe('generateText', () => {
                 DefaultStepResult {
                   "content": [
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -2230,7 +2224,6 @@ describe('generateText', () => {
       expect(result.toolCalls).toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -2305,7 +2298,6 @@ describe('generateText', () => {
         expect(result.content).toMatchInlineSnapshot(`
           [
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -2316,7 +2308,7 @@ describe('generateText', () => {
               "type": "tool-call",
             },
             {
-              "dynamic": false,
+              "dynamic": undefined,
               "input": {
                 "value": "value",
               },
@@ -2327,7 +2319,6 @@ describe('generateText', () => {
               "type": "tool-result",
             },
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -2338,7 +2329,7 @@ describe('generateText', () => {
               "type": "tool-call",
             },
             {
-              "dynamic": false,
+              "dynamic": undefined,
               "error": "ERROR",
               "input": {
                 "value": "value",
@@ -2607,7 +2598,6 @@ describe('generateText', () => {
       expect(result.content).toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -2715,7 +2705,6 @@ describe('generateText', () => {
       expect(result.content).toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -2726,7 +2715,7 @@ describe('generateText', () => {
             "type": "tool-call",
           },
           {
-            "dynamic": false,
+            "dynamic": undefined,
             "input": {
               "value": "test",
             },
@@ -2745,7 +2734,7 @@ describe('generateText', () => {
       expect(result.toolResults).toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
+            "dynamic": undefined,
             "input": {
               "value": "test",
             },

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -625,6 +625,7 @@ async function executeTools<TOOLS extends ToolSet>({
               toolName,
               input,
               output: result,
+              dynamic: tool.type === 'dynamic',
             } as ToolResultUnion<TOOLS>;
           } catch (error) {
             recordErrorOnSpan(span, error);
@@ -634,6 +635,7 @@ async function executeTools<TOOLS extends ToolSet>({
               toolName,
               input,
               error,
+              dynamic: tool.type === 'dynamic',
             } as ToolErrorUnion<TOOLS>;
           }
         },
@@ -808,6 +810,7 @@ function asContent<TOOLS extends ToolSet>({
               input: toolCall.input,
               error: part.result,
               providerExecuted: true,
+              dynamic: toolCall.dynamic,
             } as ToolErrorUnion<TOOLS>;
           }
 
@@ -818,6 +821,7 @@ function asContent<TOOLS extends ToolSet>({
             input: toolCall.input,
             output: part.result,
             providerExecuted: true,
+            dynamic: toolCall.dynamic,
           } as ToolResultUnion<TOOLS>;
         }
       }

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -1,10 +1,10 @@
+import { dynamicTool } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { InvalidToolInputError } from '../../src/error/invalid-tool-input-error';
-import { NoSuchToolError } from '../../src/error/no-such-tool-error';
+import { InvalidToolInputError } from '../error/invalid-tool-input-error';
+import { NoSuchToolError } from '../error/no-such-tool-error';
+import { ToolCallRepairError } from '../error/tool-call-repair-error';
 import { tool } from '../tool';
 import { parseToolCall } from './parse-tool-call';
-import { ToolCallRepairError } from '../../src/error/tool-call-repair-error';
-import { dynamicTool } from '../../../provider-utils/src/types/tool';
 
 describe('parseToolCall', () => {
   it('should successfully parse a valid tool call', async () => {

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -29,7 +29,6 @@ describe('parseToolCall', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "dynamic": false,
         "input": {
           "param1": "test",
           "param2": 42,
@@ -71,7 +70,6 @@ describe('parseToolCall', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "dynamic": false,
         "input": {
           "param1": "test",
           "param2": 42,
@@ -109,7 +107,6 @@ describe('parseToolCall', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "dynamic": false,
         "input": {},
         "providerExecuted": undefined,
         "providerMetadata": undefined,
@@ -140,7 +137,6 @@ describe('parseToolCall', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "dynamic": false,
         "input": {},
         "providerExecuted": undefined,
         "providerMetadata": undefined,
@@ -262,7 +258,6 @@ describe('parseToolCall', () => {
       // Verify the repaired result was used
       expect(result).toMatchInlineSnapshot(`
         {
-          "dynamic": false,
           "input": {
             "param1": "test",
             "param2": 42,

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -27,12 +27,20 @@ describe('parseToolCall', () => {
       system: undefined,
     });
 
-    expect(result).toEqual({
-      type: 'tool-call',
-      toolCallId: '123',
-      toolName: 'testTool',
-      input: { param1: 'test', param2: 42 },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "dynamic": false,
+        "input": {
+          "param1": "test",
+          "param2": 42,
+        },
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "toolCallId": "123",
+        "toolName": "testTool",
+        "type": "tool-call",
+      }
+    `);
   });
 
   it('should successfully parse a valid tool call with provider metadata', async () => {
@@ -63,6 +71,7 @@ describe('parseToolCall', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
+        "dynamic": false,
         "input": {
           "param1": "test",
           "param2": 42,
@@ -98,12 +107,17 @@ describe('parseToolCall', () => {
       system: undefined,
     });
 
-    expect(result).toEqual({
-      type: 'tool-call',
-      toolCallId: '123',
-      toolName: 'testTool',
-      input: {},
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "dynamic": false,
+        "input": {},
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "toolCallId": "123",
+        "toolName": "testTool",
+        "type": "tool-call",
+      }
+    `);
   });
 
   it('should successfully process empty object tool calls for tools that have no inputSchema', async () => {
@@ -124,12 +138,17 @@ describe('parseToolCall', () => {
       system: undefined,
     });
 
-    expect(result).toEqual({
-      type: 'tool-call',
-      toolCallId: '123',
-      toolName: 'testTool',
-      input: {},
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "dynamic": false,
+        "input": {},
+        "providerExecuted": undefined,
+        "providerMetadata": undefined,
+        "toolCallId": "123",
+        "toolName": "testTool",
+        "type": "tool-call",
+      }
+    `);
   });
 
   it('should throw NoSuchToolError when tools is null', async () => {
@@ -241,12 +260,20 @@ describe('parseToolCall', () => {
       });
 
       // Verify the repaired result was used
-      expect(result).toEqual({
-        type: 'tool-call',
-        toolCallId: '123',
-        toolName: 'testTool',
-        input: { param1: 'test', param2: 42 },
-      });
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "dynamic": false,
+          "input": {
+            "param1": "test",
+            "param2": 42,
+          },
+          "providerExecuted": undefined,
+          "providerMetadata": undefined,
+          "toolCallId": "123",
+          "toolName": "testTool",
+          "type": "tool-call",
+        }
+      `);
     });
 
     it('should re-throw error if tool call repair returns null', async () => {

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -1,9 +1,8 @@
-import { dynamicTool } from '@ai-sdk/provider-utils';
+import { dynamicTool, tool } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
 import { ToolCallRepairError } from '../error/tool-call-repair-error';
-import { tool } from '../tool';
 import { parseToolCall } from './parse-tool-call';
 
 describe('parseToolCall', () => {

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -1,13 +1,13 @@
 import { LanguageModelV2ToolCall } from '@ai-sdk/provider';
 import {
   asSchema,
+  ModelMessage,
   safeParseJSON,
   safeValidateTypes,
 } from '@ai-sdk/provider-utils';
-import { InvalidToolInputError } from '../../src/error/invalid-tool-input-error';
-import { NoSuchToolError } from '../../src/error/no-such-tool-error';
-import { ToolCallRepairError } from '../../src/error/tool-call-repair-error';
-import { ModelMessage } from '../prompt';
+import { InvalidToolInputError } from '../error/invalid-tool-input-error';
+import { NoSuchToolError } from '../error/no-such-tool-error';
+import { ToolCallRepairError } from '../error/tool-call-repair-error';
 import { ToolCallUnion } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { ToolSet } from './tool-set';

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -114,5 +114,6 @@ async function doParseToolCall<TOOLS extends ToolSet>({
     input: parseResult.value,
     providerExecuted: toolCall.providerExecuted,
     providerMetadata: toolCall.providerMetadata,
+    dynamic: tool.type === 'dynamic',
   };
 }

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -107,13 +107,22 @@ async function doParseToolCall<TOOLS extends ToolSet>({
     });
   }
 
-  return {
-    type: 'tool-call',
-    toolCallId: toolCall.toolCallId,
-    toolName,
-    input: parseResult.value,
-    providerExecuted: toolCall.providerExecuted,
-    providerMetadata: toolCall.providerMetadata,
-    dynamic: tool.type === 'dynamic',
-  };
+  return tool.type === 'dynamic'
+    ? {
+        type: 'tool-call',
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        input: parseResult.value,
+        providerExecuted: toolCall.providerExecuted,
+        providerMetadata: toolCall.providerMetadata,
+        dynamic: true,
+      }
+    : {
+        type: 'tool-call',
+        toolCallId: toolCall.toolCallId,
+        toolName,
+        input: parseResult.value,
+        providerExecuted: toolCall.providerExecuted,
+        providerMetadata: toolCall.providerMetadata,
+      };
 }

--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -110,7 +110,6 @@ describe('runToolsTransformation', () => {
       .toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -121,7 +120,6 @@ describe('runToolsTransformation', () => {
             "type": "tool-call",
           },
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -184,7 +182,6 @@ describe('runToolsTransformation', () => {
       .toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -195,7 +192,6 @@ describe('runToolsTransformation', () => {
             "type": "tool-call",
           },
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -262,7 +258,6 @@ describe('runToolsTransformation', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "dynamic": false,
           "input": {
             "value": "test",
           },
@@ -273,7 +268,6 @@ describe('runToolsTransformation', () => {
           "type": "tool-call",
         },
         {
-          "dynamic": false,
           "input": {
             "value": "test",
           },
@@ -346,7 +340,6 @@ describe('runToolsTransformation', () => {
       .toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -357,7 +350,6 @@ describe('runToolsTransformation', () => {
             "type": "tool-call",
           },
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },

--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -110,6 +110,7 @@ describe('runToolsTransformation', () => {
       .toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -120,6 +121,7 @@ describe('runToolsTransformation', () => {
             "type": "tool-call",
           },
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -182,6 +184,7 @@ describe('runToolsTransformation', () => {
       .toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -192,6 +195,7 @@ describe('runToolsTransformation', () => {
             "type": "tool-call",
           },
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -258,6 +262,7 @@ describe('runToolsTransformation', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
+          "dynamic": false,
           "input": {
             "value": "test",
           },
@@ -268,6 +273,7 @@ describe('runToolsTransformation', () => {
           "type": "tool-call",
         },
         {
+          "dynamic": false,
           "input": {
             "value": "test",
           },
@@ -340,6 +346,7 @@ describe('runToolsTransformation', () => {
       .toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -350,6 +357,7 @@ describe('runToolsTransformation', () => {
             "type": "tool-call",
           },
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -350,6 +350,7 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       toolName: string;
       providerMetadata?: ProviderMetadata;
       providerExecuted?: boolean;
+      isDynamic?: boolean;
     }
   | {
       type: 'tool-input-end';

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -350,7 +350,7 @@ export type TextStreamPart<TOOLS extends ToolSet> =
       toolName: string;
       providerMetadata?: ProviderMetadata;
       providerExecuted?: boolean;
-      isDynamic?: boolean;
+      dynamic?: boolean;
     }
   | {
       type: 'tool-input-end';

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1195,7 +1195,6 @@ describe('streamText', () => {
               "type": "tool-input-end",
             },
             {
-              "dynamic": false,
               "input": {
                 "value": "Sparkle Day",
               },
@@ -4081,7 +4080,6 @@ describe('streamText', () => {
       expect(await result.toolCalls).toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -4128,7 +4126,6 @@ describe('streamText', () => {
       expect(await result.toolResults).toMatchInlineSnapshot(`
         [
           {
-            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -4267,7 +4264,6 @@ describe('streamText', () => {
             "url": "https://example.com",
           },
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -4282,7 +4278,6 @@ describe('streamText', () => {
             "type": "tool-call",
           },
           {
-            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -4390,7 +4385,6 @@ describe('streamText', () => {
               "type": "text",
             },
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -4401,7 +4395,6 @@ describe('streamText', () => {
               "type": "tool-call",
             },
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -4477,7 +4470,6 @@ describe('streamText', () => {
                   "type": "text",
                 },
                 {
-                  "dynamic": false,
                   "input": {
                     "value": "value",
                   },
@@ -4488,7 +4480,6 @@ describe('streamText', () => {
                   "type": "tool-call",
                 },
                 {
-                  "dynamic": false,
                   "input": {
                     "value": "value",
                   },
@@ -4564,7 +4555,6 @@ describe('streamText', () => {
           "text": "Hello, world!",
           "toolCalls": [
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -4577,7 +4567,6 @@ describe('streamText', () => {
           ],
           "toolResults": [
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -5368,7 +5357,6 @@ describe('streamText', () => {
                 "type": "reasoning-end",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -5379,7 +5367,6 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -5555,7 +5542,6 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -5566,7 +5552,6 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -5742,7 +5727,6 @@ describe('streamText', () => {
                     "type": "reasoning",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -5753,7 +5737,6 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -5948,7 +5931,6 @@ describe('streamText', () => {
                     "type": "reasoning",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -5959,7 +5941,6 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -6489,7 +6470,6 @@ describe('streamText', () => {
                 DefaultStepResult {
                   "content": [
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -6500,7 +6480,6 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -6675,7 +6654,6 @@ describe('streamText', () => {
                 DefaultStepResult {
                   "content": [
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -6686,7 +6664,6 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -6965,7 +6942,6 @@ describe('streamText', () => {
                 "type": "reasoning-end",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -6976,7 +6952,6 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -7152,7 +7127,6 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -7163,7 +7137,6 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "VALUE",
                       },
@@ -7339,7 +7312,6 @@ describe('streamText', () => {
                     "type": "reasoning",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -7350,7 +7322,6 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "VALUE",
                     },
@@ -7545,7 +7516,6 @@ describe('streamText', () => {
                     "type": "reasoning",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -7556,7 +7526,6 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "VALUE",
                     },
@@ -7795,7 +7764,7 @@ describe('streamText', () => {
                 "ai.response.msToFirstChunk": 100,
                 "ai.response.text": "",
                 "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
-                "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"},"dynamic":false}]",
+                "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",
                 "ai.settings.maxRetries": 2,
                 "ai.usage.inputTokens": 3,
                 "ai.usage.outputTokens": 10,
@@ -8067,7 +8036,6 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -8078,7 +8046,6 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -8159,7 +8126,6 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -8170,7 +8136,6 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -8366,7 +8331,6 @@ describe('streamText', () => {
         expect(await result.content).toMatchInlineSnapshot(`
           [
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -8387,7 +8351,6 @@ describe('streamText', () => {
               "type": "tool-result",
             },
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -8439,7 +8402,6 @@ describe('streamText', () => {
                 "type": "tool-input-end",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -8460,7 +8422,6 @@ describe('streamText', () => {
                 "type": "tool-result",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -9271,7 +9232,6 @@ describe('streamText', () => {
               "warnings": [],
             },
             {
-              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -9282,7 +9242,6 @@ describe('streamText', () => {
               "type": "tool-call",
             },
             {
-              "dynamic": false,
               "error": [Error: test error],
               "input": {
                 "value": "value",
@@ -9334,7 +9293,6 @@ describe('streamText', () => {
           DefaultStepResult {
             "content": [
               {
-                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -9345,7 +9303,6 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
-                "dynamic": false,
                 "error": [Error: test error],
                 "input": {
                   "value": "value",
@@ -9703,7 +9660,6 @@ describe('streamText', () => {
         expect(await result.toolCalls).toMatchInlineSnapshot(`
           [
             {
-              "dynamic": false,
               "input": {
                 "value": "VALUE",
               },
@@ -9753,7 +9709,6 @@ describe('streamText', () => {
         expect(await result.toolResults).toMatchInlineSnapshot(`
           [
             {
-              "dynamic": false,
               "input": {
                 "value": "VALUE",
               },
@@ -9817,7 +9772,6 @@ describe('streamText', () => {
                   "type": "text",
                 },
                 {
-                  "dynamic": false,
                   "input": {
                     "value": "VALUE",
                   },
@@ -9828,7 +9782,6 @@ describe('streamText', () => {
                   "type": "tool-call",
                 },
                 {
-                  "dynamic": false,
                   "input": {
                     "value": "VALUE",
                   },
@@ -10031,7 +9984,6 @@ describe('streamText', () => {
                 "type": "text",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10042,7 +9994,6 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10118,7 +10069,6 @@ describe('streamText', () => {
                     "type": "text",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "VALUE",
                     },
@@ -10129,7 +10079,6 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
-                    "dynamic": false,
                     "input": {
                       "value": "VALUE",
                     },
@@ -10205,7 +10154,6 @@ describe('streamText', () => {
             "text": "HELLO, WORLD!",
             "toolCalls": [
               {
-                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10218,7 +10166,6 @@ describe('streamText', () => {
             ],
             "toolResults": [
               {
-                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10309,7 +10256,6 @@ describe('streamText', () => {
                 "type": "text",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10320,7 +10266,6 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10541,7 +10486,6 @@ describe('streamText', () => {
               "type": "tool-input-delta",
             },
             {
-              "dynamic": false,
               "input": {
                 "value": "TEST",
               },
@@ -10552,7 +10496,6 @@ describe('streamText', () => {
               "type": "tool-call",
             },
             {
-              "dynamic": false,
               "input": {
                 "value": "TEST",
               },
@@ -12124,7 +12067,6 @@ describe('streamText', () => {
                 DefaultStepResult {
                   "content": [
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -12135,7 +12077,6 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
-                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -12215,7 +12156,6 @@ describe('streamText', () => {
                 "warnings": [],
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -12226,7 +12166,6 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
-                "dynamic": false,
                 "input": {
                   "value": "value",
                 },

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1195,6 +1195,7 @@ describe('streamText', () => {
               "type": "tool-input-end",
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "Sparkle Day",
               },
@@ -4080,6 +4081,7 @@ describe('streamText', () => {
       expect(await result.toolCalls).toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -4126,6 +4128,7 @@ describe('streamText', () => {
       expect(await result.toolResults).toMatchInlineSnapshot(`
         [
           {
+            "dynamic": false,
             "input": {
               "value": "value",
             },
@@ -4264,6 +4267,7 @@ describe('streamText', () => {
             "url": "https://example.com",
           },
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -4278,6 +4282,7 @@ describe('streamText', () => {
             "type": "tool-call",
           },
           {
+            "dynamic": false,
             "input": {
               "value": "test",
             },
@@ -4385,6 +4390,7 @@ describe('streamText', () => {
               "type": "text",
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -4395,6 +4401,7 @@ describe('streamText', () => {
               "type": "tool-call",
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -4470,6 +4477,7 @@ describe('streamText', () => {
                   "type": "text",
                 },
                 {
+                  "dynamic": false,
                   "input": {
                     "value": "value",
                   },
@@ -4480,6 +4488,7 @@ describe('streamText', () => {
                   "type": "tool-call",
                 },
                 {
+                  "dynamic": false,
                   "input": {
                     "value": "value",
                   },
@@ -4555,6 +4564,7 @@ describe('streamText', () => {
           "text": "Hello, world!",
           "toolCalls": [
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -4567,6 +4577,7 @@ describe('streamText', () => {
           ],
           "toolResults": [
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -5357,6 +5368,7 @@ describe('streamText', () => {
                 "type": "reasoning-end",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -5367,6 +5379,7 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -5542,6 +5555,7 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -5552,6 +5566,7 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -5727,6 +5742,7 @@ describe('streamText', () => {
                     "type": "reasoning",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -5737,6 +5753,7 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -5931,6 +5948,7 @@ describe('streamText', () => {
                     "type": "reasoning",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -5941,6 +5959,7 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -6470,6 +6489,7 @@ describe('streamText', () => {
                 DefaultStepResult {
                   "content": [
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -6480,6 +6500,7 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -6654,6 +6675,7 @@ describe('streamText', () => {
                 DefaultStepResult {
                   "content": [
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -6664,6 +6686,7 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -6942,6 +6965,7 @@ describe('streamText', () => {
                 "type": "reasoning-end",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -6952,6 +6976,7 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -7127,6 +7152,7 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -7137,6 +7163,7 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "VALUE",
                       },
@@ -7312,6 +7339,7 @@ describe('streamText', () => {
                     "type": "reasoning",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -7322,6 +7350,7 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "VALUE",
                     },
@@ -7516,6 +7545,7 @@ describe('streamText', () => {
                     "type": "reasoning",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "value",
                     },
@@ -7526,6 +7556,7 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "VALUE",
                     },
@@ -7764,7 +7795,7 @@ describe('streamText', () => {
                 "ai.response.msToFirstChunk": 100,
                 "ai.response.text": "",
                 "ai.response.timestamp": "1970-01-01T00:00:00.000Z",
-                "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"}}]",
+                "ai.response.toolCalls": "[{"type":"tool-call","toolCallId":"call-1","toolName":"tool1","input":{"value":"value"},"dynamic":false}]",
                 "ai.settings.maxRetries": 2,
                 "ai.usage.inputTokens": 3,
                 "ai.usage.outputTokens": 10,
@@ -8036,6 +8067,7 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -8046,6 +8078,7 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -8126,6 +8159,7 @@ describe('streamText', () => {
                       "type": "reasoning",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -8136,6 +8170,7 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -8331,6 +8366,7 @@ describe('streamText', () => {
         expect(await result.content).toMatchInlineSnapshot(`
           [
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -8351,6 +8387,7 @@ describe('streamText', () => {
               "type": "tool-result",
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -8402,6 +8439,7 @@ describe('streamText', () => {
                 "type": "tool-input-end",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -8422,6 +8460,7 @@ describe('streamText', () => {
                 "type": "tool-result",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -9232,6 +9271,7 @@ describe('streamText', () => {
               "warnings": [],
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "value",
               },
@@ -9242,6 +9282,7 @@ describe('streamText', () => {
               "type": "tool-call",
             },
             {
+              "dynamic": false,
               "error": [Error: test error],
               "input": {
                 "value": "value",
@@ -9293,6 +9334,7 @@ describe('streamText', () => {
           DefaultStepResult {
             "content": [
               {
+                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -9303,6 +9345,7 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
+                "dynamic": false,
                 "error": [Error: test error],
                 "input": {
                   "value": "value",
@@ -9660,6 +9703,7 @@ describe('streamText', () => {
         expect(await result.toolCalls).toMatchInlineSnapshot(`
           [
             {
+              "dynamic": false,
               "input": {
                 "value": "VALUE",
               },
@@ -9709,6 +9753,7 @@ describe('streamText', () => {
         expect(await result.toolResults).toMatchInlineSnapshot(`
           [
             {
+              "dynamic": false,
               "input": {
                 "value": "VALUE",
               },
@@ -9772,6 +9817,7 @@ describe('streamText', () => {
                   "type": "text",
                 },
                 {
+                  "dynamic": false,
                   "input": {
                     "value": "VALUE",
                   },
@@ -9782,6 +9828,7 @@ describe('streamText', () => {
                   "type": "tool-call",
                 },
                 {
+                  "dynamic": false,
                   "input": {
                     "value": "VALUE",
                   },
@@ -9984,6 +10031,7 @@ describe('streamText', () => {
                 "type": "text",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -9994,6 +10042,7 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10069,6 +10118,7 @@ describe('streamText', () => {
                     "type": "text",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "VALUE",
                     },
@@ -10079,6 +10129,7 @@ describe('streamText', () => {
                     "type": "tool-call",
                   },
                   {
+                    "dynamic": false,
                     "input": {
                       "value": "VALUE",
                     },
@@ -10154,6 +10205,7 @@ describe('streamText', () => {
             "text": "HELLO, WORLD!",
             "toolCalls": [
               {
+                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10166,6 +10218,7 @@ describe('streamText', () => {
             ],
             "toolResults": [
               {
+                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10256,6 +10309,7 @@ describe('streamText', () => {
                 "type": "text",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10266,6 +10320,7 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "VALUE",
                 },
@@ -10486,6 +10541,7 @@ describe('streamText', () => {
               "type": "tool-input-delta",
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "TEST",
               },
@@ -10496,6 +10552,7 @@ describe('streamText', () => {
               "type": "tool-call",
             },
             {
+              "dynamic": false,
               "input": {
                 "value": "TEST",
               },
@@ -12067,6 +12124,7 @@ describe('streamText', () => {
                 DefaultStepResult {
                   "content": [
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -12077,6 +12135,7 @@ describe('streamText', () => {
                       "type": "tool-call",
                     },
                     {
+                      "dynamic": false,
                       "input": {
                         "value": "value",
                       },
@@ -12156,6 +12215,7 @@ describe('streamText', () => {
                 "warnings": [],
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "value",
                 },
@@ -12166,6 +12226,7 @@ describe('streamText', () => {
                 "type": "tool-call",
               },
               {
+                "dynamic": false,
                 "input": {
                   "value": "value",
                 },

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -1152,6 +1152,7 @@ describe('streamText', () => {
               "warnings": [],
             },
             {
+              "dynamic": false,
               "id": "call_O17Uplv4lJvD6DVdIvFFeRMw",
               "toolName": "test-tool",
               "type": "tool-input-start",
@@ -4227,6 +4228,7 @@ describe('streamText', () => {
             "type": "text-delta",
           },
           {
+            "dynamic": false,
             "id": "2",
             "toolName": "tool1",
             "type": "tool-input-start",
@@ -6171,15 +6173,12 @@ describe('streamText', () => {
                 "input": {
                   "value": "value",
                 },
-                "providerExecuted": undefined,
-                "providerMetadata": undefined,
                 "toolCallId": "call-1",
                 "toolName": "tool1",
                 "type": "tool-input-available",
               },
               {
                 "output": "result1",
-                "providerExecuted": undefined,
                 "toolCallId": "call-1",
                 "type": "tool-output-available",
               },
@@ -7887,15 +7886,12 @@ describe('streamText', () => {
                 "input": {
                   "value": "value",
                 },
-                "providerExecuted": undefined,
-                "providerMetadata": undefined,
                 "toolCallId": "call-1",
                 "toolName": "tool1",
                 "type": "tool-input-available",
               },
               {
                 "output": "RESULT1",
-                "providerExecuted": undefined,
                 "toolCallId": "call-1",
                 "type": "tool-output-available",
               },
@@ -8388,6 +8384,7 @@ describe('streamText', () => {
                 "warnings": [],
               },
               {
+                "dynamic": false,
                 "id": "call-1",
                 "providerExecuted": true,
                 "toolName": "web_search",
@@ -8486,6 +8483,7 @@ describe('streamText', () => {
                 "type": "start-step",
               },
               {
+                "dynamic": false,
                 "providerExecuted": true,
                 "toolCallId": "call-1",
                 "toolName": "web_search",
@@ -8501,7 +8499,6 @@ describe('streamText', () => {
                   "value": "value",
                 },
                 "providerExecuted": true,
-                "providerMetadata": undefined,
                 "toolCallId": "call-1",
                 "toolName": "web_search",
                 "type": "tool-input-available",
@@ -8517,7 +8514,6 @@ describe('streamText', () => {
                   "value": "value",
                 },
                 "providerExecuted": true,
-                "providerMetadata": undefined,
                 "toolCallId": "call-2",
                 "toolName": "web_search",
                 "type": "tool-input-available",
@@ -8623,134 +8619,134 @@ describe('streamText', () => {
       it('should include dynamic tool call and result in the full stream', async () => {
         expect(await convertAsyncIterableToArray(result.fullStream))
           .toMatchInlineSnapshot(`
-          [
-            {
-              "type": "start",
-            },
-            {
-              "request": {},
-              "type": "start-step",
-              "warnings": [],
-            },
-            {
-              "id": "call-1",
-              "toolName": "dynamicTool",
-              "type": "tool-input-start",
-            },
-            {
-              "delta": "{ "value": "value" }",
-              "id": "call-1",
-              "type": "tool-input-delta",
-            },
-            {
-              "id": "call-1",
-              "type": "tool-input-end",
-            },
-            {
-              "dynamic": true,
-              "input": {
-                "value": "value",
+            [
+              {
+                "type": "start",
               },
-              "providerExecuted": undefined,
-              "providerMetadata": undefined,
-              "toolCallId": "call-1",
-              "toolName": "dynamicTool",
-              "type": "tool-call",
-            },
-            {
-              "dynamic": true,
-              "input": {
-                "value": "value",
+              {
+                "request": {},
+                "type": "start-step",
+                "warnings": [],
               },
-              "output": {
-                "value": "test-result",
+              {
+                "dynamic": true,
+                "id": "call-1",
+                "toolName": "dynamicTool",
+                "type": "tool-input-start",
               },
-              "providerExecuted": undefined,
-              "providerMetadata": undefined,
-              "toolCallId": "call-1",
-              "toolName": "dynamicTool",
-              "type": "tool-result",
-            },
-            {
-              "finishReason": "tool-calls",
-              "providerMetadata": undefined,
-              "response": {
-                "headers": undefined,
-                "id": "id-0",
-                "modelId": "mock-model-id",
-                "timestamp": 1970-01-01T00:00:00.000Z,
+              {
+                "delta": "{ "value": "value" }",
+                "id": "call-1",
+                "type": "tool-input-delta",
               },
-              "type": "finish-step",
-              "usage": {
-                "cachedInputTokens": undefined,
-                "inputTokens": 3,
-                "outputTokens": 10,
-                "reasoningTokens": undefined,
-                "totalTokens": 13,
+              {
+                "id": "call-1",
+                "type": "tool-input-end",
               },
-            },
-            {
-              "finishReason": "tool-calls",
-              "totalUsage": {
-                "cachedInputTokens": undefined,
-                "inputTokens": 3,
-                "outputTokens": 10,
-                "reasoningTokens": undefined,
-                "totalTokens": 13,
+              {
+                "dynamic": true,
+                "input": {
+                  "value": "value",
+                },
+                "providerExecuted": undefined,
+                "providerMetadata": undefined,
+                "toolCallId": "call-1",
+                "toolName": "dynamicTool",
+                "type": "tool-call",
               },
-              "type": "finish",
-            },
-          ]
-        `);
+              {
+                "dynamic": true,
+                "input": {
+                  "value": "value",
+                },
+                "output": {
+                  "value": "test-result",
+                },
+                "providerExecuted": undefined,
+                "providerMetadata": undefined,
+                "toolCallId": "call-1",
+                "toolName": "dynamicTool",
+                "type": "tool-result",
+              },
+              {
+                "finishReason": "tool-calls",
+                "providerMetadata": undefined,
+                "response": {
+                  "headers": undefined,
+                  "id": "id-0",
+                  "modelId": "mock-model-id",
+                  "timestamp": 1970-01-01T00:00:00.000Z,
+                },
+                "type": "finish-step",
+                "usage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokens": 3,
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
+              },
+              {
+                "finishReason": "tool-calls",
+                "totalUsage": {
+                  "cachedInputTokens": undefined,
+                  "inputTokens": 3,
+                  "outputTokens": 10,
+                  "reasoningTokens": undefined,
+                  "totalTokens": 13,
+                },
+                "type": "finish",
+              },
+            ]
+          `);
       });
 
       it('should include dynamic tool call and result in the ui message stream', async () => {
         expect(await convertReadableStreamToArray(result.toUIMessageStream()))
           .toMatchInlineSnapshot(`
-          [
-            {
-              "type": "start",
-            },
-            {
-              "type": "start-step",
-            },
-            {
-              "providerExecuted": undefined,
-              "toolCallId": "call-1",
-              "toolName": "dynamicTool",
-              "type": "tool-input-start",
-            },
-            {
-              "inputTextDelta": "{ "value": "value" }",
-              "toolCallId": "call-1",
-              "type": "tool-input-delta",
-            },
-            {
-              "input": {
-                "value": "value",
+            [
+              {
+                "type": "start",
               },
-              "providerExecuted": undefined,
-              "providerMetadata": undefined,
-              "toolCallId": "call-1",
-              "toolName": "dynamicTool",
-              "type": "tool-input-available",
-            },
-            {
-              "output": {
-                "value": "test-result",
+              {
+                "type": "start-step",
               },
-              "providerExecuted": undefined,
-              "toolCallId": "call-1",
-              "type": "tool-output-available",
-            },
-            {
-              "type": "finish-step",
-            },
-            {
-              "type": "finish",
-            },
-          ]
-        `);
+              {
+                "dynamic": true,
+                "toolCallId": "call-1",
+                "toolName": "dynamicTool",
+                "type": "tool-input-start",
+              },
+              {
+                "inputTextDelta": "{ "value": "value" }",
+                "toolCallId": "call-1",
+                "type": "tool-input-delta",
+              },
+              {
+                "dynamic": true,
+                "input": {
+                  "value": "value",
+                },
+                "toolCallId": "call-1",
+                "toolName": "dynamicTool",
+                "type": "tool-input-available",
+              },
+              {
+                "dynamic": true,
+                "output": {
+                  "value": "test-result",
+                },
+                "toolCallId": "call-1",
+                "type": "tool-output-available",
+              },
+              {
+                "type": "finish-step",
+              },
+              {
+                "type": "finish",
+              },
+            ]
+          `);
       });
     });
   });
@@ -9635,15 +9631,12 @@ describe('streamText', () => {
               "input": {
                 "value": "value",
               },
-              "providerExecuted": undefined,
-              "providerMetadata": undefined,
               "toolCallId": "call-1",
               "toolName": "tool1",
               "type": "tool-input-available",
             },
             {
               "errorText": "test error",
-              "providerExecuted": undefined,
               "toolCallId": "call-1",
               "type": "tool-output-error",
             },
@@ -10682,6 +10675,7 @@ describe('streamText', () => {
               "type": "reasoning-delta",
             },
             {
+              "dynamic": false,
               "id": "call-1",
               "toolName": "tool1",
               "type": "tool-input-start",
@@ -12446,15 +12440,12 @@ describe('streamText', () => {
               "input": {
                 "value": "value",
               },
-              "providerExecuted": undefined,
-              "providerMetadata": undefined,
               "toolCallId": "call-1",
               "toolName": "tool1",
               "type": "tool-input-available",
             },
             {
               "output": "result1",
-              "providerExecuted": undefined,
               "toolCallId": "call-1",
               "type": "tool-output-available",
             },

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6832,7 +6832,7 @@ describe('streamText', () => {
           TextStreamPart<{ tool1: Tool<{ value: string }, string> }>
         >({
           transform(chunk, controller) {
-            if (chunk.type === 'tool-result') {
+            if (chunk.type === 'tool-result' && !chunk.dynamic) {
               chunk.output = chunk.output.toUpperCase();
               chunk.input = {
                 ...chunk.input,
@@ -9512,7 +9512,7 @@ describe('streamText', () => {
               };
             }
 
-            if (chunk.type === 'tool-result') {
+            if (chunk.type === 'tool-result' && !chunk.dynamic) {
               chunk.output = chunk.output.toUpperCase();
               chunk.input = {
                 ...chunk.input,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -9505,7 +9505,7 @@ describe('streamText', () => {
             }
 
             // assuming test arg structure:
-            if (chunk.type === 'tool-call') {
+            if (chunk.type === 'tool-call' && !chunk.dynamic) {
               chunk.input = {
                 ...chunk.input,
                 value: chunk.input.value.toUpperCase(),

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1271,7 +1271,10 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                         });
                       }
 
-                      controller.enqueue(chunk);
+                      controller.enqueue({
+                        ...chunk,
+                        dynamic: tool?.type === 'dynamic',
+                      });
                       break;
                     }
 
@@ -1755,7 +1758,10 @@ However, the LLM results are expected to be small enough to not cause issues.
                 type: 'tool-input-start',
                 toolCallId: part.id,
                 toolName: part.toolName,
-                providerExecuted: part.providerExecuted,
+                ...(part.providerExecuted != null
+                  ? { providerExecuted: part.providerExecuted }
+                  : {}),
+                ...(part.dynamic != null ? { dynamic: part.dynamic } : {}),
               });
               break;
             }
@@ -1775,8 +1781,13 @@ However, the LLM results are expected to be small enough to not cause issues.
                 toolCallId: part.toolCallId,
                 toolName: part.toolName,
                 input: part.input,
-                providerExecuted: part.providerExecuted,
-                providerMetadata: part.providerMetadata,
+                ...(part.providerExecuted != null
+                  ? { providerExecuted: part.providerExecuted }
+                  : {}),
+                ...(part.providerMetadata != null
+                  ? { providerMetadata: part.providerMetadata }
+                  : {}),
+                ...(part.dynamic != null ? { dynamic: part.dynamic } : {}),
               });
               break;
             }
@@ -1786,7 +1797,10 @@ However, the LLM results are expected to be small enough to not cause issues.
                 type: 'tool-output-available',
                 toolCallId: part.toolCallId,
                 output: part.output,
-                providerExecuted: part.providerExecuted,
+                ...(part.providerExecuted != null
+                  ? { providerExecuted: part.providerExecuted }
+                  : {}),
+                ...(part.dynamic != null ? { dynamic: part.dynamic } : {}),
               });
               break;
             }
@@ -1796,7 +1810,10 @@ However, the LLM results are expected to be small enough to not cause issues.
                 type: 'tool-output-error',
                 toolCallId: part.toolCallId,
                 errorText: onError(part.error),
-                providerExecuted: part.providerExecuted,
+                ...(part.providerExecuted != null
+                  ? { providerExecuted: part.providerExecuted }
+                  : {}),
+                ...(part.dynamic != null ? { dynamic: part.dynamic } : {}),
               });
               break;
             }

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -1,7 +1,7 @@
+import { tool } from '@ai-sdk/provider-utils';
 import z from 'zod/v4';
 import { DefaultGeneratedFile } from './generated-file';
 import { toResponseMessages } from './to-response-messages';
-import { tool } from '../tool';
 
 describe('toResponseMessages', () => {
   it('should return an assistant message with text when no tool calls or results', () => {

--- a/packages/ai/src/generate-text/tool-call.ts
+++ b/packages/ai/src/generate-text/tool-call.ts
@@ -4,16 +4,26 @@ import { ToolSet } from './tool-set';
 import { ProviderMetadata } from '../types';
 
 // transforms the tools into a tool call union
-export type ToolCallUnion<TOOLS extends ToolSet> = ValueOf<{
-  [NAME in keyof TOOLS]: {
-    type: 'tool-call';
-    toolCallId: string;
-    toolName: NAME & string;
-    input: TOOLS[NAME] extends Tool<infer PARAMETERS> ? PARAMETERS : never;
-    providerExecuted?: boolean;
-    dynamic?: boolean;
-    providerMetadata?: ProviderMetadata;
-  };
-}>;
+export type ToolCallUnion<TOOLS extends ToolSet> =
+  | ValueOf<{
+      [NAME in keyof TOOLS]: {
+        type: 'tool-call';
+        toolCallId: string;
+        toolName: NAME & string;
+        input: TOOLS[NAME] extends Tool<infer PARAMETERS> ? PARAMETERS : never;
+        providerExecuted?: boolean;
+        dynamic?: false | undefined;
+        providerMetadata?: ProviderMetadata;
+      };
+    }>
+  | {
+      type: 'tool-call';
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      providerExecuted?: boolean;
+      dynamic: true;
+      providerMetadata?: ProviderMetadata;
+    };
 
 export type ToolCallArray<TOOLS extends ToolSet> = Array<ToolCallUnion<TOOLS>>;

--- a/packages/ai/src/generate-text/tool-call.ts
+++ b/packages/ai/src/generate-text/tool-call.ts
@@ -11,6 +11,7 @@ export type ToolCallUnion<TOOLS extends ToolSet> = ValueOf<{
     toolName: NAME & string;
     input: TOOLS[NAME] extends Tool<infer PARAMETERS> ? PARAMETERS : never;
     providerExecuted?: boolean;
+    isDynamic?: boolean;
     providerMetadata?: ProviderMetadata;
   };
 }>;

--- a/packages/ai/src/generate-text/tool-call.ts
+++ b/packages/ai/src/generate-text/tool-call.ts
@@ -11,7 +11,7 @@ export type ToolCallUnion<TOOLS extends ToolSet> = ValueOf<{
     toolName: NAME & string;
     input: TOOLS[NAME] extends Tool<infer PARAMETERS> ? PARAMETERS : never;
     providerExecuted?: boolean;
-    isDynamic?: boolean;
+    dynamic?: boolean;
     providerMetadata?: ProviderMetadata;
   };
 }>;

--- a/packages/ai/src/generate-text/tool-output.ts
+++ b/packages/ai/src/generate-text/tool-output.ts
@@ -11,6 +11,7 @@ type ToToolResultObject<TOOLS extends ToolSet> = ValueOf<{
     input: InferToolInput<TOOLS[NAME]>;
     output: InferToolOutput<TOOLS[NAME]>;
     providerExecuted?: boolean;
+    isDynamic?: boolean;
   };
 }>;
 
@@ -28,6 +29,7 @@ type ToToolErrorObject<TOOLS extends ToolSet> = ValueOf<{
     input: InferToolInput<TOOLS[NAME]>;
     error: unknown;
     providerExecuted?: boolean;
+    isDynamic?: boolean;
   };
 }>;
 

--- a/packages/ai/src/generate-text/tool-output.ts
+++ b/packages/ai/src/generate-text/tool-output.ts
@@ -11,7 +11,7 @@ type ToToolResultObject<TOOLS extends ToolSet> = ValueOf<{
     input: InferToolInput<TOOLS[NAME]>;
     output: InferToolOutput<TOOLS[NAME]>;
     providerExecuted?: boolean;
-    isDynamic?: boolean;
+    dynamic?: boolean;
   };
 }>;
 
@@ -29,7 +29,7 @@ type ToToolErrorObject<TOOLS extends ToolSet> = ValueOf<{
     input: InferToolInput<TOOLS[NAME]>;
     error: unknown;
     providerExecuted?: boolean;
-    isDynamic?: boolean;
+    dynamic?: boolean;
   };
 }>;
 

--- a/packages/ai/src/generate-text/tool-output.ts
+++ b/packages/ai/src/generate-text/tool-output.ts
@@ -3,17 +3,27 @@ import { InferToolInput, InferToolOutput } from '@ai-sdk/provider-utils';
 import { ToolSet } from './tool-set';
 
 // transforms the tools into a tool result union
-type ToToolResultObject<TOOLS extends ToolSet> = ValueOf<{
-  [NAME in keyof TOOLS]: {
-    type: 'tool-result';
-    toolCallId: string;
-    toolName: NAME & string;
-    input: InferToolInput<TOOLS[NAME]>;
-    output: InferToolOutput<TOOLS[NAME]>;
-    providerExecuted?: boolean;
-    dynamic?: boolean;
-  };
-}>;
+type ToToolResultObject<TOOLS extends ToolSet> =
+  | ValueOf<{
+      [NAME in keyof TOOLS]: {
+        type: 'tool-result';
+        toolCallId: string;
+        toolName: NAME & string;
+        input: InferToolInput<TOOLS[NAME]>;
+        output: InferToolOutput<TOOLS[NAME]>;
+        providerExecuted?: boolean;
+        dynamic?: false | undefined;
+      };
+    }>
+  | {
+      type: 'tool-result';
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      output: unknown;
+      providerExecuted?: boolean;
+      dynamic: true;
+    };
 
 export type ToolResultUnion<TOOLS extends ToolSet> = ToToolResultObject<TOOLS>;
 
@@ -21,17 +31,27 @@ export type ToolResultArray<TOOLS extends ToolSet> = Array<
   ToolResultUnion<TOOLS>
 >;
 
-type ToToolErrorObject<TOOLS extends ToolSet> = ValueOf<{
-  [NAME in keyof TOOLS]: {
-    type: 'tool-error';
-    toolCallId: string;
-    toolName: NAME & string;
-    input: InferToolInput<TOOLS[NAME]>;
-    error: unknown;
-    providerExecuted?: boolean;
-    dynamic?: boolean;
-  };
-}>;
+type ToToolErrorObject<TOOLS extends ToolSet> =
+  | ValueOf<{
+      [NAME in keyof TOOLS]: {
+        type: 'tool-error';
+        toolCallId: string;
+        toolName: NAME & string;
+        input: InferToolInput<TOOLS[NAME]>;
+        error: unknown;
+        providerExecuted?: boolean;
+        dynamic?: false | undefined;
+      };
+    }>
+  | {
+      type: 'tool-error';
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      error: unknown;
+      providerExecuted?: boolean;
+      dynamic: true;
+    };
 
 export type ToolErrorUnion<TOOLS extends ToolSet> = ToToolErrorObject<TOOLS>;
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,10 +2,17 @@
 export {
   asSchema,
   createIdGenerator,
+  dynamicTool,
   generateId,
   jsonSchema,
+  tool,
   type IdGenerator,
+  type InferToolInput,
+  type InferToolOutput,
   type Schema,
+  type Tool,
+  type ToolCallOptions,
+  type ToolExecuteFunction,
 } from '@ai-sdk/provider-utils';
 
 // directory exports

--- a/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
@@ -556,7 +556,6 @@ describe('simulateStreamingMiddleware', () => {
             "type": "text-end",
           },
           {
-            "dynamic": false,
             "input": {
               "expression": "2+2",
             },
@@ -567,7 +566,6 @@ describe('simulateStreamingMiddleware', () => {
             "type": "tool-call",
           },
           {
-            "dynamic": false,
             "input": {
               "location": "New York",
             },

--- a/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
+++ b/packages/ai/src/middleware/simulate-streaming-middleware.test.ts
@@ -556,6 +556,7 @@ describe('simulateStreamingMiddleware', () => {
             "type": "text-end",
           },
           {
+            "dynamic": false,
             "input": {
               "expression": "2+2",
             },
@@ -566,6 +567,7 @@ describe('simulateStreamingMiddleware', () => {
             "type": "tool-call",
           },
           {
+            "dynamic": false,
             "input": {
               "location": "New York",
             },

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
@@ -42,6 +42,7 @@ export function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
       const toolType = tool.type;
       switch (toolType) {
         case undefined:
+        case 'dynamic':
         case 'function':
           return {
             type: 'function' as const,

--- a/packages/ai/src/tool/index.ts
+++ b/packages/ai/src/tool/index.ts
@@ -7,13 +7,3 @@ export type {
 } from './mcp/json-rpc-message';
 export { createMCPClient as experimental_createMCPClient } from './mcp/mcp-client';
 export type { MCPTransport } from './mcp/mcp-transport';
-
-// re-exports from provider-utils
-export {
-  tool,
-  type Tool,
-  type ToolCallOptions,
-  type ToolExecuteFunction,
-  type InferToolInput,
-  type InferToolOutput,
-} from '@ai-sdk/provider-utils';

--- a/packages/ai/src/tool/mcp/mcp-client.test.ts
+++ b/packages/ai/src/tool/mcp/mcp-client.test.ts
@@ -45,6 +45,8 @@ describe('MCPClient', () => {
         },
       },
     });
+    expect(tool).toHaveProperty('type');
+    expect(tool.type).toBe('dynamic');
 
     const toolCall = tool.execute;
     expect(toolCall).toBeDefined();

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -37,11 +37,13 @@ export const uiMessageChunkSchema = z.union([
     toolCallId: z.string(),
     toolName: z.string(),
     providerExecuted: z.boolean().optional(),
+    dynamic: z.boolean().optional(),
   }),
   z.strictObject({
     type: z.literal('tool-input-delta'),
     toolCallId: z.string(),
     inputTextDelta: z.string(),
+    dynamic: z.boolean().optional(),
   }),
   z.strictObject({
     type: z.literal('tool-input-available'),
@@ -50,18 +52,21 @@ export const uiMessageChunkSchema = z.union([
     input: z.unknown(),
     providerExecuted: z.boolean().optional(),
     providerMetadata: providerMetadataSchema.optional(),
+    dynamic: z.boolean().optional(),
   }),
   z.strictObject({
     type: z.literal('tool-output-available'),
     toolCallId: z.string(),
     output: z.unknown(),
     providerExecuted: z.boolean().optional(),
+    dynamic: z.boolean().optional(),
   }),
   z.strictObject({
     type: z.literal('tool-output-error'),
     toolCallId: z.string(),
     errorText: z.string(),
     providerExecuted: z.boolean().optional(),
+    dynamic: z.boolean().optional(),
   }),
   z.strictObject({
     type: z.literal('reasoning'),
@@ -194,29 +199,34 @@ export type UIMessageChunk<
       input: unknown;
       providerExecuted?: boolean;
       providerMetadata?: ProviderMetadata;
+      dynamic?: boolean;
     }
   | {
       type: 'tool-output-available';
       toolCallId: string;
       output: unknown;
       providerExecuted?: boolean;
+      dynamic?: boolean;
     }
   | {
       type: 'tool-output-error';
       toolCallId: string;
       errorText: string;
       providerExecuted?: boolean;
+      dynamic?: boolean;
     }
   | {
       type: 'tool-input-start';
       toolCallId: string;
       toolName: string;
       providerExecuted?: boolean;
+      dynamic?: boolean;
     }
   | {
       type: 'tool-input-delta';
       toolCallId: string;
       inputTextDelta: string;
+      dynamic?: boolean;
     }
   | {
       type: 'source-url';

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -43,7 +43,6 @@ export const uiMessageChunkSchema = z.union([
     type: z.literal('tool-input-delta'),
     toolCallId: z.string(),
     inputTextDelta: z.string(),
-    dynamic: z.boolean().optional(),
   }),
   z.strictObject({
     type: z.literal('tool-input-available'),
@@ -226,7 +225,6 @@ export type UIMessageChunk<
       type: 'tool-input-delta';
       toolCallId: string;
       inputTextDelta: string;
-      dynamic?: boolean;
     }
   | {
       type: 'source-url';

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -798,4 +798,73 @@ describe('convertToModelMessages', () => {
       `);
     });
   });
+
+  describe('when converting dynamic tool invocations', () => {
+    it('should convert a dynamic tool invocation', () => {
+      const result = convertToModelMessages(
+        [
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'dynamic-tool',
+                toolName: 'screenshot',
+                state: 'output-available',
+                toolCallId: 'call-1',
+                input: { value: 'value-1' },
+                output: 'result-1',
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [{ type: 'text', text: 'Thanks!' }],
+          },
+        ],
+        { ignoreIncompleteToolCalls: true },
+      );
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "input": {
+                  "value": "value-1",
+                },
+                "toolCallId": "call-1",
+                "toolName": "screenshot",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "text",
+                  "value": "result-1",
+                },
+                "toolCallId": "call-1",
+                "toolName": "screenshot",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+          {
+            "content": [
+              {
+                "text": "Thanks!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -7,6 +7,7 @@ import { ToolSet } from '../generate-text/tool-set';
 import { createToolModelOutput } from '../prompt/create-tool-model-output';
 import { MessageConversionError } from '../prompt/message-conversion-error';
 import {
+  DynamicToolUIPart,
   FileUIPart,
   getToolName,
   isToolUIPart,
@@ -92,7 +93,11 @@ export function convertToModelMessages(
       case 'assistant': {
         if (message.parts != null) {
           let block: Array<
-            TextUIPart | ToolUIPart<UITools> | ReasoningUIPart | FileUIPart
+            | TextUIPart
+            | ToolUIPart<UITools>
+            | ReasoningUIPart
+            | FileUIPart
+            | DynamicToolUIPart
           > = [];
 
           function processBlock() {
@@ -123,6 +128,25 @@ export function convertToModelMessages(
                   text: part.text,
                   providerOptions: part.providerMetadata,
                 });
+              } else if (part.type === 'dynamic-tool') {
+                const toolName = part.toolName;
+
+                if (part.state === 'input-streaming') {
+                  throw new MessageConversionError({
+                    originalMessage: message,
+                    message: `incomplete tool input is not supported: ${part.toolCallId}`,
+                  });
+                } else {
+                  content.push({
+                    type: 'tool-call' as const,
+                    toolCallId: part.toolCallId,
+                    toolName,
+                    input: part.input,
+                    ...(part.callProviderMetadata != null
+                      ? { providerOptions: part.callProviderMetadata }
+                      : {}),
+                  });
+                }
               } else if (isToolUIPart(part)) {
                 const toolName = getToolName(part);
 
@@ -176,9 +200,11 @@ export function convertToModelMessages(
             });
 
             // check if there are tool invocations with results in the block
-            const toolParts = block
-              .filter(isToolUIPart)
-              .filter(part => part.providerExecuted !== true);
+            const toolParts = block.filter(
+              part =>
+                (isToolUIPart(part) && part.providerExecuted !== true) ||
+                part.type === 'dynamic-tool',
+            ) as (ToolUIPart<UITools> | DynamicToolUIPart)[];
 
             // tool message with tool results
             if (toolParts.length > 0) {
@@ -188,7 +214,10 @@ export function convertToModelMessages(
                   switch (toolPart.state) {
                     case 'output-error':
                     case 'output-available': {
-                      const toolName = getToolName(toolPart);
+                      const toolName =
+                        toolPart.type === 'dynamic-tool'
+                          ? toolPart.toolName
+                          : getToolName(toolPart);
 
                       return {
                         type: 'tool-result',
@@ -226,6 +255,7 @@ export function convertToModelMessages(
               part.type === 'text' ||
               part.type === 'reasoning' ||
               part.type === 'file' ||
+              part.type === 'dynamic-tool' ||
               isToolUIPart(part)
             ) {
               block.push(part);

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -32,6 +32,7 @@ export {
   getToolName,
   isToolUIPart,
   type DataUIPart,
+  type DynamicToolUIPart,
   type FileUIPart,
   type InferUITool,
   type InferUITools,

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -4859,7 +4859,6 @@ describe('processUIMessageStream', () => {
           type: 'tool-input-delta',
           toolCallId: 'tool-call-1',
           inputTextDelta: '{ "query": "test" }',
-          dynamic: true,
         },
         {
           type: 'tool-input-available',

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -4566,7 +4566,7 @@ describe('processUIMessageStream', () => {
       });
     });
 
-    it('should not call onToolCall for provider-executed tools', async () => {
+    it('should not call onToolCall', async () => {
       expect(onToolCallInvoked).toBe(false);
     });
 
@@ -4782,18 +4782,110 @@ describe('processUIMessageStream', () => {
         ]
       `);
     });
+  });
 
-    it('should call onToolCall for client-executed tools', async () => {
-      let onToolCallInvoked = false;
+  it('should call onToolCall for client-executed tools', async () => {
+    let onToolCallInvoked = false;
+
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'tool-call-id',
+        toolName: 'tool-name',
+        input: { query: 'test' },
+      },
+      { type: 'finish-step' },
+      { type: 'finish' },
+    ]);
+
+    state = createStreamingUIMessageState({
+      messageId: 'msg-123',
+      lastMessage: undefined,
+    });
+
+    await consumeStream({
+      stream: processUIMessageStream({
+        stream,
+        onToolCall: async () => {
+          onToolCallInvoked = true;
+        },
+        runUpdateMessageJob,
+        onError: error => {
+          throw error;
+        },
+      }),
+    });
+
+    expect(onToolCallInvoked).toBe(true);
+
+    expect(state.message.parts).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "step-start",
+        },
+        {
+          "errorText": undefined,
+          "input": {
+            "query": "test",
+          },
+          "output": undefined,
+          "providerExecuted": undefined,
+          "state": "input-available",
+          "toolCallId": "tool-call-id",
+          "type": "tool-tool-name",
+        },
+      ]
+    `);
+  });
+
+  describe('dynamic tools', () => {
+    let onToolCallInvoked: boolean;
+
+    beforeEach(async () => {
+      onToolCallInvoked = false;
 
       const stream = createUIMessageStream([
         { type: 'start', messageId: 'msg-123' },
         { type: 'start-step' },
         {
+          type: 'tool-input-start',
+          toolCallId: 'tool-call-1',
+          toolName: 't1',
+          dynamic: true,
+        },
+        {
+          type: 'tool-input-delta',
+          toolCallId: 'tool-call-1',
+          inputTextDelta: '{ "query": "test" }',
+          dynamic: true,
+        },
+        {
           type: 'tool-input-available',
-          toolCallId: 'tool-call-id',
-          toolName: 'tool-name',
+          toolCallId: 'tool-call-1',
+          toolName: 't1',
           input: { query: 'test' },
+          dynamic: true,
+        },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'tool-call-2',
+          toolName: 't1',
+          input: { query: 'test' },
+          dynamic: true,
+        },
+        {
+          type: 'tool-output-available',
+          toolCallId: 'tool-call-1',
+          output: { result: 'provider-result' },
+          dynamic: true,
+        },
+        {
+          type: 'tool-output-error',
+          toolCallId: 'tool-call-2',
+          errorText: 'error-text',
+          dynamic: true,
         },
         { type: 'finish-step' },
         { type: 'finish' },
@@ -4807,7 +4899,7 @@ describe('processUIMessageStream', () => {
       await consumeStream({
         stream: processUIMessageStream({
           stream,
-          onToolCall: async () => {
+          onToolCall: () => {
             onToolCallInvoked = true;
           },
           runUpdateMessageJob,
@@ -4816,10 +4908,202 @@ describe('processUIMessageStream', () => {
           },
         }),
       });
+    });
 
-      expect(onToolCallInvoked).toBe(true);
+    it('should not call onToolCall', async () => {
+      expect(onToolCallInvoked).toBe(false);
+    });
 
-      expect(state.message.parts).toMatchInlineSnapshot(`
+    it('should call the update function with the correct arguments', async () => {
+      expect(writeCalls).toMatchInlineSnapshot(`
+        [
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": undefined,
+                  "output": undefined,
+                  "state": "input-streaming",
+                  "toolCallId": "tool-call-1",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "query": "test",
+                  },
+                  "output": undefined,
+                  "state": "input-streaming",
+                  "toolCallId": "tool-call-1",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "query": "test",
+                  },
+                  "output": undefined,
+                  "state": "input-available",
+                  "toolCallId": "tool-call-1",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "query": "test",
+                  },
+                  "output": undefined,
+                  "state": "input-available",
+                  "toolCallId": "tool-call-1",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "query": "test",
+                  },
+                  "output": undefined,
+                  "state": "input-available",
+                  "toolCallId": "tool-call-2",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "query": "test",
+                  },
+                  "output": {
+                    "result": "provider-result",
+                  },
+                  "state": "output-available",
+                  "toolCallId": "tool-call-1",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "query": "test",
+                  },
+                  "output": undefined,
+                  "state": "input-available",
+                  "toolCallId": "tool-call-2",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "query": "test",
+                  },
+                  "output": {
+                    "result": "provider-result",
+                  },
+                  "state": "output-available",
+                  "toolCallId": "tool-call-1",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+                {
+                  "errorText": "error-text",
+                  "input": {
+                    "query": "test",
+                  },
+                  "output": undefined,
+                  "state": "output-error",
+                  "toolCallId": "tool-call-2",
+                  "toolName": "t1",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+        ]
+      `);
+    });
+
+    it('should have the correct final message state', async () => {
+      expect(state!.message.parts).toMatchInlineSnapshot(`
         [
           {
             "type": "step-start",
@@ -4829,11 +5113,24 @@ describe('processUIMessageStream', () => {
             "input": {
               "query": "test",
             },
+            "output": {
+              "result": "provider-result",
+            },
+            "state": "output-available",
+            "toolCallId": "tool-call-1",
+            "toolName": "t1",
+            "type": "dynamic-tool",
+          },
+          {
+            "errorText": "error-text",
+            "input": {
+              "query": "test",
+            },
             "output": undefined,
-            "providerExecuted": undefined,
-            "state": "input-available",
-            "toolCallId": "tool-call-id",
-            "type": "tool-tool-name",
+            "state": "output-error",
+            "toolCallId": "tool-call-2",
+            "toolName": "t1",
+            "type": "dynamic-tool",
           },
         ]
       `);

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -36,7 +36,7 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
   activeReasoningParts: Record<string, ReasoningUIPart>;
   partialToolCalls: Record<
     string,
-    { text: string; index: number; toolName: string }
+    { text: string; index: number; toolName: string; dynamic?: boolean }
   >;
 };
 
@@ -398,6 +398,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 text: '',
                 toolName: chunk.toolName,
                 index: toolInvocations.length,
+                dynamic: chunk.dynamic,
               };
 
               if (chunk.dynamic) {
@@ -430,7 +431,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 partialToolCall.text,
               );
 
-              if (chunk.dynamic) {
+              if (partialToolCall.dynamic) {
                 updateDynamicToolPart({
                   toolCallId: chunk.toolCallId,
                   toolName: partialToolCall.toolName,

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -79,6 +79,7 @@ export type UIMessagePart<
   | TextUIPart
   | ReasoningUIPart
   | ToolUIPart<TOOLS>
+  | DynamicToolUIPart
   | SourceUrlUIPart
   | SourceDocumentUIPart
   | FileUIPart
@@ -235,6 +236,40 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
       }
   );
 }>;
+
+export type DynamicToolUIPart = {
+  type: 'dynamic-tool';
+  toolName: string;
+  toolCallId: string;
+} & (
+  | {
+      state: 'input-streaming';
+      input: unknown | undefined;
+      output?: never;
+      errorText?: never;
+    }
+  | {
+      state: 'input-available';
+      input: unknown;
+      output?: never;
+      errorText?: never;
+      callProviderMetadata?: ProviderMetadata;
+    }
+  | {
+      state: 'output-available';
+      input: unknown;
+      output: unknown;
+      errorText?: never;
+      callProviderMetadata?: ProviderMetadata;
+    }
+  | {
+      state: 'output-error';
+      input: unknown;
+      output?: never;
+      errorText: string;
+      callProviderMetadata?: ProviderMetadata;
+    }
+);
 
 export function isToolUIPart<TOOLS extends UITools>(
   part: UIMessagePart<UIDataTypes, TOOLS>,

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -15,12 +15,13 @@ export type { ModelMessage } from './model-message';
 export type { ProviderOptions } from './provider-options';
 export type { SystemModelMessage } from './system-model-message';
 export {
+  dynamicTool,
   tool,
+  type InferToolInput,
+  type InferToolOutput,
   type Tool,
   type ToolCallOptions,
   type ToolExecuteFunction,
-  type InferToolInput,
-  type InferToolOutput,
 } from './tool';
 export type { ToolCall } from './tool-call';
 export type { ToolContent, ToolModelMessage } from './tool-model-message';

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -185,3 +185,18 @@ export function tool(tool: Tool<never, never>): Tool<never, never>;
 export function tool(tool: any): any {
   return tool;
 }
+
+/**
+Helper function for defining a dynamic tool.
+ */
+export function dynamicTool(tool: {
+  description?: string;
+  providerOptions?: ProviderOptions;
+  inputSchema: FlexibleSchema<unknown>;
+  execute: ToolExecuteFunction<unknown, unknown>;
+  toModelOutput?: (output: unknown) => LanguageModelV2ToolResultPart['output'];
+}): Tool<unknown, unknown> & {
+  type: 'dynamic';
+} {
+  return { ...tool, type: 'dynamic' };
+}

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -126,13 +126,20 @@ If not provided, the tool will not be executed automatically.
   (
     | {
         /**
-Function tool.
+Tool with user-defined input and output schemas.
      */
         type?: undefined | 'function';
       }
     | {
         /**
-Provider-defined tool.
+Tool that is defined at runtime (e.g. an MCP tool).
+The types of input and output are not known at development time.
+       */
+        type: 'dynamic';
+      }
+    | {
+        /**
+Tool with provider-defined input and output schemas.
      */
         type: 'provider-defined';
 


### PR DESCRIPTION
## Background

MCP tools that are defined without providing schemas have no type information at development time. This breaks type inference, especially for UI parts when dynamic MCP tools and regular tools are mixed. Similarly, tools that are defined at app runtime (e.g. user supplied functions) are conflicting with typing.

## Summary

* introduce `dynamic` tool type
* introduce `dynamicTool` helper
* mcp client tools without schemas are dynamic tools
* change tool call, result, and error unions to support dynamic tools (breaking change)
* add dynamic flag to ui message chunks
* add `dynamic-tool` ui message part

## Verification

- [x] manually test behavior and type inference on generate text example with dynamic tools
- [x] manually test behavior and type inference on stream text example with dynamic tools
- [x] manually test behavior and type inference on ui examples that mixes static tool and dynamic tools

## Tasks

- [x] add dynamic tool type
- [x] dynamic tool helper
- [x] update mcp client to return dynamic tools when no schemas are specified
- [x] extend tool call union
- [x] extend tool result union
- [x] extend tool error union
- [x] add dynamic flag to generate results (call, output, error)
- [x] add generate example
- [x] add dynamic flag to stream text chunks for tool calls (call, output, error)
- [x] add stream example
- [x] add ui message chunks for dynamic tool calls
- [x] add ui message support for dynamic tool calls
- [x] ui message chunk processing (dynamic tools)
- [x] convert ui message dynamic tool calls back to regular tool call inputs
- [x] stream text ui message stream for dynamic tool calls
- [x] add ui example
- [x] changeset

## Future work
Add useChat onToolCall for dynamic tools

## Related Issues
