### PR TITLE
feat (ai): export experimental MCPClient and MCPClientConfig interfaces

### DIFF
--- a/.changeset/twelve-actors-tease.md
+++ b/.changeset/twelve-actors-tease.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): export experimental MCPClient and MCPClientConfig interfaces

--- a/examples/mcp/src/http/client.ts
+++ b/examples/mcp/src/http/client.ts
@@ -1,6 +1,11 @@
 import { openai } from '@ai-sdk/openai';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { experimental_createMCPClient, generateText, stepCountIs } from 'ai';
+import {
+  experimental_createMCPClient as createMCPClient,
+  experimental_MCPClient as MCPClient,
+  generateText,
+  stepCountIs,
+} from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -8,7 +13,7 @@ async function main() {
     new URL('http://localhost:3000/mcp'),
   );
 
-  const mcpClient = await experimental_createMCPClient({
+  const mcpClient: MCPClient = await createMCPClient({
     transport,
   });
 

--- a/packages/ai/src/tool/index.ts
+++ b/packages/ai/src/tool/index.ts
@@ -5,5 +5,9 @@ export type {
   JSONRPCRequest,
   JSONRPCResponse,
 } from './mcp/json-rpc-message';
-export { createMCPClient as experimental_createMCPClient } from './mcp/mcp-client';
+export {
+  createMCPClient as experimental_createMCPClient,
+  type MCPClientConfig as experimental_MCPClientConfig,
+  type MCPClientType as experimental_MCPClient,
+} from './mcp/mcp-client';
 export type { MCPTransport } from './mcp/mcp-transport';

--- a/packages/ai/src/tool/index.ts
+++ b/packages/ai/src/tool/index.ts
@@ -8,6 +8,6 @@ export type {
 export {
   createMCPClient as experimental_createMCPClient,
   type MCPClientConfig as experimental_MCPClientConfig,
-  type MCPClientType as experimental_MCPClient,
+  type MCPClient as experimental_MCPClient,
 } from './mcp/mcp-client';
 export type { MCPTransport } from './mcp/mcp-transport';

--- a/packages/ai/src/tool/mcp/mcp-client.ts
+++ b/packages/ai/src/tool/mcp/mcp-client.ts
@@ -40,7 +40,7 @@ import {
 
 const CLIENT_VERSION = '1.0.0';
 
-interface MCPClientConfig {
+export interface MCPClientConfig {
   /** Transport configuration for connecting to the MCP server */
   transport: MCPTransportConfig | MCPTransport;
   /** Optional callback for uncaught errors */
@@ -51,10 +51,15 @@ interface MCPClientConfig {
 
 export async function createMCPClient(
   config: MCPClientConfig,
-): Promise<MCPClient> {
+): Promise<MCPClientType> {
   const client = new MCPClient(config);
   await client.init();
   return client;
+}
+
+export interface MCPClientType {
+  tools: () => Promise<McpToolSet>;
+  close: () => Promise<void>;
 }
 
 /**
@@ -74,7 +79,7 @@ export async function createMCPClient(
  * - Session management (when passing a sessionId to an instance of the Streamable HTTP transport)
  * - Resumable SSE streams
  */
-class MCPClient {
+class MCPClient implements MCPClientType {
   private transport: MCPTransport;
   private onUncaughtError?: (error: unknown) => void;
   private clientInfo: ClientConfiguration;

--- a/packages/ai/src/tool/mcp/mcp-client.ts
+++ b/packages/ai/src/tool/mcp/mcp-client.ts
@@ -51,14 +51,17 @@ export interface MCPClientConfig {
 
 export async function createMCPClient(
   config: MCPClientConfig,
-): Promise<MCPClientType> {
-  const client = new MCPClient(config);
+): Promise<MCPClient> {
+  const client = new DefaultMCPClient(config);
   await client.init();
   return client;
 }
 
-export interface MCPClientType {
-  tools: () => Promise<McpToolSet>;
+export interface MCPClient {
+  tools<TOOL_SCHEMAS extends ToolSchemas = 'automatic'>(options?: {
+    schemas?: TOOL_SCHEMAS;
+  }): Promise<McpToolSet<TOOL_SCHEMAS>>;
+
   close: () => Promise<void>;
 }
 
@@ -79,7 +82,7 @@ export interface MCPClientType {
  * - Session management (when passing a sessionId to an instance of the Streamable HTTP transport)
  * - Resumable SSE streams
  */
-class MCPClient implements MCPClientType {
+class DefaultMCPClient implements MCPClient {
   private transport: MCPTransport;
   private onUncaughtError?: (error: unknown) => void;
   private clientInfo: ClientConfiguration;


### PR DESCRIPTION
## Background

Only a limited set of MCP interfaces is exposed to limit API surface.

## Summary

* export `experimental_MCPClient` type
* export `experimental_MCPClientConfig` type

## Related Issues

Resolves #7557