### PR TITLE
refactor(hume-provider): use `satisfies` for stricter type checking of `HumeProvider`

### DIFF
--- a/packages/hume/src/hume-provider.ts
+++ b/packages/hume/src/hume-provider.ts
@@ -1,4 +1,4 @@
-import { ProviderV2, SpeechModelV2 } from '@ai-sdk/provider';
+import { SpeechModelV2, ProviderV2 } from '@ai-sdk/provider';
 import { FetchFunction, loadApiKey } from '@ai-sdk/provider-utils';
 import { HumeSpeechModel } from './hume-speech-model';
 
@@ -58,10 +58,10 @@ export function createHume(options: HumeProviderSettings = {}): HumeProvider {
     };
   };
 
-  provider.speech = createSpeechModel;
-  provider.speechModel = createSpeechModel;
+  // provider.speech = createSpeechModel;
+  // provider.speechModel = createSpeechModel;
 
-  return provider satisfies HumeProvider;
+  return provider as HumeProvider;
 }
 
 /**

--- a/packages/hume/src/hume-provider.ts
+++ b/packages/hume/src/hume-provider.ts
@@ -1,4 +1,4 @@
-import { SpeechModelV2, ProviderV2 } from '@ai-sdk/provider';
+import { ProviderV2, SpeechModelV2 } from '@ai-sdk/provider';
 import { FetchFunction, loadApiKey } from '@ai-sdk/provider-utils';
 import { HumeSpeechModel } from './hume-speech-model';
 
@@ -61,7 +61,7 @@ export function createHume(options: HumeProviderSettings = {}): HumeProvider {
   provider.speech = createSpeechModel;
   provider.speechModel = createSpeechModel;
 
-  return provider as HumeProvider;
+  return provider satisfies HumeProvider;
 }
 
 /**

--- a/packages/hume/src/hume-provider.ts
+++ b/packages/hume/src/hume-provider.ts
@@ -58,8 +58,8 @@ export function createHume(options: HumeProviderSettings = {}): HumeProvider {
     };
   };
 
-  // provider.speech = createSpeechModel;
-  // provider.speechModel = createSpeechModel;
+  provider.speech = createSpeechModel;
+  provider.speechModel = createSpeechModel;
 
   return provider as HumeProvider;
 }

--- a/packages/hume/src/hume-provider.ts
+++ b/packages/hume/src/hume-provider.ts
@@ -61,7 +61,7 @@ export function createHume(options: HumeProviderSettings = {}): HumeProvider {
   provider.speech = createSpeechModel;
   provider.speechModel = createSpeechModel;
 
-  return provider as HumeProvider;
+  return provider satisfies HumeProvider;
 }
 
 /**


### PR DESCRIPTION
## Summary

Using `as` for type assertions can mask structural mismatches.
Switching to satisfies improves type safety by ensuring the provider truly fills the type of `HumeProvider`

| with `satisfies` | with `as` |
|--------|--------|
| <img width="400" height="205" alt="image" src="https://github.com/user-attachments/assets/3c76e12d-2b96-4265-803b-233a8bf61b55" /> | <img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/78acb34d-3f3d-4708-90b8-ae1ebe92bcb3" /> |


## Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (independent of automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
