### PR TITLE
fix (ai): support abort during retry waits

### DIFF
--- a/.changeset/three-humans-report.md
+++ b/.changeset/three-humans-report.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+fix (ai): support abort during retry waits

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -92,7 +92,10 @@ Only applicable for HTTP-based providers.
     });
   }
 
-  const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
 
   const baseTelemetryAttributes = getBaseTelemetryAttributes({
     model,

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -79,7 +79,10 @@ Only applicable for HTTP-based providers.
     });
   }
 
-  const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
 
   const baseTelemetryAttributes = getBaseTelemetryAttributes({
     model,

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -122,7 +122,10 @@ Only applicable for HTTP-based providers.
     });
   }
 
-  const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
 
   // default to 1 if the model has not specified limits on
   // how many images can be generated in a single call

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -243,7 +243,10 @@ Default and recommended: 'auto' (best mode for the model).
     enumValues,
   });
 
-  const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
 
   const outputStrategy = getOutputStrategy({
     output,

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -427,6 +427,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
 
     const { maxRetries, retry } = prepareRetries({
       maxRetries: maxRetriesArg,
+      abortSignal,
     });
 
     const callSettings = prepareCallSettings(settings);

--- a/packages/ai/src/generate-speech/generate-speech.ts
+++ b/packages/ai/src/generate-speech/generate-speech.ts
@@ -121,7 +121,10 @@ Only applicable for HTTP-based providers.
     });
   }
 
-  const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
 
   const result = await retry(() =>
     model.doGenerate({

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -226,7 +226,10 @@ A function that attempts to repair a tool call that failed to parse.
   }): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
   const model = resolveLanguageModel(modelArg);
   const stopConditions = asArray(stopWhen);
-  const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
 
   const callSettings = prepareCallSettings(settings);
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -944,6 +944,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
 
     const { maxRetries, retry } = prepareRetries({
       maxRetries: maxRetriesArg,
+      abortSignal,
     });
 
     const tracer = getTracer(telemetry);

--- a/packages/ai/src/transcribe/transcribe.ts
+++ b/packages/ai/src/transcribe/transcribe.ts
@@ -87,7 +87,11 @@ Only applicable for HTTP-based providers.
     });
   }
 
-  const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
+
   const audioData =
     audio instanceof URL
       ? (await download({ url: audio })).data

--- a/packages/ai/src/util/prepare-retries.test.ts
+++ b/packages/ai/src/util/prepare-retries.test.ts
@@ -2,6 +2,9 @@ import { expect, it } from 'vitest';
 import { prepareRetries } from './prepare-retries';
 
 it('should set default values correctly when no input is provided', () => {
-  const defaultResult = prepareRetries({ maxRetries: undefined });
+  const defaultResult = prepareRetries({
+    maxRetries: undefined,
+    abortSignal: undefined,
+  });
   expect(defaultResult.maxRetries).toBe(2);
 });

