### PR TITLE
feat(provider/openai): full implementation for Files API file-ids and urls in Images, PDFs, across Chat and Responses

### DIFF
--- a/.changeset/witty-melons-invent.md
+++ b/.changeset/witty-melons-invent.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Files from the OpenAI Files API are now supported, mirroring functionality of OpenAI Chat and Responses API, respectively. Also, the AI SDK supports URLs for PDFs in the responses API the same way it did for completions.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -862,8 +862,7 @@ You can also pass a file-id from the OpenAI Files API.
 ```ts
 {
   type: 'image',
-  image: 'file-8EFBcWHsQxZV7YGezBC1fq',
-
+  image: 'file-8EFBcWHsQxZV7YGezBC1fq'
 }
 ```
 

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -388,7 +388,7 @@ You can also pass the URL of an image.
   type: 'image',
   image: 'https://sample.edu/image.png',
 }
-````
+```
 
 #### PDF support
 
@@ -866,7 +866,7 @@ You can also pass a file-id from the OpenAI Files API.
   image: 'file-8EFBcWHsQxZV7YGezBC1fq',
 
 }
-````
+```
 
 You can also pass the URL of an image.
 

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -831,7 +831,7 @@ Learn more about reasoning summaries in the [OpenAI documentation](https://platf
 
 #### Image Support
 
-The OpenAI Chat API supports Image inputs for appropriate models.
+The OpenAI Responses API supports Image inputs for appropriate models.
 You can pass Image files as part of the message content using the 'image' type:
 
 ```ts

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -352,6 +352,44 @@ const openaiMetadata = (await result.providerMetadata)?.openai;
 const logprobs = openaiMetadata?.logprobs;
 ```
 
+#### Image Support
+
+The OpenAI Chat API supports Image inputs for appropriate models.
+You can pass Image files as part of the message content using the 'image' type:
+
+````ts
+const result = await generateText({
+  model: openai('gpt-4o'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Please describe the image.',
+        },
+        {
+          type: 'image',
+          image: fs.readFileSync('./data/image.png'),
+        },
+      ],
+    },
+  ],
+});
+``
+
+Multimodal models will have access to the image and can analyze and conversate about it.
+The image should be passed using the `image` field.
+
+You can also pass the URL of an image.
+
+```ts
+{
+  type: 'image',
+  image: 'https://sample.edu/image.png',
+}
+````
+
 #### PDF support
 
 The OpenAI Chat API supports reading PDF files.
@@ -384,6 +422,28 @@ The model will have access to the contents of the PDF file and
 respond to questions about it.
 The PDF file should be passed using the `data` field,
 and the `mediaType` should be set to `'application/pdf'`.
+
+You can also pass a file-id from the OpenAI Files API.
+
+```ts
+{
+  type: 'file',
+  data: 'file-8EFBcWHsQxZV7YGezBC1fq',
+  mediaType: 'application/pdf',
+  filename: 'ai.pdf', // optional
+}
+```
+
+You can also pass the URL of a PDF.
+
+```ts
+{
+  type: 'file',
+  data: 'https://sample.edu/example.pdf',
+  mediaType: 'application/pdf',
+  filename: 'ai.pdf', // optional
+}
+```
 
 #### Predicted Outputs
 
@@ -769,6 +829,54 @@ console.log('Reasoning:', result.reasoning);
 
 Learn more about reasoning summaries in the [OpenAI documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries).
 
+#### Image Support
+
+The OpenAI Chat API supports Image inputs for appropriate models.
+You can pass Image files as part of the message content using the 'image' type:
+
+````ts
+const result = await generateText({
+  model: openai('gpt-4o'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Please describe the image.',
+        },
+        {
+          type: 'image',
+          image: fs.readFileSync('./data/image.png'),
+        },
+      ],
+    },
+  ],
+});
+``
+
+Multimodal models will have access to the image and can analyze and conversate about it.
+The image should be passed using the `image` field.
+
+You can also pass a file-id from the OpenAI Files API.
+
+```ts
+{
+  type: 'image',
+  image: 'file-8EFBcWHsQxZV7YGezBC1fq',
+
+}
+````
+
+You can also pass the URL of an image.
+
+```ts
+{
+  type: 'image',
+  image: 'https://sample.edu/image.png',
+}
+```
+
 #### PDF support
 
 The OpenAI Responses API supports reading PDF files.
