### PR TITLE
fix(provider/openai): do not set `response_format` to `verbose_json` if model is `gpt-4o-transcribe`

### DIFF
--- a/.changeset/witty-bees-greet.md
+++ b/.changeset/witty-bees-greet.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(provider/openai): do not set `response_format` to `verbose_json` if model is `gpt-4o-transcribe` or `gpt-4o-mini-transcribe`
+
+These two models do not support it:
+https://platform.openai.com/docs/api-reference/audio/createTranscription#audio_createtranscription-response_format

--- a/packages/openai/src/transcription/openai-transcription-model.test.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.test.ts
@@ -182,7 +182,7 @@ describe('doGenerate', () => {
     expect(result.response.modelId).toBe('whisper-1');
   });
 
-  it('should pass response_format when specified', async () => {
+  it('should pass response_format when `providerOptions.openai.timestampGranularities` is set', async () => {
     prepareJsonResponse();
 
     await model.doGenerate({
@@ -204,6 +204,35 @@ describe('doGenerate', () => {
         },
         "model": "whisper-1",
         "response_format": "verbose_json",
+        "temperature": "0",
+        "timestamp_granularities": "word",
+      }
+    `);
+  });
+
+  it('should not set pass response_format to "verbose_json" when model is "gpt-4o-transcribe"', async () => {
+    prepareJsonResponse();
+
+    const model = provider.transcription('gpt-4o-transcribe');
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        openai: {
+          timestampGranularities: ['word'],
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyMultipart).toMatchInlineSnapshot(`
+      {
+        "file": File {
+          Symbol(kHandle): Blob {},
+          Symbol(kLength): 40169,
+          Symbol(kType): "audio/wav",
+        },
+        "model": "gpt-4o-transcribe",
+        "response_format": "json",
         "temperature": "0",
         "timestamp_granularities": "word",
       }

--- a/packages/openai/src/transcription/openai-transcription-model.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.ts
@@ -137,7 +137,14 @@ export class OpenAITranscriptionModel implements TranscriptionModelV2 {
         include: openAIOptions.include,
         language: openAIOptions.language,
         prompt: openAIOptions.prompt,
-        response_format: 'verbose_json', // always use verbose_json to get segments
+        // https://platform.openai.com/docs/api-reference/audio/createTranscription#audio_createtranscription-response_format
+        // prefer verbose_json to get segments for models that support it
+        response_format: [
+          'gpt-4o-transcribe',
+          'gpt-4o-mini-transcribe',
+        ].includes(this.modelId)
+          ? 'json'
+          : 'verbose_json',
         temperature: openAIOptions.temperature,
         timestamp_granularities: openAIOptions.timestampGranularities,
       };


### PR DESCRIPTION
## Background

As of #8011, `response_format` was always set to `verbose_json` if `providerOptions.openai` is truthy, causing the following error

> response_format 'verbose_json' is not compatible with model 'gpt-4o-transcribe'. Use 'json' or 'text' instead.

## Summary

_TBD_

## Manual Verification

```ts
import { readFile } from 'node:fs/promises';

import { openai } from '@ai-sdk/openai';
import { experimental_transcribe as transcribe } from 'ai';

import 'dotenv/config';

async function main() {
  const result = await transcribe({
    model: openai.transcription('gpt-4o-transcribe'),
    audio: await readFile('data/galileo.mp3'),
    providerOptions: {
      openai: {
        timestampGranularities: ['word']
      }
    }
  });
}

main().catch(console.error);
```

## Tasks


- [x] Tests have been added / updated (for bug fixes / features)
- [x] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)
- [x] Investigate impact on [timestamp_granularities](https://platform.openai.com/docs/api-reference/audio/createTranscription#audio_createtranscription-timestamp_granularities_) ("`response_format` must be set to `verbose_json`")

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

closes #8214