--- a/packages/ai/src/util/prepare-retries.ts
+++ b/packages/ai/src/util/prepare-retries.ts
@@ -9,8 +9,10 @@ import {
  */
 export function prepareRetries({
   maxRetries,
+  abortSignal,
 }: {
   maxRetries: number | undefined;
+  abortSignal: AbortSignal | undefined;
 }): {
   maxRetries: number;
   retry: RetryFunction;
@@ -39,6 +41,7 @@ export function prepareRetries({
     maxRetries: maxRetriesResult,
     retry: retryWithExponentialBackoffRespectingRetryHeaders({
       maxRetries: maxRetriesResult,
+      abortSignal,
     }),
   };
 }

--- a/packages/ai/src/util/retry-with-exponential-backoff.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.ts
@@ -6,56 +6,47 @@ export type RetryFunction = <OUTPUT>(
   fn: () => PromiseLike<OUTPUT>,
 ) => PromiseLike<OUTPUT>;
 
-/**
- * Determines the retry delay for a failed API call by checking rate limit headers.
- *
- * This matches the implementation used by both Anthropic and OpenAI client SDKs:
- * - First checks for 'retry-after-ms' header (milliseconds)
- * - Falls back to 'retry-after' header (seconds or HTTP date)
- * - Only uses the header value if it's reasonable (between 0 and 60 seconds)
- * - Falls back to exponential backoff if no valid headers or if the delay is unreasonable
- *
- * @param error - The API call error containing response headers
- * @param exponentialBackoffDelay - The calculated exponential backoff delay to use as fallback
- * @returns The delay in milliseconds to wait before retrying
- */
-function getRetryDelay(
-  error: APICallError,
-  exponentialBackoffDelay: number,
-): number {
+function getRetryDelayInMs({
+  error,
+  exponentialBackoffDelay,
+}: {
+  error: APICallError;
+  exponentialBackoffDelay: number;
+}): number {
   const headers = error.responseHeaders;
+
   if (!headers) return exponentialBackoffDelay;
 
-  let timeoutMillis: number | undefined;
+  let ms: number | undefined;
 
-  // Note the `retry-after-ms` header may not be standard, but is a good idea and we'd like proactive support for it.
+  // retry-ms is more precise than retry-after and used by e.g. OpenAI
   const retryAfterMs = headers['retry-after-ms'];
   if (retryAfterMs) {
     const timeoutMs = parseFloat(retryAfterMs);
     if (!Number.isNaN(timeoutMs)) {
-      timeoutMillis = timeoutMs;
+      ms = timeoutMs;
     }
   }
 
   // About the Retry-After header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
   const retryAfter = headers['retry-after'];
-  if (retryAfter && timeoutMillis === undefined) {
+  if (retryAfter && ms === undefined) {
     const timeoutSeconds = parseFloat(retryAfter);
     if (!Number.isNaN(timeoutSeconds)) {
-      timeoutMillis = timeoutSeconds * 1000;
+      ms = timeoutSeconds * 1000;
     } else {
-      timeoutMillis = Date.parse(retryAfter) - Date.now();
+      ms = Date.parse(retryAfter) - Date.now();
     }
   }
 
-  // If the API asks us to wait a certain amount of time (and it's a reasonable amount),
-  // just do what it says, but otherwise calculate a default
+  // check that the delay is reasonable:
   if (
-    timeoutMillis !== undefined &&
-    0 <= timeoutMillis &&
-    timeoutMillis < 60 * 1000
+    ms != null &&
+    !Number.isNaN(ms) &&
+    0 <= ms &&
+    (ms < 60 * 1000 || ms < exponentialBackoffDelay)
   ) {
-    return timeoutMillis;
+    return ms;
   }
 
   return exponentialBackoffDelay;
@@ -117,10 +108,12 @@ async function _retryWithExponentialBackoff<OUTPUT>(
       error.isRetryable === true &&
       tryNumber <= maxRetries
     ) {
-      // Check for rate limit headers and use them if reasonable (0-60s)
-      const actualDelay = getRetryDelay(error, delayInMs);
-
-      await delay(actualDelay);
+      await delay(
+        getRetryDelayInMs({
+          error,
+          exponentialBackoffDelay: delayInMs,
+        }),
+      );
       return _retryWithExponentialBackoff(
         f,
         { maxRetries, delayInMs: backoffFactor * delayInMs, backoffFactor },

--- a/packages/provider-utils/src/delay.test.ts
+++ b/packages/provider-utils/src/delay.test.ts
@@ -1,0 +1,211 @@
+import { delay } from './delay';
+
+describe('delay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('basic delay functionality', () => {
+    it('should resolve after the specified delay', async () => {
+      const delayPromise = delay(1000);
+
+      // Promise should not be resolved immediately
+      let resolved = false;
+      delayPromise.then(() => {
+        resolved = true;
+      });
+
+      expect(resolved).toBe(false);
+
+      // Advance timers by less than the delay
+      await vi.advanceTimersByTimeAsync(500);
+      expect(resolved).toBe(false);
+
+      // Advance timers to complete the delay
+      await vi.advanceTimersByTimeAsync(500);
+      expect(resolved).toBe(true);
+
+      // Verify the promise resolves
+      await expect(delayPromise).resolves.toBeUndefined();
+    });
+
+    it('should resolve immediately when delayInMs is null', async () => {
+      const delayPromise = delay(null);
+      await expect(delayPromise).resolves.toBeUndefined();
+    });
+
+    it('should resolve immediately when delayInMs is undefined', async () => {
+      const delayPromise = delay(undefined);
+      await expect(delayPromise).resolves.toBeUndefined();
+    });
+
+    it('should resolve immediately when delayInMs is 0', async () => {
+      const delayPromise = delay(0);
+
+      // Even with 0 delay, setTimeout is used, so we need to advance timers
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(delayPromise).resolves.toBeUndefined();
+    });
+  });
+
+  describe('abort signal functionality', () => {
+    it('should reject immediately if signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const delayPromise = delay(1000, { signal: controller.signal });
+
+      await expect(delayPromise).rejects.toThrow('Delay was aborted');
+      expect(vi.getTimerCount()).toBe(0); // No timer should be set
+    });
+
+    it('should reject when signal is aborted during delay', async () => {
+      const controller = new AbortController();
+      const delayPromise = delay(1000, { signal: controller.signal });
+
+      // Advance time partially
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Abort the signal
+      controller.abort();
+
+      await expect(delayPromise).rejects.toThrow('Delay was aborted');
+    });
+
+    it('should clean up timeout when aborted', async () => {
+      const controller = new AbortController();
+      const delayPromise = delay(1000, { signal: controller.signal });
+
+      expect(vi.getTimerCount()).toBe(1);
+
+      controller.abort();
+
+      try {
+        await delayPromise;
+      } catch {
+        // Expected to throw
+      }
+
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('should clean up event listener when delay completes normally', async () => {
+      const controller = new AbortController();
+      const addEventListenerSpy = vi.spyOn(
+        controller.signal,
+        'addEventListener',
+      );
+      const removeEventListenerSpy = vi.spyOn(
+        controller.signal,
+        'removeEventListener',
+      );
+
+      const delayPromise = delay(1000, { signal: controller.signal });
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        'abort',
+        expect.any(Function),
+      );
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await delayPromise;
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'abort',
+        expect.any(Function),
+      );
+    });
+
+    it('should work without signal option', async () => {
+      const delayPromise = delay(1000);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(delayPromise).resolves.toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should create proper DOMException for abort', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const delayPromise = delay(1000, { signal: controller.signal });
+
+      try {
+        await delayPromise;
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(DOMException);
+        expect((error as DOMException).message).toBe('Delay was aborted');
+        expect((error as DOMException).name).toBe('AbortError');
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle very large delays', async () => {
+      const delayPromise = delay(Number.MAX_SAFE_INTEGER);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      let resolved = false;
+      delayPromise.then(() => {
+        resolved = true;
+      });
+
+      expect(resolved).toBe(false);
+
+      // Fast forward to complete
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(delayPromise).resolves.toBeUndefined();
+    });
+
+    it('should handle negative delays (treated as 0)', async () => {
+      const delayPromise = delay(-100);
+
+      vi.advanceTimersByTime(0);
+      await expect(delayPromise).resolves.toBeUndefined();
+    });
+
+    it('should handle multiple delays simultaneously', async () => {
+      const delay1 = delay(100);
+      const delay2 = delay(200);
+      const delay3 = delay(300);
+
+      let resolved1 = false;
+      let resolved2 = false;
+      let resolved3 = false;
+
+      delay1.then(() => {
+        resolved1 = true;
+      });
+      delay2.then(() => {
+        resolved2 = true;
+      });
+      delay3.then(() => {
+        resolved3 = true;
+      });
+
+      // After 100ms, only first should resolve
+      await vi.advanceTimersByTimeAsync(100);
+      expect(resolved1).toBe(true);
+      expect(resolved2).toBe(false);
+      expect(resolved3).toBe(false);
+
+      // After 200ms, first two should resolve
+      await vi.advanceTimersByTimeAsync(100);
+      expect(resolved1).toBe(true);
+      expect(resolved2).toBe(true);
+      expect(resolved3).toBe(false);
+
+      // After 300ms, all should resolve
+      await vi.advanceTimersByTimeAsync(100);
+      expect(resolved1).toBe(true);
+      expect(resolved2).toBe(true);
+      expect(resolved3).toBe(true);
+    });
+  });
+});

--- a/packages/provider-utils/src/delay.test.ts
+++ b/packages/provider-utils/src/delay.test.ts
@@ -57,7 +57,7 @@ describe('delay', () => {
       const controller = new AbortController();
       controller.abort();
 
-      const delayPromise = delay(1000, { signal: controller.signal });
+      const delayPromise = delay(1000, { abortSignal: controller.signal });
 
       await expect(delayPromise).rejects.toThrow('Delay was aborted');
       expect(vi.getTimerCount()).toBe(0); // No timer should be set
@@ -65,7 +65,7 @@ describe('delay', () => {
 
     it('should reject when signal is aborted during delay', async () => {
       const controller = new AbortController();
-      const delayPromise = delay(1000, { signal: controller.signal });
+      const delayPromise = delay(1000, { abortSignal: controller.signal });
 
       // Advance time partially
       await vi.advanceTimersByTimeAsync(500);
@@ -78,7 +78,7 @@ describe('delay', () => {
 
     it('should clean up timeout when aborted', async () => {
       const controller = new AbortController();
-      const delayPromise = delay(1000, { signal: controller.signal });
+      const delayPromise = delay(1000, { abortSignal: controller.signal });
 
       expect(vi.getTimerCount()).toBe(1);
 
@@ -104,7 +104,7 @@ describe('delay', () => {
         'removeEventListener',
       );
 
-      const delayPromise = delay(1000, { signal: controller.signal });
+      const delayPromise = delay(1000, { abortSignal: controller.signal });
 
       expect(addEventListenerSpy).toHaveBeenCalledWith(
         'abort',
@@ -133,7 +133,7 @@ describe('delay', () => {
       const controller = new AbortController();
       controller.abort();
 
-      const delayPromise = delay(1000, { signal: controller.signal });
+      const delayPromise = delay(1000, { abortSignal: controller.signal });
 
       try {
         await delayPromise;

--- a/packages/provider-utils/src/delay.ts
+++ b/packages/provider-utils/src/delay.ts
@@ -8,14 +8,14 @@
 export async function delay(
   delayInMs?: number | null,
   options?: {
-    signal?: AbortSignal;
+    abortSignal?: AbortSignal;
   },
 ): Promise<void> {
   if (delayInMs == null) {
     return Promise.resolve();
   }
 
-  const signal = options?.signal;
+  const signal = options?.abortSignal;
 
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {

--- a/packages/provider-utils/src/delay.ts
+++ b/packages/provider-utils/src/delay.ts
@@ -1,10 +1,47 @@
 /**
  * Creates a Promise that resolves after a specified delay
  * @param delayInMs - The delay duration in milliseconds. If null or undefined, resolves immediately.
+ * @param signal - Optional AbortSignal to cancel the delay
  * @returns A Promise that resolves after the specified delay
+ * @throws {DOMException} When the signal is aborted
  */
-export async function delay(delayInMs?: number | null): Promise<void> {
-  return delayInMs == null
-    ? Promise.resolve()
-    : new Promise(resolve => setTimeout(resolve, delayInMs));
+export async function delay(
+  delayInMs?: number | null,
+  options?: {
+    signal?: AbortSignal;
+  },
+): Promise<void> {
+  if (delayInMs == null) {
+    return Promise.resolve();
+  }
+
+  const signal = options?.signal;
+
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayInMs);
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    const onAbort = () => {
+      cleanup();
+      reject(createAbortError());
+    };
+
+    signal?.addEventListener('abort', onAbort);
+  });
+}
+
+function createAbortError(): DOMException {
+  return new DOMException('Delay was aborted', 'AbortError');
 }

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -257,7 +257,7 @@ functionality that can be fully encapsulated in the provider.
     renderFinished.resolve(undefined);
   }
 
-  const { retry } = prepareRetries({ maxRetries });
+  const { retry } = prepareRetries({ maxRetries, abortSignal });
 
   const validatedPrompt = await standardizePrompt({
     system,


### PR DESCRIPTION
## Background

Abort was delayed during the delays when retrying.

## Summary

* add abort signal support to delay
* pass abort signal into delay from the retry function

## Related Issues

Fixes #7656