### PR TITLE
chore(ai): remove console.log from test

### DIFF
--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -12148,7 +12148,6 @@ describe('streamText', () => {
                   pullCalls = 0;
                 },
                 pull(controller) {
-                  console.log('pull', { streamCalls, pullCalls });
                   if (streamCalls === 1) {
                     switch (pullCalls++) {
                       case 0:


### PR DESCRIPTION
## Background

A `console.log` slipped into the streamText test.

## Summary

remove console.log from test