### PR TITLE
docs: remove @beta tags for release

### DIFF
--- a/content/cookbook/00-guides/01-rag-chatbot.mdx
+++ b/content/cookbook/00-guides/01-rag-chatbot.mdx
@@ -282,7 +282,7 @@ This function will take an input string and split it by periods, filtering out a
 
 You will use the AI SDK to create embeddings. This will require two more dependencies, which you can install by running the following command:
 
-<Snippet text="pnpm add ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta" />
+<Snippet text="pnpm add ai @ai-sdk/react @ai-sdk/openai" />
 
 This will install the [AI SDK](/docs), AI SDK's React hooks, and AI SDK's [OpenAI provider](/providers/ai-sdk-providers/openai).
 

--- a/content/cookbook/00-guides/02-multi-modal-chatbot.mdx
+++ b/content/cookbook/00-guides/02-multi-modal-chatbot.mdx
@@ -58,22 +58,13 @@ Install `ai` and `@ai-sdk/openai`, the AI SDK package and the AI SDK's [ OpenAI 
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet
-        text="pnpm add ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta"
-        dark
-      />
+      <Snippet text="pnpm add ai @ai-sdk/react @ai-sdk/openai" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="npm install ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta"
-        dark
-      />
+      <Snippet text="npm install ai @ai-sdk/react @ai-sdk/openai" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="yarn add ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta"
-        dark
-      />
+      <Snippet text="yarn add ai @ai-sdk/react @ai-sdk/openai" dark />
     </Tab>
   </Tabs>
 </div>
@@ -380,7 +371,7 @@ const result = streamText({
 });
 ```
 
-Install the provider package (`@ai-sdk/anthropic@beta` or `@ai-sdk/google@beta`) and update your API keys in `.env.local`. The rest of your code remains the same.
+Install the provider package (`@ai-sdk/anthropic` or `@ai-sdk/google`) and update your API keys in `.env.local`. The rest of your code remains the same.
 
 <Note>
   Different providers may have varying file size limits and performance

--- a/content/cookbook/00-guides/05-computer-use.mdx
+++ b/content/cookbook/00-guides/05-computer-use.mdx
@@ -88,7 +88,7 @@ This reference implementation serves as a foundation to understand the requireme
 
 First, ensure you have the AI SDK and [Anthropic AI SDK provider](/providers/ai-sdk-providers/anthropic) installed:
 
-<Snippet text="pnpm add ai@beta @ai-sdk/anthropic@beta" />
+<Snippet text="pnpm add ai @ai-sdk/anthropic" />
 
 You can add Computer Use to your AI SDK applications using provider-defined-client tools. These tools accept various input parameters (like display height and width in the case of the computer tool) and then require that you define an execute function.
 

--- a/content/cookbook/00-guides/18-claude-4.mdx
+++ b/content/cookbook/00-guides/18-claude-4.mdx
@@ -81,7 +81,7 @@ Let's explore building a chatbot with [Next.js](https://nextjs.org), the AI SDK,
 
 In a new Next.js application, first install the AI SDK and the Anthropic provider:
 
-<Snippet text="pnpm install ai@beta @ai-sdk/anthropic@beta" />
+<Snippet text="pnpm install ai @ai-sdk/anthropic" />
 
 Then, create a route handler for the chat endpoint:
 

--- a/content/cookbook/00-guides/20-sonnet-3-7.mdx
+++ b/content/cookbook/00-guides/20-sonnet-3-7.mdx
@@ -80,7 +80,7 @@ Let's explore building a chatbot with [Next.js](https://nextjs.org), the AI SDK,
 
 In a new Next.js application, first install the AI SDK and the Anthropic provider:
 
-<Snippet text="pnpm install ai@beta @ai-sdk/anthropic@beta" />
+<Snippet text="pnpm install ai @ai-sdk/anthropic" />
 
 Then, create a route handler for the chat endpoint:
 

--- a/content/cookbook/00-guides/22-gpt-4-5.mdx
+++ b/content/cookbook/00-guides/22-gpt-4-5.mdx
@@ -115,7 +115,7 @@ Let's explore building a chatbot with [Next.js](https://nextjs.org), the AI SDK,
 
 In a new Next.js application, first install the AI SDK and the OpenAI provider:
 
-<Snippet text="pnpm install ai@beta @ai-sdk/openai@beta @ai-sdk/react@beta" />
+<Snippet text="pnpm install ai @ai-sdk/openai @ai-sdk/react" />
 
 Then, create a route handler for the chat endpoint:
 

--- a/content/cookbook/00-guides/24-o3.mdx
+++ b/content/cookbook/00-guides/24-o3.mdx
@@ -155,7 +155,7 @@ Let's explore building a chatbot with [Next.js](https://nextjs.org), the AI SDK,
 
 In a new Next.js application, first install the AI SDK and the DeepSeek provider:
 
-<Snippet text="pnpm install ai@beta @ai-sdk/openai@beta @ai-sdk/react@beta" />
+<Snippet text="pnpm install ai @ai-sdk/openai @ai-sdk/react" />
 
 Then, create a route handler for the chat endpoint:
 

--- a/content/cookbook/00-guides/25-r1.mdx
+++ b/content/cookbook/00-guides/25-r1.mdx
@@ -136,7 +136,7 @@ Let's explore building a chatbot with [Next.js](https://nextjs.org), the AI SDK,
 
 In a new Next.js application, first install the AI SDK and the DeepSeek provider:
 
-<Snippet text="pnpm install ai@beta @ai-sdk/deepseek@beta @ai-sdk/react@beta" />
+<Snippet text="pnpm install ai @ai-sdk/deepseek @ai-sdk/react" />
 
 Then, create a route handler for the chat endpoint:
 

--- a/content/docs/01-announcing-ai-sdk-5-beta/index.mdx
+++ b/content/docs/01-announcing-ai-sdk-5-beta/index.mdx
@@ -44,7 +44,7 @@ To install the AI SDK 5 Beta, run the following command:
 
 ```bash
 # replace with your provider and framework
