### PR TITLE
fix(docs): correct import of `stopWhen` in Next.js App Router guide

### DIFF
--- a/content/docs/02-getting-started/02-nextjs-app-router.mdx
+++ b/content/docs/02-getting-started/02-nextjs-app-router.mdx
@@ -380,7 +380,7 @@ import {
   UIMessage,
   convertToModelMessages,
   tool,
-  stopWhen,
+  stepCountIs,
 } from 'ai';
 import { z } from 'zod';
 


### PR DESCRIPTION
## Summary

This PR fixes an incorrect import in the Next.js App Router quickstart documentation.

### What Changed

- Replaced `stopWhen` with `stepCountIs` in the import statement.
- `stopWhen` is a configuration property used in `streamText()` and is not exported by the `ai` package.

### Why

- The current example throws an error during compilation: `Module '"ai"' has no exported member 'stopWhen'`.
- This fix ensures the code sample runs as intended.
