### PR TITLE
fix(openai): missing url citations from web search tools

### DIFF
--- a/.changeset/rare-onions-argue.md
+++ b/.changeset/rare-onions-argue.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): missing url citations from web search tools

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -1903,7 +1903,7 @@ describe('doStream', () => {
           type: 'finish',
           finishReason: 'stop',
         }),
-      ])
+      ]),
     );
   });
 


### PR DESCRIPTION
## background

OpenAI's `web_search_preview` tool returns citation annotations in API responses to provide source attribution, but the AI SDK was not extracting these annotations, so we added them
## summary

- add url_citation annotation support to openai chat model
- extract citations as source content blocks in both streaming and non-streaming modes

## verification

- all tests pass including new annotation extraction tests
- citations properly converted to source content blocks with dynamic IDs
- works in both `generateText` and `streamText` modes

## tasks

- [x] annotations field added to openaiChatResponseSchema and openaiChatChunkSchema
- [x] citation processing in doGenerate and doStream methods
- [x] tests added for both streaming and non-streaming scenarios

## future work
* add file_citation annotation support for file_search tool

related issue - #7749