### PR TITLE
feat(ai): add reasoning text to generateObject result

### DIFF
--- a/.changeset/olive-dolls-buy.md
+++ b/.changeset/olive-dolls-buy.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add reasoning text to generateObject result

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -207,6 +207,41 @@ const { object } = await generateObject({
 });
 ```
 
+## Accessing Reasoning
+
+You can access the reasoning used by the language model to generate the object via the `reasoning` property on the result. This property contains a string with the model's thought process, if available.
+
+```ts
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { generateObject } from 'ai';
+import { z } from 'zod/v4';
+
+const result = await generateObject({
+  model: openai('gpt-5'),
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(
+        z.object({
+          name: z.string(),
+          amount: z.string(),
+        }),
+      ),
+      steps: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate a lasagna recipe.',
+  providerOptions: {
+    openai: {
+      strictJsonSchema: true,
+      reasoningSummary: 'detailed',
+    } satisfies OpenAIResponsesProviderOptions,
+  },
+});
+
+console.log(result.reasoning);
+```
+
 ## Error Handling
 
 When `generateObject` cannot generate a valid object, it throws a [`AI_NoObjectGeneratedError`](/docs/reference/ai-sdk-errors/ai-no-object-generated-error).

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -681,6 +681,12 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
       ],
     },
     {
+      name: 'reasoning',
+      type: 'string | undefined',
+      description:
+        'The reasoning that was used to generate the object. Concatenated from all reasoning parts.',
+    },
+    {
       name: 'warnings',
       type: 'CallWarning[] | undefined',
       description:

--- a/examples/ai-core/src/generate-object/openai-reasoning.ts
+++ b/examples/ai-core/src/generate-object/openai-reasoning.ts
@@ -1,11 +1,11 @@
-import { openai } from '@ai-sdk/openai';
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod/v4';
 
 async function main() {
   const result = await generateObject({
-    model: openai('o1'),
+    model: openai('gpt-5'),
     schema: z.object({
       recipe: z.object({
         name: z.string(),
@@ -19,10 +19,16 @@ async function main() {
       }),
     }),
     prompt: 'Generate a lasagna recipe.',
+    providerOptions: {
+      openai: {
+        strictJsonSchema: true,
+        reasoningSummary: 'detailed',
+      } satisfies OpenAIResponsesProviderOptions,
+    },
   });
 
+  console.log(result.reasoning);
   console.log(JSON.stringify(result.object.recipe, null, 2));
-  console.log();
   console.log('Token usage:', result.usage);
   console.log('Finish reason:', result.finishReason);
 }

--- a/packages/ai/src/generate-object/__snapshots__/generate-object.test.ts.snap
+++ b/packages/ai/src/generate-object/__snapshots__/generate-object.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`telemetry > should not record telemetry inputs / outputs when disabled 1`] = `
+exports[`generateObject > telemetry > should not record telemetry inputs / outputs when disabled 1`] = `
 [
   {
     "attributes": {
@@ -46,7 +46,7 @@ exports[`telemetry > should not record telemetry inputs / outputs when disabled 
 ]
 `;
 
-exports[`telemetry > should record telemetry data when enabled 1`] = `
+exports[`generateObject > telemetry > should record telemetry data when enabled 1`] = `
 [
   {
     "attributes": {

--- a/packages/ai/src/generate-object/generate-object-result.ts
+++ b/packages/ai/src/generate-object/generate-object-result.ts
@@ -17,6 +17,12 @@ export interface GenerateObjectResult<OBJECT> {
   readonly object: OBJECT;
 
   /**
+   * The reasoning that was used to generate the object.
+   * Concatenated from all reasoning parts.
+   */
+  readonly reasoning: string | undefined;
+
+  /**
   The reason why the generation finished.
      */
   readonly finishReason: FinishReason;

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -1026,4 +1026,36 @@ describe('generateObject', () => {
       expect(supportedUrlsCalled).toBe(true);
     });
   });
+
+  describe('reasoning', () => {
+    it('should include reasoning in the result', async () => {
+      const model = new MockLanguageModelV2({
+        doGenerate: async () => ({
+          ...dummyResponseValues,
+          content: [
+            { type: 'reasoning', text: 'This is a test reasoning.' },
+            { type: 'reasoning', text: 'This is another test reasoning.' },
+            { type: 'text', text: '{ "content": "Hello, world!" }' },
+          ],
+        }),
+      });
+
+      const result = await generateObject({
+        model,
+        schema: z.object({ content: z.string() }),
+        prompt: 'prompt',
+      });
+
+      expect(result.reasoning).toMatchInlineSnapshot(`
+        "This is a test reasoning.
+        This is another test reasoning."
+      `);
+
+      expect(result.object).toMatchInlineSnapshot(`
+        {
+          "content": "Hello, world!",
+        }
+      `);
+    });
+  });
 });

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -21,27 +21,28 @@ const dummyResponseValues = {
   warnings: [],
 };
 
-describe('output = "object"', () => {
-  describe('result.object', () => {
-    it('should generate object', async () => {
-      const model = new MockLanguageModelV2({
-        doGenerate: {
-          ...dummyResponseValues,
-          content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-        },
-      });
-      const result = await generateObject({
-        model,
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-      });
+describe('generateObject', () => {
+  describe('output = "object"', () => {
+    describe('result.object', () => {
+      it('should generate object', async () => {
+        const model = new MockLanguageModelV2({
+          doGenerate: {
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
+          },
+        });
+        const result = await generateObject({
+          model,
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+        });
 
-      expect(result.object).toMatchInlineSnapshot(`
+        expect(result.object).toMatchInlineSnapshot(`
         {
           "content": "Hello, world!",
         }
       `);
