### PR TITLE
feat(ai): re-export zodSchema from main package

### DIFF
--- a/.changeset/giant-jobs-tell.md
+++ b/.changeset/giant-jobs-tell.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): re-export zodSchema from main package

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -6,6 +6,7 @@ export {
   generateId,
   jsonSchema,
   tool,
+  zodSchema,
   type IdGenerator,
   type InferToolInput,
   type InferToolOutput,


### PR DESCRIPTION
## background

Users migrating to v5 encountered breaking changes when `zodSchema` was no longer available from the main `ai` package import, forcing them to change imports to `@ai-sdk/provider-utils` for circular dependency support.

## summary

- re-export zodSchema from main ai package for backward compatibility

## verification

- zodSchema now available via `import { zodSchema } from 'ai'`

## tasks

- [x] add zodSchema to re-exports in packages/ai/src/index.ts 

related issue #7455