### PR TITLE
fix(examples/svelte): update tool call types for current api

### DIFF
--- a/.changeset/yellow-planes-sell.md
+++ b/.changeset/yellow-planes-sell.md
@@ -1,5 +1,0 @@
----
-'@example/sveltekit-openai': patch
----
-
-fix(examples/svelte): update tool call types for current api

--- a/.changeset/yellow-planes-sell.md
+++ b/.changeset/yellow-planes-sell.md
@@ -1,0 +1,5 @@
+---
+'@example/sveltekit-openai': patch
+---
+
+fix(examples/svelte): update tool call types for current api

--- a/examples/sveltekit-openai/src/routes/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/+page.svelte
@@ -1,27 +1,27 @@
 <main>
-  <header class="text-center my-8">
-    <h1 class="text-4xl font-bold mb-4">OpenAI + SvelteKit Demo</h1>
+  <header class="my-8 text-center">
+    <h1 class="mb-4 text-4xl font-bold">OpenAI + SvelteKit Demo</h1>
     <p class="text-gray-600">
       Select a demo to explore different OpenAI integration examples:
     </p>
   </header>
 
-  <nav class="flex flex-col items-center gap-4 m-4">
+  <nav class="flex flex-col gap-4 items-center m-4">
     <a
       href="/chat"
-      class="w-full max-w-sm py-3 px-6 bg-gray-100 hover:bg-gray-200 rounded-lg text-center transition-colors duration-200"
+      class="px-6 py-3 w-full max-w-sm text-center bg-gray-100 rounded-lg transition-colors duration-200 hover:bg-gray-200"
     >
       Chat Demo
     </a>
     <a
       href="/completion"
-      class="w-full max-w-sm py-3 px-6 bg-gray-100 hover:bg-gray-200 rounded-lg text-center transition-colors duration-200"
+      class="px-6 py-3 w-full max-w-sm text-center bg-gray-100 rounded-lg transition-colors duration-200 hover:bg-gray-200"
     >
       Completion Demo
     </a>
     <a
       href="/structured-object"
-      class="w-full max-w-sm py-3 px-6 bg-gray-100 hover:bg-gray-200 rounded-lg text-center transition-colors duration-200"
+      class="px-6 py-3 w-full max-w-sm text-center bg-gray-100 rounded-lg transition-colors duration-200 hover:bg-gray-200"
     >
       Structured Object Demo
     </a>

--- a/examples/sveltekit-openai/src/routes/api/chat/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/chat/+server.ts
@@ -1,20 +1,19 @@
 import { env } from '$env/dynamic/private';
 import { createOpenAI } from '@ai-sdk/openai';
-import { convertToModelMessages, streamText } from 'ai';
+import { convertToModelMessages, streamText, stepCountIs } from 'ai';
 import { z } from 'zod/v4';
 
 const openai = createOpenAI({
   apiKey: env?.OPENAI_API_KEY,
 });
 
