### PR TITLE
docs: add a2a community provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -78,6 +78,7 @@ The open-source community has created the following providers:
 - [Claude Code Provider](/providers/community-providers/claude-code) (`ai-sdk-provider-claude-code`)
 - [Built-in AI Provider](/providers/community-providers/built-in-ai) (`built-in-ai`)
 - [Gemini CLI Provider](/providers/community-providers/gemini-cli) (`ai-sdk-provider-gemini-cli`)
+- [A2A Provider](/providers/community-providers/a2a) (`a2a-ai-provider`)
 
 ## Self-Hosted Models
 

--- a/content/providers/03-community-providers/05-a2a.mdx
+++ b/content/providers/03-community-providers/05-a2a.mdx
@@ -41,7 +41,7 @@ Install the `a2a-ai-provider` from npm:
 To create a provider instance for an A2A server:
 
 ```ts
-import { a2a } from "a2a-ai-provider";
+import { a2a } from 'a2a-ai-provider';
 ```
 
 ## Examples
@@ -51,8 +51,8 @@ You can now use the provider with the AI SDK like this:
 ### `generateText`
 
 ```ts
-import { a2a } from "a2a-ai-provider";
-import { generateText } from "ai";
+import { a2a } from 'a2a-ai-provider';
+import { generateText } from 'ai';
 
 const result = await generateText({
   model: a2a('https://your-a2a-server.example.com'),
@@ -65,18 +65,18 @@ console.log(result.text);
 ### `streamText`
 
 ```ts
-import { a2a } from "a2a-ai-provider";
-import { streamText } from "ai"
+import { a2a } from 'a2a-ai-provider';
+import { streamText } from 'ai';
 
-const chatId = "unique-chat-id"; // for each conversation to keep history in a2a server
+const chatId = 'unique-chat-id'; // for each conversation to keep history in a2a server
 
 const streamResult = streamText({
   model: a2a('https://your-a2a-server.example.com'),
   prompt: 'What is love?',
   providerOptions: {
-    "a2a": {
-      "contextId": chatId,
-    }
+    a2a: {
+      contextId: chatId,
+    },
   },
 });
 

--- a/content/providers/03-community-providers/05-a2a.mdx
+++ b/content/providers/03-community-providers/05-a2a.mdx
@@ -1,0 +1,98 @@
+---
+title: A2A
+description: A2A Protocol Provider for the AI SDK
+---
+
+# A2A
+
+The [dracoblue/a2a-ai-provider](https://github.com/dracoblue/a2a-ai-provider) is a community provider enables the use of [A2A protocol](https://a2aproject.github.io/A2A/specification/) compliant agents with the [AI SDK](https://ai-sdk.dev/). This allows developers to stream, send, and receive text, tool calls, and artifacts using a standardized JSON-RPC interface over HTTP.
+
+<Note type="warning">
+  The `a2a-ai-provider` package is under constant development.
+</Note>
+
+The provider supports (by using the official a2a-js sdk [@a2a-js/sdk](https://github.com/a2aproject/a2a-js)):
+
+- **Streaming Text Responses** via `sendSubscribe` and SSE
+- **File & Artifact Uploads** to the A2A server
+- **Multi-modal Messaging** with support for text and file parts
+- **Full JSON-RPC 2.0 Compliance** for A2A-compatible LLM agents
+
+Learn more about A2A at the [A2A Project Site](https://a2aproject.github.io/A2A/).
+
+## Setup
+
+Install the `a2a-ai-provider` from npm:
+
+<Tabs items={['pnpm', 'npm', 'yarn']}>
+  <Tab>
+    <Snippet text="pnpm add a2a-ai-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="npm install a2a-ai-provider" dark />
+  </Tab>
+  <Tab>
+    <Snippet text="yarn add a2a-ai-provider" dark />
+  </Tab>
+</Tabs>
+
+## Provider Instance
+
+To create a provider instance for an A2A server:
+
+```ts
+import { a2a } from "a2a-ai-provider";
+```
+
+## Examples
+
+You can now use the provider with the AI SDK like this:
+
+### `generateText`
+
+```ts
+import { a2a } from "a2a-ai-provider";
+import { generateText } from "ai";
+
+const result = await generateText({
+  model: a2a('https://your-a2a-server.example.com'),
+  prompt: 'What is love?',
+});
+
+console.log(result.text);
+```
+
+### `streamText`
+
+```ts
+import { a2a } from "a2a-ai-provider";
+import { streamText } from "ai"
+
+const chatId = "unique-chat-id"; // for each conversation to keep history in a2a server
+
+const streamResult = streamText({
+  model: a2a('https://your-a2a-server.example.com'),
+  prompt: 'What is love?',
+  providerOptions: {
+    "a2a": {
+      "contextId": chatId,
+    }
+  },
+});
+
+await streamResult.consumeStream();
+
+console.log(await streamResult.content);
+```
+
+## Features
+
+- **Text Streaming**: Streams token-by-token output from the A2A server
+- **File Uploads**: Send files as part of your prompts
+- **Artifact Handling**: Receives file artifacts in streamed or final results
+
+## Additional Resources
+
+- [GitHub Repository](https://github.com/DracoBlue/a2a-ai-provider)
+- [A2A Protocol Spec](https://a2aproject.github.io/A2A/specification/)
+- License: MIT


### PR DESCRIPTION
## Background

For #7442 and #6639 I decided to create a community provider for the a2a protocol from https://a2a-protocol.org/latest/ .

## Summary

This is just a documentation change to add the a2a provider to the index.

## Manual Verification

Afterwards it should be available at https://ai-sdk.dev/providers/community-providers/a2a

## Tasks

- [x] Documentation has been added / updated (for bug fixes / features)

## Related Issues

- for the issue about a2a provider #7442
- for the discussion on a2a provider #6639
