### PR TITLE
chore(docs): Update OpenAI model capabilities table to remove Audio from GPT 5 family

### DIFF
--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1159,10 +1159,10 @@ The following optional provider options are available for OpenAI completion mode
 | `o3`                   | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `o4-mini`              | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `chatgpt-4o-latest`    | <Check size={18} /> | <Cross size={18} /> | <Cross size={18} /> | <Cross size={18} /> |
-| `gpt-5`                | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gpt-5-mini`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gpt-5-nano`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gpt-5-chat-latest`    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5`                | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5-mini`           | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5-nano`           | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5-chat-latest`    | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   The table above lists popular models. Please see the [OpenAI


### PR DESCRIPTION
@dancer @lgrammel Please take a look! The OpenAI models table currently shows the GPT 5 family as accepting audio inputs, but unfortunately that isn't currently the case. FYI @thomasrosen

Vercel AI docs:
<img width="712" height="814" alt="Screenshot 2025-08-13 at 10 05 52 AM" src="https://github.com/user-attachments/assets/9828e832-9dc4-4fc8-aa74-ed62dccd6ff7" />

OpenAI docs:
<img width="987" height="662" alt="Screenshot 2025-08-13 at 10 06 07 AM" src="https://github.com/user-attachments/assets/49d048e0-78cb-47dd-a4ca-11cec4ddf30b" />


## Background

Feature mismatch in docs

## Summary

Simply updated the checks to cross in the openai model docs