### PR TITLE
feat(provider/gateway): Hide Cohere embedding models with no pricing info

### DIFF
--- a/.changeset/shy-jeans-grow.md
+++ b/.changeset/shy-jeans-grow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): Hide Cohere embedding models with no pricing info

--- a/packages/gateway/src/gateway-embedding-model-settings.ts
+++ b/packages/gateway/src/gateway-embedding-model-settings.ts
@@ -1,9 +1,5 @@
 export type GatewayEmbeddingModelId =
   | 'amazon/titan-embed-text-v2'
-  // | 'cohere/embed-english-light-v3.0'
-  // | 'cohere/embed-english-v3.0'
-  // | 'cohere/embed-multilingual-light-v3.0'
-  // | 'cohere/embed-multilingual-v3.0'
   | 'cohere/embed-v4.0'
   | 'google/gemini-embedding-001'
   | 'google/text-embedding-005'

--- a/packages/gateway/src/gateway-embedding-model-settings.ts
+++ b/packages/gateway/src/gateway-embedding-model-settings.ts
@@ -1,9 +1,9 @@
 export type GatewayEmbeddingModelId =
   | 'amazon/titan-embed-text-v2'
-  | 'cohere/embed-english-light-v3.0'
-  | 'cohere/embed-english-v3.0'
-  | 'cohere/embed-multilingual-light-v3.0'
-  | 'cohere/embed-multilingual-v3.0'
+  // | 'cohere/embed-english-light-v3.0'
+  // | 'cohere/embed-english-v3.0'
+  // | 'cohere/embed-multilingual-light-v3.0'
+  // | 'cohere/embed-multilingual-v3.0'
   | 'cohere/embed-v4.0'
   | 'google/gemini-embedding-001'
   | 'google/text-embedding-005'


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

4 Cohere embedding models were added as part of the Gateway embeddings feature, but there isn't any pricing info available.

## Summary

Commented them out (in the hopes that they can be re-added in the future)

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks as needed.

Please check if the PR fulfills the following requirements:
-->

- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)