### PR TITLE
docs: update ai-sdk-ollama to alternative providers for Ollama

### DIFF
--- a/content/providers/03-community-providers/03-ollama.mdx
+++ b/content/providers/03-community-providers/03-ollama.mdx
@@ -102,18 +102,19 @@ console.log(
 );
 ```
 
- ## Alternative Providers
+## Alternative Providers
 
-  There is an alternative provider package called [`ai-sdk-ollama` by jagreehal](https://github.com/jagreehal/ai-sdk-ollama), which uses the official
-  [`Ollama`](https://www.npmjs.com/package/ollama) JavaScript client library instead of direct HTTP API calls.
+There is an alternative provider package called [`ai-sdk-ollama` by jagreehal](https://github.com/jagreehal/ai-sdk-ollama), which uses the official
+[`Ollama`](https://www.npmjs.com/package/ollama) JavaScript client library instead of direct HTTP API calls.
 
-  Key differences:
-  - Uses the official `ollama` npm package for communication
-  - Provides automatic environment detection (Node.js vs browser)
-  - Includes built-in error handling and retries via the official client
-  - Supports both CommonJS and ESM module formats
-  - Full TypeScript support with type-safe Ollama-specific options via `providerOptions.ollama`
+Key differences:
 
-  This approach leverages Ollama's official client library, which may provide better compatibility with
-  Ollama updates and additional features like model management. Both providers implement the AI SDK
-  specification, so you can choose based on your specific requirements and preferences.
+- Uses the official `ollama` npm package for communication
+- Provides automatic environment detection (Node.js vs browser)
+- Includes built-in error handling and retries via the official client
+- Supports both CommonJS and ESM module formats
+- Full TypeScript support with type-safe Ollama-specific options via `providerOptions.ollama`
+
+This approach leverages Ollama's official client library, which may provide better compatibility with
+Ollama updates and additional features like model management. Both providers implement the AI SDK
+specification, so you can choose based on your specific requirements and preferences.

--- a/content/providers/03-community-providers/03-ollama.mdx
+++ b/content/providers/03-community-providers/03-ollama.mdx
@@ -105,7 +105,7 @@ console.log(
  ## Alternative Providers
 
   There is an alternative provider package called [`ai-sdk-ollama` by jagreehal](https://github.com/jagreehal/ai-sdk-ollama), which uses the official
-  Ollama JavaScript client library instead of direct HTTP API calls.
+  [`Ollama`](https://www.npmjs.com/package/ollama) JavaScript client library instead of direct HTTP API calls.
 
   Key differences:
   - Uses the official `ollama` npm package for communication

--- a/content/providers/03-community-providers/03-ollama.mdx
+++ b/content/providers/03-community-providers/03-ollama.mdx
@@ -102,8 +102,18 @@ console.log(
 );
 ```
 
-## Alternative Providers
+ ## Alternative Providers
 
-There is an alternative provider package called [`ai-sdk-ollama` by jagreehal](https://github.com/jagreehal/ai-sdk-ollama), which is fundamentally different from this provider. Instead of using the HTTP API directly, it leverages the [`ollama`](https://www.npmjs.com/package/ollama) package for communication.
+  There is an alternative provider package called [`ai-sdk-ollama` by jagreehal](https://github.com/jagreehal/ai-sdk-ollama), which uses the official
+  Ollama JavaScript client library instead of direct HTTP API calls.
 
-This approach may have different tradeoffs in terms of performance, compatibility, and features. It may be better or worse for your use case, so you may want to review both options to decide which fits your needs best.
+  Key differences:
+  - Uses the official `ollama` npm package for communication
+  - Provides automatic environment detection (Node.js vs browser)
+  - Includes built-in error handling and retries via the official client
+  - Supports both CommonJS and ESM module formats
+  - Full TypeScript support with type-safe Ollama-specific options via `providerOptions.ollama`
+
+  This approach leverages Ollama's official client library, which may provide better compatibility with
+  Ollama updates and additional features like model management. Both providers implement the AI SDK
+  specification, so you can choose based on your specific requirements and preferences.


### PR DESCRIPTION
## Background

The current Ollama provider documentation contains Alternative Providers section, this PR updates the content.

  ## Summary

  This PR updates documentation for `ai-sdk-ollama` as an alternative provider in the Ollama documentation.
   This provider uses the official `ollama` npm package instead of direct HTTP calls, providing
  automatic environment detection, built-in error handling, and full TypeScript support for
  Ollama-specific options.

  ## Manual Verification

  <!-- Not needed for documentation changes -->

  ## Tasks

  - [x] Documentation has been added / updated (for bug fixes / features)

  ## Future Work

  <!-- Not needed -->

  ## Related Issues

  Related to #6924 - Provides additional provider options for Ollama users