### PR TITLE
feat(openai): add file_search_call.results support to include parameter

### DIFF
--- a/.changeset/slimy-otters-tease.md
+++ b/.changeset/slimy-otters-tease.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add file_search_call.results support to include parameter

--- a/examples/ai-core/src/generate-text/openai-provider-defined-tools.ts
+++ b/examples/ai-core/src/generate-text/openai-provider-defined-tools.ts
@@ -20,7 +20,7 @@ async function main() {
       fileSearch: openai.tools.fileSearch({
         maxNumResults: 5,
         ranking: {
-          ranker: 'semantic',
+          ranker: 'auto',
         },
       }),
     },

--- a/examples/ai-core/src/generate-text/provider-defined-tools-working.ts
+++ b/examples/ai-core/src/generate-text/provider-defined-tools-working.ts
@@ -20,7 +20,7 @@ async function main() {
   const openaiFileSearch = openai.tools.fileSearch({
     maxNumResults: 5,
     ranking: {
-      ranker: 'semantic',
+      ranker: 'auto',
     },
   });
 

--- a/examples/next-openai/app/api/chat-openai-file-search/route.ts
+++ b/examples/next-openai/app/api/chat-openai-file-search/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
       file_search: openai.tools.fileSearch({
         maxNumResults: 10,
         ranking: {
-          ranker: 'semantic',
+          ranker: 'auto',
         },
         // vectorStoreIds: ['vs_123'], // optional: specify vector store IDs
         // filters: { key: 'category', type: 'eq', value: 'technical' }, // optional: filter results

--- a/packages/openai/src/openai-prepare-tools.test.ts
+++ b/packages/openai/src/openai-prepare-tools.test.ts
@@ -68,7 +68,7 @@ it('should correctly prepare provider-defined-server tools', () => {
           vectorStoreIds: ['vs_123'],
           maxNumResults: 10,
           ranking: {
-            ranker: 'semantic',
+            ranker: 'auto',
           },
         },
       },
@@ -96,7 +96,7 @@ it('should correctly prepare provider-defined-server tools', () => {
       vector_store_ids: ['vs_123'],
       max_num_results: 10,
       ranking_options: {
-        ranker: 'semantic',
+        ranker: 'auto',
       },
     },
     {

--- a/packages/openai/src/openai-types.ts
+++ b/packages/openai/src/openai-types.ts
@@ -21,7 +21,7 @@ export interface OpenAIFileSearchTool {
   vector_store_ids?: string[];
   max_num_results?: number;
   ranking_options?: {
-    ranker?: 'auto' | 'keyword' | 'semantic';
+    ranker?: 'auto' | 'default-2024-08-21';
   };
   filters?:
     | {

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -84,7 +84,7 @@ export type OpenAIResponsesTool =
       vector_store_ids?: string[];
       max_num_results?: number;
       ranking_options?: {
-        ranker?: 'auto' | 'keyword' | 'semantic';
+        ranker?: 'auto' | 'default-2024-08-21';
       };
       filters?:
         | {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -590,6 +590,51 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send include provider option for file search results', async () => {
+        const { warnings } = await createModel('gpt-4o-mini').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              include: ['file_search_call.results'],
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-4o-mini',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          include: ['file_search_call.results'],
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should send include provider option with multiple values', async () => {
+        const { warnings } = await createModel('o3-mini').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              include: [
+                'reasoning.encrypted_content',
+                'file_search_call.results',
+              ],
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'o3-mini',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          include: ['reasoning.encrypted_content', 'file_search_call.results'],
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send responseFormat json format', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           responseFormat: { type: 'json' },

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1122,7 +1122,9 @@ const openaiResponsesProviderOptionsSchema = z.object({
   instructions: z.string().nullish(),
   reasoningSummary: z.string().nullish(),
   serviceTier: z.enum(['auto', 'flex', 'priority']).nullish(),
-  include: z.array(z.enum(['reasoning.encrypted_content'])).nullish(),
+  include: z
+    .array(z.enum(['reasoning.encrypted_content', 'file_search_call.results']))
+    .nullish(),
 });
 
 export type OpenAIResponsesProviderOptions = z.infer<

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -34,7 +34,7 @@ export const fileSearchArgsSchema = z.object({
    */
   ranking: z
     .object({
-      ranker: z.enum(['auto', 'keyword', 'semantic']).optional(),
+      ranker: z.enum(['auto', 'default-2024-08-21']).optional(),
     })
     .optional(),
 
@@ -66,7 +66,7 @@ export const fileSearch = createProviderDefinedToolFactory<
      * Ranking options for the search.
      */
     ranking?: {
-      ranker?: 'auto' | 'keyword' | 'semantic';
+      ranker?: 'auto' | 'default-2024-08-21';
     };
 
     /**


### PR DESCRIPTION
## background

openai's responses api supports returning file search results in responses via the `include` parameter, but we only supported `reasoning.encrypted_content`. users needed access to file search results for debugging and transparency when using file search tools.

## summary

- add `file_search_call.results` to include parameter enum
- update ranking options to match current API (`auto`, `default-2024-08-21`)

## verification

- all tests pass
- include parameter correctly passes through to openai api
- file search ranking validation updated to current API spec

## tasks

- [x] extend include parameter schema for file_search_call.results  
- [x] update ranking options from deprecated values
- [x] fix test assertions for new ranking values

## future work

* monitor openai api for additional include parameter options

related issue #7636