### PR TITLE
feat(openai): add flex processing support for gpt-5 models

### DIFF
--- a/.changeset/odd-bags-sin.md
+++ b/.changeset/odd-bags-sin.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add flex processing support for gpt-5 models

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -220,7 +220,7 @@ The following optional provider options are available for OpenAI chat models:
 - **serviceTier** _'auto' | 'flex'_
 
   Service tier for the request. Set to 'flex' for 50% cheaper processing
-  at the cost of increased latency. Only available for o3 and o4-mini models.
+  at the cost of increased latency. Only available for o3, o4-mini, and gpt-5 models.
   Defaults to 'auto'.
 
 - **strictJsonSchema** _boolean_
@@ -688,7 +688,7 @@ The following provider options are available:
 
 - **serviceTier** _'auto' | 'flex'_
   Service tier for the request. Set to 'flex' for 50% cheaper processing
-  at the cost of increased latency. Only available for o3 and o4-mini models.
+  at the cost of increased latency. Only available for o3, o4-mini, and gpt-5 models.
   Defaults to 'auto'.
 
 - **include** _Array&lt;string&gt;_

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -1508,7 +1508,7 @@ describe('doGenerate', () => {
     expect(result.warnings).toContainEqual({
       type: 'unsupported-setting',
       setting: 'serviceTier',
-      details: 'flex processing is only available for o3 and o4-mini models',
+      details: 'flex processing is only available for o3, o4-mini, and gpt-5 models',
     });
   });
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -1508,7 +1508,8 @@ describe('doGenerate', () => {
     expect(result.warnings).toContainEqual({
       type: 'unsupported-setting',
       setting: 'serviceTier',
-      details: 'flex processing is only available for o3, o4-mini, and gpt-5 models',
+      details:
+        'flex processing is only available for o3, o4-mini, and gpt-5 models',
     });
   });
 

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -264,7 +264,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'serviceTier',
-        details: 'flex processing is only available for o3, o4-mini, and gpt-5 models',
+        details:
+          'flex processing is only available for o3, o4-mini, and gpt-5 models',
       });
       baseArgs.service_tier = undefined;
     }
@@ -844,7 +845,11 @@ function isReasoningModel(modelId: string) {
 }
 
 function supportsFlexProcessing(modelId: string) {
-  return modelId.startsWith('o3') || modelId.startsWith('o4-mini') || modelId.startsWith('gpt-5');
+  return (
+    modelId.startsWith('o3') ||
+    modelId.startsWith('o4-mini') ||
+    modelId.startsWith('gpt-5')
+  );
 }
 
 function supportsPriorityProcessing(modelId: string) {

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -264,7 +264,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'serviceTier',
-        details: 'flex processing is only available for o3 and o4-mini models',
+        details: 'flex processing is only available for o3, o4-mini, and gpt-5 models',
       });
       baseArgs.service_tier = undefined;
     }
@@ -844,7 +844,7 @@ function isReasoningModel(modelId: string) {
 }
 
 function supportsFlexProcessing(modelId: string) {
-  return modelId.startsWith('o3') || modelId.startsWith('o4-mini');
+  return modelId.startsWith('o3') || modelId.startsWith('o4-mini') || modelId.startsWith('gpt-5');
 }
 
 function supportsPriorityProcessing(modelId: string) {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -200,7 +200,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'serviceTier',
-        details: 'flex processing is only available for o3, o4-mini, and gpt-5 models',
+        details:
+          'flex processing is only available for o3, o4-mini, and gpt-5 models',
       });
       // Remove from args if not supported
       delete (baseArgs as any).service_tier;
@@ -1138,7 +1139,11 @@ function getResponsesModelConfig(modelId: string): ResponsesModelConfig {
 }
 
 function supportsFlexProcessing(modelId: string): boolean {
-  return modelId.startsWith('o3') || modelId.startsWith('o4-mini') || modelId.startsWith('gpt-5');
+  return (
+    modelId.startsWith('o3') ||
+    modelId.startsWith('o4-mini') ||
+    modelId.startsWith('gpt-5')
+  );
 }
 
 function supportsPriorityProcessing(modelId: string): boolean {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -200,7 +200,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'serviceTier',
-        details: 'flex processing is only available for o3 and o4-mini models',
+        details: 'flex processing is only available for o3, o4-mini, and gpt-5 models',
       });
       // Remove from args if not supported
       delete (baseArgs as any).service_tier;
@@ -1138,7 +1138,7 @@ function getResponsesModelConfig(modelId: string): ResponsesModelConfig {
 }
 
 function supportsFlexProcessing(modelId: string): boolean {
-  return modelId.startsWith('o3') || modelId.startsWith('o4-mini');
+  return modelId.startsWith('o3') || modelId.startsWith('o4-mini') || modelId.startsWith('gpt-5');
 }
 
 function supportsPriorityProcessing(modelId: string): boolean {


### PR DESCRIPTION
## background

openai released gpt-5 models that support the "flex" service tier for cost-efficient processing, but the sdk was rejecting flex processing requests for these models and showing warnings that only o3 and o4-mini models support this feature

## summary

- add gpt-5 models to flex processing allowlist
- update warning messages to include gpt-5 models

## verification

- warning messages updated to reflect new supported models
- service tier properly included for gpt-5 models

## tasks

- [x] update supportsFlexProcessing function in openai-chat-language-model.ts
- [x] update supportsFlexProcessing function in openai-responses-language-model.ts  
- [x] update warning messages in both files
- [x] update test expectations
- [x] update docs 

related issue - #7889 