### PR TITLE
fix(ai/ui): convert provider metadata for system messages to model messages

### DIFF
--- a/.changeset/good-moose-guess.md
+++ b/.changeset/good-moose-guess.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai/ui): convert provider metadata for system messages to model messages

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -70,7 +70,7 @@ describe('convertToModelMessages', () => {
 
     it('should convert a system message with Anthropic cache control metadata', () => {
       const SYSTEM_PROMPT = 'You are a helpful assistant.';
-      
+
       const systemMessage = {
         id: 'system',
         role: 'system' as const,

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -13,6 +13,60 @@ describe('convertToModelMessages', () => {
 
       expect(result).toEqual([{ role: 'system', content: 'System message' }]);
     });
+
+    it('should convert a system message with provider metadata', () => {
+      const result = convertToModelMessages([
+        {
+          role: 'system',
+          parts: [
+            {
+              text: 'System message with metadata',
+              type: 'text',
+              providerMetadata: { testProvider: { systemSignature: 'abc123' } },
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'system',
+          content: 'System message with metadata',
+          providerOptions: { testProvider: { systemSignature: 'abc123' } },
+        },
+      ]);
+    });
+
+    it('should merge provider metadata from multiple text parts in system message', () => {
+      const result = convertToModelMessages([
+        {
+          role: 'system',
+          parts: [
+            {
+              text: 'Part 1',
+              type: 'text',
+              providerMetadata: { provider1: { key1: 'value1' } },
+            },
+            {
+              text: ' Part 2',
+              type: 'text',
+              providerMetadata: { provider2: { key2: 'value2' } },
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'system',
+          content: 'Part 1 Part 2',
+          providerOptions: {
+            provider1: { key1: 'value1' },
+            provider2: { key2: 'value2' },
+          },
+        },
+      ]);
+    });
   });
 
   describe('user message', () => {

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -67,6 +67,40 @@ describe('convertToModelMessages', () => {
         },
       ]);
     });
+
+    it('should convert a system message with Anthropic cache control metadata', () => {
+      const SYSTEM_PROMPT = 'You are a helpful assistant.';
+      
+      const systemMessage = {
+        id: 'system',
+        role: 'system' as const,
+        parts: [
+          {
+            type: 'text' as const,
+            text: SYSTEM_PROMPT,
+            providerMetadata: {
+              anthropic: {
+                cacheControl: { type: 'ephemeral' },
+              },
+            },
+          },
+        ],
+      };
+
+      const result = convertToModelMessages([systemMessage]);
+
+      expect(result).toEqual([
+        {
+          role: 'system',
+          content: SYSTEM_PROMPT,
+          providerOptions: {
+            anthropic: {
+              cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+      ]);
+    });
   });
 
   describe('user message', () => {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -54,7 +54,7 @@ export function convertToModelMessages(
         const content = textParts
           .map(part => (part.type === 'text' ? part.text : ''))
           .join('');
-        
+
         // Collect provider metadata from text parts
         const providerMetadata = textParts.reduce((acc, part) => {
           if (part.type === 'text' && part.providerMetadata != null) {
@@ -62,7 +62,7 @@ export function convertToModelMessages(
           }
           return acc;
         }, {});
-        
+
         modelMessages.push({
           role: 'system',
           content,

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -51,13 +51,9 @@ export function convertToModelMessages(
     switch (message.role) {
       case 'system': {
         const textParts = message.parts.filter(part => part.type === 'text');
-        const content = textParts
-          .map(part => (part.type === 'text' ? part.text : ''))
-          .join('');
 
-        // Collect provider metadata from text parts
         const providerMetadata = textParts.reduce((acc, part) => {
-          if (part.type === 'text' && part.providerMetadata != null) {
+          if (part.providerMetadata != null) {
             return { ...acc, ...part.providerMetadata };
           }
           return acc;
@@ -65,7 +61,7 @@ export function convertToModelMessages(
 
         modelMessages.push({
           role: 'system',
-          content,
+          content: textParts.map(part => part.text).join(''),
           ...(Object.keys(providerMetadata).length > 0
             ? { providerOptions: providerMetadata }
             : {}),

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -50,11 +50,25 @@ export function convertToModelMessages(
   for (const message of messages) {
     switch (message.role) {
       case 'system': {
+        const textParts = message.parts.filter(part => part.type === 'text');
+        const content = textParts
+          .map(part => (part.type === 'text' ? part.text : ''))
+          .join('');
+        
+        // Collect provider metadata from text parts
+        const providerMetadata = textParts.reduce((acc, part) => {
+          if (part.type === 'text' && part.providerMetadata != null) {
+            return { ...acc, ...part.providerMetadata };
+          }
+          return acc;
+        }, {});
+        
         modelMessages.push({
           role: 'system',
-          content: message.parts
-            .map(part => (part.type === 'text' ? part.text : ''))
-            .join(''),
+          content,
+          ...(Object.keys(providerMetadata).length > 0
+            ? { providerOptions: providerMetadata }
+            : {}),
         });
         break;
       }


### PR DESCRIPTION
@lgrammel Please take a look! Just doing my part to help out with an open issue. FYI @raymondhechen

## Background
- https://github.com/vercel/ai/issues/7612
> bug: provider metadata for system ui messages should be converted to model msgs

## Summary
- Added unit tests for system message conversion that match existing assistant + user unit tests with provider metadata
- Added a unit test for the specific case mentioned in the source issue
- Grab provider metadata from the content parts and apply to the final model message

## Verification
- Unit tests matching that of the assistant and user tests
- Unit test matching the original issue
- All unit tests work as expected
- Quick vibecoded test harness with UI messages with anthropic cache control headers works as expected and fills + reads from cache with this change