### PR TITLE
fix(ai): prevent message parts carryover in streaming responses

### DIFF
--- a/.changeset/fix-message-parts-carryover.md
+++ b/.changeset/fix-message-parts-carryover.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix message parts carryover in streaming responses with multiple messages


### PR DESCRIPTION
## Issue

https://github.com/vercel/ai/issues/8227

## Summary

Fixes a bug where parts from previous messages were carried over to subsequent messages when multiple assistant messages arrived in the same HTTP streaming response. This resulted in message contamination where later messages contained both their own parts and parts from earlier messages.

## Changes

### Core Fix
- **Refactored message creation logic** into reusable helper functions:
  - `createFreshAssistantMessage()`: Creates a fresh assistant message with empty parts array
  - `resetActiveStreamingParts()`: Resets all active streaming parts to prevent carryover
- **Enhanced `start` case handling** in `processUIMessageStream()` to detect new messages and reset state appropriately
- **Improved maintainability** by eliminating code duplication between message creation scenarios

### Test Coverage
- Added comprehensive test case `multiple messages in same HTTP response` that reproduces the exact scenario described in the issue
- Validates that each message contains only its own parts without carryover
- Ensures proper isolation between messages in the same streaming response

## Technical Details

### Before (Problematic Behavior)
```typescript
case 'start': {
  if (chunk.messageId != null) {
    state.message.id = chunk.messageId; // ❌ Only changed ID, kept same parts array
  }
  // ... parts array and active state carried over
}
```

### After (Fixed Behavior) 
```typescript
case 'start': {
  if (chunk.messageId != null && chunk.messageId !== state.message.id) {
    // ✅ Create completely fresh message and reset all state
    state.message = createFreshAssistantMessage<UI_MESSAGE>(chunk.messageId);
    resetActiveStreamingParts(state);
  } else if (chunk.messageId != null) {
    state.message.id = chunk.messageId;
  }
  // ...
}
```

## Example Scenario Fixed

**Input Stream:**
```
data: {"type":"start","messageId":"1"}
data: {"type":"text-start","id":"text1"}
data: {"type":"text-delta","id":"text1","delta":"Retrieving the weather!"}
data: {"type":"text-end","id":"text1"}
data: {"type":"data-notification","data":{"agent":"weather", "status": "fetching"}}
data: {"type":"finish"}

data: {"type":"start","messageId":"2"} // ← New message starts here
data: {"type":"text-start","id":"text2"}
data: {"type":"text-delta","id":"text2","delta":"Got the temp!"}
data: {"type":"text-end","id":"text2"}
data: {"type":"data-notification", "data":{"agent":"weather", "status": "ready", "temperature": 100}}
data: {"type":"finish"}
```

**Before (Buggy):** Message 2 contained parts from Message 1 + its own parts  
**After (Fixed):** Message 2 contains only its own parts

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
