### PR TITLE
fix(google): add thought signature support for reasoning

### DIFF
--- a/.changeset/brave-students-clean.md
+++ b/.changeset/brave-students-clean.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): add thought signature support for reasoning

--- a/examples/ai-core/src/stream-text/google-reasoning-with-tools.ts
+++ b/examples/ai-core/src/stream-text/google-reasoning-with-tools.ts
@@ -13,7 +13,9 @@ async function main() {
         parameters: z.object({
           a: z.number().describe('First number'),
           b: z.number().describe('Second number'),
-          operation: z.enum(['add', 'subtract', 'multiply', 'divide']).describe('Mathematical operation'),
+          operation: z
+            .enum(['add', 'subtract', 'multiply', 'divide'])
+            .describe('Mathematical operation'),
         }),
       },
     },
@@ -35,13 +37,19 @@ async function main() {
         break;
       case 'reasoning-delta':
         if (chunk.providerMetadata?.google?.thoughtSignature) {
-          console.log('[Reasoning with signature]:', chunk.providerMetadata.google.thoughtSignature);
+          console.log(
+            '[Reasoning with signature]:',
+            chunk.providerMetadata.google.thoughtSignature,
+          );
         }
         break;
       case 'tool-call':
         console.log('\nTool call:', chunk.toolName, chunk.input);
         if (chunk.providerMetadata?.google?.thoughtSignature) {
-          console.log('[Tool signature]:', chunk.providerMetadata.google.thoughtSignature);
+          console.log(
+            '[Tool signature]:',
+            chunk.providerMetadata.google.thoughtSignature,
+          );
         }
         break;
     }

--- a/examples/ai-core/src/stream-text/google-reasoning-with-tools.ts
+++ b/examples/ai-core/src/stream-text/google-reasoning-with-tools.ts
@@ -1,0 +1,55 @@
+import { google } from '@ai-sdk/google';
+import { streamText } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = streamText({
+    model: google('gemini-2.0-flash-thinking-exp'),
+    prompt: 'Calculate the sum of 2+2 using the calculate function.',
+    tools: {
+      calculate: {
+        description: 'Calculate the result of a mathematical expression',
+        parameters: z.object({
+          a: z.number().describe('First number'),
+          b: z.number().describe('Second number'),
+          operation: z.enum(['add', 'subtract', 'multiply', 'divide']).describe('Mathematical operation'),
+        }),
+      },
+    },
+    toolChoice: 'required',
+    providerOptions: {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: -1,
+          includeThoughts: true,
+        },
+      },
+    },
+  });
+
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta':
+        process.stdout.write(chunk.text);
+        break;
+      case 'reasoning-delta':
+        if (chunk.providerMetadata?.google?.thoughtSignature) {
+          console.log('[Reasoning with signature]:', chunk.providerMetadata.google.thoughtSignature);
+        }
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', chunk.toolName, chunk.input);
+        if (chunk.providerMetadata?.google?.thoughtSignature) {
+          console.log('[Tool signature]:', chunk.providerMetadata.google.thoughtSignature);
+        }
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -24,6 +24,66 @@ describe('system messages', () => {
   });
 });
 
