### PR TITLE
fix(ai): use parsed tool input if possible when validation fails

### DIFF
--- a/.changeset/stale-ladybugs-smoke.md
+++ b/.changeset/stale-ladybugs-smoke.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): use parsed tool input if possible when validation fails

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2914,7 +2914,9 @@ describe('generateText', () => {
               "message": "Invalid input: expected string, received undefined"
             }
           ]],
-              "input": "{ "cities": "San Francisco" }",
+              "input": {
+                "cities": "San Francisco",
+              },
               "invalid": true,
               "toolCallId": "call-1",
               "toolName": "cityAttractions",
@@ -2933,7 +2935,9 @@ describe('generateText', () => {
               "message": "Invalid input: expected string, received undefined"
             }
           ]",
-              "input": "{ "cities": "San Francisco" }",
+              "input": {
+                "cities": "San Francisco",
+              },
               "toolCallId": "call-1",
               "toolName": "cityAttractions",
               "type": "tool-error",
@@ -2948,7 +2952,9 @@ describe('generateText', () => {
             {
               "content": [
                 {
-                  "input": "{ "cities": "San Francisco" }",
+                  "input": {
+                    "cities": "San Francisco",
+                  },
                   "providerExecuted": undefined,
                   "providerOptions": undefined,
                   "toolCallId": "call-1",

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -165,7 +165,7 @@ describe('parseToolCall', () => {
       {
         "dynamic": true,
         "error": [AI_NoSuchToolError: Model tried to call unavailable tool 'testTool'. No tools are available.],
-        "input": "{}",
+        "input": {},
         "invalid": true,
         "toolCallId": "123",
         "toolName": "testTool",
@@ -199,7 +199,7 @@ describe('parseToolCall', () => {
       {
         "dynamic": true,
         "error": [AI_NoSuchToolError: Model tried to call unavailable tool 'nonExistentTool'. Available tools: testTool.],
-        "input": "{}",
+        "input": {},
         "invalid": true,
         "toolCallId": "123",
         "toolName": "nonExistentTool",
@@ -243,7 +243,9 @@ describe('parseToolCall', () => {
           "message": "Invalid input: expected number, received undefined"
         }
       ]],
-        "input": "{"param1": "test"}",
+        "input": {
+          "param1": "test",
+        },
         "invalid": true,
         "toolCallId": "123",
         "toolName": "testTool",

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -72,12 +72,16 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       return await doParseToolCall({ toolCall: repairedToolCall, tools });
     }
   } catch (error) {
+    // use parsed input when possible
+    const parsedInput = await safeParseJSON({ text: toolCall.input });
+    const input = parsedInput.success ? parsedInput.value : toolCall.input;
+
     // TODO AI SDK 6: special invalid tool call parts
     return {
       type: 'tool-call',
       toolCallId: toolCall.toolCallId,
       toolName: toolCall.toolName,
-      input: toolCall.input,
+      input,
       dynamic: true,
       invalid: true,
       error,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -12577,7 +12577,9 @@ describe('streamText', () => {
               "message": "Invalid input: expected string, received undefined"
             }
           ]],
-              "input": "{ "cities": "San Francisco" }",
+              "input": {
+                "cities": "San Francisco",
+              },
               "invalid": true,
               "toolCallId": "call-1",
               "toolName": "cityAttractions",
@@ -12596,7 +12598,9 @@ describe('streamText', () => {
               "message": "Invalid input: expected string, received undefined"
             }
           ]",
-              "input": "{ "cities": "San Francisco" }",
+              "input": {
+                "cities": "San Francisco",
+              },
               "toolCallId": "call-1",
               "toolName": "cityAttractions",
               "type": "tool-error",
@@ -12645,7 +12649,9 @@ describe('streamText', () => {
                 "message": "Invalid input: expected string, received undefined"
               }
             ]],
-                "input": "{ "cities": "San Francisco" }",
+                "input": {
+                  "cities": "San Francisco",
+                },
                 "invalid": true,
                 "toolCallId": "call-1",
                 "toolName": "cityAttractions",
@@ -12664,7 +12670,9 @@ describe('streamText', () => {
                 "message": "Invalid input: expected string, received undefined"
               }
             ]",
-                "input": "{ "cities": "San Francisco" }",
+                "input": {
+                  "cities": "San Francisco",
+                },
                 "toolCallId": "call-1",
                 "toolName": "cityAttractions",
                 "type": "tool-error",
@@ -12734,7 +12742,9 @@ describe('streamText', () => {
                 "message": "Invalid input: expected string, received undefined"
               }
             ]",
-                "input": "{ "cities": "San Francisco" }",
+                "input": {
+                  "cities": "San Francisco",
+                },
                 "toolCallId": "call-1",
                 "toolName": "cityAttractions",
                 "type": "tool-input-error",


### PR DESCRIPTION
## Background

Tool call parts with string input (in case of validation errors) were rejected by the Google GenAI API (see #7869 )

## Summary

When possible, use the parsed json input object even when the tool call validation fails.

## Manual Verification

Tested example from #7869

## Related Issues

Fixes #7869 