### PR TITLE
docs(provider): document all tool call properties

### DIFF
--- a/packages/provider/src/language-model/v2/language-model-v2-tool-call.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-tool-call.ts
@@ -1,17 +1,24 @@
 import { SharedV2ProviderMetadata } from '../../shared/v2/shared-v2-provider-metadata';
 
 /**
-Tool calls that the model has generated.
-     */
+ * Tool calls that the model has generated.
+ */
 export type LanguageModelV2ToolCall = {
   type: 'tool-call';
 
+  /**
+   * The identifier of the tool call. It must be unique across all tool calls.
+   */
   toolCallId: string;
+
+  /**
+   * The name of the tool that should be called.
+   */
   toolName: string;
 
   /**
-Stringified JSON object with the tool call arguments. Must match the
-parameters schema of the tool.
+   * Stringified JSON object with the tool call arguments. Must match the
+   * parameters schema of the tool.
    */
   input: string;
 


### PR DESCRIPTION
## Background

It was not specified that tool call ids need to be unique.

## Summary

Add jsdoc comments for tool call specification.

## Related Issues
Fixes #7727