### PR TITLE
feat(providers/google-vertex): Add taskType support for Text Embedding Model

### DIFF
--- a/.changeset/itchy-wombats-behave.md
+++ b/.changeset/itchy-wombats-behave.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+feat(providers/google-vertex) Add TaskType support for Text Embedding Model

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -679,6 +679,7 @@ const { embedding } = await embed({
   providerOptions: {
     google: {
       outputDimensionality: 512, // optional, number of dimensions for the embedding
+      taskType: 'SEMANTIC_SIMILARITY', // optional, specifies the task type for generating embeddings
     },
   },
 });
@@ -689,6 +690,19 @@ The following optional provider options are available for Google Vertex AI embed
 - **outputDimensionality**: _number_
 
   Optional reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end.
+
+- **taskType**: _string_
+
+  Optional. Specifies the task type for generating embeddings. Supported task types include:
+
+  - `SEMANTIC_SIMILARITY`: Optimized for text similarity.
+  - `CLASSIFICATION`: Optimized for text classification.
+  - `CLUSTERING`: Optimized for clustering texts based on similarity.
+  - `RETRIEVAL_DOCUMENT`: Optimized for document retrieval.
+  - `RETRIEVAL_QUERY`: Optimized for query-based retrieval.
+  - `QUESTION_ANSWERING`: Optimized for answering questions.
+  - `FACT_VERIFICATION`: Optimized for verifying factual information.
+  - `CODE_RETRIEVAL_QUERY`: Optimized for retrieving code blocks based on natural language queries.
 
 #### Model Capabilities
 

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -24,7 +24,11 @@ const server = createTestServer({
 
 describe('GoogleVertexEmbeddingModel', () => {
   const mockModelId = 'textembedding-gecko@001';
-  const mockProviderOptions = { outputDimensionality: 768 };
+  const mockProviderOptions = {
+    outputDimensionality: 768,
+    taskType: 'SEMANTIC_SIMILARITY',
+  };
+
   const mockConfig = {
     provider: 'google-vertex',
     region: 'us-central1',
@@ -117,6 +121,24 @@ describe('GoogleVertexEmbeddingModel', () => {
       instances: testValues.map(value => ({ content: value })),
       parameters: {
         outputDimensionality: mockProviderOptions.outputDimensionality,
+        taskType: mockProviderOptions.taskType,
+      },
+    });
+  });
+
+  it('should pass the taskType setting', async () => {
+    prepareJsonResponse();
+
+    await model.doEmbed({
+      values: testValues,
+      providerOptions: { google: { taskType: 'SEMANTIC_SIMILARITY' } },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      instances: testValues.map(value => ({ content: value })),
+      parameters: {
+        outputDimensionality: mockProviderOptions.outputDimensionality,
+        taskType: mockProviderOptions.taskType,
       },
     });
   });

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -131,13 +131,12 @@ describe('GoogleVertexEmbeddingModel', () => {
 
     await model.doEmbed({
       values: testValues,
-      providerOptions: { google: { taskType: 'SEMANTIC_SIMILARITY' } },
+      providerOptions: { google: { taskType: mockProviderOptions.taskType } },
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       instances: testValues.map(value => ({ content: value })),
       parameters: {
-        outputDimensionality: mockProviderOptions.outputDimensionality,
         taskType: mockProviderOptions.taskType,
       },
     });

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -80,6 +80,7 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV2<string> {
         instances: values.map(value => ({ content: value })),
         parameters: {
           outputDimensionality: googleOptions.outputDimensionality,
+          taskType: googleOptions.taskType,
         },
       },
       failedResponseHandler: googleVertexFailedResponseHandler,

--- a/packages/google-vertex/src/google-vertex-embedding-options.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-options.ts
@@ -18,6 +18,31 @@ export const googleVertexEmbeddingProviderOptions = z.object({
    * If set, excessive values in the output embedding are truncated from the end.
    */
   outputDimensionality: z.number().optional(),
+
+  /**
+   * Optional. Specifies the task type for generating embeddings.
+   * Supported task types:
+   * - SEMANTIC_SIMILARITY: Optimized for text similarity.
+   * - CLASSIFICATION: Optimized for text classification.
+   * - CLUSTERING: Optimized for clustering texts based on similarity.
+   * - RETRIEVAL_DOCUMENT: Optimized for document retrieval.
+   * - RETRIEVAL_QUERY: Optimized for query-based retrieval.
+   * - QUESTION_ANSWERING: Optimized for answering questions.
+   * - FACT_VERIFICATION: Optimized for verifying factual information.
+   * - CODE_RETRIEVAL_QUERY: Optimized for retrieving code blocks based on natural language queries.
+   */
+  taskType: z
+    .enum([
+      'SEMANTIC_SIMILARITY',
+      'CLASSIFICATION',
+      'CLUSTERING',
+      'RETRIEVAL_DOCUMENT',
+      'RETRIEVAL_QUERY',
+      'QUESTION_ANSWERING',
+      'FACT_VERIFICATION',
+      'CODE_RETRIEVAL_QUERY',
+    ])
+    .optional(),
 });
 
 export type GoogleVertexEmbeddingProviderOptions = z.infer<


### PR DESCRIPTION
Added support of task types in @ai-sdk/google-vertex Text Embedding Models https://github.com/vercel/ai/issues/7673

## Background
According to [Docs](https://ai.google.dev/gemini-api/docs/embeddings#task-types), Google Generative AI supports optimized embeddings for performing various task types such as document retrival, semantic similarity, fact verification, etc. It will be great to support this Google Generative AI embedding settings also in AI SDK.

## Summary
Added support for task types in @ai-sdk/google-vertex Embedding Models.
a copy of [pr 5714](https://github.com/vercel/ai/pull/5714)

## Tasks
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If required, a patch changeset for relevant packages has been added
- [x] You've run pnpm prettier-fix to fix any formatting issues

## Related Issues
https://github.com/vercel/ai/issues/7673

