### PR TITLE
feat(huggingface): add responses api support

### DIFF
--- a/.changeset/curly-planes-film.md
+++ b/.changeset/curly-planes-film.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/huggingface': patch
+---
+
+feat(huggingface): add responses api support with mcp tools and annotations

--- a/examples/ai-core/src/generate-text/huggingface-responses-annotations.ts
+++ b/examples/ai-core/src/generate-text/huggingface-responses-annotations.ts
@@ -1,0 +1,30 @@
+import { huggingface } from '@ai-sdk/huggingface';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: huggingface.responses('deepseek-ai/DeepSeek-V3-0324'),
+    prompt:
+      'What are the latest developments in artificial intelligence research? Include sources.',
+  });
+
+  console.log(result.text);
+  console.log();
+
+  if (result.content) {
+    const sources = result.content.filter(part => part.type === 'source');
+    if (sources.length > 0) {
+      console.log('Sources:');
+      sources.forEach((source, index) => {
+        if (source.type === 'source' && source.sourceType === 'url') {
+          console.log(
+            `${index + 1}. ${source.title || 'Untitled'}: ${source.url}`,
+          );
+        }
+      });
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/huggingface-responses.ts
+++ b/examples/ai-core/src/generate-text/huggingface-responses.ts
@@ -1,0 +1,14 @@
+import { huggingface } from '@ai-sdk/huggingface';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: huggingface.responses('moonshotai/Kimi-K2-Instruct'),
+    prompt: 'Tell me a three sentence bedtime story about a unicorn.',
+  });
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/huggingface-responses.ts
+++ b/examples/ai-core/src/stream-text/huggingface-responses.ts
@@ -1,0 +1,19 @@
+import { huggingface } from '@ai-sdk/huggingface';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: huggingface.responses('moonshotai/Kimi-K2-Instruct'),
+    prompt: 'Tell me a three sentence bedtime story about a unicorn.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+}
+
+main().catch(console.error);

--- a/packages/huggingface/src/huggingface-config.ts
+++ b/packages/huggingface/src/huggingface-config.ts
@@ -1,0 +1,9 @@
+import { FetchFunction } from '@ai-sdk/provider-utils';
+
+export type HuggingFaceConfig = {
+  provider: string;
+  url: (options: { modelId: string; path: string }) => string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  generateId?: () => string;
+};

--- a/packages/huggingface/src/huggingface-error.ts
+++ b/packages/huggingface/src/huggingface-error.ts
@@ -1,0 +1,17 @@
+import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const huggingfaceErrorDataSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    type: z.string().optional(),
+    code: z.string().optional(),
+  }),
+});
+
+export type HuggingFaceErrorData = z.infer<typeof huggingfaceErrorDataSchema>;
+
+export const huggingfaceFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: huggingfaceErrorDataSchema,
+  errorToMessage: data => data.error.message,
+});

--- a/packages/huggingface/src/huggingface-provider.test.ts
+++ b/packages/huggingface/src/huggingface-provider.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHuggingFace } from './huggingface-provider';
+import { loadApiKey } from '@ai-sdk/provider-utils';
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+
+const OpenAICompatibleChatLanguageModelMock = vi.mocked(
+  OpenAICompatibleChatLanguageModel,
+);
+
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  OpenAICompatibleChatLanguageModel: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/provider-utils', () => ({
+  loadApiKey: vi.fn().mockReturnValue('mock-api-key'),
+  withoutTrailingSlash: vi.fn(url => url?.replace(/\/$/, '') ?? url),
+  createJsonErrorResponseHandler: vi.fn(),
+}));
+
+describe('HuggingFaceProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createHuggingFace', () => {
+    it('should create provider with default configuration', () => {
+      const provider = createHuggingFace();
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('model-id');
+      expect(constructorCall[1]).toMatchInlineSnapshot(`
+        {
+          "fetch": undefined,
+          "headers": [Function],
+          "provider": "huggingface.chat",
+          "url": [Function],
+        }
+      `);
+
+      // Trigger headers function to test loadApiKey call
+      constructorCall[1].headers();
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: undefined,
+        environmentVariableName: 'HF_TOKEN',
+        description: 'Hugging Face',
+      });
+    });
+
+    it('should create provider with custom configuration', () => {
+      const options = {
+        apiKey: 'custom-api-key',
+        baseURL: 'https://custom.url/v1',
+        headers: { 'Custom-Header': 'value' },
+        fetch: vi.fn(),
+      };
+      const provider = createHuggingFace(options);
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].fetch).toBe(options.fetch);
+
+      // Trigger headers function to test loadApiKey call
+      constructorCall[1].headers();
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: 'custom-api-key',
+        environmentVariableName: 'HF_TOKEN',
+        description: 'Hugging Face',
+      });
+    });
+
+    it('should construct correct headers', () => {
+      const options = {
+        apiKey: 'test-api-key',
+        headers: { 'Custom-Header': 'custom-value' },
+      };
+      const provider = createHuggingFace(options);
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const headers = constructorCall[1].headers();
+
+      expect(headers).toMatchInlineSnapshot(`
+        {
+          "Authorization": "Bearer mock-api-key",
+          "Custom-Header": "custom-value",
+        }
+      `);
+    });
+
+    it('should construct correct URL', () => {
+      const provider = createHuggingFace({
+        baseURL: 'https://custom.url/v1',
+      });
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const url = constructorCall[1].url({
+        modelId: 'model-id',
+        path: '/chat/completions',
+      });
+
+      expect(url).toBe('https://custom.url/v1/chat/completions');
+    });
+  });
+
+  describe('model creation methods', () => {
+    it('should create chat model when called as function', () => {
+      const provider = createHuggingFace();
+      const model = provider('meta-llama/Llama-3.1-8B-Instruct');
+
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+      expect(OpenAICompatibleChatLanguageModelMock).toHaveBeenCalledWith(
+        'meta-llama/Llama-3.1-8B-Instruct',
+        expect.objectContaining({
+          provider: 'huggingface.chat',
+        }),
+      );
+    });
+
+    it('should support model:provider format', () => {
+      const provider = createHuggingFace();
+      const model = provider('deepseek-ai/DeepSeek-V3-0324:sambanova');
+
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+      expect(OpenAICompatibleChatLanguageModelMock).toHaveBeenCalledWith(
+        'deepseek-ai/DeepSeek-V3-0324:sambanova',
+        expect.objectContaining({
+          provider: 'huggingface.chat',
+        }),
+      );
+    });
+
+    it('should create chat model using chat method', () => {
+      const provider = createHuggingFace();
+      const model = provider.chat('meta-llama/Llama-3.1-8B-Instruct');
+
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+      expect(OpenAICompatibleChatLanguageModelMock).toHaveBeenCalledWith(
+        'meta-llama/Llama-3.1-8B-Instruct',
+        expect.objectContaining({
+          provider: 'huggingface.chat',
+        }),
+      );
+    });
+
+    it('should create language model using languageModel method', () => {
+      const provider = createHuggingFace();
+      const model = provider.languageModel('meta-llama/Llama-3.1-8B-Instruct');
+
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+      expect(OpenAICompatibleChatLanguageModelMock).toHaveBeenCalledWith(
+        'meta-llama/Llama-3.1-8B-Instruct',
+        expect.objectContaining({
+          provider: 'huggingface.chat',
+        }),
+      );
+    });
+  });
+
+  describe('unsupported model types', () => {
+    it('should throw NoSuchModelError for text embedding models', () => {
+      const provider = createHuggingFace();
+
+      expect(() => provider.textEmbeddingModel('any-model')).toThrowError(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Hugging Face OpenAI-compatible API does not support text embeddings',
+          ),
+        }),
+      );
+    });
+
+    it('should throw NoSuchModelError for image models', () => {
+      const provider = createHuggingFace();
+
+      expect(() => provider.imageModel('any-model')).toThrowError(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Hugging Face OpenAI-compatible API does not support image generation',
+          ),
+        }),
+      );
+    });
+  });
+
+  describe('provider metadata', () => {
+    it('should use correct provider name', () => {
+      const provider = createHuggingFace();
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].provider).toBe('huggingface.chat');
+    });
+
+    it('should use default base URL', () => {
+      const provider = createHuggingFace();
+      provider('model-id');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const url = constructorCall[1].url({
+        modelId: 'model-id',
+        path: '/chat/completions',
+      });
+
+      expect(url).toBe('https://router.huggingface.co/v1/chat/completions');
+    });
+  });
+});

