### PR TITLE
feat(provider/groq): added changeset for openai gpt-oss model ids 

### DIFF
--- a/.changeset/thin-comics-fetch.md
+++ b/.changeset/thin-comics-fetch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+feat(provider/groq): added openai gpt-oss model ids


### PR DESCRIPTION
## background

openai recently exposed the gpt-oss-20b and gpt-oss-120b checkpoints through groq
resolves https://github.com/vercel/ai/pull/7827#issuecomment-3162897918

## summary

- added changeset