### PR TITLE
fix(providers): correct Base64 for Uint8Array data parts in chat messages 

### DIFF
--- a/.changeset/four-bugs-reflect.md
+++ b/.changeset/four-bugs-reflect.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/groq': patch
+---
+
+fix(providers): use convertToBase64 for Uint8Array image parts to produce valid data URLs; keep mediaType normalization and URL passthrough

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -30,6 +30,35 @@ describe('user messages', () => {
     ]);
   });
 
+  it('should convert messages with image parts from Uint8Array', async () => {
+    const result = convertToGroqChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hi' },
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hi' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should convert messages with only a text part to a string content', async () => {
     const result = convertToGroqChatMessages([
       {

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -3,6 +3,7 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { GroqChatPrompt } from './groq-api-types';
+import { convertToBase64 } from '@ai-sdk/provider-utils';
 
 export function convertToGroqChatMessages(
   prompt: LanguageModelV2Prompt,
@@ -45,7 +46,7 @@ export function convertToGroqChatMessages(
                     url:
                       part.data instanceof URL
                         ? part.data.toString()
-                        : `data:${mediaType};base64,${part.data}`,
+                        : `data:${mediaType};base64,${convertToBase64(part.data)}`,
                   },
                 };
               }

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -19,6 +19,40 @@ describe('user messages', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should convert messages with image parts from Uint8Array', async () => {
+    const result = convertToMistralChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hi' },
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "text": "Hi",
+              "type": "text",
+            },
+            {
+              "image_url": "data:image/png;base64,AAECAw==",
+              "type": "image_url",
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
   it('should convert messages with PDF file parts using URL', () => {
     const result = convertToMistralChatMessages([
       {

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -3,6 +3,7 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { MistralPrompt } from './mistral-chat-prompt';
+import { convertToBase64 } from '@ai-sdk/provider-utils';
 
 export function convertToMistralChatMessages(
   prompt: LanguageModelV2Prompt,
@@ -40,7 +41,7 @@ export function convertToMistralChatMessages(
                     image_url:
                       part.data instanceof URL
                         ? part.data.toString()
-                        : `data:${mediaType};base64,${part.data}`,
+                        : `data:${mediaType};base64,${convertToBase64(part.data)}`,
                   };
                 } else if (part.mediaType === 'application/pdf') {
                   return {

--- a/packages/openai-compatible/src/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/convert-to-openai-compatible-chat-messages.test.ts
@@ -41,6 +41,35 @@ describe('user messages', () => {
     ]);
   });
 
+  it('should convert messages with image parts from Uint8Array', async () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hi' },
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hi' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should handle URL-based images', async () => {
     const result = convertToOpenAICompatibleChatMessages([
       {

--- a/packages/openai-compatible/src/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/convert-to-openai-compatible-chat-messages.ts
@@ -4,6 +4,7 @@ import {
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { OpenAICompatibleChatPrompt } from './openai-compatible-api-types';
+import { convertToBase64 } from '@ai-sdk/provider-utils';
 
 function getOpenAIMetadata(message: {
   providerOptions?: SharedV2ProviderMetadata;
@@ -54,7 +55,7 @@ export function convertToOpenAICompatibleChatMessages(
                       url:
                         part.data instanceof URL
                           ? part.data.toString()
-                          : `data:${mediaType};base64,${part.data}`,
+                          : `data:${mediaType};base64,${convertToBase64(part.data)}`,
                     },
                     ...partMetadata,
                   };

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
@@ -111,6 +111,36 @@ describe('convertToOpenAIResponsesMessages', () => {
       ]);
     });
 
+    it('should convert messages with image parts using Uint8Array', async () => {
+      const result = await convertToOpenAIResponsesMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: new Uint8Array([0, 1, 2, 3]),
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_image',
+              image_url: 'data:image/png;base64,AAECAw==',
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should convert messages with image parts using file_id', async () => {
       const result = await convertToOpenAIResponsesMessages({
         prompt: [

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.ts
@@ -76,7 +76,7 @@ export async function convertToOpenAIResponsesMessages({
                           part.data.startsWith('file-')
                         ? { file_id: part.data }
                         : {
-                            image_url: `data:${mediaType};base64,${part.data}`,
+                            image_url: `data:${mediaType};base64,${convertToBase64(part.data)}`,
                           }),
                     detail: part.providerOptions?.openai?.imageDetail,
                   };


### PR DESCRIPTION
## Background

When a user message contains a file part whose `data` is a Uint8Array, the previous implementation created an incorrect Base64 string when constructing data URLs for image parts. This led to malformed `data:<mediaType>;base64,...` strings and downstream provider validation/decoding errors in chat APIs.

## Summary

Bug fix to ensure correct Base64 encoding for binary/file content parts across providers by using `convertToBase64(part.data)`:

- Use `convertToBase64` when building `image_url.url` for non-URL data.
- Applied consistently across affected providers.