### PR TITLE
fix(docs): openai gpt-5-chat-latest does not support tools

### DIFF
--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1162,7 +1162,7 @@ The following optional provider options are available for OpenAI completion mode
 | `gpt-5`                | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-5-mini`           | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-5-nano`           | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gpt-5-chat-latest`    | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gpt-5-chat-latest`    | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Cross size={18} /> |
 
 <Note>
   The table above lists popular models. Please see the [OpenAI


### PR DESCRIPTION
closes #8260