### PR TITLE
fix(ai): preserve filename for file parts in convertToModelMessages

### DIFF
--- a/.changeset/thirty-falcons-return.md
+++ b/.changeset/thirty-falcons-return.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): preserve filename for file parts in convertToModelMessages

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -216,7 +216,6 @@ describe('convertToModelMessages', () => {
     ]);
   });
 
-
   describe('assistant message', () => {
     it('should convert a simple assistant text message', () => {
       const result = convertToModelMessages([

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -188,6 +188,35 @@ describe('convertToModelMessages', () => {
     });
   });
 
+  it('should not include filename for user file parts when not provided', () => {
+    const result = convertToModelMessages([
+      {
+        role: 'user',
+        parts: [
+          {
+            type: 'file',
+            mediaType: 'image/jpeg',
+            url: 'https://example.com/image.jpg',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            mediaType: 'image/jpeg',
+            data: 'https://example.com/image.jpg',
+          },
+        ],
+      },
+    ]);
+  });
+
+
   describe('assistant message', () => {
     it('should convert a simple assistant text message', () => {
       const result = convertToModelMessages([

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -156,6 +156,36 @@ describe('convertToModelMessages', () => {
         },
       ]);
     });
+
+    it('should include filename for user file parts when provided', () => {
+      const result = convertToModelMessages([
+        {
+          role: 'user',
+          parts: [
+            {
+              type: 'file',
+              mediaType: 'image/jpeg',
+              url: 'https://example.com/image.jpg',
+              filename: 'image.jpg',
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image/jpeg',
+              data: 'https://example.com/image.jpg',
+              filename: 'image.jpg',
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('assistant message', () => {
@@ -284,6 +314,36 @@ describe('convertToModelMessages', () => {
           ],
         },
       ] satisfies ModelMessage[]);
+    });
+
+    it('should include filename for assistant file parts when provided', () => {
+      const result = convertToModelMessages([
+        {
+          role: 'assistant',
+          parts: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              url: 'data:image/png;base64,dGVzdA==',
+              filename: 'test.png',
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: 'data:image/png;base64,dGVzdA==',
+              filename: 'test.png',
+            },
+          ],
+        },
+      ] as unknown as ModelMessage[]);
     });
 
     it('should handle assistant message with tool output available', () => {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -88,7 +88,9 @@ export function convertToModelMessages(
                   return {
                     type: 'file' as const,
                     mediaType: part.mediaType,
-                    filename: part.filename,
+                    ...(part.filename != null
+                      ? { filename: part.filename }
+                      : {}),
                     data: part.url,
                   };
                 default:
@@ -130,7 +132,9 @@ export function convertToModelMessages(
                 content.push({
                   type: 'file' as const,
                   mediaType: part.mediaType,
-                  filename: part.filename,
+                  ...(part.filename != null
+                    ? { filename: part.filename }
+                    : {}),
                   data: part.url,
                 });
               } else if (part.type === 'reasoning') {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -130,6 +130,7 @@ export function convertToModelMessages(
                 content.push({
                   type: 'file' as const,
                   mediaType: part.mediaType,
+                  filename: part.filename,
                   data: part.url,
                 });
               } else if (part.type === 'reasoning') {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -88,9 +88,7 @@ export function convertToModelMessages(
                   return {
                     type: 'file' as const,
                     mediaType: part.mediaType,
-                    ...(part.filename != null
-                      ? { filename: part.filename }
-                      : {}),
+                    filename: part.filename,
                     data: part.url,
                   };
                 default:
@@ -132,9 +130,7 @@ export function convertToModelMessages(
                 content.push({
                   type: 'file' as const,
                   mediaType: part.mediaType,
-                  ...(part.filename != null
-                    ? { filename: part.filename }
-                    : {}),
+                  filename: part.filename,
                   data: part.url,
                 });
               } else if (part.type === 'reasoning') {


### PR DESCRIPTION
Fix filename preservation for UI file parts in convertToModelMessages

- Include `filename` when mapping UI `file` parts to model messages so downstream providers receive the original filename
