### PR TITLE
chore (provider/openai-compatible): inline usage fallback logic

### DIFF
--- a/.changeset/tasty-moles-tie.md
+++ b/.changeset/tasty-moles-tie.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+chore (provider/openai-compatible): inline usage fallback logic

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.ts
@@ -415,10 +415,9 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
               });
             }
 
-            // usage may be at the top level or nested under choices[0]
-            const topLevelUsage = value.usage;
-            const choiceLevelUsage = value.choices?.[0]?.usage;
-            const effectiveUsage = topLevelUsage ?? choiceLevelUsage;
+            // Usage may be at the top level per spec or nested under choices[0]
+            // for some providers (e.g. moonshotai).
+            const effectiveUsage = value.usage ?? value.choices?.[0]?.usage;
             if (effectiveUsage != null) {
               const {
                 prompt_tokens,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Spotted small code cleanliness opportunity on review.

## Summary

<!-- What did you change? -->
Inlined unnecessarily verbose local variables for new usage fallback logic.
