### PR TITLE
fix(openai): add missing file_search_call handlers in responses streaming

### DIFF
--- a/.changeset/sharp-ravens-hear.md
+++ b/.changeset/sharp-ravens-hear.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): add missing file_search_call handlers in responses streaming

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2223,6 +2223,137 @@ describe('OpenAIResponsesLanguageModel', () => {
           ]
         `);
       });
+
+      it('should handle file_search tool calls in generate', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_67cf3390786881908b27489d7e8cfb6b',
+            object: 'response',
+            created_at: 1741632400,
+            status: 'completed',
+            error: null,
+            incomplete_details: null,
+            input: [],
+            instructions: null,
+            max_output_tokens: null,
+            model: 'gpt-4o-mini-2024-07-18',
+            output: [
+              {
+                type: 'file_search_call',
+                id: 'fs_67cf3390e9608190869b5d45698a7067',
+                status: 'completed',
+                queries: ['AI information'],
+                results: [
+                  {
+                    attributes: {
+                      file_id: 'file-123',
+                      filename: 'ai_guide.pdf',
+                      score: 0.95,
+                      text: 'AI is a field of computer science',
+                    },
+                  },
+                ],
+              },
+              {
+                id: 'msg_67cf33924ea88190b8c12bf68c1f6416',
+                type: 'message',
+                status: 'completed',
+                role: 'assistant',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'Based on the search results, here is the information you requested.',
+                    annotations: [],
+                  },
+                ],
+              },
+            ],
+            parallel_tool_calls: true,
+            previous_response_id: null,
+            reasoning: {
+              effort: null,
+              summary: null,
+            },
+            store: true,
+            temperature: 0,
+            text: {
+              format: {
+                type: 'text',
+              },
+            },
+            tool_choice: 'auto',
+            tools: [
+              {
+                type: 'file_search',
+              },
+            ],
+            top_p: 1,
+            truncation: 'disabled',
+            usage: {
+              input_tokens: 327,
+              input_tokens_details: {
+                cached_tokens: 0,
+              },
+              output_tokens: 834,
+              output_tokens_details: {
+                reasoning_tokens: 0,
+              },
+              total_tokens: 1161,
+            },
+            user: null,
+            metadata: {},
+          },
+        };
+
+        const result = await createModel('gpt-4o-mini').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "input": "",
+              "providerExecuted": true,
+              "toolCallId": "fs_67cf3390e9608190869b5d45698a7067",
+              "toolName": "file_search",
+              "type": "tool-call",
+            },
+            {
+              "providerExecuted": true,
+              "result": {
+                "queries": [
+                  "AI information",
+                ],
+                "results": [
+                  {
+                    "attributes": {
+                      "file_id": "file-123",
+                      "filename": "ai_guide.pdf",
+                      "score": 0.95,
+                      "text": "AI is a field of computer science",
+                    },
+                  },
+                ],
+                "status": "completed",
+                "type": "file_search_tool_result",
+              },
+              "toolCallId": "fs_67cf3390e9608190869b5d45698a7067",
+              "toolName": "file_search",
+              "type": "tool-result",
+            },
+            {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                },
+              },
+              "text": "Based on the search results, here is the information you requested.",
+              "type": "text",
+            },
+          ]
+        `);
+      });
     });
 
     describe('errors', () => {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2784,53 +2784,79 @@ describe('OpenAIResponsesLanguageModel', () => {
 
         expect(await convertReadableStreamToArray(stream))
           .toMatchInlineSnapshot(`
-          [
-            {
-              "type": "stream-start",
-              "warnings": [],
-            },
-            {
-              "id": "resp_67cf3390786881908b27489d7e8cfb6b",
-              "modelId": "gpt-4o-mini-2024-07-18",
-              "timestamp": 2025-03-10T18:46:40.000Z,
-              "type": "response-metadata",
-            },
-            {
-              "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
-              "providerMetadata": {
-                "openai": {
-                  "itemId": "msg_67cf33924ea88190b8c12bf68c1f6416",
+            [
+              {
+                "type": "stream-start",
+                "warnings": [],
+              },
+              {
+                "id": "resp_67cf3390786881908b27489d7e8cfb6b",
+                "modelId": "gpt-4o-mini-2024-07-18",
+                "timestamp": 2025-03-10T18:46:40.000Z,
+                "type": "response-metadata",
+              },
+              {
+                "id": "fs_67cf3390e9608190869b5d45698a7067",
+                "toolName": "file_search",
+                "type": "tool-input-start",
+              },
+              {
+                "id": "fs_67cf3390e9608190869b5d45698a7067",
+                "type": "tool-input-end",
+              },
+              {
+                "input": "",
+                "providerExecuted": true,
+                "toolCallId": "fs_67cf3390e9608190869b5d45698a7067",
+                "toolName": "file_search",
+                "type": "tool-call",
+              },
+              {
+                "providerExecuted": true,
+                "result": {
+                  "status": "completed",
+                  "type": "file_search_tool_result",
+                },
+                "toolCallId": "fs_67cf3390e9608190869b5d45698a7067",
+                "toolName": "file_search",
+                "type": "tool-result",
+              },
+              {
+                "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                  },
+                },
+                "type": "text-start",
+              },
+              {
+                "delta": "Based on the search results, here is the information you requested.",
+                "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                "type": "text-delta",
+              },
+              {
+                "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                "type": "text-end",
+              },
+              {
+                "finishReason": "tool-calls",
+                "providerMetadata": {
+                  "openai": {
+                    "responseId": "resp_67cf3390786881908b27489d7e8cfb6b",
+                  },
+                },
+                "type": "finish",
+                "usage": {
+                  "cachedInputTokens": 0,
+                  "inputTokens": 327,
+                  "outputTokens": 834,
+                  "reasoningTokens": 0,
+                  "totalTokens": 1161,
                 },
               },
-              "type": "text-start",
-            },
-            {
-              "delta": "Based on the search results, here is the information you requested.",
-              "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
-              "type": "text-delta",
-            },
-            {
-              "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
-              "type": "text-end",
-            },
-            {
-              "finishReason": "stop",
-              "providerMetadata": {
-                "openai": {
-                  "responseId": "resp_67cf3390786881908b27489d7e8cfb6b",
-                },
-              },
-              "type": "finish",
-              "usage": {
-                "cachedInputTokens": 0,
-                "inputTokens": 327,
-                "outputTokens": 834,
-                "reasoningTokens": 0,
-                "totalTokens": 1161,
-              },
-            },
-          ]
-        `);
+            ]
+          `);
       });
     });
 

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2814,6 +2814,117 @@ describe('OpenAIResponsesLanguageModel', () => {
               {
                 "providerExecuted": true,
                 "result": {
+                  "queries": undefined,
+                  "results": undefined,
+                  "status": "completed",
+                  "type": "file_search_tool_result",
+                },
+                "toolCallId": "fs_67cf3390e9608190869b5d45698a7067",
+                "toolName": "file_search",
+                "type": "tool-result",
+              },
+              {
+                "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                  },
+                },
+                "type": "text-start",
+              },
+              {
+                "delta": "Based on the search results, here is the information you requested.",
+                "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                "type": "text-delta",
+              },
+              {
+                "id": "msg_67cf33924ea88190b8c12bf68c1f6416",
+                "type": "text-end",
+              },
+              {
+                "finishReason": "tool-calls",
+                "providerMetadata": {
+                  "openai": {
+                    "responseId": "resp_67cf3390786881908b27489d7e8cfb6b",
+                  },
+                },
+                "type": "finish",
+                "usage": {
+                  "cachedInputTokens": 0,
+                  "inputTokens": 327,
+                  "outputTokens": 834,
+                  "reasoningTokens": 0,
+                  "totalTokens": 1161,
+                },
+              },
+            ]
+          `);
+      });
+
+      it('should handle file_search tool calls with results', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'stream-chunks',
+          chunks: [
+            `data:{"type":"response.created","response":{"id":"resp_67cf3390786881908b27489d7e8cfb6b","object":"response","created_at":1741632400,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"file_search"}],"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+            `data:{"type":"response.output_item.added","output_index":0,"item":{"type":"file_search_call","id":"fs_67cf3390e9608190869b5d45698a7067","status":"in_progress"}}\n\n`,
+            `data:{"type":"response.output_item.done","output_index":0,"item":{"type":"file_search_call","id":"fs_67cf3390e9608190869b5d45698a7067","status":"completed","queries":["AI information"],"results":[{"attributes":{"file_id":"file-123","filename":"ai_guide.pdf","score":0.95,"text":"AI is a field of computer science"}}]}}\n\n`,
+            `data:{"type":"response.output_item.added","output_index":1,"item":{"type":"message","id":"msg_67cf33924ea88190b8c12bf68c1f6416","status":"in_progress","role":"assistant","content":[]}}\n\n`,
+            `data:{"type":"response.output_text.delta","item_id":"msg_67cf33924ea88190b8c12bf68c1f6416","output_index":1,"content_index":0,"delta":"Based on the search results, here is the information you requested."}\n\n`,
+            `data:{"type":"response.output_item.done","output_index":1,"item":{"type":"message","id":"msg_67cf33924ea88190b8c12bf68c1f6416","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Based on the search results, here is the information you requested.","annotations":[]}]}}\n\n`,
+            `data:{"type":"response.completed","response":{"id":"resp_67cf3390786881908b27489d7e8cfb6b","object":"response","created_at":1741632400,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-mini-2024-07-18","output":[{"type":"file_search_call","id":"fs_67cf3390e9608190869b5d45698a7067","status":"completed","queries":["AI information"],"results":[{"attributes":{"file_id":"file-123","filename":"ai_guide.pdf","score":0.95,"text":"AI is a field of computer science"}}]},{"type":"message","id":"msg_67cf33924ea88190b8c12bf68c1f6416","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Based on the search results, here is the information you requested.","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"file_search"}],"top_p":1,"truncation":"disabled","usage":{"input_tokens":327,"input_tokens_details":{"cached_tokens":0},"output_tokens":834,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1161},"user":null,"metadata":{}}}\n\n`,
+          ],
+        };
+
+        const { stream } = await createModel('gpt-4o-mini').doStream({
+          prompt: TEST_PROMPT,
+          includeRawChunks: false,
+        });
+
+        expect(await convertReadableStreamToArray(stream))
+          .toMatchInlineSnapshot(`
+            [
+              {
+                "type": "stream-start",
+                "warnings": [],
+              },
+              {
+                "id": "resp_67cf3390786881908b27489d7e8cfb6b",
+                "modelId": "gpt-4o-mini-2024-07-18",
+                "timestamp": 2025-03-10T18:46:40.000Z,
+                "type": "response-metadata",
+              },
+              {
+                "id": "fs_67cf3390e9608190869b5d45698a7067",
+                "toolName": "file_search",
+                "type": "tool-input-start",
+              },
+              {
+                "id": "fs_67cf3390e9608190869b5d45698a7067",
+                "type": "tool-input-end",
+              },
+              {
+                "input": "",
+                "providerExecuted": true,
+                "toolCallId": "fs_67cf3390e9608190869b5d45698a7067",
+                "toolName": "file_search",
+                "type": "tool-call",
+              },
+              {
+                "providerExecuted": true,
+                "result": {
+                  "queries": [
+                    "AI information",
+                  ],
+                  "results": [
+                    {
+                      "attributes": {
+                        "file_id": "file-123",
+                        "filename": "ai_guide.pdf",
+                        "score": 0.95,
+                        "text": "AI is a field of computer science",
+                      },
+                    },
+                  ],
                   "status": "completed",
                   "type": "file_search_tool_result",
                 },

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2814,8 +2814,6 @@ describe('OpenAIResponsesLanguageModel', () => {
               {
                 "providerExecuted": true,
                 "result": {
-                  "queries": undefined,
-                  "results": undefined,
                   "status": "completed",
                   "type": "file_search_tool_result",
                 },

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -322,6 +322,15 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 type: z.literal('file_search_call'),
                 id: z.string(),
                 status: z.string().optional(),
+                queries: z.array(z.string()).optional(),
+                results: z.array(z.object({
+                  attributes: z.object({
+                    file_id: z.string(),
+                    filename: z.string(),
+                    score: z.number(),
+                    text: z.string(),
+                  }),
+                })).optional(),
               }),
               z.object({
                 type: z.literal('reasoning'),
@@ -479,6 +488,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             result: {
               type: 'file_search_tool_result',
               status: part.status || 'completed',
+              queries: part.queries,
+              results: part.results,
             },
             providerExecuted: true,
           });
@@ -761,6 +772,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   result: {
                     type: 'file_search_tool_result',
                     status: value.item.status || 'completed',
+                    queries: value.item.queries,
+                    results: value.item.results,
                   },
                   providerExecuted: true,
                 });
@@ -968,6 +981,15 @@ const responseOutputItemAddedSchema = z.object({
       type: z.literal('file_search_call'),
       id: z.string(),
       status: z.string(),
+      queries: z.array(z.string()).optional(),
+      results: z.array(z.object({
+        attributes: z.object({
+          file_id: z.string(),
+          filename: z.string(),
+          score: z.number(),
+          text: z.string(),
+        }),
+      })).optional(),
     }),
   ]),
 });
