### PR TITLE
chore(docs): mention processDataStream was removed in migration guide

### DIFF
--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1714,6 +1714,8 @@ import { getTextFromDataUrl } from '@ai-sdk/ui-utils';
 import { getTextFromDataUrl } from 'ai';
 ```
 
+**Note**: `processDataStream` was removed entirely in v5.0. Use `readUIMessageStream` instead for processing UI message streams, or use the more configurable Chat/useChat APIs for most use cases.
+
 ### useCompletion Changes
 
 The `data` property has been removed from the `useCompletion` hook.


### PR DESCRIPTION
## background

processDataStream was removed in v5, and we needed to mention this in the migration guide

related issue - #8017