### PR TITLE
Allow passing model string for embeddings

### DIFF
--- a/examples/ai-core/src/embed-many/gateway.ts
+++ b/examples/ai-core/src/embed-many/gateway.ts
@@ -1,10 +1,9 @@
-import { gateway } from '@ai-sdk/gateway';
 import { embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
   const result = await embedMany({
-    model: gateway.textEmbeddingModel('openai/text-embedding-3-small'),
+    model: 'openai/text-embedding-3-large',
     values: [
       'sunny day at the beach',
       'rainy afternoon in the city',

--- a/examples/ai-core/src/embed/gateway.ts
+++ b/examples/ai-core/src/embed/gateway.ts
@@ -1,10 +1,9 @@
-import { gateway } from '@ai-sdk/gateway';
 import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
   const result = await embed({
-    model: gateway.textEmbeddingModel('openai/text-embedding-3-small'),
+    model: 'openai/text-embedding-3-small',
     value: 'sunny day at the beach',
   });
 

--- a/packages/ai/core/prompt/resolve-embedding-model.ts
+++ b/packages/ai/core/prompt/resolve-embedding-model.ts
@@ -3,11 +3,11 @@ import { EmbeddingModelV2 } from '@ai-sdk/provider';
 import { EmbeddingModel } from '../../src/types/embedding-model';
 
 export function resolveEmbeddingModel<VALUE = string>(
-  model: EmbeddingModel<VALUE>
+  model: EmbeddingModel<VALUE>,
 ): EmbeddingModelV2<VALUE> {
   if (typeof model === 'string') {
     return gateway.textEmbeddingModel(model) as EmbeddingModelV2<VALUE>;
   }
-  
+
   return model as EmbeddingModelV2<VALUE>;
 }

--- a/packages/ai/core/prompt/resolve-embedding-model.ts
+++ b/packages/ai/core/prompt/resolve-embedding-model.ts
@@ -1,0 +1,13 @@
+import { gateway } from '@ai-sdk/gateway';
+import { EmbeddingModelV2 } from '@ai-sdk/provider';
+import { EmbeddingModel } from '../../src/types/embedding-model';
+
+export function resolveEmbeddingModel<VALUE = string>(
+  model: EmbeddingModel<VALUE>
+): EmbeddingModelV2<VALUE> {
+  if (typeof model === 'string') {
+    return gateway.textEmbeddingModel(model) as EmbeddingModelV2<VALUE>;
+  }
+  
+  return model as EmbeddingModelV2<VALUE>;
+}

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -86,7 +86,7 @@ Only applicable for HTTP-based providers.
   maxParallelCalls?: number;
 }): Promise<EmbedManyResult<VALUE>> {
   const resolvedModel = resolveEmbeddingModel<VALUE>(model);
-  
+
   if (resolvedModel.specificationVersion !== 'v2') {
     throw new UnsupportedModelVersionError({
       version: resolvedModel.specificationVersion,

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -73,7 +73,7 @@ Only applicable for HTTP-based providers.
   experimental_telemetry?: TelemetrySettings;
 }): Promise<EmbedResult<VALUE>> {
   const resolvedModel = resolveEmbeddingModel<VALUE>(model);
-  
+
   if (resolvedModel.specificationVersion !== 'v2') {
     throw new UnsupportedModelVersionError({
       version: resolvedModel.specificationVersion,

--- a/packages/ai/src/types/embedding-model.ts
+++ b/packages/ai/src/types/embedding-model.ts
@@ -1,9 +1,12 @@
+import { GatewayEmbeddingModelId } from '@ai-sdk/gateway';
 import { EmbeddingModelV2, EmbeddingModelV2Embedding } from '@ai-sdk/provider';
 
 /**
 Embedding model that is used by the AI SDK Core functions.
 */
-export type EmbeddingModel<VALUE> = EmbeddingModelV2<VALUE>;
+export type EmbeddingModel<VALUE = string> = VALUE extends string 
+  ? GatewayEmbeddingModelId | EmbeddingModelV2<VALUE>
+  : EmbeddingModelV2<VALUE>;
 
 /**
 Embedding.

--- a/packages/ai/src/types/embedding-model.ts
+++ b/packages/ai/src/types/embedding-model.ts
@@ -4,7 +4,7 @@ import { EmbeddingModelV2, EmbeddingModelV2Embedding } from '@ai-sdk/provider';
 /**
 Embedding model that is used by the AI SDK Core functions.
 */
-export type EmbeddingModel<VALUE = string> = VALUE extends string 
+export type EmbeddingModel<VALUE = string> = VALUE extends string
   ? GatewayEmbeddingModelId | EmbeddingModelV2<VALUE>
   : EmbeddingModelV2<VALUE>;
 

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,4 +1,5 @@
 export type { GatewayModelId } from './gateway-language-model-settings';
+export type { GatewayEmbeddingModelId } from './gateway-embedding-model-settings';
 export type {
   GatewayLanguageModelEntry,
   GatewayLanguageModelSpecification,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Previously, embeddings models could only be used by calling `.textEmbeddingModel()` on a `gateway` instance

## Summary

Now, users can pass in model strings directly. LIMITATION: If users need to specify custom params (e.g. base url, api key, etc.) or call `createOpenAICompatible`, they'd still need to use `gateway.textEmbeddingModel()` because `gateway` alone returns a language model type. In order to change that, I'd have to make a breaking change to how language models work - probably by returning a union type. Worth it?

## Manual Verification

Tests and example scripts pass/work

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)