-      expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
+        expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -55,7 +56,7 @@ describe('output = "object"', () => {
           },
         ]
       `);
-      expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
+        expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
         {
           "description": undefined,
           "name": undefined,
@@ -75,133 +76,137 @@ describe('output = "object"', () => {
           "type": "json",
         }
       `);
+      });
+
+      it('should use name and description', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV2({
+            doGenerate: async ({ prompt, responseFormat }) => {
+              expect(responseFormat).toStrictEqual({
+                type: 'json',
+                name: 'test-name',
+                description: 'test description',
+                schema: {
+                  $schema: 'http://json-schema.org/draft-07/schema#',
+                  additionalProperties: false,
+                  properties: { content: { type: 'string' } },
+                  required: ['content'],
+                  type: 'object',
+                },
+              });
+
+              expect(prompt).toStrictEqual([
+                {
+                  role: 'user',
+                  content: [{ type: 'text', text: 'prompt' }],
+                  providerOptions: undefined,
+                },
+              ]);
+
+              return {
+                ...dummyResponseValues,
+                content: [
+                  { type: 'text', text: '{ "content": "Hello, world!" }' },
+                ],
+              };
+            },
+          }),
+          schema: z.object({ content: z.string() }),
+          schemaName: 'test-name',
+          schemaDescription: 'test description',
+          prompt: 'prompt',
+        });
+
+        assert.deepStrictEqual(result.object, { content: 'Hello, world!' });
+      });
     });
 
-    it('should use name and description', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async ({ prompt, responseFormat }) => {
-            expect(responseFormat).toStrictEqual({
-              type: 'json',
-              name: 'test-name',
-              description: 'test description',
-              schema: {
-                $schema: 'http://json-schema.org/draft-07/schema#',
-                additionalProperties: false,
-                properties: { content: { type: 'string' } },
-                required: ['content'],
-                type: 'object',
-              },
-            });
-
-            expect(prompt).toStrictEqual([
-              {
-                role: 'user',
-                content: [{ type: 'text', text: 'prompt' }],
-                providerOptions: undefined,
-              },
-            ]);
-
-            return {
+    describe('result.request', () => {
+      it('should contain request information', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV2({
+            doGenerate: async () => ({
               ...dummyResponseValues,
               content: [
                 { type: 'text', text: '{ "content": "Hello, world!" }' },
               ],
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        schemaName: 'test-name',
-        schemaDescription: 'test description',
-        prompt: 'prompt',
-      });
-
-      assert.deepStrictEqual(result.object, { content: 'Hello, world!' });
-    });
-  });
-
-  describe('result.request', () => {
-    it('should contain request information', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async () => ({
-            ...dummyResponseValues,
-            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-            request: {
-              body: 'test body',
-            },
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-      });
-
-      expect(result.request).toStrictEqual({
-        body: 'test body',
-      });
-    });
-  });
-
-  describe('result.response', () => {
-    it('should contain response information', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async () => ({
-            ...dummyResponseValues,
-            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-            response: {
-              id: 'test-id-from-model',
-              timestamp: new Date(10000),
-              modelId: 'test-response-model-id',
-              headers: {
-                'custom-response-header': 'response-header-value',
+              request: {
+                body: 'test body',
               },
-              body: 'test body',
-            },
+            }),
           }),
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-      });
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+        });
 
-      expect(result.response).toStrictEqual({
-        id: 'test-id-from-model',
-        timestamp: new Date(10000),
-        modelId: 'test-response-model-id',
-        headers: {
-          'custom-response-header': 'response-header-value',
-        },
-        body: 'test body',
+        expect(result.request).toStrictEqual({
+          body: 'test body',
+        });
       });
     });
-  });
 
