### PR TITLE
feat(examples): add gpt-5 model examples and e2e tests

### DIFF
--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1058,6 +1058,9 @@ The following optional provider options are available for OpenAI completion mode
 | `o3`                   | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `o4-mini`              | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `chatgpt-4o-latest`    | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
+| `gpt-5`                | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5-mini`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5-nano`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   The table above lists popular models. Please see the [OpenAI

--- a/examples/ai-core/src/e2e/openai.test.ts
+++ b/examples/ai-core/src/e2e/openai.test.ts
@@ -29,6 +29,9 @@ createFeatureTestSuite({
       createChatModel('gpt-4o-mini'),
       createChatModel('gpt-3.5-turbo'),
       createChatModel('gpt-4-turbo-preview'),
+      createChatModel('gpt-5'),
+      createChatModel('gpt-5-mini'),
+      createChatModel('gpt-5-nano'),
     ],
     embeddingModels: [
       createEmbeddingModelWithCapabilities(

--- a/examples/ai-core/src/generate-object/openai-5-reasoning.ts
+++ b/examples/ai-core/src/generate-object/openai-5-reasoning.ts
@@ -1,0 +1,30 @@
+import { openai } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod/v4';
+
+async function main() {
+  const result = await generateObject({
+    model: openai('gpt-5'),
+    schema: z.object({
+      analysis: z.object({
+        problem: z.string(),
+        solution: z.object({
+          approach: z.string(),
+          steps: z.array(z.string()),
+          timeComplexity: z.string(),
+          spaceComplexity: z.string(),
+        }),
+        code: z.string(),
+      }),
+    }),
+    prompt: 'Analyze and solve: How would you implement a function to find the longest palindromic substring in a string?',
+  });
+
+  console.log(JSON.stringify(result.object.analysis, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-object/openai-5-reasoning.ts
+++ b/examples/ai-core/src/generate-object/openai-5-reasoning.ts
@@ -18,7 +18,8 @@ async function main() {
         code: z.string(),
       }),
     }),
-    prompt: 'Analyze and solve: How would you implement a function to find the longest palindromic substring in a string?',
+    prompt:
+      'Analyze and solve: How would you implement a function to find the longest palindromic substring in a string?',
   });
 
   console.log(JSON.stringify(result.object.analysis, null, 2));

--- a/examples/ai-core/src/generate-text/openai-reasoning-tools.ts
+++ b/examples/ai-core/src/generate-text/openai-reasoning-tools.ts
@@ -12,7 +12,9 @@ async function main() {
       calculator: tool({
         description: 'Calculate mathematical expressions',
         inputSchema: z.object({
-          expression: z.string().describe('The mathematical expression to calculate'),
+          expression: z
+            .string()
+            .describe('The mathematical expression to calculate'),
         }),
         execute: async ({ expression }) => {
           try {
@@ -24,7 +26,8 @@ async function main() {
         },
       }),
     },
-    prompt: 'What is the weather in San Francisco? Then calculate how many days are in 3 weeks.',
+    prompt:
+      'What is the weather in San Francisco? Then calculate how many days are in 3 weeks.',
     maxOutputTokens: 1000,
   });
 

--- a/examples/ai-core/src/generate-text/openai-reasoning-tools.ts
+++ b/examples/ai-core/src/generate-text/openai-reasoning-tools.ts
@@ -1,0 +1,37 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod/v4';
+import { weatherTool } from '../tools/weather-tool';
+
+async function main() {
+  const { text, reasoning, toolCalls, usage } = await generateText({
+    model: openai('gpt-5'),
+    tools: {
+      weather: weatherTool,
+      calculator: tool({
+        description: 'Calculate mathematical expressions',
+        inputSchema: z.object({
+          expression: z.string().describe('The mathematical expression to calculate'),
+        }),
+        execute: async ({ expression }) => {
+          try {
+            const result = eval(expression);
+            return { expression, result };
+          } catch (error) {
+            return { expression, error: 'Invalid expression' };
+          }
+        },
+      }),
+    },
+    prompt: 'What is the weather in San Francisco? Then calculate how many days are in 3 weeks.',
+    maxOutputTokens: 1000,
+  });
+
+  console.log('Text:', text);
+  console.log('\nReasoning:', reasoning);
+  console.log('\nTool Calls:', toolCalls);
+  console.log('\nUsage:', usage);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-object/openai-5-reasoning.ts
+++ b/examples/ai-core/src/stream-object/openai-5-reasoning.ts
@@ -20,7 +20,8 @@ async function main() {
         recommendations: z.array(z.string()),
       }),
     }),
