### PR TITLE
fix(docs): wrap stream in an object for createUIMessageStreamResponse in Human-in-the-Loop example

### DIFF
--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -110,7 +110,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return createUIMessageStreamResponse(stream);
+  return createUIMessageStreamResponse({ stream });
 }
 ```
 
@@ -172,7 +172,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return createUIMessageStreamResponse(stream);
+  return createUIMessageStreamResponse({ stream });
 }
 ```
 


### PR DESCRIPTION
 ## Summary
  This PR fixes an incorrect usage of `createUIMessageStreamResponse` in the Human-in-the-Loop documentation example.

  ## Problem
  The current example shows:
  ```typescript
  return createUIMessageStreamResponse(stream);

  However, this causes a runtime error:
  TypeError: Cannot read properties of undefined (reading 'pipeThrough')

  Solution

  The createUIMessageStreamResponse function expects an object with a stream property, not the stream directly:
  return createUIMessageStreamResponse({ stream });