### PR TITLE
feat(providers/amazon-bedrock): add tool cache point support

### DIFF
--- a/.changeset/loud-ladybugs-attack.md
+++ b/.changeset/loud-ladybugs-attack.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': minor
+---
+
+Added support for cache points in tools

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -373,7 +373,8 @@ Likewise, tools can also have cache points set:
 
 ```ts
 import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { generateText } from 'ai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
 
 const result = await generateText({
   model: bedrock('anthropic.claude-3-5-sonnet-20241022-v2:0'),

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -280,7 +280,7 @@ See the [Amazon Bedrock Guardrails documentation](https://docs.aws.amazon.com/be
   page](https://aws.amazon.com/bedrock/prompt-caching/).
 </Note>
 
-In messages, you can use the `providerOptions` property to set cache points. Set the `bedrock` property in the `providerOptions` object to `{ cachePoint: { type: 'default' } }` to create a cache point.
+In messages and tools, you can use the `providerOptions` property to set cache points. Set the `bedrock` property in the `providerOptions` object to `{ cachePoint: { type: 'default' } }` to create a cache point.
 
 Cache usage information is returned in the `providerMetadata` object`. See examples below.
 
@@ -367,6 +367,35 @@ console.log(
 //   cacheReadInputTokens: 1337,
 //   cacheWriteInputTokens: 42,
 // }
+```
+
+Likewise, tools can also have cache points set:
+
+```ts
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: bedrock('anthropic.claude-3-5-sonnet-20241022-v2:0'),
+  messages: [
+    {
+      role: 'user',
+      content: 'Test out some of your tools.',
+    },
+  ],
+  tools: {
+    echo: tool({
+      description: 'Echo back the input',
+      inputSchema: z.object({
+        input: z.string(),
+      }),
+      execute: ({ input }) => input,
+      providerOptions: {
+        bedrock: { cachePoint: { type: 'default' } },
+      },
+    }),
+  },
+});
 ```
 
 ## Reasoning

--- a/examples/ai-core/src/generate-text/amazon-bedrock-cache-point-tool-call.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-cache-point-tool-call.ts
@@ -13,6 +13,9 @@ const weatherTool = tool({
     location,
     temperature: weatherData[location],
   }),
+  providerOptions: {
+    bedrock: { cachePoint: { type: 'default' } },
+  },
 });
 
 const weatherData: Record<string, number> = {
@@ -128,14 +131,6 @@ async function main() {
       weather: weatherTool,
     },
     prompt: 'What is the weather in San Francisco?',
-    // TODO: need a way to set cachePoint on `tools`.
-    providerOptions: {
-      bedrock: {
-        cachePoint: {
-          type: 'default',
-        },
-      },
-    },
   });
 
   // typed tool calls:

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -1793,6 +1793,65 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass tool cache points correctly', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool-1',
+          inputSchema: {
+            type: 'object',
+          },
+        },
+        {
+          type: 'function',
+          name: 'test-tool-2',
+          inputSchema: {
+            type: 'object',
+          },
+          providerOptions: {
+            bedrock: { cachePoint: { type: 'default' } },
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: 'test-tool-1',
+              inputSchema: {
+                json: {
+                  type: 'object',
+                },
+              },
+            },
+          },
+          {
+            toolSpec: {
+              name: 'test-tool-2',
+              inputSchema: {
+                json: {
+                  type: 'object',
+                },
+              },
+            },
+          },
+          {
+            cachePoint: {
+              type: 'default',
+            },
+          },
+        ],
+      },
+    });
+  });
+
   it('should handle Anthropic provider-defined tools', async () => {
     mockPrepareAnthropicTools.mockReturnValue({
       tools: [{ name: 'bash', type: 'bash_20241022' }],

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -9,7 +9,13 @@ import {
   anthropicTools,
   prepareTools as prepareAnthropicTools,
 } from '@ai-sdk/anthropic/internal';
-import { BedrockTool, BedrockToolConfiguration } from './bedrock-api-types';
+import {
+  BEDROCK_CACHE_POINT,
+  BedrockCachePoint,
+  BedrockTool,
+  BedrockToolConfiguration,
+} from './bedrock-api-types';
+import { getCachePoint } from './convert-to-bedrock-chat-messages';
 
 export function prepareTools({
   tools,
@@ -70,7 +76,7 @@ export function prepareTools({
   const functionTools = supportedTools.filter(t => t.type === 'function');
 
   let additionalTools: Record<string, unknown> | undefined = undefined;
-  const bedrockTools: BedrockTool[] = [];
+  const bedrockTools: (BedrockTool | BedrockCachePoint)[] = [];
 
   const usingAnthropicTools =
     isAnthropicModel && providerDefinedTools.length > 0;
@@ -146,6 +152,9 @@ export function prepareTools({
         },
       },
     });
+    if (getCachePoint(tool.providerOptions)) {
+      bedrockTools.push(BEDROCK_CACHE_POINT);
+    }
   }
 
   // Handle toolChoice for standard Bedrock tools, but NOT for Anthropic provider-defined tools

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -22,7 +22,7 @@ import {
 } from './bedrock-api-types';
 import { bedrockReasoningMetadataSchema } from './bedrock-chat-language-model';
 
-function getCachePoint(
+export function getCachePoint(
   providerMetadata: SharedV2ProviderMetadata | undefined,
 ): BedrockCachePoint | undefined {
   return providerMetadata?.bedrock?.cachePoint as BedrockCachePoint | undefined;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Currently AI SDK does not support adding cache points in the tool section. Provider options allow passing such data, but for tools in particular the presence of the field is ignored.

## Summary

<!-- What did you change? -->

Added a check for cachePoint in providerOptions of tools based on the existing code for system / message sections.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

Validated that the constructed request conforms to the correct [schema provided by Bedrock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Tool.html). Added a unit test for this as well.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

Fixes #4472
