### PR TITLE
vertex provider for providerOptions now consistent across all models

### DIFF
--- a/.changeset/metal-carpets-allow.md
+++ b/.changeset/metal-carpets-allow.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/google': patch
+---
+
+when running from vertex make sure to allow providing the vertex provider in providerOptions for consistency

--- a/packages/google-vertex/src/google-vertex-chat-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-chat-model.test.ts
@@ -1,0 +1,165 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/provider-utils/test';
+import { createVertex } from './google-vertex-provider';
+
+const TEST_PROMPT: LanguageModelV2Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+const SAFETY_RATINGS = [
+  {
+    category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+    probability: 'NEGLIGIBLE',
+  },
+  {
+    category: 'HARM_CATEGORY_HATE_SPEECH',
+    probability: 'NEGLIGIBLE',
+  },
+  {
+    category: 'HARM_CATEGORY_HARASSMENT',
+    probability: 'NEGLIGIBLE',
+  },
+  {
+    category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+    probability: 'NEGLIGIBLE',
+  },
+];
+
+const TEST_BASE_URL =
+  'https://vertex.googleapis.com/v1/projects/test-project/locations/global/publishers/google';
+
+const MODEL_ID = 'gemini-2.5-flash';
+
+const vertexProvider = createVertex({
+  project: 'test-project',
+  location: 'global',
+  baseURL: TEST_BASE_URL,
+  generateId: () => 'test-id',
+});
+const model = vertexProvider.languageModel(MODEL_ID);
+
+describe('doGenerate', () => {
+  const TEST_URL = `${TEST_BASE_URL}/models/${MODEL_ID}:generateContent`;
+
+  const server = createTestServer({
+    [TEST_URL]: {},
+  });
+
+  const prepareJsonResponse = ({
+    content = '',
+    usage = {
+      promptTokenCount: 1,
+      candidatesTokenCount: 2,
+      totalTokenCount: 3,
+    },
+    headers,
+  }: {
+    content?: string;
+    usage?: {
+      promptTokenCount: number;
+      candidatesTokenCount: number;
+      totalTokenCount: number;
+    };
+    headers?: Record<string, string>;
+  }) => {
+    server.urls[TEST_URL].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: content.length > 0 ? [{ text: content }] : [],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        promptFeedback: { safetyRatings: SAFETY_RATINGS },
+        usageMetadata: usage,
+      },
+    };
+  };
+
+  it('should pass responseModalities from providerOptions.vertex', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        vertex: {
+          responseModalities: ['TEXT', 'IMAGE'],
+          foo: 'bar',
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody).toMatchObject({
+      generationConfig: {
+        responseModalities: ['TEXT', 'IMAGE'],
+      },
+    });
+  });
+
+  it('should omit responseSchema when structuredOutputs is false', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { location: { type: 'string' } },
+        },
+      },
+      providerOptions: {
+        vertex: {
+          structuredOutputs: false,
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody).toMatchObject({
+      generationConfig: {
+        responseMimeType: 'application/json',
+      },
+    });
+    expect(requestBody.generationConfig).not.toHaveProperty('responseSchema');
+  });
+
+  it('should pass thinkingConfig and produce no warnings', async () => {
+    prepareJsonResponse({});
+
+    const { warnings } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        vertex: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingBudget: 500,
+          },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(0);
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody).toMatchObject({
+      generationConfig: {
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingBudget: 500,
+        },
+      },
+    });
+  });
+});

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -68,7 +68,7 @@ describe('GoogleVertexEmbeddingModel', () => {
 
     const { embeddings } = await model.doEmbed({
       values: testValues,
-      providerOptions: { google: mockProviderOptions },
+      providerOptions: { vertex: mockProviderOptions },
     });
 
     expect(embeddings).toStrictEqual(dummyEmbeddings);
@@ -83,7 +83,7 @@ describe('GoogleVertexEmbeddingModel', () => {
 
     const { response } = await model.doEmbed({
       values: testValues,
-      providerOptions: { google: mockProviderOptions },
+      providerOptions: { vertex: mockProviderOptions },
     });
 
     expect(response?.headers).toStrictEqual({
@@ -103,7 +103,7 @@ describe('GoogleVertexEmbeddingModel', () => {
 
     const { usage } = await model.doEmbed({
       values: testValues,
-      providerOptions: { google: mockProviderOptions },
+      providerOptions: { vertex: mockProviderOptions },
     });
 
     expect(usage).toStrictEqual({ tokens: 25 });
@@ -114,7 +114,7 @@ describe('GoogleVertexEmbeddingModel', () => {
 
     await model.doEmbed({
       values: testValues,
-      providerOptions: { google: mockProviderOptions },
+      providerOptions: { vertex: mockProviderOptions },
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -131,7 +131,7 @@ describe('GoogleVertexEmbeddingModel', () => {
 
     await model.doEmbed({
       values: testValues,
-      providerOptions: { google: { taskType: mockProviderOptions.taskType } },
+      providerOptions: { vertex: { taskType: mockProviderOptions.taskType } },
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -172,7 +172,7 @@ describe('GoogleVertexEmbeddingModel', () => {
     await expect(
       model.doEmbed({
         values: tooManyValues,
-        providerOptions: { google: mockProviderOptions },
+        providerOptions: { vertex: mockProviderOptions },
       }),
     ).rejects.toThrow(TooManyEmbeddingValuesForCallError);
   });
@@ -202,7 +202,7 @@ describe('GoogleVertexEmbeddingModel', () => {
     const response = await modelWithCustomUrl.doEmbed({
       values: testValues,
       providerOptions: {
-        google: { outputDimensionality: 768 },
+        vertex: { outputDimensionality: 768 },
       },
     });
 
@@ -241,7 +241,7 @@ describe('GoogleVertexEmbeddingModel', () => {
     const response = await modelWithCustomFetch.doEmbed({
       values: testValues,
       providerOptions: {
-        google: { outputDimensionality: 768 },
+        vertex: { outputDimensionality: 768 },
       },
     });
 

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -49,7 +49,7 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV2<string> {
     // Parse provider options
     const googleOptions =
       (await parseProviderOptions({
-        provider: 'google',
+        provider: 'vertex',
         providerOptions,
         schema: googleVertexEmbeddingProviderOptions,
       })) ?? {};

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -94,7 +94,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
     const warnings: LanguageModelV2CallWarning[] = [];
 
     const googleOptions = await parseProviderOptions({
-      provider: 'google',
+      // make sure to use the correct provider when coming from vertex
+      provider: this.config.provider.startsWith('google.vertex')
+        ? 'vertex'
+        : 'google',
       providerOptions,
       schema: googleGenerativeAIProviderOptions,
     });


### PR DESCRIPTION
## Background
a small fix for #7783. Another option is to just make everything google, tell me what you guys prefer

## Summary
specifying the provider in the provider option was inconsistent and kinda confusing when using vertex. an example: 
```js
...
 providerOptions: {
   google: { // had to provided google here otherwise options weren't used when using either the vertex provider or the google one
     cachedContent: cachedContentName,
   },
 },
...
```
i would expect:
```js
...
 providerOptions: {
   vertex: { 
     cachedContent: cachedContentName,
   },
 },
...
```

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues
Fixes #7783. 