@@ -1007,6 +1029,15 @@ const responseOutputItemDoneSchema = z.object({
       type: z.literal('file_search_call'),
       id: z.string(),
       status: z.literal('completed'),
+      queries: z.array(z.string()).optional(),
+      results: z.array(z.object({
+        attributes: z.object({
+          file_id: z.string(),
+          filename: z.string(),
+          score: z.number(),
+          text: z.string(),
+        }),
+      })).optional(),
     }),
   ]),
 });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -323,18 +323,14 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 id: z.string(),
                 status: z.string().optional(),
                 queries: z.array(z.string()).optional(),
-                results: z
-                  .array(
-                    z.object({
-                      attributes: z.object({
-                        file_id: z.string(),
-                        filename: z.string(),
-                        score: z.number(),
-                        text: z.string(),
-                      }),
-                    }),
-                  )
-                  .optional(),
+                results: z.array(z.object({
+                  attributes: z.object({
+                    file_id: z.string(),
+                    filename: z.string(),
+                    score: z.number(),
+                    text: z.string(),
+                  }),
+                })).optional(),
               }),
               z.object({
                 type: z.literal('reasoning'),
@@ -492,8 +488,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             result: {
               type: 'file_search_tool_result',
               status: part.status || 'completed',
-              queries: part.queries,
-              results: part.results,
+              ...(part.queries && { queries: part.queries }),
+              ...(part.results && { results: part.results }),
             },
             providerExecuted: true,
           });
