### PR TITLE
docs(openai): add store: false guidance for reasoning models

### DIFF
--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -593,7 +593,12 @@ The following provider options are available:
   Whether to use parallel tool calls. Defaults to `true`.
 
 - **store** _boolean_
+
   Whether to store the generation. Defaults to `true`.
+
+  When using reasoning models (o1, o3, o4-mini) with multi-step tool calls and `store: false`,
+  include `['reasoning.encrypted_content']` in the `include` option to ensure reasoning
+  content is available across conversation steps.
 
 - **metadata** _Record&lt;string, string&gt;_
   Additional metadata to store with the generation.
@@ -622,6 +627,12 @@ The following provider options are available:
   Service tier for the request. Set to 'flex' for 50% cheaper processing
   at the cost of increased latency. Only available for o3 and o4-mini models.
   Defaults to 'auto'.
+
+- **include** _Array&lt;string&gt;_
+  Specifies additional content to include in the response. Supported values:
+  `['reasoning.encrypted_content']` for accessing reasoning content across conversation steps,
+  and `['file_search_call.results']` for including file search results in responses.
+  Defaults to `undefined`.
 
 The OpenAI responses provider also returns provider-specific metadata:
 


### PR DESCRIPTION
## background

users encountered errors when using reasoning models with `store: false` and multi-step tool calls due to missing reasoning history references. the documentation didn't explain how to handle this scenario.

## summary

- add guidance for store: false with reasoning models
- document include parameter usage for reasoning content

related issue - #7543