### PR TITLE
feat(provider/openai-compatible): Update OpenAI compat embedding schema to support providerMetadata

### DIFF
--- a/.changeset/fluffy-avocados-guess.md
+++ b/.changeset/fluffy-avocados-guess.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+feat(provider/openai-compatible): Update OpenAI compat embedding schema to support providerMetadata

--- a/packages/openai-compatible/src/openai-compatible-embedding-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-embedding-model.ts
@@ -132,6 +132,7 @@ export class OpenAICompatibleEmbeddingModel
       usage: response.usage
         ? { tokens: response.usage.prompt_tokens }
         : undefined,
+      providerMetadata: response.providerMetadata,
       response: { headers: responseHeaders, body: rawValue },
     };
   }
@@ -142,4 +143,7 @@ export class OpenAICompatibleEmbeddingModel
 const openaiTextEmbeddingResponseSchema = z.object({
   data: z.array(z.object({ embedding: z.array(z.number()) })),
   usage: z.object({ prompt_tokens: z.number() }).nullish(),
+  providerMetadata: z
+    .record(z.string(), z.record(z.string(), z.any()))
+    .optional(),
 });


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

We're adding OpenAI compat support in the Gateway and making the `providerMetadata` available to the client

## Summary

Updates the schema to support the providerMetadata field

## Verification

Tested manually with example scripts

## Tasks

- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)