### PR TITLE
react: useObject – add non-streaming fallback for RN/Expo (fixes #7817)

### DIFF
--- a/.changeset/use-object-fallback-react.md
+++ b/.changeset/use-object-fallback-react.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/react': patch
+---
+
+Fix `experimental_useObject()` to support environments without `ReadableStream`/`TextDecoderStream` (e.g., React Native/Expo) by adding a non-streaming JSON fallback. Also add tests for non-stream responses and empty bodies. Fixes #7817.
+
+


### PR DESCRIPTION
This PR fixes an error in `experimental_useObject()` when running in environments without `ReadableStream`/`TextDecoderStream` (e.g., Expo/React Native), which caused `Error: The response body is empty.`

Changes:
- Detect streaming capability; if unavailable, fall back to `response.text()` and parse once.
- Preserve progressive updates when streaming is available.
- Add UI tests for non-stream JSON and empty responses in `@ai-sdk/react`.
- Add changeset for `@ai-sdk/react`.

This addresses the issue reported in #7817 and allows RN/Expo users to successfully use `useObject` without stream support while still preferring streaming where available.