### PR TITLE
docs(perplexity): Add support image input

### DIFF
--- a/content/providers/01-ai-sdk-providers/70-perplexity.mdx
+++ b/content/providers/01-ai-sdk-providers/70-perplexity.mdx
@@ -139,10 +139,10 @@ You can enable image responses by setting `return_images: true` in the provider 
 | Model                 | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | --------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | `sonar-deep-research` | <Cross size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
-| `sonar-reasoning-pro` | <Cross size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
-| `sonar-reasoning`     | <Cross size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
-| `sonar-pro`           | <Cross size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
-| `sonar`               | <Cross size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
+| `sonar-reasoning-pro` | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
+| `sonar-reasoning`     | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
+| `sonar-pro`           | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
+| `sonar`               | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 
 <Note>
   Please see the [Perplexity docs](https://docs.perplexity.ai) for detailed API


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->
`@ai-sdk/perplexity` now supports image input, a feature added in PR #7141.

## Summary

<!-- What did you change? -->
I've updated the Model Capabilities table to reflect that the `@ai-sdk/perplexity` package now supports image input.

