### PR TITLE
feat(openai): add verbosity parameter support for chat api

### DIFF
--- a/.changeset/thin-eyes-sort.md
+++ b/.changeset/thin-eyes-sort.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai': patch
 ---
 
-add verbosity settings in openai provider options
+feat(openai): add verbosity parameter support for chat api

--- a/.changeset/thin-eyes-sort.md
+++ b/.changeset/thin-eyes-sort.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+add verbosity settings in openai provider options

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -228,7 +228,7 @@ The following optional provider options are available for OpenAI chat models:
   Whether to use strict JSON schema validation.
   Defaults to `false`.
 
-- **verbosity** _'low' | 'medium' | 'high'_
+- **textVerbosity** _'low' | 'medium' | 'high'_
 
   Controls the verbosity of the model's responses. Lower values will result in more concise responses, while higher values will result in more verbose responses.
 

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -188,7 +188,7 @@ The following optional provider options are available for OpenAI chat models:
   A unique identifier representing your end-user, which can help OpenAI to
   monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
 
-- **reasoningEffort** _'minimal' | 'low' | 'medium' | 'high'_
+- **reasoningEffort** _'low' | 'medium' | 'high'_
 
   Reasoning effort for reasoning models. Defaults to `medium`. If you use
   `providerOptions` to set the `reasoningEffort` option, this

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -188,7 +188,7 @@ The following optional provider options are available for OpenAI chat models:
   A unique identifier representing your end-user, which can help OpenAI to
   monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
 
-- **reasoningEffort** _'low' | 'medium' | 'high'_
+- **reasoningEffort** _'minimal' | 'low' | 'medium' | 'high'_
 
   Reasoning effort for reasoning models. Defaults to `medium`. If you use
   `providerOptions` to set the `reasoningEffort` option, this
@@ -227,6 +227,10 @@ The following optional provider options are available for OpenAI chat models:
 
   Whether to use strict JSON schema validation.
   Defaults to `false`.
+
+- **verbosity** _'low' | 'medium' | 'high'_
+
+  Controls the verbosity of the model's responses. Lower values will result in more concise responses, while higher values will result in more verbose responses.
 
 #### Reasoning
 

--- a/examples/ai-core/src/generate-text/openai-gpt-chat-verbosity.ts
+++ b/examples/ai-core/src/generate-text/openai-gpt-chat-verbosity.ts
@@ -1,0 +1,20 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: openai.chat('gpt-5'),
+    prompt: 'Write a poem about a boy and his first pet dog.',
+    providerOptions: {
+      openai: {
+        textVerbosity: 'low',
+      },
+    },
+  });
+
+  console.log('Response:', result.response?.body);
+  console.log('Request:', result.request?.body);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-gpt5-verbosity.ts
+++ b/examples/ai-core/src/generate-text/openai-gpt5-verbosity.ts
@@ -4,11 +4,11 @@ import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: openai.chat('gpt-5'),
+    model: openai.responses('gpt-5'),
     prompt: 'Write a poem about a boy and his first pet dog.',
     providerOptions: {
       openai: {
-        textVerbosity: 'high',
+        textVerbosity: 'low',
       },
     },
   });

--- a/examples/ai-core/src/generate-text/openai-gpt5-verbosity.ts
+++ b/examples/ai-core/src/generate-text/openai-gpt5-verbosity.ts
@@ -4,11 +4,11 @@ import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: openai.responses('gpt-5'),
+    model: openai.chat('gpt-5'),
     prompt: 'Write a poem about a boy and his first pet dog.',
     providerOptions: {
       openai: {
-        textVerbosity: 'low',
+        textVerbosity: 'high',
       },
     },
   });

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -1352,6 +1352,25 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should send verbosity setting', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: {
+          verbosity: 'low',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: 'Hello' }],
+      verbosity: 'low',
+    });
+  });
+
   it('should send store extension setting', async () => {
     prepareJsonResponse({ content: '' });
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -499,6 +499,25 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass textVerbosity setting from provider options', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const model = provider.chat('gpt-4o');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: { textVerbosity: 'low' },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+      verbosity: 'low',
+    });
+  });
+
   it('should pass tools and toolChoice', async () => {
     prepareJsonResponse({ content: '' });
 
@@ -1353,24 +1372,7 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should send verbosity setting', async () => {
-    prepareJsonResponse({ content: '' });
 
-    await model.doGenerate({
-      prompt: TEST_PROMPT,
-      providerOptions: {
-        openai: {
-          verbosity: 'low',
-        },
-      },
-    });
-
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: 'Hello' }],
-      verbosity: 'low',
-    });
-  });
 
   it('should send store extension setting', async () => {
     prepareJsonResponse({ content: '' });

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -1372,8 +1372,6 @@ describe('doGenerate', () => {
     });
   });
 
