### PR TITLE
feat (provider/openai): add reasoning model config

### DIFF
--- a/.changeset/slimy-moose-breathe.md
+++ b/.changeset/slimy-moose-breathe.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat (provider/openai): add reasoning model config

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -840,7 +840,7 @@ const openaiChatChunkSchema = z.union([
 ]);
 
 function isReasoningModel(modelId: string) {
-  return modelId.startsWith('o');
+  return modelId.startsWith('o') || modelId.startsWith('gpt-5');
 }
 
 function supportsFlexProcessing(modelId: string) {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1110,6 +1110,7 @@ function getResponsesModelConfig(modelId: string): ResponsesModelConfig {
   // o series reasoning models:
   if (
     modelId.startsWith('o') ||
+    modelId.startsWith('gpt-5') ||
     modelId.startsWith('codex-') ||
     modelId.startsWith('computer-use')
   ) {


### PR DESCRIPTION
## Background

OpenAI has reasoning in new models.

## Summary

Support additional reasoning model id prefixes.
