### PR TITLE
fix(provider/mistral): inject JSON generation instruction when response format is JSON

### DIFF
--- a/.changeset/orange-carpets-glow.md
+++ b/.changeset/orange-carpets-glow.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+fix(provider/mistral): inject JSON generation instruction when response format is JSON

--- a/examples/ai-core/src/generate-object/mistral.ts
+++ b/examples/ai-core/src/generate-object/mistral.ts
@@ -1,5 +1,5 @@
 import { mistral } from '@ai-sdk/mistral';
-import { generateObject, NoObjectGeneratedError } from 'ai';
+import { generateObject } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod/v4';
 
@@ -27,11 +27,4 @@ async function main() {
   console.log('Finish reason:', result.finishReason);
 }
 
-main().catch(error => {
-  if (NoObjectGeneratedError.isInstance(error)) {
-    console.error(JSON.stringify(error.response, null, 2));
-  }
-
-  console.error(error);
-  process.exit(1);
-});
+main().catch(console.error);

--- a/examples/ai-core/src/generate-object/mistral.ts
+++ b/examples/ai-core/src/generate-object/mistral.ts
@@ -1,5 +1,5 @@
 import { mistral } from '@ai-sdk/mistral';
-import { generateObject } from 'ai';
+import { generateObject, NoObjectGeneratedError } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod/v4';
 
@@ -27,4 +27,11 @@ async function main() {
   console.log('Finish reason:', result.finishReason);
 }
 
