### PR TITLE
fix(provider-utils): fix tools type inference

### DIFF
--- a/.changeset/slimy-berries-push.md
+++ b/.changeset/slimy-berries-push.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): fix tools type inference

--- a/examples/ai-core/src/stream-text/google-reasoning-with-tools.ts
+++ b/examples/ai-core/src/stream-text/google-reasoning-with-tools.ts
@@ -10,7 +10,7 @@ async function main() {
     tools: {
       calculate: {
         description: 'Calculate the result of a mathematical expression',
-        parameters: z.object({
+        inputSchema: z.object({
           a: z.number().describe('First number'),
           b: z.number().describe('Second number'),
           operation: z

--- a/packages/ai/src/prompt/create-tool-model-output.test.ts
+++ b/packages/ai/src/prompt/create-tool-model-output.test.ts
@@ -1,5 +1,6 @@
 import { Tool } from '@ai-sdk/provider-utils';
 import { createToolModelOutput } from './create-tool-model-output';
+import z from 'zod/v4';
 
 describe('createToolModelOutput', () => {
   describe('error cases', () => {
@@ -58,6 +59,7 @@ describe('createToolModelOutput', () => {
           type: 'text',
           value: `Custom output: ${output}`,
         }),
+        inputSchema: z.object({}),
       };
 
       const result = createToolModelOutput({
@@ -78,6 +80,7 @@ describe('createToolModelOutput', () => {
           type: 'json',
           value: { processed: output, timestamp: '2023-01-01' },
         }),
+        inputSchema: z.object({}),
       };
 
       const complexOutput = { data: [1, 2, 3], status: 'success' };
@@ -102,6 +105,7 @@ describe('createToolModelOutput', () => {
             { type: 'text', text: 'Additional information' },
           ],
         }),
+        inputSchema: z.object({}),
       };
 
       const result = createToolModelOutput({
@@ -137,6 +141,7 @@ describe('createToolModelOutput', () => {
     it('should return text type for string output even with tool that has no toModelOutput', () => {
       const toolWithoutToModelOutput: Tool = {
         description: 'A tool without toModelOutput',
+        inputSchema: z.object({}),
       };
 
       const result = createToolModelOutput({
@@ -269,6 +274,7 @@ describe('createToolModelOutput', () => {
   describe('edge cases', () => {
     it('should prioritize isError over tool.toModelOutput', () => {
       const mockTool: Tool = {
+        inputSchema: z.object({}),
         toModelOutput: () => ({
           type: 'text',
           value: 'This should not be called',

--- a/packages/provider-utils/src/types/tool.test-d.ts
+++ b/packages/provider-utils/src/types/tool.test-d.ts
@@ -7,7 +7,7 @@ import {
 import { tool } from './tool';
 
 describe('tool helper', () => {
-  it('should work with only parameters', () => {
+  it('should work with fixed inputSchema', () => {
     const toolType = tool({
       inputSchema: z.object({ number: z.number() }),
     });
@@ -20,7 +20,20 @@ describe('tool helper', () => {
     >();
   });
 
-  it('should work with both inputSchema and output', () => {
+  it('should work with flexible inputSchema', <T>() => {
+    const inputSchema: FlexibleSchema<T> = null as any;
+
+    const toolType = tool({
+      inputSchema,
+    });
+
+    expectTypeOf(toolType).toEqualTypeOf<Tool<T, never>>();
+    expectTypeOf(toolType.execute).toEqualTypeOf<undefined>();
+    expectTypeOf(toolType.execute).not.toEqualTypeOf<Function>();
+    expectTypeOf(toolType.inputSchema).toEqualTypeOf<FlexibleSchema<T>>();
+  });
+
+  it('should work with inputSchema and execute function', () => {
     const toolType = tool({
       inputSchema: z.object({ number: z.number() }),
       execute: async input => {

--- a/packages/provider-utils/src/types/tool.test-d.ts
+++ b/packages/provider-utils/src/types/tool.test-d.ts
@@ -7,15 +7,6 @@ import {
 import { tool } from './tool';
 
 describe('tool helper', () => {
-  it('should work with no parameters and no output', () => {
-    const toolType = tool({});
-
-    expectTypeOf(toolType).toEqualTypeOf<Tool<never, never>>();
-    expectTypeOf(toolType.execute).toEqualTypeOf<undefined>();
-    expectTypeOf(toolType.execute).not.toEqualTypeOf<Function>();
-    expectTypeOf(toolType.inputSchema).toEqualTypeOf<undefined>();
-  });
-
   it('should work with only parameters', () => {
     const toolType = tool({
       inputSchema: z.object({ number: z.number() }),
@@ -27,19 +18,6 @@ describe('tool helper', () => {
     expectTypeOf(toolType.inputSchema).toEqualTypeOf<
       FlexibleSchema<{ number: number }>
     >();
-  });
-
-  it('should work with only output', () => {
-    const toolType = tool({
-      execute: async () => 'test' as const,
-    });
-
-    expectTypeOf(toolType).toEqualTypeOf<Tool<never, 'test'>>();
-    expectTypeOf(toolType.execute).toMatchTypeOf<
-      ToolExecuteFunction<never, 'test'> | undefined
-    >();
-    expectTypeOf(toolType.execute).not.toEqualTypeOf<undefined>();
-    expectTypeOf(toolType.inputSchema).toEqualTypeOf<undefined>();
   });
 
   it('should work with both inputSchema and output', () => {

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -68,72 +68,66 @@ to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
    */
   providerOptions?: ProviderOptions;
-} & NeverOptional<
-  INPUT,
-  {
-    /**
+
+  /**
 The schema of the input that the tool expects. The language model will use this to generate the input.
 It is also used to validate the output of the language model.
 Use descriptions to make the input understandable for the language model.
    */
-    inputSchema: FlexibleSchema<INPUT>;
+  inputSchema: FlexibleSchema<INPUT>;
 
-    /**
-     * Optional function that is called when the argument streaming starts.
-     * Only called when the tool is used in a streaming context.
-     */
-    onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
+  /**
+   * Optional function that is called when the argument streaming starts.
+   * Only called when the tool is used in a streaming context.
+   */
+  onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
 
-    /**
-     * Optional function that is called when an argument streaming delta is available.
-     * Only called when the tool is used in a streaming context.
-     */
-    onInputDelta?: (
-      options: { inputTextDelta: string } & ToolCallOptions,
-    ) => void | PromiseLike<void>;
+  /**
+   * Optional function that is called when an argument streaming delta is available.
+   * Only called when the tool is used in a streaming context.
+   */
+  onInputDelta?: (
+    options: { inputTextDelta: string } & ToolCallOptions,
+  ) => void | PromiseLike<void>;
 
+  /**
+   * Optional function that is called when a tool call can be started,
+   * even if the execute function is not provided.
+   */
+  onInputAvailable?: (
+    options: {
+      input: [INPUT] extends [never] ? undefined : INPUT;
+    } & ToolCallOptions,
+  ) => void | PromiseLike<void>;
+} & NeverOptional<
+  OUTPUT,
+  {
     /**
-     * Optional function that is called when a tool call can be started,
-     * even if the execute function is not provided.
-     */
-    onInputAvailable?: (
-      options: {
-        input: [INPUT] extends [never] ? undefined : INPUT;
-      } & ToolCallOptions,
-    ) => void | PromiseLike<void>;
-  }
-> &
-  NeverOptional<
-    OUTPUT,
-    {
-      /**
 Optional conversion function that maps the tool result to an output that can be used by the language model.
 
 If not provided, the tool result will be sent as a JSON object.
       */
-      toModelOutput?: (
-        output: OUTPUT,
-      ) => LanguageModelV2ToolResultPart['output'];
-    } & (
-      | {
-          /**
+    toModelOutput?: (output: OUTPUT) => LanguageModelV2ToolResultPart['output'];
+  } & (
+    | {
+        /**
 An async function that is called with the arguments from the tool call and produces a result.
 If not provided, the tool will not be executed automatically.
 
 @args is the input of the tool call.
 @options.abortSignal is a signal that can be used to abort the tool call.
       */
-          execute: ToolExecuteFunction<INPUT, OUTPUT>;
+        execute: ToolExecuteFunction<INPUT, OUTPUT>;
 
-          outputSchema?: FlexibleSchema<OUTPUT>;
-        }
-      | {
-          outputSchema: FlexibleSchema<OUTPUT>;
+        outputSchema?: FlexibleSchema<OUTPUT>;
+      }
+    | {
+        outputSchema: FlexibleSchema<OUTPUT>;
 
-          execute?: never;
-        }
-    )
-  > &
+        execute?: never;
+      }
+  )
+> &
   (
     | {
         /**


### PR DESCRIPTION
## Background

Tools must always have input schemas. The type definition of tools was incorrect, because it allowed for optional input schemas. This led to type inference issues such as #7681 

## Summary

Always require `inputSchema` on tools.

## Manual Verification

Verified that example from #7681 works.

## Related Issues

Fixes #7681 