### PR TITLE
fix(provider/openai): support file_citation annotations in responses api

### DIFF
--- a/.changeset/fast-boxes-poke.md
+++ b/.changeset/fast-boxes-poke.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(provider/openai): support file_citation annotations in responses api


### PR DESCRIPTION
## background

when mixing `web_search_preview` and `file_search` tools in openai responses api, we threw schema validation errors because the response schema only supported `url_citation` annotations but the api was returning both `url_citation` and `file_citation` types

## summary

- add support for `file_citation` annotations in openai responses api schema
- update annotation processing to handle both citation types
- added tests for mixed citation scenarios

## verification

- all tests pass including new citation-specific tests
- mixed web_search_preview and file_search tools work without validation errors
- file citations map correctly to document sources

## tasks

- [x] update response schema to support discriminated union of url_citation and file_citation
- [x] update streaming annotation schema for both citation types
- [x] add doGenerate test for mixed citations
- [x] add doStream test for mixed citations  
- [x] add test for file_citation only scenario

related issue - #8030