### PR TITLE
feat (provider/gateway): add z.ai and glm-4.5 models

### DIFF
--- a/.changeset/lazy-plants-repeat.md
+++ b/.changeset/lazy-plants-repeat.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add z.ai and glm-4.5 models

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -77,4 +77,6 @@ export type GatewayModelId =
   | 'xai/grok-3-mini'
   | 'xai/grok-3-mini-fast'
   | 'xai/grok-4'
+  | 'zai/glm-4.5'
+  | 'zai/glm-4.5-air'
   | (string & {});


### PR DESCRIPTION
## Background

AI Gateway has added z.ai's new GLM-4.5 models.

## Summary

Added new model ids to the language model options.
