### PR TITLE
fix(provider/groq): add missing provider.transcriptionModel

### DIFF
--- a/.changeset/brown-hornets-sniff.md
+++ b/.changeset/brown-hornets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+fix (provider/groq): add missing provider.transcriptionModel

--- a/packages/groq/src/groq-provider.ts
+++ b/packages/groq/src/groq-provider.ts
@@ -117,6 +117,7 @@ export function createGroq(options: GroqProviderSettings = {}): GroqProvider {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };
   provider.transcription = createTranscriptionModel;
+  provider.transcriptionModel = createTranscriptionModel;
 
   provider.tools = groqTools;
 


### PR DESCRIPTION
## Background

using registry results in error `NoSuchModelError [AI_NoSuchModelError]: No such transcriptionModel: groq > whisper-large-v3`

## Summary

Added provider.transcriptionModel to groq provider