### PR TITLE
fix(provider/utils): fix FlexibleSchema type inference with zod/v3

### DIFF
--- a/.changeset/polite-ways-agree.md
+++ b/.changeset/polite-ways-agree.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider/utils): fix FlexibleSchema type inference with zod/v3

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -26,7 +26,12 @@ export type Schema<OBJECT = unknown> = Validator<OBJECT> & {
   readonly jsonSchema: JSONSchema7;
 };
 
-export type FlexibleSchema<T> = z4.core.$ZodType<T> | z3.Schema<T> | Schema<T>;
+// Note: Zod types here exactly match the types in zod-schema.ts
+// to prevent type errors when using zod schemas with flexible schemas.
+export type FlexibleSchema<T> =
+  | z4.core.$ZodType<T, any>
+  | z3.Schema<T, z3.ZodTypeDef, any>
+  | Schema<T>;
 
 export type InferSchema<SCHEMA> = SCHEMA extends z3.Schema
   ? z3.infer<SCHEMA>


### PR DESCRIPTION
## Background

In AI SDK 5 there was a regression that broke type inference with `zod/v3` schemas that had a `transform` call (see #7944 ).

## Summary

Fix `FlexibleSchema` type definition.

## Manual Verification

Reproduced error and verified fix on example that matches #7944 

## Related Issues

Fixes #7944 