### PR TITLE
fix(fal): handle null file_name and file_size in image responses

### DIFF
--- a/.changeset/chatty-candles-change.md
+++ b/.changeset/chatty-candles-change.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fal': patch
+---
+
+fix(fal): handle null file_name and file_size in image responses

--- a/packages/fal/src/fal-image-model.test.ts
+++ b/packages/fal/src/fal-image-model.test.ts
@@ -391,7 +391,8 @@ describe('FalImageModel', () => {
           timings: { inference: 5.875932216644287 },
           seed: 328395684,
           has_nsfw_concepts: [false],
-          prompt: 'A female model holding this book, keeping the book unchanged.',
+          prompt:
+            'A female model holding this book, keeping the book unchanged.',
         },
       };
 

--- a/packages/fal/src/fal-image-model.test.ts
+++ b/packages/fal/src/fal-image-model.test.ts
@@ -373,5 +373,54 @@ describe('FalImageModel', () => {
       expect(result.images[0]).toBeInstanceOf(Uint8Array);
       expect(result.images[1]).toBeInstanceOf(Uint8Array);
     });
+
+    it('should handle null file_name and file_size values', async () => {
+      server.urls['https://api.example.com/stable-diffusion-xl'].response = {
+        type: 'json-value',
+        body: {
+          images: [
+            {
+              url: 'https://api.example.com/image.png',
+              content_type: 'image/png',
+              file_name: null,
+              file_size: null,
+              width: 944,
+              height: 1104,
+            },
+          ],
+          timings: { inference: 5.875932216644287 },
+          seed: 328395684,
+          has_nsfw_concepts: [false],
+          prompt: 'A female model holding this book, keeping the book unchanged.',
+        },
+      };
+
+      const model = createBasicModel();
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        providerOptions: {},
+        size: undefined,
+        seed: undefined,
+        aspectRatio: undefined,
+      });
+
+      expect(result.images).toHaveLength(1);
+      expect(result.images[0]).toBeInstanceOf(Uint8Array);
+      expect(result.providerMetadata?.fal).toMatchObject({
+        images: [
+          {
+            width: 944,
+            height: 1104,
+            contentType: 'image/png',
+            fileName: null,
+            fileSize: null,
+            nsfw: false,
+          },
+        ],
+        timings: { inference: 5.875932216644287 },
+        seed: 328395684,
+      });
+    });
   });
 });

--- a/packages/fal/src/fal-image-model.ts
+++ b/packages/fal/src/fal-image-model.ts
@@ -214,18 +214,18 @@ const falImageSchema = z.object({
   height: z.number().optional(),
   content_type: z.string().optional(),
   // e.g. https://fal.ai/models/fal-ai/flowedit/api#schema-output
-  file_name: z.string().optional(),
+  file_name: z.string().nullable().optional(),
   file_data: z.string().optional(),
-  file_size: z.number().optional(),
+  file_size: z.number().nullable().optional(),
 });
 
 // https://fal.ai/models/fal-ai/lora/api#type-File
 const loraFileSchema = z.object({
   url: z.string(),
   content_type: z.string().optional(),
-  file_name: z.string().optional(),
+  file_name: z.string().nullable().optional(),
   file_data: z.string().optional(),
-  file_size: z.number().optional(),
+  file_size: z.number().nullable().optional(),
 });
 
 const commonResponseSchema = z.object({


### PR DESCRIPTION
## background

fal.ai kontext image editing model returns null values for file_name and file_size fields in image responses, but the ai sdk validation schema expected these fields to be string/number or undefined, causing type validation errors.

## summary

- update falImageSchema to allow nullable file_name and file_size fields
- update loraFileSchema for consistency
- added tests for null values scenario

## verification

- all tests pass including new test for null values
- kontext model responses with null file_name/file_size now validate successfully
- null values preserved in provider metadata as expected

## tasks

- [x] falImageSchema updated with nullable() for file_name and file_size
- [x] loraFileSchema updated for consistency
- [x] test case added replicating exact kontext scenario
- [x] test validates null values are preserved in metadata

## future work

* monitor other fal models that may return null values in different fields

related issue - #7735