-main().catch(console.error);
+main().catch(error => {
+  if (NoObjectGeneratedError.isInstance(error)) {
+    console.error(JSON.stringify(error.response, null, 2));
+  }
+
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -502,6 +502,106 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should inject JSON instruction for JSON response format', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const { request } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+      },
+    });
+
+    expect(request).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "document_image_limit": undefined,
+          "document_page_limit": undefined,
+          "max_tokens": undefined,
+          "messages": [
+            {
+              "content": "You MUST answer with JSON.",
+              "role": "system",
+            },
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "mistral-small-latest",
+          "random_seed": undefined,
+          "response_format": {
+            "type": "json_object",
+          },
+          "safe_prompt": undefined,
+          "temperature": undefined,
+          "tool_choice": undefined,
+          "tools": undefined,
+          "top_p": undefined,
+        },
+      }
+    `);
+  });
+
+  it('should inject JSON instruction for JSON response format with schema', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const { request } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    });
+
+    expect(request).toMatchInlineSnapshot(`
+      {
+        "body": {
+          "document_image_limit": undefined,
+          "document_page_limit": undefined,
+          "max_tokens": undefined,
+          "messages": [
+            {
+              "content": "JSON schema:
+      {"type":"object","properties":{"name":{"type":"string"}}}
+      You MUST answer with a JSON object that matches the JSON schema above.",
+              "role": "system",
+            },
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "mistral-small-latest",
+          "random_seed": undefined,
+          "response_format": {
+            "type": "json_object",
+          },
+          "safe_prompt": undefined,
+          "temperature": undefined,
+          "tool_choice": undefined,
+          "tools": undefined,
+          "top_p": undefined,
+        },
+      }
+    `);
+  });
+
   it('should extract content when message content is a content object', async () => {
     server.urls['https://api.mistral.ai/v1/chat/completions'].response = {
       type: 'json-value',

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -12,7 +12,7 @@ import {
   createJsonResponseHandler,
   FetchFunction,
   generateId,
-  injectJsonInstruction,
+  injectJsonInstructionIntoMessages,
   parseProviderOptions,
   ParseResult,
   postJsonToApi,
@@ -123,25 +123,13 @@ export class MistralChatLanguageModel implements LanguageModelV2 {
       });
     }
 
+    // For Mistral we need to need to instruct the model to return a JSON object.
+    // https://docs.mistral.ai/capabilities/structured-output/structured_output_overview/
     if (responseFormat?.type === 'json') {
-      let systemMessage = prompt.find(message => message.role === 'system');
-
-      if (systemMessage == null) {
-        systemMessage = {
-          role: 'system',
-          content: '',
-        };
-
-        prompt.unshift(systemMessage);
-      }
-
-      // inject JSON schema instruction
-      const jsonSchemaInstruction = injectJsonInstruction({
-        prompt: systemMessage.content,
+      prompt = injectJsonInstructionIntoMessages({
+        messages: prompt,
         schema: responseFormat.schema,
       });
-
-      systemMessage.content = jsonSchemaInstruction;
     }
 
     const baseArgs = {

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -110,7 +110,7 @@ export class MistralChatLanguageModel implements LanguageModelV2 {
       });
     }
 
-    // TODO remove when we have JSON schema support
+    // TODO remove when we have JSON schema support (see OpenAI implementation)
     if (
       responseFormat != null &&
       responseFormat.type === 'json' &&
@@ -146,7 +146,7 @@ export class MistralChatLanguageModel implements LanguageModelV2 {
       random_seed: seed,
 
       // response format:
-      // TODO add JSON schema support
+      // TODO add JSON schema support (see OpenAI implementation)
       response_format:
         responseFormat?.type === 'json' ? { type: 'json_object' } : undefined,
 

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -6,6 +6,7 @@ export * from './fetch-function';
 export { createIdGenerator, generateId, type IdGenerator } from './generate-id';
 export * from './get-error-message';
 export * from './get-from-api';
+export * from './inject-json-instruction';
 export * from './is-abort-error';
 export { isUrlSupported } from './is-url-supported';
 export * from './load-api-key';
@@ -17,8 +18,8 @@ export { parseProviderOptions } from './parse-provider-options';
 export * from './post-to-api';
 export {
   createProviderDefinedToolFactory,
-  type ProviderDefinedToolFactory,
   createProviderDefinedToolFactoryWithOutputSchema,
+  type ProviderDefinedToolFactory,
   type ProviderDefinedToolFactoryWithOutputSchema,
 } from './provider-defined-tool-factory';
 export * from './remove-undefined-entries';

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -6,7 +6,7 @@ export * from './fetch-function';
 export { createIdGenerator, generateId, type IdGenerator } from './generate-id';
 export * from './get-error-message';
 export * from './get-from-api';
-export * from './inject-json-instruction';
+export { injectJsonInstructionIntoMessages } from './inject-json-instruction';
 export * from './is-abort-error';
 export { isUrlSupported } from './is-url-supported';
 export * from './load-api-key';

--- a/packages/provider-utils/src/inject-json-instruction.test.ts
+++ b/packages/provider-utils/src/inject-json-instruction.test.ts
@@ -1,0 +1,180 @@
+import { JSONSchema7 } from '@ai-sdk/provider';
+import { injectJsonInstruction } from './inject-json-instruction';
+
+const basicSchema: JSONSchema7 = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    age: { type: 'number' },
+  },
+  required: ['name', 'age'],
+};
+
+it('should handle basic case with prompt and schema', () => {
+  const result = injectJsonInstruction({
+    prompt: 'Generate a person',
+    schema: basicSchema,
+  });
+  expect(result).toBe(
+    'Generate a person\n\n' +
+      'JSON schema:\n' +
+      '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
+      'You MUST answer with a JSON object that matches the JSON schema above.',
+  );
+});
+
+it('should handle only prompt, no schema', () => {
+  const result = injectJsonInstruction({
+    prompt: 'Generate a person',
+  });
+  expect(result).toBe('Generate a person\n\nYou MUST answer with JSON.');
+});
+
+it('should handle only schema, no prompt', () => {
+  const result = injectJsonInstruction({
+    schema: basicSchema,
+  });
+  expect(result).toBe(
+    'JSON schema:\n' +
+      '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
+      'You MUST answer with a JSON object that matches the JSON schema above.',
+  );
+});
+
+it('should handle no prompt, no schema', () => {
+  const result = injectJsonInstruction({});
+  expect(result).toBe('You MUST answer with JSON.');
+});
+
+it('should handle custom schemaPrefix and schemaSuffix', () => {
+  const result = injectJsonInstruction({
+    prompt: 'Generate a person',
+    schema: basicSchema,
+    schemaPrefix: 'Custom prefix:',
+    schemaSuffix: 'Custom suffix',
+  });
+  expect(result).toBe(
+    'Generate a person\n\n' +
+      'Custom prefix:\n' +
+      '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
+      'Custom suffix',
+  );
+});
+
+it('should handle empty string prompt', () => {
+  const result = injectJsonInstruction({
+    prompt: '',
+    schema: basicSchema,
+  });
+  expect(result).toBe(
+    'JSON schema:\n' +
+      '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
+      'You MUST answer with a JSON object that matches the JSON schema above.',
+  );
+});
+
+it('should handle empty object schema', () => {
+  const result = injectJsonInstruction({
+    prompt: 'Generate something',
+    schema: {},
+  });
+  expect(result).toBe(
+    'Generate something\n\n' +
+      'JSON schema:\n' +
+      '{}\n' +
+      'You MUST answer with a JSON object that matches the JSON schema above.',
+  );
+});
+
+it('should handle complex nested schema', () => {
+  const complexSchema: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      person: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+          address: {
+            type: 'object',
+            properties: {
+              street: { type: 'string' },
+              city: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+  };
+  const result = injectJsonInstruction({
+    prompt: 'Generate a complex person',
+    schema: complexSchema,
+  });
+  expect(result).toBe(
+    'Generate a complex person\n\n' +
+      'JSON schema:\n' +
+      '{"type":"object","properties":{"person":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"},"address":{"type":"object","properties":{"street":{"type":"string"},"city":{"type":"string"}}}}}}}\n' +
+      'You MUST answer with a JSON object that matches the JSON schema above.',
+  );
+});
+
+it('should handle schema with special characters', () => {
+  const specialSchema: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      'special@property': { type: 'string' },
+      'emoji😊': { type: 'string' },
+    },
+  };
+  const result = injectJsonInstruction({
+    schema: specialSchema,
+  });
+  expect(result).toBe(
+    'JSON schema:\n' +
+      '{"type":"object","properties":{"special@property":{"type":"string"},"emoji😊":{"type":"string"}}}\n' +
+      'You MUST answer with a JSON object that matches the JSON schema above.',
+  );
+});
+
+it('should handle very long prompt and schema', () => {
+  const longPrompt = 'A'.repeat(1000);
+  const longSchema: JSONSchema7 = {
+    type: 'object',
+    properties: {},
+  };
+  for (let i = 0; i < 100; i++) {
+    longSchema.properties![`prop${i}`] = { type: 'string' };
+  }
+  const result = injectJsonInstruction({
+    prompt: longPrompt,
+    schema: longSchema,
+  });
+  expect(result).toBe(
+    longPrompt +
+      '\n\n' +
+      'JSON schema:\n' +
+      JSON.stringify(longSchema) +
+      '\n' +
+      'You MUST answer with a JSON object that matches the JSON schema above.',
+  );
+});
+
+it('should handle null values for optional parameters', () => {
+  const result = injectJsonInstruction({
+    prompt: null as any,
+    schema: null as any,
+    schemaPrefix: null as any,
+    schemaSuffix: null as any,
+  });
+  expect(result).toBe('');
+});
+
+it('should handle undefined values for optional parameters', () => {
+  const result = injectJsonInstruction({
+    prompt: undefined,
+    schema: undefined,
+    schemaPrefix: undefined,
+    schemaSuffix: undefined,
+  });
+  expect(result).toBe('You MUST answer with JSON.');
+});

--- a/packages/provider-utils/src/inject-json-instruction.test.ts
+++ b/packages/provider-utils/src/inject-json-instruction.test.ts
@@ -1,5 +1,8 @@
-import { JSONSchema7 } from '@ai-sdk/provider';
-import { injectJsonInstruction } from './inject-json-instruction';
+import { JSONSchema7, LanguageModelV2Prompt } from '@ai-sdk/provider';
+import {
+  injectJsonInstruction,
+  injectJsonInstructionIntoMessages,
+} from './inject-json-instruction';
 
 const basicSchema: JSONSchema7 = {
   type: 'object',
@@ -178,5 +181,223 @@ describe('injectJsonInstruction', () => {
       schemaSuffix: undefined,
     });
     expect(result).toBe('You MUST answer with JSON.');
+  });
+});
+
+describe('injectJsonInstructionIntoMessages', () => {
+  it('should handle basic case with prompt and schema', () => {
+    const result = injectJsonInstructionIntoMessages({
+      messages: [{ role: 'system', content: 'Generate a person' }],
+      schema: basicSchema,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "Generate a person
+
+      JSON schema:
+      {"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}
+      You MUST answer with a JSON object that matches the JSON schema above.",
+          "role": "system",
+        },
+      ]
+    `);
+  });
+
+  it('should not mutate the input messages array', () => {
+    const originalMessages: LanguageModelV2Prompt = [
+      { role: 'system', content: 'Generate a person' },
+    ];
+
+    injectJsonInstructionIntoMessages({
+      messages: originalMessages,
+      schema: basicSchema,
+    });
+
+    expect(originalMessages).toEqual([
+      { role: 'system', content: 'Generate a person' },
+    ]);
+  });
+
+  it('should handle empty messages array', () => {
+    const result = injectJsonInstructionIntoMessages({
+      messages: [],
+      schema: basicSchema,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "JSON schema:
+      {"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}
+      You MUST answer with a JSON object that matches the JSON schema above.",
+          "role": "system",
+        },
+      ]
+    `);
+  });
+
+  it('should handle messages without initial system message', () => {
+    const result = injectJsonInstructionIntoMessages({
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hi there' }],
+        },
+      ],
+      schema: basicSchema,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "JSON schema:
+      {"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}
+      You MUST answer with a JSON object that matches the JSON schema above.",
+          "role": "system",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello",
+              "type": "text",
+            },
+          ],
+          "role": "user",
+        },
+        {
+          "content": [
+            {
+              "text": "Hi there",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ]
+    `);
+  });
+
+  it('should handle system message with empty content', () => {
+    const result = injectJsonInstructionIntoMessages({
+      messages: [
+        { role: 'system', content: '' },
+        { role: 'user', content: [{ type: 'text', text: 'Generate data' }] },
+      ],
+      schema: basicSchema,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "JSON schema:
+      {"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}
+      You MUST answer with a JSON object that matches the JSON schema above.",
+          "role": "system",
+        },
+        {
+          "content": [
+            {
+              "text": "Generate data",
+              "type": "text",
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
+  it('should preserve all non-system messages', () => {
+    const result = injectJsonInstructionIntoMessages({
+      messages: [
+        { role: 'system', content: 'You are helpful' },
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+        { role: 'user', content: [{ type: 'text', text: 'Generate person' }] },
+      ],
+      schema: basicSchema,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "You are helpful
+
+      JSON schema:
+      {"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}
+      You MUST answer with a JSON object that matches the JSON schema above.",
+          "role": "system",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello",
+              "type": "text",
+            },
+          ],
+          "role": "user",
+        },
+        {
+          "content": [
+            {
+              "text": "Hi",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+        {
+          "content": [
+            {
+              "text": "Generate person",
+              "type": "text",
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
+  it('should handle case with no schema', () => {
+    const result = injectJsonInstructionIntoMessages({
+      messages: [{ role: 'system', content: 'Generate data' }],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "Generate data
+
+      You MUST answer with JSON.",
+          "role": "system",
+        },
+      ]
+    `);
+  });
+
+  it('should handle custom schema prefix and suffix', () => {
+    const result = injectJsonInstructionIntoMessages({
+      messages: [{ role: 'system', content: 'Generate data' }],
+      schema: basicSchema,
+      schemaPrefix: 'Custom schema:',
+      schemaSuffix: 'Follow this format exactly.',
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "Generate data
+
+      Custom schema:
+      {"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}
+      Follow this format exactly.",
+          "role": "system",
+        },
+      ]
+    `);
   });
 });

--- a/packages/provider-utils/src/inject-json-instruction.test.ts
+++ b/packages/provider-utils/src/inject-json-instruction.test.ts
@@ -10,171 +10,173 @@ const basicSchema: JSONSchema7 = {
   required: ['name', 'age'],
 };
 
-it('should handle basic case with prompt and schema', () => {
-  const result = injectJsonInstruction({
-    prompt: 'Generate a person',
-    schema: basicSchema,
+describe('injectJsonInstruction', () => {
+  it('should handle basic case with prompt and schema', () => {
+    const result = injectJsonInstruction({
+      prompt: 'Generate a person',
+      schema: basicSchema,
+    });
+    expect(result).toBe(
+      'Generate a person\n\n' +
+        'JSON schema:\n' +
+        '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
+        'You MUST answer with a JSON object that matches the JSON schema above.',
+    );
   });
-  expect(result).toBe(
-    'Generate a person\n\n' +
+
+  it('should handle only prompt, no schema', () => {
+    const result = injectJsonInstruction({
+      prompt: 'Generate a person',
+    });
+    expect(result).toBe('Generate a person\n\nYou MUST answer with JSON.');
+  });
+
+  it('should handle only schema, no prompt', () => {
+    const result = injectJsonInstruction({
+      schema: basicSchema,
+    });
+    expect(result).toBe(
       'JSON schema:\n' +
-      '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
-      'You MUST answer with a JSON object that matches the JSON schema above.',
-  );
-});
-
-it('should handle only prompt, no schema', () => {
-  const result = injectJsonInstruction({
-    prompt: 'Generate a person',
+        '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
+        'You MUST answer with a JSON object that matches the JSON schema above.',
+    );
   });
-  expect(result).toBe('Generate a person\n\nYou MUST answer with JSON.');
-});
 
-it('should handle only schema, no prompt', () => {
-  const result = injectJsonInstruction({
-    schema: basicSchema,
+  it('should handle no prompt, no schema', () => {
+    const result = injectJsonInstruction({});
+    expect(result).toBe('You MUST answer with JSON.');
   });
-  expect(result).toBe(
-    'JSON schema:\n' +
-      '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
-      'You MUST answer with a JSON object that matches the JSON schema above.',
-  );
-});
 
-it('should handle no prompt, no schema', () => {
-  const result = injectJsonInstruction({});
-  expect(result).toBe('You MUST answer with JSON.');
-});
-
-it('should handle custom schemaPrefix and schemaSuffix', () => {
-  const result = injectJsonInstruction({
-    prompt: 'Generate a person',
-    schema: basicSchema,
-    schemaPrefix: 'Custom prefix:',
-    schemaSuffix: 'Custom suffix',
+  it('should handle custom schemaPrefix and schemaSuffix', () => {
+    const result = injectJsonInstruction({
+      prompt: 'Generate a person',
+      schema: basicSchema,
+      schemaPrefix: 'Custom prefix:',
+      schemaSuffix: 'Custom suffix',
+    });
+    expect(result).toBe(
+      'Generate a person\n\n' +
+        'Custom prefix:\n' +
+        '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
+        'Custom suffix',
+    );
   });
-  expect(result).toBe(
-    'Generate a person\n\n' +
-      'Custom prefix:\n' +
-      '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
-      'Custom suffix',
-  );
-});
 
-it('should handle empty string prompt', () => {
-  const result = injectJsonInstruction({
-    prompt: '',
-    schema: basicSchema,
-  });
-  expect(result).toBe(
-    'JSON schema:\n' +
-      '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
-      'You MUST answer with a JSON object that matches the JSON schema above.',
-  );
-});
-
-it('should handle empty object schema', () => {
-  const result = injectJsonInstruction({
-    prompt: 'Generate something',
-    schema: {},
-  });
-  expect(result).toBe(
-    'Generate something\n\n' +
+  it('should handle empty string prompt', () => {
+    const result = injectJsonInstruction({
+      prompt: '',
+      schema: basicSchema,
+    });
+    expect(result).toBe(
       'JSON schema:\n' +
-      '{}\n' +
-      'You MUST answer with a JSON object that matches the JSON schema above.',
-  );
-});
+        '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name","age"]}\n' +
+        'You MUST answer with a JSON object that matches the JSON schema above.',
+    );
+  });
 
-it('should handle complex nested schema', () => {
-  const complexSchema: JSONSchema7 = {
-    type: 'object',
-    properties: {
-      person: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          age: { type: 'number' },
-          address: {
-            type: 'object',
-            properties: {
-              street: { type: 'string' },
-              city: { type: 'string' },
+  it('should handle empty object schema', () => {
+    const result = injectJsonInstruction({
+      prompt: 'Generate something',
+      schema: {},
+    });
+    expect(result).toBe(
+      'Generate something\n\n' +
+        'JSON schema:\n' +
+        '{}\n' +
+        'You MUST answer with a JSON object that matches the JSON schema above.',
+    );
+  });
+
+  it('should handle complex nested schema', () => {
+    const complexSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        person: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' },
+            address: {
+              type: 'object',
+              properties: {
+                street: { type: 'string' },
+                city: { type: 'string' },
+              },
             },
           },
         },
       },
-    },
-  };
-  const result = injectJsonInstruction({
-    prompt: 'Generate a complex person',
-    schema: complexSchema,
+    };
+    const result = injectJsonInstruction({
+      prompt: 'Generate a complex person',
+      schema: complexSchema,
+    });
+    expect(result).toBe(
+      'Generate a complex person\n\n' +
+        'JSON schema:\n' +
+        '{"type":"object","properties":{"person":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"},"address":{"type":"object","properties":{"street":{"type":"string"},"city":{"type":"string"}}}}}}}\n' +
+        'You MUST answer with a JSON object that matches the JSON schema above.',
+    );
   });
-  expect(result).toBe(
-    'Generate a complex person\n\n' +
+
+  it('should handle schema with special characters', () => {
+    const specialSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        'special@property': { type: 'string' },
+        'emoji😊': { type: 'string' },
+      },
+    };
+    const result = injectJsonInstruction({
+      schema: specialSchema,
+    });
+    expect(result).toBe(
       'JSON schema:\n' +
-      '{"type":"object","properties":{"person":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"},"address":{"type":"object","properties":{"street":{"type":"string"},"city":{"type":"string"}}}}}}}\n' +
-      'You MUST answer with a JSON object that matches the JSON schema above.',
-  );
-});
-
-it('should handle schema with special characters', () => {
-  const specialSchema: JSONSchema7 = {
-    type: 'object',
-    properties: {
-      'special@property': { type: 'string' },
-      'emoji😊': { type: 'string' },
-    },
-  };
-  const result = injectJsonInstruction({
-    schema: specialSchema,
+        '{"type":"object","properties":{"special@property":{"type":"string"},"emoji😊":{"type":"string"}}}\n' +
+        'You MUST answer with a JSON object that matches the JSON schema above.',
+    );
   });
-  expect(result).toBe(
-    'JSON schema:\n' +
-      '{"type":"object","properties":{"special@property":{"type":"string"},"emoji😊":{"type":"string"}}}\n' +
-      'You MUST answer with a JSON object that matches the JSON schema above.',
-  );
-});
 
-it('should handle very long prompt and schema', () => {
-  const longPrompt = 'A'.repeat(1000);
-  const longSchema: JSONSchema7 = {
-    type: 'object',
-    properties: {},
-  };
-  for (let i = 0; i < 100; i++) {
-    longSchema.properties![`prop${i}`] = { type: 'string' };
-  }
-  const result = injectJsonInstruction({
-    prompt: longPrompt,
-    schema: longSchema,
+  it('should handle very long prompt and schema', () => {
+    const longPrompt = 'A'.repeat(1000);
+    const longSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {},
+    };
+    for (let i = 0; i < 100; i++) {
+      longSchema.properties![`prop${i}`] = { type: 'string' };
+    }
+    const result = injectJsonInstruction({
+      prompt: longPrompt,
+      schema: longSchema,
+    });
+    expect(result).toBe(
+      longPrompt +
+        '\n\n' +
+        'JSON schema:\n' +
+        JSON.stringify(longSchema) +
+        '\n' +
+        'You MUST answer with a JSON object that matches the JSON schema above.',
+    );
   });
-  expect(result).toBe(
-    longPrompt +
-      '\n\n' +
-      'JSON schema:\n' +
-      JSON.stringify(longSchema) +
-      '\n' +
-      'You MUST answer with a JSON object that matches the JSON schema above.',
-  );
-});
 
-it('should handle null values for optional parameters', () => {
-  const result = injectJsonInstruction({
-    prompt: null as any,
-    schema: null as any,
-    schemaPrefix: null as any,
-    schemaSuffix: null as any,
+  it('should handle null values for optional parameters', () => {
+    const result = injectJsonInstruction({
+      prompt: null as any,
+      schema: null as any,
+      schemaPrefix: null as any,
+      schemaSuffix: null as any,
+    });
+    expect(result).toBe('');
   });
-  expect(result).toBe('');
-});
 
-it('should handle undefined values for optional parameters', () => {
-  const result = injectJsonInstruction({
-    prompt: undefined,
-    schema: undefined,
-    schemaPrefix: undefined,
-    schemaSuffix: undefined,
+  it('should handle undefined values for optional parameters', () => {
+    const result = injectJsonInstruction({
+      prompt: undefined,
+      schema: undefined,
+      schemaPrefix: undefined,
+      schemaSuffix: undefined,
+    });
+    expect(result).toBe('You MUST answer with JSON.');
   });
-  expect(result).toBe('You MUST answer with JSON.');
 });

--- a/packages/provider-utils/src/inject-json-instruction.ts
+++ b/packages/provider-utils/src/inject-json-instruction.ts
@@ -1,0 +1,30 @@
+import { JSONSchema7 } from '@ai-sdk/provider';
+
+const DEFAULT_SCHEMA_PREFIX = 'JSON schema:';
+const DEFAULT_SCHEMA_SUFFIX =
+  'You MUST answer with a JSON object that matches the JSON schema above.';
+const DEFAULT_GENERIC_SUFFIX = 'You MUST answer with JSON.';
+
+export function injectJsonInstruction({
+  prompt,
+  schema,
+  schemaPrefix = schema != null ? DEFAULT_SCHEMA_PREFIX : undefined,
+  schemaSuffix = schema != null
+    ? DEFAULT_SCHEMA_SUFFIX
+    : DEFAULT_GENERIC_SUFFIX,
+}: {
+  prompt?: string;
+  schema?: JSONSchema7;
+  schemaPrefix?: string;
+  schemaSuffix?: string;
+}): string {
+  return [
+    prompt != null && prompt.length > 0 ? prompt : undefined,
+    prompt != null && prompt.length > 0 ? '' : undefined, // add a newline if prompt is not null
+    schemaPrefix,
+    schema != null ? JSON.stringify(schema) : undefined,
+    schemaSuffix,
+  ]
+    .filter(line => line != null)
+    .join('\n');
+}

--- a/packages/provider-utils/src/inject-json-instruction.ts
+++ b/packages/provider-utils/src/inject-json-instruction.ts
@@ -1,4 +1,8 @@
-import { JSONSchema7 } from '@ai-sdk/provider';
+import {
+  JSONSchema7,
+  LanguageModelV2Message,
+  LanguageModelV2Prompt,
+} from '@ai-sdk/provider';
 
 const DEFAULT_SCHEMA_PREFIX = 'JSON schema:';
 const DEFAULT_SCHEMA_SUFFIX =
@@ -27,4 +31,33 @@ export function injectJsonInstruction({
   ]
     .filter(line => line != null)
     .join('\n');
+}
+
+export function injectJsonInstructionIntoMessages({
+  messages,
+  schema,
+  schemaPrefix,
+  schemaSuffix,
+}: {
+  messages: LanguageModelV2Prompt;
+  schema?: JSONSchema7;
+  schemaPrefix?: string;
+  schemaSuffix?: string;
+}): LanguageModelV2Prompt {
+  const systemMessage: LanguageModelV2Message =
+    messages[0]?.role === 'system'
+      ? { ...messages[0] }
+      : { role: 'system', content: '' };
+
+  systemMessage.content = injectJsonInstruction({
+    prompt: systemMessage.content,
+    schema,
+    schemaPrefix,
+    schemaSuffix,
+  });
+
+  return [
+    systemMessage,
+    ...(messages[0]?.role === 'system' ? messages.slice(1) : messages),
+  ];
 }


### PR DESCRIPTION
## Background

Mistral object generation was broken in AI SDK 5, because the JSON generation instruction was no longer added to the system prompt.

## Summary

<!-- What did you change? -->

## Manual Verification

* Ran `examples/ai-core/src/generate-object/mistral.ts`
* Ran `examples/ai-core/src/stream-object/mistral.ts`

## Future Work

- Add support for Mistral `json_schema` [response format](https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post)
- Add injection support to OpenAI compatible provider and apply in DeepSeek provider

## Related Issues

Fixes https://github.com/vercel/ai/issues/8119