-export const POST = async ({ request }) => {
+export const POST = async ({ request }: { request: Request }) => {
   const { messages } = await request.json();
 
   const result = streamText({
     model: openai('gpt-4o'),
     messages: convertToModelMessages(messages),
-    toolCallStreaming: true,
-    maxSteps: 5, // multi-steps for server-side tools
+    stopWhen: stepCountIs(5),
     tools: {
       // server-side tool with execute function:
       getWeatherInformation: {

--- a/examples/sveltekit-openai/src/routes/api/chat/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/chat/+server.ts
@@ -13,7 +13,7 @@ export const POST = async ({ request }: { request: Request }) => {
   const result = streamText({
     model: openai('gpt-4o'),
     messages: convertToModelMessages(messages),
-    stopWhen: stepCountIs(5),
+    stopWhen: stepCountIs(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:
       getWeatherInformation: {

--- a/examples/sveltekit-openai/src/routes/api/completion/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/completion/+server.ts
@@ -21,7 +21,7 @@ Here are some examples:
 It is VERY IMPORTANT that your completion continues the prompt and does not repeat the prompt.
 `;
 
-export const POST = async ({ request }) => {
+export const POST = async ({ request }: { request: Request }) => {
   const { prompt } = await request.json();
 
   const result = streamText({

--- a/examples/sveltekit-openai/src/routes/api/structured-object/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/structured-object/+server.ts
@@ -7,7 +7,7 @@ const openai = createOpenAI({
   apiKey: env?.OPENAI_API_KEY,
 });
 
-export async function POST({ request }) {
+export async function POST({ request }: { request: Request }) {
   const context = await request.json();
 
   const result = streamObject({

--- a/examples/sveltekit-openai/src/routes/chat/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat/+page.svelte
@@ -5,8 +5,6 @@
   import { Chat } from '@ai-sdk/svelte';
 
   const chat = new Chat({
-    maxSteps: 5,
-
     // run client-side tools that are automatically executed:
     async onToolCall({ toolCall }) {
       // artificial 2 second delay
@@ -14,7 +12,13 @@
 
       if (toolCall.toolName === 'getLocation') {
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
-        return cities[Math.floor(Math.random() * cities.length)];
+        const location = cities[Math.floor(Math.random() * cities.length)];
+        
+        await chat.addToolResult({
+          toolCallId: toolCall.toolCallId,
+          tool: 'getLocation',
+          output: location,
+        });
       }
     },
   });
@@ -40,7 +44,7 @@
   <div
     class="grid h-full w-full max-w-4xl grid-cols-1 grid-rows-[1fr,120px] p-2"
   >
-    <div class="w-full h-full overflow-y-auto">
+    <div class="overflow-y-auto w-full h-full">
       {#each chat.messages as message (message.id)}
         <div
           class="{mapRoleToClass(
@@ -50,61 +54,61 @@
           {#each message.parts as part, i (i)}
             {#if part.type === 'text'}
               {part.text}
-            {:else if part.type === 'tool-invocation'}
-              {@const toolCallId = part.toolInvocation.toolCallId}
-              {@const toolName = part.toolInvocation.toolName}
-              {@const state = part.toolInvocation.state}
+            {:else if part.type === 'tool-askForConfirmation'}
+              {@const toolCallId = part.toolCallId}
+              {@const state = part.state}
 
-              {#if toolName === 'askForConfirmation'}
-                {#if state === 'call'}
-                  <div class="flex flex-col gap-2">
-                    {part.toolInvocation.input.message}
-                    <div class="flex gap-2">
-                      <Button
-                        variant="default"
-                        onclick={() =>
-                          chat.addToolResult({
-                            toolCallId,
-                            result: 'Yes, confirmed',
-                          })}>Yes</Button
-                      >
-                      <Button
-                        variant="secondary"
-                        onclick={() =>
-                          chat.addToolResult({
-                            toolCallId,
-                            result: 'No, denied',
-                          })}>No</Button
-                      >
-                    </div>
+              {#if state === 'input-available'}
+                {@const input = part.input as { message: string }}
+                <div class="flex flex-col gap-2">
+                  {input.message}
+                  <div class="flex gap-2">
+                    <Button
+                      variant="default"
+                      onclick={() =>
+                        chat.addToolResult({
+                          toolCallId,
+                          tool: 'askForConfirmation',
+                          output: 'Yes, confirmed',
+                        })}>Yes</Button
+                    >
+                    <Button
+                      variant="secondary"
+                      onclick={() =>
+                        chat.addToolResult({
+                          toolCallId,
+                          tool: 'askForConfirmation',
+                          output: 'No, denied',
+                        })}>No</Button
+                    >
                   </div>
-                {:else if state === 'result'}
-                  <div class="text-gray-500">
-                    {part.toolInvocation.result}
-                  </div>
-                {/if}
-              {:else if toolName === 'getLocation'}
-                {#if state === 'call'}
-                  <div class="text-gray-500">Getting location...</div>
-                {:else if state === 'result'}
-                  <div class="text-gray-500">
-                    Location: {part.toolInvocation.result}
-                  </div>
-                {/if}
-              {:else if toolName === 'getWeatherInformation'}
-                {#if state === 'partial-call'}
-                  <pre>{JSON.stringify(part.toolInvocation, null, 2)}</pre>
-                {:else if state === 'call'}
-                  <div class="text-gray-500">
-                    Getting weather information for {part.toolInvocation.args
-                      .city}...
-                  </div>
-                {:else if state === 'result'}
-                  <div class="text-gray-500">
-                    Weather in {part.toolInvocation.input.city}: {part
-                      .toolInvocation.result}
-                  </div>
-                {/if}
+                </div>
+              {:else if state === 'output-available'}
+                <div class="text-gray-500">
+                  {part.output}
+                </div>
+              {/if}
+            {:else if part.type === 'tool-getLocation'}
+              {#if part.state === 'input-available'}
+                <div class="text-gray-500">Getting location...</div>
+              {:else if part.state === 'output-available'}
+                <div class="text-gray-500">
+                  Location: {part.output}
+                </div>
+              {/if}
+            {:else if part.type === 'tool-getWeatherInformation'}
+              {#if part.state === 'input-streaming'}
+                <pre>{JSON.stringify(part, null, 2)}</pre>
+              {:else if part.state === 'input-available'}
+                {@const input = part.input as { city: string }}
+                <div class="text-gray-500">
+                  Getting weather information for {input.city}...
+                </div>
+              {:else if part.state === 'output-available'}
+                {@const input = part.input as { city: string }}
+                <div class="text-gray-500">
+                  Weather in {input.city}: {part.output}
+                </div>
               {/if}
             {/if}
           {/each}
@@ -134,7 +138,7 @@
         {disabled}
         type="submit"
         size="icon"
-        class="absolute bottom-3 right-3"
+        class="absolute right-3 bottom-3"
       >
         <ArrowUp />
       </Button>

--- a/examples/sveltekit-openai/src/routes/chat/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat/+page.svelte
@@ -13,7 +13,7 @@
       if (toolCall.toolName === 'getLocation') {
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
         const location = cities[Math.floor(Math.random() * cities.length)];
-        
+
         await chat.addToolResult({
           toolCallId: toolCall.toolCallId,
           tool: 'getLocation',

--- a/examples/sveltekit-openai/src/routes/chat/[id]/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat/[id]/+page.svelte
@@ -18,7 +18,7 @@
       if (toolCall.toolName === 'getLocation') {
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
         const location = cities[Math.floor(Math.random() * cities.length)];
-        
+
         await chat.addToolResult({
           toolCallId: toolCall.toolCallId,
           tool: 'getLocation',

--- a/examples/sveltekit-openai/src/routes/chat/[id]/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat/[id]/+page.svelte
@@ -4,10 +4,12 @@
   import Button from '$lib/components/ui/button/button.svelte';
   import { Textarea } from '$lib/components/ui/textarea/index.js';
   import { Chat } from '@ai-sdk/svelte';
+  import { stepCountIs } from 'ai';
+
+  const stopWhen = stepCountIs(5);
 
   const chat = new Chat({
     id: page.params.id,
-    maxSteps: 5,
     // run client-side tools that are automatically executed:
     async onToolCall({ toolCall }) {
       // artificial 2 second delay
@@ -15,7 +17,13 @@
 
       if (toolCall.toolName === 'getLocation') {
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
-        return cities[Math.floor(Math.random() * cities.length)];
+        const location = cities[Math.floor(Math.random() * cities.length)];
+        
+        await chat.addToolResult({
+          toolCallId: toolCall.toolCallId,
+          tool: 'getLocation',
+          output: location,
+        });
       }
     },
   });
@@ -43,7 +51,7 @@
   <div
     class="grid h-full w-full max-w-4xl grid-cols-1 grid-rows-[1fr,120px] p-2"
   >
-    <div class="w-full h-full overflow-y-auto">
+    <div class="overflow-y-auto w-full h-full">
       {#each chat.messages as message (message.id)}
         <div
           class="{mapRoleToClass(
@@ -53,61 +61,58 @@
           {#each message.parts as part, i (i)}
             {#if part.type === 'text'}
               {part.text}
-            {:else if part.type === 'tool-invocation'}
-              {@const toolCallId = part.toolInvocation.toolCallId}
-              {@const toolName = part.toolInvocation.toolName}
-              {@const state = part.toolInvocation.state}
-
-              {#if toolName === 'askForConfirmation'}
-                {#if state === 'call'}
-                  <div class="flex flex-col gap-2">
-                    {part.toolInvocation.input.message}
-                    <div class="flex gap-2">
-                      <Button
-                        variant="default"
-                        onclick={() =>
-                          chat.addToolResult({
-                            toolCallId,
-                            result: 'Yes, confirmed',
-                          })}>Yes</Button
-                      >
-                      <Button
-                        variant="secondary"
-                        onclick={() =>
-                          chat.addToolResult({
-                            toolCallId,
-                            result: 'No, denied',
-                          })}>No</Button
-                      >
-                    </div>
+            {:else if part.type === 'tool-askForConfirmation'}
+              {#if part.state === 'input-available'}
+                {@const input = part.input as { message: string }}
+                <div class="flex flex-col gap-2">
+                  {input.message}
+                  <div class="flex gap-2">
+                    <Button
+                      variant="default"
+                      onclick={() =>
+                        chat.addToolResult({
+                          toolCallId: part.toolCallId,
+                          tool: 'askForConfirmation',
+                          output: 'Yes, confirmed',
+                        })}>Yes</Button
+                    >
+                    <Button
+                      variant="secondary"
+                      onclick={() =>
+                        chat.addToolResult({
+                          toolCallId: part.toolCallId,
+                          tool: 'askForConfirmation',
+                          output: 'No, denied',
+                        })}>No</Button
+                    >
                   </div>
-                {:else if state === 'result'}
-                  <div class="text-gray-500">
-                    {part.toolInvocation.result}
-                  </div>
-                {/if}
-              {:else if toolName === 'getLocation'}
-                {#if state === 'call'}
-                  <div class="text-gray-500">Getting location...</div>
-                {:else if state === 'result'}
-                  <div class="text-gray-500">
-                    Location: {part.toolInvocation.result}
-                  </div>
-                {/if}
-              {:else if toolName === 'getWeatherInformation'}
-                {#if state === 'partial-call'}
-                  <pre>{JSON.stringify(part.toolInvocation, null, 2)}</pre>
-                {:else if state === 'call'}
-                  <div class="text-gray-500">
-                    Getting weather information for {part.toolInvocation.args
-                      .city}...
-                  </div>
-                {:else if state === 'result'}
-                  <div class="text-gray-500">
-                    Weather in {part.toolInvocation.input.city}: {part
-                      .toolInvocation.result}
-                  </div>
-                {/if}
+                </div>
+              {:else if part.state === 'output-available'}
+                <div class="text-gray-500">
+                  {part.output}
+                </div>
+              {/if}
+            {:else if part.type === 'tool-getLocation'}
+              {#if part.state === 'input-available'}
+                <div class="text-gray-500">Getting location...</div>
+              {:else if part.state === 'output-available'}
+                <div class="text-gray-500">
+                  Location: {part.output}
+                </div>
+              {/if}
+            {:else if part.type === 'tool-getWeatherInformation'}
+              {#if part.state === 'input-streaming'}
+                <pre>{JSON.stringify(part, null, 2)}</pre>
+              {:else if part.state === 'input-available'}
+                {@const input = part.input as { city: string }}
+                <div class="text-gray-500">
+                  Getting weather information for {input.city}...
+                </div>
+              {:else if part.state === 'output-available'}
+                {@const input = part.input as { city: string }}
+                <div class="text-gray-500">
+                  Weather in {input.city}: {part.output}
+                </div>
               {/if}
             {/if}
           {/each}
@@ -137,7 +142,7 @@
         {disabled}
         type="submit"
         size="icon"
-        class="absolute bottom-3 right-3"
+        class="absolute right-3 bottom-3"
       >
         <ArrowUp />
       </Button>

--- a/examples/sveltekit-openai/src/routes/chat/[id]/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat/[id]/+page.svelte
@@ -4,9 +4,6 @@
   import Button from '$lib/components/ui/button/button.svelte';
   import { Textarea } from '$lib/components/ui/textarea/index.js';
   import { Chat } from '@ai-sdk/svelte';
-  import { stepCountIs } from 'ai';
-
-  const stopWhen = stepCountIs(5);
 
   const chat = new Chat({
     id: page.params.id,


### PR DESCRIPTION
## background

SvelteKit examples were using outdated tool invocation patterns that caused TypeScript errors when opened in editors, breaking the developer experience for users trying the examples.

## summary

- fix tool part type checking patterns
- update onToolCall callback return types
- correct addToolResult api usage
- remove deprecated properties

## verification

- tool calls work with proper type safety
- client-server tool execution functions correctly
- multi-step tool flows execute as expected

## tasks

- [x] tool part access patterns updated from .toolInvocation to direct properties
- [x] addToolResult api corrected to use tool/output parameters
- [x] removed unsupported maxSteps from client chat initialization