### PR TITLE
docs: add knowledge base agent recipe (using upstash search)

### DIFF
--- a/content/cookbook/00-guides/01-rag-chatbot.mdx
+++ b/content/cookbook/00-guides/01-rag-chatbot.mdx
@@ -86,7 +86,7 @@ As mentioned above, embeddings are a way to represent the semantic meaning of **
 
 Chunking refers to the process of breaking down a particular source material into smaller pieces. There are many different approaches to chunking and it’s worth experimenting as the most effective approach can differ by use case. A simple and common approach to chunking (and what you will be using in this guide) is separating written content by sentences.
 
-Once your source material is appropriately chunked, you can embed each one and then store the embedding and the chunk together in a database. Embeddings can be stored in any database that supports vectors. For this tutorial, you will be using [Postgres](https://www.postgresql.org/) alongside the [pgvector](https://github.com/pgvector/pgvector) plugin.
+Once your source material is appropriately chunked, you can embed each one and then store the embedding and the chunk together in a database. Embeddings can be stored in any database that supports vectors. For this tutorial, you will be using [Postgres](https://www.postgresql.org/) alongside the [pgvector](https://github.com/pgvector/pgvector) plugin. Alternatively, you can use [Upstash Search](https://upstash.com/docs/search) which provides hybrid search combining input enrichment, reranking, semantic search, full-text search for more accurate results.
 
 <MDXImage
   srcLight="/images/rag-guide-1.png"
@@ -120,7 +120,7 @@ This project will use the following stack:
 - [ AI SDK ](/docs)
 - [OpenAI](https://openai.com)
 - [ Drizzle ORM ](https://orm.drizzle.team)
-- [ Postgres ](https://www.postgresql.org/) with [ pgvector ](https://github.com/pgvector/pgvector)
+- [ Postgres ](https://www.postgresql.org/) with [ pgvector ](https://github.com/pgvector/pgvector) or [Upstash Search](https://upstash.com/docs/search)
 - [ shadcn-ui ](https://ui.shadcn.com) and [ TailwindCSS ](https://tailwindcss.com) for styling
 
 ### Clone Repo
@@ -360,6 +360,8 @@ export const createResource = async (input: NewResourceParams) => {
 
 This function is a [Server Action](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#with-client-components), as denoted by the `“use server”;` directive at the top of the file. This means that it can be called anywhere in your Next.js application. This function will take an input, run it through a [Zod](https://zod.dev) schema to ensure it adheres to the correct schema, and then creates a new resource in the database. This is the ideal location to generate and store embeddings of the newly created resources.
 
+#### PostgreSQL Implementation
+
 Update the file with the following code:
 
 ```tsx filename="lib/actions/resources.ts" highlight="9-10,21-27,29"
@@ -401,6 +403,64 @@ export const createResource = async (input: NewResourceParams) => {
 ```
 
 First, you call the `generateEmbeddings` function created in the previous step, passing in the source material (`content`). Once you have your embeddings (`e`) of the source material, you can save them to the database, passing the `resourceId` alongside each embedding.
+
+#### Upstash Search Implementation
+
+Alternatively, for Upstash Search, update the file like this:
+
+```tsx filename="lib/actions/resources.ts"
+'use server';
+
+import { Search } from '@upstash/search';
+
+type ChunkContent = {
+  text: string;
+  source: string;
+  timestamp: number;
+};
+
+const search = new Search({
+  url: process.env.UPSTASH_SEARCH_REST_URL!,
+  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
+});
+
+const index = search.index<ChunkContent>('knowledge-base');
+
+export const createResource = async (input: { content: string }) => {
+  try {
+    const { content } = input;
+    
+    if (!content) {
+      return { error: 'Content is required' };
+    }
+
+    // Chunk and store directly in Upstash Search
+    const chunks = content
+      .split('.')
+      .map(chunk => chunk.trim())
+      .filter(chunk => chunk.length > 0);
+    
+    const timestamp = Date.now();
+    
+    await index.upsert(
+      chunks.map((chunk, i) => ({
+        id: `${timestamp}-chunk-${i}`,
+        content: {
+          text: chunk,
+          source: 'user-input',
+          timestamp,
+        },
+      }))
+    );
+
+    return { success: true };
+  } catch (error) {
+    return { error: 'Failed to create resource' };
+  }
+};
+```
+
+When using Upstash Search, you can directly chunk the content and store it in the search index. The `createResource` function will take the input, split it into chunks, and then upsert each chunk into the Upstash Search index.
 
 ### Create Root Page
 
@@ -770,6 +830,41 @@ In this code, you add two functions:
 
 - `generateEmbedding`: generate a single embedding from an input string
 - `findRelevantContent`: embeds the user’s query, searches the database for similar items, then returns relevant items
+
+If you wish to use [Upstash Search](https://upstash.com/docs/search), you can define `findRelevantContent` in the following way:
+
+```tsx filename="lib/ai/upstash-search.ts"
+import { Search } from '@upstash/search';
+
+type ChunkContent = {
+  text: string;
+  source: string;
+  timestamp: number;
+};
+
+const search = new Search({
+  url: process.env.UPSTASH_SEARCH_REST_URL!,
+  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
+});
+
+const index = search.index<ChunkContent>('knowledge-base');
+
+export const findRelevantContent = async (
+  query: string,
+  maxResults: number = 10
+): Promise<string> => {
+  const results = await index.search({
+    query,
+    limit: maxResults,
+    reranking: true,
+  });
+
+  return results.hits
+    .map(hit => hit.data?.text)
+    .filter(Boolean)
+    .join('\n\n');
+};
+```
 
 With that done, it’s onto the final step: creating the tool.
 

--- a/content/cookbook/00-guides/01-rag-chatbot.mdx
+++ b/content/cookbook/00-guides/01-rag-chatbot.mdx
@@ -429,7 +429,7 @@ const index = search.index<ChunkContent>('knowledge-base');
 export const createResource = async (input: { content: string }) => {
   try {
     const { content } = input;
-
+    
     if (!content) {
       return { error: 'Content is required' };
     }
@@ -439,9 +439,9 @@ export const createResource = async (input: { content: string }) => {
       .split('.')
       .map(chunk => chunk.trim())
       .filter(chunk => chunk.length > 0);
-
+    
     const timestamp = Date.now();
-
+    
     await index.upsert(
       chunks.map((chunk, i) => ({
         id: `${timestamp}-chunk-${i}`,
@@ -450,7 +450,7 @@ export const createResource = async (input: { content: string }) => {
           source: 'user-input',
           timestamp,
         },
-      })),
+      }))
     );
 
     return { success: true };
@@ -851,7 +851,7 @@ const index = search.index<ChunkContent>('knowledge-base');
 
 export const findRelevantContent = async (
   query: string,
-  maxResults: number = 10,
+  maxResults: number = 10
 ): Promise<string> => {
   const results = await index.search({
     query,

--- a/content/cookbook/00-guides/01-rag-chatbot.mdx
+++ b/content/cookbook/00-guides/01-rag-chatbot.mdx
@@ -429,7 +429,7 @@ const index = search.index<ChunkContent>('knowledge-base');
 export const createResource = async (input: { content: string }) => {
   try {
     const { content } = input;
-    
+
     if (!content) {
       return { error: 'Content is required' };
     }
@@ -439,9 +439,9 @@ export const createResource = async (input: { content: string }) => {
       .split('.')
       .map(chunk => chunk.trim())
       .filter(chunk => chunk.length > 0);
-    
+
     const timestamp = Date.now();
-    
+
     await index.upsert(
       chunks.map((chunk, i) => ({
         id: `${timestamp}-chunk-${i}`,
@@ -450,7 +450,7 @@ export const createResource = async (input: { content: string }) => {
           source: 'user-input',
           timestamp,
         },
-      }))
+      })),
     );
 
     return { success: true };
@@ -851,7 +851,7 @@ const index = search.index<ChunkContent>('knowledge-base');
 
 export const findRelevantContent = async (
   query: string,
-  maxResults: number = 10
+  maxResults: number = 10,
 ): Promise<string> => {
   const results = await index.search({
     query,

--- a/content/cookbook/00-guides/01-rag-chatbot.mdx
+++ b/content/cookbook/00-guides/01-rag-chatbot.mdx
@@ -86,7 +86,7 @@ As mentioned above, embeddings are a way to represent the semantic meaning of **
 
 Chunking refers to the process of breaking down a particular source material into smaller pieces. There are many different approaches to chunking and it’s worth experimenting as the most effective approach can differ by use case. A simple and common approach to chunking (and what you will be using in this guide) is separating written content by sentences.
 
-Once your source material is appropriately chunked, you can embed each one and then store the embedding and the chunk together in a database. Embeddings can be stored in any database that supports vectors. For this tutorial, you will be using [Postgres](https://www.postgresql.org/) alongside the [pgvector](https://github.com/pgvector/pgvector) plugin. Alternatively, you can use [Upstash Search](https://upstash.com/docs/search) which provides hybrid search combining input enrichment, reranking, semantic search, full-text search for more accurate results.
+Once your source material is appropriately chunked, you can embed each one and then store the embedding and the chunk together in a database. Embeddings can be stored in any database that supports vectors. For this tutorial, you will be using [Postgres](https://www.postgresql.org/) alongside the [pgvector](https://github.com/pgvector/pgvector) plugin.
 
 <MDXImage
   srcLight="/images/rag-guide-1.png"
@@ -120,7 +120,7 @@ This project will use the following stack:
 - [ AI SDK ](/docs)
 - [OpenAI](https://openai.com)
 - [ Drizzle ORM ](https://orm.drizzle.team)
-- [ Postgres ](https://www.postgresql.org/) with [ pgvector ](https://github.com/pgvector/pgvector) or [Upstash Search](https://upstash.com/docs/search)
+- [ Postgres ](https://www.postgresql.org/) with [ pgvector ](https://github.com/pgvector/pgvector)
 - [ shadcn-ui ](https://ui.shadcn.com) and [ TailwindCSS ](https://tailwindcss.com) for styling
 
 ### Clone Repo
@@ -360,8 +360,6 @@ export const createResource = async (input: NewResourceParams) => {
 
 This function is a [Server Action](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#with-client-components), as denoted by the `“use server”;` directive at the top of the file. This means that it can be called anywhere in your Next.js application. This function will take an input, run it through a [Zod](https://zod.dev) schema to ensure it adheres to the correct schema, and then creates a new resource in the database. This is the ideal location to generate and store embeddings of the newly created resources.
 
-#### PostgreSQL Implementation
-
 Update the file with the following code:
 
 ```tsx filename="lib/actions/resources.ts" highlight="9-10,21-27,29"
@@ -403,64 +401,6 @@ export const createResource = async (input: NewResourceParams) => {
 ```
 
 First, you call the `generateEmbeddings` function created in the previous step, passing in the source material (`content`). Once you have your embeddings (`e`) of the source material, you can save them to the database, passing the `resourceId` alongside each embedding.
-
-#### Upstash Search Implementation
-
-Alternatively, for Upstash Search, update the file like this:
-
-```tsx filename="lib/actions/resources.ts"
-'use server';
-
-import { Search } from '@upstash/search';
-
-type ChunkContent = {
-  text: string;
-  source: string;
-  timestamp: number;
-};
-
-const search = new Search({
-  url: process.env.UPSTASH_SEARCH_REST_URL!,
-  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
-});
-
-const index = search.index<ChunkContent>('knowledge-base');
-
-export const createResource = async (input: { content: string }) => {
-  try {
-    const { content } = input;
-    
-    if (!content) {
-      return { error: 'Content is required' };
-    }
-
-    // Chunk and store directly in Upstash Search
-    const chunks = content
-      .split('.')
-      .map(chunk => chunk.trim())
-      .filter(chunk => chunk.length > 0);
-    
-    const timestamp = Date.now();
-    
-    await index.upsert(
-      chunks.map((chunk, i) => ({
-        id: `${timestamp}-chunk-${i}`,
-        content: {
-          text: chunk,
-          source: 'user-input',
-          timestamp,
-        },
-      }))
-    );
-
-    return { success: true };
-  } catch (error) {
-    return { error: 'Failed to create resource' };
-  }
-};
-```
-
-When using Upstash Search, you can directly chunk the content and store it in the search index. The `createResource` function will take the input, split it into chunks, and then upsert each chunk into the Upstash Search index.
 
 ### Create Root Page
 
@@ -830,41 +770,6 @@ In this code, you add two functions:
 
 - `generateEmbedding`: generate a single embedding from an input string
 - `findRelevantContent`: embeds the user’s query, searches the database for similar items, then returns relevant items
-
-If you wish to use [Upstash Search](https://upstash.com/docs/search), you can define `findRelevantContent` in the following way:
-
-```tsx filename="lib/ai/upstash-search.ts"
-import { Search } from '@upstash/search';
-
-type ChunkContent = {
-  text: string;
-  source: string;
-  timestamp: number;
-};
-
-const search = new Search({
-  url: process.env.UPSTASH_SEARCH_REST_URL!,
-  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
-});
-
-const index = search.index<ChunkContent>('knowledge-base');
-
-export const findRelevantContent = async (
-  query: string,
-  maxResults: number = 10
-): Promise<string> => {
-  const results = await index.search({
-    query,
-    limit: maxResults,
-    reranking: true,
-  });
-
-  return results.hits
-    .map(hit => hit.data?.text)
-    .filter(Boolean)
-    .join('\n\n');
-};
-```
 
 With that done, it’s onto the final step: creating the tool.
 

--- a/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
+++ b/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
@@ -9,7 +9,9 @@ tags: ['node']
 Retrieval Augmented Generation (RAG) is a technique that enhances the capabilities of language models by providing them with relevant information from external sources during the generation process.
 This approach allows the model to access and incorporate up-to-date or specific knowledge that may not be present in its original training data.
 
-This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as an input (`essay.txt`). This example uses a simple in-memory vector database to store and retrieve relevant information. For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot) which will show you how to build a RAG chatbot with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/) and [Postgres](https://postgresql.org).
+This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as an input (`essay.txt`). This example uses a simple in-memory vector database to store and retrieve relevant information. Alternatively, you can check out our [Knowledge Base Agent example](/cookbook/node/knowledge-base-agent) which uses Upstash Search to generate embeddings and manage the knowledge base.
+
+For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot) which will show you how to build a RAG chatbot with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/) and [Postgres](https://postgresql.org).
 
 ```ts
 import fs from 'fs';

--- a/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
+++ b/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
@@ -9,7 +9,7 @@ tags: ['node']
 Retrieval Augmented Generation (RAG) is a technique that enhances the capabilities of language models by providing them with relevant information from external sources during the generation process.
 This approach allows the model to access and incorporate up-to-date or specific knowledge that may not be present in its original training data.
 
-This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as an input (`essay.txt`). Below you'll find two implementations: one using a simple in-memory vector database, and another using [Upstash Search](https://upstash.com/docs/search) for persistent hybrid search. For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot) which will show you how to build a RAG chatbot with [Next.js](https://nextjs.org).
+This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as an input (`essay.txt`). This example uses a simple in-memory vector database to store and retrieve relevant information. For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot) which will show you how to build a RAG chatbot with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/) and [Postgres](https://postgresql.org).
 
 ```ts
 import fs from 'fs';
@@ -64,80 +64,6 @@ async function main() {
 
              Question: ${input}`,
   });
-  console.log(text);
-}
-
-main().catch(console.error);
-```
-
-## Using Upstash Search
-
-For production applications, you'll want to persist your data in a searchable database. [Upstash Search](https://upstash.com/docs/search) provides a search solution that combines input enrichment, reranking, semantic search, full-text search for more accurate results:
-
-```ts
-import fs from 'fs';
-import path from 'path';
-import dotenv from 'dotenv';
-import { openai } from '@ai-sdk/openai';
-import { generateText } from 'ai';
-import { Search } from '@upstash/search';
-
-dotenv.config();
-
-type ChunkContent = {
-  text: string;
-  section: string;
-};
-
-// Initialize Upstash Search client
-const search = new Search({
-  url: process.env.UPSTASH_SEARCH_REST_URL!,
-  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
-});
-
-const index = search.index<ChunkContent>('essay-chunks');
-
-async function main() {
-  const essay = fs.readFileSync(path.join(__dirname, 'essay.txt'), 'utf8');
-  const chunks = essay
-    .split('.')
-    .map(chunk => chunk.trim())
-    .filter(chunk => chunk.length > 0 && chunk !== '\n');
-
-  // Upsert chunks to Upstash Search
-  await index.upsert(
-    chunks.map((chunk, i) => ({
-      id: `chunk-${i}`,
-      content: {
-        text: chunk,
-        section: `section-${Math.floor(i / 10)}`, // Group chunks into sections
-      },
-    }))
-  );
-
-  const input =
-    'What were the two main things the author worked on before college?';
-
-  // Search for relevant context using hybrid search
-  const results = await index.search({
-    query: input,
-    limit: 3,
-    reranking: true,
-  });
-
-  const context = results.hits
-    .map(hit => hit.data?.text)
-    .filter(Boolean)
-    .join('\n');
-
-  const { text } = await generateText({
-    model: openai('gpt-4o'),
-    prompt: `Answer the following question based only on the provided context:
-             ${context}
-
-             Question: ${input}`,
-  });
-  
   console.log(text);
 }
 

--- a/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
+++ b/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
@@ -112,7 +112,7 @@ async function main() {
         text: chunk,
         section: `section-${Math.floor(i / 10)}`, // Group chunks into sections
       },
-    }))
+    })),
   );
 
   const input =
@@ -137,7 +137,7 @@ async function main() {
 
              Question: ${input}`,
   });
-  
+
   console.log(text);
 }
 

--- a/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
+++ b/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
@@ -112,7 +112,7 @@ async function main() {
         text: chunk,
         section: `section-${Math.floor(i / 10)}`, // Group chunks into sections
       },
-    })),
+    }))
   );
 
   const input =
@@ -137,7 +137,7 @@ async function main() {
 
              Question: ${input}`,
   });
-
+  
   console.log(text);
 }
 

--- a/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
+++ b/content/cookbook/05-node/100-retrieval-augmented-generation.mdx
@@ -9,7 +9,7 @@ tags: ['node']
 Retrieval Augmented Generation (RAG) is a technique that enhances the capabilities of language models by providing them with relevant information from external sources during the generation process.
 This approach allows the model to access and incorporate up-to-date or specific knowledge that may not be present in its original training data.
 
-This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as an input (`essay.txt`). This example uses a simple in-memory vector database to store and retrieve relevant information. For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot) which will show you how to build a RAG chatbot with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/) and [Postgres](https://postgresql.org).
+This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as an input (`essay.txt`). Below you'll find two implementations: one using a simple in-memory vector database, and another using [Upstash Search](https://upstash.com/docs/search) for persistent hybrid search. For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot) which will show you how to build a RAG chatbot with [Next.js](https://nextjs.org).
 
 ```ts
 import fs from 'fs';
@@ -64,6 +64,80 @@ async function main() {
 
              Question: ${input}`,
   });
+  console.log(text);
+}
+
+main().catch(console.error);
+```
+
+## Using Upstash Search
+
+For production applications, you'll want to persist your data in a searchable database. [Upstash Search](https://upstash.com/docs/search) provides a search solution that combines input enrichment, reranking, semantic search, full-text search for more accurate results:
+
+```ts
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { Search } from '@upstash/search';
+
+dotenv.config();
+
+type ChunkContent = {
+  text: string;
+  section: string;
+};
+
+// Initialize Upstash Search client
+const search = new Search({
+  url: process.env.UPSTASH_SEARCH_REST_URL!,
+  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
+});
+
+const index = search.index<ChunkContent>('essay-chunks');
+
+async function main() {
+  const essay = fs.readFileSync(path.join(__dirname, 'essay.txt'), 'utf8');
+  const chunks = essay
+    .split('.')
+    .map(chunk => chunk.trim())
+    .filter(chunk => chunk.length > 0 && chunk !== '\n');
+
+  // Upsert chunks to Upstash Search
+  await index.upsert(
+    chunks.map((chunk, i) => ({
+      id: `chunk-${i}`,
+      content: {
+        text: chunk,
+        section: `section-${Math.floor(i / 10)}`, // Group chunks into sections
+      },
+    }))
+  );
+
+  const input =
+    'What were the two main things the author worked on before college?';
+
+  // Search for relevant context using hybrid search
+  const results = await index.search({
+    query: input,
+    limit: 3,
+    reranking: true,
+  });
+
+  const context = results.hits
+    .map(hit => hit.data?.text)
+    .filter(Boolean)
+    .join('\n');
+
+  const { text } = await generateText({
+    model: openai('gpt-4o'),
+    prompt: `Answer the following question based only on the provided context:
+             ${context}
+
+             Question: ${input}`,
+  });
+  
   console.log(text);
 }
 

--- a/content/cookbook/05-node/101-knowledge-base-agent.mdx
+++ b/content/cookbook/05-node/101-knowledge-base-agent.mdx
@@ -1,16 +1,16 @@
 ---
 title: Knowledge Base Agent
-description: Build an AI agent that can read from and write to a knowledge base using Upstash Search and AI SDK tools
+description: Build an AI agent that can read from and write to a knowledge base using Upstash Search and the AI SDK
 tags: ['node', 'retrieval', 'tools']
 ---
 
-In this cookbook, you'll learn how to build an AI agent that can interact with a knowledge base using [Upstash Search](https://upstash.com/docs/search). The agent will be able to both retrieve information from the knowledge base and add new resources to it, leveraging AI SDK tools.
+In this recipe, you'll learn how to build an AI agent that can interact with a knowledge base using [Upstash Search](https://upstash.com/docs/search). The agent will be able to both retrieve information from the knowledge base and add new resources to it, leveraging AI SDK tools.
 
 Upstash Search offers input enrichment, reranking, semantic search, and full-text search for highly accurate results. It also provides a built-in embedding service, eliminating the need for a separate embedding provider. This makes it convenient for building and managing simple knowledge bases.
 
 This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as input data (`essay.txt`).
 
-For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot), which shows you how to build a RAG chatbot with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/), and [Postgres](https://postgresql.org).
+For a more in-depth guide, check out the [RAG Agent Guide](/docs/guides/rag-chatbot), which shows you how to build a RAG Agent with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/), and [Postgres](https://postgresql.org).
 
 ## Getting Started
 
@@ -21,17 +21,38 @@ UPSTASH_SEARCH_REST_URL="***"
 UPSTASH_SEARCH_REST_TOKEN="***"
 ```
 
+## Project Setup
+
+Create a new empty directory for your project and initialize pnpm:
+
+```bash
+mkdir knowledge-base-agent
+cd knowledge-base-agent
+pnpm init
+```
+
+Install the AI SDK, OpenAI provider, Upstash Search packages, and tsx as a dev dependency:
+
+```bash
+pnpm i ai zod @ai-sdk/openai @upstash/search
+pnpm i -D tsx
+```
+
+Finally, download and save the input essay:
+
+```bash
+curl -o essay.txt https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt
+```
+
 ## Setting Up the Knowledge Base
 
-Next, let's set up the initial knowledge base by reading a file and uploading its content to Upstash Search. Create a script called `setup-knowledge-base.ts`:
+Next, let's set up the initial knowledge base by reading a file and uploading its content to Upstash Search. Create a script called `setup.ts`:
 
-```ts
+```ts filename="setup.ts"
 import fs from 'fs';
 import path from 'path';
-import dotenv from 'dotenv';
+import 'dotenv/config';
 import { Search } from '@upstash/search';
-
-dotenv.config();
 
 type KnowledgeContent = {
   text: string;
@@ -69,7 +90,9 @@ async function setupKnowledgeBase() {
       },
     }));
     await index.upsert(batch);
-    console.log(`Upserted ${Math.min(i + batch.length, chunks.length)} chunks out of ${chunks.length} chunks`);
+    console.log(
+      `Upserted ${Math.min(i + batch.length, chunks.length)} chunks out of ${chunks.length} chunks`,
+    );
   }
 }
 
@@ -77,65 +100,53 @@ async function setupKnowledgeBase() {
 setupKnowledgeBase().catch(console.error);
 ```
 
-If you navigate to the Upstash Console and check the data browser of your Search database, you will see that the essay has been indexed.
+Run the setup script to populate your knowledge base:
+
+```bash
+pnpm tsx setup.ts
+```
+
+Navigate to the Upstash Console and check the data browser of your Search database. You should see the essay has been indexed.
 
 ## Building the Knowledge Base Agent
 
-Now let's create an AI agent that can interact with this knowledge base using tools. Create a new file called `knowledge-base-agent.ts`:
+Now let's create an agent that can interact with this knowledge base. Create a new file called `agent.ts`:
 
-```ts
+```ts filename="agent.ts"
 import { openai } from '@ai-sdk/openai';
-import {
-  tool,
-  stepCountIs,
-  convertToModelMessages,
-  type UIMessage,
-  generateText,
-} from 'ai';
+import { tool, stepCountIs, generateText, generateId } from 'ai';
 import { z } from 'zod';
 import { Search } from '@upstash/search';
-import { randomUUID } from 'crypto';
 
-// Initialize Upstash Search
-import dotenv from 'dotenv';
-
-dotenv.config();
+import 'dotenv/config';
 
 const search = new Search({
   url: process.env.UPSTASH_SEARCH_REST_URL!,
   token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
 });
+
 const index = search.index('knowledge-base');
 
-type KnowledgeContent = {
-  text: string;
-  section: string;
-  title?: string;
-};
-
 async function main(prompt: string) {
-  const messages: UIMessage[] = [{
-    id: "user-prompt",
-    role: "user",
-    parts: [{
-      type: "text",
-      text: prompt
-    }]
-  }];
-
   const { text } = await generateText({
     model: openai('gpt-4o'),
-    messages: convertToModelMessages(messages),
+    prompt,
     stopWhen: stepCountIs(5),
     tools: {
       addResource: tool({
-        description: 'Add a new resource or piece of information to the knowledge base',
+        description:
+          'Add a new resource or piece of information to the knowledge base',
         inputSchema: z.object({
-          resource: z.string().describe('The content or resource to add to the knowledge base'),
-          title: z.string().optional().describe('Optional title for the resource'),
+          resource: z
+            .string()
+            .describe('The content or resource to add to the knowledge base'),
+          title: z
+            .string()
+            .optional()
+            .describe('Optional title for the resource'),
         }),
         execute: async ({ resource, title }) => {
-          const id = randomUUID();
+          const id = generateId();
           await index.upsert({
             id,
             content: {
@@ -147,12 +158,17 @@ async function main(prompt: string) {
           return `Successfully added resource "${title || 'Untitled'}" to knowledge base with ID: ${id}`;
         },
       }),
-
       searchKnowledge: tool({
-        description: 'Search the knowledge base to find relevant information for answering questions',
+        description:
+          'Search the knowledge base to find relevant information for answering questions',
         inputSchema: z.object({
-          query: z.string().describe('The search query to find relevant information'),
-          limit: z.number().optional().describe('Maximum number of results to return (default: 3)'),
+          query: z
+            .string()
+            .describe('The search query to find relevant information'),
+          limit: z
+            .number()
+            .optional()
+            .describe('Maximum number of results to return (default: 3)'),
         }),
         execute: async ({ query, limit = 3 }) => {
           const results = await index.search({
@@ -165,7 +181,7 @@ async function main(prompt: string) {
             return 'No relevant information found in the knowledge base.';
           }
 
-          const formattedResults = results.map((hit, i) => ({
+          return results.map((hit, i) => ({
             resourceId: hit.id,
             rank: i + 1,
             title: hit.content.title || 'Untitled',
@@ -173,11 +189,8 @@ async function main(prompt: string) {
             section: hit.content.section || 'unknown',
             score: hit.score,
           }));
-
-          return JSON.stringify(formattedResults, null, 2);
         },
       }),
-
       deleteResource: tool({
         description: 'Delete a resource from the knowledge base',
         inputSchema: z.object({
@@ -193,14 +206,30 @@ async function main(prompt: string) {
         },
       }),
     },
+    // log out intermediate steps
+    onStepFinish: ({ toolResults }) => {
+      if (toolResults.length > 0) {
+        console.log('Tool results:');
+        console.dir(toolResults, { depth: null });
+      }
+    },
   });
 
   return text;
 }
 
-const question = "What are the two main things I worked on before college? (utilize knowledge base)";
+const question =
+  'What are the two main things I worked on before college? (utilize knowledge base)';
 
 main(question).then(console.log).catch(console.error);
+```
+
+## Running the Agent
+
+Now let's run the agent:
+
+```bash
+pnpm tsx agent.ts
 ```
 
 The agent will utilize the knowledge base to answer questions, add new resources, and delete existing ones as needed. You can modify the `question` variable to test different queries and interactions with the knowledge base.

--- a/content/cookbook/05-node/101-knowledge-base-agent.mdx
+++ b/content/cookbook/05-node/101-knowledge-base-agent.mdx
@@ -1,0 +1,199 @@
+---
+title: Knowledge Base Agent
+description: Build an AI agent that can read from and write to a knowledge base using Upstash Search and AI SDK tools
+tags: ['node', 'retrieval', 'tools']
+---
+
+In this cookbook, you'll learn how to build an AI agent that can interact with a knowledge base using [Upstash Search](https://upstash.com/docs/search). The agent will be able to both retrieve information from the knowledge base and add new resources to it, leveraging AI SDK tools.
+
+Upstash Search offers input enrichment, reranking, semantic search, and full-text search for highly accurate results. It also provides a built-in embedding service, eliminating the need for a separate embedding provider. This makes it convenient for building and managing simple knowledge bases.
+
+This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as an input (`essay.txt`).
+
+For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot) which will show you how to build a RAG chatbot with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/) and [Postgres](https://postgresql.org).
+
+## Getting Started
+
+First, install the necessary dependencies. You can use the following command to install them:
+
+```bash
+pnpm install @upstash/search @ai-sdk/openai ai zod dotenv
+```
+
+Next, create an Uptash Search database on [Upstash Console](https://console.upstash.com/search). Once created, you will get a REST URL and a token. Set these in your environment variables:
+
+```bash
+UPSTASH_SEARCH_REST_URL="***"
+UPSTASH_SEARCH_REST_TOKEN="***"
+```
+
+## Setting Up the Knowledge Base
+
+Next, let's set up the initial knowledge base by reading a file and uploading its content to Upstash Search:
+
+```ts
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import { Search } from '@upstash/search';
+
+dotenv.config();
+
+type KnowledgeContent = {
+  text: string;
+  section: string;
+  title?: string;
+};
+
+// Initialize Upstash Search client
+const search = new Search({
+  url: process.env.UPSTASH_SEARCH_REST_URL!,
+  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
+});
+
+const index = search.index<KnowledgeContent>('knowledge-base');
+
+async function setupKnowledgeBase() {
+  // Read and process the source file
+  const content = fs.readFileSync(path.join(__dirname, 'essay.txt'), 'utf8');
+
+  // Split content into meaningful chunks
+  const chunks = content
+    .split(/\n\s*\n/) // Split by double line breaks (paragraphs)
+    .map(chunk => chunk.trim())
+    .filter(chunk => chunk.length > 50) // Only keep substantial chunks
+
+  // Upload chunks to Upstash Search in batches of 100
+  const batchSize = 100;
+  for (let i = 0; i < chunks.length; i += batchSize) {
+    const batch = chunks.slice(i, i + batchSize).map((chunk, j) => ({
+      id: `chunk-${i + j}`,
+      content: {
+        text: chunk,
+        section: `section-${Math.floor((i + j) / 10)}`,
+        title: chunk.split('\n')[0] || `Chunk ${i + j + 1}`,
+      },
+    }));
+    await index.upsert(batch);
+    console.log(`Upserted ${Math.min(i + batch.length, chunks.length)} chunks out of ${chunks.length} chunks`);
+  }
+}
+
+// Run setup
+setupKnowledgeBase().catch(console.error);
+```
+
+## Building the Knowledge Base Agent
+
+Now let's create an AI agent that can interact with this knowledge base using tools:
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import {
+  streamText,
+  tool,
+  stepCountIs,
+  convertToModelMessages,
+  type UIMessage,
+} from 'ai';
+import { z } from 'zod';
+import { Search } from '@upstash/search';
+import { randomUUID } from 'crypto';
+
+// Initialize Upstash Search
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const search = new Search({
+  url: process.env.UPSTASH_SEARCH_REST_URL!,
+  token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
+});
+const index = search.index('knowledge-base');
+
+type KnowledgeContent = {
+  text: string;
+  section: string;
+  title?: string;
+};
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    messages: convertToModelMessages(messages),
+    stopWhen: stepCountIs(5),
+    tools: {
+      addResource: tool({
+        description: 'Add a new resource or piece of information to the knowledge base',
+        inputSchema: z.object({
+          resource: z.string().describe('The content or resource to add to the knowledge base'),
+          title: z.string().optional().describe('Optional title for the resource'),
+        }),
+        execute: async ({ resource, title }) => {
+          const id = randomUUID();
+          await index.upsert({
+            id,
+            content: {
+              text: resource,
+              section: 'user-added',
+              title: title || `Resource ${id.slice(0, 8)}`,
+            },
+          });
+          return `Successfully added resource "${title || 'Untitled'}" to knowledge base with ID: ${id}`;
+        },
+      }),
+
+      searchKnowledge: tool({
+        description: 'Search the knowledge base to find relevant information for answering questions',
+        inputSchema: z.object({
+          query: z.string().describe('The search query to find relevant information'),
+          limit: z.number().optional().describe('Maximum number of results to return (default: 3)'),
+        }),
+        execute: async ({ query, limit = 3 }) => {
+          const results = await index.search({
+            query,
+            limit,
+            reranking: true,
+          });
+
+          if (results.length === 0) {
+            return 'No relevant information found in the knowledge base.';
+          }
+
+          const formattedResults = results.map((hit, i) => ({
+            resourceId: hit.id,
+            rank: i + 1,
+            title: hit.content.title || 'Untitled',
+            content: hit.content.text || '',
+            section: hit.content.section || 'unknown',
+            score: hit.score,
+          }));
+
+          return JSON.stringify(formattedResults, null, 2);
+        },
+      }),
+
+      deleteResource: tool({
+        description: 'Delete a resource from the knowledge base',
+        inputSchema: z.object({
+          resourceId: z.string().describe('The ID of the resource to delete'),
+        }),
+        execute: async ({ resourceId }) => {
+          try {
+            await index.delete({ ids: [resourceId] });
+            return `Successfully deleted resource with ID: ${resourceId}`;
+          } catch (error) {
+            return `Failed to delete resource: ${error instanceof Error ? error.message : 'Unknown error'}`;
+          }
+        },
+      }),
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+For example, if you prompt the agent with "What are the two main things I worked on before college? (utilize knowledge base)", it will accurately answer by retrieving relevant information from the knowledge base.

--- a/content/cookbook/05-node/101-knowledge-base-agent.mdx
+++ b/content/cookbook/05-node/101-knowledge-base-agent.mdx
@@ -20,7 +20,7 @@ First, install the necessary dependencies. You can use the following command to 
 pnpm install @upstash/search @ai-sdk/openai ai zod dotenv
 ```
 
-Next, create an Uptash Search database on [Upstash Console](https://console.upstash.com/search). Once created, you will get a REST URL and a token. Set these in your environment variables:
+Next, create an Upstash Search database on [Upstash Console](https://console.upstash.com/search). Once created, you will get a REST URL and a token. Set these in your environment variables:
 
 ```bash
 UPSTASH_SEARCH_REST_URL="***"

--- a/content/cookbook/05-node/101-knowledge-base-agent.mdx
+++ b/content/cookbook/05-node/101-knowledge-base-agent.mdx
@@ -8,19 +8,13 @@ In this cookbook, you'll learn how to build an AI agent that can interact with a
 
 Upstash Search offers input enrichment, reranking, semantic search, and full-text search for highly accurate results. It also provides a built-in embedding service, eliminating the need for a separate embedding provider. This makes it convenient for building and managing simple knowledge bases.
 
-This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as an input (`essay.txt`).
+This example uses [the following essay](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt) as input data (`essay.txt`).
 
-For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot) which will show you how to build a RAG chatbot with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/) and [Postgres](https://postgresql.org).
+For a more in-depth guide, check out the [RAG Chatbot Guide](/docs/guides/rag-chatbot), which shows you how to build a RAG chatbot with [Next.js](https://nextjs.org), [Drizzle ORM](https://orm.drizzle.team/), and [Postgres](https://postgresql.org).
 
 ## Getting Started
 
-First, install the necessary dependencies. You can use the following command to install them:
-
-```bash
-pnpm install @upstash/search @ai-sdk/openai ai zod dotenv
-```
-
-Next, create an Upstash Search database on [Upstash Console](https://console.upstash.com/search). Once created, you will get a REST URL and a token. Set these in your environment variables:
+Create an Upstash Search database on [Upstash Console](https://console.upstash.com/search). Once created, you will get a REST URL and a token. Set these in your environment variables:
 
 ```bash
 UPSTASH_SEARCH_REST_URL="***"
@@ -29,7 +23,7 @@ UPSTASH_SEARCH_REST_TOKEN="***"
 
 ## Setting Up the Knowledge Base
 
-Next, let's set up the initial knowledge base by reading a file and uploading its content to Upstash Search:
+Next, let's set up the initial knowledge base by reading a file and uploading its content to Upstash Search. Create a script called `setup-knowledge-base.ts`:
 
 ```ts
 import fs from 'fs';
@@ -61,7 +55,7 @@ async function setupKnowledgeBase() {
   const chunks = content
     .split(/\n\s*\n/) // Split by double line breaks (paragraphs)
     .map(chunk => chunk.trim())
-    .filter(chunk => chunk.length > 50) // Only keep substantial chunks
+    .filter(chunk => chunk.length > 50); // Only keep substantial chunks
 
   // Upload chunks to Upstash Search in batches of 100
   const batchSize = 100;
@@ -83,18 +77,20 @@ async function setupKnowledgeBase() {
 setupKnowledgeBase().catch(console.error);
 ```
 
+If you navigate to the Upstash Console and check the data browser of your Search database, you will see that the essay has been indexed.
+
 ## Building the Knowledge Base Agent
 
-Now let's create an AI agent that can interact with this knowledge base using tools:
+Now let's create an AI agent that can interact with this knowledge base using tools. Create a new file called `knowledge-base-agent.ts`:
 
 ```ts
 import { openai } from '@ai-sdk/openai';
 import {
-  streamText,
   tool,
   stepCountIs,
   convertToModelMessages,
   type UIMessage,
+  generateText,
 } from 'ai';
 import { z } from 'zod';
 import { Search } from '@upstash/search';
@@ -117,10 +113,17 @@ type KnowledgeContent = {
   title?: string;
 };
 
-export async function POST(req: Request) {
-  const { messages }: { messages: UIMessage[] } = await req.json();
+async function main(prompt: string) {
+  const messages: UIMessage[] = [{
+    id: "user-prompt",
+    role: "user",
+    parts: [{
+      type: "text",
+      text: prompt
+    }]
+  }];
 
-  const result = streamText({
+  const { text } = await generateText({
     model: openai('gpt-4o'),
     messages: convertToModelMessages(messages),
     stopWhen: stepCountIs(5),
@@ -192,8 +195,12 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  return text;
 }
+
+const question = "What are the two main things I worked on before college? (utilize knowledge base)";
+
+main(question).then(console.log).catch(console.error);
 ```
 
-For example, if you prompt the agent with "What are the two main things I worked on before college? (utilize knowledge base)", it will accurately answer by retrieving relevant information from the knowledge base.
+The agent will utilize the knowledge base to answer questions, add new resources, and delete existing ones as needed. You can modify the `question` variable to test different queries and interactions with the knowledge base.

--- a/content/cookbook/05-node/101-knowledge-base-agent.mdx
+++ b/content/cookbook/05-node/101-knowledge-base-agent.mdx
@@ -125,7 +125,13 @@ const search = new Search({
   token: process.env.UPSTASH_SEARCH_REST_TOKEN!,
 });
 
-const index = search.index('knowledge-base');
+type KnowledgeContent = {
+  text: string;
+  section: string;
+  title?: string;
+};
+
+const index = search.index<KnowledgeContent>('knowledge-base');
 
 async function main(prompt: string) {
   const { text } = await generateText({


### PR DESCRIPTION
## Background

We would love to include Upstash Search in RAG examples in AI SDK docs.

With Upstash Search, you can:
- Create a database with a single click
- Upsert/Query text directly, without an external embedding service
- Use built-in input enrichment, reranking, semantic search, full text search

## Summary

Added knowledge base agent which uses Upstash Search.

In the guide, we upsert some initial data to the knowledge base. Then we define an agent which uses this knowledge base.

## Tasks

- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

