### PR TITLE
ci(release): attribute automated commits to https://github.com/apps/vercel-ai-sdk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           version: pnpm ci:version
           publish: pnpm ci:release
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
Small follow up to #7972.

Turns out that unless [explicitly disabled](https://github.com/changesets/action/blob/04d574e831923498156e0b2b93152878063203a3/src/index.ts#L33-L38) the action is [configuring the git author to `github-actions[bot]`](https://github.com/changesets/action/blob/04d574e831923498156e0b2b93152878063203a3/src/git.ts#L62-L75).