### PR TITLE
fix(ai): convert user message text/file part provider metadata in convertToModelMessages

### DIFF
--- a/.changeset/funny-clocks-trade.md
+++ b/.changeset/funny-clocks-trade.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): convert user message text/file part provider metadata in convertToModelMessages

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -127,6 +127,40 @@ describe('convertToModelMessages', () => {
       `);
     });
 
+    it('should convert a simple user message with provider metadata', () => {
+      const result = convertToModelMessages([
+        {
+          role: 'user',
+          parts: [
+            {
+              text: 'Hello, AI!',
+              type: 'text',
+              providerMetadata: { testProvider: { signature: '1234567890' } },
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "providerOptions": {
+                  "testProvider": {
+                    "signature": "1234567890",
+                  },
+                },
+                "text": "Hello, AI!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+
     it('should handle user message file parts', () => {
       const result = convertToModelMessages([
         {
@@ -150,6 +184,38 @@ describe('convertToModelMessages', () => {
               type: 'file',
               mediaType: 'image/jpeg',
               data: 'https://example.com/image.jpg',
+            },
+            { type: 'text', text: 'Check this image' },
+          ],
+        },
+      ]);
+    });
+
+    it('should handle user message file parts with provider metadata', () => {
+      const result = convertToModelMessages([
+        {
+          role: 'user',
+          parts: [
+            {
+              type: 'file',
+              mediaType: 'image/jpeg',
+              url: 'https://example.com/image.jpg',
+              providerMetadata: { testProvider: { signature: '1234567890' } },
+            },
+            { type: 'text', text: 'Check this image' },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image/jpeg',
+              data: 'https://example.com/image.jpg',
+              providerOptions: { testProvider: { signature: '1234567890' } },
             },
             { type: 'text', text: 'Check this image' },
           ],

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -83,6 +83,9 @@ export function convertToModelMessages(
                   return {
                     type: 'text' as const,
                     text: part.text,
+                    ...(part.providerMetadata != null
+                      ? { providerOptions: part.providerMetadata }
+                      : {}),
                   };
                 case 'file':
                   return {
@@ -90,6 +93,9 @@ export function convertToModelMessages(
                     mediaType: part.mediaType,
                     filename: part.filename,
                     data: part.url,
+                    ...(part.providerMetadata != null
+                      ? { providerOptions: part.providerMetadata }
+                      : {}),
                   };
                 default:
                   return part;


### PR DESCRIPTION
## Background

Provider metadata in UI message user parts was not converted correctly (see #7950 ).

## Summary

Add conversion of user message text/file part provider metadata in convertToModelMessages.

## Related Issues

Fixes #7950