### PR TITLE
feat(ai): add provider-defined toolChoice type

### DIFF
--- a/.changeset/nice-wombats-hammer.md
+++ b/.changeset/nice-wombats-hammer.md
@@ -1,0 +1,15 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/xai': patch
+'ai': patch
+---
+
+add provider-defined toolChoice type to pass through to providers

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
@@ -369,4 +369,56 @@ describe('prepareToolsAndToolChoice', () => {
       }
     `);
   });
+
+  it('should handle provider-defined toolChoice passthrough', () => {
+    const result = prepareToolsAndToolChoice({
+      tools: mockTools,
+      toolChoice: { type: 'provider-defined', toolChoice: { any: 'thing' } },
+      activeTools: undefined,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "toolChoice": {
+            "any": "thing",
+          },
+          "type": "provider-defined",
+        },
+        "tools": [
+          {
+            "description": "Tool 1 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {},
+              "type": "object",
+            },
+            "name": "tool1",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+          {
+            "description": "Tool 2 description",
+            "inputSchema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "additionalProperties": false,
+              "properties": {
+                "city": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "city",
+              ],
+              "type": "object",
+            },
+            "name": "tool2",
+            "providerOptions": undefined,
+            "type": "function",
+          },
+        ],
+      }
+    `);
+  });
 });

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
@@ -69,6 +69,17 @@ export function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
         ? { type: 'auto' }
         : typeof toolChoice === 'string'
           ? { type: toolChoice }
-          : { type: 'tool' as const, toolName: toolChoice.toolName as string },
+          : typeof toolChoice === 'object' &&
+              'type' in toolChoice &&
+              toolChoice.type === 'provider-defined' &&
+              'toolChoice' in toolChoice
+            ? {
+                type: 'provider-defined' as const,
+                toolChoice: toolChoice.toolChoice,
+              }
+            : {
+                type: 'tool' as const,
+                toolName: toolChoice.toolName as string,
+              },
   };
 }

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -41,9 +41,11 @@ Tool choice for the generation. It supports the following settings:
 - `required`: the model must call a tool. It can choose which tool to call.
 - `none`: the model must not call tools
 - `{ type: 'tool', toolName: string (typed) }`: the model must call the specified tool
+- `{ type: 'provider-defined', toolChoice: unknown }`: pass through the tool choice to the provider
  */
 export type ToolChoice<TOOLS extends Record<string, unknown>> =
   | 'auto'
   | 'none'
   | 'required'
