### PR TITLE
fix(docs): remove beta from migration guide

### DIFF
--- a/content/docs/08-migration-guides/index.mdx
+++ b/content/docs/08-migration-guides/index.mdx
@@ -6,7 +6,7 @@ collapsed: true
 
 # Migration Guides
 
-- [ Migrate AI SDK 4.x to 5.0 Beta ](/docs/migration-guides/migration-guide-5-0)
+- [ Migrate AI SDK 4.x to 5.0 ](/docs/migration-guides/migration-guide-5-0)
 - [ Migrate AI SDK 4.1 to 4.2 ](/docs/migration-guides/migration-guide-4-2)
 - [ Migrate AI SDK 4.0 to 4.1 ](/docs/migration-guides/migration-guide-4-1)
 - [ Migrate AI SDK 3.4 to 4.0 ](/docs/migration-guides/migration-guide-4-0)


### PR DESCRIPTION
## background

removed beta tag from migration guide as v5 has been released