### PR TITLE
feat(provider/openai): add support for prompt_cache_key

### DIFF
--- a/.changeset/clever-jars-behave.md
+++ b/.changeset/clever-jars-behave.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add support for prompt_cache_key

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -232,6 +232,10 @@ The following optional provider options are available for OpenAI chat models:
 
   Controls the verbosity of the model's responses. Lower values will result in more concise responses, while higher values will result in more verbose responses.
 
+- **promptCacheKey** _string_
+
+  A cache key for manual prompt caching control. Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
 #### Reasoning
 
 OpenAI has introduced the `o1`,`o3`, and `o4` series of [reasoning models](https://platform.openai.com/docs/guides/reasoning).
@@ -591,6 +595,28 @@ console.log(`usage:`, {
 });
 ```
 
+To improve cache hit rates, you can manually control caching using the `promptCacheKey` option:
+
+```ts highlight="7-11"
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const { text, usage, providerMetadata } = await generateText({
+  model: openai('gpt-5'),
+  prompt: `A 1024-token or longer prompt...`,
+  providerOptions: {
+    openai: {
+      promptCacheKey: 'my-custom-cache-key-123',
+    },
+  },
+});
+
+console.log(`usage:`, {
+  ...usage,
+  cachedPromptTokens: providerMetadata?.openai?.cachedPromptTokens,
+});
+```
+
 #### Audio Input
 
 With the `gpt-4o-audio-preview` model, you can pass audio files to the model.
@@ -702,6 +728,9 @@ The following provider options are available:
   `['reasoning.encrypted_content']` for accessing reasoning content across conversation steps,
   and `['file_search_call.results']` for including file search results in responses.
   Defaults to `undefined`.
+
+- **promptCacheKey** _string_
+  A cache key for manual prompt caching control. Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
 
 The OpenAI responses provider also returns provider-specific metadata:
 

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -272,6 +272,7 @@ describe('doGenerate', () => {
           "parallel_tool_calls": undefined,
           "prediction": undefined,
           "presence_penalty": undefined,
+          "prompt_cache_key": undefined,
           "reasoning_effort": undefined,
           "response_format": undefined,
           "seed": undefined,
@@ -1414,6 +1415,25 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should send promptCacheKey extension value', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: {
+          promptCacheKey: 'test-cache-key-123',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: 'Hello' }],
+      prompt_cache_key: 'test-cache-key-123',
+    });
+  });
+
   it('should remove temperature setting for gpt-4o-search-preview and add warning', async () => {
     prepareJsonResponse();
 
@@ -2545,6 +2565,7 @@ describe('doStream', () => {
           "parallel_tool_calls": undefined,
           "prediction": undefined,
           "presence_penalty": undefined,
+          "prompt_cache_key": undefined,
           "reasoning_effort": undefined,
           "response_format": undefined,
           "seed": undefined,

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -173,6 +173,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       prediction: openaiOptions.prediction,
       reasoning_effort: openaiOptions.reasoningEffort,
       service_tier: openaiOptions.serviceTier,
+      prompt_cache_key: openaiOptions.promptCacheKey,
 
       // messages:
       messages,

--- a/packages/openai/src/chat/openai-chat-options.ts
+++ b/packages/openai/src/chat/openai-chat-options.ts
@@ -136,6 +136,12 @@ export const openaiProviderOptions = z.object({
    * Lower values will result in more concise responses, while higher values will result in more verbose responses.
    */
   textVerbosity: z.enum(['low', 'medium', 'high']).optional(),
+
+  /**
+   * A cache key for prompt caching. Allows manual control over prompt caching behavior.
+   * Useful for improving cache hit rates and working around automatic caching issues.
+   */
+  promptCacheKey: z.string().optional(),
 });
 
 export type OpenAIProviderOptions = z.infer<typeof openaiProviderOptions>;

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -734,6 +734,27 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send promptCacheKey provider option', async () => {
+        const { warnings } = await createModel('gpt-5').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              promptCacheKey: 'test-cache-key-123',
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          prompt_cache_key: 'test-cache-key-123',
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send responseFormat json format', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           responseFormat: { type: 'json' },

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -140,6 +140,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       instructions: openaiOptions?.instructions,
       service_tier: openaiOptions?.serviceTier,
       include: openaiOptions?.include,
+      prompt_cache_key: openaiOptions?.promptCacheKey,
 
       // model-specific settings:
       ...(modelConfig.isReasoningModel &&
@@ -1176,6 +1177,7 @@ const openaiResponsesProviderOptionsSchema = z.object({
     .array(z.enum(['reasoning.encrypted_content', 'file_search_call.results']))
     .nullish(),
   textVerbosity: z.enum(['low', 'medium', 'high']).nullish(),
+  promptCacheKey: z.string().nullish(),
 });
 
 export type OpenAIResponsesProviderOptions = z.infer<


### PR DESCRIPTION
# Provider/OpenAI: Add support for prompt_cache_key

  ## Background

  - The OpenAI responses API supports a `prompt_cache_key` parameter that can be set to influence routing and
  improve cache hit rates.
  - OpenAI supports automatic prompt caching, however this does not seem to work with GPT-5 (see #7908). Even if
  fixed, setting this key would allow more control over the caching behavior (see
  https://platform.openai.com/docs/guides/prompt-caching, Section "Best Practices").

  ## Summary

  Implement `prompt_cache_key` support in `providerOptions.openai` for both Chat Completions and Responses APIs.

  ## Tests

  - Added test for Chat Completions API
  - Added test for Responses API

  ## Manual Verification

  I ran an example on GPT-5 with a system prompt > 1k tokens and ensured that:
  a) The `cached_tokens` value in the response was > 0
  b) The `prompt_cache_key` value in the response matched what I configured in `providerOptions`

  ## Tasks

  - [x] Tests have been added/updated
  - [x] Documentation has been added/updated
  - [x] A patch changeset for relevant packages has been added (run `pnpm changeset` in the project root)
  - [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

  ## Related Issues

  Fixes #7908