### PR TITLE
feat(amazon-bedrock): add support for Claude Opus 4.1 model

### DIFF
--- a/.changeset/hip-actors-knock.md
+++ b/.changeset/hip-actors-knock.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Add support for Anthropic Claude Opus 4.1 model (anthropic.claude-opus-4-1-20250805-v1:0)

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -556,6 +556,7 @@ These tools can be used in conjunction with the `anthropic.claude-3-5-sonnet-202
 | `amazon.titan-text-lite-v1`                 | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
 | `anthropic.claude-sonnet-4-20250514-v1:0`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `anthropic.claude-opus-4-20250514-v1:0`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `anthropic.claude-opus-4-1-20250805-v1:0`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `anthropic.claude-3-7-sonnet-20250219-v1:0` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `anthropic.claude-3-5-sonnet-20241022-v2:0` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `anthropic.claude-3-5-sonnet-20240620-v1:0` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/packages/amazon-bedrock/src/bedrock-chat-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.ts
@@ -9,6 +9,7 @@ export type BedrockChatModelId =
   | 'anthropic.claude-instant-v1'
   | 'anthropic.claude-sonnet-4-20250514-v1:0'
   | 'anthropic.claude-opus-4-20250514-v1:0'
+  | 'anthropic.claude-opus-4-1-20250805-v1:0'
   | 'anthropic.claude-3-7-sonnet-20250219-v1:0'
   | 'anthropic.claude-3-5-sonnet-20240620-v1:0'
   | 'anthropic.claude-3-5-sonnet-20241022-v2:0'


### PR DESCRIPTION
## Description

This PR adds support for the new Anthropic Claude Opus 4.1 model (`anthropic.claude-opus-4-1-20250805-v1:0`) in Amazon Bedrock.

## Changes

- Added `anthropic.claude-opus-4-1-20250805-v1:0` to the `BedrockChatModelId` type definition
- Updated documentation to include the new model in the Model Capabilities table

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have added a changeset using `pnpm changeset`
- [x] I have run `pnpm prettier-fix` to format my code
- [x] I have run `pnpm test` to ensure all tests pass
- [x] I have run `pnpm build` to ensure the package builds successfully