### PR TITLE
feat(provider/openai): support Responses API `file_url` for PDFs

### DIFF
--- a/.changeset/enable-openai-response-file-url.md
+++ b/.changeset/enable-openai-response-file-url.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Support Responses API input_file file_url passthrough for PDFs.
+
+This adds:
+
+- file_url variant to OpenAIResponses user content
+- PDF URL mapping to input_file with file_url in Responses converter
+- PDF URL support in supportedUrls to avoid auto-download

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.test.ts
@@ -358,24 +358,34 @@ describe('convertToOpenAIResponsesMessages', () => {
       ).rejects.toThrow('file part media type text/plain');
     });
 
-    it('should throw error for file URLs', async () => {
-      await expect(
-        convertToOpenAIResponsesMessages({
-          prompt: [
+    it('should convert PDF file parts with URL to input_file with file_url', async () => {
+      const result = await convertToOpenAIResponsesMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                mediaType: 'application/pdf',
+                data: new URL('https://example.com/document.pdf'),
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
             {
-              role: 'user',
-              content: [
-                {
-                  type: 'file',
-                  mediaType: 'application/pdf',
-                  data: new URL('https://example.com/document.pdf'),
-                },
-              ],
+              type: 'input_file',
+              file_url: 'https://example.com/document.pdf',
             },
           ],
-          systemMessageMode: 'system',
-        }),
-      ).rejects.toThrow('PDF file parts with URLs');
+        },
+      ]);
     });
 
     describe('Azure OpenAI file ID support', () => {

--- a/packages/openai/src/responses/convert-to-openai-responses-messages.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-messages.ts
@@ -93,10 +93,10 @@ export async function convertToOpenAIResponsesMessages({
                   };
                 } else if (part.mediaType === 'application/pdf') {
                   if (part.data instanceof URL) {
-                    // The AI SDK automatically downloads files for user file parts with URLs
-                    throw new UnsupportedFunctionalityError({
-                      functionality: 'PDF file parts with URLs',
-                    });
+                    return {
+                      type: 'input_file',
+                      file_url: part.data.toString(),
+                    };
                   }
                   return {
                     type: 'input_file',

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -24,6 +24,7 @@ export type OpenAIResponsesUserMessage = {
     | { type: 'input_text'; text: string }
     | { type: 'input_image'; image_url: string }
     | { type: 'input_image'; file_id: string }
+    | { type: 'input_file'; file_url: string }
     | { type: 'input_file'; filename: string; file_data: string }
     | { type: 'input_file'; file_id: string }
   >;

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -84,6 +84,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
 
   readonly supportedUrls: Record<string, RegExp[]> = {
     'image/*': [/^https?:\/\/.*$/],
+    'application/pdf': [/^https?:\/\/.*$/],
   };
 
   get provider(): string {


### PR DESCRIPTION
## Background

The OpenAI Responses API now supports `{ type: "input_file", file_url }`, but the SDK throws a "PDF file parts with URLs" error when trying to use a URL for a pdf.

## Summary

- Added `file_url` variant to `OpenAIResponsesUserMessage`.
- Map `application/pdf` URL parts to `{ type: 'input_file', file_url }` in `convert-to-openai-responses-messages`.
- Whitelisted `'application/pdf'` in `supportedUrls` to avoid auto-download.
- Updated tests to assert `file_url` behavior.

## Manual Verification

- Script to test with an example PDF
- Global fetch listener to ensure no download is attempted now

<img width="645" height="629" alt="image" src="https://github.com/user-attachments/assets/c76a85dc-a679-4812-ad54-1225cee071d9" />