-npm install ai@beta @ai-sdk/openai@beta @ai-sdk/react@beta
+npm install ai @ai-sdk/openai @ai-sdk/react
 ```
 
 <Note type="warning">

--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -52,22 +52,13 @@ Install `ai`, `@ai-sdk/react`, and `@ai-sdk/openai`, the AI package, AI SDK's Re
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet
-        text="pnpm add ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta zod"
-        dark
-      />
+      <Snippet text="pnpm add ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="npm install ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta zod"
-        dark
-      />
+      <Snippet text="npm install ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="yarn add ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta zod"
-        dark
-      />
+      <Snippet text="yarn add ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
   </Tabs>
 </div>

--- a/content/docs/02-getting-started/03-nextjs-pages-router.mdx
+++ b/content/docs/02-getting-started/03-nextjs-pages-router.mdx
@@ -50,22 +50,13 @@ Install `ai`, `@ai-sdk/react`, and `@ai-sdk/openai`, the AI package, AI SDK's Re
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet
-        text="pnpm add ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta zod"
-        dark
-      />
+      <Snippet text="pnpm add ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="npm install ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta zod"
-        dark
-      />
+      <Snippet text="npm install ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="yarn add ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta zod"
-        dark
-      />
+      <Snippet text="yarn add ai @ai-sdk/react @ai-sdk/openai zod" dark />
     </Tab>
   </Tabs>
 </div>

--- a/content/docs/02-getting-started/04-svelte.mdx
+++ b/content/docs/02-getting-started/04-svelte.mdx
@@ -46,22 +46,16 @@ Install `ai` and `@ai-sdk/openai`, the AI SDK's OpenAI provider.
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
+      <Snippet text="pnpm add -D ai @ai-sdk/openai @ai-sdk/svelte zod" dark />
+    </Tab>
+    <Tab>
       <Snippet
-        text="pnpm add -D ai@beta @ai-sdk/openai@beta @ai-sdk/svelte@beta zod"
+        text="npm install -D ai @ai-sdk/openai @ai-sdk/svelte zod"
         dark
       />
     </Tab>
     <Tab>
-      <Snippet
-        text="npm install -D ai@beta @ai-sdk/openai@beta @ai-sdk/svelte@beta zod"
-        dark
-      />
-    </Tab>
-    <Tab>
-      <Snippet
-        text="yarn add -D ai@beta @ai-sdk/openai@beta @ai-sdk/svelte@beta zod"
-        dark
-      />
+      <Snippet text="yarn add -D ai @ai-sdk/openai @ai-sdk/svelte zod" dark />
     </Tab>
   </Tabs>
 </div>

--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -44,22 +44,13 @@ Install `ai` and `@ai-sdk/openai`, the AI SDK's OpenAI provider.
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet
-        text="pnpm add ai@beta @ai-sdk/openai@beta @ai-sdk/vue@beta zod"
-        dark
-      />
+      <Snippet text="pnpm add ai @ai-sdk/openai @ai-sdk/vue zod" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="npm install ai@beta @ai-sdk/openai@beta @ai-sdk/vue@beta zod"
-        dark
-      />
+      <Snippet text="npm install ai @ai-sdk/openai @ai-sdk/vue zod" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="yarn add ai@beta @ai-sdk/openai@beta @ai-sdk/vue@beta zod"
-        dark
-      />
+      <Snippet text="yarn add ai @ai-sdk/openai @ai-sdk/vue zod" dark />
     </Tab>
   </Tabs>
 </div>

--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -44,22 +44,13 @@ Install `ai`, `@ai-sdk/react` and `@ai-sdk/openai`, the AI package, the AI React
 <div className="my-4">
   <Tabs items={['pnpm', 'npm', 'yarn']}>
     <Tab>
-      <Snippet
-        text="pnpm add ai@beta @ai-sdk/openai@beta @ai-sdk/react@beta zod"
-        dark
-      />
+      <Snippet text="pnpm add ai @ai-sdk/openai @ai-sdk/react zod" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="npm install ai@beta @ai-sdk/openai@beta @ai-sdk/react@beta zod"
-        dark
-      />
+      <Snippet text="npm install ai @ai-sdk/openai @ai-sdk/react zod" dark />
     </Tab>
     <Tab>
-      <Snippet
-        text="yarn add ai@beta @ai-sdk/openai@beta @ai-sdk/react@beta zod"
-        dark
-      />
+      <Snippet text="yarn add ai @ai-sdk/openai @ai-sdk/react zod" dark />
     </Tab>
   </Tabs>
 </div>

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -28,10 +28,10 @@ description: Learn how to upgrade AI SDK 4.0 to 5.0 Beta.
 
 You need to update the following packages to the following versions in your `package.json` file(s):
 
-- `ai` package: `5.0.0@beta`
-- `@ai-sdk/provider` package: `2.0.0@beta`
-- `@ai-sdk/provider-utils` package: `3.0.0@beta`
-- `@ai-sdk/*` packages: `2.0.0@beta` (other `@ai-sdk` packages)
+- `ai` package: `5.0.0`
+- `@ai-sdk/provider` package: `2.0.0`
+- `@ai-sdk/provider-utils` package: `3.0.0`
+- `@ai-sdk/*` packages: `2.0.0` (other `@ai-sdk` packages)
 
 Additionally, you need to update the following peer dependencies:
 
@@ -40,7 +40,7 @@ Additionally, you need to update the following peer dependencies:
 An example upgrade command would be:
 
 ```
-npm install ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta zod@3.25.0
+npm install ai @ai-sdk/react @ai-sdk/openai zod@3.25.0
 ```
 
 ## Codemods
@@ -62,25 +62,25 @@ You can run all codemods provided as part of the 5.0 upgrade process by running
 the following command from the root of your project:
 
 ```sh
-npx @ai-sdk/codemod@beta upgrade
+npx @ai-sdk/codemod upgrade
 ```
 
 To run only the v5 codemods (v4 → v5 migration):
 
 ```sh
-npx @ai-sdk/codemod@beta v5
+npx @ai-sdk/codemod v5
 ```
 
 Individual codemods can be run by specifying the name of the codemod:
 
 ```sh
-npx @ai-sdk/codemod@beta <codemod-name> <path>
+npx @ai-sdk/codemod <codemod-name> <path>
 ```
 
 For example, to run a specific v5 codemod:
 
 ```sh
-npx @ai-sdk/codemod@beta v5/rename-format-stream-part src/
+npx @ai-sdk/codemod v5/rename-format-stream-part src/
 ```
 
 See also the [table of codemods](#codemod-table). In addition, the latest set of
@@ -1127,7 +1127,7 @@ import { useChat } from '@ai-sdk/react';
 ```
 
 <Note>
-  Don't forget to install the new package: `npm install @ai-sdk/react@beta`
+  Don't forget to install the new package: `npm install @ai-sdk/react`
 </Note>
 
 ### useChat Changes
@@ -1879,7 +1879,7 @@ const response = createUIMessageStreamResponse({
 ```
 
 <Note>
-  Don't forget to install the new package: `npm install @ai-sdk/langchain@beta`
+  Don't forget to install the new package: `npm install @ai-sdk/langchain`
 </Note>
 
 #### LlamaIndex Adapter Moved to `@ai-sdk/llamaindex`
@@ -1902,7 +1902,7 @@ const response = createUIMessageStreamResponse({
 ```
 
 <Note>
-  Don't forget to install the new package: `npm install @ai-sdk/llamaindex@beta`
+  Don't forget to install the new package: `npm install @ai-sdk/llamaindex`
 </Note>
 
 ## Streaming Architecture

--- a/content/docs/10-cli/index.mdx
+++ b/content/docs/10-cli/index.mdx
@@ -7,7 +7,7 @@ description: Learn about the AI SDK CLI.
 
 The AI SDK CLI is a command-line tool for interacting with AI models directly from your terminal. Generate text, attach files, and stream responses using a simple command-line interface.
 
-<Snippet text="npx ai@beta 'Hello, world!'" />
+<Snippet text="npx ai 'Hello, world!'" />
 
 ## Getting Started
 

--- a/content/providers/03-community-providers/100-gemini-cli.mdx
+++ b/content/providers/03-community-providers/100-gemini-cli.mdx
@@ -24,13 +24,13 @@ The Gemini CLI provider is available in the `ai-sdk-provider-gemini-cli` module.
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm add ai-sdk-provider-gemini-cli@beta ai@beta" dark />
+    <Snippet text="pnpm add ai-sdk-provider-gemini-cli ai" dark />
   </Tab>
   <Tab>
-    <Snippet text="npm install ai-sdk-provider-gemini-cli@beta ai@beta" dark />
+    <Snippet text="npm install ai-sdk-provider-gemini-cli ai" dark />
   </Tab>
   <Tab>
-    <Snippet text="yarn add ai-sdk-provider-gemini-cli@beta ai@beta" dark />
+    <Snippet text="yarn add ai-sdk-provider-gemini-cli ai" dark />
   </Tab>
 </Tabs>
 

--- a/content/providers/03-community-providers/99-claude-code.mdx
+++ b/content/providers/03-community-providers/99-claude-code.mdx
@@ -24,13 +24,13 @@ The Claude Code provider is available in the `ai-sdk-provider-claude-code` modul
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
-    <Snippet text="pnpm add ai-sdk-provider-claude-code@beta ai@beta" dark />
+    <Snippet text="pnpm add ai-sdk-provider-claude-code ai" dark />
   </Tab>
   <Tab>
-    <Snippet text="npm install ai-sdk-provider-claude-code@beta ai@beta" dark />
+    <Snippet text="npm install ai-sdk-provider-claude-code ai" dark />
   </Tab>
   <Tab>
-    <Snippet text="yarn add ai-sdk-provider-claude-code@beta ai@beta" dark />
+    <Snippet text="yarn add ai-sdk-provider-claude-code ai" dark />
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## background

ai sdk is now generally available and no longer in beta, but docs still referenced @beta installation commands.

## summary

- remove @beta tags from pnpm add ai@beta commands
- update installation instructions to use stable release

## verification

- all installation commands now reference stable v5
- docs reflect releas

## tasks

- [x] removed @beta from installation commands across docs
- [x] updated package installation references to stable version