### PR TITLE
feat(provider/google): Add gemini-embedding-001 and export embedding provider options

### DIFF
--- a/.changeset/thin-geese-bake.md
+++ b/.changeset/thin-geese-bake.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Add gemini-embedding-001 model, add embedding provider options type export

--- a/content/docs/03-ai-sdk-core/30-embeddings.mdx
+++ b/content/docs/03-ai-sdk-core/30-embeddings.mdx
@@ -202,6 +202,7 @@ Several providers offer embedding models:
 | [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-3-large`        | 3072                 |
 | [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-3-small`        | 1536                 |
 | [OpenAI](/providers/ai-sdk-providers/openai#embedding-models)                             | `text-embedding-ada-002`        | 1536                 |
+| [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai#embedding-models) | `gemini-embedding-001`          | 3072                 |
 | [Google Generative AI](/providers/ai-sdk-providers/google-generative-ai#embedding-models) | `text-embedding-004`            | 768                  |
 | [Mistral](/providers/ai-sdk-providers/mistral#embedding-models)                           | `mistral-embed`                 | 1024                 |
 | [Cohere](/providers/ai-sdk-providers/cohere#embedding-models)                             | `embed-english-v3.0`            | 1024                 |

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -685,7 +685,7 @@ You can create models that call the [Google Generative AI embeddings API](https:
 using the `.textEmbedding()` factory method.
 
 ```ts
-const model = google.textEmbedding('text-embedding-004');
+const model = google.textEmbedding('gemini-embedding-001');
 ```
 
 The Google Generative AI provider sends API calls to the right endpoint based on the type of embedding:
@@ -699,7 +699,7 @@ Google Generative AI embedding models support aditional settings. You can pass t
 import { google } from '@ai-sdk/google';
 import { embed } from 'ai';
 
-const model = google.textEmbedding('text-embedding-004');
+const model = google.textEmbedding('gemini-embedding-001');
 
 const { embedding } = await embed({
   model,
@@ -734,9 +734,10 @@ The following optional provider options are available for Google Generative AI e
 
 ### Model Capabilities
 
-| Model                | Default Dimensions | Custom Dimensions   |
-| -------------------- | ------------------ | ------------------- |
-| `text-embedding-004` | 768                | <Check size={18} /> |
+| Model                  | Default Dimensions | Custom Dimensions   |
+| ---------------------- | ------------------ | ------------------- |
+| `gemini-embedding-001` | 3072               | <Check size={18} /> |
+| `text-embedding-004`   | 768                | <Check size={18} /> |
 
 ## Image Models
 

--- a/examples/ai-core/src/e2e/google.test.ts
+++ b/examples/ai-core/src/e2e/google.test.ts
@@ -55,7 +55,7 @@ createFeatureTestSuite({
     ],
     embeddingModels: [
       createEmbeddingModelWithCapabilities(
-        provider.textEmbeddingModel('text-embedding-004'),
+        provider.textEmbeddingModel('gemini-embedding-001'),
       ),
     ],
     imageModels: [createImageModel('imagen-3.0-generate-002')],

--- a/examples/ai-core/src/embed-many/google.ts
+++ b/examples/ai-core/src/embed-many/google.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const { embeddings, usage } = await embedMany({
-    model: google.textEmbeddingModel('text-embedding-004'),
+    model: google.textEmbeddingModel('gemini-embedding-001'),
     values: [
       'sunny day at the beach',
       'rainy afternoon in the city',

--- a/examples/ai-core/src/embed/google.ts
+++ b/examples/ai-core/src/embed/google.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const { embedding, usage } = await embed({
-    model: google.textEmbeddingModel('text-embedding-004'),
+    model: google.textEmbeddingModel('gemini-embedding-001'),
     value: 'sunny day at the beach',
   });
 

--- a/packages/google/src/google-generative-ai-embedding-model.test.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.test.ts
@@ -10,10 +10,10 @@ const dummyEmbeddings = [
 const testValues = ['sunny day at the beach', 'rainy day in the city'];
 
 const provider = createGoogleGenerativeAI({ apiKey: 'test-api-key' });
-const model = provider.textEmbeddingModel('text-embedding-004');
+const model = provider.textEmbeddingModel('gemini-embedding-001');
 
 const URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:something';
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:something';
 
 const server = createTestServer({
   [URL]: {},
@@ -87,7 +87,7 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       requests: testValues.map(value => ({
-        model: 'models/text-embedding-004',
+        model: 'models/gemini-embedding-001',
         content: { role: 'user', parts: [{ text: value }] },
       })),
     });
@@ -96,7 +96,7 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
   it('should pass the outputDimensionality setting', async () => {
     prepareBatchJsonResponse();
 
-    await provider.embedding('text-embedding-004').doEmbed({
+    await provider.embedding('gemini-embedding-001').doEmbed({
       values: testValues,
       providerOptions: {
         google: { outputDimensionality: 64 },
@@ -105,7 +105,7 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       requests: testValues.map(value => ({
-        model: 'models/text-embedding-004',
+        model: 'models/gemini-embedding-001',
         content: { role: 'user', parts: [{ text: value }] },
         outputDimensionality: 64,
       })),
@@ -115,14 +115,14 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
   it('should pass the taskType setting', async () => {
     prepareBatchJsonResponse();
 
-    await provider.embedding('text-embedding-004').doEmbed({
+    await provider.embedding('gemini-embedding-001').doEmbed({
       values: testValues,
       providerOptions: { google: { taskType: 'SEMANTIC_SIMILARITY' } },
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       requests: testValues.map(value => ({
-        model: 'models/text-embedding-004',
+        model: 'models/gemini-embedding-001',
         content: { role: 'user', parts: [{ text: value }] },
         taskType: 'SEMANTIC_SIMILARITY',
       })),
@@ -139,7 +139,7 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
       },
     });
 
-    await provider.embedding('text-embedding-004').doEmbed({
+    await provider.embedding('gemini-embedding-001').doEmbed({
       values: testValues,
       headers: {
         'Custom-Request-Header': 'request-header-value',
@@ -155,7 +155,7 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
   });
 
   it('should throw an error if too many values are provided', async () => {
-    const model = new GoogleGenerativeAIEmbeddingModel('text-embedding-004', {
+    const model = new GoogleGenerativeAIEmbeddingModel('gemini-embedding-001', {
       provider: 'google.generative-ai',
       baseURL: 'https://generativelanguage.googleapis.com/v1beta',
       headers: () => ({}),
@@ -164,33 +164,33 @@ describe('GoogleGenerativeAIEmbeddingModel', () => {
     const tooManyValues = Array(2049).fill('test');
 
     await expect(model.doEmbed({ values: tooManyValues })).rejects.toThrow(
-      'Too many values for a single embedding call. The google.generative-ai model "text-embedding-004" can only embed up to 2048 values per call, but 2049 values were provided.',
+      'Too many values for a single embedding call. The google.generative-ai model "gemini-embedding-001" can only embed up to 2048 values per call, but 2049 values were provided.',
     );
   });
 
   it('should use the batch embeddings endpoint', async () => {
     prepareBatchJsonResponse();
-    const model = provider.textEmbeddingModel('text-embedding-004');
+    const model = provider.textEmbeddingModel('gemini-embedding-001');
     await model.doEmbed({
       values: testValues,
     });
 
     expect(server.calls[0].requestUrl).toBe(
-      'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContents',
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents',
     );
   });
 
   it('should use the single embeddings endpoint', async () => {
     prepareSingleJsonResponse();
 
-    const model = provider.textEmbeddingModel('text-embedding-004');
+    const model = provider.textEmbeddingModel('gemini-embedding-001');
 
     await model.doEmbed({
       values: [testValues[0]],
     });
 
     expect(server.calls[0].requestUrl).toBe(
-      'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent',
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:embedContent',
     );
   });
 });

--- a/packages/google/src/google-generative-ai-embedding-options.ts
+++ b/packages/google/src/google-generative-ai-embedding-options.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4';
 
 export type GoogleGenerativeAIEmbeddingModelId =
+  | 'gemini-embedding-001'
   | 'text-embedding-004'
   | (string & {});
 

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -2,6 +2,7 @@ export type { GoogleErrorData } from './google-error';
 export type { GoogleGenerativeAIProviderOptions } from './google-generative-ai-options';
 export type { GoogleGenerativeAIProviderMetadata } from './google-generative-ai-prompt';
 export type { GoogleGenerativeAIImageProviderOptions } from './google-generative-ai-image-model';
+export type { GoogleGenerativeAIEmbeddingProviderOptions } from './google-generative-ai-embedding-options';
 export { createGoogleGenerativeAI, google } from './google-provider';
 export type {
   GoogleGenerativeAIProvider,


### PR DESCRIPTION
## Background

`gemini-embedding-001` is now the default embedding model for Google Generative AI, as `text-embedding-004` is now considered [legacy](https://ai.google.dev/gemini-api/docs/embeddings#models).

Also, for better TS compatibility between AI SDK v5 and `@ai-sdk/google`, we need to export `GoogleGenerativeAIEmbeddingProviderOptions`.

## Summary

This PR adds `gemini-embedding-001` model throughout, replacing the legacy `text-embedding-004`.

This PR also adds `GoogleGenerativeAIEmbeddingProviderOptions` export for `@ai-sdk/google` package so that users can type their AI SDK v5 provider options properly, e.g.:

```
{
  providerOptions: {
      google: {
        outputDimensionality: 1536,
        taskType: "RETRIEVAL_QUERY",
      } satisfies GoogleGenerativeAIEmbeddingProviderOptions,
  }
}
```

## Verification

- I have been using `gemini-embedding-001` model for my production app, using AI SDK v4 and v5.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)