-
-
   it('should send store extension setting', async () => {
     prepareJsonResponse({ content: '' });
 

--- a/packages/openai/src/openai-chat-language-model.test.ts
+++ b/packages/openai/src/openai-chat-language-model.test.ts
@@ -284,6 +284,7 @@ describe('doGenerate', () => {
           "top_logprobs": undefined,
           "top_p": undefined,
           "user": undefined,
+          "verbosity": undefined,
         },
       }
     `);
@@ -2560,6 +2561,7 @@ describe('doStream', () => {
           "top_logprobs": undefined,
           "top_p": undefined,
           "user": undefined,
+          "verbosity": undefined,
         },
       }
     `);

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -140,7 +140,6 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
             : undefined,
       user: openaiOptions.user,
       parallel_tool_calls: openaiOptions.parallelToolCalls,
-      verbosity: openaiOptions.verbosity,
 
       // standardized settings:
       max_tokens: maxOutputTokens,
@@ -149,7 +148,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       frequency_penalty: frequencyPenalty,
       presence_penalty: presencePenalty,
       response_format:
-        responseFormat?.type === 'json'
+        responseFormat?.type === 'json' 
           ? structuredOutputs && responseFormat.schema != null
             ? {
                 type: 'json_schema',
@@ -164,6 +163,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
           : undefined,
       stop: stopSequences,
       seed,
+      verbosity: openaiOptions.textVerbosity,
 
       // openai specific settings:
       // TODO remove in next major version; we auto-map maxOutputTokens now

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -140,6 +140,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
             : undefined,
       user: openaiOptions.user,
       parallel_tool_calls: openaiOptions.parallelToolCalls,
+      verbosity: openaiOptions.verbosity,
 
       // standardized settings:
       max_tokens: maxOutputTokens,

--- a/packages/openai/src/openai-chat-language-model.ts
+++ b/packages/openai/src/openai-chat-language-model.ts
@@ -148,7 +148,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       frequency_penalty: frequencyPenalty,
       presence_penalty: presencePenalty,
       response_format:
-        responseFormat?.type === 'json' 
+        responseFormat?.type === 'json'
           ? structuredOutputs && responseFormat.schema != null
             ? {
                 type: 'json_schema',

--- a/packages/openai/src/openai-chat-options.ts
+++ b/packages/openai/src/openai-chat-options.ts
@@ -85,7 +85,7 @@ export const openaiProviderOptions = z.object({
   /**
    * Reasoning effort for reasoning models. Defaults to `medium`.
    */
-  reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+  reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
 
   /**
    * Maximum number of completion tokens to generate. Useful for reasoning models.

--- a/packages/openai/src/openai-chat-options.ts
+++ b/packages/openai/src/openai-chat-options.ts
@@ -130,6 +130,13 @@ export const openaiProviderOptions = z.object({
    * @default false
    */
   strictJsonSchema: z.boolean().optional(),
+
+  /**
+   * Constrains the verbosity of the model's response. Lower values will result in
+   * more concise responses, while higher values will result in more verbose
+   * responses. Currently supported values are `low`, `medium`, and `high`.
+   */
+  verbosity: z.enum(['low', 'medium', 'high']).optional(),
 });
 
 export type OpenAIProviderOptions = z.infer<typeof openaiProviderOptions>;

--- a/packages/openai/src/openai-chat-options.ts
+++ b/packages/openai/src/openai-chat-options.ts
@@ -132,11 +132,10 @@ export const openaiProviderOptions = z.object({
   strictJsonSchema: z.boolean().optional(),
 
   /**
-   * Constrains the verbosity of the model's response. Lower values will result in
-   * more concise responses, while higher values will result in more verbose
-   * responses. Currently supported values are `low`, `medium`, and `high`.
+   * Controls the verbosity of the model's responses.
+   * Lower values will result in more concise responses, while higher values will result in more verbose responses.
    */
-  verbosity: z.enum(['low', 'medium', 'high']).optional(),
+  textVerbosity: z.enum(['low', 'medium', 'high']).optional(),
 });
 
 export type OpenAIProviderOptions = z.infer<typeof openaiProviderOptions>;

--- a/packages/openai/src/openai-chat-options.ts
+++ b/packages/openai/src/openai-chat-options.ts
@@ -85,7 +85,7 @@ export const openaiProviderOptions = z.object({
   /**
    * Reasoning effort for reasoning models. Defaults to `medium`.
    */
-  reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+  reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
 
   /**
    * Maximum number of completion tokens to generate. Useful for reasoning models.


### PR DESCRIPTION
## background

openai released documentation for a new `verbosity` parameter in their chat api that allows controlling output length with values 'low', 'medium', and 'high'. this parameter enables developers to get more concise or verbose responses without modifying prompts

## summary

- add verbosity parameter to openai chat api
- update zod schema to validate verbosity values
- add documentation with usage examples

## verification

- verbosity parameter is correctly passed 
- documentation follows existing patterns
- example demonstrates verbosity 
