### PR TITLE
fix(fal): handle empty timings object in image responses

### DIFF
--- a/.changeset/shy-beers-behave.md
+++ b/.changeset/shy-beers-behave.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fal': patch
+---
+
+fix(fal): handle empty timings object in image responses

--- a/packages/fal/src/fal-image-model.test.ts
+++ b/packages/fal/src/fal-image-model.test.ts
@@ -423,5 +423,54 @@ describe('FalImageModel', () => {
         seed: 328395684,
       });
     });
+
+    it('should handle empty timings object', async () => {
+      server.urls['https://api.example.com/stable-diffusion-xl'].response = {
+        type: 'json-value',
+        body: {
+          images: [
+            {
+              url: 'https://api.example.com/image.png',
+              content_type: 'image/png',
+              file_name: null,
+              file_size: null,
+              width: 880,
+              height: 1184,
+            },
+          ],
+          timings: {},
+          seed: 235205040,
+          has_nsfw_concepts: [false],
+          prompt: 'Change the plates to colorful ones',
+        },
+      };
+
+      const model = createBasicModel();
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        providerOptions: {},
+        size: undefined,
+        seed: undefined,
+        aspectRatio: undefined,
+      });
+
+      expect(result.images).toHaveLength(1);
+      expect(result.images[0]).toBeInstanceOf(Uint8Array);
+      expect(result.providerMetadata?.fal).toMatchObject({
+        images: [
+          {
+            width: 880,
+            height: 1184,
+            contentType: 'image/png',
+            fileName: null,
+            fileSize: null,
+            nsfw: false,
+          },
+        ],
+        timings: {},
+        seed: 235205040,
+      });
+    });
   });
 });

--- a/packages/fal/src/fal-image-model.ts
+++ b/packages/fal/src/fal-image-model.ts
@@ -231,7 +231,7 @@ const loraFileSchema = z.object({
 const commonResponseSchema = z.object({
   timings: z
     .object({
-      inference: z.number(),
+      inference: z.number().optional(),
     })
     .optional(),
   seed: z.number().optional(),


### PR DESCRIPTION
## background

fal.ai's kontext image editing models sometimes return an empty `timings` object `{}` instead of omitting the field or including the `inference` property. the current schema validation required `timings.inference` to be a number when `timings` was present, causing type validation errors.

## summary

- make `timings.inference` field optional in response schema
- added test for empty timings object scenario

## verification

- all existing tests pass
- new test verifies empty timings object handling
- schema now accepts both `timings: {}` and `timings: { inference: 5.875 }`

## tasks

- [x] update commonResponseSchema to make inference optional
- [x] add test case for empty timings object

related issue - #7735