### PR TITLE
feat(codemod): `IDGenerator` type renamed to `IdGenerator`

### DIFF
--- a/.changeset/slimy-bottles-punch.md
+++ b/.changeset/slimy-bottles-punch.md
@@ -1,0 +1,17 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+### Codemod for: "`IDGenerator` type renamed to `IdGenerator`"
+
+This change adds a new codemod which handles the change from
+
+```ts
+import { IDGenerator } from 'ai';
+```
+
+to
+
+```ts
+import { IdGenerator } from 'ai';
+```

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -2878,6 +2878,7 @@ For more information, see the [Codemods](#codemods) section.
 | ------------------------------------------------ | ----------------------------------------------------- |
 | **AI SDK Core Changes**                          |                                                       |
 | Flatten streamText file properties               | `v5/flatten-streamtext-file-properties`               |
+| IDGenerator → IdGenerator                        | `v5/rename-IDGenerator-to-IdGenerator`                |
 | Import LanguageModelV2 from provider package     | `v5/import-LanguageModelV2-from-provider-package`     |
 | Migrate to data stream protocol v2               | `v5/migrate-to-data-stream-protocol-v2`               |
 | Move image model maxImagesPerCall                | `v5/move-image-model-maxImagesPerCall`                |

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -2878,6 +2878,7 @@ For more information, see the [Codemods](#codemods) section.
 | ------------------------------------------------ | ----------------------------------------------------- |
 | **AI SDK Core Changes**                          |                                                       |
 | Flatten streamText file properties               | `v5/flatten-streamtext-file-properties`               |
+| ID Generation Changes                            | `v5/require-createIdGenerator-size-argument`          |
 | IDGenerator → IdGenerator                        | `v5/rename-IDGenerator-to-IdGenerator`                |
 | Import LanguageModelV2 from provider package     | `v5/import-LanguageModelV2-from-provider-package`     |
 | Migrate to data stream protocol v2               | `v5/migrate-to-data-stream-protocol-v2`               |

--- a/packages/codemod/src/codemods/v5/rename-IDGenerator-to-IdGenerator.ts
+++ b/packages/codemod/src/codemods/v5/rename-IDGenerator-to-IdGenerator.ts
@@ -1,0 +1,50 @@
+import { createTransformer } from '../lib/create-transformer';
+
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  // Track local names of imported IDGenerator
+  const localNames = new Set<string>();
+
+  // Find and update imports from 'ai'
+  root
+    .find(j.ImportDeclaration)
+    .filter(path => path.node.source.value === 'ai')
+    .forEach(path => {
+      path.node.specifiers?.forEach(specifier => {
+        if (
+          specifier.type === 'ImportSpecifier' &&
+          specifier.imported.type === 'Identifier' &&
+          specifier.imported.name === 'IDGenerator'
+        ) {
+          context.hasChanges = true;
+
+          // Track the local name (could be aliased)
+          const localName = specifier.local?.name || specifier.imported.name;
+          localNames.add(localName);
+
+          // Update import name but keep the alias if it exists
+          specifier.imported.name = 'IdGenerator';
+          // Don't change the local name if it's aliased
+        }
+      });
+    });
+
+  // Find and update all references to the imported type
+  root
+    .find(j.Identifier)
+    .filter(path => {
+      return (
+        localNames.has(path.node.name) &&
+        // Avoid modifying the import statement itself
+        path.parent.node.type !== 'ImportSpecifier'
+      );
+    })
+    .forEach(path => {
+      context.hasChanges = true;
+      // Replace with the new name only if it was the original IDGenerator
+      if (path.node.name === 'IDGenerator') {
+        path.node.name = 'IdGenerator';
+      }
+    });
+});

