### PR TITLE
feat(ai): add validateUIMessages function

### DIFF
--- a/.changeset/two-peaches-march.md
+++ b/.changeset/two-peaches-march.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add validateUIMessages function

--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -55,18 +55,7 @@ function getChatFile(id: string): string {
 
 ## Loading an existing chat
 
-When the user navigates to the chat page with a chat ID, we need to load the chat messages and display them.
-
-```tsx filename="app/chat/[id]/page.tsx"
-import { loadChat } from '@util/chat-store';
-import Chat from '@ui/chat';
-
-export default async function Page(props: { params: Promise<{ id: string }> }) {
-  const { id } = await props.params; // get the chat ID from the URL
-  const messages = await loadChat(id); // load the chat messages
-  return <Chat id={id} initialMessages={messages} />; // display the chat
-}
-```
+When the user navigates to the chat page with a chat ID, we need to load the chat messages from storage.
 
 The `loadChat` function in our file-based chat store is implemented as follows:
 
@@ -81,8 +70,135 @@ export async function loadChat(id: string): Promise<UIMessage[]> {
 // ... rest of the file
 ```
 
-The display component is a simple chat component that uses the `useChat` hook to
-send and receive messages:
+## Validating messages on the server
+
+When processing messages on the server that contain tool calls, custom metadata, or data parts, you should validate them using `validateUIMessages` before sending them to the model.
+
+### Validation with tools
+
+When your messages include tool calls, validate them against your tool definitions:
+
+```tsx filename="app/api/chat/route.ts" highlight="7-25,32-37"
+import {
+  convertToModelMessages,
+  streamText,
+  UIMessage,
+  validateUIMessages,
+  tool,
+} from 'ai';
+import { z } from 'zod';
+import { loadChat, saveChat } from '@util/chat-store';
+import { openai } from '@ai-sdk/openai';
+import { dataPartsSchema, metadataSchema } from '@util/schemas';
+
+// Define your tools
+const tools = {
+  weather: tool({
+    description: 'Get weather information',
+    parameters: z.object({
+      location: z.string(),
+      units: z.enum(['celsius', 'fahrenheit']),
+    }),
+    execute: async ({ location, units }) => {
+      /* tool implementation */
+    },
+  }),
+  // other tools
+};
+
+export async function POST(req: Request) {
+  const { message, id } = await req.json();
+
+  // Load previous messages from database
+  const rawMessages = await loadChat(id);
+
+  // Validate loaded messages against
+  // tools, data parts schema, and metadata schema
+  const validatedMessages = await validateUIMessages({
+    messages: rawMessages,
+    tools, // Ensures tool calls in messages match current schemas
+    dataPartsSchema,
+    metadataSchema,
+  });
+
+  // Append new message to validated messages
+  const messages = [...validatedMessages, message];
+
+  const result = streamText({
+    model: openai('gpt-4o-mini'),
+    messages: convertToModelMessages(messages),
+    tools,
+  });
+
+  return result.toUIMessageStreamResponse({
+    originalMessages: messages,
+    onFinish: ({ messages }) => {
+      saveChat({ chatId: id, messages });
+    },
+  });
+}
+```
+
+### Handling validation errors
+
+Handle validation errors gracefully when messages from the database don't match current schemas:
+
+```tsx filename="app/api/chat/route.ts" highlight="3,10-24"
+import {
+  convertToModelMessages,
+  streamText,
+  validateUIMessages,
+  AITypeValidationError,
+} from 'ai';
+import { type MyUIMessage } from '@/types';
+
+export async function POST(req: Request) {
+  const { message, id } = await req.json();
+
+  // Load and validate messages from database
+  let validatedMessages: MyUIMessage[];
+
+  try {
+    const dbMessages = await loadMessagesFromDB(id);
+    validatedMessages = await validateUIMessages({
+      messages: dbMessages,
+      tools,
+      metadataSchema,
+    });
+  } catch (error) {
+    if (error instanceof AITypeValidationError) {
+      // Log validation error for monitoring
+      console.error('Database messages validation failed:', error);
+      // Could implement message migration or filtering here
+      // For now, start with empty history
+      validatedMessages = [];
+    } else {
+      throw error;
+    }
+  }
+
+  const messages = [...validatedMessages, message];
+
+  // Continue with validated messages...
+}
+```
+
+## Displaying the chat
+
+Once messages are loaded from storage, you can display them in your chat UI. Here's how to set up the page component and the chat display:
+
+```tsx filename="app/chat/[id]/page.tsx"
+import { loadChat } from '@util/chat-store';
+import Chat from '@ui/chat';
+
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const { id } = await props.params;
+  const messages = await loadChat(id);
+  return <Chat id={id} initialMessages={messages} />;
+}
+```
+
+The chat component uses the `useChat` hook to manage the conversation:
 
 ```tsx filename="ui/chat.tsx" highlight="10-16"
 'use client';
@@ -146,6 +262,11 @@ export default function Chat({
   `useChat` message format is designed for frontend display, and contains
   additional fields such as `id` and `createdAt`. We recommend storing the
   messages in the `useChat` message format.
+
+When loading messages from storage that contain tools, metadata, or custom data
+parts, validate them using `validateUIMessages` before processing (see the
+[validation section](#validating-messages-from-database) above).
+
 </Note>
 
 Storing messages is done in the `onFinish` callback of the `toUIMessageStreamResponse` function.
@@ -328,10 +449,11 @@ const {
 });
 ```
 
-On the server, you can then load the previous messages and append the new message to the previous messages:
+On the server, you can then load the previous messages and append the new message to the previous messages. If your messages contain tools, metadata, or custom data parts, you should validate them:
 
-```tsx filename="app/api/chat/route.ts" highlight="2-11"
-import { convertToModelMessages, UIMessage } from 'ai';
+```tsx filename="app/api/chat/route.ts" highlight="2-11,14-18"
+import { convertToModelMessages, UIMessage, validateUIMessages } from 'ai';
+// import your tools and schemas
 
 export async function POST(req: Request) {
   // get the last message from the client:
@@ -340,8 +462,16 @@ export async function POST(req: Request) {
   // load the previous messages from the server:
   const previousMessages = await loadChat(id);
 
-  // append the new message to the previous messages:
-  const messages = [...previousMessages, message];
+  // validate messages if they contain tools, metadata, or data parts:
+  const validatedMessages = await validateUIMessages({
+    messages: previousMessages,
+    tools, // if using tools
+    metadataSchema, // if using custom metadata
+    dataSchemas, // if using custom data parts
+  });
+
+  // append the new message to the validated messages:
+  const messages = [...validatedMessages, message];
 
   const result = streamText({
     // ...

--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -112,21 +112,21 @@ export async function POST(req: Request) {
   // Load previous messages from database
   const rawMessages = await loadChat(id);
 
+  // Append new message to raw messages
+  const messages = [...rawMessages, message];
+
   // Validate loaded messages against
   // tools, data parts schema, and metadata schema
   const validatedMessages = await validateUIMessages({
-    messages: rawMessages,
+    messages,
     tools, // Ensures tool calls in messages match current schemas
     dataPartsSchema,
     metadataSchema,
   });
 
-  // Append new message to validated messages
-  const messages = [...validatedMessages, message];
-
   const result = streamText({
     model: openai('gpt-4o-mini'),
-    messages: convertToModelMessages(messages),
+    messages: convertToModelMessages(validatedMessages),
     tools,
   });
 

--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -110,10 +110,10 @@ export async function POST(req: Request) {
   const { message, id } = await req.json();
 
   // Load previous messages from database
-  const rawMessages = await loadChat(id);
+  const previousMessages = await loadChat(id);
 
-  // Append new message to raw messages
-  const messages = [...rawMessages, message];
+  // Append new message to previousMessages messages
+  const messages = [...previousMessages, message];
 
   // Validate loaded messages against
   // tools, data parts schema, and metadata schema
@@ -159,9 +159,10 @@ export async function POST(req: Request) {
   let validatedMessages: MyUIMessage[];
 
   try {
-    const dbMessages = await loadMessagesFromDB(id);
+    const previousMessages = await loadMessagesFromDB(id);
     validatedMessages = await validateUIMessages({
-      messages: dbMessages,
+      // append the new message to the previous messages:
+      messages: [...previousMessages, message],
       tools,
       metadataSchema,
     });
@@ -176,8 +177,6 @@ export async function POST(req: Request) {
       throw error;
     }
   }
-
-  const messages = [...validatedMessages, message];
 
   // Continue with validated messages...
 }
@@ -464,22 +463,20 @@ export async function POST(req: Request) {
 
   // validate messages if they contain tools, metadata, or data parts:
   const validatedMessages = await validateUIMessages({
-    messages: previousMessages,
+    // append the new message to the previous messages:
+    messages: [...previousMessages, message],
     tools, // if using tools
     metadataSchema, // if using custom metadata
     dataSchemas, // if using custom data parts
   });
 
-  // append the new message to the validated messages:
-  const messages = [...validatedMessages, message];
-
   const result = streamText({
     // ...
-    messages: convertToModelMessages(messages),
+    messages: convertToModelMessages(validatedMessages),
   });
 
   return result.toUIMessageStreamResponse({
-    originalMessages: messages,
+    originalMessages: validatedMessages,
     onFinish: ({ messages }) => {
       saveChat({ chatId: id, messages });
     },

--- a/content/docs/07-reference/01-ai-sdk-core/32-validate-ui-messages.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/32-validate-ui-messages.mdx
@@ -1,0 +1,117 @@
+---
+title: validateUIMessages
+description: API Reference for validateUIMessages
+---
+
+# `validateUIMessages`
+
+`validateUIMessages` is an async function that validates UI messages against schemas for metadata, data parts, and tools. It ensures type safety and data integrity for your message arrays before processing or rendering.
+
+## Basic Usage
+
+Simple validation without custom schemas:
+
+```typescript
+import { validateUIMessages } from 'ai';
+
+const messages = [
+  {
+    id: '1',
+    role: 'user',
+    parts: [{ type: 'text', text: 'Hello!' }],
+  },
+];
+
+const validatedMessages = await validateUIMessages({
+  messages,
+});
+```
+
+## Advanced Usage
+
+Comprehensive validation with custom metadata, data parts, and tools:
+
+```typescript
+import { validateUIMessages, tool } from 'ai';
+import { z } from 'zod';
+
+// Define schemas
+const metadataSchema = z.object({
+  timestamp: z.string().datetime(),
+  userId: z.string(),
+});
+
+const dataSchemas = {
+  chart: z.object({
+    data: z.array(z.number()),
+    labels: z.array(z.string()),
+  }),
+  image: z.object({
+    url: z.string().url(),
+    caption: z.string(),
+  }),
+};
+
+const tools = {
+  weather: tool({
+    description: 'Get weather info',
+    parameters: z.object({
+      location: z.string(),
+    }),
+    execute: async ({ location }) => `Weather in ${location}: sunny`,
+  }),
+};
+
+// Messages with custom parts
+const messages = [
+  {
+    id: '1',
+    role: 'user',
+    metadata: { timestamp: '2024-01-01T00:00:00Z', userId: 'user123' },
+    parts: [
+      { type: 'text', text: 'Show me a chart' },
+      {
+        type: 'data-chart',
+        data: { data: [1, 2, 3], labels: ['A', 'B', 'C'] },
+      },
+    ],
+  },
+  {
+    id: '2',
+    role: 'assistant',
+    parts: [
+      {
+        type: 'tool-weather',
+        toolCallId: 'call_123',
+        state: 'output-available',
+        input: { location: 'San Francisco' },
+        output: 'Weather in San Francisco: sunny',
+      },
+    ],
+  },
+];
+
+// Validate with all schemas
+const validatedMessages = await validateUIMessages({
+  messages,
+  metadataSchema,
+  dataSchemas,
+  tools,
+});
+```
+
+## Key Features
+
+- **Async validation**: Returns a Promise for validated message arrays
+- **Optional schemas**: Only validates parts that have corresponding schemas provided
+- **Type safety**: Maintains TypeScript types throughout the validation process
+- **Error handling**: Throws `TypeValidationError` for invalid data or missing schemas
+- **Flexible validation**: Validates metadata, custom data parts, and tool inputs/outputs independently
+
+## Validation Behavior
+
+- **Messages structure**: Always validates basic message structure (id, role, parts)
+- **Metadata**: Only validated if `metadataSchema` is provided
+- **Data parts**: Only validated if matching schema exists in `dataSchemas`
+- **Tools**: Only validated if matching tool exists in `tools` object
+- **Missing schemas**: Throws error if data/tool parts exist without corresponding schemas

--- a/content/docs/07-reference/01-ai-sdk-core/32-validate-ui-messages.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/32-validate-ui-messages.mdx
@@ -99,19 +99,3 @@ const validatedMessages = await validateUIMessages({
   tools,
 });
 ```
-
-## Key Features
-
-- **Async validation**: Returns a Promise for validated message arrays
-- **Optional schemas**: Only validates parts that have corresponding schemas provided
-- **Type safety**: Maintains TypeScript types throughout the validation process
-- **Error handling**: Throws `TypeValidationError` for invalid data or missing schemas
-- **Flexible validation**: Validates metadata, custom data parts, and tool inputs/outputs independently
-
-## Validation Behavior
-
-- **Messages structure**: Always validates basic message structure (id, role, parts)
-- **Metadata**: Only validated if `metadataSchema` is provided
-- **Data parts**: Only validated if matching schema exists in `dataSchemas`
-- **Tools**: Only validated if matching tool exists in `tools` object
-- **Missing schemas**: Throws error if data/tool parts exist without corresponding schemas

--- a/examples/next-openai/app/api/use-chat-tools/route.ts
+++ b/examples/next-openai/app/api/use-chat-tools/route.ts
@@ -7,6 +7,7 @@ import {
   tool,
   UIDataTypes,
   UIMessage,
+  validateUIMessages,
 } from 'ai';
 import { z } from 'zod/v4';
 
@@ -84,7 +85,12 @@ export type UseChatToolsMessage = UIMessage<
 >;
 
 export async function POST(req: Request) {
-  const { messages } = await req.json();
+  const body = await req.json();
+
+  const messages = await validateUIMessages<UseChatToolsMessage>({
+    messages: body.messages,
+    tools,
+  });
 
   const result = streamText({
     model: openai('gpt-4o'),

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -52,3 +52,4 @@ export {
   type CompletionRequestOptions,
   type UseCompletionOptions,
 } from './use-completion';
+export { validateUIMessages } from './validate-ui-messages';

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -41,6 +41,27 @@ describe('validateUIMessages', () => {
         ]
       `);
     });
+
+    it('should throw type validation error when metadata is invalid ', async () => {
+      await expect(
+        validateUIMessages<UIMessage<{ foo: string }>>({
+          messages: [
+            {
+              id: '1',
+              role: 'user',
+              metadata: { foo: 123 },
+              parts: [{ type: 'text', text: 'Hello, world!' }],
+            },
+          ],
+          metadataSchema: z.object({
+            foo: z.string(),
+          }),
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [AI_TypeValidationError: Type validation failed: Value: {"foo":123}.
+        Error message: [{"expected":"string","code":"invalid_type","path":["foo"],"message":"Invalid input: expected string, received number"}]]
+      `);
+    });
   });
 
   describe('text parts', () => {

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -94,4 +94,35 @@ describe('validateUIMessages', () => {
       `);
     });
   });
+
+  describe('reasoning parts', () => {
+    it('should validate an assistant message with a reasoning part', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [{ type: 'reasoning', text: 'Hello, world!' }],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "text": "Hello, world!",
+                "type": "reasoning",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -245,4 +245,34 @@ describe('validateUIMessages', () => {
       `);
     });
   });
+
+  describe('step start parts', () => {
+    it('should validate an assistant message with a step start part', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [{ type: 'step-start' }],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "type": "step-start",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -432,6 +432,26 @@ describe('validateUIMessages', () => {
         Error message: [{"expected":"string","code":"invalid_type","path":["foo"],"message":"Invalid input: expected string, received number"}]]
       `);
     });
+
+    it('should throw type validation error when there is no data schema for a data part', async () => {
+      await expect(
+        validateUIMessages<UIMessage<never, { foo: { foo: string } }>>({
+          messages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [{ type: 'data-bar', data: { foo: 'bar' } }],
+            },
+          ],
+          dataSchemas: {
+            foo: z.object({ foo: z.string() }),
+          },
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [AI_TypeValidationError: Type validation failed: Value: {"foo":"bar"}.
+        Error message: No data schema found for data part bar]
+      `);
+    });
   });
 
   describe('dynamic tool parts', () => {

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1,0 +1,35 @@
+import { UIMessage } from './ui-messages';
+import { validateUIMessages } from './validate-ui-messages';
+
+describe('validateUIMessages', () => {
+  describe('text parts', () => {
+    it('should validate a user message with a text part', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello, world!' }],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -207,4 +207,42 @@ describe('validateUIMessages', () => {
       `);
     });
   });
+
+  describe('file parts', () => {
+    it('should validate an assistant message with a file part', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'file',
+                mediaType: 'text/plain',
+                url: 'https://example.com',
+              },
+            ],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "mediaType": "text/plain",
+                "type": "file",
+                "url": "https://example.com",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1,7 +1,48 @@
+import { z } from 'zod/v4';
 import { UIMessage } from './ui-messages';
 import { validateUIMessages } from './validate-ui-messages';
 
 describe('validateUIMessages', () => {
+  describe('metadata', () => {
+    it('should validate a user message with metadata', async () => {
+      const messages = await validateUIMessages<UIMessage<{ foo: string }>>({
+        messages: [
+          {
+            id: '1',
+            role: 'user',
+            metadata: {
+              foo: 'bar',
+            },
+            parts: [{ type: 'text', text: 'Hello, world!' }],
+          },
+        ],
+        metadataSchema: z.object({
+          foo: z.string(),
+        }),
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage<{ foo: string }>>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "metadata": {
+              "foo": "bar",
+            },
+            "parts": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
+  });
+
   describe('text parts', () => {
     it('should validate a user message with a text part', async () => {
       const messages = await validateUIMessages({

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -389,4 +389,180 @@ describe('validateUIMessages', () => {
       `);
     });
   });
+
+  describe('dynamic tool parts', () => {
+    it('should validate an assistant message with a dynamic tool part in input-streaming state', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'dynamic-tool',
+                toolName: 'foo',
+                toolCallId: '1',
+                state: 'input-streaming',
+                input: { foo: 'bar' },
+              },
+            ],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "input": {
+                  "foo": "bar",
+                },
+                "state": "input-streaming",
+                "toolCallId": "1",
+                "toolName": "foo",
+                "type": "dynamic-tool",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should validate an assistant message with a dynamic tool part in input-available state', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'dynamic-tool',
+                toolName: 'foo',
+                toolCallId: '1',
+                state: 'input-available',
+                input: { foo: 'bar' },
+              },
+            ],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "input": {
+                  "foo": "bar",
+                },
+                "state": "input-available",
+                "toolCallId": "1",
+                "toolName": "foo",
+                "type": "dynamic-tool",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should validate an assistant message with a dynamic tool part in output-available state', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'dynamic-tool',
+                toolName: 'foo',
+                toolCallId: '1',
+                state: 'output-available',
+                input: { foo: 'bar' },
+                output: { result: 'success' },
+              },
+            ],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "input": {
+                  "foo": "bar",
+                },
+                "output": {
+                  "result": "success",
+                },
+                "state": "output-available",
+                "toolCallId": "1",
+                "toolName": "foo",
+                "type": "dynamic-tool",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should validate an assistant message with a dynamic tool part in output-error state', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'dynamic-tool',
+                toolName: 'foo',
+                toolCallId: '1',
+                state: 'output-error',
+                input: { foo: 'bar' },
+                errorText: 'Tool execution failed',
+              },
+            ],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "errorText": "Tool execution failed",
+                "input": {
+                  "foo": "bar",
+                },
+                "state": "output-error",
+                "toolCallId": "1",
+                "toolName": "foo",
+                "type": "dynamic-tool",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -101,6 +101,50 @@ describe('validateUIMessages', () => {
         Error message: [{"expected":"string","code":"invalid_type","path":["foo"],"message":"Invalid input: expected string, received number"}]]
       `);
     });
+
+    it('should validate text part with provider metadata', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'user',
+            parts: [
+              {
+                type: 'text',
+                text: 'Hello, world!',
+                providerMetadata: {
+                  someProvider: {
+                    custom: 'metadata',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "providerMetadata": {
+                  "someProvider": {
+                    "custom": "metadata",
+                  },
+                },
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+        ]
+      `);
+    });
   });
 
   describe('text parts', () => {

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -125,4 +125,86 @@ describe('validateUIMessages', () => {
       `);
     });
   });
+
+  describe('source url parts', () => {
+    it('should validate an assistant message with a source url part', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'source-url',
+                sourceId: '1',
+                url: 'https://example.com',
+                title: 'Example',
+              },
+            ],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "sourceId": "1",
+                "title": "Example",
+                "type": "source-url",
+                "url": "https://example.com",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('source document parts', () => {
+    it('should validate an assistant message with a source document part', async () => {
+      const messages = await validateUIMessages({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'source-document',
+                sourceId: '1',
+                mediaType: 'text/plain',
+                title: 'Example',
+                filename: 'example.txt',
+              },
+            ],
+          },
+        ],
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<UIMessage>>();
+
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "filename": "example.txt",
+                "mediaType": "text/plain",
+                "sourceId": "1",
+                "title": "Example",
+                "type": "source-document",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -1,7 +1,6 @@
 import { TypeValidationError } from '@ai-sdk/provider';
 import {
   StandardSchemaV1,
-  tool,
   Tool,
   validateTypes,
   Validator,

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -38,6 +38,14 @@ const sourceDocumentUIPartSchema = z.object({
   providerMetadata: providerMetadataSchema.optional(),
 });
 
+const fileUIPartSchema = z.object({
+  type: z.literal('file'),
+  mediaType: z.string(),
+  filename: z.string().optional(),
+  url: z.string(),
+  providerMetadata: providerMetadataSchema.optional(),
+});
+
 const uiMessageSchema = z.object({
   id: z.string(),
   role: z.enum(['system', 'user', 'assistant']),
@@ -48,6 +56,7 @@ const uiMessageSchema = z.object({
       reasoningUIPartSchema,
       sourceUrlUIPartSchema,
       sourceDocumentUIPartSchema,
+      fileUIPartSchema,
     ]),
   ),
 });

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -1,0 +1,9 @@
+import { UIMessage } from './ui-messages';
+
+export function validateUIMessages<UI_MESSAGE extends UIMessage>({
+  messages,
+}: {
+  messages: unknown;
+}): Array<UI_MESSAGE> {
+  throw new Error('Not implemented');
+}

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -46,6 +46,10 @@ const fileUIPartSchema = z.object({
   providerMetadata: providerMetadataSchema.optional(),
 });
 
+const stepStartUIPartSchema = z.object({
+  type: z.literal('step-start'),
+});
+
 const uiMessageSchema = z.object({
   id: z.string(),
   role: z.enum(['system', 'user', 'assistant']),
@@ -57,6 +61,7 @@ const uiMessageSchema = z.object({
       sourceUrlUIPartSchema,
       sourceDocumentUIPartSchema,
       fileUIPartSchema,
+      stepStartUIPartSchema,
     ]),
   ),
 });

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -1,12 +1,20 @@
-import { z } from 'zod/v4';
-import { UIMessage } from './ui-messages';
 import { validateTypes } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { providerMetadataSchema } from '../types/provider-metadata';
+import { UIMessage } from './ui-messages';
+
+const textUIPartSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+  state: z.enum(['streaming', 'done']).optional(),
+  providerMetadata: providerMetadataSchema.optional(),
+});
 
 const uiMessageSchema = z.object({
   id: z.string(),
   role: z.enum(['system', 'user', 'assistant']),
   metadata: z.unknown().optional(),
-  parts: z.array(z.unknown()),
+  parts: z.array(z.discriminatedUnion('type', [textUIPartSchema])),
 });
 
 export async function validateUIMessages<UI_MESSAGE extends UIMessage>({

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -1,9 +1,23 @@
+import { z } from 'zod/v4';
 import { UIMessage } from './ui-messages';
+import { validateTypes } from '@ai-sdk/provider-utils';
 
-export function validateUIMessages<UI_MESSAGE extends UIMessage>({
+const uiMessageSchema = z.object({
+  id: z.string(),
+  role: z.enum(['system', 'user', 'assistant']),
+  metadata: z.unknown().optional(),
+  parts: z.array(z.unknown()),
+});
+
+export async function validateUIMessages<UI_MESSAGE extends UIMessage>({
   messages,
 }: {
   messages: unknown;
-}): Array<UI_MESSAGE> {
-  throw new Error('Not implemented');
+}): Promise<Array<UI_MESSAGE>> {
+  const validatedMessages = await validateTypes({
+    value: messages,
+    schema: z.array(uiMessageSchema),
+  });
+
+  return validatedMessages as Array<UI_MESSAGE>;
 }

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -164,7 +164,7 @@ export async function validateUIMessages<UI_MESSAGE extends UIMessage>({
         const dataName = dataPart.type.slice(5);
         const dataSchema = dataSchemas[dataName];
 
-        if (dataSchema == null) {
+        if (!dataSchema) {
           throw new TypeValidationError({
             value: dataPart.data,
             cause: `No data schema found for data part ${dataName}`,

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -6,6 +6,7 @@ import {
 import { z } from 'zod/v4';
 import { providerMetadataSchema } from '../types/provider-metadata';
 import { DataUIPart, InferUIMessageData, UIMessage } from './ui-messages';
+import { TypeValidationError } from '@ai-sdk/provider';
 
 const textUIPartSchema = z.object({
   type: z.literal('text'),
@@ -163,8 +164,11 @@ export async function validateUIMessages<UI_MESSAGE extends UIMessage>({
         const dataName = dataPart.type.slice(5);
         const dataSchema = dataSchemas[dataName];
 
-        if (!dataSchema) {
-          continue; // TODO: throw error
+        if (dataSchema == null) {
+          throw new TypeValidationError({
+            value: dataPart.data,
+            cause: `No data schema found for data part ${dataName}`,
+          });
         }
 
         await validateTypes({

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -14,11 +14,20 @@ const textUIPartSchema = z.object({
   providerMetadata: providerMetadataSchema.optional(),
 });
 
+const reasoningUIPartSchema = z.object({
+  type: z.literal('reasoning'),
+  text: z.string(),
+  state: z.enum(['streaming', 'done']).optional(),
+  providerMetadata: providerMetadataSchema.optional(),
+});
+
 const uiMessageSchema = z.object({
   id: z.string(),
   role: z.enum(['system', 'user', 'assistant']),
   metadata: z.unknown().optional(),
-  parts: z.array(z.discriminatedUnion('type', [textUIPartSchema])),
+  parts: z.array(
+    z.discriminatedUnion('type', [textUIPartSchema, reasoningUIPartSchema]),
+  ),
 });
 
 export async function validateUIMessages<UI_MESSAGE extends UIMessage>({

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -21,12 +21,34 @@ const reasoningUIPartSchema = z.object({
   providerMetadata: providerMetadataSchema.optional(),
 });
 
+const sourceUrlUIPartSchema = z.object({
+  type: z.literal('source-url'),
+  sourceId: z.string(),
+  url: z.string(),
+  title: z.string().optional(),
+  providerMetadata: providerMetadataSchema.optional(),
+});
+
+const sourceDocumentUIPartSchema = z.object({
+  type: z.literal('source-document'),
+  sourceId: z.string(),
+  mediaType: z.string(),
+  title: z.string(),
+  filename: z.string().optional(),
+  providerMetadata: providerMetadataSchema.optional(),
+});
+
 const uiMessageSchema = z.object({
   id: z.string(),
   role: z.enum(['system', 'user', 'assistant']),
   metadata: z.unknown().optional(),
   parts: z.array(
-    z.discriminatedUnion('type', [textUIPartSchema, reasoningUIPartSchema]),
+    z.discriminatedUnion('type', [
+      textUIPartSchema,
+      reasoningUIPartSchema,
+      sourceUrlUIPartSchema,
+      sourceDocumentUIPartSchema,
+    ]),
   ),
 });
 


### PR DESCRIPTION
## Background

Validating UI messages is often necessary, e.g. when they are loaded from the DB or received through REST requests.

## Summary

Add `validateUIMessages` function.

## Example

```ts
const messages = await validateUIMessages<UseChatToolsMessage>({
  messages: body.messages,
  tools,
});
```  

## Manual Verification

- [x] test ui tool calling example with validation

## Tasks

- [x] implementation TextUIPart
- [x] implementation ReasoningUIPart
- [x] implementation SourceUrlUIPart
- [x] implementation SourceDocumentUIPart
- [x] implementation FileUIPart
- [x] metadata
- [x] implementation StepStartUIPart
- [x] implementation  DataUIPart<DATA_TYPES>
- [x] implementation  DynamicToolUIPart
- [x] implementation ToolUIPart<TOOLS>
- [x] test provider metadata
- [x] test data ui part missing schema
- [x] documentation (reference)
- [x] documentation (guide)
- [x] example updates
- [x] changeset

## Related Issues

Fixes #6763