### PR TITLE
feat (provider/groq): add service tier provider option

### DIFF
--- a/.changeset/tricky-kiwis-smell.md
+++ b/.changeset/tricky-kiwis-smell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+feat (provider/groq): add service tier provider option

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -97,6 +97,7 @@ const result = await generateText({
       reasoningEffort: 'default',
       parallelToolCalls: true, // Enable parallel function calling (default: true)
       user: 'user-123', // Unique identifier for end-user (optional)
+      serviceTier: 'flex', // Use flex tier for higher throughput (optional)
     },
   },
   prompt: 'How many "r"s are in the word "strawberry"?',
@@ -142,6 +143,16 @@ The following optional provider options are available for Groq language models:
 - **user** _string_
 
   A unique identifier representing your end-user, which can help with monitoring and abuse detection.
+
+- **serviceTier** _'on_demand' | 'flex' | 'auto'_
+
+  Service tier for the request. Defaults to `'on_demand'`.
+
+  - `'on_demand'`: Default tier with consistent performance and fairness
+  - `'flex'`: Higher throughput tier (10x rate limits) optimized for workloads that can handle occasional request failures
+  - `'auto'`: Uses on_demand rate limits first, then falls back to flex tier if exceeded
+
+  For more details about service tiers and their benefits, see [Groq's Flex Processing documentation](https://console.groq.com/docs/flex-processing).
 
 <Note>Only Groq reasoning models support the `reasoningFormat` option.</Note>
 

--- a/examples/ai-core/src/stream-text/groq-service-tier.ts
+++ b/examples/ai-core/src/stream-text/groq-service-tier.ts
@@ -1,0 +1,25 @@
+import { groq, GroqProviderOptions } from '@ai-sdk/groq';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: groq('gemma2-9b-it'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    providerOptions: {
+      groq: {
+        serviceTier: 'flex',
+      } satisfies GroqProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -259,6 +259,25 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass serviceTier provider option', async () => {
+    prepareJsonResponse();
+
+    await provider('gemma2-9b-it').doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        groq: {
+          serviceTier: 'flex',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gemma2-9b-it',
+      messages: [{ role: 'user', content: 'Hello' }],
+      service_tier: 'flex',
+    });
+  });
+
   it('should pass tools and toolChoice', async () => {
     prepareJsonResponse({ content: '' });
 

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -145,6 +145,7 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
         // provider options:
         reasoning_format: groqOptions?.reasoningFormat,
         reasoning_effort: groqOptions?.reasoningEffort,
+        service_tier: groqOptions?.serviceTier,
 
         // messages:
         messages: convertToGroqChatMessages(prompt),

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -48,6 +48,16 @@ export const groqProviderOptions = z.object({
    * @default true
    */
   structuredOutputs: z.boolean().optional(),
+
+  /**
+   * Service tier for the request.
+   * - 'on_demand': Default tier with consistent performance and fairness
+   * - 'flex': Higher throughput tier optimized for workloads that can handle occasional request failures
+   * - 'auto': Uses on_demand rate limits, then falls back to flex tier if exceeded
+   *
+   * @default 'on_demand'
+   */
+  serviceTier: z.enum(['on_demand', 'flex', 'auto']).optional(),
 });
 
 export type GroqProviderOptions = z.infer<typeof groqProviderOptions>;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Groq has added support for [service tiers](https://console.groq.com/docs/flex-processing) to allow variable priority and pricing.

## Summary

Added a new provider option to allow specifying the service tier.

## Manual Verification

Added and test with an included `stream-text` example script.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset`in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix`in the project root)
