### PR TITLE
feat(openai): add priority processing support for gpt-5 models

### DIFF
--- a/.changeset/stupid-weeks-vanish.md
+++ b/.changeset/stupid-weeks-vanish.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add priority processing support for gpt-5 models

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -686,9 +686,10 @@ The following provider options are available:
 - **strictJsonSchema** _boolean_
   Whether to use strict JSON schema validation. Defaults to `false`.
 
-- **serviceTier** _'auto' | 'flex'_
+- **serviceTier** _'auto' | 'flex' | 'priority'_
   Service tier for the request. Set to 'flex' for 50% cheaper processing
-  at the cost of increased latency. Only available for o3, o4-mini, and gpt-5 models.
+  at the cost of increased latency (available for o3, o4-mini, and gpt-5 models).
+  Set to 'priority' for faster processing with Enterprise access (available for gpt-4, gpt-5, gpt-5-mini, o3, o4-mini; gpt-5-nano is not supported).
   Defaults to 'auto'.
 
 - **include** _Array&lt;string&gt;_

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -1581,7 +1581,7 @@ describe('doGenerate', () => {
       type: 'unsupported-setting',
       setting: 'serviceTier',
       details:
-        'priority processing is only available for supported models (GPT-4, o3, o4-mini) and requires Enterprise access',
+        'priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported',
     });
   });
 

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -279,7 +279,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
         type: 'unsupported-setting',
         setting: 'serviceTier',
         details:
-          'priority processing is only available for supported models (GPT-4, o3, o4-mini) and requires Enterprise access',
+          'priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported',
       });
       baseArgs.service_tier = undefined;
     }
@@ -855,6 +855,8 @@ function supportsFlexProcessing(modelId: string) {
 function supportsPriorityProcessing(modelId: string) {
   return (
     modelId.startsWith('gpt-4') ||
+    modelId.startsWith('gpt-5-mini') ||
+    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-nano')) ||
     modelId.startsWith('o3') ||
     modelId.startsWith('o4-mini')
   );

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -216,7 +216,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
         type: 'unsupported-setting',
         setting: 'serviceTier',
         details:
-          'priority processing is only available for supported models (GPT-4, o3, o4-mini) and requires Enterprise access',
+          'priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported',
       });
       // Remove from args if not supported
       delete (baseArgs as any).service_tier;
@@ -1149,6 +1149,8 @@ function supportsFlexProcessing(modelId: string): boolean {
 function supportsPriorityProcessing(modelId: string): boolean {
   return (
     modelId.startsWith('gpt-4') ||
+    modelId.startsWith('gpt-5-mini') ||
+    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-nano')) ||
     modelId.startsWith('o3') ||
     modelId.startsWith('o4-mini')
   );


### PR DESCRIPTION
## background

openai released gpt-5 and gpt-5-mini models that support the "priority" service tier for faster processing, but the sdk was rejecting priority processing requests for these models. gpt-5-nano does not support priority processing

## summary

- add gpt-5 and gpt-5-mini models to priority processing allowlist
- exclude gpt-5-nano from priority processing support
- update warning messages and documentation

## verification

- existing test coverage validates priority processing works correctly
- warning messages updated to reflect new supported models
- service tier properly included/excluded based on model support

## tasks

- [x] update supportsPriorityProcessing to include gpt-5 and gpt-5-mini but exclude gpt-5-nano
- [x] update warning messages in both chat and responses apis
- [x] add priority processing to serviceTier documentation with supported models
- [x] update openai provider documentation