--- a/packages/codemod/src/lib/upgrade.ts
+++ b/packages/codemod/src/lib/upgrade.ts
@@ -43,6 +43,7 @@ const bundle = [
   'v5/rename-converttocoremessages-to-converttomodelmessages',
   'v5/rename-core-message-to-model-message',
   'v5/rename-datastream-transform-stream',
+  'v5/rename-IDGenerator-to-IdGenerator',
   'v5/rename-languagemodelv1providermetadata',
   'v5/rename-max-tokens-to-max-output-tokens',
   'v5/rename-message-to-ui-message',

--- a/packages/codemod/src/test/__testfixtures__/rename-IDGenerator-to-IdGenerator.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/rename-IDGenerator-to-IdGenerator.input.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import { IDGenerator } from 'ai';
+import { type IDGenerator as GeneratorType, someFunction, otherFunction } from 'ai';
+
+// Variable declarations with type annotations
+const generator1: IDGenerator = createGenerator();
+let generator2: IDGenerator;
+var generator3: IDGenerator = null;
+
+// Function declarations with IDGenerator parameters
+function processGenerator(gen: IDGenerator): void {
+  console.log(gen);
+}
+
+// Arrow functions with IDGenerator parameters
+const handleGenerator = (gen: IDGenerator): IDGenerator => {
+  return gen;
+};
+
+// Function return types
+function createCustomGenerator(): IDGenerator {
+  return {} as IDGenerator;
+}
+
+// Type aliases and interfaces
+type MyGenerator = IDGenerator;
+interface GeneratorConfig {
+  generator: IDGenerator;
+}
+
+// Class properties
+class GeneratorService {
+  private generator: IDGenerator;
+  
+  constructor(gen: IDGenerator) {
+    this.generator = gen;
+  }
+  
+  getGenerator(): IDGenerator {
+    return this.generator;
+  }
+}
+
+// Generic types
+type GeneratorArray = Array<IDGenerator>;
+type GeneratorMap = Map<string, IDGenerator>;
+
+// Object type annotations
+const config: {
+  primary: IDGenerator;
+  secondary?: IDGenerator;
+} = {
+  primary: generator1,
+  secondary: generator2
+};
+
+// Should NOT be transformed - different package
+import { IDGenerator as OtherGenerator } from 'other-package';
+const otherGen: OtherGenerator = null;

--- a/packages/codemod/src/test/__testfixtures__/rename-IDGenerator-to-IdGenerator.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/rename-IDGenerator-to-IdGenerator.output.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import { IdGenerator } from 'ai';
+import { type IdGenerator as GeneratorType, someFunction, otherFunction } from 'ai';
+
+// Variable declarations with type annotations
+const generator1: IdGenerator = createGenerator();
+let generator2: IdGenerator;
+var generator3: IdGenerator = null;
+
+// Function declarations with IDGenerator parameters
+function processGenerator(gen: IdGenerator): void {
+  console.log(gen);
+}
+
+// Arrow functions with IDGenerator parameters
+const handleGenerator = (gen: IdGenerator): IdGenerator => {
+  return gen;
+};
+
+// Function return types
+function createCustomGenerator(): IdGenerator {
+  return {} as IdGenerator;
+}
+
+// Type aliases and interfaces
+type MyGenerator = IdGenerator;
+interface GeneratorConfig {
+  generator: IdGenerator;
+}
+
+// Class properties
+class GeneratorService {
+  private generator: IdGenerator;
+  
+  constructor(gen: IdGenerator) {
+    this.generator = gen;
+  }
+  
+  getGenerator(): IdGenerator {
+    return this.generator;
+  }
+}
+
+// Generic types
+type GeneratorArray = Array<IdGenerator>;
+type GeneratorMap = Map<string, IdGenerator>;
+
+// Object type annotations
+const config: {
+  primary: IdGenerator;
+  secondary?: IdGenerator;
+} = {
+  primary: generator1,
+  secondary: generator2
+};
+
+// Should NOT be transformed - different package
+import { IDGenerator as OtherGenerator } from 'other-package';
+const otherGen: OtherGenerator = null;

--- a/packages/codemod/src/test/rename-IDGenerator-to-IdGenerator.test.ts
+++ b/packages/codemod/src/test/rename-IDGenerator-to-IdGenerator.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v5/rename-IDGenerator-to-IdGenerator';
+import { testTransform } from './test-utils';
+
+describe('rename-IDGenerator-to-IdGenerator', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'rename-IDGenerator-to-IdGenerator');
+  });
+});


### PR DESCRIPTION
## Background

Closes #7769

## Summary

This change adds a new codemod which handles the change from

```ts
import { IDGenerator } from 'ai';
```

to

```ts
import { IdGenerator } from 'ai';
```


## Manual Verification

I ran the codemod locally.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

- #6552
- #7769
