### PR TITLE
docs(nextjs-app-router): fix incorrect code block highlight lines

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -373,7 +373,7 @@ By setting `stopWhen: stepCountIs(5)`, you're allowing the model to use up to 5 
 
 Update your `app/api/chat/route.ts` file to add a new tool to convert the temperature from Fahrenheit to Celsius:
 
-```tsx filename="app/api/chat/route.ts" highlight="27-40"
+```tsx filename="app/api/chat/route.ts" highlight="34-47"
 import { openai } from '@ai-sdk/openai';
 import {
   streamText,


### PR DESCRIPTION
# what does this PR do?

Previously, the highlight=\"27-40\" range included unrelated lines and missed part of the actual convertFahrenheitToCelsius tool. Updated to highlight=\"34-47\" to accurately reflect the new tool block for better clarity and correctness.

