### PR TITLE
feat(ai): export LanguageModelMiddleware type

### DIFF
--- a/.changeset/wet-rocks-poke.md
+++ b/.changeset/wet-rocks-poke.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): export LanguageModelMiddleware type

--- a/packages/ai/src/middleware/default-settings-middleware.ts
+++ b/packages/ai/src/middleware/default-settings-middleware.ts
@@ -1,7 +1,5 @@
-import {
-  LanguageModelV2CallOptions,
-  LanguageModelV2Middleware,
-} from '@ai-sdk/provider';
+import { LanguageModelV2CallOptions } from '@ai-sdk/provider';
+import { LanguageModelMiddleware } from '../types';
 import { mergeObjects } from '../util/merge-objects';
 
 /**
@@ -25,7 +23,7 @@ export function defaultSettingsMiddleware({
     headers?: LanguageModelV2CallOptions['headers'];
     providerOptions?: LanguageModelV2CallOptions['providerOptions'];
   }>;
-}): LanguageModelV2Middleware {
+}): LanguageModelMiddleware {
   return {
     middlewareVersion: 'v2',
     transformParams: async ({ params }) => {

--- a/packages/ai/src/middleware/extract-reasoning-middleware.ts
+++ b/packages/ai/src/middleware/extract-reasoning-middleware.ts
@@ -1,8 +1,8 @@
 import type {
   LanguageModelV2Content,
-  LanguageModelV2Middleware,
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider';
+import { LanguageModelMiddleware } from '../types/language-model-middleware';
 import { getPotentialStartIndex } from '../util/get-potential-start-index';
 
 /**
@@ -21,7 +21,7 @@ export function extractReasoningMiddleware({
   tagName: string;
   separator?: string;
   startWithReasoning?: boolean;
-}): LanguageModelV2Middleware {
+}): LanguageModelMiddleware {
   const openingTag = `<${tagName}>`;
   const closingTag = `<\/${tagName}>`;
 

--- a/packages/ai/src/middleware/simulate-streaming-middleware.ts
+++ b/packages/ai/src/middleware/simulate-streaming-middleware.ts
@@ -1,12 +1,10 @@
-import type {
-  LanguageModelV2Middleware,
-  LanguageModelV2StreamPart,
-} from '@ai-sdk/provider';
+import type { LanguageModelV2StreamPart } from '@ai-sdk/provider';
+import { LanguageModelMiddleware } from '../types';
 
 /**
  * Simulates streaming chunks with the response from a generate call.
  */
