### PR TITLE
feat (ai): support dynamic tools in Chat onToolCall

### DIFF
--- a/.changeset/wicked-geese-tie.md
+++ b/.changeset/wicked-geese-tie.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+feat (ai): support dynamic tools in Chat onToolCall

--- a/packages/ai/src/ui/chat.test-d.ts
+++ b/packages/ai/src/ui/chat.test-d.ts
@@ -18,12 +18,6 @@ type ToolCallArgument<TOOLS extends ToolSet | UITools> = Parameters<
   ToolCallCallback<TOOLS>
 >[0]['toolCall'];
 
-type ToolCallReturnType<TOOLS extends ToolSet | UITools> = ReturnType<
-  ToolCallCallback<TOOLS>
->;
-
-type ToolCallOutput<T> = T | void | Promise<T | void>;
-
 describe('onToolCall', () => {
   describe('no helpers', () => {
     it('single tool with output schema', () => {
@@ -34,7 +28,9 @@ describe('onToolCall', () => {
         };
       };
 
-      expectTypeOf<ToolCallArgument<Tools>>().toMatchTypeOf<{
+      expectTypeOf<
+        ToolCallArgument<Tools> & { dynamic?: false }
+      >().toMatchTypeOf<{
         toolName: 'simple';
         input: number;
       }>();
@@ -48,7 +44,9 @@ describe('onToolCall', () => {
         };
       };
 
-      expectTypeOf<ToolCallArgument<Tools>>().toMatchTypeOf<{
+      expectTypeOf<
+        ToolCallArgument<Tools> & { dynamic?: false }
+      >().toMatchTypeOf<{
         toolName: 'simple';
         input: number;
       }>();
@@ -71,7 +69,9 @@ describe('onToolCall', () => {
         };
       };
 
-      expectTypeOf<ToolCallArgument<Tools>>().toMatchTypeOf<
+      expectTypeOf<
+        ToolCallArgument<Tools> & { dynamic?: false }
+      >().toMatchTypeOf<
         | {
             toolName: 'simple';
             input: number;
@@ -101,7 +101,9 @@ describe('onToolCall', () => {
         };
       };
 
-      expectTypeOf<ToolCallArgument<Tools>>().toMatchTypeOf<
+      expectTypeOf<
+        ToolCallArgument<Tools> & { dynamic?: false }
+      >().toMatchTypeOf<
         | {
             toolName: 'simple';
             input: number;
@@ -128,7 +130,9 @@ describe('onToolCall', () => {
         simple,
       };
 
-      expectTypeOf<ToolCallArgument<typeof tools>>().toMatchTypeOf<{
+      expectTypeOf<
+        ToolCallArgument<typeof tools> & { dynamic?: false }
+      >().toMatchTypeOf<{
         toolName: 'simple';
         input: number;
       }>();
@@ -143,7 +147,9 @@ describe('onToolCall', () => {
         simple,
       };
 
-      expectTypeOf<ToolCallArgument<typeof tools>>().toMatchTypeOf<{
+      expectTypeOf<
+        ToolCallArgument<typeof tools> & { dynamic?: false }
+      >().toMatchTypeOf<{
         toolName: 'simple';
         input: number;
       }>();
@@ -172,7 +178,9 @@ describe('onToolCall', () => {
         complex,
       };
 
-      expectTypeOf<ToolCallArgument<typeof tools>>().toMatchTypeOf<
+      expectTypeOf<
+        ToolCallArgument<typeof tools> & { dynamic?: false }
+      >().toMatchTypeOf<
         | {
             toolName: 'simple';
             input: number;
@@ -204,7 +212,9 @@ describe('onToolCall', () => {
         complex,
       };
 
-      expectTypeOf<ToolCallArgument<typeof tools>>().toMatchTypeOf<
+      expectTypeOf<
+        ToolCallArgument<typeof tools> & { dynamic?: false }
+      >().toMatchTypeOf<
         | {
             toolName: 'simple';
             input: number;

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -4909,8 +4909,8 @@ describe('processUIMessageStream', () => {
       });
     });
 
-    it('should not call onToolCall', async () => {
-      expect(onToolCallInvoked).toBe(false);
+    it('should invoke onToolCall for dynamic tools', async () => {
+      expect(onToolCallInvoked).toBe(true);
     });
 
     it('should call the update function with the correct arguments', async () => {

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -477,7 +477,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               // In the future we should make this non-blocking, which
               // requires additional state management for error handling etc.
               // Skip calling onToolCall for provider-executed tools since they are already executed
-              if (onToolCall && !chunk.providerExecuted && !chunk.dynamic) {
+              if (onToolCall && !chunk.providerExecuted) {
                 await onToolCall({
                   toolCall: chunk as InferUIMessageToolCall<UI_MESSAGE>,
                 });

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -295,11 +295,13 @@ export type InferUIMessageTools<T extends UIMessage> =
 export type InferUIMessageToolOutputs<UI_MESSAGE extends UIMessage> =
   InferUIMessageTools<UI_MESSAGE>[keyof InferUIMessageTools<UI_MESSAGE>]['output'];
 
-export type InferUIMessageToolCall<UI_MESSAGE extends UIMessage> = ValueOf<{
-  [NAME in keyof InferUIMessageTools<UI_MESSAGE>]: ToolCall<
-    NAME & string,
-    InferUIMessageTools<UI_MESSAGE>[NAME] extends { input: infer INPUT }
-      ? INPUT
-      : never
-  >;
-}>;
+export type InferUIMessageToolCall<UI_MESSAGE extends UIMessage> =
+  | ValueOf<{
+      [NAME in keyof InferUIMessageTools<UI_MESSAGE>]: ToolCall<
+        NAME & string,
+        InferUIMessageTools<UI_MESSAGE>[NAME] extends { input: infer INPUT }
+          ? INPUT
+          : never
+      > & { dynamic?: false };
+    }>
+  | (ToolCall<string, unknown> & { dynamic: true });

--- a/packages/provider-utils/src/types/tool-call.ts
+++ b/packages/provider-utils/src/types/tool-call.ts
@@ -23,4 +23,9 @@ Arguments of the tool call. This is a JSON-serializable object that matches the 
    * If this flag is not set or is false, the tool call will be executed by the client.
    */
   providerExecuted?: boolean;
+
+  /**
+   * Whether the tool is dynamic.
+   */
+  dynamic?: boolean;
 }

--- a/packages/provider-utils/src/types/tool-result.ts
+++ b/packages/provider-utils/src/types/tool-result.ts
@@ -22,4 +22,14 @@ Arguments of the tool call. This is a JSON-serializable object that matches the 
 Result of the tool call. This is the result of the tool's execution.
      */
   output: OUTPUT;
+
+  /**
+   * Whether the tool result has been executed by the provider.
+   */
+  providerExecuted?: boolean;
+
+  /**
+   * Whether the tool is dynamic.
+   */
+  dynamic?: boolean;
 }


### PR DESCRIPTION
## Background

#7595 introduced dynamic tools without adding support in the `Chat` `onToolCall` callback.

## Summary

- support dynamic tools in Chat onToolCall (breaking change)

## Migration

You need to add a check for dynamic if you want type inference on static tools in `onToolCall`:

```ts
const { messages } = useChat<YourMessage>({
  async onToolCall({ toolCall }) {
    if (toolCall.dynamic) {
      // handle dynamic tools
      return;
    }

    // types for static tools are narrowed
  },
});
```

## Verification

- [x] test type inference in onToolCall

## Tasks

- [x] extend onToolCall type to support dynamic tools
- [x] invoke onToolCall in process message stream
- [x] changeset

## Related Issues

Follow up from #7595