### PR TITLE
fix(ai): Set status to ready when reconnect stream is null

### DIFF
--- a/.changeset/tender-kids-film.md
+++ b/.changeset/tender-kids-film.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Set status to ready when reconnect stream is null

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -499,6 +499,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         });
 
         if (reconnect == null) {
+          this.setStatus({ status: 'ready' });
           return; // no active stream found, so we do not resume
         }
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

In the resume-stream flow, an active stream may not exist. In this case, the server returns 204 and the client should move on. However, prior to this fix, the useChat status would remain as "submitted" instead of being reset to "ready".

## Summary

<!-- What did you change? -->

This commit addresses the issue by setting status to "ready" before returning early in the makeRequest function.

## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

To reproduce the issue, call `resumeStream` when there is no active stream. Make sure your server is returning 204 in this case. If you log the `status` returned from `useChat`, you can see that it stays as `submitted`. It never gets reset back to `ready`.

With this fix in place, the logs showed `status` being reset to `ready` after receiving the 204 from the server.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)