### PR TITLE
feat(provider/openai): add support for safety_identifier

### DIFF
--- a/.changeset/odd-rings-ring.md
+++ b/.changeset/odd-rings-ring.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add support for safety_identifier

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -236,6 +236,10 @@ The following optional provider options are available for OpenAI chat models:
 
   A cache key for manual prompt caching control. Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
 
+- **safetyIdentifier** _string_
+
+  A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies. The IDs should be a string that uniquely identifies each user.
+
 #### Reasoning
 
 OpenAI has introduced the `o1`,`o3`, and `o4` series of [reasoning models](https://platform.openai.com/docs/guides/reasoning).
@@ -731,6 +735,9 @@ The following provider options are available:
 
 - **promptCacheKey** _string_
   A cache key for manual prompt caching control. Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
+- **safetyIdentifier** \_string_0
+  A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies. The IDs should be a string that uniquely identifies each user.
 
 The OpenAI responses provider also returns provider-specific metadata:
 

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -275,6 +275,7 @@ describe('doGenerate', () => {
           "prompt_cache_key": undefined,
           "reasoning_effort": undefined,
           "response_format": undefined,
+          "safety_identifier": undefined,
           "seed": undefined,
           "service_tier": undefined,
           "stop": undefined,
@@ -1434,6 +1435,25 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should send safetyIdentifier extension value', async () => {
+    prepareJsonResponse({ content: '' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: {
+          safetyIdentifier: 'test-safety-identifier-123',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: 'Hello' }],
+      safety_identifier: 'test-safety-identifier-123',
+    });
+  });
+
   it('should remove temperature setting for gpt-4o-search-preview and add warning', async () => {
     prepareJsonResponse();
 
@@ -2568,6 +2588,7 @@ describe('doStream', () => {
           "prompt_cache_key": undefined,
           "reasoning_effort": undefined,
           "response_format": undefined,
+          "safety_identifier": undefined,
           "seed": undefined,
           "service_tier": undefined,
           "stop": undefined,

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -174,6 +174,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV2 {
       reasoning_effort: openaiOptions.reasoningEffort,
       service_tier: openaiOptions.serviceTier,
       prompt_cache_key: openaiOptions.promptCacheKey,
+      safety_identifier: openaiOptions.safetyIdentifier,
 
       // messages:
       messages,

--- a/packages/openai/src/chat/openai-chat-options.ts
+++ b/packages/openai/src/chat/openai-chat-options.ts
@@ -130,6 +130,15 @@ export const openaiProviderOptions = z.object({
    * Useful for improving cache hit rates and working around automatic caching issues.
    */
   promptCacheKey: z.string().optional(),
+
+  /**
+   * A stable identifier used to help detect users of your application
+   * that may be violating OpenAI's usage policies. The IDs should be a
+   * string that uniquely identifies each user. We recommend hashing their
+   * username or email address, in order to avoid sending us any identifying
+   * information.
+   */
+  safetyIdentifier: z.string().optional(),
 });
 
 export type OpenAIProviderOptions = z.infer<typeof openaiProviderOptions>;

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -756,6 +756,27 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send safetyIdentifier provider option', async () => {
+        const { warnings } = await createModel('gpt-5').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              safetyIdentifier: 'test-safety-identifier-123',
+            },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          safety_identifier: 'test-safety-identifier-123',
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send responseFormat json format', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           responseFormat: { type: 'json' },

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -142,6 +142,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       service_tier: openaiOptions?.serviceTier,
       include: openaiOptions?.include,
       prompt_cache_key: openaiOptions?.promptCacheKey,
+      safety_identifier: openaiOptions?.safetyIdentifier,
 
       // model-specific settings:
       ...(modelConfig.isReasoningModel &&
@@ -1163,6 +1164,7 @@ function supportsPriorityProcessing(modelId: string): boolean {
   );
 }
 
+// TODO AI SDK 6: use optional here instead of nullish
 const openaiResponsesProviderOptionsSchema = z.object({
   metadata: z.any().nullish(),
   parallelToolCalls: z.boolean().nullish(),
@@ -1179,6 +1181,7 @@ const openaiResponsesProviderOptionsSchema = z.object({
     .nullish(),
   textVerbosity: z.enum(['low', 'medium', 'high']).nullish(),
   promptCacheKey: z.string().nullish(),
+  safetyIdentifier: z.string().nullish(),
 });
 
 export type OpenAIResponsesProviderOptions = z.infer<


### PR DESCRIPTION
## Background

OpenAI added a new `safety_identifier` option.

## Summary

Add support for `safety_identifier`.