### PR TITLE
fix(provider/vertex): pass taskType for each content value

### DIFF
--- a/.changeset/eleven-buckets-heal.md
+++ b/.changeset/eleven-buckets-heal.md
@@ -2,4 +2,4 @@
 '@ai-sdk/google-vertex': patch
 ---
 
-bugfix to actaully pass task type correctly for google vertex
+fix(provider/vertex): pass taskType for each content value. taskType needs to be passed in instances and not parameters for google-vertex

--- a/.changeset/eleven-buckets-heal.md
+++ b/.changeset/eleven-buckets-heal.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+bugfix to actaully pass task type correctly for google vertex

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -118,15 +118,17 @@ describe('GoogleVertexEmbeddingModel', () => {
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      instances: testValues.map(value => ({ content: value })),
+      instances: testValues.map(value => ({
+        content: value,
+        taskType: mockProviderOptions.taskType,
+      })),
       parameters: {
         outputDimensionality: mockProviderOptions.outputDimensionality,
-        taskType: mockProviderOptions.taskType,
       },
     });
   });
 
-  it('should pass the taskType setting', async () => {
+  it('should pass the taskType setting in instances', async () => {
     prepareJsonResponse();
 
     await model.doEmbed({
@@ -135,10 +137,11 @@ describe('GoogleVertexEmbeddingModel', () => {
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      instances: testValues.map(value => ({ content: value })),
-      parameters: {
+      instances: testValues.map(value => ({
+        content: value,
         taskType: mockProviderOptions.taskType,
-      },
+      })),
+      parameters: {},
     });
   });
 

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -77,10 +77,12 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV2<string> {
       url,
       headers: mergedHeaders,
       body: {
-        instances: values.map(value => ({ content: value })),
+        instances: values.map(value => ({
+          content: value,
+          taskType: googleOptions.taskType,
+        })),
         parameters: {
           outputDimensionality: googleOptions.outputDimensionality,
-          taskType: googleOptions.taskType,
         },
       },
       failedResponseHandler: googleVertexFailedResponseHandler,


### PR DESCRIPTION
## Background
hello, when adding taskType for vertex (https://github.com/vercel/ai/pull/7715) i made a mistake (its different from the google api). the taskType needs to be passed in instances instead of parameters.

also added the autoTruncate parameter from the api

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
