### PR TITLE
fix(ai): Added providerOptions to agent.stream and agent.generate

### DIFF
--- a/.changeset/good-cameras-marry.md
+++ b/.changeset/good-cameras-marry.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Added providerOptions to agent stream and generate calls

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,4 +1,4 @@
-import { IdGenerator } from '@ai-sdk/provider-utils';
+import { IdGenerator, ProviderOptions } from '@ai-sdk/provider-utils';
 import {
   generateText,
   GenerateTextOnStepFinishCallback,
@@ -125,6 +125,12 @@ from the provider to the AI SDK and enable provider-specific
 results that can be fully encapsulated in the provider.
    */
       providerMetadata?: ProviderMetadata;
+      /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+         */
+      providerOptions?: ProviderOptions;
     },
   ): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
     return generateText({ ...this.settings, ...options });
@@ -138,6 +144,12 @@ from the provider to the AI SDK and enable provider-specific
 results that can be fully encapsulated in the provider.
    */
       providerMetadata?: ProviderMetadata;
+      /**
+Additional provider-specific metadata. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+         */
+      providerOptions?: ProviderOptions;
     },
   ): StreamTextResult<TOOLS, OUTPUT_PARTIAL> {
     return streamText({ ...this.settings, ...options });


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

`experimental_Agent` had no way to pass `providerOptions` in the `stream` or `generate` calls. As a result, there was no way to access provider options using calls made by `experimental_Agent` in `LanguageModelV2Middleware`. This has major implications as `providerOptions` is typically used for things such as enabling reasoning in many models.

## Summary

Added `providerOptions` to the `stream` and `generate` functions in `experimental_Agent`, this gets passed down in the resulting `generateText` or `streamText` calls.

## Manual Verification

I manually tested this and it worked. Essentially, you'd create an agent that uses a model wrapped in middleware, then pass provider options to it:

```typescript
agent.stream({
      messages: convertToModelMessages(chatRequest.messages),
      providerOptions
    });
```

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

- Review how `providerMetadata` in `experimental_Agent` is used

## Related Issues

Fixes issue discovered in #7989 