--- a/packages/huggingface/src/huggingface-provider.ts
+++ b/packages/huggingface/src/huggingface-provider.ts
@@ -1,0 +1,125 @@
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+import {
+  LanguageModelV2,
+  NoSuchModelError,
+  ProviderV2,
+} from '@ai-sdk/provider';
+import {
+  FetchFunction,
+  loadApiKey,
+  withoutTrailingSlash,
+} from '@ai-sdk/provider-utils';
+import { HuggingFaceChatModelId } from './huggingface-chat-options';
+import { HuggingFaceResponsesLanguageModel } from './responses/huggingface-responses-language-model';
+import { HuggingFaceResponsesModelId } from './responses/huggingface-responses-settings';
+
+export interface HuggingFaceProviderSettings {
+  /**
+Hugging Face API key.
+*/
+  apiKey?: string;
+  /**
+Base URL for the API calls.
+*/
+  baseURL?: string;
+  /**
+Custom headers to include in the requests.
+*/
+  headers?: Record<string, string>;
+  /**
+Custom fetch implementation. You can use it as a middleware to intercept requests,
+or to provide a custom fetch implementation for e.g. testing.
+*/
+  fetch?: FetchFunction;
+}
+
+export interface HuggingFaceProvider extends ProviderV2 {
+  /**
+Creates a model for text generation.
+*/
+  (modelId: HuggingFaceChatModelId): LanguageModelV2;
+
+  /**
+Creates a Hugging Face model for text generation.
+*/
+  languageModel(modelId: HuggingFaceChatModelId): LanguageModelV2;
+
+  /**
+Creates a Hugging Face chat model for text generation.
+*/
+  chat(modelId: HuggingFaceChatModelId): LanguageModelV2;
+
+  /**
+Creates a Hugging Face responses model for text generation.
+*/
+  responses(modelId: HuggingFaceResponsesModelId): LanguageModelV2;
+}
+
+/**
+Create a Hugging Face provider instance.
+ */
+export function createHuggingFace(
+  options: HuggingFaceProviderSettings = {},
+): HuggingFaceProvider {
+  const baseURL =
+    withoutTrailingSlash(options.baseURL) ?? 'https://router.huggingface.co/v1';
+
+  const getHeaders = () => ({
+    Authorization: `Bearer ${loadApiKey({
+      apiKey: options.apiKey,
+      environmentVariableName: 'HF_TOKEN',
+      description: 'Hugging Face',
+    })}`,
+    ...options.headers,
+  });
+
+  const createLanguageModel = (modelId: HuggingFaceChatModelId) => {
+    return new OpenAICompatibleChatLanguageModel(modelId, {
+      provider: 'huggingface.chat',
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  const createResponsesModel = (modelId: HuggingFaceResponsesModelId) => {
+    return new HuggingFaceResponsesLanguageModel(modelId, {
+      provider: 'huggingface.responses',
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  const provider = (modelId: HuggingFaceChatModelId) =>
+    createLanguageModel(modelId);
+
+  provider.languageModel = createLanguageModel;
+  provider.chat = createLanguageModel;
+  provider.responses = createResponsesModel;
+
+  provider.textEmbeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'textEmbeddingModel',
+      message:
+        'Hugging Face OpenAI-compatible API does not support text embeddings. Use the Hugging Face Inference API directly for embeddings.',
+    });
+  };
+
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'imageModel',
+      message:
+        'Hugging Face OpenAI-compatible API does not support image generation. Use the Hugging Face Inference API directly for image models.',
+    });
+  };
+
+  return provider;
+}
+
+/**
+Default Hugging Face provider instance.
+ */
+export const huggingface = createHuggingFace();

--- a/packages/huggingface/src/index.ts
+++ b/packages/huggingface/src/index.ts
@@ -1,0 +1,10 @@
+export { createHuggingFace, huggingface } from './huggingface-provider';
+export type {
+  HuggingFaceProvider,
+  HuggingFaceProviderSettings,
+} from './huggingface-provider';
+export type {
+  HuggingFaceResponsesModelId,
+  HuggingFaceResponsesSettings,
+} from './responses/huggingface-responses-settings';
+export type { OpenAICompatibleErrorData as HuggingFaceErrorData } from '@ai-sdk/openai-compatible';

