### PR TITLE
fix(ai): make `chat.addToolResult()` compatible with dynamic tool calls

### DIFF
--- a/.changeset/green-goats-beam.md
+++ b/.changeset/green-goats-beam.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): make `chat.addToolResult()` compatible with dynamic tool calls

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1217,6 +1217,149 @@ describe('Chat', () => {
         }
       `);
     });
+
+    it('should send message when a dynamic tool result is submitted', async () => {
+      server.urls['http://localhost:3000/api/chat'].response = [
+        {
+          type: 'stream-chunks',
+          chunks: [
+            formatChunk({ type: 'start' }),
+            formatChunk({ type: 'start-step' }),
+            formatChunk({
+              type: 'tool-input-available',
+              dynamic: true,
+              toolCallId: 'tool-call-0',
+              toolName: 'test-tool',
+              input: { testArg: 'test-value' },
+            }),
+            formatChunk({ type: 'finish-step' }),
+            formatChunk({ type: 'finish' }),
+          ],
+        },
+        {
+          type: 'stream-chunks',
+          chunks: [
+            formatChunk({ type: 'start' }),
+            formatChunk({ type: 'start-step' }),
+            formatChunk({ type: 'finish-step' }),
+            formatChunk({ type: 'finish' }),
+          ],
+        },
+      ];
+
+      let callCount = 0;
+      const onFinishPromise = createResolvablePromise<void>();
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: new DefaultChatTransport({
+          api: 'http://localhost:3000/api/chat',
+        }),
+        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+        onFinish: () => {
+          callCount++;
+          if (callCount === 2) {
+            onFinishPromise.resolve();
+          }
+        },
+      });
+
+      await chat.sendMessage({
+        text: 'Hello, world!',
+      });
+
+      // user submits the tool result
+      await chat.addToolResult({
+        tool: 'test-tool',
+        toolCallId: 'tool-call-0',
+        output: 'test-result',
+      });
+
+      // UI should show the tool result
+      expect(chat.messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "id-0",
+            "metadata": undefined,
+            "parts": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "id": "id-1",
+            "metadata": undefined,
+            "parts": [
+              {
+                "type": "step-start",
+              },
+              {
+                "errorText": undefined,
+                "input": {
+                  "testArg": "test-value",
+                },
+                "output": "test-result",
+                "preliminary": undefined,
+                "state": "output-available",
+                "toolCallId": "tool-call-0",
+                "toolName": "test-tool",
+                "type": "dynamic-tool",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+
+      await onFinishPromise.promise;
+
+      // 2nd call should happen after the stream is finished
+      expect(server.calls.length).toBe(2);
+
+      // check details of the 2nd call
+      expect(await server.calls[1].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "id": "123",
+          "messageId": "id-1",
+          "messages": [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "input": {
+                    "testArg": "test-value",
+                  },
+                  "output": "test-result",
+                  "state": "output-available",
+                  "toolCallId": "tool-call-0",
+                  "toolName": "test-tool",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          "trigger": "submit-message",
+        }
+      `);
+    });
   });
 
   describe('clearError', () => {

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -17,7 +17,7 @@ import {
 } from './process-ui-message-stream';
 import {
   InferUIMessageToolCall,
-  isToolUIPart,
+  isToolOrDynamicToolUIPart,
   type DataUIPart,
   type FileUIPart,
   type InferUIMessageData,
@@ -417,7 +417,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       this.state.replaceMessage(messages.length - 1, {
         ...lastMessage,
         parts: lastMessage.parts.map(part =>
-          isToolUIPart(part) && part.toolCallId === toolCallId
+          isToolOrDynamicToolUIPart(part) && part.toolCallId === toolCallId
             ? { ...part, state: 'output-available', output }
             : part,
         ),
@@ -427,7 +427,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       if (this.activeResponse) {
         this.activeResponse.state.message.parts =
           this.activeResponse.state.message.parts.map(part =>
-            isToolUIPart(part) && part.toolCallId === toolCallId
+            isToolOrDynamicToolUIPart(part) && part.toolCallId === toolCallId
               ? {
                   ...part,
                   state: 'output-available',

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -1044,6 +1044,13 @@ describe('convertToModelMessages', () => {
                 toolCallId: 'call-3',
                 input: { value: 'value-3' },
               },
+              {
+                type: 'dynamic-tool',
+                toolName: 'tool-screenshot2',
+                state: 'input-available',
+                toolCallId: 'call-3',
+                input: { value: 'value-3' },
+              },
               { type: 'text', text: 'response', state: 'done' },
             ],
           },

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -10,6 +10,7 @@ import {
   DynamicToolUIPart,
   FileUIPart,
   getToolName,
+  isToolOrDynamicToolUIPart,
   isToolUIPart,
   ReasoningUIPart,
   TextUIPart,
@@ -40,7 +41,7 @@ export function convertToModelMessages(
       ...message,
       parts: message.parts.filter(
         part =>
-          !isToolUIPart(part) ||
+          !isToolOrDynamicToolUIPart(part) ||
           (part.state !== 'input-streaming' &&
             part.state !== 'input-available'),
       ),

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -30,7 +30,9 @@ export { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-me
 export { TextStreamChatTransport } from './text-stream-chat-transport';
 export {
   getToolName,
+  getToolOrDynamicToolName,
   isToolUIPart,
+  isToolOrDynamicToolUIPart,
   type DataUIPart,
   type DynamicToolUIPart,
   type FileUIPart,

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-tool-calls.ts
@@ -1,4 +1,4 @@
-import { isToolUIPart, UIMessage } from './ui-messages';
+import { isToolOrDynamicToolUIPart, UIMessage } from './ui-messages';
 
 /**
 Check if the message is an assistant message with completed tool calls.
@@ -26,7 +26,7 @@ export function lastAssistantMessageIsCompleteWithToolCalls({
 
   const lastStepToolInvocations = message.parts
     .slice(lastStepStartIndex + 1)
-    .filter(part => isToolUIPart(part) || part.type === 'dynamic-tool');
+    .filter(isToolOrDynamicToolUIPart);
 
   return (
     lastStepToolInvocations.length > 0 &&

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -293,7 +293,7 @@ export function isToolOrDynamicToolUIPart<TOOLS extends UITools>(
 }
 
 export function getToolName<TOOLS extends UITools>(
-  part: ToolUIPart<TOOLS>
+  part: ToolUIPart<TOOLS>,
 ): keyof TOOLS {
   return part.type.split('-').slice(1).join('-') as keyof TOOLS;
 }

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -280,10 +280,31 @@ export function isToolUIPart<TOOLS extends UITools>(
   return part.type.startsWith('tool-');
 }
 
+export function isDynamicToolUIPart(
+  part: UIMessagePart<UIDataTypes, UITools>,
+): part is DynamicToolUIPart {
+  return part.type === 'dynamic-tool';
+}
+
+export function isToolOrDynamicToolUIPart<TOOLS extends UITools>(
+  part: UIMessagePart<UIDataTypes, TOOLS>,
+): part is ToolUIPart<TOOLS> | DynamicToolUIPart {
+  return isToolUIPart(part) || isDynamicToolUIPart(part);
+}
+
 export function getToolName<TOOLS extends UITools>(
-  part: ToolUIPart<TOOLS>,
+  part: ToolUIPart<TOOLS> | DynamicToolUIPart,
 ): keyof TOOLS {
   return part.type.split('-').slice(1).join('-') as keyof TOOLS;
+}
+
+export function getToolOrDynamicToolName(
+  part: ToolUIPart<UITools> | DynamicToolUIPart,
+): string {
+  if (isDynamicToolUIPart(part)) {
+    return part.toolName;
+  }
+  return part.type.split('-').slice(1).join('-');
 }
 
 export type InferUIMessageMetadata<T extends UIMessage> =

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -293,7 +293,7 @@ export function isToolOrDynamicToolUIPart<TOOLS extends UITools>(
 }
 
 export function getToolName<TOOLS extends UITools>(
-  part: ToolUIPart<TOOLS> | DynamicToolUIPart,
+  part: ToolUIPart<TOOLS>
 ): keyof TOOLS {
   return part.type.split('-').slice(1).join('-') as keyof TOOLS;
 }


### PR DESCRIPTION
## Background

`dynamic-tool` parts are ignored in the current version of `addToolResult`, but following other APIs, it should be supported just as any other tool.

## Summary

Add support for dynamic tools in `chat.addToolResult()`.

## Future Work

- Revisit function name `isToolOrDynamicToolUIPart` and similar in AI SDK 6, aiming for different naming re static/dynamic tools with Tools as unified name.

## Related Issues

Fixes #7896