### PR TITLE
fix(migration-guides): use correct highlighting for Vue code

### DIFF
--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1593,7 +1593,7 @@ The Vue.js integration has been completely restructured, replacing the `useChat`
 
 #### useChat Replaced with Chat Class
 
-```vue filename="@ai-sdk/vue v1"
+```typescript filename="@ai-sdk/vue v1"
 <script setup>
 import { useChat } from '@ai-sdk/vue';
 
@@ -1603,7 +1603,7 @@ const { messages, input, handleSubmit } = useChat({
 </script>
 ```
 
-```vue filename="@ai-sdk/vue v2"
+```typescript filename="@ai-sdk/vue v2"
 <script setup>
 import { Chat } from '@ai-sdk/vue';
 import { DefaultChatTransport } from 'ai';
@@ -1626,7 +1626,7 @@ const handleSubmit = (e: Event) => {
 
 Messages now use a `parts` array instead of a `content` string.
 
-```vue filename="@ai-sdk/vue v1"
+```typescript filename="@ai-sdk/vue v1"
 <template>
   <div v-for="message in messages" :key="message.id">
     <div>{{ message.role }}: {{ message.content }}</div>
@@ -1634,7 +1634,7 @@ Messages now use a `parts` array instead of a `content` string.
 </template>
 ```
 
-```vue filename="@ai-sdk/vue v2"
+```typescript filename="@ai-sdk/vue v2"
 <template>
   <div v-for="message in chat.messages" :key="message.id">
     <div>{{ message.role }}:</div>


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The migration guides previously used incorrect syntax highlighting for Vue code blocks, which could cause confusion or reduce readability for users following the documentation.

## Summary

This PR updates the migration guides to use the correct syntax highlighting for Vue code blocks, ensuring that code examples are properly formatted and easier to read.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
