### PR TITLE
OpenAI-compatible: convert v5 assistant "tool-result" parts

### DIFF
--- a/.changeset/pink-scissors-sleep.md
+++ b/.changeset/pink-scissors-sleep.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai-compat):convert v5 assistant "tool-result" parts

--- a/.changeset/pink-scissors-sleep.md
+++ b/.changeset/pink-scissors-sleep.md
@@ -2,4 +2,4 @@
 '@ai-sdk/openai-compatible': patch
 ---
 
-fix(openai-compat):convert v5 assistant "tool-result" parts
+fix(openai-compat): convert v5 assistant "tool-result" parts

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -196,6 +196,53 @@ describe('tool calls', () => {
       },
     ]);
   });
+
+  it('should convert tool-result parts in assistant messages to tool messages', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me call a tool and process the result.' },
+          {
+            type: 'tool-call',
+            input: { operation: 'add', x: 5, y: 3 },
+            toolCallId: 'calc-123',
+            toolName: 'calculator',
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'calc-123',
+            toolName: 'calculator',
+            output: { type: 'json', value: { result: 8 } },
+          },
+          { type: 'text', text: 'The calculation is complete.' },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content:
+          'Let me call a tool and process the result.The calculation is complete.',
+        tool_calls: [
+          {
+            type: 'function',
+            id: 'calc-123',
+            function: {
+              name: 'calculator',
+              arguments: JSON.stringify({ operation: 'add', x: 5, y: 3 }),
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'calc-123',
+        content: JSON.stringify({ result: 8 }),
+      },
+    ]);
+  });
 });
 
 describe('provider-specific metadata merging', () => {


### PR DESCRIPTION
## Background

Since ai-sdk v5, `tool-result` parts can now be used in `assistant` role messages. This PR fixes the OpenAI-compatible provider to convert these parts into separate `tool` role messages.

Without it, OpenRouter returns a 400 error for this message:

```json
{
  "role": "assistant",
  "content" :[
    {"type":"text","text":"I'll read the agent.json file for you."},
    {"type":"tool-call","toolCallId":"toolu_vrtx_017UdY865gdrWQyTj7E7vMYQ","toolName":"text_editor_view","input":{"path":"agent.json"}},

    // This is the issue
    {"type":"tool-result","toolCallId":"toolu_vrtx_017UdY865gdrWQyTj7E7vMYQ","toolName":"text_editor_view","output":{"type":"text","value":"{\n  \"model\": \"claude-sonnet-4\",\n  \"temperature\": 0.2,\n  \"mcpServers\": {\n    \"js-dev\": {\n      \"type\": \"stdio\",\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"@soapbox.pub/js-dev-mcp@latest\"]\n    },\n    \"nostr\": {\n      \"type\": \"stdio\",\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"@nostrbook/mcp@latest\"]\n    }\n  }\n}\n"}}
  ]
}
```

Example wrong API request:

```json
{
  "model":"anthropic/claude-sonnet-4",
  "messages":[
    {"role":"user","content":"Read agent.json"},
    {"role":"assistant","content":"I'll read the agent.json file for you.","tool_calls":[{"id":"toolu_vrtx_017UdY865gdrWQyTj7E7vMYQ","type":"function","function":{"name":"text_editor_view","arguments":"{\"path\":\"agent.json\"}"}}]}

    // There is no "tool" message here
  ]
}
```

Example API error:

```json
{
    "message": "Provider returned error",
    "code": 400,
    "metadata": {
        "raw": "{\"message\":\"messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_vrtx_017UdY865gdrWQyTj7E7vMYQ. Each `tool_use` block must have a corresponding `tool_result` block in the next message.\"}",
        "provider_name": "Amazon Bedrock"
    }
}
```

Fixed request:

```json
{
  "model":"anthropic/claude-sonnet-4",
  "messages":[
    {"role":"user","content":"Read agent.json"},
    {"role":"assistant","content":"I'll read the agent.json file for you.","tool_calls":[{"id":"tool1","type":"function","function":{"name":"text_editor_view","arguments":"{\"path\":\"agent.json\"}"}}]},
    {"role":"tool","tool_call_id":"tool1","content":"{\n  \"model\": \"claude-sonnet-4\",\n  \"temperature\": 0.2,\n  \"mcpServers\": {\n    \"js-dev\": {\n      \"type\": \"stdio\",\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"@soapbox.pub/js-dev-mcp@latest\"]\n    },\n    \"nostr\": {\n      \"type\": \"stdio\",\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"@nostrbook/mcp@latest\"]\n    }\n  }\n}\n"}
  ]
}
```

Btw, `streamText` chunk-order naturally leads to putting `tool-result`s in `assistant` messages.

## Summary

Extended the OpenAI-compatible provider to support the full v5 AssistantModelMessage type.

## Manual Verification

Added tests and ran `cd packages/openai-compatible && pnpm test:node src/chat/convert-to-openai-compatible-chat-messages.test.ts`

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)