### PR TITLE
fix(vue): ensure UIMessage parts array updates propagate correctly to child components during streaming

### DIFF
--- a/.changeset/lucky-tools-deny.md
+++ b/.changeset/lucky-tools-deny.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/vue': patch
+---
+
+Fix UIMessage reactivity issues in Vue by introducing a `deepToRaw` utility and updating `replaceMessage` to ensure message parts arrays update correctly when passed as props to child components.

--- a/packages/vue/src/chat.vue.ts
+++ b/packages/vue/src/chat.vue.ts
@@ -6,6 +6,7 @@ import {
   UIMessage,
 } from 'ai';
 import { Ref, ref } from 'vue';
+import { deepToRaw } from './utils';
 
 class VueChatState<UI_MESSAGE extends UIMessage>
   implements ChatState<UI_MESSAGE>
@@ -52,7 +53,7 @@ class VueChatState<UI_MESSAGE extends UIMessage>
 
   replaceMessage = (index: number, message: UI_MESSAGE) => {
     // message is cloned here because vue's deep reactivity shows unexpected behavior, particularly when updating tool invocation parts
-    this.messagesRef.value[index] = { ...message };
+    this.messagesRef.value[index] = deepToRaw(message);
   };
 
   snapshot = <T>(value: T): T => value;

--- a/packages/vue/src/utils.ts
+++ b/packages/vue/src/utils.ts
@@ -1,0 +1,18 @@
+import { isProxy, isReactive, isRef, toRaw } from 'vue';
+
+/**
+ * Converts a reactive object to a plain object.
+ */
+export function deepToRaw<T>(input: T): T {
+  if (Array.isArray(input)) {
+    return input.map(item => deepToRaw(item)) as unknown as T;
+  } else if (isRef(input) || isReactive(input) || isProxy(input)) {
+    return deepToRaw(toRaw(input));
+  } else if (input && typeof input === 'object') {
+    return Object.keys(input).reduce((acc, key) => {
+      (acc as any)[key] = deepToRaw((input as any)[key]);
+      return acc;
+    }, {} as T);
+  }
+  return input;
+}


### PR DESCRIPTION
## Background
While streaming messages, updates to the `parts` array elements were not propagating correctly to child components when passed as props. This issue occurred due to unexpected behavior in Vue’s reactivity system, where partially replacing reactive objects did not always trigger updates.

## Summary
- Introduced a `deepToRaw` utility to safely convert Vue reactive objects into plain objects.
- Updated the `replaceMessage` method to use `deepToRaw`, ensuring that updates to the `parts` array are properly reflected in child components when passed as props.

## Manual Verification
- Tested streaming messages within a Vue app.
- Verified that each element of the `parts` array now updates correctly in child components.
- Confirmed that props passed to child components reflect the latest state without requiring additional reactivity workarounds.

## Tasks
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work
## Related Issues