### PR TITLE
chore(docs): add migration v4-v5 on migration page 

### DIFF
--- a/content/docs/08-migration-guides/index.mdx
+++ b/content/docs/08-migration-guides/index.mdx
@@ -6,6 +6,7 @@ collapsed: true
 
 # Migration Guides
 
+- [ Migrate AI SDK 4.0 to 5.0 ](https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0)
 - [ Migrate AI SDK 4.1 to 4.2 ](/docs/migration-guides/migration-guide-4-2)
 - [ Migrate AI SDK 4.0 to 4.1 ](/docs/migration-guides/migration-guide-4-1)
 - [ Migrate AI SDK 3.4 to 4.0 ](/docs/migration-guides/migration-guide-4-0)


### PR DESCRIPTION
## background

updated migration page to include v4 - v5

## summary

- added link to v4 to v5 taking the users to [v5 sdk migration guis](https://vercel.slack.com/archives/D08URTB377D/p1754652145133589)
https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0