### PR TITLE
fix(ai): expand mp3 detection to support all mpeg frame headers

### DIFF
--- a/.changeset/fresh-jobs-lie.md
+++ b/.changeset/fresh-jobs-lie.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): expand mp3 detection to support all mpeg frame headers

--- a/packages/ai/src/util/detect-media-type.ts
+++ b/packages/ai/src/util/detect-media-type.ts
@@ -59,6 +59,31 @@ export const audioMediaTypeSignatures = [
     base64Prefix: '//s=',
   },
   {
+    mediaType: 'audio/mpeg' as const,
+    bytesPrefix: [0xff, 0xfa],
+    base64Prefix: '//o=',
+  },
+  {
+    mediaType: 'audio/mpeg' as const,
+    bytesPrefix: [0xff, 0xf3],
+    base64Prefix: '//M=',
+  },
+  {
+    mediaType: 'audio/mpeg' as const,
+    bytesPrefix: [0xff, 0xf2],
+    base64Prefix: '//I=',
+  },
+  {
+    mediaType: 'audio/mpeg' as const,
+    bytesPrefix: [0xff, 0xe3],
+    base64Prefix: '/+M=',
+  },
+  {
+    mediaType: 'audio/mpeg' as const,
+    bytesPrefix: [0xff, 0xe2],
+    base64Prefix: '/+I=',
+  },
+  {
     mediaType: 'audio/wav' as const,
     bytesPrefix: [0x52, 0x49, 0x46, 0x46],
     base64Prefix: 'UklGR',


### PR DESCRIPTION
## background

azure openai transcription was rejecting mp3 files with "unrecognized file format" error because the media type detection was too narrow, only recognizing mp3 files with specific frame headers (0xff 0xfb) and falling back to audio/wav for other valid mp3 variants

## summary

- expand mp3 signature detection to handle all common mpeg frame headers
- add support for mpeg-1, mpeg-2, and mpeg-2.5 layer 3 variants
- ensure mp3 files are correctly detected as audio/mpeg instead of audio/wav fallback

## verification

- all 6 common mp3 frame header patterns now correctly detect as audio/mpeg
- local testing with mp3 files covering different mpeg versions

related issue - #8013