### PR TITLE
fix(examples/vue): update tool call patterns for current api

### DIFF
--- a/examples/nuxt-openai/pages/index.vue
+++ b/examples/nuxt-openai/pages/index.vue
@@ -42,7 +42,7 @@ const handleSubmit = (e: Event) => {
       <button
         type="button"
         class="px-4 py-2 mt-4 text-blue-500 border border-blue-500 rounded-md"
-        @click="() => chat.reload()"
+        @click="() => chat.regenerate()"
       >
         Retry
       </button>

--- a/examples/nuxt-openai/pages/use-chat-request/index.vue
+++ b/examples/nuxt-openai/pages/use-chat-request/index.vue
@@ -8,7 +8,7 @@ const chat = new Chat({
   transport: new DefaultChatTransport({
     api: '/api/use-chat-request',
     // only send the last message to the server:
-    prepareRequest({ messages, id }) {
+    prepareSendMessagesRequest({ messages, id }) {
       return { body: { message: messages[messages.length - 1], id } };
     },
   }),


### PR DESCRIPTION
## background

vue examples were using outdated tool invocation patterns that caused TypeScript errors when opened in editors

## summary

- fix tool part access patterns from `.toolInvocation` to direct properties
- update `addToolResult` api to use `tool`/`output` parameters
- correct method names (`reload()` → `regenerate()`)
- remove unsupported `maxSteps` from chat initialization
- fix transport options (`prepareRequest` → `prepareSendMessagesRequest`)

## verification  

- tool calls work with proper type safety
- client-server tool execution functions correctly
- multi-step tool flows execute as expected

## tasks

- [x] tool part access patterns updated from `.toolInvocation` to direct properties
- [x] `addToolResult` api corrected to use `tool`/`output` parameters  
- [x] method names fixed (`reload()` → `regenerate()`)
- [x] removed unsupported `maxSteps` from client chat initialization
- [x] transport options corrected (`prepareRequest` → `prepareSendMessagesRequest`)