### PR TITLE
feat(provider/google): add labels field to providerOptions

### DIFF
--- a/.changeset/nine-fans-grin.md
+++ b/.changeset/nine-fans-grin.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+add labels field to providerOptions

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -315,6 +315,12 @@ The following optional provider options are available for Google Vertex models:
   This is useful for generating transcripts with accurate timestamps.
   Consult [Google's Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding) for usage details.
 
+- **labels** _object_
+
+  Optional. Defines labels used in billing reports.
+
+  Consult [Google's Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls) for usage details.
+
 You can use Google Vertex language models to generate text with the `generateText` function:
 
 ```ts highlight="1,4"

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -169,6 +169,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV2 {
         tools: googleTools,
         toolConfig: googleToolConfig,
         cachedContent: googleOptions?.cachedContent,
+        labels: googleOptions?.labels,
       },
       warnings: [...warnings, ...toolWarnings],
     };

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -105,7 +105,7 @@ Optional. A list of unique safety settings for blocking unsafe content.
   audioTimestamp: z.boolean().optional(),
 
   /**
-   * Optional. Defines labels used in billing reports.
+   * Optional. Defines labels used in billing reports. Available on Vertex AI only.
    *
    * https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls
    */

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -103,6 +103,13 @@ Optional. A list of unique safety settings for blocking unsafe content.
    * https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding
    */
   audioTimestamp: z.boolean().optional(),
+
+  /**
+   * Optional. Defines labels used in billing reports.
+   *
+   * https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls
+   */
+  labels: z.record(z.string(), z.string()).optional(),
 });
 
 export type GoogleGenerativeAIProviderOptions = z.infer<


### PR DESCRIPTION
## Background

We were trying to break down our Vertex bill but the SDK is filtering out the labels field.

## Summary

Added the `labels` field to the `providerOptions` Zod schema as documented [here](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls).

## Manual Verification

Verification in progress (takes ~24h for bill to update).

## Tasks

- [x] Added docs
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

Might make sense to split Google Vertex and Google provider options in the future as there's quite a bit in here already that seems to be Vertex-only.
