### PR TITLE
feat (provider/gateway): add anthropic claude 4.1 opus model id

### DIFF
--- a/.changeset/perfect-badgers-clean.md
+++ b/.changeset/perfect-badgers-clean.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add anthropic claude 4.1 opus model id

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -14,6 +14,7 @@ export type GatewayModelId =
   | 'anthropic/claude-3.7-sonnet'
   | 'anthropic/claude-4-opus'
   | 'anthropic/claude-4-sonnet'
+  | 'anthropic/claude-4.1-opus'
   | 'cohere/command-a'
   | 'cohere/command-r'
   | 'cohere/command-r-plus'


### PR DESCRIPTION
## Background

Anthropic released the new Claude 4.1 Opus model and we've added it to AI Gateway.

## Summary

Add the new Anthropic Claude 4.1 Opus model id to Gateway settings