@@ -776,8 +772,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   result: {
                     type: 'file_search_tool_result',
                     status: value.item.status || 'completed',
-                    queries: value.item.queries,
-                    results: value.item.results,
+                    ...(value.item.queries && { queries: value.item.queries }),
+                    ...(value.item.results && { results: value.item.results }),
                   },
                   providerExecuted: true,
                 });
@@ -986,18 +982,14 @@ const responseOutputItemAddedSchema = z.object({
       id: z.string(),
       status: z.string(),
       queries: z.array(z.string()).optional(),
-      results: z
-        .array(
-          z.object({
-            attributes: z.object({
-              file_id: z.string(),
-              filename: z.string(),
-              score: z.number(),
-              text: z.string(),
-            }),
-          }),
-        )
-        .optional(),
+      results: z.array(z.object({
+        attributes: z.object({
+          file_id: z.string(),
+          filename: z.string(),
+          score: z.number(),
+          text: z.string(),
+        }),
+      })).optional(),
     }),
   ]),
 });
@@ -1038,18 +1030,14 @@ const responseOutputItemDoneSchema = z.object({
       id: z.string(),
       status: z.literal('completed'),
       queries: z.array(z.string()).optional(),
-      results: z
-        .array(
-          z.object({
-            attributes: z.object({
-              file_id: z.string(),
-              filename: z.string(),
-              score: z.number(),
-              text: z.string(),
-            }),
-          }),
-        )
-        .optional(),
+      results: z.array(z.object({
+        attributes: z.object({
+          file_id: z.string(),
+          filename: z.string(),
+          score: z.number(),
+          text: z.string(),
+        }),
+      })).optional(),
     }),
   ]),
 });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -323,14 +323,18 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 id: z.string(),
                 status: z.string().optional(),
                 queries: z.array(z.string()).optional(),
