### PR TITLE
make prompt type bit strict

### DIFF
--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -9,18 +9,18 @@ export type Prompt = {
 System message to include in the prompt. Can be used with `prompt` or `messages`.
    */
   system?: string;
-
+} & ({
   /**
 A prompt. It can be either a text prompt or a list of messages.
 
 You can either use `prompt` or `messages` but not both.
 */
   prompt?: string | Array<ModelMessage>;
-
+} | {
   /**
 A list of messages.
 
 You can either use `prompt` or `messages` but not both.
    */
   messages?: Array<ModelMessage>;
-};
+});


### PR DESCRIPTION
## Background

This restriction is mentioned in docs but enforced in types

## Summary

Updated `Prompt` type to enforce either `messages` or `prompt` fields at type level