-    prompt: 'Analyze the impact of artificial intelligence on modern software development practices.',
+    prompt:
+      'Analyze the impact of artificial intelligence on modern software development practices.',
   });
 
   for await (const partialObject of result.partialObjectStream) {

--- a/examples/ai-core/src/stream-object/openai-5-reasoning.ts
+++ b/examples/ai-core/src/stream-object/openai-5-reasoning.ts
@@ -1,0 +1,32 @@
+import { openai } from '@ai-sdk/openai';
+import { streamObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod/v4';
+
+async function main() {
+  const result = streamObject({
+    model: openai('gpt-5'),
+    schema: z.object({
+      analysis: z.object({
+        topic: z.string(),
+        keyPoints: z.array(
+          z.object({
+            point: z.string(),
+            explanation: z.string(),
+            importance: z.enum(['low', 'medium', 'high']),
+          }),
+        ),
+        conclusion: z.string(),
+        recommendations: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Analyze the impact of artificial intelligence on modern software development practices.',
+  });
+
+  for await (const partialObject of result.partialObjectStream) {
+    console.clear();
+    console.log(partialObject);
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/openai-5-reasoning.ts
+++ b/examples/ai-core/src/stream-text/openai-5-reasoning.ts
@@ -1,0 +1,86 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod/v4';
+import { weatherTool } from '../tools/weather-tool';
+
+async function main() {
+  const result = streamText({
+    model: openai('gpt-5'),
+    tools: {
+      weather: weatherTool,
+      cityAttractions: {
+        inputSchema: z.object({ city: z.string() }),
+      },
+    },
+    prompt: 'What is the weather in San Francisco?',
+  });
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-delta': {
+        console.log('Text:', part.text);
+        break;
+      }
+
+      case 'tool-call': {
+        if (part.dynamic) {
+          continue;
+        }
+
+        switch (part.toolName) {
+          case 'cityAttractions': {
+            console.log('TOOL CALL cityAttractions');
+            console.log(`city: ${part.input.city}`); // string
+            break;
+          }
+
+          case 'weather': {
+            console.log('TOOL CALL weather');
+            console.log(`location: ${part.input.location}`); // string
+            break;
+          }
+        }
+
+        break;
+      }
+
+      case 'tool-result': {
+        if (part.dynamic) {
+          continue;
+        }
+
+        switch (part.toolName) {
+          // NOT AVAILABLE (NO EXECUTE METHOD)
+          // case 'cityAttractions': {
+          //   console.log('TOOL RESULT cityAttractions');
+          //   console.log(`city: ${part.input.city}`); // string
+          //   console.log(`result: ${part.result}`);
+          //   break;
+          // }
+
+          case 'weather': {
+            console.log('TOOL RESULT weather');
+            console.log(`location: ${part.input.location}`); // string
+            console.log(`temperature: ${part.output.temperature}`); // number
+            break;
+          }
+        }
+
+        break;
+      }
+
+      case 'finish': {
+        console.log('Finish reason:', part.finishReason);
+        console.log('Total Usage:', part.totalUsage);
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', part.error);
+        break;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/openai/src/openai-chat-options.ts
+++ b/packages/openai/src/openai-chat-options.ts
@@ -46,6 +46,9 @@ export type OpenAIChatModelId =
   | 'gpt-3.5-turbo'
   | 'gpt-3.5-turbo-1106'
   | 'chatgpt-4o-latest'
+  | 'gpt-5'
+  | 'gpt-5-mini'
+  | 'gpt-5-nano'
   | (string & {});
 
 export const openaiProviderOptions = z.object({


### PR DESCRIPTION
## background

openai released gpt-5 model. need examples demonstrating the new model

## summary

- add gpt-5 model examples for stream text, generate text, stream object, generate object
- add e2e test coverage for new examples

## verification

- all tests pass including new gpt-5 examples
- examples demonstrate gpt-5 capabilities across all sdk functions

## tasks

- [x] add openai-reasoning-tools.ts example with gpt-5
- [x] add openai-5-reasoning.ts examples for generate/stream object
- [x] add e2e test coverage for gpt-5 examples
- [x] examples follow existing patterns and schemas

## future work
* update examples once gpt-5 reasoning features are fully documented
