### PR TITLE
fix(provider/groq): strip unsupported reasoning fields for non-reasoning models

### DIFF
--- a/.changeset/nervous-lemons-dress.md
+++ b/.changeset/nervous-lemons-dress.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+fix(groq): strip unsupported `reasoning` fields for non-reasoning models

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -123,7 +123,7 @@ describe('tool calls', () => {
       [
         {
           "content": "",
-          "reasoning": "",
+          "reasoning": undefined,
           "role": "assistant",
           "tool_calls": [
             {
@@ -180,6 +180,28 @@ describe('tool calls', () => {
               "type": "function",
             },
           ],
+        },
+      ]
+    `);
+  });
+
+  it('should not include reasoning field when no reasoning content is present', () => {
+    const result = convertToGroqChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Hello, how can I help you?' },
+        ],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "Hello, how can I help you?",
+          "reasoning": undefined,
+          "role": "assistant",
+          "tool_calls": undefined,
         },
       ]
     `);

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -189,9 +189,7 @@ describe('tool calls', () => {
     const result = convertToGroqChatMessages([
       {
         role: 'assistant',
-        content: [
-          { type: 'text', text: 'Hello, how can I help you?' },
-        ],
+        content: [{ type: 'text', text: 'Hello, how can I help you?' }],
       },
     ]);
 

--- a/packages/groq/src/convert-to-groq-chat-messages.test.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.test.ts
@@ -123,7 +123,6 @@ describe('tool calls', () => {
       [
         {
           "content": "",
-          "reasoning": undefined,
           "role": "assistant",
           "tool_calls": [
             {
@@ -197,9 +196,7 @@ describe('tool calls', () => {
       [
         {
           "content": "Hello, how can I help you?",
-          "reasoning": undefined,
           "role": "assistant",
-          "tool_calls": undefined,
         },
       ]
     `);

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -97,7 +97,7 @@ export function convertToGroqChatMessages(
         messages.push({
           role: 'assistant',
           content: text,
-          reasoning,
+          reasoning: reasoning.length > 0 ? reasoning : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });
 

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -97,8 +97,8 @@ export function convertToGroqChatMessages(
         messages.push({
           role: 'assistant',
           content: text,
-          reasoning: reasoning.length > 0 ? reasoning : undefined,
-          tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+          ... (reasoning.length > 0 ? { reasoning } : null ),
+          ... (toolCalls.length > 0 ? { tool_calls: toolCalls } : null ),
         });
 
         break;

--- a/packages/groq/src/convert-to-groq-chat-messages.ts
+++ b/packages/groq/src/convert-to-groq-chat-messages.ts
@@ -97,8 +97,8 @@ export function convertToGroqChatMessages(
         messages.push({
           role: 'assistant',
           content: text,
-          ... (reasoning.length > 0 ? { reasoning } : null ),
-          ... (toolCalls.length > 0 ? { tool_calls: toolCalls } : null ),
+          ...(reasoning.length > 0 ? { reasoning } : null),
+          ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : null),
         });
 
         break;


### PR DESCRIPTION
## Background
Groq models that do not support reasoning (e.g., `moonshotai/kimi-k2-instruct`) return a 400 error if the request includes a `reasoning` field:

```
messages[X].reasoning: reasoning is not supported with this model
```

The AI SDK’s `convertToGroqChatMessages` function was always including a `reasoning` property on assistant messages, even when it was an empty string.

## Summary

This change ensures that `reasoning` is only included in the serialized request if it contains actual content:

- Updated `convertToGroqChatMessages` to set `reasoning: undefined` when empty
- Added a unit test to confirm `reasoning` is omitted when there’s no reasoning content
- Retains reasoning behavior for models that support it

## Related Issues
Fixes #8056