### PR TITLE
fix: broken param formatting on mixedbread and jina provider page

### DIFF
--- a/content/providers/03-community-providers/60-mixedbread.mdx
+++ b/content/providers/03-community-providers/60-mixedbread.mdx
@@ -59,7 +59,7 @@ You can use the following optional settings to customize the Mixedbread provider
 
   Custom headers to include in the requests.
 
-- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise<Response>_
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
 
   Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation. Defaults to the global `fetch` function. You can use it as a middleware to intercept requests, or to provide a custom fetch implementation for e.g. testing.
 

--- a/content/providers/03-community-providers/62-jina-ai.mdx
+++ b/content/providers/03-community-providers/62-jina-ai.mdx
@@ -60,7 +60,7 @@ You can use the following optional settings to customize the Jina provider insta
 
   Custom headers to include in the requests.
 
-- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise<Response>_
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
 
   Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
   Defaults to the global `fetch` function.


### PR DESCRIPTION
XML tag with `<Response>` is currently breaking docs builds. This fixes.