### PR TITLE
chore(docs): fix cookbook toolcall typing issue

### DIFF
--- a/content/cookbook/05-node/50-call-tools.mdx
+++ b/content/cookbook/05-node/50-call-tools.mdx
@@ -73,6 +73,10 @@ async function main() {
 
   // typed tool calls:
   for (const toolCall of result.toolCalls) {
+    if (toolCall.dynamic) {
+      continue;
+    }
+
     switch (toolCall.toolName) {
       case 'cityAttractions': {
         toolCall.input.city; // string
@@ -129,6 +133,10 @@ async function main() {
 
   // typed tool results for tools with execute method:
   for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) {
+      continue;
+    }
+
     switch (toolResult.toolName) {
       case 'weather': {
         toolResult.input.location; // string


### PR DESCRIPTION
# background

fixes missing dynamic tool filtering in cookbook example that prevented proper typescript typing of tool calls

## summary
- added `if (toolCall.dynamic) { continue; }` filter to tool calls loop  
- added `if (toolResult.dynamic) { continue; }` filter to tool results loop

related issue - #7778