### PR TITLE
feat (ui): add Chat.clearError()

### DIFF
--- a/.changeset/witty-bees-flash.md
+++ b/.changeset/witty-bees-flash.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/react': patch
+'ai': patch
+---
+
+feat (ui): add Chat.clearError()

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -84,7 +84,8 @@ Allows you to easily create a conversational user interface for your chatbot app
               name: 'prepareSendMessagesRequest',
               type: 'PrepareSendMessagesRequest',
               isOptional: true,
-              description: 'A function to customize the request before chat API calls.',
+              description:
+                'A function to customize the request before chat API calls.',
               properties: [
                 {
                   type: 'PrepareSendMessagesRequest',
@@ -142,8 +143,8 @@ Allows you to easily create a conversational user interface for your chatbot app
                               type: 'string | undefined',
                               description: 'The message ID if applicable',
                             },
-                          ]
-                        }
+                          ],
+                        },
                       ],
                     },
                   ],
@@ -154,7 +155,8 @@ Allows you to easily create a conversational user interface for your chatbot app
               name: 'prepareReconnectToStreamRequest',
               type: 'PrepareReconnectToStreamRequest',
               isOptional: true,
-              description: 'A function to customize the request before reconnect API call.',
+              description:
+                'A function to customize the request before reconnect API call.',
               properties: [
                 {
                   type: 'PrepareReconnectToStreamRequest',
@@ -162,7 +164,8 @@ Allows you to easily create a conversational user interface for your chatbot app
                     {
                       name: 'options',
                       type: 'PrepareReconnectToStreamRequestOptions',
-                      description: 'Options for preparing the reconnect request',
+                      description:
+                        'Options for preparing the reconnect request',
                       properties: [
                         {
                           type: 'PrepareReconnectToStreamRequestOptions',
@@ -197,8 +200,8 @@ Allows you to easily create a conversational user interface for your chatbot app
                               type: 'string',
                               description: `The API endpoint to use for the request. If not specified, it defaults to the transport’s API endpoint combined with the chat ID: /api/chat/{chatId}/stream.`,
                             },
-                          ]
-                        }
+                          ],
+                        },
                       ],
                     },
                   ],
@@ -271,8 +274,7 @@ Allows you to easily create a conversational user interface for your chatbot app
       description:
         'Whether to resume an ongoing chat generation stream. Defaults to false.',
     },
-
-]}
+  ]}
 />
 
 ### Returns
@@ -370,6 +372,11 @@ Allows you to easily create a conversational user interface for your chatbot app
       type: '() => void',
       description:
         'Function to abort the current streaming response from the assistant.',
+    },
+    {
+      name: 'clearError',
+      type: '() => void',
+      description: 'Clears the error state.',
     },
     {
       name: 'resumeStream',

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -893,6 +893,36 @@ describe('Chat', () => {
         ]
       `);
     });
+
+    it('should handle error parts', async () => {
+      server.urls['http://localhost:3000/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'start' }),
+          formatChunk({ type: 'error', errorText: 'test-error' }),
+        ],
+      };
+
+      const errorPromise = createResolvablePromise<void>();
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: new DefaultChatTransport({
+          api: 'http://localhost:3000/api/chat',
+        }),
+        onError: () => errorPromise.resolve(),
+      });
+
+      chat.sendMessage({
+        text: 'Hello, world!',
+      });
+
+      await errorPromise.promise;
+
+      expect(chat.error).toMatchInlineSnapshot(`[Error: test-error]`);
+      expect(chat.status).toBe('error');
+    });
   });
 
   describe('sendAutomaticallyWhen', () => {
@@ -1182,6 +1212,43 @@ describe('Chat', () => {
           "trigger": "submit-message",
         }
       `);
+    });
+  });
+
+  describe('clearError', () => {
+    it('should clear the error and set the status to ready', async () => {
+      server.urls['http://localhost:3000/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'start' }),
+          formatChunk({ type: 'error', errorText: 'test-error' }),
+        ],
+      };
+
+      const errorPromise = createResolvablePromise<void>();
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: new DefaultChatTransport({
+          api: 'http://localhost:3000/api/chat',
+        }),
+        onError: () => errorPromise.resolve(),
+      });
+
+      chat.sendMessage({
+        text: 'Hello, world!',
+      });
+
+      await errorPromise.promise;
+
+      expect(chat.error).toMatchInlineSnapshot(`[Error: test-error]`);
+      expect(chat.status).toBe('error');
+
+      chat.clearError();
+
+      expect(chat.error).toBeUndefined();
+      expect(chat.status).toBe('ready');
     });
   });
 });

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -391,6 +391,16 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     await this.makeRequest({ trigger: 'resume-stream', ...options });
   };
 
+  /**
+   * Clear the error state and set the status to ready if the chat is in an error state.
+   */
+  clearError = () => {
+    if (this.status === 'error') {
+      this.state.error = undefined;
+      this.setStatus({ status: 'ready' });
+    }
+  };
+
   addToolResult = async <TOOL extends keyof InferUIMessageTools<UI_MESSAGE>>({
     tool,
     toolCallId,

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -34,6 +34,7 @@ export type UseChatHelpers<UI_MESSAGE extends UIMessage> = {
   | 'addToolResult'
   | 'status'
   | 'messages'
+  | 'clearError'
 >;
 
 export type UseChatOptions<UI_MESSAGE extends UIMessage> = (
@@ -121,6 +122,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     setMessages,
     sendMessage: chatRef.current.sendMessage,
     regenerate: chatRef.current.regenerate,
+    clearError: chatRef.current.clearError,
     stop: chatRef.current.stop,
     error,
     resumeStream: chatRef.current.resumeStream,


### PR DESCRIPTION
## Background

After errors have occurred, there needs to be a way to reset the chat state.

## Summary

Add `clearError` function to Chat and useChat.

## Related Issues

Fixes #4742 