### PR TITLE
Fix Documentation guides

### DIFF
--- a/content/cookbook/00-guides/index.mdx
+++ b/content/cookbook/00-guides/index.mdx
@@ -13,27 +13,27 @@ These use-case specific guides are intended to help you build real applications 
       title: 'RAG Chatbot',
       description:
         'Learn how to build a retrieval-augmented generation chatbot with the AI SDK.',
-      href: '/docs/guides/rag-chatbot',
+      href: '/cookbook/guides/rag-chatbot',
     },
     {
       title: 'Multimodal Chatbot',
       description: 'Learn how to build a multimodal chatbot with the AI SDK.',
-      href: '/docs/guides/multi-modal-chatbot',
+      href: '/cookbook/guides/multi-modal-chatbot',
     },
     {
       title: 'Get started with Llama 3.1',
       description: 'Get started with Llama 3.1 using the AI SDK.',
-      href: '/docs/guides/llama-3_1',
+      href: '/cookbook/guides/llama-3_1',
     },
     {
       title: 'Get started with OpenAI o1',
       description: 'Get started with OpenAI o1 using the AI SDK.',
-      href: '/docs/guides/o1',
+      href: '/cookbook/guides/o1',
     },
     {
       title: 'Get started with Gemini 2.5',
       description: 'Get started with Gemini 2.5 using the AI SDK.',
-      href: '/docs/guides/gemini-2-5',
+      href: '/cookbook/guides/gemini-2-5',
     },
   ]}
 />


### PR DESCRIPTION
# what does this PR do? 

Fixes the urls on the https://ai-sdk.dev/cookbook/guides page. Currently they redicted from /docs to /cookbook which works for all except Gemini. There it ends up on a 404. This fixes those links to be correct. 