### PR TITLE
fix(openai-compatible): filter empty content to ensure chunk order

### DIFF
--- a/.changeset/lazy-moles-compare.md
+++ b/.changeset/lazy-moles-compare.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+filter empty content to ensure chunk order

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -974,11 +974,6 @@ describe('doStream', () => {
           "type": "text-start",
         },
         {
-          "delta": "",
-          "id": "txt-0",
-          "type": "text-delta",
-        },
-        {
           "delta": "Hello",
           "id": "txt-0",
           "type": "text-delta",
@@ -1020,9 +1015,9 @@ describe('doStream', () => {
       type: 'stream-chunks',
       chunks: [
         `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
-          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Let me think"},"finish_reason":null}]}\n\n`,
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":"", "reasoning_content":"Let me think"},"finish_reason":null}]}\n\n`,
         `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
-          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"reasoning_content":" about this"},"finish_reason":null}]}\n\n`,
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"", "reasoning_content":" about this"},"finish_reason":null}]}\n\n`,
         `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
           `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"Here's"},"finish_reason":null}]}\n\n`,
         `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
@@ -1454,15 +1449,6 @@ describe('doStream', () => {
           "type": "response-metadata",
         },
         {
-          "id": "txt-0",
-          "type": "text-start",
-        },
-        {
-          "delta": "",
-          "id": "txt-0",
-          "type": "text-delta",
-        },
-        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "toolName": "searchGoogle",
           "type": "tool-input-start",
@@ -1501,10 +1487,6 @@ describe('doStream', () => {
           "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "toolName": "searchGoogle",
           "type": "tool-call",
-        },
-        {
-          "id": "txt-0",
-          "type": "text-end",
         },
         {
           "finishReason": "tool-calls",

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -463,7 +463,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
             const delta = choice.delta;
 
             // enqueue reasoning before text deltas:
-            if (delta.reasoning_content != null) {
+            if (delta.reasoning_content) {
               if (!isActiveReasoning) {
                 controller.enqueue({
                   type: 'reasoning-start',
@@ -479,7 +479,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
               });
             }
 
-            if (delta.content != null) {
+            if (delta.content) {
               if (!isActiveText) {
                 controller.enqueue({ type: 'text-start', id: 'txt-0' });
                 isActiveText = true;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

When the server responds with a stream like this (`delta: {content: '', reasoning_content:'some text'}`), the current processing mechanism cannot prioritize the `reasoning_content` chunk over the `content` chunk. This is because encountering an empty string prematurely triggers a `text-start` event.

https://github.com/DeJeune/ai/blob/b41563153eadd5f3f0c6afa747239f0b37c6ff47/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts#L1017-L1019

Therefore, it is necessary to filter out empty strings.

## Summary

<!-- What did you change? -->

 filter out empty strings.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)