### PR TITLE
fix(provider/openai): exclude gpt-5-chat from reasoning model

### DIFF
--- a/.changeset/violet-plums-compete.md
+++ b/.changeset/violet-plums-compete.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(packages/openai): exclude gpt-5-chat from reasoning model detection

--- a/.changeset/violet-plums-compete.md
+++ b/.changeset/violet-plums-compete.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai': patch
 ---
 
-fix(provider/openai): exclude gpt-5-chat from reasoning model detection
+fix(provider/openai): exclude gpt-5-chat from reasoning model

--- a/.changeset/violet-plums-compete.md
+++ b/.changeset/violet-plums-compete.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai': patch
 ---
 
-fix(packages/openai): exclude gpt-5-chat from reasoning model detection
+fix(provider/openai): exclude gpt-5-chat from reasoning model detection

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -844,7 +844,10 @@ const openaiChatChunkSchema = z.union([
 ]);
 
 function isReasoningModel(modelId: string) {
-  return (modelId.startsWith('o') || modelId.startsWith('gpt-5')) && !modelId.startsWith('gpt-5-chat');
+  return (
+    (modelId.startsWith('o') || modelId.startsWith('gpt-5')) &&
+    !modelId.startsWith('gpt-5-chat')
+  );
 }
 
 function supportsFlexProcessing(modelId: string) {
@@ -859,7 +862,9 @@ function supportsPriorityProcessing(modelId: string) {
   return (
     modelId.startsWith('gpt-4') ||
     modelId.startsWith('gpt-5-mini') ||
-    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-nano') && !modelId.startsWith('gpt-5-chat')) ||
+    (modelId.startsWith('gpt-5') &&
+      !modelId.startsWith('gpt-5-nano') &&
+      !modelId.startsWith('gpt-5-chat')) ||
     modelId.startsWith('o3') ||
     modelId.startsWith('o4-mini')
   );

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -844,14 +844,14 @@ const openaiChatChunkSchema = z.union([
 ]);
 
 function isReasoningModel(modelId: string) {
-  return modelId.startsWith('o') || modelId.startsWith('gpt-5');
+  return (modelId.startsWith('o') || modelId.startsWith('gpt-5')) && !modelId.startsWith('gpt-5-chat');
 }
 
 function supportsFlexProcessing(modelId: string) {
   return (
     modelId.startsWith('o3') ||
     modelId.startsWith('o4-mini') ||
-    modelId.startsWith('gpt-5')
+    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-chat'))
   );
 }
 
@@ -859,7 +859,7 @@ function supportsPriorityProcessing(modelId: string) {
   return (
     modelId.startsWith('gpt-4') ||
     modelId.startsWith('gpt-5-mini') ||
-    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-nano')) ||
+    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-nano') && !modelId.startsWith('gpt-5-chat')) ||
     modelId.startsWith('o3') ||
     modelId.startsWith('o4-mini')
   );

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1248,7 +1248,9 @@ function supportsPriorityProcessing(modelId: string): boolean {
   return (
     modelId.startsWith('gpt-4') ||
     modelId.startsWith('gpt-5-mini') ||
-    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-nano') && !modelId.startsWith('gpt-5-chat')) ||
+    (modelId.startsWith('gpt-5') &&
+      !modelId.startsWith('gpt-5-nano') &&
+      !modelId.startsWith('gpt-5-chat')) ||
     modelId.startsWith('o3') ||
     modelId.startsWith('o4-mini')
   );

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1197,6 +1197,15 @@ type ResponsesModelConfig = {
 };
 
 function getResponsesModelConfig(modelId: string): ResponsesModelConfig {
+  // gpt-5-chat models are non-reasoning
+  if (modelId.startsWith('gpt-5-chat')) {
+    return {
+      isReasoningModel: false,
+      systemMessageMode: 'system',
+      requiredAutoTruncation: false,
+    };
+  }
+
   // o series reasoning models:
   if (
     modelId.startsWith('o') ||
@@ -1231,7 +1240,7 @@ function supportsFlexProcessing(modelId: string): boolean {
   return (
     modelId.startsWith('o3') ||
     modelId.startsWith('o4-mini') ||
-    modelId.startsWith('gpt-5')
+    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-chat'))
   );
 }
 
@@ -1239,7 +1248,7 @@ function supportsPriorityProcessing(modelId: string): boolean {
   return (
     modelId.startsWith('gpt-4') ||
     modelId.startsWith('gpt-5-mini') ||
-    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-nano')) ||
+    (modelId.startsWith('gpt-5') && !modelId.startsWith('gpt-5-nano') && !modelId.startsWith('gpt-5-chat')) ||
     modelId.startsWith('o3') ||
     modelId.startsWith('o4-mini')
   );

--- a/packages/openai/src/responses/openai-responses-settings.ts
+++ b/packages/openai/src/responses/openai-responses-settings.ts
@@ -15,7 +15,6 @@ export const openaiResponsesReasoningModelIds = [
   'gpt-5-mini-2025-08-07',
   'gpt-5-nano',
   'gpt-5-nano-2025-08-07',
-  'gpt-5-chat-latest',
 ] as const;
 
 export const openaiResponsesModelIds = [
@@ -51,6 +50,7 @@ export const openaiResponsesModelIds = [
   'gpt-3.5-turbo',
   'gpt-3.5-turbo-1106',
   'chatgpt-4o-latest',
+  'gpt-5-chat-latest',
   ...openaiResponsesReasoningModelIds,
 ] as const;
 


### PR DESCRIPTION
## background

gpt-5-chat models were being incorrectly treated as reasoning models because they matched the broad `gpt-5-` prefix checks, but according to openai docs they are non-reasoning models with many gpt-5 features disabled

## summary

- exclude gpt-5-chat from reasoning model checks across chat and responses apis
- remove gpt-5-chat-latest from reasoning model list

## verification

- all tests pass including existing reasoning model tests
- gpt-5-chat models now treated as non-reasoning
- other gpt-5 models still correctly identified as reasoning models

## tasks

- [x] remove gpt-5-chat-latest from reasoning model list in responses settings
- [x] update isreasoningmodel function to exclude gpt-5-chat prefix
- [x] update getresponsesmodelconfig to handle gpt-5-chat as non-reasoning
- [x] exclude gpt-5-chat from flex and priority processing support checks