-  describe('zod schema', () => {
-    it('should generate object when using zod transform', async () => {
-      const model = new MockLanguageModelV2({
-        doGenerate: {
-          ...dummyResponseValues,
-          content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-        },
+    describe('result.response', () => {
+      it('should contain response information', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV2({
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [
+                { type: 'text', text: '{ "content": "Hello, world!" }' },
+              ],
+              response: {
+                id: 'test-id-from-model',
+                timestamp: new Date(10000),
+                modelId: 'test-response-model-id',
+                headers: {
+                  'custom-response-header': 'response-header-value',
+                },
+                body: 'test body',
+              },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+        });
+
+        expect(result.response).toStrictEqual({
+          id: 'test-id-from-model',
+          timestamp: new Date(10000),
+          modelId: 'test-response-model-id',
+          headers: {
+            'custom-response-header': 'response-header-value',
+          },
+          body: 'test body',
+        });
       });
+    });
 
-      const result = await generateObject({
-        model,
-        schema: z.object({
-          content: z
-            .string()
-            .transform(value => value.length)
-            .pipe(z.number()),
-        }),
-        prompt: 'prompt',
-      });
+    describe('zod schema', () => {
+      it('should generate object when using zod transform', async () => {
+        const model = new MockLanguageModelV2({
+          doGenerate: {
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
+          },
+        });
 
-      expect(result.object).toMatchInlineSnapshot(`
+        const result = await generateObject({
+          model,
+          schema: z.object({
+            content: z
+              .string()
+              .transform(value => value.length)
+              .pipe(z.number()),
+          }),
+          prompt: 'prompt',
+        });
+
+        expect(result.object).toMatchInlineSnapshot(`
         {
           "content": 13,
         }
       `);
-      expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
+        expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -215,7 +220,7 @@ describe('output = "object"', () => {
           },
         ]
       `);
-      expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
+        expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
         {
           "description": undefined,
           "name": undefined,
@@ -235,33 +240,33 @@ describe('output = "object"', () => {
           "type": "json",
         }
       `);
-    });
-
-    it('should generate object when using zod prePreprocess', async () => {
-      const model = new MockLanguageModelV2({
-        doGenerate: {
-          ...dummyResponseValues,
-          content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-        },
       });
 
-      const result = await generateObject({
-        model,
-        schema: z.object({
-          content: z.preprocess(
-            val => (typeof val === 'number' ? String(val) : val),
-            z.string(),
-          ),
-        }),
-        prompt: 'prompt',
-      });
+      it('should generate object when using zod prePreprocess', async () => {
+        const model = new MockLanguageModelV2({
+          doGenerate: {
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
+          },
+        });
 
-      expect(result.object).toMatchInlineSnapshot(`
+        const result = await generateObject({
+          model,
+          schema: z.object({
+            content: z.preprocess(
+              val => (typeof val === 'number' ? String(val) : val),
+              z.string(),
+            ),
+          }),
+          prompt: 'prompt',
+        });
+
+        expect(result.object).toMatchInlineSnapshot(`
         {
           "content": "Hello, world!",
         }
       `);
-      expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
+        expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -275,7 +280,7 @@ describe('output = "object"', () => {
           },
         ]
       `);
-      expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
+        expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
         {
           "description": undefined,
           "name": undefined,
@@ -295,35 +300,35 @@ describe('output = "object"', () => {
           "type": "json",
         }
       `);
+      });
     });
-  });
 
-  describe('custom schema', () => {
-    it('should generate object', async () => {
-      const model = new MockLanguageModelV2({
-        doGenerate: {
-          ...dummyResponseValues,
-          content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-        },
-      });
+    describe('custom schema', () => {
+      it('should generate object', async () => {
+        const model = new MockLanguageModelV2({
+          doGenerate: {
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
+          },
+        });
 
-      const result = await generateObject({
-        model,
-        schema: jsonSchema({
-          type: 'object',
-          properties: { content: { type: 'string' } },
-          required: ['content'],
-          additionalProperties: false,
-        }),
-        prompt: 'prompt',
-      });
+        const result = await generateObject({
+          model,
+          schema: jsonSchema({
+            type: 'object',
+            properties: { content: { type: 'string' } },
+            required: ['content'],
+            additionalProperties: false,
+          }),
+          prompt: 'prompt',
+        });
 
-      expect(result.object).toMatchInlineSnapshot(`
+        expect(result.object).toMatchInlineSnapshot(`
         {
           "content": "Hello, world!",
         }
       `);
-      expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
+        expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
         [
           {
             "content": [
@@ -337,7 +342,7 @@ describe('output = "object"', () => {
           },
         ]
       `);
-      expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
+        expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
         {
           "description": undefined,
           "name": undefined,
@@ -356,357 +361,364 @@ describe('output = "object"', () => {
           "type": "json",
         }
       `);
-    });
-  });
-
-  describe('result.toJsonResponse', () => {
-    it('should return JSON response', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async ({}) => ({
-            ...dummyResponseValues,
-            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-          }),
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
       });
-
-      const response = result.toJsonResponse();
-
-      assert.strictEqual(response.status, 200);
-      assert.strictEqual(
-        response.headers.get('Content-Type'),
-        'application/json; charset=utf-8',
-      );
-
-      assert.deepStrictEqual(
-        await convertReadableStreamToArray(
-          response.body!.pipeThrough(new TextDecoderStream()),
-        ),
-        ['{"content":"Hello, world!"}'],
-      );
     });
-  });
 
-  describe('result.providerMetadata', () => {
-    it('should contain provider metadata', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async ({}) => ({
-            ...dummyResponseValues,
-            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-            providerMetadata: {
-              exampleProvider: {
-                a: 10,
-                b: 20,
+    describe('result.toJsonResponse', () => {
+      it('should return JSON response', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV2({
+            doGenerate: async ({}) => ({
+              ...dummyResponseValues,
+              content: [
+                { type: 'text', text: '{ "content": "Hello, world!" }' },
+              ],
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+        });
+
+        const response = result.toJsonResponse();
+
+        assert.strictEqual(response.status, 200);
+        assert.strictEqual(
+          response.headers.get('Content-Type'),
+          'application/json; charset=utf-8',
+        );
+
+        assert.deepStrictEqual(
+          await convertReadableStreamToArray(
+            response.body!.pipeThrough(new TextDecoderStream()),
+          ),
+          ['{"content":"Hello, world!"}'],
+        );
+      });
+    });
+
+    describe('result.providerMetadata', () => {
+      it('should contain provider metadata', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV2({
+            doGenerate: async ({}) => ({
+              ...dummyResponseValues,
+              content: [
+                { type: 'text', text: '{ "content": "Hello, world!" }' },
+              ],
+              providerMetadata: {
+                exampleProvider: {
+                  a: 10,
+                  b: 20,
+                },
               },
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+        });
+
+        expect(result.providerMetadata).toStrictEqual({
+          exampleProvider: {
+            a: 10,
+            b: 20,
+          },
+        });
+      });
+    });
+
+    describe('options.headers', () => {
+      it('should pass headers to model', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV2({
+            doGenerate: async ({ headers }) => {
+              expect(headers).toStrictEqual({
+                'custom-request-header': 'request-header-value',
+              });
+
+              return {
+                ...dummyResponseValues,
+                content: [
+                  { type: 'text', text: '{ "content": "headers test" }' },
+                ],
+              };
             },
           }),
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-      });
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          headers: { 'custom-request-header': 'request-header-value' },
+        });
 
-      expect(result.providerMetadata).toStrictEqual({
-        exampleProvider: {
-          a: 10,
-          b: 20,
-        },
-      });
-    });
-  });
-
-  describe('options.headers', () => {
-    it('should pass headers to model', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async ({ headers }) => {
-            expect(headers).toStrictEqual({
-              'custom-request-header': 'request-header-value',
-            });
-
-            return {
-              ...dummyResponseValues,
-              content: [
-                { type: 'text', text: '{ "content": "headers test" }' },
-              ],
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-        headers: { 'custom-request-header': 'request-header-value' },
-      });
-
-      expect(result.object).toStrictEqual({ content: 'headers test' });
-    });
-  });
-
-  describe('options.repairText', () => {
-    it('should be able to repair a JSONParseError', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async ({}) => {
-            return {
-              ...dummyResponseValues,
-              content: [
-                {
-                  type: 'text',
-                  text: '{ "content": "provider metadata test" ',
-                },
-              ],
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-        experimental_repairText: async ({ text, error }) => {
-          expect(error).toBeInstanceOf(JSONParseError);
-          expect(text).toStrictEqual('{ "content": "provider metadata test" ');
-          return text + '}';
-        },
-      });
-
-      expect(result.object).toStrictEqual({
-        content: 'provider metadata test',
+        expect(result.object).toStrictEqual({ content: 'headers test' });
       });
     });
 
-    it('should be able to repair a TypeValidationError', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async ({}) => {
-            return {
-              ...dummyResponseValues,
-              content: [
-                {
-                  type: 'text',
-                  text: '{ "content-a": "provider metadata test" }',
-                },
-              ],
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-        experimental_repairText: async ({ text, error }) => {
-          expect(error).toBeInstanceOf(TypeValidationError);
-          expect(text).toStrictEqual(
-            '{ "content-a": "provider metadata test" }',
-          );
-          return `{ "content": "provider metadata test" }`;
-        },
-      });
-
-      expect(result.object).toStrictEqual({
-        content: 'provider metadata test',
-      });
-    });
-
-    it('should be able to handle repair that returns null', async () => {
-      const result = generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async ({}) => {
-            return {
-              ...dummyResponseValues,
-              content: [
-                {
-                  type: 'text',
-                  text: '{ "content-a": "provider metadata test" }',
-                },
-              ],
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-        experimental_repairText: async ({ text, error }) => {
-          expect(error).toBeInstanceOf(TypeValidationError);
-          expect(text).toStrictEqual(
-            '{ "content-a": "provider metadata test" }',
-          );
-          return null;
-        },
-      });
-
-      expect(result).rejects.toThrow(
-        'No object generated: response did not match schema.',
-      );
-    });
-  });
-
-  describe('options.providerOptions', () => {
-    it('should pass provider options to model', async () => {
-      const result = await generateObject({
-        model: new MockLanguageModelV2({
-          doGenerate: async ({ providerOptions }) => {
-            expect(providerOptions).toStrictEqual({
-              aProvider: { someKey: 'someValue' },
-            });
-
-            return {
-              ...dummyResponseValues,
-              content: [
-                {
-                  type: 'text',
-                  text: '{ "content": "provider metadata test" }',
-                },
-              ],
-            };
-          },
-        }),
-        schema: z.object({ content: z.string() }),
-        prompt: 'prompt',
-        providerOptions: {
-          aProvider: { someKey: 'someValue' },
-        },
-      });
-
-      expect(result.object).toStrictEqual({
-        content: 'provider metadata test',
-      });
-    });
-  });
-
-  describe('error handling', () => {
-    function verifyNoObjectGeneratedError(
-      error: unknown,
-      { message }: { message: string },
-    ) {
-      originalVerifyNoObjectGeneratedError(error, {
-        message,
-        response: {
-          id: 'id-1',
-          timestamp: new Date(123),
-          modelId: 'm-1',
-        },
-        usage: {
-          inputTokens: 10,
-          outputTokens: 20,
-          totalTokens: 30,
-          reasoningTokens: undefined,
-          cachedInputTokens: undefined,
-        },
-        finishReason: 'stop',
-      });
-    }
-
-    it('should throw NoObjectGeneratedError when schema validation fails', async () => {
-      try {
-        await generateObject({
+    describe('options.repairText', () => {
+      it('should be able to repair a JSONParseError', async () => {
+        const result = await generateObject({
           model: new MockLanguageModelV2({
-            doGenerate: async ({}) => ({
-              ...dummyResponseValues,
-              content: [{ type: 'text', text: '{ "content": 123 }' }],
-            }),
+            doGenerate: async ({}) => {
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text: '{ "content": "provider metadata test" ',
+                  },
+                ],
+              };
+            },
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
+          experimental_repairText: async ({ text, error }) => {
+            expect(error).toBeInstanceOf(JSONParseError);
+            expect(text).toStrictEqual(
+              '{ "content": "provider metadata test" ',
+            );
+            return text + '}';
+          },
         });
 
-        fail('must throw error');
-      } catch (error) {
-        verifyNoObjectGeneratedError(error, {
-          message: 'No object generated: response did not match schema.',
+        expect(result.object).toStrictEqual({
+          content: 'provider metadata test',
         });
-      }
-    });
+      });
 
-    it('should throw NoObjectGeneratedError when parsing fails', async () => {
-      try {
-        await generateObject({
+      it('should be able to repair a TypeValidationError', async () => {
+        const result = await generateObject({
           model: new MockLanguageModelV2({
-            doGenerate: async ({}) => ({
-              ...dummyResponseValues,
-              content: [{ type: 'text', text: '{ broken json' }],
-            }),
+            doGenerate: async ({}) => {
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text: '{ "content-a": "provider metadata test" }',
+                  },
+                ],
+              };
+            },
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
+          experimental_repairText: async ({ text, error }) => {
+            expect(error).toBeInstanceOf(TypeValidationError);
+            expect(text).toStrictEqual(
+              '{ "content-a": "provider metadata test" }',
+            );
+            return `{ "content": "provider metadata test" }`;
+          },
         });
 
-        fail('must throw error');
-      } catch (error) {
-        verifyNoObjectGeneratedError(error, {
-          message: 'No object generated: could not parse the response.',
+        expect(result.object).toStrictEqual({
+          content: 'provider metadata test',
         });
-      }
-    });
+      });
 
-    it('should throw NoObjectGeneratedError when parsing fails with repairResponse', async () => {
-      try {
-        await generateObject({
+      it('should be able to handle repair that returns null', async () => {
+        const result = generateObject({
           model: new MockLanguageModelV2({
-            doGenerate: async ({}) => ({
-              ...dummyResponseValues,
-              content: [{ type: 'text', text: '{ broken json' }],
-            }),
+            doGenerate: async ({}) => {
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text: '{ "content-a": "provider metadata test" }',
+                  },
+                ],
+              };
+            },
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_repairText: async ({ text }) => text + '{',
+          experimental_repairText: async ({ text, error }) => {
+            expect(error).toBeInstanceOf(TypeValidationError);
+            expect(text).toStrictEqual(
+              '{ "content-a": "provider metadata test" }',
+            );
+            return null;
+          },
         });
 
-        fail('must throw error');
-      } catch (error) {
-        verifyNoObjectGeneratedError(error, {
-          message: 'No object generated: could not parse the response.',
-        });
-      }
+        expect(result).rejects.toThrow(
+          'No object generated: response did not match schema.',
+        );
+      });
     });
 
-    it('should throw NoObjectGeneratedError when no text is available', async () => {
-      try {
-        await generateObject({
+    describe('options.providerOptions', () => {
+      it('should pass provider options to model', async () => {
+        const result = await generateObject({
           model: new MockLanguageModelV2({
-            doGenerate: async ({}) => ({
-              ...dummyResponseValues,
-              content: [],
-            }),
+            doGenerate: async ({ providerOptions }) => {
+              expect(providerOptions).toStrictEqual({
+                aProvider: { someKey: 'someValue' },
+              });
+
+              return {
+                ...dummyResponseValues,
+                content: [
+                  {
+                    type: 'text',
+                    text: '{ "content": "provider metadata test" }',
+                  },
+                ],
+              };
+            },
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
+          providerOptions: {
+            aProvider: { someKey: 'someValue' },
+          },
         });
 
-        fail('must throw error');
-      } catch (error) {
-        verifyNoObjectGeneratedError(error, {
-          message: 'No object generated: the model did not return a response.',
+        expect(result.object).toStrictEqual({
+          content: 'provider metadata test',
+        });
+      });
+    });
+
+    describe('error handling', () => {
+      function verifyNoObjectGeneratedError(
+        error: unknown,
+        { message }: { message: string },
+      ) {
+        originalVerifyNoObjectGeneratedError(error, {
+          message,
+          response: {
+            id: 'id-1',
+            timestamp: new Date(123),
+            modelId: 'm-1',
+          },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 20,
+            totalTokens: 30,
+            reasoningTokens: undefined,
+            cachedInputTokens: undefined,
+          },
+          finishReason: 'stop',
         });
       }
+
+      it('should throw NoObjectGeneratedError when schema validation fails', async () => {
+        try {
+          await generateObject({
+            model: new MockLanguageModelV2({
+              doGenerate: async ({}) => ({
+                ...dummyResponseValues,
+                content: [{ type: 'text', text: '{ "content": 123 }' }],
+              }),
+            }),
+            schema: z.object({ content: z.string() }),
+            prompt: 'prompt',
+          });
+
+          fail('must throw error');
+        } catch (error) {
+          verifyNoObjectGeneratedError(error, {
+            message: 'No object generated: response did not match schema.',
+          });
+        }
+      });
+
+      it('should throw NoObjectGeneratedError when parsing fails', async () => {
+        try {
+          await generateObject({
+            model: new MockLanguageModelV2({
+              doGenerate: async ({}) => ({
+                ...dummyResponseValues,
+                content: [{ type: 'text', text: '{ broken json' }],
+              }),
+            }),
+            schema: z.object({ content: z.string() }),
+            prompt: 'prompt',
+          });
+
+          fail('must throw error');
+        } catch (error) {
+          verifyNoObjectGeneratedError(error, {
+            message: 'No object generated: could not parse the response.',
+          });
+        }
+      });
+
+      it('should throw NoObjectGeneratedError when parsing fails with repairResponse', async () => {
+        try {
+          await generateObject({
+            model: new MockLanguageModelV2({
+              doGenerate: async ({}) => ({
+                ...dummyResponseValues,
+                content: [{ type: 'text', text: '{ broken json' }],
+              }),
+            }),
+            schema: z.object({ content: z.string() }),
+            prompt: 'prompt',
+            experimental_repairText: async ({ text }) => text + '{',
+          });
+
+          fail('must throw error');
+        } catch (error) {
+          verifyNoObjectGeneratedError(error, {
+            message: 'No object generated: could not parse the response.',
+          });
+        }
+      });
+
+      it('should throw NoObjectGeneratedError when no text is available', async () => {
+        try {
+          await generateObject({
+            model: new MockLanguageModelV2({
+              doGenerate: async ({}) => ({
+                ...dummyResponseValues,
+                content: [],
+              }),
+            }),
+            schema: z.object({ content: z.string() }),
+            prompt: 'prompt',
+          });
+
+          fail('must throw error');
+        } catch (error) {
+          verifyNoObjectGeneratedError(error, {
+            message:
+              'No object generated: the model did not return a response.',
+          });
+        }
+      });
     });
   });
-});
 
-describe('output = "array"', () => {
-  it('should generate an array with 3 elements', async () => {
-    const model = new MockLanguageModelV2({
-      doGenerate: {
-        ...dummyResponseValues,
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              elements: [
-                { content: 'element 1' },
-                { content: 'element 2' },
-                { content: 'element 3' },
-              ],
-            }),
-          },
-        ],
-      },
-    });
+  describe('output = "array"', () => {
+    it('should generate an array with 3 elements', async () => {
+      const model = new MockLanguageModelV2({
+        doGenerate: {
+          ...dummyResponseValues,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                elements: [
+                  { content: 'element 1' },
+                  { content: 'element 2' },
+                  { content: 'element 3' },
+                ],
+              }),
+            },
+          ],
+        },
+      });
 
-    const result = await generateObject({
-      model,
-      schema: z.object({ content: z.string() }),
-      output: 'array',
-      prompt: 'prompt',
-    });
+      const result = await generateObject({
+        model,
+        schema: z.object({ content: z.string() }),
+        output: 'array',
+        prompt: 'prompt',
+      });
 
-    expect(result.object).toMatchInlineSnapshot(`
+      expect(result.object).toMatchInlineSnapshot(`
       [
         {
           "content": "element 1",
@@ -719,7 +731,7 @@ describe('output = "array"', () => {
         },
       ]
     `);
-    expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
+      expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
       [
         {
           "content": [
@@ -733,7 +745,7 @@ describe('output = "array"', () => {
         },
       ]
     `);
-    expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
+      expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
       {
         "description": undefined,
         "name": undefined,
@@ -765,32 +777,32 @@ describe('output = "array"', () => {
         "type": "json",
       }
     `);
+    });
   });
-});
 
-describe('output = "enum"', () => {
-  it('should generate an enum value', async () => {
-    const model = new MockLanguageModelV2({
-      doGenerate: {
-        ...dummyResponseValues,
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({ result: 'sunny' }),
-          },
-        ],
-      },
-    });
+  describe('output = "enum"', () => {
+    it('should generate an enum value', async () => {
+      const model = new MockLanguageModelV2({
+        doGenerate: {
+          ...dummyResponseValues,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ result: 'sunny' }),
+            },
+          ],
+        },
+      });
 
-    const result = await generateObject({
-      model,
-      output: 'enum',
-      enum: ['sunny', 'rainy', 'snowy'],
-      prompt: 'prompt',
-    });
+      const result = await generateObject({
+        model,
+        output: 'enum',
+        enum: ['sunny', 'rainy', 'snowy'],
+        prompt: 'prompt',
+      });
 
-    expect(result.object).toEqual('sunny');
-    expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
+      expect(result.object).toEqual('sunny');
+      expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
       [
         {
           "content": [
@@ -804,7 +816,7 @@ describe('output = "enum"', () => {
         },
       ]
     `);
-    expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
+      expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
       {
         "description": undefined,
         "name": undefined,
@@ -829,30 +841,30 @@ describe('output = "enum"', () => {
         "type": "json",
       }
     `);
+    });
   });
-});
 
-describe('output = "no-schema"', () => {
-  it('should generate object', async () => {
-    const model = new MockLanguageModelV2({
-      doGenerate: {
-        ...dummyResponseValues,
-        content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-      },
-    });
+  describe('output = "no-schema"', () => {
+    it('should generate object', async () => {
+      const model = new MockLanguageModelV2({
+        doGenerate: {
+          ...dummyResponseValues,
+          content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
+        },
+      });
 
-    const result = await generateObject({
-      model,
-      output: 'no-schema',
-      prompt: 'prompt',
-    });
+      const result = await generateObject({
+        model,
+        output: 'no-schema',
+        prompt: 'prompt',
+      });
 
-    expect(result.object).toMatchInlineSnapshot(`
+      expect(result.object).toMatchInlineSnapshot(`
       {
         "content": "Hello, world!",
       }
     `);
-    expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
+      expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
       [
         {
           "content": [
@@ -866,7 +878,7 @@ describe('output = "no-schema"', () => {
         },
       ]
     `);
-    expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
+      expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
       {
         "description": undefined,
         "name": undefined,
@@ -874,138 +886,144 @@ describe('output = "no-schema"', () => {
         "type": "json",
       }
     `);
-  });
-});
-
-describe('telemetry', () => {
-  let tracer: MockTracer;
-
-  beforeEach(() => {
-    tracer = new MockTracer();
+    });
   });
 
-  it('should not record any telemetry data when not explicitly enabled', async () => {
-    await generateObject({
-      model: new MockLanguageModelV2({
-        doGenerate: async () => ({
-          ...dummyResponseValues,
-          content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-        }),
-      }),
-      schema: z.object({ content: z.string() }),
-      prompt: 'prompt',
+  describe('telemetry', () => {
+    let tracer: MockTracer;
+
+    beforeEach(() => {
+      tracer = new MockTracer();
     });
 
-    assert.deepStrictEqual(tracer.jsonSpans, []);
-  });
-
-  it('should record telemetry data when enabled', async () => {
-    await generateObject({
-      model: new MockLanguageModelV2({
-        doGenerate: async () => ({
-          ...dummyResponseValues,
-          content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-          response: {
-            id: 'test-id-from-model',
-            timestamp: new Date(10000),
-            modelId: 'test-response-model-id',
-          },
-          providerMetadata: {
-            testProvider: {
-              testKey: 'testValue',
-            },
-          },
-        }),
-      }),
-      schema: z.object({ content: z.string() }),
-      schemaName: 'test-name',
-      schemaDescription: 'test description',
-      prompt: 'prompt',
-      topK: 0.1,
-      topP: 0.2,
-      frequencyPenalty: 0.3,
-      presencePenalty: 0.4,
-      temperature: 0.5,
-      headers: {
-        header1: 'value1',
-        header2: 'value2',
-      },
-      experimental_telemetry: {
-        isEnabled: true,
-        functionId: 'test-function-id',
-        metadata: {
-          test1: 'value1',
-          test2: false,
-        },
-        tracer,
-      },
-    });
-
-    expect(tracer.jsonSpans).toMatchSnapshot();
-  });
-
-  it('should not record telemetry inputs / outputs when disabled', async () => {
-    await generateObject({
-      model: new MockLanguageModelV2({
-        doGenerate: async () => ({
-          ...dummyResponseValues,
-          content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
-          response: {
-            id: 'test-id-from-model',
-            timestamp: new Date(10000),
-            modelId: 'test-response-model-id',
-          },
-        }),
-      }),
-      schema: z.object({ content: z.string() }),
-      prompt: 'prompt',
-      experimental_telemetry: {
-        isEnabled: true,
-        recordInputs: false,
-        recordOutputs: false,
-        tracer,
-      },
-    });
-
-    expect(tracer.jsonSpans).toMatchSnapshot();
-  });
-});
-
-describe('options.messages', () => {
-  it('should support models that use "this" context in supportedUrls', async () => {
-    let supportedUrlsCalled = false;
-    class MockLanguageModelWithImageSupport extends MockLanguageModelV2 {
-      constructor() {
-        super({
-          supportedUrls: () => {
-            supportedUrlsCalled = true;
-            // Reference 'this' to verify context
-            return this.modelId === 'mock-model-id'
-              ? ({ 'image/*': [/^https:\/\/.*$/] } as Record<string, RegExp[]>)
-              : {};
-          },
+    it('should not record any telemetry data when not explicitly enabled', async () => {
+      await generateObject({
+        model: new MockLanguageModelV2({
           doGenerate: async () => ({
             ...dummyResponseValues,
             content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
           }),
-        });
-      }
-    }
+        }),
+        schema: z.object({ content: z.string() }),
+        prompt: 'prompt',
+      });
 
-    const model = new MockLanguageModelWithImageSupport();
-
-    const result = await generateObject({
-      model,
-      schema: z.object({ content: z.string() }),
-      messages: [
-        {
-          role: 'user',
-          content: [{ type: 'image', image: 'https://example.com/test.jpg' }],
-        },
-      ],
+      assert.deepStrictEqual(tracer.jsonSpans, []);
     });
 
-    expect(result.object).toStrictEqual({ content: 'Hello, world!' });
-    expect(supportedUrlsCalled).toBe(true);
+    it('should record telemetry data when enabled', async () => {
+      await generateObject({
+        model: new MockLanguageModelV2({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
+            response: {
+              id: 'test-id-from-model',
+              timestamp: new Date(10000),
+              modelId: 'test-response-model-id',
+            },
+            providerMetadata: {
+              testProvider: {
+                testKey: 'testValue',
+              },
+            },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        schemaName: 'test-name',
+        schemaDescription: 'test description',
+        prompt: 'prompt',
+        topK: 0.1,
+        topP: 0.2,
+        frequencyPenalty: 0.3,
+        presencePenalty: 0.4,
+        temperature: 0.5,
+        headers: {
+          header1: 'value1',
+          header2: 'value2',
+        },
+        experimental_telemetry: {
+          isEnabled: true,
+          functionId: 'test-function-id',
+          metadata: {
+            test1: 'value1',
+            test2: false,
+          },
+          tracer,
+        },
+      });
+
+      expect(tracer.jsonSpans).toMatchSnapshot();
+    });
+
+    it('should not record telemetry inputs / outputs when disabled', async () => {
+      await generateObject({
+        model: new MockLanguageModelV2({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: '{ "content": "Hello, world!" }' }],
+            response: {
+              id: 'test-id-from-model',
+              timestamp: new Date(10000),
+              modelId: 'test-response-model-id',
+            },
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        prompt: 'prompt',
+        experimental_telemetry: {
+          isEnabled: true,
+          recordInputs: false,
+          recordOutputs: false,
+          tracer,
+        },
+      });
+
+      expect(tracer.jsonSpans).toMatchSnapshot();
+    });
+  });
+
+  describe('options.messages', () => {
+    it('should support models that use "this" context in supportedUrls', async () => {
+      let supportedUrlsCalled = false;
+      class MockLanguageModelWithImageSupport extends MockLanguageModelV2 {
+        constructor() {
+          super({
+            supportedUrls: () => {
+              supportedUrlsCalled = true;
+              // Reference 'this' to verify context
+              return this.modelId === 'mock-model-id'
+                ? ({ 'image/*': [/^https:\/\/.*$/] } as Record<
+                    string,
+                    RegExp[]
+                  >)
+                : {};
+            },
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [
+                { type: 'text', text: '{ "content": "Hello, world!" }' },
+              ],
+            }),
+          });
+        }
+      }
+
+      const model = new MockLanguageModelWithImageSupport();
+
+      const result = await generateObject({
+        model,
+        schema: z.object({ content: z.string() }),
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'image', image: 'https://example.com/test.jpg' }],
+          },
+        ],
+      });
+
+      expect(result.object).toStrictEqual({ content: 'Hello, world!' });
+      expect(supportedUrlsCalled).toBe(true);
+    });
   });
 });

--- a/packages/ai/src/generate-text/extract-reasoning-content.ts
+++ b/packages/ai/src/generate-text/extract-reasoning-content.ts
@@ -1,0 +1,17 @@
+import {
+  LanguageModelV2Content,
+  LanguageModelV2Reasoning,
+} from '@ai-sdk/provider';
+
+export function extractReasoningContent(
+  content: LanguageModelV2Content[],
+): string | undefined {
+  const parts = content.filter(
+    (content): content is LanguageModelV2Reasoning =>
+      content.type === 'reasoning',
+  );
+
+  return parts.length === 0
+    ? undefined
+    : parts.map(content => content.text).join('\n');
+}

--- a/packages/ai/src/generate-text/extract-text-content.ts
+++ b/packages/ai/src/generate-text/extract-text-content.ts
@@ -1,6 +1,6 @@
 import { LanguageModelV2Content, LanguageModelV2Text } from '@ai-sdk/provider';
 
-export function extractContentText(
+export function extractTextContent(
   content: LanguageModelV2Content[],
 ): string | undefined {
   const parts = content.filter(

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -33,7 +33,7 @@ import { addLanguageModelUsage, LanguageModelUsage } from '../types/usage';
 import { asArray } from '../util/as-array';
 import { prepareRetries } from '../util/prepare-retries';
 import { ContentPart } from './content-part';
-import { extractContentText } from './extract-content-text';
+import { extractTextContent } from './extract-text-content';
 import { GenerateTextResult } from './generate-text-result';
 import { DefaultGeneratedFile } from './generated-file';
 import { Output } from './output';
@@ -395,7 +395,7 @@ A function that attempts to repair a tool call that failed to parse.
                     attributes: {
                       'ai.response.finishReason': result.finishReason,
                       'ai.response.text': {
-                        output: () => extractContentText(result.content),
+                        output: () => extractTextContent(result.content),
                       },
                       'ai.response.toolCalls': {
                         output: () => {
@@ -556,7 +556,7 @@ A function that attempts to repair a tool call that failed to parse.
             attributes: {
               'ai.response.finishReason': currentModelResponse.finishReason,
               'ai.response.text': {
-                output: () => extractContentText(currentModelResponse.content),
+                output: () => extractTextContent(currentModelResponse.content),
               },
               'ai.response.toolCalls': {
                 output: () => {


### PR DESCRIPTION
## Background

It can be useful to log or inspect reasoning information when generating objects (see #6474)

## Summary

Add reasoning output to `generateObject`.

## Manual Verification

Run `examples/ai-core/src/generate-object/openai-reasoning.ts`.

## Tasks
- [x] example
- [x] implementation
- [x] test
- [x] ref docs
- [x] guide docs
- [x] changeset

## Related Issues

Superseedes #4985
Fixes #6474