### PR TITLE
fix(docs): remove compatibility warnings for Azure AI provider

### DIFF
--- a/content/providers/03-community-providers/14-azure-ai.mdx
+++ b/content/providers/03-community-providers/14-azure-ai.mdx
@@ -5,18 +5,11 @@ description: Learn how to use the @quail-ai/azure-ai-provider for the AI SDK.
 
 # Azure Custom Provider for AI SDK
 
-<Note type="warning">
-  This community provider is not yet compatible with AI SDK 5. Please wait for
-  the provider to be updated or consider using an [AI SDK 5 compatible
-  provider](/providers/ai-sdk-providers).
-</Note>
-
 The **[Quail-AI/azure-ai-provider](https://github.com/QuailAI/azure-ai-provider)** enables unofficial integration with Azure-hosted language models that use Azure's native APIs instead of the standard OpenAI API format.
 
 ## Language Models
 
 This provider works with any model in the Azure AI Foundry that is compatible with the Azure-Rest AI-inference API.
-**Note:** This provider is not compatible with the Azure OpenAI models. For those, please use the [Azure OpenAI Provider](/providers/ai-sdk-providers/azure).
 
 ### Models Tested:
 


### PR DESCRIPTION
## Summary
Updated provider to version 2 which supports AI SDK 5 and uses the new language model.