### PR TITLE
feat(codemod): require-createIdGenerator-size-argument

### DIFF
--- a/.changeset/grumpy-pots-exist.md
+++ b/.changeset/grumpy-pots-exist.md
@@ -1,0 +1,28 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+### new codemode for: "`createIdGenerator()` now requires a size argument"
+
+The codemod added in this change addresses the following change in v5
+
+Before:
+
+```ts
+import { createIdGenerator } from 'ai';
+
+const generator = createIdGenerator({ prefix: 'msg' });
+const id2 = generator(16); // Custom size at call time
+```
+
+After:
+
+```ts
+import { createIdGenerator } from 'ai';
+
+const generator32 = createIdGenerator({ size: 32 });
+const id1 = generator32(); // Fixed size from creation
+
+const generator16 = createIdGenerator({ prefix: 'msg', size: 16 });
+const id2 = generator16(); // Fixed size from creation
+```

--- a/packages/codemod/src/codemods/v5/require-createIdGenerator-size-argument.ts
+++ b/packages/codemod/src/codemods/v5/require-createIdGenerator-size-argument.ts
@@ -13,7 +13,7 @@ export default createTransformer((fileInfo, api, options, context) => {
   root
     .find(j.VariableDeclarator)
     .filter(path => {
-      return (
+      return Boolean(
         path.node.init &&
         j.CallExpression.check(path.node.init) &&
         j.Identifier.check(path.node.init.callee) &&

--- a/packages/codemod/src/codemods/v5/require-createIdGenerator-size-argument.ts
+++ b/packages/codemod/src/codemods/v5/require-createIdGenerator-size-argument.ts
@@ -15,9 +15,9 @@ export default createTransformer((fileInfo, api, options, context) => {
     .filter(path => {
       return Boolean(
         path.node.init &&
-        j.CallExpression.check(path.node.init) &&
-        j.Identifier.check(path.node.init.callee) &&
-        path.node.init.callee.name === 'createIdGenerator'
+          j.CallExpression.check(path.node.init) &&
+          j.Identifier.check(path.node.init.callee) &&
+          path.node.init.callee.name === 'createIdGenerator',
       );
     })
     .forEach(path => {

--- a/packages/codemod/src/codemods/v5/require-createIdGenerator-size-argument.ts
+++ b/packages/codemod/src/codemods/v5/require-createIdGenerator-size-argument.ts
@@ -1,0 +1,118 @@
+import { createTransformer } from '../lib/create-transformer';
+
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  // Map to track generator variable names and their createIdGenerator call sites
+  const generatorVariables = new Map<string, any>();
+
+  // Map to track generator variable names and the sizes used in calls
+  const generatorSizes = new Map<string, number>();
+
+  // First pass: Find all createIdGenerator variable declarations
+  root
+    .find(j.VariableDeclarator)
+    .filter(path => {
+      return (
+        path.node.init &&
+        j.CallExpression.check(path.node.init) &&
+        j.Identifier.check(path.node.init.callee) &&
+        path.node.init.callee.name === 'createIdGenerator'
+      );
+    })
+    .forEach(path => {
+      if (j.Identifier.check(path.node.id)) {
+        generatorVariables.set(path.node.id.name, path);
+      }
+    });
+
+  // Also find createIdGenerator assignments (not just declarations)
+  root
+    .find(j.AssignmentExpression)
+    .filter(path => {
+      return (
+        j.CallExpression.check(path.node.right) &&
+        j.Identifier.check(path.node.right.callee) &&
+        path.node.right.callee.name === 'createIdGenerator' &&
+        j.Identifier.check(path.node.left)
+      );
+    })
+    .forEach(path => {
+      if (j.Identifier.check(path.node.left)) {
+        generatorVariables.set(path.node.left.name, path);
+      }
+    });
+
+  // Second pass: Find calls to generator variables to extract size arguments
+  root
+    .find(j.CallExpression)
+    .filter(path => {
+      return (
+        j.Identifier.check(path.node.callee) &&
+        generatorVariables.has(path.node.callee.name)
+      );
+    })
+    .forEach(path => {
+      const generatorName = (path.node.callee as any).name;
+      const args = path.node.arguments;
+
+      if (
+        args.length > 0 &&
+        j.Literal.check(args[0]) &&
+        typeof args[0].value === 'number'
+      ) {
+        const size = args[0].value as number;
+        // Store the size for this generator (assuming all calls use same size)
+        if (!generatorSizes.has(generatorName)) {
+          generatorSizes.set(generatorName, size);
+        }
+      }
+    });
+
+  // Third pass: Update createIdGenerator calls to include size in options
+  generatorVariables.forEach((path, generatorName) => {
+    const size = generatorSizes.get(generatorName);
+    if (size !== undefined) {
+      // Handle both variable declarations and assignments
+      const callExpression = j.VariableDeclarator.check(path.node)
+        ? (path.node.init as any)
+        : (path.node.right as any); // AssignmentExpression
+      const args = callExpression.arguments;
+
+      if (args.length === 0) {
+        // createIdGenerator() -> createIdGenerator({ size: X })
+        callExpression.arguments = [
+          j.objectExpression([
+            j.objectProperty(j.identifier('size'), j.literal(size)),
+          ]),
+        ];
+      } else if (args.length === 1 && j.ObjectExpression.check(args[0])) {
+        // createIdGenerator({ prefix: 'msg' }) -> createIdGenerator({ prefix: 'msg', size: X })
+        const existingProps = args[0].properties;
+        const sizeProperty = j.objectProperty(
+          j.identifier('size'),
+          j.literal(size),
+        );
+        args[0].properties = [...existingProps, sizeProperty];
+      }
+
+      context.hasChanges = true;
+    }
+  });
+
+  // Fourth pass: Remove size arguments from generator function calls
+  root
+    .find(j.CallExpression)
+    .filter(path => {
+      return (
+        j.Identifier.check(path.node.callee) &&
+        generatorVariables.has(path.node.callee.name)
+      );
+    })
+    .forEach(path => {
+      if (path.node.arguments.length > 0) {
+        path.node.arguments = [];
+        context.hasChanges = true;
+      }
+    });
+});

--- a/packages/codemod/src/lib/upgrade.ts
+++ b/packages/codemod/src/lib/upgrade.ts
@@ -59,6 +59,7 @@ const bundle = [
   'v5/rsc-package',
   'v5/flatten-streamtext-file-properties',
   'v5/import-LanguageModelV2-from-provider-package',
+  'v5/require-createIdGenerator-size-argument',
   'v5/migrate-to-data-stream-protocol-v2',
   'v5/move-image-model-maxImagesPerCall',
   'v5/move-langchain-adapter',

--- a/packages/codemod/src/test/__testfixtures__/require-createIdGenerator-size-argument.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/require-createIdGenerator-size-argument.input.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import { createIdGenerator } from 'ai';
+
+// Case 1: createIdGenerator() with size passed to generator call
+const generator = createIdGenerator({ prefix: 'msg' });
+const id2 = generator(16);
+
+// Case 2: createIdGenerator() without options, size passed to generator call
+const generator2 = createIdGenerator();
+const id3 = generator2(32);
+
+// Case 3: Multiple calls with same size
+const generator3 = createIdGenerator({ prefix: 'user' });
+const id4 = generator3(8);
+const id5 = generator3(8);
+
+// Case 4: Generator without size argument (should remain unchanged)
+const generator4 = createIdGenerator({ size: 24 });
+const id6 = generator4();
+
+// Case 5: Multiple generators
+const msgGenerator = createIdGenerator({ prefix: 'msg' });
+const userGenerator = createIdGenerator({ prefix: 'user' });
+const msgId = msgGenerator(16);
+const userId = userGenerator(12);
+
+// Case 6: Generator assigned later
+let laterGenerator;
+laterGenerator = createIdGenerator();
+const laterId = laterGenerator(20);

--- a/packages/codemod/src/test/__testfixtures__/require-createIdGenerator-size-argument.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/require-createIdGenerator-size-argument.output.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+import { createIdGenerator } from 'ai';
+
+// Case 1: createIdGenerator() with size passed to generator call
+const generator = createIdGenerator({
+  prefix: 'msg',
+  size: 16
+});
+const id2 = generator();
+
+// Case 2: createIdGenerator() without options, size passed to generator call
+const generator2 = createIdGenerator({
+  size: 32
+});
+const id3 = generator2();
+
+// Case 3: Multiple calls with same size
+const generator3 = createIdGenerator({
+  prefix: 'user',
+  size: 8
+});
+const id4 = generator3();
+const id5 = generator3();
+
+// Case 4: Generator without size argument (should remain unchanged)
+const generator4 = createIdGenerator({ size: 24 });
+const id6 = generator4();
+
+// Case 5: Multiple generators
+const msgGenerator = createIdGenerator({
+  prefix: 'msg',
+  size: 16
+});
+const userGenerator = createIdGenerator({
+  prefix: 'user',
+  size: 12
+});
+const msgId = msgGenerator();
+const userId = userGenerator();
+
+// Case 6: Generator assigned later
+let laterGenerator;
+laterGenerator = createIdGenerator({
+  size: 20
+});
+const laterId = laterGenerator();

--- a/packages/codemod/src/test/require-createIdGenerator-size-argument.test.ts
+++ b/packages/codemod/src/test/require-createIdGenerator-size-argument.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v5/require-createIdGenerator-size-argument';
+import { testTransform } from './test-utils';
+
+describe('require-createIdGenerator-size-argument', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'require-createIdGenerator-size-argument');
+  });
+});


### PR DESCRIPTION
## Background

Closes #7764

## Summary

Added codemod to address this change:

Before:

```ts
import { createIdGenerator } from 'ai';

const generator = createIdGenerator({ prefix: 'msg' });
const id2 = generator(16); // Custom size at call time
```

After:

```ts
import { createIdGenerator } from 'ai';

const generator32 = createIdGenerator({ size: 32 });
const id1 = generator32(); // Fixed size from creation

const generator16 = createIdGenerator({ prefix: 'msg', size: 16 });
const id2 = generator16(); // Fixed size from creation
```

## Manual Verification

I ran the codemod manually

```
npx @ai-sdk/codemod@latest upgrade --include=v5/require-createIdGenerator-size-argument --target=/Users/gr2m/code/vercel/ai/packages/codemod/test-manual.js
```

With this test file

```ts
import { createIdGenerator } from 'ai';

const generator = createIdGenerator({ prefix: 'msg' });
const id2 = generator(16); // Custom size at call time

const generator2 = createIdGenerator();
const id3 = generator2(32);

const generator3 = createIdGenerator({ prefix: 'user' });
const id4 = generator3(8);
const id5 = generator3(8);
```

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

In theory there might be code where people pass different sizes to the same ID generator method:

```ts
const generator2 = createIdGenerator();
const id32 = generator2(32);
const id16 = generator2(16);
```

This is not covered by this codemod, and it would make it more complicated. If it becomes a problem we can update the codemod accordingly.

## Related Issues

- #6552
- #7764