--- a/packages/huggingface/src/responses/convert-to-huggingface-responses-messages.ts
+++ b/packages/huggingface/src/responses/convert-to-huggingface-responses-messages.ts
@@ -1,0 +1,119 @@
+import {
+  LanguageModelV2CallWarning,
+  LanguageModelV2Prompt,
+  UnsupportedFunctionalityError,
+} from '@ai-sdk/provider';
+
+export async function convertToHuggingFaceResponsesMessages({
+  prompt,
+}: {
+  prompt: LanguageModelV2Prompt;
+}): Promise<{
+  input: string | Array<any>;
+  warnings: Array<LanguageModelV2CallWarning>;
+}> {
+  const messages: Array<any> = [];
+  const warnings: Array<LanguageModelV2CallWarning> = [];
+
+  for (const { role, content } of prompt) {
+    switch (role) {
+      case 'system': {
+        messages.push({ role: 'system', content });
+        break;
+      }
+
+      case 'user': {
+        messages.push({
+          role: 'user',
+          content: content.map(part => {
+            switch (part.type) {
+              case 'text': {
+                return { type: 'input_text', text: part.text };
+              }
+              case 'file': {
+                if (part.mediaType.startsWith('image/')) {
+                  const mediaType =
+                    part.mediaType === 'image/*'
+                      ? 'image/jpeg'
+                      : part.mediaType;
+
+                  return {
+                    type: 'input_image',
+                    image_url:
+                      part.data instanceof URL
+                        ? part.data.toString()
+                        : `data:${mediaType};base64,${part.data}`,
+                  };
+                } else {
+                  throw new UnsupportedFunctionalityError({
+                    functionality: `file part media type ${part.mediaType}`,
+                  });
+                }
+              }
+              default: {
+                const _exhaustiveCheck: never = part;
+                throw new Error(`Unsupported part type: ${_exhaustiveCheck}`);
+              }
+            }
+          }),
+        });
+
+        break;
+      }
+
+      case 'assistant': {
+        for (const part of content) {
+          switch (part.type) {
+            case 'text': {
+              messages.push({
+                role: 'assistant',
+                content: [{ type: 'output_text', text: part.text }],
+              });
+              break;
+            }
+            case 'tool-call': {
+              warnings.push({
+                type: 'unsupported-setting',
+                setting: 'tool-calls in assistant messages',
+              });
+              break;
+            }
+
+            case 'tool-result': {
+              warnings.push({
+                type: 'other',
+                message: `tool result parts in assistant messages are not supported for HuggingFace responses`,
+              });
+              break;
+            }
+
+            case 'reasoning': {
+              warnings.push({
+                type: 'other',
+                message: `reasoning parts are not supported for HuggingFace responses`,
+              });
+              break;
+            }
+          }
+        }
+
+        break;
+      }
+
+      case 'tool': {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'tool messages',
+        });
+        break;
+      }
+
+      default: {
+        const _exhaustiveCheck: never = role;
+        throw new Error(`Unsupported role: ${_exhaustiveCheck}`);
+      }
+    }
+  }
+
+  return { input: messages, warnings };
+}