-export function simulateStreamingMiddleware(): LanguageModelV2Middleware {
+export function simulateStreamingMiddleware(): LanguageModelMiddleware {
   return {
     middlewareVersion: 'v2',
     wrapStream: async ({ doGenerate }) => {

--- a/packages/ai/src/middleware/wrap-language-model.ts
+++ b/packages/ai/src/middleware/wrap-language-model.ts
@@ -1,8 +1,5 @@
-import {
-  LanguageModelV2,
-  LanguageModelV2CallOptions,
-  LanguageModelV2Middleware,
-} from '@ai-sdk/provider';
+import { LanguageModelV2, LanguageModelV2CallOptions } from '@ai-sdk/provider';
+import { LanguageModelMiddleware } from '../types';
 import { asArray } from '../util/as-array';
 
 /**
@@ -24,7 +21,7 @@ export const wrapLanguageModel = ({
   providerId,
 }: {
   model: LanguageModelV2;
-  middleware: LanguageModelV2Middleware | LanguageModelV2Middleware[];
+  middleware: LanguageModelMiddleware | LanguageModelMiddleware[];
   modelId?: string;
   providerId?: string;
 }): LanguageModelV2 => {
@@ -49,7 +46,7 @@ const doWrap = ({
   providerId,
 }: {
   model: LanguageModelV2;
-  middleware: LanguageModelV2Middleware;
+  middleware: LanguageModelMiddleware;
   modelId?: string;
   providerId?: string;
 }): LanguageModelV2 => {

--- a/packages/ai/src/middleware/wrap-provider.ts
+++ b/packages/ai/src/middleware/wrap-provider.ts
@@ -1,4 +1,5 @@
-import type { LanguageModelV2Middleware, ProviderV2 } from '@ai-sdk/provider';
+import type { ProviderV2 } from '@ai-sdk/provider';
+import { LanguageModelMiddleware } from '../types/language-model-middleware';
 import { wrapLanguageModel } from './wrap-language-model';
 
 /**
@@ -17,9 +18,7 @@ export function wrapProvider({
   languageModelMiddleware,
 }: {
   provider: ProviderV2;
-  languageModelMiddleware:
-    | LanguageModelV2Middleware
-    | LanguageModelV2Middleware[];
+  languageModelMiddleware: LanguageModelMiddleware | LanguageModelMiddleware[];
 }): ProviderV2 {
   const wrappedProvider = {
     languageModel(modelId: string) {

--- a/packages/ai/src/registry/provider-registry.ts
+++ b/packages/ai/src/registry/provider-registry.ts
@@ -2,14 +2,14 @@ import {
   EmbeddingModelV2,
   ImageModelV2,
   LanguageModelV2,
-  LanguageModelV2Middleware,
   NoSuchModelError,
   ProviderV2,
   SpeechModelV2,
   TranscriptionModelV2,
 } from '@ai-sdk/provider';
-import { NoSuchProviderError } from './no-such-provider-error';
 import { wrapLanguageModel } from '../middleware/wrap-language-model';
+import { LanguageModelMiddleware } from '../types';
+import { NoSuchProviderError } from './no-such-provider-error';
 
 type ExtractLiteralUnion<T> = T extends string
   ? string extends T
@@ -90,8 +90,8 @@ export function createProviderRegistry<
   }: {
     separator?: SEPARATOR;
     languageModelMiddleware?:
-      | LanguageModelV2Middleware
-      | LanguageModelV2Middleware[];
+      | LanguageModelMiddleware
+      | LanguageModelMiddleware[];
   } = {},
 ): ProviderRegistryProvider<PROVIDERS, SEPARATOR> {
   const registry = new DefaultProviderRegistry<PROVIDERS, SEPARATOR>({
@@ -122,8 +122,8 @@ class DefaultProviderRegistry<
   private providers: PROVIDERS = {} as PROVIDERS;
   private separator: SEPARATOR;
   private languageModelMiddleware?:
-    | LanguageModelV2Middleware
-    | LanguageModelV2Middleware[];
+    | LanguageModelMiddleware
+    | LanguageModelMiddleware[];
 
   constructor({
     separator,
@@ -131,8 +131,8 @@ class DefaultProviderRegistry<
   }: {
     separator: SEPARATOR;
     languageModelMiddleware?:
-      | LanguageModelV2Middleware
-      | LanguageModelV2Middleware[];
+      | LanguageModelMiddleware
+      | LanguageModelMiddleware[];
   }) {
     this.separator = separator;
     this.languageModelMiddleware = languageModelMiddleware;

--- a/packages/ai/src/types/index.ts
+++ b/packages/ai/src/types/index.ts
@@ -1,3 +1,4 @@
+export type { JSONSchema7 } from '@ai-sdk/provider';
 export type { Embedding, EmbeddingModel } from './embedding-model';
 export type {
   ImageModel,
@@ -6,13 +7,13 @@ export type {
 } from './image-model';
 export type { ImageModelResponseMetadata } from './image-model-response-metadata';
 export type { JSONValue } from './json-value';
-export type { JSONSchema7 } from '@ai-sdk/provider';
 export type {
   CallWarning,
   FinishReason,
   LanguageModel,
   ToolChoice,
 } from './language-model';
+export type { LanguageModelMiddleware } from './language-model-middleware';
 export type { LanguageModelRequestMetadata } from './language-model-request-metadata';
 export type { LanguageModelResponseMetadata } from './language-model-response-metadata';
 export type { Provider } from './provider';

--- a/packages/ai/src/types/language-model-middleware.ts
+++ b/packages/ai/src/types/language-model-middleware.ts
@@ -1,0 +1,3 @@
+import { LanguageModelV2Middleware } from '@ai-sdk/provider';
+
+export type LanguageModelMiddleware = LanguageModelV2Middleware;


### PR DESCRIPTION
## Background

Users need a type for extracting and storing middleware (see #8083 ).

## Summary

* Export `LanguageModelMiddleware` type
* Use `LanguageModelMiddleware` type instead of `LanguageModelV2Middleware` in `ai` package

## Related Issues

Fixes #8083