### PR TITLE
feat(ai): add providerOptions to prepareStep result

### DIFF
--- a/.changeset/angry-timers-trade.md
+++ b/.changeset/angry-timers-trade.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+add providerOptions to prepareStep result

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -592,6 +592,13 @@ To see `generateText` in action, check out [these examples](#examples).
               isOptional: true,
               description: 'Modify the input messages for this step.',
             },
+            {
+              name: 'providerOptions',
+              type: 'Record<string,Record<string,JSONValue>>',
+              isOptional: true,
+              description:
+                'Additional provider-specific options for this step. Merges with and overrides outer providerOptions for this step.',
+            },
           ],
         },
       ],

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -643,6 +643,13 @@ To see `streamText` in action, check out [these examples](#examples).
               isOptional: true,
               description: 'Modify the input messages for this step.',
             },
+            {
+              name: 'providerOptions',
+              type: 'Record<string,Record<string,JSONValue>>',
+              isOptional: true,
+              description:
+                'Additional provider-specific options for this step. Merges with and overrides outer providerOptions for this step.',
+            },
           ],
         },
       ],

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -2737,6 +2737,7 @@ The `prepareStep` function receives `{ steps, stepNumber, model }` and can retur
 - `activeTools`: Which tools to make available
 - `toolChoice`: Tool selection strategy
 - `system`: System message for this step
+- `providerOptions`: Provider-specific option overrides for this step
 - `undefined`: Use default settings
 
 ### Temperature Default Removal

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -32,6 +32,7 @@ import { LanguageModel, ToolChoice } from '../types';
 import { addLanguageModelUsage, LanguageModelUsage } from '../types/usage';
 import { asArray } from '../util/as-array';
 import { prepareRetries } from '../util/prepare-retries';
+import { mergeObjects } from '../util/merge-objects';
 import { ContentPart } from './content-part';
 import { extractTextContent } from './extract-text-content';
 import { GenerateTextResult } from './generate-text-result';
@@ -374,7 +375,10 @@ A function that attempts to repair a tool call that failed to parse.
                   toolChoice: stepToolChoice,
                   responseFormat: output?.responseFormat,
                   prompt: promptMessages,
-                  providerOptions,
+                  providerOptions: mergeObjects(
+                    providerOptions,
+                    prepareStepResult?.providerOptions,
+                  ),
                   abortSignal,
                   headers,
                 });

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -1,4 +1,4 @@
-import { ModelMessage, Tool } from '@ai-sdk/provider-utils';
+import { ModelMessage, ProviderOptions, Tool } from '@ai-sdk/provider-utils';
 import { LanguageModel, ToolChoice } from '../types/language-model';
 import { StepResult } from './step-result';
 
@@ -31,5 +31,6 @@ export type PrepareStepResult<
       activeTools?: Array<keyof NoInfer<TOOLS>>;
       system?: string;
       messages?: Array<ModelMessage>;
+      providerOptions?: ProviderOptions;
     }
   | undefined;

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -60,6 +60,7 @@ import { createStitchableStream } from '../util/create-stitchable-stream';
 import { DelayedPromise } from '../util/delayed-promise';
 import { now as originalNow } from '../util/now';
 import { prepareRetries } from '../util/prepare-retries';
+import { mergeObjects } from '../util/merge-objects';
 import { ContentPart } from './content-part';
 import { Output } from './output';
 import { PrepareStepFunction } from './prepare-step';
@@ -1133,7 +1134,10 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                     toolChoice: stepToolChoice,
                     responseFormat: output?.responseFormat,
                     prompt: promptMessages,
-                    providerOptions,
+                    providerOptions: mergeObjects(
+                      providerOptions,
+                      prepareStepResult?.providerOptions,
+                    ),
                     abortSignal,
                     headers,
                     includeRawChunks,


### PR DESCRIPTION

## Background

You can currently do this by doing:
```
prepareStep: () => {
  return {
      model: wrapLanguageModel({
          model: responses('gpt-5'),
          middleware: defaultSettingsMiddleware({
              settings: {
                  providerOptions: {
                     // etc
                  },
               }
          }
     })
  }
}
```
This was very hard to figure out.  I think it makes sense to make it its own option.

This is very useful for the `previousResponseId` field for the responses API - among other settings.


## Summary

added `providerOptions` to `prepareStep` result

this will `mergeObjects` with the outer `providerOptions`

## Manual Verification

Want to get confirmation this is acceptable before

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
