### PR TITLE
feat(provider/openai): expose web search queries in responses api

### DIFF
--- a/.changeset/kind-geese-dream.md
+++ b/.changeset/kind-geese-dream.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai': patch
 ---
 
-feature(provider/openai): expose web search queries in responses api
+feat(provider/openai): expose web search queries in responses api

--- a/.changeset/kind-geese-dream.md
+++ b/.changeset/kind-geese-dream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feature(provider/openai): expose web search queries in responses api

--- a/examples/ai-core/src/generate-text/openai-web-search-action.ts
+++ b/examples/ai-core/src/generate-text/openai-web-search-action.ts
@@ -1,0 +1,25 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: openai.responses('o3-2025-04-16'),
+    prompt: 'What happened in tech news today?',
+    tools: {
+      web_search_preview: openai.tools.webSearchPreview({
+        searchContextSize: 'medium',
+      }),
+    },
+  });
+
+  for (const toolCall of result.toolCalls) {
+    if (toolCall.toolName === 'web_search_preview') {
+      console.log('Search query:', toolCall.input);
+    }
+  }
+
+  console.log(result.text);
+}
+
+main().catch(console.error);

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2506,6 +2506,101 @@ describe('OpenAIResponsesLanguageModel', () => {
           ]
         `);
       });
+
+      it('should handle web search with action query field', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_test',
+            object: 'response',
+            created_at: 1741630255,
+            status: 'completed',
+            error: null,
+            incomplete_details: null,
+            instructions: null,
+            max_output_tokens: null,
+            model: 'o3-2025-04-16',
+            output: [
+              {
+                type: 'web_search_call',
+                id: 'ws_test',
+                status: 'completed',
+                action: {
+                  type: 'search',
+                  query: 'Vercel AI SDK next version features'
+                }
+              },
+              {
+                type: 'message',
+                id: 'msg_test',
+                status: 'completed',
+                role: 'assistant',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'Based on the search results, here are the upcoming features.',
+                    annotations: []
+                  }
+                ]
+              }
+            ],
+            parallel_tool_calls: true,
+            previous_response_id: null,
+            reasoning: { effort: null, summary: null },
+            store: true,
+            temperature: 0,
+            text: { format: { type: 'text' } },
+            tool_choice: 'auto',
+            tools: [{ type: 'web_search_preview', search_context_size: 'medium' }],
+            top_p: 1,
+            truncation: 'disabled',
+            usage: {
+              input_tokens: 50,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens: 25,
+              output_tokens_details: { reasoning_tokens: 0 },
+              total_tokens: 75
+            },
+            user: null,
+            metadata: {}
+          }
+        };
+
+        const result = await createModel('o3-2025-04-16').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(result.content).toMatchInlineSnapshot(`
+          [
+            {
+              "input": "Vercel AI SDK next version features",
+              "providerExecuted": true,
+              "toolCallId": "ws_test",
+              "toolName": "web_search_preview",
+              "type": "tool-call",
+            },
+            {
+              "providerExecuted": true,
+              "result": {
+                "query": "Vercel AI SDK next version features",
+                "status": "completed",
+              },
+              "toolCallId": "ws_test",
+              "toolName": "web_search_preview",
+              "type": "tool-result",
+            },
+            {
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "msg_test",
+                },
+              },
+              "text": "Based on the search results, here are the upcoming features.",
+              "type": "text",
+            },
+          ]
+        `);
+      });
     });
 
     describe('errors', () => {
@@ -2821,6 +2916,110 @@ describe('OpenAIResponsesLanguageModel', () => {
               "outputTokens": 478,
               "reasoningTokens": 123,
               "totalTokens": 1021,
+            },
+          },
+        ]
+      `);
+    });
+
+    it('should handle streaming web search with action query field', async () => {
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.created","response":{"id":"resp_test","object":"response","created_at":1741630255,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"o3-2025-04-16","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":"medium","summary":"auto"},"store":true,"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"web_search_preview","search_context_size":"medium"}],"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"type":"web_search_call","id":"ws_test","status":"in_progress","action":{"type":"search","query":"Vercel AI SDK next version features"}}}\n\n`,
+          `data:{"type":"response.web_search_call.in_progress","output_index":0,"item_id":"ws_test"}\n\n`,
+          `data:{"type":"response.web_search_call.searching","output_index":0,"item_id":"ws_test"}\n\n`,
+          `data:{"type":"response.web_search_call.completed","output_index":0,"item_id":"ws_test"}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"type":"web_search_call","id":"ws_test","status":"completed","action":{"type":"search","query":"Vercel AI SDK next version features"}}}\n\n`,
+          `data:{"type":"response.output_item.added","output_index":1,"item":{"type":"message","id":"msg_test","status":"in_progress","role":"assistant","content":[]}}\n\n`,
+          `data:{"type":"response.content_part.added","item_id":"msg_test","output_index":1,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}\n\n`,
+          `data:{"type":"response.output_text.delta","item_id":"msg_test","output_index":1,"content_index":0,"delta":"Based on the search results, here are the upcoming features."}\n\n`,
+          `data:{"type":"response.output_text.done","item_id":"msg_test","output_index":1,"content_index":0,"text":"Based on the search results, here are the upcoming features."}\n\n`,
+          `data:{"type":"response.content_part.done","item_id":"msg_test","output_index":1,"content_index":0,"part":{"type":"output_text","text":"Based on the search results, here are the upcoming features.","annotations":[]}}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":1,"item":{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Based on the search results, here are the upcoming features.","annotations":[]}]}}\n\n`,
+          `data:{"type":"response.completed","response":{"id":"resp_test","object":"response","created_at":1741630255,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"o3-2025-04-16","output":[{"type":"web_search_call","id":"ws_test","status":"completed","action":{"type":"search","query":"Vercel AI SDK next version features"}},{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Based on the search results, here are the upcoming features.","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":"medium","summary":"auto"},"store":true,"temperature":0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"web_search_preview","search_context_size":"medium"}],"top_p":1,"truncation":"disabled","usage":{"input_tokens":50,"input_tokens_details":{"cached_tokens":0},"output_tokens":25,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":75},"user":null,"metadata":{}}}\n\n`,
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const { stream } = await createModel('o3-2025-04-16').doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const result = await convertReadableStreamToArray(stream);
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "id": "resp_test",
+            "modelId": "o3-2025-04-16",
+            "timestamp": 2025-03-10T18:10:55.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "id": "ws_test",
+            "toolName": "web_search_preview",
+            "type": "tool-input-start",
+          },
+          {
+            "id": "ws_test",
+            "type": "tool-input-end",
+          },
+          {
+            "input": "Vercel AI SDK next version features",
+            "providerExecuted": true,
+            "toolCallId": "ws_test",
+            "toolName": "web_search_preview",
+            "type": "tool-call",
+          },
+          {
+            "providerExecuted": true,
+            "result": {
+              "query": "Vercel AI SDK next version features",
+              "status": "completed",
+              "type": "web_search_tool_result",
+            },
+            "toolCallId": "ws_test",
+            "toolName": "web_search_preview",
+            "type": "tool-result",
+          },
+          {
+            "id": "msg_test",
+            "providerMetadata": {
+              "openai": {
+                "itemId": "msg_test",
+              },
+            },
+            "type": "text-start",
+          },
+          {
+            "delta": "Based on the search results, here are the upcoming features.",
+            "id": "msg_test",
+            "type": "text-delta",
+          },
+          {
+            "id": "msg_test",
+            "type": "text-end",
+          },
+          {
+            "finishReason": "tool-calls",
+            "providerMetadata": {
+              "openai": {
+                "responseId": "resp_test",
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "cachedInputTokens": 0,
+              "inputTokens": 50,
+              "outputTokens": 25,
+              "reasoningTokens": 0,
+              "totalTokens": 75,
             },
           },
         ]

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2527,8 +2527,8 @@ describe('OpenAIResponsesLanguageModel', () => {
                 status: 'completed',
                 action: {
                   type: 'search',
-                  query: 'Vercel AI SDK next version features'
-                }
+                  query: 'Vercel AI SDK next version features',
+                },
               },
               {
                 type: 'message',
@@ -2539,10 +2539,10 @@ describe('OpenAIResponsesLanguageModel', () => {
                   {
                     type: 'output_text',
                     text: 'Based on the search results, here are the upcoming features.',
-                    annotations: []
-                  }
-                ]
-              }
+                    annotations: [],
+                  },
+                ],
+              },
             ],
             parallel_tool_calls: true,
             previous_response_id: null,