@@ -795,6 +903,28 @@ const result = await generateText({
     },
   ],
 });
+```
+
+You can also pass a file-id from the OpenAI Files API.
+
+```ts
+{
+  type: 'file',
+  data: 'file-8EFBcWHsQxZV7YGezBC1fq',
+  mediaType: 'application/pdf',
+  filename: 'ai.pdf', // optional
+}
+```
+
+You can also pass the URL of a pdf.
+
+```ts
+{
+  type: 'file',
+  data: 'https://sample.edu/example.pdf',
+  mediaType: 'application/pdf',
+  filename: 'ai.pdf', // optional
+}
 ```
 
 The model will have access to the contents of the PDF file and

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -430,7 +430,6 @@ You can also pass a file-id from the OpenAI Files API.
   type: 'file',
   data: 'file-8EFBcWHsQxZV7YGezBC1fq',
   mediaType: 'application/pdf',
-  filename: 'ai.pdf', // optional
 }
 ```
 
@@ -912,7 +911,6 @@ You can also pass a file-id from the OpenAI Files API.
   type: 'file',
   data: 'file-8EFBcWHsQxZV7YGezBC1fq',
   mediaType: 'application/pdf',
-  filename: 'ai.pdf', // optional
 }
 ```
 

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -357,7 +357,7 @@ const logprobs = openaiMetadata?.logprobs;
 The OpenAI Chat API supports Image inputs for appropriate models.
 You can pass Image files as part of the message content using the 'image' type:
 
-````ts
+```ts
 const result = await generateText({
   model: openai('gpt-4o'),
   messages: [
@@ -376,7 +376,7 @@ const result = await generateText({
     },
   ],
 });
-``
+```
 
 Multimodal models will have access to the image and can analyze and conversate about it.
 The image should be passed using the `image` field.
@@ -834,7 +834,7 @@ Learn more about reasoning summaries in the [OpenAI documentation](https://platf
 The OpenAI Chat API supports Image inputs for appropriate models.
 You can pass Image files as part of the message content using the 'image' type:
 
-````ts
+```ts
 const result = await generateText({
   model: openai('gpt-4o'),
   messages: [
@@ -853,7 +853,7 @@ const result = await generateText({
     },
   ],
 });
-``
+```
 
 Multimodal models will have access to the image and can analyze and conversate about it.
 The image should be passed using the `image` field.

--- a/packages/openai/src/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.test.ts
@@ -312,6 +312,37 @@ describe('user messages', () => {
       ]);
     });
 
+    it('should convert messages with PDF file parts using file_id', async () => {
+      const result = convertToOpenAIChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data: 'file-pdf-12345',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file: {
+                file_id: 'file-pdf-12345',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should use default filename for PDF file parts when not provided', async () => {
       const base64Data = 'AQIDBAU=';
 

--- a/packages/openai/src/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/convert-to-openai-chat-messages.ts
@@ -123,10 +123,14 @@ export function convertToOpenAIChatMessages({
 
                   return {
                     type: 'file',
-                    file: {
-                      filename: part.filename ?? `part-${index}.pdf`,
-                      file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
-                    },
+                    file:
+                      typeof part.data === 'string' &&
+                      part.data.startsWith('file-')
+                        ? { file_id: part.data }
+                        : {
+                            filename: part.filename ?? `part-${index}.pdf`,
+                            file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
+                          },
                   };
                 } else {
                   throw new UnsupportedFunctionalityError({

--- a/packages/openai/src/openai-chat-prompt.ts
+++ b/packages/openai/src/openai-chat-prompt.ts
@@ -45,7 +45,7 @@ export interface ChatCompletionContentPartInputAudio {
 
 export interface ChatCompletionContentPartFile {
   type: 'file';
-  file: { filename: string; file_data: string };
+  file: { filename: string; file_data: string } | { file_id: string };
 }
 
 export interface ChatCompletionAssistantMessage {

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
@@ -111,6 +111,36 @@ describe('convertToOpenAIResponsesMessages', () => {
       ]);
     });
 
+    it('should convert messages with image parts using file_id', async () => {
+      const result = await convertToOpenAIResponsesMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: 'file-12345',
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_image',
+              file_id: 'file-12345',
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should use default mime type for binary images', async () => {
       const result = await convertToOpenAIResponsesMessages({
         prompt: [
@@ -205,6 +235,36 @@ describe('convertToOpenAIResponsesMessages', () => {
               type: 'input_file',
               filename: 'document.pdf',
               file_data: 'data:application/pdf;base64,AQIDBAU=',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert messages with PDF file parts using file_id', async () => {
+      const result = await convertToOpenAIResponsesMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data: 'file-pdf-12345',
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_file',
+              file_id: 'file-pdf-12345',
             },
           ],
         },

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -23,7 +23,9 @@ export type OpenAIResponsesUserMessage = {
   content: Array<
     | { type: 'input_text'; text: string }
     | { type: 'input_image'; image_url: string }
+    | { type: 'input_image'; file_id: string }
     | { type: 'input_file'; filename: string; file_data: string }
+    | { type: 'input_file'; file_id: string }
   >;
 };
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

### New Support

### OpenAI API File ID Support

In the OpenAI API, File IDs from the Files API are supported for the following use cases that the SDK does not yet support:

#### Relevant Use Cases for FileID

- **PDFs in the Chat API** using FileID
- **PDFs in the Responses API** using FileID
- **Images in the Responses API** usingFileID

### OpenAI API Full URL Support

#### Relevant Use Cases for URL
- **PDFs in the Responses API** using URL (already supported in the SDK's use of Chat API)


#### Additional Notes

The SDK's workaround for supporting URL inputs for PDFs in the Chat API was not implemented for the Responses API.
Instead of using the workaround as this PR does, it may be worthwhile to leverage the Responses API's native support for URL.

## Summary

<!-- What did you change? -->

Added support to reflect what's supported in the API 

The API column represents the OpenAI API
SDK main represents the current state of the AI SDK
SDK PR represents this PR

#### Table 1: Chat API PDF

| Feature | API | SDK Main | SDK PR |
|---------|-----|----------|--------|
| Files API ID | ✅ | ❌ | ✅ |
| URL | ❌ | ✅ | ✅ |
| base64 | ✅ | ✅ | ✅ |

#### Table 2: Chat API Image

| Feature | API | SDK Main | SDK PR |
|---------|-----|----------|--------|
| Files API ID | ❌ | ❌ | ❌ |
| URL | ✅ | ✅ | ✅ |
| base64 | ✅ | ✅ | ✅ |

#### Table 3: Responses PDF

| Feature | API | SDK Main | SDK PR |
|---------|-----|----------|--------|
| Files API ID | ✅ | ❌ | ✅ |
| URL | ✅ | ❌ | ✅ |
| b64 | ✅ | ✅ | ✅ |

#### Table 4: Responses Image

| Feature | API | SDK Main | SDK PR |
|---------|-----|----------|--------|
| Files API ID | ✅ | ❌ | ✅ |
| URL | ✅ | ✅ | ✅ |
| b64 | ✅ | ✅ | ✅ |
## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

I ran javascript scripts to query the OpenAI API through fetch in order to compare expected results against what is in the documentation.

I then made a simple node project using the latest version of the AI SDK to verify support discrepancies 

Finally, I tested the build from my PR to verify the changes worked.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->
It may be worthwhile to leverage the Responses API's native support for URL instead of extending the workaround used in Chat to Responses. I think it was beyond the scope of the PR


## Related Issues
Fixes #7581 
Fixes #7803 
<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
