### PR TITLE
fix(providers/google-vertex): taskType now properly transforms to snake case in final payload

### DIFF
--- a/.changeset/silver-avocados-hide.md
+++ b/.changeset/silver-avocados-hide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+The taskType parameter now properly maps to snake case in the final payload.

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -121,7 +121,7 @@ describe('GoogleVertexEmbeddingModel', () => {
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       instances: testValues.map(value => ({
         content: value,
-        taskType: mockProviderOptions.taskType,
+        task_type: mockProviderOptions.taskType,
       })),
       parameters: {
         outputDimensionality: mockProviderOptions.outputDimensionality,

--- a/packages/google-vertex/src/google-vertex-embedding-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.test.ts
@@ -141,7 +141,7 @@ describe('GoogleVertexEmbeddingModel', () => {
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
       instances: testValues.map(value => ({
         content: value,
-        taskType: mockProviderOptions.taskType,
+        task_type: mockProviderOptions.taskType,
       })),
       parameters: {},
     });

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -79,7 +79,7 @@ export class GoogleVertexEmbeddingModel implements EmbeddingModelV2<string> {
       body: {
         instances: values.map(value => ({
           content: value,
-          taskType: googleOptions.taskType,
+          task_type: googleOptions.taskType,
         })),
         parameters: {
           outputDimensionality: googleOptions.outputDimensionality,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

The google vertex text embedding api was silently ignoring all requests with `taskType` through the AI SDK because the SDK was sending an HTTP payload where taskType remained camel case. 

Fields inside of instances should be snake case
<img width="791" height="306" alt="image" src="https://github.com/user-attachments/assets/459741ad-0faf-4033-8f8f-aff675b60741" />


## Summary

<!-- What did you change? -->

I changed the internal payload, and corresponding test, to send snake case payloads to the google embeddings API.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->
I made fetch requests to the vertex API to see how task_type affected outputs. Then I verified that passing taskType would be silently ignored (different output, no error).

I then ran the same example on the current release of the AI SDK and verified that outputs were the same irrespective of taskType parameter. Furthermore, outputs were identical to the fetch requests where taskType was silently ignored, or not included at all.

I verified this behavior with the documentation.

Finally I ran the same test on my own build to verify that results from the AI SDK with `taskType` were equivalent to raw API requests that included `task_type`

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->
 
I would love to check if this issue exists in the google gen AI provider. After that, I would love to add support for the title field for google embedding APIs.

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
Fixes #8235 