### PR TITLE
chore (providers): remove model shorthand deprecation warnings

### DIFF
--- a/.changeset/gold-worms-relax.md
+++ b/.changeset/gold-worms-relax.md
@@ -1,0 +1,17 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/togetherai': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/deepinfra': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/replicate': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+'@ai-sdk/luma': patch
+'@ai-sdk/fal': patch
+'@ai-sdk/xai': patch
+---
+
+chore (providers): remove model shorthand deprecation warnings

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -110,7 +110,6 @@ export interface AmazonBedrockProvider extends ProviderV2 {
 
   /**
 Creates a model for image generation.
-@deprecated Use `imageModel` instead.
    */
   image(modelId: BedrockImageModelId): ImageModelV2;
 

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -24,14 +24,8 @@ Creates a model for text generation.
 */
   languageModel(modelId: AnthropicMessagesModelId): LanguageModelV2;
 
-  /**
-@deprecated Use `.languageModel()` instead.
-*/
   chat(modelId: AnthropicMessagesModelId): LanguageModelV2;
 
-  /**
-@deprecated Use `.languageModel()` instead.
-   */
   messages(modelId: AnthropicMessagesModelId): LanguageModelV2;
 
   /**

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -41,13 +41,12 @@ Creates an Azure OpenAI completion model for text generation.
   completion(deploymentId: string): LanguageModelV2;
 
   /**
-@deprecated Use `textEmbeddingModel` instead.
+@deprecated Use `textEmbedding` instead.
    */
   embedding(deploymentId: string): EmbeddingModelV2<string>;
 
   /**
    * Creates an Azure OpenAI DALL-E model for image generation.
-   * @deprecated Use `imageModel` instead.
    */
   image(deploymentId: string): ImageModelV2;
 
@@ -56,9 +55,6 @@ Creates an Azure OpenAI completion model for text generation.
    */
   imageModel(deploymentId: string): ImageModelV2;
 
-  /**
-@deprecated Use `textEmbeddingModel` instead.
-   */
   textEmbedding(deploymentId: string): EmbeddingModelV2<string>;
 
   /**

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -53,7 +53,6 @@ Creates a chat model for text generation.
 
   /**
 Creates a model for image generation.
-@deprecated Use `imageModel` instead.
   */
   image(modelId: DeepInfraImageModelId): ImageModelV2;
 

--- a/packages/fal/src/fal-provider.ts
+++ b/packages/fal/src/fal-provider.ts
@@ -39,7 +39,6 @@ requests, or to provide a custom fetch implementation for e.g. testing.
 export interface FalProvider extends ProviderV2 {
   /**
 Creates a model for image generation.
-@deprecated Use `imageModel` instead.
    */
   image(modelId: FalImageModelId): ImageModelV2;
 

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -84,7 +84,6 @@ Creates a text embedding model for text generation.
 
   /**
 Creates a model for image generation.
-@deprecated Use `imageModel` instead.
 */
   image(modelId: FireworksImageModelId): ImageModelV2;
 

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -22,8 +22,6 @@ import {
 } from './google-generative-ai-image-settings';
 import { GoogleGenerativeAIImageModel } from './google-generative-ai-image-model';
 
-import { isSupportedFileUrl } from './google-supported-file-url';
-
 export interface GoogleGenerativeAIProvider extends ProviderV2 {
   (modelId: GoogleGenerativeAIModelId): LanguageModelV2;
 
@@ -45,15 +43,12 @@ Creates a model for image generation.
   generativeAI(modelId: GoogleGenerativeAIModelId): LanguageModelV2;
 
   /**
-@deprecated Use `textEmbeddingModel()` instead.
+@deprecated Use `textEmbedding()` instead.
    */
   embedding(
     modelId: GoogleGenerativeAIEmbeddingModelId,
   ): EmbeddingModelV2<string>;
 
-  /**
-@deprecated Use `textEmbeddingModel()` instead.
- */
   textEmbedding(
     modelId: GoogleGenerativeAIEmbeddingModelId,
   ): EmbeddingModelV2<string>;

--- a/packages/luma/src/luma-provider.ts
+++ b/packages/luma/src/luma-provider.ts
@@ -31,7 +31,6 @@ or to provide a custom fetch implementation for e.g. testing.
 export interface LumaProvider extends ProviderV2 {
   /**
 Creates a model for image generation.
-@deprecated Use `imageModel` instead.
   */
   image(modelId: LumaImageModelId): ImageModelV2;
 

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -28,13 +28,10 @@ Creates a model for text generation.
   chat(modelId: MistralChatModelId): LanguageModelV2;
 
   /**
-@deprecated Use `textEmbeddingModel()` instead.
+@deprecated Use `textEmbedding()` instead.
    */
   embedding(modelId: MistralEmbeddingModelId): EmbeddingModelV2<string>;
 
-  /**
-@deprecated Use `textEmbeddingModel()` instead.
-   */
   textEmbedding(modelId: MistralEmbeddingModelId): EmbeddingModelV2<string>;
 
   textEmbeddingModel: (

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -57,8 +57,6 @@ Creates a model for text embeddings.
 
   /**
 Creates a model for text embeddings.
-
-@deprecated Use `textEmbeddingModel` instead.
    */
   textEmbedding(modelId: OpenAIEmbeddingModelId): EmbeddingModelV2<string>;
 
@@ -69,7 +67,6 @@ Creates a model for text embeddings.
 
   /**
 Creates a model for image generation.
-@deprecated Use `imageModel` instead.
    */
   image(modelId: OpenAIImageModelId): ImageModelV2;
 

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -32,7 +32,6 @@ or to provide a custom fetch implementation for e.g. testing.
 export interface ReplicateProvider extends ProviderV2 {
   /**
    * Creates a Replicate image generation model.
-   * @deprecated Use `imageModel` instead.
    */
   image(modelId: ReplicateImageModelId): ReplicateImageModel;
 

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -70,7 +70,6 @@ Creates a text embedding model for text generation.
 
   /**
 Creates a model for image generation.
-@deprecated Use `imageModel` instead.
 */
   image(modelId: TogetherAIImageModelId): ImageModelV2;
 

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -42,7 +42,6 @@ Creates an Xai chat model for text generation.
 
   /**
 Creates an Xai image model for image generation.
-@deprecated Use `imageModel` instead.
    */
   image(modelId: XaiImageModelId): ImageModelV2;
 


### PR DESCRIPTION
## Background

We have shorthand helpers for model creations, e.g. `.image`. Those helpers are a convention and synonyms for e.g. `.imageModel`. They were deprecated as we had plans to move to `.abcModel`, but for DX reasons it is good to have shorthands.

## Summary

Remove shorthand model constructor deprecation.