### PR TITLE
Add addToolResult as input for onToolCall

### DIFF
--- a/.changeset/lucky-cougars-mate.md
+++ b/.changeset/lucky-cougars-mate.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Add addToolResult as input for onToolCall

--- a/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
@@ -124,7 +124,8 @@ import {
 import { useState } from 'react';
 
 export default function Chat() {
-  const { messages, sendMessage, addToolResult } = useChat({
+  // Enhanced API (recommended): addToolResult is passed as parameter
+  const { messages, sendMessage } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/chat',
     }),
@@ -132,11 +133,11 @@ export default function Chat() {
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
     // run client-side tools that are automatically executed:
-    async onToolCall({ toolCall }) {
+    async onToolCall({ toolCall, addToolResult }) {
       if (toolCall.toolName === 'getLocation') {
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
 
-        // No await - avoids potential deadlocks
+        // addToolResult is available directly in the callback
         addToolResult({
           tool: 'getLocation',
           toolCallId: toolCall.toolCallId,
@@ -145,6 +146,28 @@ export default function Chat() {
       }
     },
   });
+
+  // Alternative: Legacy API (still supported for backward compatibility)
+  // const { messages, sendMessage, addToolResult } = useChat({
+  //   transport: new DefaultChatTransport({
+  //     api: '/api/chat',
+  //   }),
+  //
+  //   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  //
+  //   async onToolCall({ toolCall }) {
+  //     if (toolCall.toolName === 'getLocation') {
+  //       const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
+  //
+  //       // addToolResult accessed from closure
+  //       addToolResult({
+  //         tool: 'getLocation',
+  //         toolCallId: toolCall.toolCallId,
+  //         output: cities[Math.floor(Math.random() * cities.length)],
+  //       });
+  //     }
+  //   },
+  // });
   const [input, setInput] = useState('');
 
   return (

--- a/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
@@ -124,7 +124,6 @@ import {
 import { useState } from 'react';
 
 export default function Chat() {
-  // Enhanced API (recommended): addToolResult is passed as parameter
   const { messages, sendMessage } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/chat',
@@ -137,7 +136,7 @@ export default function Chat() {
       if (toolCall.toolName === 'getLocation') {
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
 
-        // addToolResult is available directly in the callback
+        // No await - avoids potential deadlocks
         addToolResult({
           tool: 'getLocation',
           toolCallId: toolCall.toolCallId,
@@ -147,27 +146,6 @@ export default function Chat() {
     },
   });
 
-  // Alternative: Legacy API (still supported for backward compatibility)
-  // const { messages, sendMessage, addToolResult } = useChat({
-  //   transport: new DefaultChatTransport({
-  //     api: '/api/chat',
-  //   }),
-  //
-  //   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-  //
-  //   async onToolCall({ toolCall }) {
-  //     if (toolCall.toolName === 'getLocation') {
-  //       const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
-  //
-  //       // addToolResult accessed from closure
-  //       addToolResult({
-  //         tool: 'getLocation',
-  //         toolCallId: toolCall.toolCallId,
-  //         output: cities[Math.floor(Math.random() * cities.length)],
-  //       });
-  //     }
-  //   },
-  // });
   const [input, setInput] = useState('');
 
   return (

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -227,10 +227,10 @@ Allows you to easily create a conversational user interface for your chatbot app
     },
     {
       name: 'onToolCall',
-      type: '({toolCall: ToolCall}) => void | Promise<void>',
+      type: '({toolCall: ToolCall, addToolResult?: Function}) => void | Promise<void>',
       isOptional: true,
       description:
-        'Optional callback function that is invoked when a tool call is received. You must call addToolResult to provide the tool result.',
+        'Optional callback function that is invoked when a tool call is received. The enhanced API provides addToolResult as a parameter for better modularity, or you can still access it from the hook return value for backward compatibility.',
     },
     {
       name: 'sendAutomaticallyWhen',

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -230,7 +230,7 @@ Allows you to easily create a conversational user interface for your chatbot app
       type: '({toolCall: ToolCall, addToolResult?: Function}) => void | Promise<void>',
       isOptional: true,
       description:
-        'Optional callback function that is invoked when a tool call is received. The enhanced API provides addToolResult as a parameter for better modularity, or you can still access it from the hook return value for backward compatibility.',
+        'Optional callback function that is invoked when a tool call is received. You must call addToolResult to provide the tool result.',
     },
     {
       name: 'sendAutomaticallyWhen',

--- a/content/docs/09-troubleshooting/05-tool-invocation-missing-result.mdx
+++ b/content/docs/09-troubleshooting/05-tool-invocation-missing-result.mdx
@@ -57,7 +57,7 @@ const { messages, sendMessage } = useChat({
     if (toolCall.toolName === 'getLocation') {
       const result = await getLocationData();
 
-      // addToolResult is available directly in the callback
+      // Important: Don't await inside onToolCall to avoid deadlocks
       addToolResult({
         tool: 'getLocation',
         toolCallId: toolCall.toolCallId,
@@ -66,22 +66,6 @@ const { messages, sendMessage } = useChat({
     }
   },
 });
-
-// Alternative: Legacy API (still supported)
-// const { messages, sendMessage, addToolResult } = useChat({
-//   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-//   onToolCall: async ({ toolCall }) => {
-//     if (toolCall.toolName === 'getLocation') {
-//       const result = await getLocationData();
-//       // addToolResult accessed from closure
-//       addToolResult({
-//         tool: 'getLocation',
-//         toolCallId: toolCall.toolCallId,
-//         output: result,
-//       });
-//     }
-//   },
-// });
 ```
 
 ```tsx

--- a/content/docs/09-troubleshooting/05-tool-invocation-missing-result.mdx
+++ b/content/docs/09-troubleshooting/05-tool-invocation-missing-result.mdx
@@ -47,16 +47,17 @@ import {
   lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
 
-const { messages, sendMessage, addToolResult } = useChat({
+// Enhanced API (recommended): addToolResult is passed as parameter
+const { messages, sendMessage } = useChat({
   // Automatically submit when all tool results are available
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
   // Handle tool calls in onToolCall
-  onToolCall: async ({ toolCall }) => {
+  onToolCall: async ({ toolCall, addToolResult }) => {
     if (toolCall.toolName === 'getLocation') {
       const result = await getLocationData();
 
-      // Important: Don't await inside onToolCall to avoid deadlocks
+      // addToolResult is available directly in the callback
       addToolResult({
         tool: 'getLocation',
         toolCallId: toolCall.toolCallId,
@@ -65,6 +66,22 @@ const { messages, sendMessage, addToolResult } = useChat({
     }
   },
 });
+
+// Alternative: Legacy API (still supported)
+// const { messages, sendMessage, addToolResult } = useChat({
+//   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+//   onToolCall: async ({ toolCall }) => {
+//     if (toolCall.toolName === 'getLocation') {
+//       const result = await getLocationData();
+//       // addToolResult accessed from closure
+//       addToolResult({
+//         tool: 'getLocation',
+//         toolCallId: toolCall.toolCallId,
+//         output: result,
+//       });
+//     }
+//   },
+// });
 ```
 
 ```tsx

--- a/examples/next-openai/app/use-chat-reasoning-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-reasoning-tools/page.tsx
@@ -6,32 +6,26 @@ import { DefaultChatTransport } from 'ai';
 import { ReasoningToolsMessage } from '../api/use-chat-reasoning-tools/route';
 
 export default function Chat() {
-  const { messages, sendMessage, addToolResult, status } =
-    useChat<ReasoningToolsMessage>({
-      transport: new DefaultChatTransport({
-        api: '/api/use-chat-reasoning-tools',
-      }),
+  const { messages, sendMessage, status } = useChat<ReasoningToolsMessage>({
+    transport: new DefaultChatTransport({
+      api: '/api/use-chat-reasoning-tools',
+    }),
 
-      // run client-side tools that are automatically executed:
-      async onToolCall({ toolCall }) {
-        // artificial 2 second delay
-        await new Promise(resolve => setTimeout(resolve, 2000));
+    // run client-side tools that are automatically executed:
+    async onToolCall({ toolCall, addToolResult }) {
+      // artificial 2 second delay
+      await new Promise(resolve => setTimeout(resolve, 2000));
 
-        if (toolCall.toolName === 'getLocation') {
-          const cities = [
-            'New York',
-            'Los Angeles',
-            'Chicago',
-            'San Francisco',
-          ];
-          addToolResult({
-            tool: 'getLocation',
-            toolCallId: toolCall.toolCallId,
-            output: cities[Math.floor(Math.random() * cities.length)],
-          });
-        }
-      },
-    });
+      if (toolCall.toolName === 'getLocation') {
+        const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
+        addToolResult({
+          tool: 'getLocation',
+          toolCallId: toolCall.toolCallId,
+          output: cities[Math.floor(Math.random() * cities.length)],
+        });
+      }
+    },
+  });
 
   console.log(structuredClone(messages));
 

--- a/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
+++ b/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
@@ -9,26 +9,25 @@ import {
 import { StreamingToolCallsMessage } from '../api/use-chat-streaming-tool-calls/route';
 
 export default function Chat() {
-  const { messages, status, sendMessage, addToolResult } =
-    useChat<StreamingToolCallsMessage>({
-      transport: new DefaultChatTransport({
-        api: '/api/use-chat-streaming-tool-calls',
-      }),
+  const { messages, status, sendMessage } = useChat<StreamingToolCallsMessage>({
+    transport: new DefaultChatTransport({
+      api: '/api/use-chat-streaming-tool-calls',
+    }),
 
-      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
-      // run client-side tools that are automatically executed:
-      async onToolCall({ toolCall }) {
-        if (toolCall.toolName === 'showWeatherInformation') {
-          // display tool. add tool result that informs the llm that the tool was executed.
-          addToolResult({
-            tool: 'showWeatherInformation',
-            toolCallId: toolCall.toolCallId,
-            output: 'Weather information was shown to the user.',
-          });
-        }
-      },
-    });
+    // run client-side tools that are automatically executed:
+    async onToolCall({ toolCall, addToolResult }) {
+      if (toolCall.toolName === 'showWeatherInformation') {
+        // display tool. add tool result that informs the llm that the tool was executed.
+        addToolResult({
+          tool: 'showWeatherInformation',
+          toolCallId: toolCall.toolCallId,
+          output: 'Weather information was shown to the user.',
+        });
+      }
+    },
+  });
 
   // used to only render the role when it changes:
   let lastRole: string | undefined = undefined;

--- a/examples/next-openai/app/use-chat-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-tools/page.tsx
@@ -9,32 +9,26 @@ import {
 import { UseChatToolsMessage } from '../api/use-chat-tools/route';
 
 export default function Chat() {
-  const { messages, sendMessage, addToolResult, status } =
-    useChat<UseChatToolsMessage>({
-      transport: new DefaultChatTransport({ api: '/api/use-chat-tools' }),
-      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  const { messages, sendMessage, status } = useChat<UseChatToolsMessage>({
+    transport: new DefaultChatTransport({ api: '/api/use-chat-tools' }),
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
-      // run client-side tools that are automatically executed:
-      async onToolCall({ toolCall }) {
-        // artificial 2 second delay
-        await new Promise(resolve => setTimeout(resolve, 2000));
+    // run client-side tools that are automatically executed:
+    async onToolCall({ toolCall, addToolResult }) {
+      // artificial 2 second delay
+      await new Promise(resolve => setTimeout(resolve, 2000));
 
-        if (toolCall.toolName === 'getLocation') {
-          const cities = [
-            'New York',
-            'Los Angeles',
-            'Chicago',
-            'San Francisco',
-          ];
+      if (toolCall.toolName === 'getLocation') {
+        const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
 
-          addToolResult({
-            tool: 'getLocation',
-            toolCallId: toolCall.toolCallId,
-            output: cities[Math.floor(Math.random() * cities.length)],
-          });
-        }
-      },
-    });
+        addToolResult({
+          tool: 'getLocation',
+          toolCallId: toolCall.toolCallId,
+          output: cities[Math.floor(Math.random() * cities.length)],
+        });
+      }
+    },
+  });
 
   return (
     <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -91,6 +91,13 @@ export type ChatOnErrorCallback = (error: Error) => void;
 export type ChatOnToolCallCallback<UI_MESSAGE extends UIMessage = UIMessage> =
   (options: {
     toolCall: InferUIMessageToolCall<UI_MESSAGE>;
+    addToolResult?: <
+      TOOL extends keyof InferUIMessageTools<UI_MESSAGE>,
+    >(options: {
+      tool: TOOL;
+      toolCallId: string;
+      output: InferUIMessageTools<UI_MESSAGE>[TOOL]['output'];
+    }) => Promise<void>;
   }) => void | PromiseLike<void>;
 
 export type ChatOnDataCallback<UI_MESSAGE extends UIMessage> = (
@@ -550,6 +557,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         stream: processUIMessageStream({
           stream,
           onToolCall: this.onToolCall,
+          addToolResult: this.addToolResult,
           onData: this.onData,
           messageMetadataSchema: this.messageMetadataSchema,
           dataPartSchemas: this.dataPartSchemas,

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -5018,7 +5018,7 @@ describe('processUIMessageStream', () => {
           onToolCallInvoked = true;
           receivedAddToolResult = addToolResult;
         },
-        addToolResult: mockAddToolResult, // Provide addToolResult - testing new API
+        addToolResult: mockAddToolResult,
         runUpdateMessageJob,
         onError: error => {
           throw error;

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -4946,6 +4946,90 @@ describe('processUIMessageStream', () => {
     `);
   });
 
+  it('should call onToolCall without addToolResult parameter (backward compatibility)', async () => {
+    let onToolCallInvoked = false;
+    let receivedAddToolResult: any = 'NOT_SET';
+
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'tool-call-id',
+        toolName: 'tool-name',
+        input: { query: 'test' },
+      },
+      { type: 'finish-step' },
+      { type: 'finish' },
+    ]);
+
+    state = createStreamingUIMessageState({
+      messageId: 'msg-123',
+      lastMessage: undefined,
+    });
+
+    await consumeStream({
+      stream: processUIMessageStream({
+        stream,
+        onToolCall: async ({ toolCall, addToolResult }) => {
+          onToolCallInvoked = true;
+          receivedAddToolResult = addToolResult;
+        },
+        // Note: addToolResult is not provided - testing old API
+        runUpdateMessageJob,
+        onError: error => {
+          throw error;
+        },
+      }),
+    });
+
+    expect(onToolCallInvoked).toBe(true);
+    expect(receivedAddToolResult).toBeUndefined();
+  });
+
+  it('should call onToolCall with addToolResult parameter when provided', async () => {
+    let onToolCallInvoked = false;
+    let receivedAddToolResult: any = 'NOT_SET';
+
+    const stream = createUIMessageStream([
+      { type: 'start', messageId: 'msg-123' },
+      { type: 'start-step' },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'tool-call-id',
+        toolName: 'tool-name',
+        input: { query: 'test' },
+      },
+      { type: 'finish-step' },
+      { type: 'finish' },
+    ]);
+
+    state = createStreamingUIMessageState({
+      messageId: 'msg-123',
+      lastMessage: undefined,
+    });
+
+    const mockAddToolResult = async () => {};
+
+    await consumeStream({
+      stream: processUIMessageStream({
+        stream,
+        onToolCall: async ({ toolCall, addToolResult }) => {
+          onToolCallInvoked = true;
+          receivedAddToolResult = addToolResult;
+        },
+        addToolResult: mockAddToolResult, // Provide addToolResult - testing new API
+        runUpdateMessageJob,
+        onError: error => {
+          throw error;
+        },
+      }),
+    });
+
+    expect(onToolCallInvoked).toBe(true);
+    expect(receivedAddToolResult).toBe(mockAddToolResult);
+  });
+
   describe('dynamic tools', () => {
     let onToolCallInvoked: boolean;
 

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -506,13 +506,11 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               // Skip calling onToolCall for provider-executed tools since they are already executed
               if (onToolCall && !chunk.providerExecuted) {
                 if (addToolResult) {
-                  // New API: pass addToolResult as parameter
                   await onToolCall({
                     toolCall: chunk as InferUIMessageToolCall<UI_MESSAGE>,
                     addToolResult,
                   });
                 } else {
-                  // Old API: call without addToolResult (backward compatibility)
                   await onToolCall({
                     toolCall: chunk as InferUIMessageToolCall<UI_MESSAGE>,
                   });

--- a/packages/angular/src/lib/chat.ng.test.ts
+++ b/packages/angular/src/lib/chat.ng.test.ts
@@ -377,9 +377,9 @@ describe('onToolCall', () => {
     ({ resolve, promise: toolCallPromise } = promiseWithResolvers<void>());
 
     chat = new Chat({
-      async onToolCall({ toolCall }) {
+      async onToolCall({ toolCall, addToolResult }) {
         await toolCallPromise;
-        chat.addToolResult({
+        addToolResult({
           tool: 'test-tool',
           toolCallId: toolCall.toolCallId,
           output: `test-tool-response: ${toolCall.toolName} ${

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -657,8 +657,8 @@ describe('onToolCall', () => {
   let toolCallPromise: Promise<void>;
 
   setupTestComponent(() => {
-    const { messages, sendMessage, addToolResult } = useChat({
-      async onToolCall({ toolCall }) {
+    const { messages, sendMessage } = useChat({
+      async onToolCall({ toolCall, addToolResult }) {
         await toolCallPromise;
         addToolResult({
           tool: 'test-tool',

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -368,10 +368,10 @@ describe('onToolCall', () => {
     ({ resolve, promise: toolCallPromise } = promiseWithResolvers<void>());
 
     chat = new Chat({
-      async onToolCall({ toolCall }) {
+      async onToolCall({ toolCall, addToolResult }) {
         await toolCallPromise;
 
-        chat.addToolResult({
+        addToolResult({
           tool: 'test-tool',
           toolCallId: toolCall.toolCallId,
           output: `test-tool-response: ${toolCall.toolName} ${


### PR DESCRIPTION
## Background

The current API design for the useChat hook requires the onToolCall handler to rely on the addToolResult function returned from the hook's outer scope.

## Summary

Enhance the `onToolCall` callback in `useChat` to receive `addToolResult` as a direct parameter, improving modularity and making the callback self-contained.

- Added `addToolResult` as optional parameter to `onToolCall` callback

## Manual Verification


## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

Fixes [7896](https://github.com/vercel/ai/issues/7896)
Fixes [7201](https://github.com/vercel/ai/issues/7896)