### PR TITLE
fix(getting-started/nuxt): incorrect highlight line

### DIFF
--- a/content/docs/02-getting-started/05-nuxt.mdx
+++ b/content/docs/02-getting-started/05-nuxt.mdx
@@ -311,7 +311,7 @@ To solve this, you can enable multi-step tool calls using `stopWhen`. By default
 
 Modify your `server/api/chat.ts` file to include the `stopWhen` condition:
 
-```typescript filename="server/api/chat.ts" highlight="16"
+```typescript filename="server/api/chat.ts" highlight="24"
 import {
   streamText,
   UIMessage,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The Nuxt getting started documentation contained an incorrect highlight line, which could cause confusion for users following the setup instructions.

## Summary

This PR fixes the highlight line in the Nuxt getting started guide to accurately reflect the correct code section.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

https://vercel.live/link/v5.ai-sdk.dev?page=%2Fdocs%2Fgetting-started%2Fnuxt%3FvercelFinalHash%3Denhance-your-chatbot-with-tools%26vercelThreadId%3DXYber&via=in-app-copy-link&p=1