### PR TITLE
docs(02-foundation): Adjust import for  structured answers example

### DIFF
--- a/content/docs/02-foundations/06-agents.mdx
+++ b/content/docs/02-foundations/06-agents.mdx
@@ -446,7 +446,7 @@ When building an agent for tasks like mathematical analysis or report generation
 ```ts highlight="6,16-29,31,45"
 import { openai } from '@ai-sdk/openai';
 import { generateText, tool, stepCountIs } from 'ai';
-import 'dotenv/config';
+import * as mathjs from 'mathjs';
 import { z } from 'zod';
 
 const { toolCalls } = await generateText({


### PR DESCRIPTION
Propably c&p error; in the previous example the imports where correct, but mathjs was missing

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

A unnesseary dependency was used, instead a required one was missing

## Summary

Using the same imports as in the previous example (since their usage haven't changed)
