### PR TITLE
feat(openai): add file_search_call support to responses api

### DIFF
--- a/.changeset/little-doors-laugh.md
+++ b/.changeset/little-doors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add file_search_call support to responses api

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -10,6 +10,7 @@ export type OpenAIResponsesMessage =
   | OpenAIResponsesFunctionCallOutput
   | OpenAIWebSearchCall
   | OpenAIComputerCall
+  | OpenAIFileSearchCall
   | OpenAIResponsesReasoning;
 
 export type OpenAIResponsesSystemMessage = {
@@ -32,6 +33,7 @@ export type OpenAIResponsesAssistantMessage = {
     | { type: 'output_text'; text: string }
     | OpenAIWebSearchCall
     | OpenAIComputerCall
+    | OpenAIFileSearchCall
   >;
   id?: string;
 };
@@ -58,6 +60,12 @@ export type OpenAIWebSearchCall = {
 
 export type OpenAIComputerCall = {
   type: 'computer_call';
+  id: string;
+  status?: string;
+};
+
+export type OpenAIFileSearchCall = {
+  type: 'file_search_call';
   id: string;
   status?: string;
 };

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2640,7 +2640,8 @@ describe('OpenAIResponsesLanguageModel', () => {
           includeRawChunks: false,
         });
 
-        expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        expect(await convertReadableStreamToArray(stream))
+          .toMatchInlineSnapshot(`
           [
             {
               "type": "stream-start",

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2620,6 +2620,75 @@ describe('OpenAIResponsesLanguageModel', () => {
           ]
         `);
       });
+
+      it('should handle file_search tool calls', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'stream-chunks',
+          chunks: [
+            `data:{"type":"response.created","response":{"id":"resp_67cf3390786881908b27489d7e8cfb6b","object":"response","created_at":1741632400,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"file_search"}],"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+            `data:{"type":"response.output_item.added","output_index":0,"item":{"type":"file_search_call","id":"fs_67cf3390e9608190869b5d45698a7067","status":"in_progress"}}\n\n`,
+            `data:{"type":"response.output_item.done","output_index":0,"item":{"type":"file_search_call","id":"fs_67cf3390e9608190869b5d45698a7067","status":"completed"}}\n\n`,
+            `data:{"type":"response.output_item.added","output_index":1,"item":{"type":"message","id":"msg_67cf33924ea88190b8c12bf68c1f6416","status":"in_progress","role":"assistant","content":[]}}\n\n`,
+            `data:{"type":"response.output_text.delta","item_id":"msg_67cf33924ea88190b8c12bf68c1f6416","output_index":1,"content_index":0,"delta":"Based on the search results, here is the information you requested."}\n\n`,
+            `data:{"type":"response.output_item.done","output_index":1,"item":{"type":"message","id":"msg_67cf33924ea88190b8c12bf68c1f6416","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Based on the search results, here is the information you requested.","annotations":[]}]}}\n\n`,
+            `data:{"type":"response.completed","response":{"id":"resp_67cf3390786881908b27489d7e8cfb6b","object":"response","created_at":1741632400,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[{"type":"file_search_call","id":"fs_67cf3390e9608190869b5d45698a7067","status":"completed"},{"type":"message","id":"msg_67cf33924ea88190b8c12bf68c1f6416","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Based on the search results, here is the information you requested.","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"file_search"}],"top_p":1,"truncation":"disabled","usage":{"input_tokens":327,"input_tokens_details":{"cached_tokens":0},"output_tokens":834,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1161},"user":null,"metadata":{}}}\n\n`,
+          ],
+        };
+
+        const { stream } = await createModel('gpt-4o-mini').doStream({
+          prompt: TEST_PROMPT,
+          includeRawChunks: false,
+        });
+
+        expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+          [
+            {
+              "type": "stream-start",
+              "warnings": [],
+            },
+            {
+              "id": "resp_67cf3390786881908b27489d7e8cfb6b",
+              "modelId": "gpt-4o-mini-2024-07-18",
+              "timestamp": 2025-03-10T18:46:40.000Z,
+              "type": "response-metadata",
+            },
+            {
+              "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                },
+              },
+              "type": "text-start",
+            },
+            {
+              "delta": "Based on the search results, here is the information you requested.",
+              "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+              "type": "text-delta",
+            },
+            {
+              "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+              "type": "text-end",
+            },
+            {
+              "finishReason": "stop",
+              "providerMetadata": {
+                "openai": {
+                  "responseId": "resp_67cf3390786881908b27489d7e8cfb6b",
+                },
+              },
+              "type": "finish",
+              "usage": {
+                "cachedInputTokens": 0,
+                "inputTokens": 327,
+                "outputTokens": 834,
+                "reasoningTokens": 0,
+                "totalTokens": 1161,
+              },
+            },
+          ]
+        `);
+      });
     });
 
     describe('reasoning', () => {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -310,6 +310,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 status: z.string().optional(),
               }),
               z.object({
+                type: z.literal('file_search_call'),
+                id: z.string(),
+                status: z.string().optional(),
+              }),
+              z.object({
                 type: z.literal('reasoning'),
                 id: z.string(),
                 encrypted_content: z.string().nullish(),
@@ -442,6 +447,28 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             toolName: 'computer_use',
             result: {
               type: 'computer_use_tool_result',
+              status: part.status || 'completed',
+            },
+            providerExecuted: true,
+          });
+          break;
+        }
+
+        case 'file_search_call': {
+          content.push({
+            type: 'tool-call',
+            toolCallId: part.id,
+            toolName: 'file_search',
+            input: '',
+            providerExecuted: true,
+          });
+
+          content.push({
+            type: 'tool-result',
+            toolCallId: part.id,
+            toolName: 'file_search',
+            result: {
+              type: 'file_search_tool_result',
               status: part.status || 'completed',
             },
             providerExecuted: true,
@@ -890,6 +917,11 @@ const responseOutputItemAddedSchema = z.object({
       id: z.string(),
       status: z.string(),
     }),
+    z.object({
+      type: z.literal('file_search_call'),
+      id: z.string(),
+      status: z.string(),
+    }),
   ]),
 });
 
@@ -921,6 +953,11 @@ const responseOutputItemDoneSchema = z.object({
     }),
     z.object({
       type: z.literal('computer_call'),
+      id: z.string(),
+      status: z.literal('completed'),
+    }),
+    z.object({
+      type: z.literal('file_search_call'),
       id: z.string(),
       status: z.literal('completed'),
     }),


### PR DESCRIPTION
## background

openai responses api introduced file_search_call tool calls that weren't supported causing only text part to be including

## summary

- add file_search_call support to openai responses api types
- add tests for file_search call handling

## verification

- all tests pass including new file_search-specific test
- inline snapshot correctly captures file_search tool call streaming
- file_search calls parsed as tool-call and tool-result pairs with providerExecuted: true

## tasks

- [x] openai-responses-api-types.ts updated with OpenAIFileSearchCall type
- [x] openai-responses-language-model.ts handles file_search_call in streaming
- [x] tests added for file_search tool call streaming scenario
- [x] inline snapshot validation for correct parsing

related issue - #7740