-  | { type: 'tool'; toolName: Extract<keyof TOOLS, string> };
+  | { type: 'tool'; toolName: Extract<keyof TOOLS, string> }
+  | { type: 'provider-defined'; toolChoice: unknown };

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
@@ -1,0 +1,17 @@
+import { prepareTools } from './bedrock-prepare-tools';
+
+it('should passthrough provider-defined toolChoice for standard tools', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'fn',
+        description: 'd',
+        inputSchema: {},
+      },
+    ],
+    toolChoice: { type: 'provider-defined', toolChoice: { auto: {} } as any },
+    modelId: 'amazon.titan-text',
+  });
+  expect(result.toolConfig.toolChoice).toEqual({ auto: {} });
+});

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -166,6 +166,9 @@ export function prepareTools({
       case 'tool':
         bedrockToolChoice = { tool: { name: toolChoice.toolName } };
         break;
+      case 'provider-defined':
+        bedrockToolChoice = toolChoice.toolChoice as any;
+        break;
       default: {
         const _exhaustiveCheck: never = type;
         throw new UnsupportedFunctionalityError({

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -176,6 +176,24 @@ describe('prepareTools', () => {
     expect(result.toolChoice).toEqual({ type: 'tool', name: 'testFunction' });
   });
 
+  it('should passthrough provider-defined toolChoice', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: {
+        type: 'provider-defined',
+        toolChoice: { type: 'any' } as any,
+      },
+    });
+    expect(result.toolChoice).toEqual({ type: 'any' });
+  });
+
   it('should set cache control', () => {
     const result = prepareTools({
       tools: [

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -198,6 +198,13 @@ export function prepareTools({
         toolWarnings,
         betas,
       };
+    case 'provider-defined':
+      return {
+        tools: anthropicTools,
+        toolChoice: toolChoice.toolChoice as AnthropicToolChoice,
+        toolWarnings,
+        betas,
+      };
     default: {
       const _exhaustiveCheck: never = type;
       throw new UnsupportedFunctionalityError({

--- a/packages/cohere/src/cohere-prepare-tools.test.ts
+++ b/packages/cohere/src/cohere-prepare-tools.test.ts
@@ -151,4 +151,13 @@ describe('tool choice handling', () => {
       toolWarnings: [],
     });
   });
+
+  it('should passthrough provider-defined toolChoice', () => {
+    const result = prepareTools({
+      tools: [basicTool],
+      toolChoice: { type: 'provider-defined', toolChoice: 'REQUIRED' as any },
+    });
+
+    expect(result.toolChoice).toBe('REQUIRED');
+  });
 });

--- a/packages/cohere/src/cohere-prepare-tools.ts
+++ b/packages/cohere/src/cohere-prepare-tools.ts
@@ -82,6 +82,12 @@ export function prepareTools({
         toolChoice: 'REQUIRED',
         toolWarnings,
       };
+    case 'provider-defined':
+      return {
+        tools: cohereTools,
+        toolChoice: toolChoice.toolChoice as CohereToolChoice,
+        toolWarnings,
+      };
 
     default: {
       const _exhaustiveCheck: never = type;

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -185,6 +185,25 @@ it('should handle tool choice "tool"', () => {
   });
 });
 
+it('should passthrough provider-defined toolChoice', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'Test',
+        inputSchema: {},
+      },
+    ],
+    toolChoice: {
+      type: 'provider-defined',
+      toolChoice: { some: 'config' } as any,
+    },
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.toolConfig).toEqual({ some: 'config' });
+});
+
 it('should warn when mixing function and provider-defined tools', () => {
   const result = prepareTools({
     tools: [

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -184,6 +184,12 @@ export function prepareTools({
         },
         toolWarnings,
       };
+    case 'provider-defined':
+      return {
+        tools: { functionDeclarations },
+        toolConfig: toolChoice.toolChoice as any,
+        toolWarnings,
+      };
     default: {
       const _exhaustiveCheck: never = type;
       throw new UnsupportedFunctionalityError({

--- a/packages/groq/src/groq-prepare-tools.test.ts
+++ b/packages/groq/src/groq-prepare-tools.test.ts
@@ -150,6 +150,22 @@ describe('prepareTools', () => {
     });
   });
 
+  it('should passthrough provider-defined toolChoice', () => {
+    const result = prepareTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'Test',
+          inputSchema: {},
+        },
+      ],
+      toolChoice: { type: 'provider-defined', toolChoice: 'auto' },
+      modelId: 'gemma2-9b-it',
+    });
+    expect(result.toolChoice).toEqual('auto');
+  });
+
   describe('browser search tool', () => {
     it('should handle browser search tool with supported model', () => {
       const result = prepareTools({

--- a/packages/groq/src/groq-prepare-tools.ts
+++ b/packages/groq/src/groq-prepare-tools.ts
@@ -115,6 +115,12 @@ export function prepareTools({
         },
         toolWarnings,
       };
+    case 'provider-defined':
+      return {
+        tools: groqTools,
+        toolChoice: toolChoice.toolChoice as any,
+        toolWarnings,
+      };
     default: {
       const _exhaustiveCheck: never = type;
       throw new UnsupportedFunctionalityError({

--- a/packages/mistral/src/mistral-prepare-tools.ts
+++ b/packages/mistral/src/mistral-prepare-tools.ts
@@ -81,6 +81,12 @@ export function prepareTools({
         toolChoice: 'any',
         toolWarnings,
       };
+    case 'provider-defined':
+      return {
+        tools: mistralTools,
+        toolChoice: toolChoice.toolChoice as MistralToolChoice,
+        toolWarnings,
+      };
     default: {
       const _exhaustiveCheck: never = type;
       throw new UnsupportedFunctionalityError({

--- a/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.test.ts
@@ -1,0 +1,16 @@
+import { prepareTools } from './openai-compatible-prepare-tools';
+
+it('should passthrough provider-defined toolChoice', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'fn',
+        description: 'd',
+        inputSchema: {},
+      },
+    ],
+    toolChoice: { type: 'provider-defined', toolChoice: 'auto' },
+  });
+  expect(result.toolChoice).toEqual('auto');
+});

--- a/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.ts
@@ -82,6 +82,12 @@ export function prepareTools({
         },
         toolWarnings,
       };
+    case 'provider-defined':
+      return {
+        tools: openaiCompatTools,
+        toolChoice: toolChoice.toolChoice as any,
+        toolWarnings,
+      };
     default: {
       const _exhaustiveCheck: never = type;
       throw new UnsupportedFunctionalityError({

--- a/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
@@ -284,3 +284,20 @@ it('should handle tool choice "tool"', () => {
     function: { name: 'testFunction' },
   });
 });
+
+it('should passthrough provider-defined toolChoice', () => {
+  const result = prepareChatTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'Test',
+        inputSchema: {},
+      },
+    ],
+    toolChoice: { type: 'provider-defined', toolChoice: { type: 'required' } },
+    structuredOutputs: false,
+    strictJsonSchema: false,
+  });
+  expect(result.toolChoice).toEqual({ type: 'required' });
+});

--- a/packages/openai/src/chat/openai-chat-prepare-tools.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.ts
@@ -103,6 +103,12 @@ export function prepareChatTools({
         },
         toolWarnings,
       };
+    case 'provider-defined':
+      return {
+        tools: openaiTools,
+        toolChoice: toolChoice.toolChoice as OpenAIChatToolChoice,
+        toolWarnings,
+      };
     default: {
       const _exhaustiveCheck: never = type;
       throw new UnsupportedFunctionalityError({

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -126,3 +126,136 @@ export type OpenAIResponsesReasoning = {
     text: string;
   }>;
 };
+
+export type OpenAIResponsesToolChoice =
+  | OpenAIResponsesToolChoiceOptions
+  | OpenAIResponsesToolChoiceAllowed
+  | OpenAIResponsesToolChoiceTypes
+  | OpenAIResponsesToolChoiceFunction
+  | OpenAIResponsesToolChoiceMcp
+  | OpenAIResponsesToolChoiceCustom;
+
+/**
+ * Constrains the tools available to the model to a pre-defined set.
+ */
+export type OpenAIResponsesToolChoiceAllowed = {
+  /**
+   * Constrains the tools available to the model to a pre-defined set.
+   *
+   * `auto` allows the model to pick from among the allowed tools and generate a
+   * message.
+   *
+   * `required` requires the model to call one or more of the allowed tools.
+   */
+  mode: 'auto' | 'required';
+
+  /**
+   * A list of tool definitions that the model should be allowed to call.
+   *
+   * For the Responses API, the list of tool definitions might look like:
+   *
+   * ```json
+   * [
+   *   { "type": "function", "name": "get_weather" },
+   *   { "type": "mcp", "server_label": "deepwiki" },
+   *   { "type": "image_generation" }
+   * ]
+   * ```
+   */
+  tools: Array<{ [key: string]: unknown }>;
+
+  /**
+   * Allowed tool configuration type. Always `allowed_tools`.
+   */
+  type: 'allowed_tools';
+};
+
+/**
+ * Use this option to force the model to call a specific custom tool.
+ */
+export type OpenAIResponsesToolChoiceCustom = {
+  /**
+   * The name of the custom tool to call.
+   */
+  name: string;
+
+  /**
+   * For custom tool calling, the type is always `custom`.
+   */
+  type: 'custom';
+};
+
+/**
+ * Use this option to force the model to call a specific function.
+ */
+export type OpenAIResponsesToolChoiceFunction = {
+  /**
+   * The name of the function to call.
+   */
+  name: string;
+
+  /**
+   * For function calling, the type is always `function`.
+   */
+  type: 'function';
+};
+
+/**
+ * Use this option to force the model to call a specific tool on a remote MCP
+ * server.
+ */
+export type OpenAIResponsesToolChoiceMcp = {
+  /**
+   * The label of the MCP server to use.
+   */
+  server_label: string;
+
+  /**
+   * For MCP tools, the type is always `mcp`.
+   */
+  type: 'mcp';
+
+  /**
+   * The name of the tool to call on the server.
+   */
+  name?: string | null;
+};
+
+/**
+ * Controls which (if any) tool is called by the model.
+ *
+ * `none` means the model will not call any tool and instead generates a message.
+ *
+ * `auto` means the model can pick between generating a message or calling one or
+ * more tools.
+ *
+ * `required` means the model must call one or more tools.
+ */
+export type OpenAIResponsesToolChoiceOptions = 'none' | 'auto' | 'required';
+
+/**
+ * Indicates that the model should use a built-in tool to generate a response.
+ * [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
+ */
+export type OpenAIResponsesToolChoiceTypes = {
+  /**
+   * The type of hosted tool the model should to use. Learn more about
+   * [built-in tools](https://platform.openai.com/docs/guides/tools).
+   *
+   * Allowed values are:
+   *
+   * - `file_search`
+   * - `web_search_preview`
+   * - `computer_use_preview`
+   * - `code_interpreter`
+   * - `mcp`
+   * - `image_generation`
+   */
+  type:
+    | 'file_search'
+    | 'web_search_preview'
+    | 'computer_use_preview'
+    | 'image_generation'
+    | 'code_interpreter'
+    | 'mcp';
+};

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -202,4 +202,134 @@ describe('prepareResponsesTools', () => {
       expect(result.toolWarnings).toEqual([]);
     });
   });
+
+  describe('provider-defined toolChoice passthrough', () => {
+    it.each([['none'], ['auto'], ['required']])(
+      'should passthrough primitive toolChoice %s',
+      primitive => {
+        const result = prepareResponsesTools({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.code_interpreter',
+              name: 'code_interpreter',
+              args: {},
+            },
+          ],
+          toolChoice: { type: 'provider-defined', toolChoice: primitive },
+          strictJsonSchema: false,
+        });
+
+        expect(result.toolChoice).toEqual(primitive);
+        expect(result.toolWarnings).toEqual([]);
+      },
+    );
+
+    it('should passthrough built-in type selection: code_interpreter', () => {
+      const choice = { type: 'code_interpreter' } as const;
+      const result = prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'openai.code_interpreter',
+            name: 'code_interpreter',
+            args: {},
+          },
+        ],
+        toolChoice: { type: 'provider-defined', toolChoice: choice },
+        strictJsonSchema: false,
+      });
+
+      expect(result.toolChoice).toEqual(choice);
+      expect(result.toolWarnings).toEqual([]);
+    });
+
+    it('should passthrough function selection', () => {
+      const choice = { type: 'function', name: 'my_function' } as const;
+      const result = prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'openai.code_interpreter',
+            name: 'code_interpreter',
+            args: {},
+          },
+        ],
+        toolChoice: { type: 'provider-defined', toolChoice: choice },
+        strictJsonSchema: false,
+      });
+
+      expect(result.toolChoice).toEqual(choice);
+      expect(result.toolWarnings).toEqual([]);
+    });
+
+    it('should passthrough custom tool selection', () => {
+      const choice = { type: 'custom', name: 'my_custom_tool' } as const;
+      const result = prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'openai.code_interpreter',
+            name: 'code_interpreter',
+            args: {},
+          },
+        ],
+        toolChoice: { type: 'provider-defined', toolChoice: choice },
+        strictJsonSchema: false,
+      });
+
+      expect(result.toolChoice).toEqual(choice);
+      expect(result.toolWarnings).toEqual([]);
+    });
+
+    it('should passthrough MCP selection', () => {
+      const choice = {
+        type: 'mcp',
+        server_label: 'deepwiki',
+        name: 'search',
+      } as const;
+      const result = prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'openai.code_interpreter',
+            name: 'code_interpreter',
+            args: {},
+          },
+        ],
+        toolChoice: { type: 'provider-defined', toolChoice: choice },
+        strictJsonSchema: false,
+      });
+
+      expect(result.toolChoice).toEqual(choice);
+      expect(result.toolWarnings).toEqual([]);
+    });
+
+    it('should passthrough allowed_tools selection', () => {
+      const choice = {
+        type: 'allowed_tools',
+        mode: 'auto',
+        tools: [
+          { type: 'function', name: 'get_weather' },
+          { type: 'mcp', server_label: 'deepwiki' },
+          { type: 'image_generation' },
+        ],
+      } as const;
+      const result = prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'openai.code_interpreter',
+            name: 'code_interpreter',
+            args: {},
+          },
+        ],
+        toolChoice: { type: 'provider-defined', toolChoice: choice },
+        strictJsonSchema: false,
+      });
+
+      expect(result.toolChoice).toEqual(choice);
+      expect(result.toolWarnings).toEqual([]);
+    });
+  });
 });

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -3,7 +3,10 @@ import {
   LanguageModelV2CallWarning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
-import { OpenAIResponsesTool } from './openai-responses-api-types';
+import {
+  OpenAIResponsesTool,
+  OpenAIResponsesToolChoice,
+} from './openai-responses-api-types';
 import { fileSearchArgsSchema } from '../tool/file-search';
 import { codeInterpreterArgsSchema } from '../tool/code-interpreter';
 import { webSearchPreviewArgsSchema } from '../tool/web-search-preview';
@@ -18,14 +21,7 @@ export function prepareResponsesTools({
   strictJsonSchema: boolean;
 }): {
   tools?: Array<OpenAIResponsesTool>;
-  toolChoice?:
-    | 'auto'
-    | 'none'
-    | 'required'
-    | { type: 'file_search' }
-    | { type: 'web_search_preview' }
-    | { type: 'function'; name: string }
-    | { type: 'code_interpreter' };
+  toolChoice?: OpenAIResponsesToolChoice;
   toolWarnings: LanguageModelV2CallWarning[];
 } {
   // when the tools array is empty, change it to undefined to prevent errors:
@@ -120,6 +116,12 @@ export function prepareResponsesTools({
           toolChoice.toolName === 'web_search_preview'
             ? { type: toolChoice.toolName }
             : { type: 'function', name: toolChoice.toolName },
+        toolWarnings,
+      };
+    case 'provider-defined':
+      return {
+        tools: openaiTools,
+        toolChoice: toolChoice.toolChoice as OpenAIResponsesToolChoice,
         toolWarnings,
       };
     default: {

--- a/packages/provider/src/language-model/v2/language-model-v2-tool-choice.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-tool-choice.ts
@@ -2,4 +2,5 @@ export type LanguageModelV2ToolChoice =
   | { type: 'auto' } // the tool selection is automatic (can be no tool)
   | { type: 'none' } // no tool must be selected
   | { type: 'required' } // one of the available tools must be selected
-  | { type: 'tool'; toolName: string }; // a specific tool must be selected:
+  | { type: 'tool'; toolName: string } // a specific tool must be selected
+  | { type: 'provider-defined'; toolChoice: unknown }; // pass through the tool choice to the provider:

--- a/packages/xai/src/xai-prepare-tools.test.ts
+++ b/packages/xai/src/xai-prepare-tools.test.ts
@@ -1,0 +1,16 @@
+import { prepareTools } from './xai-prepare-tools';
+
+it('should passthrough provider-defined toolChoice', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'fn',
+        description: 'd',
+        inputSchema: {},
+      },
+    ],
+    toolChoice: { type: 'provider-defined', toolChoice: 'required' },
+  });
+  expect(result.toolChoice).toEqual('required');
+});

--- a/packages/xai/src/xai-prepare-tools.ts
+++ b/packages/xai/src/xai-prepare-tools.ts
@@ -82,6 +82,12 @@ export function prepareTools({
         },
         toolWarnings,
       };
+    case 'provider-defined':
+      return {
+        tools: xaiTools,
+        toolChoice: toolChoice.toolChoice as XaiToolChoice,
+        toolWarnings,
+      };
     default: {
       const _exhaustiveCheck: never = type;
       throw new UnsupportedFunctionalityError({


### PR DESCRIPTION
## Background

OpenAI released a few new `tool_choice` options ({ type: 'allowed_tools' }) and I can't seem to use them without overriding fetch

## Summary

Add new toolChoice option:

```
{ type: 'provider-defined'; toolChoice: unknown }
```

This will pass through the `unknown` toolChoice to the underlying provider

## Manual Verification

Would like to get green light on the approach before.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)


## Related Issues
https://github.com/vercel/ai/issues/8225
