### PR TITLE
docs(ai): update ToolCallUnion/ToolResultUnion to TypedToolCall/TypedToolResult

### DIFF
--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -434,13 +434,13 @@ on the tool that has been invoked.
 Similarly, the tool results are typed with `ToolResult<NAME extends string, ARGS, RESULT>`.
 
 The tools in `streamText` and `generateText` are defined as a `ToolSet`.
-The type inference helpers `ToolCallUnion<TOOLS extends ToolSet>`
-and `ToolResultUnion<TOOLS extends ToolSet>` can be used to
+The type inference helpers `TypedToolCall<TOOLS extends ToolSet>`
+and `TypedToolResult<TOOLS extends ToolSet>` can be used to
 extract the tool call and tool result types from the tools.
 
 ```ts highlight="18-19,23-24"
 import { openai } from '@ai-sdk/openai';
-import { ToolCallUnion, ToolResultUnion, generateText, tool } from 'ai';
+import { TypedToolCall, TypedToolResult, generateText, tool } from 'ai';
 import { z } from 'zod';
 
 const myToolSet = {
@@ -456,8 +456,8 @@ const myToolSet = {
   }),
 };
 
-type MyToolCall = ToolCallUnion<typeof myToolSet>;
-type MyToolResult = ToolResultUnion<typeof myToolSet>;
+type MyToolCall = TypedToolCall<typeof myToolSet>;
+type MyToolResult = TypedToolResult<typeof myToolSet>;
 
 async function generateSomething(prompt: string): Promise<{
   text: string;

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1580,13 +1580,13 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'toolCalls',
-      type: 'Promise<ToolCallUnion<TOOLS>[]>',
+      type: 'Promise<TypedToolCall<TOOLS>[]>',
       description:
         'The tool calls that have been executed. Resolved when the response is finished.',
     },
     {
       name: 'toolResults',
-      type: 'Promise<ToolResultUnion<TOOLS>[]>',
+      type: 'Promise<TypedToolResult<TOOLS>[]>',
       description:
         'The tool results that have been generated. Resolved when the all tool executions are finished.',
     },

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -2871,8 +2871,8 @@ import {
 import {
   ToolCall,
   ToolResult,
-  ResultUnion,
-  ToolCallUnion,
+  TypedToolResult,
+  TypedToolCall,
   ToolChoice,
 } from '@ai-sdk/provider-utils';
 ```


### PR DESCRIPTION
## background

The type inference helpers `ToolCallUnion` and `ToolResultUnion` were renamed to `TypedToolCall` and `TypedToolResult` for better consistency with the actual type structure.

## summary

- update type helper names in tools documentation
- update reference documentation for streamText

## verification

- all documentation updated consistently

## tasks

- [x] update tools-and-tool-calling.mdx with new type names
- [x] update stream-text reference documentation
- [x] update provider-utils import examples

## future work
* none required - documentation now matches current implementation

related issue - #7690