### PR TITLE
Fix: Resume stream status not returning to 'ready' when no active stream exists

### DIFF
--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -499,6 +499,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         });
 
         if (reconnect == null) {
+          this.setStatus({ status: 'ready' });
           return; // no active stream found, so we do not resume
         }
 


### PR DESCRIPTION
## Background

When using `resume: true` in `useChat`, the chat status gets stuck in `'submitted'` state if there's no active stream to resume. This happens because `makeRequest()` sets status to `'submitted'` but exits early without resetting to `'ready'` when `reconnectToStream()` returns `null`.

## Summary

Added `this.setStatus({ status: 'ready' })` in `makeRequest()` before early return when no active stream is found for resumption.

**Changed:**
- `packages/ai/src/ui/chat.ts` line 502: Set status to `'ready'` when `reconnect == null`

## Verification

1. Create a chat with `resume: true`
2. Verify status transitions from `'submitted'` → `'ready'` (not stuck in `'submitted'`)
3. Confirm existing behavior unchanged when active stream exists: `'submitted'` → `'streaming'` → `'ready'`

## Related Issues

Fixes chat status management issue when resuming non-existent streams.