### PR TITLE
fix(docs): corrected highlight range in tool-result example

### DIFF
--- a/content/docs/02-foundations/03-prompts.mdx
+++ b/content/docs/02-foundations/03-prompts.mdx
@@ -503,7 +503,7 @@ const result = await generateText({
 Tool results can be multi-part and multi-modal, e.g. a text and an image.
 You can use the `experimental_content` property on tool parts to specify multi-part tool results.
 
-```ts highlight="20-32"
+```ts highlight="24-46"
 const result = await generateText({
   model: 'openai/gpt-4.1',
   messages: [


### PR DESCRIPTION
Small correction in `content/docs/02-foundations/03-prompts.mdx`. 

Updated the code block so the `tool` message example (multi-part `tool-result` including the base64 media part) is displayed with `highlight="24-46"`. 

Docs-only change; no runtime/code changes.
