### PR TITLE
feat (provider/openai-compatible): look for reasoning in `reasoning` field

### DIFF
--- a/.changeset/fast-brooms-prove.md
+++ b/.changeset/fast-brooms-prove.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+feat (provider/openai-compatible): look for reasoning in 'reasoning' field as well

--- a/examples/ai-core/src/generate-text/cerebras-reasoning.ts
+++ b/examples/ai-core/src/generate-text/cerebras-reasoning.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { cerebras as provider } from '@ai-sdk/cerebras';
+import { generateText } from 'ai';
+
+async function main() {
+  const result = await generateText({
+    model: provider.chat('gpt-oss-120b'),
+    prompt: 'What is notable about Sonoran food?',
+  });
+
+  console.log('Reasoning:');
+  console.log(result.reasoning);
+  console.log();
+
+  console.log('Text:');
+  console.log(result.text);
+  console.log();
+
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/baseten-reasoning.ts
+++ b/examples/ai-core/src/stream-text/baseten-reasoning.ts
@@ -1,0 +1,29 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const baseten = createOpenAICompatible({
+    baseURL: 'https://inference.baseten.co/v1',
+    name: 'baseten',
+    apiKey: process.env.BASETEN_API_KEY,
+  });
+  const result = streamText({
+    model: baseten('openai/gpt-oss-120b'),
+    prompt: 'What is notable about Sonoran food?',
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'reasoning-delta') {
+      process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/cerebras-reasoning.ts
+++ b/examples/ai-core/src/stream-text/cerebras-reasoning.ts
@@ -1,0 +1,24 @@
+import { cerebras } from '@ai-sdk/cerebras';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: cerebras('gpt-oss-120b'),
+    prompt: 'What is notable about Sonoran food?',
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'reasoning-delta') {
+      process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.test.ts
@@ -61,6 +61,7 @@ describe('doGenerate', () => {
   function prepareJsonResponse({
     content = '',
     reasoning_content = '',
+    reasoning = '',
     tool_calls,
     function_call,
     usage = {
@@ -76,6 +77,7 @@ describe('doGenerate', () => {
   }: {
     content?: string;
     reasoning_content?: string;
+    reasoning?: string;
     tool_calls?: Array<{
       id: string;
       type: 'function';
@@ -122,6 +124,7 @@ describe('doGenerate', () => {
               role: 'assistant',
               content,
               reasoning_content,
+              reasoning,
               tool_calls,
               function_call,
             },
@@ -199,6 +202,51 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should extract reasoning from reasoning field when reasoning_content is not provided', async () => {
+    prepareJsonResponse({
+      content: 'Hello, World!',
+      reasoning: 'This is the reasoning from the reasoning field',
+    });
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        },
+      ]
+    `);
+  });
+
+  it('should prefer reasoning_content over reasoning field when both are provided', async () => {
+    prepareJsonResponse({
+      content: 'Hello, World!',
+      reasoning_content: 'This is from reasoning_content',
+      reasoning: 'This is from reasoning field',
+    });
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "Hello, World!",
+          "type": "text",
+        },
+        {
+          "text": "This is from reasoning_content",
+          "type": "reasoning",
+        },
+      ]
+    `);
+  });
+
   it('should extract usage', async () => {
     prepareJsonResponse({
       usage: { prompt_tokens: 20, total_tokens: 25, completion_tokens: 5 },
@@ -239,6 +287,7 @@ describe('doGenerate', () => {
               "index": 0,
               "message": {
                 "content": "",
+                "reasoning": "",
                 "reasoning_content": "",
                 "role": "assistant",
               },
@@ -256,7 +305,7 @@ describe('doGenerate', () => {
           },
         },
         "headers": {
-          "content-length": "298",
+          "content-length": "313",
           "content-type": "application/json",
         },
         "id": "test-id",
@@ -321,7 +370,7 @@ describe('doGenerate', () => {
 
     expect(response?.headers).toStrictEqual({
       // default headers:
-      'content-length': '335',
+      'content-length': '350',
       'content-type': 'application/json',
 
       // custom header
@@ -1071,6 +1120,172 @@ describe('doStream', () => {
         },
         {
           "delta": " my response",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "cachedInputTokens": undefined,
+            "inputTokens": 18,
+            "outputTokens": 439,
+            "reasoningTokens": undefined,
+            "totalTokens": undefined,
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should stream reasoning from reasoning field when reasoning_content is not provided', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":"", "reasoning":"Let me consider"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"", "reasoning":" this carefully"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"My answer is"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":" correct"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],` +
+          `"usage":{"prompt_tokens":18,"completion_tokens":439}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "Let me consider",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "delta": " this carefully",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "My answer is",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "delta": " correct",
+          "id": "txt-0",
+          "type": "text-delta",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-end",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-end",
+        },
+        {
+          "finishReason": "stop",
+          "providerMetadata": {
+            "test-provider": {},
+          },
+          "type": "finish",
+          "usage": {
+            "cachedInputTokens": undefined,
+            "inputTokens": 18,
+            "outputTokens": 439,
+            "reasoningTokens": undefined,
+            "totalTokens": undefined,
+          },
+        },
+      ]
+    `);
+  });
+
+  it('should prefer reasoning_content over reasoning field in streaming when both are provided', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"role":"assistant","content":"", "reasoning_content":"From reasoning_content", "reasoning":"From reasoning"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1711357598,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_3bc1b5746c","choices":[{"index":0,"delta":{"content":"Final response"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798","object":"chat.completion.chunk","created":1729171479,"model":"grok-beta",` +
+          `"system_fingerprint":"fp_10c08bf97d","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],` +
+          `"usage":{"prompt_tokens":18,"completion_tokens":439}}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": "chatcmpl-e7f8e220-656c-4455-a132-dacfc1370798",
+          "modelId": "grok-beta",
+          "timestamp": 2024-03-25T09:06:38.000Z,
+          "type": "response-metadata",
+        },
+        {
+          "id": "reasoning-0",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "From reasoning_content",
+          "id": "reasoning-0",
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "txt-0",
+          "type": "text-start",
+        },
+        {
+          "delta": "Final response",
           "id": "txt-0",
           "type": "text-delta",
         },


### PR DESCRIPTION
## Background

Some providers such as cerebras and baseten started serving `gpt-oss` models and produce reasoning content in a field named `reasoning`. The existing openai compatible language model only looks for reasoning in a `reasoning_content` field.

## Summary

The specification for reasoning content in openai chat completions response doesn't seem fully specified. Here we fall back to looking for content in `reasoning` if we don't find it in `reasoning_content`.

## Manual Verification

Added example scripts for cerebras and baseten showing missing reasoning content before, and producing reasoning content after, this change.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
