### PR TITLE
fix(provider/openai): support websearch tool results without query property

### DIFF
--- a/.changeset/little-drinks-try.md
+++ b/.changeset/little-drinks-try.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(provider/openai): support websearch tool results without query property

--- a/examples/ai-core/src/generate-text/openai-responses-websearch.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-websearch.ts
@@ -4,10 +4,12 @@ import 'dotenv/config';
 
 async function main() {
   const result = await generateText({
-    model: openai.responses('gpt-4o-mini'),
+    model: openai('gpt-5'),
     prompt: 'What happened in San Francisco last week?',
     tools: {
-      web_search_preview: openai.tools.webSearchPreview({}),
+      web_search_preview: openai.tools.webSearchPreview({
+        searchContextSize: 'high',
+      }),
     },
   });
 

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2184,6 +2184,15 @@ describe('OpenAIResponsesLanguageModel', () => {
                 },
               },
               {
+                type: 'web_search_call',
+                id: 'ws_67cf2b3051e88190b006234456fdb13d',
+                status: 'completed',
+                action: {
+                  type: 'search',
+                  // sometimes search calls do not have a query
+                },
+              },
+              {
                 type: 'message',
                 id: 'msg_67cf2b35467481908f24412e4fd40d66',
                 status: 'completed',
@@ -2303,6 +2312,22 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "status": "completed",
               },
               "toolCallId": "ws_67cf2b3051e88190b006770db6fdb13d",
+              "toolName": "web_search_preview",
+              "type": "tool-result",
+            },
+            {
+              "input": "{"action":{"type":"search"}}",
+              "providerExecuted": true,
+              "toolCallId": "ws_67cf2b3051e88190b006234456fdb13d",
+              "toolName": "web_search_preview",
+              "type": "tool-call",
+            },
+            {
+              "providerExecuted": true,
+              "result": {
+                "status": "completed",
+              },
+              "toolCallId": "ws_67cf2b3051e88190b006234456fdb13d",
               "toolName": "web_search_preview",
               "type": "tool-result",
             },

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -33,7 +33,7 @@ const webSearchCallItem = z.object({
     .discriminatedUnion('type', [
       z.object({
         type: z.literal('search'),
-        query: z.string(),
+        query: z.string().nullish(),
       }),
       z.object({
         type: z.literal('open_page'),

--- a/packages/openai/src/tool/web-search-preview.ts
+++ b/packages/openai/src/tool/web-search-preview.ts
@@ -87,7 +87,7 @@ export const webSearchPreview = createProviderDefinedToolFactory<
       .discriminatedUnion('type', [
         z.object({
           type: z.literal('search'),
-          query: z.string(),
+          query: z.string().nullish(),
         }),
         z.object({
           type: z.literal('open_page'),


### PR DESCRIPTION
## Background

Some OpenAI responses websearch tool results do not contain a `query` property (see #8264 ).

## Summary

Make `query` property `nullish` on both tool args and the response parsing.

## Manual Verification

- [x] verify that `examples/ai-core/src/stream-object/openai.ts` works

## Related Issues

Fixes #8264