### PR TITLE
fix(gateway): always download assets for language model

### DIFF
--- a/.changeset/rich-mayflies-wash.md
+++ b/.changeset/rich-mayflies-wash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): Download assets before request instead of sending as URLs

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -28,7 +28,9 @@ type GatewayChatConfig = GatewayConfig & {
 
 export class GatewayLanguageModel implements LanguageModelV2 {
   readonly specificationVersion = 'v2';
-  readonly supportedUrls = { '*/*': [/.*/] };
+  readonly supportedUrls: Record<string, RegExp[]> = {
+    // No URLs are supported. For URLs to be supported, all providers available in the gateway should support them.
+  };
 
   constructor(
     readonly modelId: GatewayModelId,


### PR DESCRIPTION
This forces assets to be downloaded for the gateway language model before sending them downstream.

- Some providers accept asset/file parts as URLs, but others don't. The gateway currently rejects URL parts for some backends, causing inconsistent behavior.
- Normalizes behavior so assets are always accepted regardless of provider.

Context:
- Using the `gateway` provider with `openai/gpt-5-mini` failed with URL asset parts, but using `openai` directly with `gpt-5-mini` worked. The gateway returned:

```
GatewayInternalServerError: 'PDF file parts with URLs' functionality not supported.
    at createGatewayErrorFromResponse (...)
    at asGatewayError (...)
    at GatewayLanguageModel.doStream (...)
```

Openai has `{'image/*': [/^https?:\/\/.*$/],}` as `supportedURLs`, but gateway-language-model.ts has `{ '*/*': [/.*/] };`

### Notes:
Another solution could be to generate a complex `supportedUrl` setting based on the `owned_by` of the `modelId` and the providers that can serve it, but it seems quite error-prone and hard to maintain. The solution proposed in this PR downloads assets even when sometimes not needed, but shines in simplicity.
