### PR TITLE
feat(provider/gateway): Expose model type in model spec

### DIFF
--- a/.changeset/fifty-tools-sip.md
+++ b/.changeset/fifty-tools-sip.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): Expose model type in model spec

--- a/packages/gateway/src/gateway-fetch-metadata.test.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.test.ts
@@ -145,17 +145,14 @@ describe('GatewayFetchMetadata', () => {
       expect(result.models[0].description).toBe('A powerful language model');
     });
 
-    it('should include specification type when present', async () => {
+    it('should accept top-level modelType when present', async () => {
       server.urls['https://api.example.com/*'].response = {
         type: 'json-value',
         body: {
           models: [
             {
               ...mockModelEntry,
-              specification: {
-                ...mockModelEntry.specification,
-                type: 'language',
-              },
+              modelType: 'language',
             },
           ],
         },
@@ -163,11 +160,10 @@ describe('GatewayFetchMetadata', () => {
 
       const metadata = createBasicMetadataFetcher();
       const result = await metadata.getAvailableModels();
-
-      expect(result.models[0].specification.type).toBe('language');
+      expect(result.models[0].modelType).toBe('language');
     });
 
-    it('should reject models with invalid specification type', async () => {
+    it('should reject invalid top-level modelType values', async () => {
       server.urls['https://api.example.com/*'].response = {
         type: 'json-value',
         body: {
@@ -179,8 +175,8 @@ describe('GatewayFetchMetadata', () => {
                 specificationVersion: 'v2' as const,
                 provider: 'test-provider',
                 modelId: 'model-invalid-type',
-                type: 'text',
               },
+              modelType: 'text',
             },
           ],
         },

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -44,7 +44,6 @@ const gatewayLanguageModelSpecificationSchema = z.object({
   specificationVersion: z.literal('v2'),
   provider: z.string(),
   modelId: z.string(),
-  type: z.enum(['language', 'embedding', 'image']).optional(),
 });
 
 const gatewayLanguageModelPricingSchema = z.object({
@@ -58,6 +57,7 @@ const gatewayLanguageModelEntrySchema = z.object({
   description: z.string().nullish(),
   pricing: gatewayLanguageModelPricingSchema.nullish(),
   specification: gatewayLanguageModelSpecificationSchema,
+  modelType: z.enum(['language', 'embedding', 'image']).optional(),
 });
 
 const gatewayFetchMetadataSchema = z.object({

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -44,6 +44,7 @@ const gatewayLanguageModelSpecificationSchema = z.object({
   specificationVersion: z.literal('v2'),
   provider: z.string(),
   modelId: z.string(),
+  type: z.enum(['language', 'embedding', 'image']).optional(),
 });
 
 const gatewayLanguageModelPricingSchema = z.object({

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -57,7 +57,7 @@ const gatewayLanguageModelEntrySchema = z.object({
   description: z.string().nullish(),
   pricing: gatewayLanguageModelPricingSchema.nullish(),
   specification: gatewayLanguageModelSpecificationSchema,
-  modelType: z.enum(['language', 'embedding', 'image']).optional(),
+  modelType: z.enum(['language', 'embedding', 'image']).nullish(),
 });
 
 const gatewayFetchMetadataSchema = z.object({

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -40,4 +40,6 @@ export interface GatewayLanguageModelEntry {
 export type GatewayLanguageModelSpecification = Pick<
   LanguageModelV2,
   'specificationVersion' | 'provider' | 'modelId'
->;
+> & {
+  type?: 'language' | 'embedding' | 'image';
+};

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -35,7 +35,7 @@ export interface GatewayLanguageModelEntry {
    * Additional AI SDK language model specifications for the model.
    */
   specification: GatewayLanguageModelSpecification;
-  
+
   /**
    * Optional field to differentiate between model types.
    */

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -39,7 +39,7 @@ export interface GatewayLanguageModelEntry {
   /**
    * Optional field to differentiate between model types.
    */
-  modelType?: 'language' | 'embedding' | 'image';
+  modelType?: 'language' | 'embedding' | 'image' | null;
 }
 
 export type GatewayLanguageModelSpecification = Pick<

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -35,11 +35,13 @@ export interface GatewayLanguageModelEntry {
    * Additional AI SDK language model specifications for the model.
    */
   specification: GatewayLanguageModelSpecification;
+  /**
+   * Optional field to differentiate between model types.
+   */
+  modelType?: 'language' | 'embedding' | 'image';
 }
 
 export type GatewayLanguageModelSpecification = Pick<
   LanguageModelV2,
   'specificationVersion' | 'provider' | 'modelId'
-> & {
-  type?: 'language' | 'embedding' | 'image';
-};
+>;

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -35,6 +35,7 @@ export interface GatewayLanguageModelEntry {
    * Additional AI SDK language model specifications for the model.
    */
   specification: GatewayLanguageModelSpecification;
+  
   /**
    * Optional field to differentiate between model types.
    */

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -3,6 +3,7 @@ export type {
   GatewayLanguageModelEntry,
   GatewayLanguageModelSpecification,
 } from './gateway-model-entry';
+export type { GatewayLanguageModelEntry as GatewayModelEntry } from './gateway-model-entry';
 export {
   createGatewayProvider,
   createGatewayProvider as createGateway,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Re: https://vercel.slack.com/archives/C08CCJK0484/p1755642299328509 @haydenbleasel 

## Summary

Exposes the model type in the model specification as a field

## Manual Verification

```
const { models } = await gatewayProvider.getAvailableModels();
const textModels = models.filter(m => m.modelType === 'language');
const embeddingModels = models.filter(m => m.modelType === 'embedding');
```

This code works now

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)