### PR TITLE
feat(azure): add speech model support and fix transcription

### DIFF
--- a/.changeset/fast-kiwis-lie.md
+++ b/.changeset/fast-kiwis-lie.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/azure': patch
+---
+
+feat(azure): add speech model support and fix transcription

--- a/examples/ai-core/src/generate-speech/azure.ts
+++ b/examples/ai-core/src/generate-speech/azure.ts
@@ -17,4 +17,4 @@ async function main() {
   await saveAudioFile(result.audio);
 }
 
-main().catch(console.error); 
+main().catch(console.error);

--- a/examples/ai-core/src/generate-speech/azure.ts
+++ b/examples/ai-core/src/generate-speech/azure.ts
@@ -1,0 +1,20 @@
+import { azure } from '@ai-sdk/azure';
+import { experimental_generateSpeech as generateSpeech } from 'ai';
+import 'dotenv/config';
+import { saveAudioFile } from '../lib/save-audio';
+
+async function main() {
+  const result = await generateSpeech({
+    model: azure.speech('tts-1'),
+    text: 'Hello from the AI SDK!',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
+
+  await saveAudioFile(result.audio);
+}
+
+main().catch(console.error); 

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -26,6 +26,8 @@ const server = createTestServer({
   'https://test-resource.openai.azure.com/openai/v1/embeddings': {},
   'https://test-resource.openai.azure.com/openai/v1/images/generations': {},
   'https://test-resource.openai.azure.com/openai/v1/responses': {},
+  'https://test-resource.openai.azure.com/openai/v1/audio/transcriptions': {},
+  'https://test-resource.openai.azure.com/openai/v1/audio/speech': {},
 });
 
 describe('chat', () => {
@@ -203,6 +205,54 @@ describe('completion', () => {
         'custom-provider-header': 'provider-header-value',
         'custom-request-header': 'request-header-value',
       });
+    });
+  });
+});
+
+describe('transcription', () => {
+  describe('doGenerate', () => {
+    it('should use correct URL format', async () => {
+      server.urls[
+        'https://test-resource.openai.azure.com/openai/v1/audio/transcriptions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          text: 'Hello, world!',
+          segments: [],
+          language: 'en',
+          duration: 5.0,
+        },
+      };
+
+      await provider.transcription('whisper-1').doGenerate({
+        audio: new Uint8Array(),
+        mediaType: 'audio/wav',
+      });
+
+      expect(server.calls[0].requestUrl).toStrictEqual(
+        'https://test-resource.openai.azure.com/openai/v1/audio/transcriptions?api-version=preview',
+      );
+    });
+  });
+});
+
+describe('speech', () => {
+  describe('doGenerate', () => {
+    it('should use correct URL format', async () => {
+      server.urls[
+        'https://test-resource.openai.azure.com/openai/v1/audio/speech'
+      ].response = {
+        type: 'json-value',
+        body: new Uint8Array([1, 2, 3]),
+      };
+
+      await provider.speech('tts-1').doGenerate({
+        text: 'Hello, world!',
+      });
+
+      expect(server.calls[0].requestUrl).toStrictEqual(
+        'https://test-resource.openai.azure.com/openai/v1/audio/speech?api-version=preview',
+      );
     });
   });
 });

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -4,6 +4,7 @@ import {
   OpenAIEmbeddingModel,
   OpenAIImageModel,
   OpenAIResponsesLanguageModel,
+  OpenAISpeechModel,
   OpenAITranscriptionModel,
 } from '@ai-sdk/openai/internal';
 import {
@@ -11,6 +12,7 @@ import {
   LanguageModelV2,
   ProviderV2,
   ImageModelV2,
+  SpeechModelV2,
   TranscriptionModelV2,
 } from '@ai-sdk/provider';
 import { FetchFunction, loadApiKey, loadSetting } from '@ai-sdk/provider-utils';
@@ -68,6 +70,11 @@ Creates an Azure OpenAI model for text embeddings.
    * Creates an Azure OpenAI model for audio transcription.
    */
   transcription(deploymentId: string): TranscriptionModelV2;
+
+  /**
+   * Creates an Azure OpenAI model for speech generation.
+   */
+  speech(deploymentId: string): SpeechModelV2;
 }
 
 export interface AzureOpenAIProviderSettings {
@@ -190,6 +197,14 @@ export function createAzure(
       fetch: options.fetch,
     });
 
+  const createSpeechModel = (modelId: string) =>
+    new OpenAISpeechModel(modelId, {
+      provider: 'azure.speech',
+      url,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const provider = function (deploymentId: string) {
     if (new.target) {
       throw new Error(
@@ -210,6 +225,7 @@ export function createAzure(
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.responses = createResponsesModel;
   provider.transcription = createTranscriptionModel;
+  provider.speech = createSpeechModel;
   return provider;
 }
 


### PR DESCRIPTION
## background

Azure OpenAI provider was missing speech generation functionality and had incomplete test coverage for transcription, preventing users from accessing TTS capabilities.

## summary

- add speech model support to Azure provider
- add missing test endpoints and examples

## verification

- all tests pass
- speech model correctly uses v1 API endpoints
- transcription tests added

related issue - #7372