@@ -2551,7 +2551,9 @@ describe('OpenAIResponsesLanguageModel', () => {
             temperature: 0,
             text: { format: { type: 'text' } },
             tool_choice: 'auto',
-            tools: [{ type: 'web_search_preview', search_context_size: 'medium' }],
+            tools: [
+              { type: 'web_search_preview', search_context_size: 'medium' },
+            ],
             top_p: 1,
             truncation: 'disabled',
             usage: {
@@ -2559,11 +2561,11 @@ describe('OpenAIResponsesLanguageModel', () => {
               input_tokens_details: { cached_tokens: 0 },
               output_tokens: 25,
               output_tokens_details: { reasoning_tokens: 0 },
-              total_tokens: 75
+              total_tokens: 75,
             },
             user: null,
-            metadata: {}
-          }
+            metadata: {},
+          },
         };
 
         const result = await createModel('o3-2025-04-16').doGenerate({

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -359,10 +359,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 type: z.literal('web_search_call'),
                 id: z.string(),
                 status: z.string().optional(),
-                action: z.object({
-                  type: z.literal('search'),
-                  query: z.string().optional(),
-                }).nullish(),
+                action: z
+                  .object({
+                    type: z.literal('search'),
+                    query: z.string().optional(),
+                  })
+                  .nullish(),
               }),
               z.object({
                 type: z.literal('computer_call'),
@@ -519,9 +521,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             type: 'tool-result',
             toolCallId: part.id,
             toolName: 'web_search_preview',
-            result: { 
+            result: {
               status: part.status || 'completed',
-              ...(part.action?.query && { query: part.action.query })
+              ...(part.action?.query && { query: part.action.query }),
             },
             providerExecuted: true,
           });
@@ -801,7 +803,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   result: {
                     type: 'web_search_tool_result',
                     status: value.item.status || 'completed',
-                    ...(value.item.action?.query && { query: value.item.action.query })
+                    ...(value.item.action?.query && {
+                      query: value.item.action.query,
+                    }),
                   },
                   providerExecuted: true,
                 });