+describe('thought signatures', () => {
+  it('should preserve thought signatures in assistant messages', async () => {
+    const result = convertToGoogleGenerativeAIMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Regular text',
+            providerOptions: { google: { thoughtSignature: 'sig1' } },
+          },
+          {
+            type: 'reasoning',
+            text: 'Reasoning text',
+            providerOptions: { google: { thoughtSignature: 'sig2' } },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call1',
+            toolName: 'test',
+            input: { value: 'test' },
+            providerOptions: { google: { thoughtSignature: 'sig3' } },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Regular text",
+                "thoughtSignature": "sig1",
+              },
+              {
+                "text": "Reasoning text",
+                "thought": true,
+                "thoughtSignature": "sig2",
+              },
+              {
+                "functionCall": {
+                  "args": {
+                    "value": "test",
+                  },
+                  "name": "test",
+                },
+                "thoughtSignature": "sig3",
+              },
+            ],
+            "role": "model",
+          },
+        ],
+        "systemInstruction": undefined,
+      }
+    `);
+  });
+});
+
 describe('Gemma model system instructions', () => {
   it('should prepend system instruction to first user message for Gemma models', async () => {
     const result = convertToGoogleGenerativeAIMessages(

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -85,7 +85,20 @@ export function convertToGoogleGenerativeAIMessages(
                 case 'text': {
                   return part.text.length === 0
                     ? undefined
-                    : { text: part.text };
+                    : { 
+                        text: part.text,
+                        thoughtSignature: part.providerOptions?.google?.thoughtSignature,
+                      };
+                }
+
+                case 'reasoning': {
+                  return part.text.length === 0
+                    ? undefined
+                    : { 
+                        text: part.text,
+                        thought: true,
+                        thoughtSignature: part.providerOptions?.google?.thoughtSignature,
+                      };
                 }
 
                 case 'file': {
@@ -117,6 +130,7 @@ export function convertToGoogleGenerativeAIMessages(
                       name: part.toolName,
                       args: part.input,
                     },
+                    thoughtSignature: part.providerOptions?.google?.thoughtSignature,
                   };
                 }
               }

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -85,19 +85,21 @@ export function convertToGoogleGenerativeAIMessages(
                 case 'text': {
                   return part.text.length === 0
                     ? undefined
-                    : { 
+                    : {
                         text: part.text,
-                        thoughtSignature: part.providerOptions?.google?.thoughtSignature,
+                        thoughtSignature:
+                          part.providerOptions?.google?.thoughtSignature,
                       };
                 }
 
                 case 'reasoning': {
                   return part.text.length === 0
                     ? undefined
-                    : { 
+                    : {
                         text: part.text,
                         thought: true,
-                        thoughtSignature: part.providerOptions?.google?.thoughtSignature,
+                        thoughtSignature:
+                          part.providerOptions?.google?.thoughtSignature,
                       };
                 }
 
@@ -130,7 +132,8 @@ export function convertToGoogleGenerativeAIMessages(
                       name: part.toolName,
                       args: part.input,
                     },
-                    thoughtSignature: part.providerOptions?.google?.thoughtSignature,
+                    thoughtSignature:
+                      part.providerOptions?.google?.thoughtSignature,
                   };
                 }
               }

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -257,6 +257,7 @@ describe('doGenerate', () => {
     expect(content).toMatchInlineSnapshot(`
       [
         {
+          "providerMetadata": undefined,
           "text": "Hello, World!",
           "type": "text",
         },
@@ -366,6 +367,7 @@ describe('doGenerate', () => {
       [
         {
           "input": "{"value":"example value"}",
+          "providerMetadata": undefined,
           "toolCallId": "test-id",
           "toolName": "test-tool",
           "type": "tool-call",
@@ -744,6 +746,7 @@ describe('doGenerate', () => {
     expect(content).toMatchInlineSnapshot(`
       [
         {
+          "providerMetadata": undefined,
           "text": "test response",
           "type": "text",
         },
@@ -1227,6 +1230,7 @@ describe('doGenerate', () => {
     expect(content).toMatchInlineSnapshot(`
       [
         {
+          "providerMetadata": undefined,
           "text": "Here is an image:",
           "type": "text",
         },
@@ -1236,6 +1240,7 @@ describe('doGenerate', () => {
           "type": "file",
         },
         {
+          "providerMetadata": undefined,
           "text": "And another image:",
           "type": "text",
         },
@@ -1364,6 +1369,7 @@ describe('doGenerate', () => {
     expect(content).toMatchInlineSnapshot(`
       [
         {
+          "providerMetadata": undefined,
           "text": "Here is content:",
           "type": "text",
         },
@@ -1415,20 +1421,140 @@ describe('doGenerate', () => {
     expect(content).toMatchInlineSnapshot(`
       [
         {
+          "providerMetadata": undefined,
           "text": "Visible text part 1. ",
           "type": "text",
         },
         {
+          "providerMetadata": undefined,
           "text": "This is a thought process.",
           "type": "reasoning",
         },
         {
+          "providerMetadata": undefined,
           "text": "Visible text part 2.",
           "type": "text",
         },
         {
+          "providerMetadata": undefined,
           "text": "Another internal thought.",
           "type": "reasoning",
+        },
+      ]
+    `);
+  });
+
+  it('should correctly parse thought signatures with reasoning parts', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: 'Visible text part 1. ', thoughtSignature: 'sig1' },
+                { text: 'This is a thought process.', thought: true, thoughtSignature: 'sig2' },
+                { text: 'Visible text part 2.', thoughtSignature: 'sig3' },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "providerMetadata": {
+            "google": {
+              "thoughtSignature": "sig1",
+            },
+          },
+          "text": "Visible text part 1. ",
+          "type": "text",
+        },
+        {
+          "providerMetadata": {
+            "google": {
+              "thoughtSignature": "sig2",
+            },
+          },
+          "text": "This is a thought process.",
+          "type": "reasoning",
+        },
+        {
+          "providerMetadata": {
+            "google": {
+              "thoughtSignature": "sig3",
+            },
+          },
+          "text": "Visible text part 2.",
+          "type": "text",
+        },
+      ]
+    `);
+  });
+
+  it('should correctly parse thought signatures with function calls', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { 
+                  functionCall: { 
+                    name: 'test-tool', 
+                    args: { value: 'test' } 
+                  },
+                  thoughtSignature: 'func_sig1' 
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{"value":"test"}",
+          "providerMetadata": {
+            "google": {
+              "thoughtSignature": "func_sig1",
+            },
+          },
+          "toolCallId": "test-id",
+          "toolName": "test-tool",
+          "type": "tool-call",
         },
       ]
     `);
@@ -1739,21 +1865,25 @@ describe('doStream', () => {
         },
         {
           "id": "0",
+          "providerMetadata": undefined,
           "type": "text-start",
         },
         {
           "delta": "Hello",
           "id": "0",
+          "providerMetadata": undefined,
           "type": "text-delta",
         },
         {
           "delta": ", ",
           "id": "0",
+          "providerMetadata": undefined,
           "type": "text-delta",
         },
         {
           "delta": "world!",
           "id": "0",
+          "providerMetadata": undefined,
           "type": "text-delta",
         },
         {
@@ -2486,16 +2616,19 @@ describe('doStream', () => {
         },
         {
           "id": "0",
+          "providerMetadata": undefined,
           "type": "reasoning-start",
         },
         {
           "delta": "I need to think about this carefully. The user wants a simple explanation.",
           "id": "0",
+          "providerMetadata": undefined,
           "type": "reasoning-delta",
         },
         {
           "delta": "Let me organize my thoughts and provide a clear answer.",
           "id": "0",
+          "providerMetadata": undefined,
           "type": "reasoning-delta",
         },
         {
@@ -2504,16 +2637,19 @@ describe('doStream', () => {
         },
         {
           "id": "1",
+          "providerMetadata": undefined,
           "type": "text-start",
         },
         {
           "delta": "Here is a simple explanation: ",
           "id": "1",
+          "providerMetadata": undefined,
           "type": "text-delta",
         },
         {
           "delta": "The concept works because of basic principles.",
           "id": "1",
+          "providerMetadata": undefined,
           "type": "text-delta",
         },
         {
@@ -2542,6 +2678,143 @@ describe('doStream', () => {
             "outputTokens": 18,
             "reasoningTokens": 142,
             "totalTokens": 174,
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream thought signatures with reasoning and text parts', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: 'I need to think about this.',
+                    thought: true,
+                    thoughtSignature: 'reasoning_sig1',
+                  },
+                ],
+                role: 'model',
+              },
+              index: 0,
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: 'Here is the answer.',
+                    thoughtSignature: 'text_sig1',
+                  },
+                ],
+                role: 'model',
+              },
+              index: 0,
+              finishReason: 'STOP',
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+        })}\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const chunks = await convertReadableStreamToArray(stream);
+
+    expect(chunks).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "0",
+          "providerMetadata": {
+            "google": {
+              "thoughtSignature": "reasoning_sig1",
+            },
+          },
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "I need to think about this.",
+          "id": "0",
+          "providerMetadata": {
+            "google": {
+              "thoughtSignature": "reasoning_sig1",
+            },
+          },
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "0",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "1",
+          "providerMetadata": {
+            "google": {
+              "thoughtSignature": "text_sig1",
+            },
+          },
+          "type": "text-start",
+        },
+        {
+          "delta": "Here is the answer.",
+          "id": "1",
+          "providerMetadata": {
+            "google": {
+              "thoughtSignature": "text_sig1",
+            },
+          },
+          "type": "text-delta",
+        },
+        {
+          "id": "1",
+          "type": "text-end",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "google": {
+              "groundingMetadata": null,
+              "safetyRatings": [
+                {
+                  "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_HATE_SPEECH",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_HARASSMENT",
+                  "probability": "NEGLIGIBLE",
+                },
+                {
+                  "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                  "probability": "NEGLIGIBLE",
+                },
+              ],
+              "urlContextMetadata": null,
+            },
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": undefined,
+            "outputTokens": undefined,
+            "totalTokens": undefined,
           },
         },
       ]

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1453,7 +1453,11 @@ describe('doGenerate', () => {
             content: {
               parts: [
                 { text: 'Visible text part 1. ', thoughtSignature: 'sig1' },
-                { text: 'This is a thought process.', thought: true, thoughtSignature: 'sig2' },
+                {
+                  text: 'This is a thought process.',
+                  thought: true,
+                  thoughtSignature: 'sig2',
+                },
                 { text: 'Visible text part 2.', thoughtSignature: 'sig3' },
               ],
               role: 'model',
@@ -1516,12 +1520,12 @@ describe('doGenerate', () => {
           {
             content: {
               parts: [
-                { 
-                  functionCall: { 
-                    name: 'test-tool', 
-                    args: { value: 'test' } 
+                {
+                  functionCall: {
+                    name: 'test-tool',
+                    args: { value: 'test' },
                   },
-                  thoughtSignature: 'func_sig1' 
+                  thoughtSignature: 'func_sig1',
                 },
               ],
               role: 'model',

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -240,23 +240,13 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
         // Clear the ID after use to avoid accidental reuse.
         lastCodeExecutionToolCallId = undefined;
       } else if ('text' in part && part.text != null && part.text.length > 0) {
-        if (part.thought === true) {
-          content.push({
-            type: 'reasoning',
-            text: part.text,
-            providerMetadata: part.thoughtSignature
-              ? { google: { thoughtSignature: part.thoughtSignature } }
-              : undefined,
-          });
-        } else {
-          content.push({
-            type: 'text',
-            text: part.text,
-            providerMetadata: part.thoughtSignature
-              ? { google: { thoughtSignature: part.thoughtSignature } }
-              : undefined,
-          });
-        }
+        content.push({
+          type: part.thought === true ? 'reasoning' : 'text',
+          text: part.text,
+          providerMetadata: part.thoughtSignature
+            ? { google: { thoughtSignature: part.thoughtSignature } }
+            : undefined,
+        });
       } else if ('functionCall' in part) {
         content.push({
           type: 'tool-call' as const,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -659,16 +659,6 @@ function getToolCallsFromParts({
       }));
 }
 
-function getTextFromParts(parts: z.infer<typeof contentSchema>['parts']) {
-  const textParts = parts?.filter(part => 'text' in part) as Array<
-    GoogleGenerativeAIContentPart & { text: string }
-  >;
-
-  return textParts == null || textParts.length === 0
-    ? undefined
-    : textParts.map(part => part.text).join('');
-}
-
 function getInlineDataParts(parts: z.infer<typeof contentSchema>['parts']) {
   return parts?.filter(
     (

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -241,18 +241,18 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
         lastCodeExecutionToolCallId = undefined;
       } else if ('text' in part && part.text != null && part.text.length > 0) {
         if (part.thought === true) {
-          content.push({ 
-            type: 'reasoning', 
+          content.push({
+            type: 'reasoning',
             text: part.text,
-            providerMetadata: part.thoughtSignature 
+            providerMetadata: part.thoughtSignature
               ? { google: { thoughtSignature: part.thoughtSignature } }
               : undefined,
           });
         } else {
-          content.push({ 
-            type: 'text', 
+          content.push({
+            type: 'text',
             text: part.text,
-            providerMetadata: part.thoughtSignature 
+            providerMetadata: part.thoughtSignature
               ? { google: { thoughtSignature: part.thoughtSignature } }
               : undefined,
           });
@@ -263,7 +263,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
           toolCallId: this.config.generateId(),
           toolName: part.functionCall.name,
           input: JSON.stringify(part.functionCall.args),
-          providerMetadata: part.thoughtSignature 
+          providerMetadata: part.thoughtSignature
             ? { google: { thoughtSignature: part.thoughtSignature } }
             : undefined,
         });
@@ -480,8 +480,12 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
                       controller.enqueue({
                         type: 'reasoning-start',
                         id: currentReasoningBlockId,
-                        providerMetadata: part.thoughtSignature 
-                          ? { google: { thoughtSignature: part.thoughtSignature } }
+                        providerMetadata: part.thoughtSignature
+                          ? {
+                              google: {
+                                thoughtSignature: part.thoughtSignature,
+                              },
+                            }
                           : undefined,
                       });
                     }
@@ -490,8 +494,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
                       type: 'reasoning-delta',
                       id: currentReasoningBlockId,
                       delta: part.text,
-                      providerMetadata: part.thoughtSignature 
-                        ? { google: { thoughtSignature: part.thoughtSignature } }
+                      providerMetadata: part.thoughtSignature
+                        ? {
+                            google: { thoughtSignature: part.thoughtSignature },
+                          }
                         : undefined,
                     });
                   } else {
@@ -510,8 +516,12 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
                       controller.enqueue({
                         type: 'text-start',
                         id: currentTextBlockId,
-                        providerMetadata: part.thoughtSignature 
-                          ? { google: { thoughtSignature: part.thoughtSignature } }
+                        providerMetadata: part.thoughtSignature
+                          ? {
+                              google: {
+                                thoughtSignature: part.thoughtSignature,
+                              },
+                            }
                           : undefined,
                       });
                     }
@@ -520,8 +530,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
                       type: 'text-delta',
                       id: currentTextBlockId,
                       delta: part.text,
-                      providerMetadata: part.thoughtSignature 
-                        ? { google: { thoughtSignature: part.thoughtSignature } }
+                      providerMetadata: part.thoughtSignature
+                        ? {
+                            google: { thoughtSignature: part.thoughtSignature },
+                          }
                         : undefined,
                     });
                   }
@@ -651,7 +663,7 @@ function getToolCallsFromParts({
         toolCallId: generateId(),
         toolName: part.functionCall.name,
         args: JSON.stringify(part.functionCall.args),
-        providerMetadata: part.thoughtSignature 
+        providerMetadata: part.thoughtSignature
           ? { google: { thoughtSignature: part.thoughtSignature } }
           : undefined,
       }));


### PR DESCRIPTION
## background

google's reasoning models lose context between turns when using function calling because thought signatures weren't being captured and preserved. these encrypted signatures are required by the api to maintain reasoning state across multi-turn conversations

## summary

- add `thoughtSignature` field to google provider schema for parts
- preserve thought signatures in `doGenerate` and `doStream` methods  
- pass signatures through provider metadata for text, reasoning, and tool-call parts
- update message converter to preserve signatures from provider options
- add tests coverage for signature handling

## verification

- all existing tests pass
- new tests verify thought signatures are correctly parsed and preserved
- streaming correctly propagates signatures through metadata

## tasks

- [x] update content schema to support thoughtSignature field
- [x] add signature handling in doGenerate for text/reasoning/tool-calls
- [x] add signature handling in doStream with provider metadata
- [x] update convert-to-google-generative-ai-messages to preserve signatures
- [x] add tests for signature parsing and streaming

related issue - #7279