### PR TITLE
feat(provider/vertex): add autoTruncate support

### DIFF
--- a/.changeset/beige-vans-grab.md
+++ b/.changeset/beige-vans-grab.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+add autoTruncate support for google vertex

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -690,6 +690,7 @@ const { embedding } = await embed({
     google: {
       outputDimensionality: 512, // optional, number of dimensions for the embedding
       taskType: 'SEMANTIC_SIMILARITY', // optional, specifies the task type for generating embeddings
+      autoTruncate: false, // optional
     },
   },
 });
@@ -713,6 +714,11 @@ The following optional provider options are available for Google Vertex AI embed
   - `QUESTION_ANSWERING`: Optimized for answering questions.
   - `FACT_VERIFICATION`: Optimized for verifying factual information.
   - `CODE_RETRIEVAL_QUERY`: Optimized for retrieving code blocks based on natural language queries.
+
+- **autoTruncate**: _boolean_
+
+  Optional. When set to true, input text will be truncated. When set to false,
+  an error is returned if the input text is longer than the maximum length supported by the model. Defaults to true.
 
 #### Model Capabilities
 

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -27,6 +27,7 @@ describe('GoogleVertexEmbeddingModel', () => {
   const mockProviderOptions = {
     outputDimensionality: 768,
     taskType: 'SEMANTIC_SIMILARITY',
+    autoTruncate: false,
   };
 
   const mockConfig = {
@@ -124,6 +125,7 @@ describe('GoogleVertexEmbeddingModel', () => {
       })),
       parameters: {
         outputDimensionality: mockProviderOptions.outputDimensionality,
+        autoTruncate: mockProviderOptions.autoTruncate,
       },
     });
   });

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -83,6 +83,7 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV2<string> {
         })),
         parameters: {
           outputDimensionality: googleOptions.outputDimensionality,
+          autoTruncate: googleOptions.autoTruncate,
         },
       },
       failedResponseHandler: googleVertexFailedResponseHandler,

--- a/packages/google-vertex/src/google-vertex-embedding-options.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-options.ts
@@ -43,6 +43,12 @@ export const googleVertexEmbeddingProviderOptions = z.object({
       'CODE_RETRIEVAL_QUERY',
     ])
     .optional(),
+
+  /**
+   * Optional. When set to true, input text will be truncated. When set to false,
+   * an error is returned if the input text is longer than the maximum length supported by the model. Defaults to true.
+   */
+  autoTruncate: z.boolean().optional(),
 });
 
 export type GoogleVertexEmbeddingProviderOptions = z.infer<


### PR DESCRIPTION

## Background
add autoTruncate support for google vertex

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
