### PR TITLE
chore(docs): add global provider configuration section

### DIFF
--- a/content/docs/03-ai-sdk-core/45-provider-management.mdx
+++ b/content/docs/03-ai-sdk-core/45-provider-management.mdx
@@ -306,3 +306,40 @@ export const registry = createProviderRegistry(
 // usage:
 const model = registry.languageModel('anthropic > reasoning');
 ```
+
+## Global Provider Configuration
+
+The AI SDK 5 includes a global provider feature that allows you to specify a model using just a plain model ID string:
+
+```ts
+import { streamText } from 'ai';
+
+const result = await streamText({
+  model: 'openai/gpt-4o', // Uses the global provider (defaults to AI Gateway)
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+```
+
+By default, the global provider is set to the Vercel AI Gateway.
+
+### Customizing the Global Provider
+
+You can set your own preferred global provider:
+
+```ts filename="setup.ts"
+import { openai } from '@ai-sdk/openai';
+
+// Initialize once during startup:
+globalThis.AI_SDK_DEFAULT_PROVIDER = openai;
+```
+
+```ts filename="app.ts"
+import { streamText } from 'ai';
+
+const result = await streamText({
+  model: 'gpt-4o', // Uses OpenAI provider without prefix
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+```
+
+This simplifies provider usage and makes it easier to switch between providers without changing your model references throughout your codebase.


### PR DESCRIPTION
## background

added global provider configuration section to provider management docs. explains how to use plain model id strings and customize the default provider

## summary

- added section explaining global provider usage with ai gateway as default
- included setup example for customizing the global provider