### PR TITLE
Failing Test: streamText does not call onAbort if the abort signal is triggered during a tool call.

### DIFF
--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -12450,7 +12450,7 @@ describe('streamText', () => {
       });
     });
 
-    describe('abort in 2nd step during tool call', () => {
+    describe('abort during tool call', () => {
       let result: StreamTextResult<any, TextStreamPart<any>>;
       let onErrorCalls: Array<{ error: unknown }> = [];
       let onAbortCalls: Array<{ steps: StepResult<any>[] }> = [];


### PR DESCRIPTION
## Background

This PR adds a failing test case showing that AbortController does not trigger onAbort when the abort signal is executed during a tool call.

## Summary

Just failing test.

## Manual Verification

We encountered this bug in our product: calling .abort() sometimes does not trigger onAbort as expected.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

Fix it

## PS

I feel the current abort implementation need additional checks.
The issue is that the stream consumer may already be closed due to the abort.
For example, if the client disconnects, nothing is consuming the stream, so probably the check in the stream transform will never be executed.

I mean this code
```
    stream = filterStreamErrors(stream, ({ error, controller }) => {
      if (isAbortError(error) && abortSignal?.aborted) {
        onAbort?.({ steps: recordedSteps });
        controller.enqueue({ type: 'abort' });
        controller.close();
      } else {
        controller.error(error);
      }
    });
```



## Related Issues

https://github.com/vercel/ai/issues/309#issuecomment-3194333386
https://github.com/vercel/ai/issues/8107
