### PR TITLE
feat(openai): add priority processing service tier support

### DIFF
--- a/.changeset/great-meals-drop.md
+++ b/.changeset/great-meals-drop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add priority processing service tier support

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -269,6 +269,20 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       baseArgs.service_tier = undefined;
     }
 
+    // Validate priority processing support
+    if (
+      openaiOptions.serviceTier === 'priority' &&
+      !supportsPriorityProcessing(this.modelId)
+    ) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'serviceTier',
+        details:
+          'priority processing is only available for supported models (GPT-4, o3, o4-mini) and requires Enterprise access',
+      });
+      baseArgs.service_tier = undefined;
+    }
+
     const {
       tools: openaiTools,
       toolChoice: openaiToolChoice,
@@ -785,6 +799,14 @@ function isReasoningModel(modelId: string) {
 
 function supportsFlexProcessing(modelId: string) {
   return modelId.startsWith('o3') || modelId.startsWith('o4-mini');
+}
+
+function supportsPriorityProcessing(modelId: string) {
+  return (
+    modelId.startsWith('gpt-4') ||
+    modelId.startsWith('o3') ||
+    modelId.startsWith('o4-mini')
+  );
 }
 
 function getSystemMessageMode(modelId: string) {

--- a/packages/openai/src/openai-chat-options.ts
+++ b/packages/openai/src/openai-chat-options.ts
@@ -112,12 +112,14 @@ export const openaiProviderOptions = z.object({
   structuredOutputs: z.boolean().optional(),
 
   /**
-   * Service tier for the request. Set to 'flex' for 50% cheaper processing
-   * at the cost of increased latency. Only available for o3 and o4-mini models.
+   * Service tier for the request.
+   * - 'auto': Default service tier
+   * - 'flex': 50% cheaper processing at the cost of increased latency. Only available for o3 and o4-mini models.
+   * - 'priority': Higher-speed processing with predictably low latency at premium cost. Available for Enterprise customers.
    *
    * @default 'auto'
    */
-  serviceTier: z.enum(['auto', 'flex']).optional(),
+  serviceTier: z.enum(['auto', 'flex', 'priority']).optional(),
 
   /**
    * Whether to use strict JSON schema validation.

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -206,6 +206,21 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       delete (baseArgs as any).service_tier;
     }
 
+    // Validate priority processing support
+    if (
+      openaiOptions?.serviceTier === 'priority' &&
+      !supportsPriorityProcessing(this.modelId)
+    ) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'serviceTier',
+        details:
+          'priority processing is only available for supported models (GPT-4, o3, o4-mini) and requires Enterprise access',
+      });
+      // Remove from args if not supported
+      delete (baseArgs as any).service_tier;
+    }
+
     const {
       tools: openaiTools,
       toolChoice: openaiToolChoice,
@@ -1088,6 +1103,14 @@ function supportsFlexProcessing(modelId: string): boolean {
   return modelId.startsWith('o3') || modelId.startsWith('o4-mini');
 }
 
+function supportsPriorityProcessing(modelId: string): boolean {
+  return (
+    modelId.startsWith('gpt-4') ||
+    modelId.startsWith('o3') ||
+    modelId.startsWith('o4-mini')
+  );
+}
+
 const openaiResponsesProviderOptionsSchema = z.object({
   metadata: z.any().nullish(),
   parallelToolCalls: z.boolean().nullish(),
@@ -1098,7 +1121,7 @@ const openaiResponsesProviderOptionsSchema = z.object({
   strictJsonSchema: z.boolean().nullish(),
   instructions: z.string().nullish(),
   reasoningSummary: z.string().nullish(),
-  serviceTier: z.enum(['auto', 'flex']).nullish(),
+  serviceTier: z.enum(['auto', 'flex', 'priority']).nullish(),
   include: z.array(z.enum(['reasoning.encrypted_content'])).nullish(),
 });
 


### PR DESCRIPTION
## background

Enterprise customers need Priority Processing - which openaireleased 

## summary

- add `priority` option to `serviceTier` provider setting
- add model validation for priority processing support

## verification

- all tests pass
- service tier parameter correctly sent to OpenAI API
- appropriate warnings shown for unsupported models

## tasks

- [x] serviceTier enum updated in chat and responses options
- [x] priority processing validation for supported models  
- [x] validation warnings for unsupported models

## future work

* monitor openai api changes for additional supported models 

related issue  #7607