@@ -1077,10 +1081,12 @@ const responseOutputItemAddedSchema = z.object({
       type: z.literal('web_search_call'),
       id: z.string(),
       status: z.string(),
-      action: z.object({
-        type: z.literal('search'),
-        query: z.string().optional(),
-      }).nullish(),
+      action: z
+        .object({
+          type: z.literal('search'),
+          query: z.string().optional(),
+        })
+        .nullish(),
     }),
     z.object({
       type: z.literal('computer_call'),
@@ -1133,10 +1139,12 @@ const responseOutputItemDoneSchema = z.object({
       type: z.literal('web_search_call'),
       id: z.string(),
       status: z.literal('completed'),
-      action: z.object({
-        type: z.literal('search'),
-        query: z.string().optional(),
-      }).nullish(),
+      action: z
+        .object({
+          type: z.literal('search'),
+          query: z.string().optional(),
+        })
+        .nullish(),
     }),
     z.object({
       type: z.literal('computer_call'),

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -359,6 +359,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 type: z.literal('web_search_call'),
                 id: z.string(),
                 status: z.string().optional(),
+                action: z.object({
+                  type: z.literal('search'),
+                  query: z.string().optional(),
+                }).nullish(),
               }),
               z.object({
                 type: z.literal('computer_call'),
@@ -507,7 +511,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             type: 'tool-call',
             toolCallId: part.id,
             toolName: 'web_search_preview',
-            input: '',
+            input: part.action?.query ?? '',
             providerExecuted: true,
           });
 
@@ -515,7 +519,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             type: 'tool-result',
             toolCallId: part.id,
             toolName: 'web_search_preview',
-            result: { status: part.status || 'completed' },
+            result: { 
+              status: part.status || 'completed',
+              ...(part.action?.query && { query: part.action.query })
+            },
             providerExecuted: true,
           });
           break;
@@ -783,7 +790,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   type: 'tool-call',
                   toolCallId: value.item.id,
                   toolName: 'web_search_preview',
-                  input: '',
+                  input: value.item.action?.query ?? '',
                   providerExecuted: true,
                 });
 
@@ -794,6 +801,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   result: {
                     type: 'web_search_tool_result',
                     status: value.item.status || 'completed',
+                    ...(value.item.action?.query && { query: value.item.action.query })
                   },
                   providerExecuted: true,
                 });
@@ -1069,6 +1077,10 @@ const responseOutputItemAddedSchema = z.object({
       type: z.literal('web_search_call'),
       id: z.string(),
       status: z.string(),
+      action: z.object({
+        type: z.literal('search'),
+        query: z.string().optional(),
+      }).nullish(),
     }),
     z.object({
       type: z.literal('computer_call'),
@@ -1121,6 +1133,10 @@ const responseOutputItemDoneSchema = z.object({
       type: z.literal('web_search_call'),
       id: z.string(),
       status: z.literal('completed'),
+      action: z.object({
+        type: z.literal('search'),
+        query: z.string().optional(),
+      }).nullish(),
     }),
     z.object({
       type: z.literal('computer_call'),


### PR DESCRIPTION
## background

when using o3 models with web search and reasoning enabled, openai returns the actual search query in the `action` field of web search calls, but we were not capturing or exposing this information to the frontend

## summary

- add `action` field support to web search call schemas in responses api
- expose search queries in tool call `input` and tool result `query` fields
- added tests for both streaming and non-streaming scenarios
- used nullish as preferred in this scenario
- added an example for users to try

## verification

- all existing tests pass including new web search action tests
- search queries are correctly exposed in both `generateText` and `streamText`
- tested example to make sure it passes

## tasks

- [x] update web search call schemas to include optional action field
- [x] modify logic to expose search queries in tool calls and results
- [x] add test for non-streaming web search with action query
- [x] add test for streaming web search with action query
- [x] verify all tests pass
- [x] added an example for users to try out 

related issue - closes #7293