--- a/packages/huggingface/src/responses/huggingface-responses-language-model.test.ts
+++ b/packages/huggingface/src/responses/huggingface-responses-language-model.test.ts
@@ -1,0 +1,824 @@
+import { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import {
+  convertReadableStreamToArray,
+  createTestServer,
+  mockId,
+} from '@ai-sdk/provider-utils/test';
+import { HuggingFaceResponsesLanguageModel } from './huggingface-responses-language-model';
+
+const TEST_PROMPT: LanguageModelV2Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+function createModel(modelId: string) {
+  return new HuggingFaceResponsesLanguageModel(modelId, {
+    provider: 'huggingface.responses',
+    url: ({ path }) => `https://router.huggingface.co/v1${path}`,
+    headers: () => ({ Authorization: `Bearer APIKEY` }),
+    generateId: mockId(),
+  });
+}
+
+describe('HuggingFaceResponsesLanguageModel', () => {
+  const server = createTestServer({
+    'https://router.huggingface.co/v1/responses': {},
+  });
+
+  describe('doGenerate', () => {
+    describe('basic text response', () => {
+      beforeEach(() => {
+        server.urls['https://router.huggingface.co/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_67c97c0203188190a025beb4a75242bc',
+            model: 'deepseek-ai/DeepSeek-V3-0324',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            instructions: null,
+            max_output_tokens: null,
+            metadata: null,
+            tool_choice: 'auto',
+            tools: [],
+            temperature: 1.0,
+            top_p: 1.0,
+            incomplete_details: null,
+            usage: {
+              input_tokens: 12,
+              output_tokens: 25,
+              total_tokens: 37,
+            },
+            output: [
+              {
+                id: 'msg_67c97c02656c81908e080dfdf4a03cd1',
+                type: 'message',
+                role: 'assistant',
+                status: 'completed',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'Hello! How can I help you today?',
+                  },
+                ],
+              },
+            ],
+            output_text: 'Hello! How can I help you today?',
+          },
+        };
+      });
+
+      it('should generate text', async () => {
+        const result = await createModel(
+          'deepseek-ai/DeepSeek-V3-0324',
+        ).doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "providerMetadata": {
+                "huggingface": {
+                  "itemId": "msg_67c97c02656c81908e080dfdf4a03cd1",
+                },
+              },
+              "text": "Hello! How can I help you today?",
+              "type": "text",
+            },
+          ]
+        `);
+      });
+
+      it('should extract usage', async () => {
+        const result = await createModel(
+          'deepseek-ai/DeepSeek-V3-0324',
+        ).doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.usage).toMatchInlineSnapshot(`
+          {
+            "inputTokens": 12,
+            "outputTokens": 25,
+            "totalTokens": 37,
+          }
+        `);
+      });
+
+      it('should extract text from output array when output_text is missing', async () => {
+        server.urls['https://router.huggingface.co/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_test',
+            model: 'deepseek-ai/DeepSeek-V3-0324',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            instructions: null,
+            max_output_tokens: null,
+            metadata: null,
+            tool_choice: 'auto',
+            tools: [],
+            temperature: 1.0,
+            top_p: 1.0,
+            incomplete_details: null,
+            usage: null,
+            output: [
+              {
+                id: 'msg_test',
+                type: 'message',
+                role: 'assistant',
+                status: 'completed',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'Extracted from output array',
+                  },
+                ],
+              },
+            ],
+            output_text: null,
+          },
+        };
+
+        const result = await createModel(
+          'deepseek-ai/DeepSeek-V3-0324',
+        ).doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "providerMetadata": {
+                "huggingface": {
+                  "itemId": "msg_test",
+                },
+              },
+              "text": "Extracted from output array",
+              "type": "text",
+            },
+          ]
+        `);
+      });
+
+      it('should handle missing usage gracefully', async () => {
+        server.urls['https://router.huggingface.co/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_test',
+            model: 'deepseek-ai/DeepSeek-V3-0324',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            instructions: null,
+            max_output_tokens: null,
+            metadata: null,
+            tool_choice: 'auto',
+            tools: [],
+            temperature: 1.0,
+            top_p: 1.0,
+            incomplete_details: null,
+            usage: null,
+            output: [],
+            output_text: 'Test response',
+          },
+        };
+
+        const result = await createModel(
+          'deepseek-ai/DeepSeek-V3-0324',
+        ).doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.usage).toMatchInlineSnapshot(`
+          {
+            "inputTokens": 0,
+            "outputTokens": 0,
+            "totalTokens": 0,
+          }
+        `);
+      });
+
+      it('should send model id, settings, and input', async () => {
+        await createModel('deepseek-ai/DeepSeek-V3-0324').doGenerate({
+          prompt: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          ],
+          temperature: 0.5,
+          topP: 0.3,
+          maxOutputTokens: 100,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'deepseek-ai/DeepSeek-V3-0324',
+          temperature: 0.5,
+          top_p: 0.3,
+          max_output_tokens: 100,
+          stream: false,
+          input: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+        });
+      });
+
+      it('should handle unsupported settings with warnings', async () => {
+        const { warnings } = await createModel(
+          'deepseek-ai/DeepSeek-V3-0324',
+        ).doGenerate({
+          prompt: TEST_PROMPT,
+          topK: 10,
+          seed: 123,
+          presencePenalty: 0.5,
+          frequencyPenalty: 0.3,
+          stopSequences: ['stop'],
+        });
+
+        expect(warnings).toMatchInlineSnapshot(`
+          [
+            {
+              "setting": "topK",
+              "type": "unsupported-setting",
+            },
+            {
+              "setting": "seed",
+              "type": "unsupported-setting",
+            },
+            {
+              "setting": "presencePenalty",
+              "type": "unsupported-setting",
+            },
+            {
+              "setting": "frequencyPenalty",
+              "type": "unsupported-setting",
+            },
+            {
+              "setting": "stopSequences",
+              "type": "unsupported-setting",
+            },
+          ]
+        `);
+      });
+
+      it('should generate text and sources from annotations', async () => {
+        server.urls['https://router.huggingface.co/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_test_annotations',
+            model: 'deepseek-ai/DeepSeek-V3-0324',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            instructions: null,
+            max_output_tokens: null,
+            metadata: null,
+            tool_choice: 'auto',
+            tools: [],
+            temperature: 1.0,
+            top_p: 1.0,
+            incomplete_details: null,
+            usage: {
+              input_tokens: 20,
+              output_tokens: 50,
+              total_tokens: 70,
+            },
+            output: [
+              {
+                id: 'msg_test_annotations',
+                type: 'message',
+                role: 'assistant',
+                status: 'completed',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'Here are some recent articles about AI: The first article discusses new developments ([example.com](https://example.com/article1)). Another piece covers industry trends ([test.com](https://test.com/article2)).',
+                    annotations: [
+                      {
+                        type: 'url_citation',
+                        url: 'https://example.com/article1',
+                        title: 'AI Developments Article',
+                      },
+                      {
+                        type: 'url_citation',
+                        url: 'https://test.com/article2',
+                        title: 'Industry Trends Report',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            output_text: null,
+          },
+        };
+
+        const result = await createModel(
+          'deepseek-ai/DeepSeek-V3-0324',
+        ).doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "providerMetadata": {
+                "huggingface": {
+                  "itemId": "msg_test_annotations",
+                },
+              },
+              "text": "Here are some recent articles about AI: The first article discusses new developments ([example.com](https://example.com/article1)). Another piece covers industry trends ([test.com](https://test.com/article2)).",
+              "type": "text",
+            },
+            {
+              "id": "id-0",
+              "sourceType": "url",
+              "title": "AI Developments Article",
+              "type": "source",
+              "url": "https://example.com/article1",
+            },
+            {
+              "id": "id-1",
+              "sourceType": "url",
+              "title": "Industry Trends Report",
+              "type": "source",
+              "url": "https://test.com/article2",
+            },
+          ]
+        `);
+      });
+
+      it('should handle MCP tools with annotations', async () => {
+        server.urls['https://router.huggingface.co/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_mcp_test',
+            model: 'deepseek-ai/DeepSeek-V3-0324',
+            object: 'response',
+            created_at: 1741257730,
+            status: 'completed',
+            error: null,
+            instructions: null,
+            max_output_tokens: null,
+            metadata: null,
+            tool_choice: 'auto',
+            tools: [],
+            temperature: 1.0,
+            top_p: 1.0,
+            incomplete_details: null,
+            usage: {
+              input_tokens: 50,
+              output_tokens: 100,
+              total_tokens: 150,
+            },
+            output: [
+              {
+                id: 'mcp_search_test',
+                type: 'mcp_call',
+                server_label: 'web_search',
+                name: 'search',
+                arguments: '{"query": "San Francisco tech events"}',
+                output: 'Found 25 tech events in San Francisco',
+              },
+              {
+                id: 'msg_mcp_response',
+                type: 'message',
+                role: 'assistant',
+                status: 'completed',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'Based on the search results, here are the latest tech events in San Francisco: There are several AI conferences ([techevents.com](https://techevents.com/sf-ai)) and startup meetups ([eventbrite.com](https://eventbrite.com/sf-startups)) happening this week.',
+                    annotations: [
+                      {
+                        type: 'url_citation',
+                        url: 'https://techevents.com/sf-ai',
+                        title: 'SF AI Conference 2025',
+                      },
+                      {
+                        type: 'url_citation',
+                        url: 'https://eventbrite.com/sf-startups',
+                        title: 'SF Startup Meetups',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            output_text: null,
+          },
+        };
+
+        const result = await createModel(
+          'deepseek-ai/DeepSeek-V3-0324',
+        ).doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "input": "{"query": "San Francisco tech events"}",
+              "providerExecuted": true,
+              "toolCallId": "mcp_search_test",
+              "toolName": "search",
+              "type": "tool-call",
+            },
+            {
+              "providerExecuted": true,
+              "result": "Found 25 tech events in San Francisco",
+              "toolCallId": "mcp_search_test",
+              "toolName": "search",
+              "type": "tool-result",
+            },
+            {
+              "providerMetadata": {
+                "huggingface": {
+                  "itemId": "msg_mcp_response",
+                },
+              },
+              "text": "Based on the search results, here are the latest tech events in San Francisco: There are several AI conferences ([techevents.com](https://techevents.com/sf-ai)) and startup meetups ([eventbrite.com](https://eventbrite.com/sf-startups)) happening this week.",
+              "type": "text",
+            },
+            {
+              "id": "id-0",
+              "sourceType": "url",
+              "title": "SF AI Conference 2025",
+              "type": "source",
+              "url": "https://techevents.com/sf-ai",
+            },
+            {
+              "id": "id-1",
+              "sourceType": "url",
+              "title": "SF Startup Meetups",
+              "type": "source",
+              "url": "https://eventbrite.com/sf-startups",
+            },
+          ]
+        `);
+      });
+    });
+  });
+
+  describe('doStream', () => {
+    it('should stream text deltas', async () => {
+      server.urls['https://router.huggingface.co/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.created","response":{"id":"resp_test","object":"response","created_at":1741269019,"status":"in_progress","model":"deepseek-ai/DeepSeek-V3-0324"}}\n\n`,
+          `data:{"type":"response.in_progress","response":{"id":"resp_test","object":"response","created_at":1741269019,"status":"in_progress"}}\n\n`,
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_test","type":"message","role":"assistant","status":"in_progress","content":[]},"sequence_number":1}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_test","output_index":0,"content_index":0,"delta":"Hello,","sequence_number":2}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_test","output_index":0,"content_index":0,"delta":" World!","sequence_number":3}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"id":"msg_test","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello, World!"}]},"sequence_number":4}\n\n`,
+          `data:{"type":"response.completed","response":{"id":"resp_test","model":"deepseek-ai/DeepSeek-V3-0324","object":"response","created_at":1741269112,"status":"completed","incomplete_details":null,"usage":{"input_tokens":12,"output_tokens":25,"total_tokens":37},"output":[{"id":"msg_test","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello, World!"}]}]},"sequence_number":5}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel(
+        'deepseek-ai/DeepSeek-V3-0324',
+      ).doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "id": "resp_test",
+            "modelId": "deepseek-ai/DeepSeek-V3-0324",
+            "timestamp": 2025-03-06T13:50:19.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "id": "msg_test",
+            "providerMetadata": {
+              "huggingface": {
+                "itemId": "msg_test",
+              },
+            },
+            "type": "text-start",
+          },
+          {
+            "delta": "Hello,",
+            "id": "msg_test",
+            "type": "text-delta",
+          },
+          {
+            "delta": " World!",
+            "id": "msg_test",
+            "type": "text-delta",
+          },
+          {
+            "id": "msg_test",
+            "type": "text-end",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "huggingface": {
+                "responseId": "resp_test",
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": 12,
+              "outputTokens": 25,
+              "totalTokens": 37,
+            },
+          },
+        ]
+      `);
+    });
+
+    it('should handle streaming without usage', async () => {
+      server.urls['https://router.huggingface.co/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_test","type":"message","role":"assistant","status":"in_progress"},"sequence_number":1}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_test","output_index":0,"content_index":0,"delta":"Hi!","sequence_number":2}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"id":"msg_test","type":"message","role":"assistant","status":"completed"},"sequence_number":3}\n\n`,
+          `data:{"type":"response.completed","response":{"id":"resp_test","status":"completed","incomplete_details":null,"usage":null},"sequence_number":4}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel(
+        'deepseek-ai/DeepSeek-V3-0324',
+      ).doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+      const finishChunk = chunks.find(chunk => chunk.type === 'finish');
+
+      expect(finishChunk?.usage).toMatchInlineSnapshot(`
+        {
+          "inputTokens": undefined,
+          "outputTokens": undefined,
+          "totalTokens": undefined,
+        }
+      `);
+    });
+
+    it('should handle non-message item types', async () => {
+      server.urls['https://router.huggingface.co/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"id":"mcp_test","type":"mcp_list_tools","server_label":"test"},"sequence_number":1}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"id":"mcp_test","type":"mcp_list_tools","server_label":"test"},"sequence_number":2}\n\n`,
+          `data:{"type":"response.completed","response":{"id":"resp_test","status":"completed","incomplete_details":null},"sequence_number":3}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel(
+        'deepseek-ai/DeepSeek-V3-0324',
+      ).doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      // Should only have stream-start and finish events (no text events for non-message items)
+      expect(chunks.map(chunk => chunk.type)).toEqual([
+        'stream-start',
+        'finish',
+      ]);
+    });
+
+    it('should handle streaming errors', async () => {
+      server.urls['https://router.huggingface.co/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_test","type":"message","role":"assistant"},"sequence_number":1}\n\n`,
+          `data:invalid json}\n\n`, // malformed JSON that will cause parsing error
+        ],
+      };
+
+      const { stream } = await createModel(
+        'deepseek-ai/DeepSeek-V3-0324',
+      ).doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+      const errorChunk = chunks.find(chunk => chunk.type === 'error');
+      const finishChunk = chunks.find(chunk => chunk.type === 'finish');
+
+      expect(errorChunk).toBeDefined();
+      expect(errorChunk?.type).toBe('error');
+      expect(finishChunk?.finishReason).toBe('error');
+    });
+
+    it('should send correct streaming request', async () => {
+      server.urls['https://router.huggingface.co/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.completed","response":{"id":"resp_test","status":"completed"},"sequence_number":1}\n\n`,
+        ],
+      };
+
+      await createModel('deepseek-ai/DeepSeek-V3-0324').doStream({
+        prompt: TEST_PROMPT,
+        temperature: 0.7,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'deepseek-ai/DeepSeek-V3-0324',
+        temperature: 0.7,
+        stream: true,
+        input: [
+          {
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Hello' }],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('message conversion', () => {
+    beforeEach(() => {
+      server.urls['https://router.huggingface.co/v1/responses'].response = {
+        type: 'json-value',
+        body: {
+          id: 'resp_test',
+          model: 'moonshotai/Kimi-K2-Instruct',
+          object: 'response',
+          created_at: 1741257730,
+          status: 'completed',
+          error: null,
+          instructions: null,
+          max_output_tokens: null,
+          metadata: null,
+          tool_choice: 'auto',
+          tools: [],
+          temperature: 1.0,
+          top_p: 1.0,
+          incomplete_details: null,
+          usage: null,
+          output: [],
+          output_text: 'Test response',
+        },
+      };
+    });
+
+    it('should convert user messages with images', async () => {
+      await createModel('deepseek-ai/DeepSeek-V3-0324').doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What do you see?' },
+              {
+                type: 'file',
+                mediaType: 'image/jpeg',
+                data: 'AQIDBA==',
+              },
+            ],
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.input[0].content).toMatchInlineSnapshot(`
+        [
+          {
+            "text": "What do you see?",
+            "type": "input_text",
+          },
+          {
+            "image_url": "data:image/jpeg;base64,AQIDBA==",
+            "type": "input_image",
+          },
+        ]
+      `);
+    });
+
+    it('should handle assistant messages', async () => {
+      await createModel('deepseek-ai/DeepSeek-V3-0324').doGenerate({
+        prompt: [
+          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'Hi there!' }] },
+          { role: 'user', content: [{ type: 'text', text: 'How are you?' }] },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.input).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "Hello",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "text": "Hi there!",
+                "type": "output_text",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "text": "How are you?",
+                "type": "input_text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+
+    it('should warn about unsupported assistant content types', async () => {
+      const { warnings } = await createModel(
+        'deepseek-ai/DeepSeek-V3-0324',
+      ).doGenerate({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'test',
+                toolName: 'test',
+                input: {},
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'test',
+                toolName: 'test',
+                output: { type: 'text', value: 'test' },
+              },
+              { type: 'reasoning', text: 'thinking...' },
+            ],
+          },
+        ],
+      });
+
+      expect(warnings).toMatchInlineSnapshot(`
+        [
+          {
+            "setting": "tool-calls in assistant messages",
+            "type": "unsupported-setting",
+          },
+          {
+            "message": "tool result parts in assistant messages are not supported for HuggingFace responses",
+            "type": "other",
+          },
+          {
+            "message": "reasoning parts are not supported for HuggingFace responses",
+            "type": "other",
+          },
+        ]
+      `);
+    });
+
+    it('should warn about tool messages', async () => {
+      const { warnings } = await createModel(
+        'deepseek-ai/DeepSeek-V3-0324',
+      ).doGenerate({
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'test',
+                toolName: 'test',
+                output: { type: 'text', value: 'test' },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(warnings).toMatchInlineSnapshot(`
+        [
+          {
+            "setting": "tool messages",
+            "type": "unsupported-setting",
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/packages/huggingface/src/responses/huggingface-responses-language-model.ts
+++ b/packages/huggingface/src/responses/huggingface-responses-language-model.ts
@@ -1,0 +1,604 @@
+import {
+  APICallError,
+  LanguageModelV2,
+  LanguageModelV2CallWarning,
+  LanguageModelV2Content,
+  LanguageModelV2FinishReason,
+  LanguageModelV2StreamPart,
+  LanguageModelV2Usage,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createEventSourceResponseHandler,
+  createJsonResponseHandler,
+  generateId,
+  parseProviderOptions,
+  ParseResult,
+  postJsonToApi,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { HuggingFaceConfig } from '../huggingface-config';
+import { huggingfaceFailedResponseHandler } from '../huggingface-error';
+import { convertToHuggingFaceResponsesMessages } from './convert-to-huggingface-responses-messages';
+import { mapHuggingFaceResponsesFinishReason } from './map-huggingface-responses-finish-reason';
+import { HuggingFaceResponsesModelId } from './huggingface-responses-settings';
+
+export class HuggingFaceResponsesLanguageModel implements LanguageModelV2 {
+  readonly specificationVersion = 'v2';
+
+  readonly modelId: HuggingFaceResponsesModelId;
+
+  private readonly config: HuggingFaceConfig;
+
+  constructor(modelId: HuggingFaceResponsesModelId, config: HuggingFaceConfig) {
+    this.modelId = modelId;
+    this.config = config;
+  }
+
+  readonly supportedUrls: Record<string, RegExp[]> = {
+    'image/*': [/^https?:\/\/.*$/],
+  };
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  private async getArgs({
+    maxOutputTokens,
+    temperature,
+    stopSequences,
+    topP,
+    topK,
+    presencePenalty,
+    frequencyPenalty,
+    seed,
+    prompt,
+    providerOptions,
+    tools,
+    toolChoice,
+    responseFormat,
+  }: Parameters<LanguageModelV2['doGenerate']>[0]) {
+    const warnings: LanguageModelV2CallWarning[] = [];
+
+    if (topK != null) {
+      warnings.push({ type: 'unsupported-setting', setting: 'topK' });
+    }
+
+    if (seed != null) {
+      warnings.push({ type: 'unsupported-setting', setting: 'seed' });
+    }
+
+    if (presencePenalty != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'presencePenalty',
+      });
+    }
+
+    if (frequencyPenalty != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'frequencyPenalty',
+      });
+    }
+
+    if (stopSequences != null) {
+      warnings.push({ type: 'unsupported-setting', setting: 'stopSequences' });
+    }
+
+    const { input, warnings: messageWarnings } =
+      await convertToHuggingFaceResponsesMessages({
+        prompt,
+      });
+
+    warnings.push(...messageWarnings);
+
+    const huggingfaceOptions = await parseProviderOptions({
+      provider: 'huggingface',
+      providerOptions,
+      schema: huggingfaceResponsesProviderOptionsSchema,
+    });
+
+    const baseArgs = {
+      model: this.modelId,
+      input,
+      temperature,
+      top_p: topP,
+      max_output_tokens: maxOutputTokens,
+
+      ...(responseFormat?.type === 'json' && {
+        text: {
+          format:
+            responseFormat.schema != null
+              ? {
+                  type: 'json_schema',
+                  strict: huggingfaceOptions?.strictJsonSchema ?? false,
+                  name: responseFormat.name ?? 'response',
+                  description: responseFormat.description,
+                  schema: responseFormat.schema,
+                }
+              : { type: 'json_object' },
+        },
+      }),
+
+      metadata: huggingfaceOptions?.metadata,
+      instructions: huggingfaceOptions?.instructions,
+    };
+
+    if (tools != null && tools.length > 0) {
+      warnings.push({ type: 'unsupported-setting', setting: 'tools' });
+    }
+
+    if (toolChoice != null) {
+      warnings.push({ type: 'unsupported-setting', setting: 'toolChoice' });
+    }
+
+    return { args: baseArgs, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<LanguageModelV2['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV2['doGenerate']>>> {
+    const { args, warnings } = await this.getArgs(options);
+
+    const body = {
+      ...args,
+      stream: false,
+    };
+
+    const url = this.config.url({
+      path: '/responses',
+      modelId: this.modelId,
+    });
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url,
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body,
+      failedResponseHandler: huggingfaceFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        huggingfaceResponsesResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    if (response.error) {
+      throw new APICallError({
+        message: response.error.message,
+        url,
+        requestBodyValues: body,
+        statusCode: 400,
+        responseHeaders,
+        responseBody: rawResponse as string,
+        isRetryable: false,
+      });
+    }
+
+    const content: Array<LanguageModelV2Content> = [];
+
+    for (const part of response.output) {
+      switch (part.type) {
+        case 'message': {
+          for (const contentPart of part.content) {
+            content.push({
+              type: 'text',
+              text: contentPart.text,
+              providerMetadata: {
+                huggingface: {
+                  itemId: part.id,
+                },
+              },
+            });
+
+            if (contentPart.annotations) {
+              for (const annotation of contentPart.annotations) {
+                content.push({
+                  type: 'source',
+                  sourceType: 'url',
+                  id: this.config.generateId?.() ?? generateId(),
+                  url: annotation.url,
+                  title: annotation.title,
+                });
+              }
+            }
+          }
+          break;
+        }
+
+        case 'mcp_call': {
+          content.push({
+            type: 'tool-call',
+            toolCallId: part.id,
+            toolName: part.name,
+            input: part.arguments,
+            providerExecuted: true,
+          });
+
+          if (part.output) {
+            content.push({
+              type: 'tool-result',
+              toolCallId: part.id,
+              toolName: part.name,
+              result: part.output,
+              providerExecuted: true,
+            });
+          }
+          break;
+        }
+
+        case 'mcp_list_tools': {
+          content.push({
+            type: 'tool-call',
+            toolCallId: part.id,
+            toolName: 'list_tools',
+            input: `{"server_label": "${part.server_label}"}`,
+            providerExecuted: true,
+          });
+
+          if (part.tools) {
+            content.push({
+              type: 'tool-result',
+              toolCallId: part.id,
+              toolName: 'list_tools',
+              result: { tools: part.tools },
+              providerExecuted: true,
+            });
+          }
+          break;
+        }
+
+        default: {
+          break;
+        }
+      }
+    }
+
+    return {
+      content,
+      finishReason: mapHuggingFaceResponsesFinishReason(
+        response.incomplete_details?.reason ?? 'stop',
+      ),
+      usage: {
+        inputTokens: response.usage?.input_tokens ?? 0,
+        outputTokens: response.usage?.output_tokens ?? 0,
+        totalTokens:
+          response.usage?.total_tokens ??
+          (response.usage?.input_tokens ?? 0) +
+            (response.usage?.output_tokens ?? 0),
+      },
+      request: { body },
+      response: {
+        id: response.id,
+        timestamp: new Date(response.created_at * 1000),
+        modelId: response.model,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      providerMetadata: {
+        huggingface: {
+          responseId: response.id,
+        },
+      },
+      warnings,
+    };
+  }
+
+  async doStream(
+    options: Parameters<LanguageModelV2['doStream']>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV2['doStream']>>> {
+    const { args, warnings } = await this.getArgs(options);
+
+    const body = {
+      ...args,
+      stream: true,
+    };
+
+    const { value: response, responseHeaders } = await postJsonToApi({
+      url: this.config.url({
+        path: '/responses',
+        modelId: this.modelId,
+      }),
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body,
+      failedResponseHandler: huggingfaceFailedResponseHandler,
+      successfulResponseHandler: createEventSourceResponseHandler(
+        huggingfaceResponsesChunkSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    let finishReason: LanguageModelV2FinishReason = 'unknown';
+    let responseId: string | null = null;
+    const usage: LanguageModelV2Usage = {
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+    };
+
+    return {
+      stream: response.pipeThrough(
+        new TransformStream<
+          ParseResult<z.infer<typeof huggingfaceResponsesChunkSchema>>,
+          LanguageModelV2StreamPart
+        >({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings });
+          },
+
+          transform(chunk, controller) {
+            if (!chunk.success) {
+              finishReason = 'error';
+              controller.enqueue({ type: 'error', error: chunk.error });
+              return;
+            }
+
+            const value = chunk.value;
+
+            if (isResponseCreatedChunk(value)) {
+              responseId = value.response.id;
+              controller.enqueue({
+                type: 'response-metadata',
+                id: value.response.id,
+                timestamp: new Date(value.response.created_at * 1000),
+                modelId: value.response.model,
+              });
+              return;
+            }
+
+            if (isResponseOutputItemAddedChunk(value)) {
+              if (
+                value.item.type === 'message' &&
+                value.item.role === 'assistant'
+              ) {
+                controller.enqueue({
+                  type: 'text-start',
+                  id: value.item.id,
+                  providerMetadata: {
+                    huggingface: {
+                      itemId: value.item.id,
+                    },
+                  },
+                });
+              }
+              return;
+            }
+
+            if (isResponseOutputItemDoneChunk(value)) {
+              if (
+                value.item.type === 'message' &&
+                value.item.role === 'assistant'
+              ) {
+                controller.enqueue({
+                  type: 'text-end',
+                  id: value.item.id,
+                });
+              }
+              return;
+            }
+
+            if (isResponseCompletedChunk(value)) {
+              responseId = value.response.id;
+              finishReason = mapHuggingFaceResponsesFinishReason(
+                value.response.incomplete_details?.reason ?? 'stop',
+              );
+              if (value.response.usage) {
+                usage.inputTokens = value.response.usage.input_tokens;
+                usage.outputTokens = value.response.usage.output_tokens;
+                usage.totalTokens =
+                  value.response.usage.total_tokens ??
+                  value.response.usage.input_tokens +
+                    value.response.usage.output_tokens;
+              }
+              return;
+            }
+
+            if (isTextDeltaChunk(value)) {
+              controller.enqueue({
+                type: 'text-delta',
+                id: value.item_id,
+                delta: value.delta,
+              });
+              return;
+            }
+          },
+
+          flush(controller) {
+            controller.enqueue({
+              type: 'finish',
+              finishReason,
+              usage,
+              providerMetadata: {
+                huggingface: {
+                  responseId,
+                },
+              },
+            });
+          },
+        }),
+      ),
+      request: { body },
+      response: { headers: responseHeaders },
+    };
+  }
+}
+
+const huggingfaceResponsesProviderOptionsSchema = z.object({
+  metadata: z.record(z.string(), z.string()).optional(),
+  instructions: z.string().optional(),
+  strictJsonSchema: z.boolean().optional(),
+});
+
+const huggingfaceResponsesResponseSchema = z.object({
+  id: z.string(),
+  model: z.string(),
+  object: z.string(),
+  created_at: z.number(),
+  status: z.string(),
+  error: z.any().nullable(),
+  instructions: z.any().nullable(),
+  max_output_tokens: z.any().nullable(),
+  metadata: z.any().nullable(),
+  tool_choice: z.any(),
+  tools: z.array(z.any()),
+  temperature: z.number(),
+  top_p: z.number(),
+  incomplete_details: z
+    .object({
+      reason: z.string(),
+    })
+    .nullable()
+    .optional(),
+  usage: z
+    .object({
+      input_tokens: z.number(),
+      input_tokens_details: z
+        .object({
+          cached_tokens: z.number(),
+        })
+        .optional(),
+      output_tokens: z.number(),
+      output_tokens_details: z
+        .object({
+          reasoning_tokens: z.number(),
+        })
+        .optional(),
+      total_tokens: z.number(),
+    })
+    .nullable()
+    .optional(),
+  output: z.array(z.any()),
+  output_text: z.string().nullable().optional(),
+});
+
+const responseOutputItemAddedSchema = z.object({
+  type: z.literal('response.output_item.added'),
+  output_index: z.number(),
+  item: z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('message'),
+      id: z.string(),
+      role: z.string().optional(),
+      status: z.string().optional(),
+      content: z.array(z.any()).optional(),
+    }),
+    z.object({
+      type: z.literal('mcp_list_tools'),
+      id: z.string(),
+      server_label: z.string(),
+      tools: z.array(z.any()).optional(),
+      error: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal('mcp_call'),
+      id: z.string(),
+      server_label: z.string(),
+      name: z.string(),
+      arguments: z.string(),
+      output: z.string().optional(),
+      error: z.string().optional(),
+    }),
+  ]),
+  sequence_number: z.number(),
+});
+
+const responseOutputItemDoneSchema = z.object({
+  type: z.literal('response.output_item.done'),
+  output_index: z.number(),
+  item: z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('message'),
+      id: z.string(),
+      role: z.string().optional(),
+      status: z.string().optional(),
+      content: z.array(z.any()).optional(),
+    }),
+    z.object({
+      type: z.literal('mcp_list_tools'),
+      id: z.string(),
+      server_label: z.string(),
+      tools: z.array(z.any()).optional(),
+      error: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal('mcp_call'),
+      id: z.string(),
+      server_label: z.string(),
+      name: z.string(),
+      arguments: z.string(),
+      output: z.string().optional(),
+      error: z.string().optional(),
+    }),
+  ]),
+  sequence_number: z.number(),
+});
+
+const textDeltaChunkSchema = z.object({
+  type: z.literal('response.output_text.delta'),
+  item_id: z.string(),
+  output_index: z.number(),
+  content_index: z.number(),
+  delta: z.string(),
+  sequence_number: z.number(),
+});
+
+const responseCompletedChunkSchema = z.object({
+  type: z.literal('response.completed'),
+  response: huggingfaceResponsesResponseSchema,
+  sequence_number: z.number(),
+});
+
+const responseCreatedChunkSchema = z.object({
+  type: z.literal('response.created'),
+  response: z.object({
+    id: z.string(),
+    object: z.string(),
+    created_at: z.number(),
+    status: z.string(),
+    model: z.string(),
+  }),
+});
+
+const huggingfaceResponsesChunkSchema = z.union([
+  responseOutputItemAddedSchema,
+  responseOutputItemDoneSchema,
+  textDeltaChunkSchema,
+  responseCompletedChunkSchema,
+  responseCreatedChunkSchema,
+  z.object({ type: z.string() }).loose(), // fallback for unknown chunks
+]);
+
+function isResponseOutputItemAddedChunk(
+  chunk: z.infer<typeof huggingfaceResponsesChunkSchema>,
+): chunk is z.infer<typeof responseOutputItemAddedSchema> {
+  return chunk.type === 'response.output_item.added';
+}
+
+function isResponseOutputItemDoneChunk(
+  chunk: z.infer<typeof huggingfaceResponsesChunkSchema>,
+): chunk is z.infer<typeof responseOutputItemDoneSchema> {
+  return chunk.type === 'response.output_item.done';
+}
+
+function isTextDeltaChunk(
+  chunk: z.infer<typeof huggingfaceResponsesChunkSchema>,
+): chunk is z.infer<typeof textDeltaChunkSchema> {
+  return chunk.type === 'response.output_text.delta';
+}
+
+function isResponseCompletedChunk(
+  chunk: z.infer<typeof huggingfaceResponsesChunkSchema>,
+): chunk is z.infer<typeof responseCompletedChunkSchema> {
+  return chunk.type === 'response.completed';
+}
+
+function isResponseCreatedChunk(
+  chunk: z.infer<typeof huggingfaceResponsesChunkSchema>,
+): chunk is z.infer<typeof responseCreatedChunkSchema> {
+  return chunk.type === 'response.created';
+}

--- a/packages/huggingface/src/responses/huggingface-responses-settings.ts
+++ b/packages/huggingface/src/responses/huggingface-responses-settings.ts
@@ -1,0 +1,7 @@
+export type HuggingFaceResponsesModelId = string;
+
+export interface HuggingFaceResponsesSettings {
+  metadata?: Record<string, string>;
+  instructions?: string;
+  strictJsonSchema?: boolean;
+}

--- a/packages/huggingface/src/responses/map-huggingface-responses-finish-reason.ts
+++ b/packages/huggingface/src/responses/map-huggingface-responses-finish-reason.ts
@@ -1,0 +1,20 @@
+import { LanguageModelV2FinishReason } from '@ai-sdk/provider';
+
+export function mapHuggingFaceResponsesFinishReason(
+  finishReason: string | null | undefined,
+): LanguageModelV2FinishReason {
+  switch (finishReason) {
+    case 'stop':
+      return 'stop';
+    case 'length':
+      return 'length';
+    case 'content_filter':
+      return 'content-filter';
+    case 'tool_calls':
+      return 'tool-calls';
+    case 'error':
+      return 'error';
+    default:
+      return 'unknown';
+  }
+}


### PR DESCRIPTION
## background

huggingface recently added support for responses api which provides capabilities like streaming, annotations, and tool integrations compared to their standard chat completions api.

## summary

- add huggingface responses language model with streaming support
- add message conversion for huggingface input format
- add url annotations processing with source content generation
- add responses method to huggingface provider
- add examples for basic responses, annotations

## verification

- all tests pass including streaming, annotations, and error handling
- added tests for responses api

## tasks

- [x] huggingface-responses-language-model.ts with proper schemas and streaming
- [x] convert-to-huggingface-responses-messages.ts for input format conversion
- [x] huggingface-responses-settings.ts for model configuration
- [x] map-huggingface-responses-finish-reason.ts for finish reason mapping
- [x] add responses method to provider with url function support
- [x] added tests to support the new responses api via huggingface
- [x] url annotations processing with generateId and source content
- [x] error handling with apicallerror for response errors
- [x] providermetadata support in content and streaming events
- [x] response-metadata events for streaming
- [x] enhanced response objects with id, timestamp, modelid
- [x] examples for basic usage, annotations

## future work

* explore additional integrations/features