### PR TITLE
feat(ai): improved type checking for prompt/messages input

### DIFF
--- a/.changeset/tidy-buckets-drive.md
+++ b/.changeset/tidy-buckets-drive.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/rsc': patch
+'ai': patch
+---
+
+feat(ai): improved type checking for prompt/messages input

--- a/packages/ai/src/generate-object/generate-object.test-d.ts
+++ b/packages/ai/src/generate-object/generate-object.test-d.ts
@@ -9,6 +9,7 @@ describe('generateObject', () => {
       output: 'enum',
       enum: ['a', 'b', 'c'] as const,
       model: undefined!,
+      messages: [],
     });
 
     expectTypeOf<typeof result.object>().toEqualTypeOf<'a' | 'b' | 'c'>;
@@ -18,6 +19,7 @@ describe('generateObject', () => {
     const result = await generateObject({
       schema: z.object({ number: z.number() }),
       model: undefined!,
+      messages: [],
     });
 
     expectTypeOf<typeof result.object>().toEqualTypeOf<{ number: number }>();
@@ -27,6 +29,7 @@ describe('generateObject', () => {
     const result = await generateObject({
       output: 'no-schema',
       model: undefined!,
+      messages: [],
     });
 
     expectTypeOf<typeof result.object>().toEqualTypeOf<JSONValue>();
@@ -37,6 +40,7 @@ describe('generateObject', () => {
       output: 'array',
       schema: z.number(),
       model: undefined!,
+      messages: [],
     });
 
     expectTypeOf<typeof result.object>().toEqualTypeOf<number[]>();

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -300,7 +300,7 @@ Default and recommended: 'auto' (best mode for the model).
           system,
           prompt,
           messages,
-        });
+        } as Prompt);
 
         const promptMessages = await convertToLanguageModelPrompt({
           prompt: standardizedPrompt,

--- a/packages/ai/src/generate-object/stream-object.test-d.ts
+++ b/packages/ai/src/generate-object/stream-object.test-d.ts
@@ -10,6 +10,7 @@ describe('streamObject', () => {
     const result = streamObject({
       schema: z.object({ number: z.number() }),
       model: undefined!,
+      prompt: 'test',
     });
 
     expectTypeOf<typeof result.finishReason>().toEqualTypeOf<
@@ -22,6 +23,7 @@ describe('streamObject', () => {
       output: 'enum',
       enum: ['a', 'b', 'c'] as const,
       model: undefined!,
+      prompt: 'test',
     });
 
     expectTypeOf<typeof result.object>().toEqualTypeOf<
@@ -37,6 +39,7 @@ describe('streamObject', () => {
     const result = streamObject({
       schema: z.object({ number: z.number() }),
       model: undefined!,
+      prompt: 'test',
     });
 
     expectTypeOf<typeof result.object>().toEqualTypeOf<
@@ -48,6 +51,7 @@ describe('streamObject', () => {
     const result = streamObject({
       output: 'no-schema',
       model: undefined!,
+      prompt: 'test',
     });
 
     expectTypeOf<typeof result.object>().toEqualTypeOf<Promise<JSONValue>>();
@@ -58,6 +62,7 @@ describe('streamObject', () => {
       output: 'array',
       schema: z.number(),
       model: undefined!,
+      prompt: 'test',
     });
 
     expectTypeOf<typeof result.partialObjectStream>().toEqualTypeOf<

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -489,7 +489,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
           system,
           prompt,
           messages,
-        });
+        } as Prompt);
 
         const callOptions = {
           responseFormat: {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -256,7 +256,7 @@ A function that attempts to repair a tool call that failed to parse.
     system,
     prompt,
     messages,
-  });
+  } as Prompt);
 
   const tracer = getTracer(telemetry);
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1020,7 +1020,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
             system,
             prompt,
             messages,
-          });
+          } as Prompt);
 
           const stepInputMessages = [
             ...initialPrompt.messages,

--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -9,18 +9,18 @@ export type Prompt = {
 System message to include in the prompt. Can be used with `prompt` or `messages`.
    */
   system?: string;
-
+} & ({
   /**
 A prompt. It can be either a text prompt or a list of messages.
 
 You can either use `prompt` or `messages` but not both.
 */
   prompt?: string | Array<ModelMessage>;
-
+} | {
   /**
 A list of messages.
 
 You can either use `prompt` or `messages` but not both.
    */
   messages?: Array<ModelMessage>;
-};
+});

--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -9,18 +9,35 @@ export type Prompt = {
 System message to include in the prompt. Can be used with `prompt` or `messages`.
    */
   system?: string;
-} & ({
-  /**
+} & (
+  | {
+      /**
 A prompt. It can be either a text prompt or a list of messages.
 
 You can either use `prompt` or `messages` but not both.
 */
-  prompt?: string | Array<ModelMessage>;
-} | {
-  /**
+      prompt: string | Array<ModelMessage>;
+
+      /**
 A list of messages.
 
 You can either use `prompt` or `messages` but not both.
    */
-  messages?: Array<ModelMessage>;
-});
+      messages?: never;
+    }
+  | {
+      /**
+A list of messages.
+
+You can either use `prompt` or `messages` but not both.
+   */
+      messages: Array<ModelMessage>;
+
+      /**
+A prompt. It can be either a text prompt or a list of messages.
+
+You can either use `prompt` or `messages` but not both.
+*/
+      prompt?: never;
+    }
+);

--- a/packages/rsc/src/stream-ui/stream-ui.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.tsx
@@ -263,7 +263,7 @@ functionality that can be fully encapsulated in the provider.
     system,
     prompt,
     messages,
-  });
+  } as Prompt);
   const result = await retry(async () =>
     model.doStream({
       ...prepareCallSettings(settings),


### PR DESCRIPTION
## Background

It was possible to enter both messages and prompt at the same time. While this was checked at runtime and threw errors, proper type validation would be preferable, as long as it does not affect autocomplete in the IDE.

## Summary

Enhance the `Prompt` type to limit to either messages or prompt, while retaining autocomplete through the use of `never`.

## Manual Verification

Tested autocomplete and error behavior using examples.

## Related Issues

Continues #8196 