-                results: z.array(z.object({
-                  attributes: z.object({
-                    file_id: z.string(),
-                    filename: z.string(),
-                    score: z.number(),
-                    text: z.string(),
-                  }),
-                })).optional(),
+                results: z
+                  .array(
+                    z.object({
+                      attributes: z.object({
+                        file_id: z.string(),
+                        filename: z.string(),
+                        score: z.number(),
+                        text: z.string(),
+                      }),
+                    }),
+                  )
+                  .optional(),
               }),
               z.object({
                 type: z.literal('reasoning'),
@@ -982,14 +986,18 @@ const responseOutputItemAddedSchema = z.object({
       id: z.string(),
       status: z.string(),
       queries: z.array(z.string()).optional(),
-      results: z.array(z.object({
-        attributes: z.object({
-          file_id: z.string(),
-          filename: z.string(),
-          score: z.number(),
-          text: z.string(),
-        }),
-      })).optional(),
+      results: z
+        .array(
+          z.object({
+            attributes: z.object({
+              file_id: z.string(),
+              filename: z.string(),
+              score: z.number(),
+              text: z.string(),
+            }),
+          }),
+        )
+        .optional(),
     }),
   ]),
 });
@@ -1030,14 +1038,18 @@ const responseOutputItemDoneSchema = z.object({
       id: z.string(),
       status: z.literal('completed'),
       queries: z.array(z.string()).optional(),
-      results: z.array(z.object({
-        attributes: z.object({
-          file_id: z.string(),
-          filename: z.string(),
-          score: z.number(),
-          text: z.string(),
-        }),
-      })).optional(),
+      results: z
+        .array(
+          z.object({
+            attributes: z.object({
+              file_id: z.string(),
+              filename: z.string(),
+              score: z.number(),
+              text: z.string(),
+            }),
+          }),
+        )
+        .optional(),
     }),
   ]),
 });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -322,7 +322,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 type: z.literal('file_search_call'),
                 id: z.string(),
                 status: z.string().optional(),
