### PR TITLE
feat(provider/groq): added openai gpt-oss model ids

### DIFF
--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -282,6 +282,8 @@ const { text } = await generateText({
 | `qwen-qwq-32b`                                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `qwen-2.5-32b`                                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `deepseek-r1-distill-qwen-32b`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `openai/gpt-oss-20b`                            | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `openai/gpt-oss-120b`                           | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   The tables above list the most commonly used models. Please see the [Groq

--- a/examples/ai-core/src/stream-text/groq-openai-oss.ts
+++ b/examples/ai-core/src/stream-text/groq-openai-oss.ts
@@ -1,0 +1,20 @@
+import { groq } from '@ai-sdk/groq';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: groq('openai/gpt-oss-120b'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -7,6 +7,8 @@ export type GroqChatModelId =
   | 'llama-3.1-8b-instant'
   | 'llama-3.3-70b-versatile'
   | 'meta-llama/llama-guard-4-12b'
+  | 'openai/gpt-oss-120b'
+  | 'openai/gpt-oss-20b'
   // preview models (selection)
   | 'deepseek-r1-distill-llama-70b'
   | 'meta-llama/llama-4-maverick-17b-128e-instruct'
@@ -23,9 +25,6 @@ export type GroqChatModelId =
   | 'qwen-qwq-32b'
   | 'qwen-2.5-32b'
   | 'deepseek-r1-distill-qwen-32b'
-  // openai
-  | 'openai/gpt-oss-120b'
-  | 'openai/gpt-oss-20b'
   | (string & {});
 
 export const groqProviderOptions = z.object({

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -23,6 +23,9 @@ export type GroqChatModelId =
   | 'qwen-qwq-32b'
   | 'qwen-2.5-32b'
   | 'deepseek-r1-distill-qwen-32b'
+  // openai
+  | 'openai/gpt-oss-120b'
+  | 'openai/gpt-oss-20b'
   | (string & {});
 
 export const groqProviderOptions = z.object({


### PR DESCRIPTION
## background
openai recently exposed the gpt-oss-20b and gpt-oss-120b checkpoints through groq

## summary
- add `openai/gpt-oss-20b` and `openai/gpt-oss-120b` to groq 
- add minimal `groq-openai-oss.ts` example demonstrating usage

## verification
- example script streams tokens from both new models locally

## tasks
- [x] groq model ids updated

related issue - #7820
