### PR TITLE
fix(providers/google-vertex): Make revised prompt nullish in schema

### DIFF
--- a/.changeset/six-flowers-unite.md
+++ b/.changeset/six-flowers-unite.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+Make revisedPrompt nullish in schema

--- a/packages/google-vertex/src/google-vertex-image-model.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.ts
@@ -108,9 +108,7 @@ export class GoogleVertexImageModel implements ImageModelV2 {
                 prompt: revisedPrompt,
               } = prediction;
 
-              return {
-                revisedPrompt,
-              };
+              return { ...(revisedPrompt != null && { revisedPrompt }) };
             }) ?? [],
         },
       },
@@ -126,7 +124,7 @@ const vertexImageResponseSchema = z.object({
       z.object({
         bytesBase64Encoded: z.string(),
         mimeType: z.string(),
-        prompt: z.string(),
+        prompt: z.string().nullish(),
       }),
     )
     .nullish(),


### PR DESCRIPTION
## Background

[Models are not guaranteed to have a `prompt` key in the response](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api#model-results-rest):

<img width="920" height="458" alt="image" src="https://github.com/user-attachments/assets/325d5134-ad69-4403-8e7c-8d794f7454e7" />

This causes an error from the SDK when using imagen-4.0 models, resulting in broken responses despite a successful generation. An error might look like:

```
message: 'Type validation failed: Value: {"predictions":[{"mimeType":"image/png","bytesBase64Encoded":"base64image"}]}.\nError message: [{"expected":"string","code":"invalid_type","path":["predictions",0,"prompt"],"message":"Invalid input: expected string, received undefined"}]'
```

Where the response might be:

```
responseBody: {
  "predictions": [
    {
      "mimeType": "image/png",
      "bytesBase64Encoded": "base64image"
    }
  ]
}
```

This is triggered by the call to [`safeParseJson` in packages/provider-utils/src/response-handler.ts](https://github.com/vercel/ai/blob/5734d676f2828a56e8d1df4a0ab10152e15955a8/packages/provider-utils/src/response-handler.ts#L143), which will be passed the responseSchema, which is expecting `prompt`, when it is not guaranteed to exist

## Summary

- Made the `prompt` value `nullish` in the response schema
- Only optionally include the revised prompt if provided.

## Verification

Do a generation on Vertex with `imagen-4.0-generate-preview-06-06`, and you wont' receive an error
## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