-                queries: z.array(z.string()).optional(),
+                queries: z.array(z.string()).nullish(),
                 results: z
                   .array(
                     z.object({
@@ -334,7 +334,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                       }),
                     }),
                   )
-                  .optional(),
+                  .nullish(),
               }),
               z.object({
                 type: z.literal('reasoning'),
@@ -985,7 +985,7 @@ const responseOutputItemAddedSchema = z.object({
       type: z.literal('file_search_call'),
       id: z.string(),
       status: z.string(),
-      queries: z.array(z.string()).optional(),
+      queries: z.array(z.string()).nullish(),
       results: z
         .array(
           z.object({
@@ -1037,7 +1037,7 @@ const responseOutputItemDoneSchema = z.object({
       type: z.literal('file_search_call'),
       id: z.string(),
       status: z.literal('completed'),
-      queries: z.array(z.string()).optional(),
+      queries: z.array(z.string()).nullish(),
       results: z
         .array(
           z.object({
@@ -1049,7 +1049,7 @@ const responseOutputItemDoneSchema = z.object({
             }),
           }),
         )
-        .optional(),
+        .nullish(),
     }),
   ]),
 });

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -623,6 +623,17 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   id: value.item.id,
                   toolName: 'computer_use',
                 });
+              } else if (value.item.type === 'file_search_call') {
+                ongoingToolCalls[value.output_index] = {
+                  toolName: 'file_search',
+                  toolCallId: value.item.id,
+                };
+
+                controller.enqueue({
+                  type: 'tool-input-start',
+                  id: value.item.id,
+                  toolName: 'file_search',
+                });
               } else if (value.item.type === 'message') {
                 controller.enqueue({
                   type: 'text-start',
@@ -722,6 +733,33 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   toolName: 'computer_use',
                   result: {
                     type: 'computer_use_tool_result',
+                    status: value.item.status || 'completed',
+                  },
+                  providerExecuted: true,
+                });
+              } else if (value.item.type === 'file_search_call') {
+                ongoingToolCalls[value.output_index] = undefined;
+                hasToolCalls = true;
+
+                controller.enqueue({
+                  type: 'tool-input-end',
+                  id: value.item.id,
+                });
+
+                controller.enqueue({
+                  type: 'tool-call',
+                  toolCallId: value.item.id,
+                  toolName: 'file_search',
+                  input: '',
+                  providerExecuted: true,
+                });
+
+                controller.enqueue({
+                  type: 'tool-result',
+                  toolCallId: value.item.id,
+                  toolName: 'file_search',
+                  result: {
+                    type: 'file_search_tool_result',
                     status: value.item.status || 'completed',
                   },
                   providerExecuted: true,


### PR DESCRIPTION
## background

openai responses api streaming was missing handlers for file_search_call events, causing users to receive only text parts instead of the expected tool-file_search message parts when using file search tools

## summary

- add file_search_call handlers for response.output_item.added events
- add file_search_call handlers for response.output_item.done events
- update test expectations to verify tool-file_search parts are generated

## verification

- existing file_search test now passes with correct tool event expectations
- streaming logic properly emits tool-input-start, tool-call, and tool-result events
- ui message processing converts these to tool-file_search parts as expected

## tasks

- [x] add file_search_call handler in response.output_item.added logic
- [x] add file_search_call handler in response.output_item.done logic  
- [x] update test snapshot to expect tool events instead of text-only

related issue - #7740