### PR TITLE
feat (provider/openai-compatible): fall back to look for usage in choices

### DIFF
--- a/.changeset/sour-ladybugs-talk.md
+++ b/.changeset/sour-ladybugs-talk.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+feat (provider/openai-compatible): fall back to look for usage in choices

--- a/examples/ai-core/src/generate-text/moonshotai.ts
+++ b/examples/ai-core/src/generate-text/moonshotai.ts
@@ -1,0 +1,23 @@
+import { openai } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const moonshotai = createOpenAICompatible({
+    baseURL: 'https://api.moonshot.ai/v1',
+    apiKey: process.env.MOONSHOTAI_API_KEY,
+    name: 'moonshotai',
+  });
+  const { text, usage } = await generateText({
+    model: moonshotai('kimi-k2-0711-preview'),
+    prompt:
+      "Tell me what's notable about Oaxacan food. Reply in only a few sentences.",
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Usage:', usage);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/moonshotai.ts
+++ b/examples/ai-core/src/stream-text/moonshotai.ts
@@ -1,0 +1,33 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const moonshotai = createOpenAICompatible({
+    baseURL: 'https://api.moonshot.ai/v1',
+    apiKey: process.env.MOONSHOTAI_API_KEY,
+    name: 'moonshotai',
+  });
+  const result = streamText({
+    model: moonshotai('kimi-k2-0711-preview'),
+    prompt: 'What is notable about Sonoran food? Answer in a few sentences.',
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'reasoning-delta') {
+      process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+    } else if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+}
+
+main().catch(console.error);

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -415,14 +415,18 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
               });
             }
 
-            if (value.usage != null) {
+            // usage may be at the top level or nested under choices[0]
+            const topLevelUsage = value.usage;
+            const choiceLevelUsage = value.choices?.[0]?.usage;
+            const effectiveUsage = topLevelUsage ?? choiceLevelUsage;
+            if (effectiveUsage != null) {
               const {
                 prompt_tokens,
                 completion_tokens,
                 total_tokens,
                 prompt_tokens_details,
                 completion_tokens_details,
-              } = value.usage;
+              } = effectiveUsage;
 
               usage.promptTokens = prompt_tokens ?? undefined;
               usage.completionTokens = completion_tokens ?? undefined;
@@ -761,6 +765,8 @@ const createOpenAICompatibleChatChunkSchema = <
             })
             .nullish(),
           finish_reason: z.string().nullish(),
+          // Some providers report usage within each choice in streaming chunks
+          usage: openaiCompatibleTokenUsageSchema,
         }),
       ),
       usage: openaiCompatibleTokenUsageSchema,


### PR DESCRIPTION
## Background

[Moonshot AI](https://platform.moonshot.ai/docs/pricing/chat) hosts their popular `kimi-k2` model with an openai-compatible endpoint. The token usage metrics are reported within the `choices[0]` entry rather than in a top level `usage` field. The AI SDK openai-compatible provider thus reports no usage metrics when used with this provider.

## Summary

Added fallback logic to look for usage metrics in `choices[0]` if we don't find it in the top level where it is normally expected.

## Manual Verification

Ran against both Moonshot model ids with included example scripts.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

We aren't looking for further usage in possible subsequent `choices` entries and summing it to produce an overall usage.