### PR TITLE
docs: remove toolcallstreaming from streamtext reference

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -499,13 +499,6 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'toolCallStreaming',
-      type: 'boolean',
-      isOptional: true,
-      description:
-        'Enable streaming of tool call deltas as they are generated. Disabled by default.',
-    },
-    {
       name: 'experimental_transform',
       type: 'StreamTextTransform | Array<StreamTextTransform>',
       isOptional: true,
@@ -1402,7 +1395,8 @@ To see `streamText` in action, check out [these examples](#examples).
         },
       ],
     },
-  ]}
+
+]}
 />
 
 ### Returns


### PR DESCRIPTION
`toolCallStreaming` has been removed and is now on by default.