### PR TITLE
fix(docs): fix `TypeValidationError` reference in Message Persistence docs

### DIFF
--- a/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-message-persistence.mdx
@@ -148,7 +148,7 @@ import {
   convertToModelMessages,
   streamText,
   validateUIMessages,
-  AITypeValidationError,
+  TypeValidationError,
 } from 'ai';
 import { type MyUIMessage } from '@/types';
 
@@ -167,7 +167,7 @@ export async function POST(req: Request) {
       metadataSchema,
     });
   } catch (error) {
-    if (error instanceof AITypeValidationError) {
+    if (error instanceof TypeValidationError) {
       // Log validation error for monitoring
       console.error('Database messages validation failed:', error);
       // Could implement message migration or filtering here


### PR DESCRIPTION
## Background

[`TypeValidationError`](https://github.com/vercel/ai/blob/c4eff2967ae1cbcb1cc8fd251447c664ea9b868c/packages/provider/src/errors/type-validation-error.ts#L8) was mistakenly referenced as `AITypeValidationError` in Message Persistence docs

## Summary

`AITypeValidationError` -> `TypeValidationError`