### PR TITLE
fix: HITL example infinite loop

### DIFF
--- a/examples/next-openai/app/api/use-chat-human-in-the-loop/route.ts
+++ b/examples/next-openai/app/api/use-chat-human-in-the-loop/route.ts
@@ -18,6 +18,7 @@ export async function POST(req: Request) {
     await req.json();
 
   const stream = createUIMessageStream({
+    originalMessages: messages,
     execute: async ({ writer }) => {
       // Utility function to handle tools that require human confirmation
       // Checks for confirmation in last message and then runs associated tool
@@ -48,6 +49,10 @@ export async function POST(req: Request) {
       writer.merge(
         result.toUIMessageStream({ originalMessages: processedMessages }),
       );
+    },
+    onFinish: ({}) => {
+      // save messages here
+      console.log('Finished!');
     },
   });
 

--- a/examples/next-openai/app/use-chat-human-in-the-loop/page.tsx
+++ b/examples/next-openai/app/use-chat-human-in-the-loop/page.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import {
-  DefaultChatTransport,
-  getToolName,
-  isToolUIPart,
-  lastAssistantMessageIsCompleteWithToolCalls,
-} from 'ai';
+import { DefaultChatTransport, getToolName, isToolUIPart } from 'ai';
 import { tools } from '../api/use-chat-human-in-the-loop/tools';
 import {
   APPROVAL,
@@ -25,7 +20,6 @@ export default function Chat() {
       transport: new DefaultChatTransport({
         api: '/api/use-chat-human-in-the-loop',
       }),
-      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     });
 
   const toolsRequiringConfirmation = getToolsRequiringConfirmation(tools);
@@ -75,6 +69,8 @@ export default function Chat() {
                             tool: toolName,
                             output: APPROVAL.YES,
                           });
+                          // trigger new message
+                          // can also use sendAutomaticallyWhen on useChat
                           sendMessage();
                         }}
                       >
@@ -88,6 +84,8 @@ export default function Chat() {
                             tool: toolName,
                             output: APPROVAL.NO,
                           });
+                          // trigger new message
+                          // can also use sendAutomaticallyWhen on useChat
                           sendMessage();
                         }}
                       >
@@ -105,6 +103,9 @@ export default function Chat() {
                       ? 'ed'
                       : 'ing'}{' '}
                     {toolName}
+                    {part.output && (
+                      <div>{JSON.stringify(part.output, null, 2)}</div>
+                    )}
                   </div>
                 </div>
               );


### PR DESCRIPTION
Fixes #7635.

Had two issues: 
- needed `originalMessages` passed into the UIMessageStream 
- removed the `sendAutomaticallyWhen` as we are already triggering a new message with `sendMessage` in the click handlers.