### PR TITLE
fix (ai): send null as tool output when tools return undefined

### DIFF
--- a/.changeset/brown-knives-marry.md
+++ b/.changeset/brown-knives-marry.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): send null as tool output when tools return undefined

--- a/packages/ai/src/prompt/create-tool-model-output.test.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.test.ts
@@ -287,7 +287,7 @@ describe('createToolModelOutput', () => {
       });
     });
 
-    it('should handle undefined output in error case', () => {
+    it('should handle undefined output in error text case', () => {
       const result = createToolModelOutput({
         output: undefined,
         tool: undefined,
@@ -300,7 +300,20 @@ describe('createToolModelOutput', () => {
       });
     });
 
-    it('should handle undefined output in non-error case', () => {
+    it('should use null for undefined output in error json case', () => {
+      const result = createToolModelOutput({
+        output: undefined,
+        tool: undefined,
+        errorMode: 'json',
+      });
+
+      expect(result).toEqual({
+        type: 'error-json',
+        value: null,
+      });
+    });
+
+    it('should use null for undefined output in non-error case', () => {
       const result = createToolModelOutput({
         output: undefined,
         tool: undefined,
@@ -309,7 +322,7 @@ describe('createToolModelOutput', () => {
 
       expect(result).toEqual({
         type: 'json',
-        value: undefined,
+        value: null,
       });
     });
   });

--- a/packages/ai/src/prompt/create-tool-model-output.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.ts
@@ -17,7 +17,7 @@ export function createToolModelOutput({
   if (errorMode === 'text') {
     return { type: 'error-text', value: getErrorMessage(output) };
   } else if (errorMode === 'json') {
-    return { type: 'error-json', value: output as JSONValue };
+    return { type: 'error-json', value: toJSONValue(output) };
   }
 
   if (tool?.toModelOutput) {
@@ -26,5 +26,9 @@ export function createToolModelOutput({
 
   return typeof output === 'string'
     ? { type: 'text', value: output }
-    : { type: 'json', value: output as JSONValue };
+    : { type: 'json', value: toJSONValue(output) };
+}
+
+function toJSONValue(value: unknown): JSONValue {
+  return value === undefined ? null : (value as JSONValue);
 }


### PR DESCRIPTION
## Background

Undefined tool outputs case errors because undefined gets dropped in JSON stringify (see #7610).

## Summary

Send `null` instead.

## Verification

Verified tools with undefined outputs do not cause breakage.

## Related Issues

Fixes #7610 