### PR TITLE
feat(react): enhance useObject to support FormData submissions

### DIFF
--- a/.changeset/happy-pugs-relate.md
+++ b/.changeset/happy-pugs-relate.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+feat (ai/react): useObject support for submitting formData

--- a/content/docs/07-reference/02-ai-sdk-ui/03-use-object.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/03-use-object.mdx
@@ -133,7 +133,8 @@ export default function Page() {
     {
       name: 'submit',
       type: '(input: INPUT) => void',
-      description: 'Calls the API with the provided input as JSON body.',
+      description:
+        'Calls the API with the provided input as JSON body or formData.',
     },
     {
       name: 'object',

--- a/packages/react/src/use-object.ts
+++ b/packages/react/src/use-object.ts
@@ -87,7 +87,7 @@ Optional error object. This is e.g. a TypeValidationError when the final object 
 
 export type Experimental_UseObjectHelpers<RESULT, INPUT> = {
   /**
-   * Calls the API with the provided input as JSON body.
+   * Calls the API with the provided input as JSON body or FormData.
    */
   submit: (input: INPUT) => void;
 

--- a/packages/react/src/use-object.ts
+++ b/packages/react/src/use-object.ts
@@ -171,16 +171,20 @@ function useObject<
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
 
+      // Detect if input is FormData
+      const isFormData = input instanceof FormData;
+
       const actualFetch = fetch ?? getOriginalFetch();
       const response = await actualFetch(api, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          // Only set Content-Type for JSON; FormData sets its own boundary
+          ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
           ...headers,
         },
         credentials,
         signal: abortController.signal,
-        body: JSON.stringify(input),
+        body: isFormData ? input : JSON.stringify(input),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Background

In some scenarios you want to submit a file to your API to get structured output back (for example, a recording in a mobile app).

## Summary

Updated the useObject hook submit method to detect FormData input and adjust the fetch request accordingly.

## Manual Verification

Verified the code on both a React app and a React native app. Could add an example if needed.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

Fixes: #5004 
