### PR TITLE
feat(provider/gateway): Add cache pricing fields to model metadata

### DIFF
--- a/.changeset/lemon-months-warn.md
+++ b/.changeset/lemon-months-warn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): Add cache pricing fields to model metadata

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -56,9 +56,7 @@ const gatewayLanguageModelPricingSchema = z
   .transform(({ input, output, input_cache_read, input_cache_write }) => ({
     input,
     output,
-    ...(input_cache_read
-      ? { cachedInputTokens: input_cache_read }
-      : {}),
+    ...(input_cache_read ? { cachedInputTokens: input_cache_read } : {}),
     ...(input_cache_write
       ? { cacheCreationInputTokens: input_cache_write }
       : {}),

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -46,10 +46,23 @@ const gatewayLanguageModelSpecificationSchema = z.object({
   modelId: z.string(),
 });
 
-const gatewayLanguageModelPricingSchema = z.object({
-  input: z.string(),
-  output: z.string(),
-});
+const gatewayLanguageModelPricingSchema = z
+  .object({
+    input: z.string(),
+    output: z.string(),
+    input_cache_read: z.string().optional(),
+    input_cache_write: z.string().optional(),
+  })
+  .transform(({ input, output, input_cache_read, input_cache_write }) => ({
+    input,
+    output,
+    ...(input_cache_read
+      ? { cachedInputTokens: input_cache_read }
+      : {}),
+    ...(input_cache_write
+      ? { cacheCreationInputTokens: input_cache_write }
+      : {}),
+  }));
 
 const gatewayLanguageModelEntrySchema = z.object({
   id: z.string(),

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -50,8 +50,8 @@ const gatewayLanguageModelPricingSchema = z
   .object({
     input: z.string(),
     output: z.string(),
-    input_cache_read: z.string().optional(),
-    input_cache_write: z.string().optional(),
+    input_cache_read: z.string().nullish(),
+    input_cache_write: z.string().nullish(),
   })
   .transform(({ input, output, input_cache_read, input_cache_write }) => ({
     input,

--- a/packages/gateway/src/gateway-model-entry.ts
+++ b/packages/gateway/src/gateway-model-entry.ts
@@ -29,6 +29,16 @@ export interface GatewayLanguageModelEntry {
      * Cost per output token in USD.
      */
     output: string;
+    /**
+     * Cost per cached input token in USD.
+     * Only present for providers/models that support prompt caching.
+     */
+    cachedInputTokens?: string;
+    /**
+     * Cost per input token to create/write cache entries in USD.
+     * Only present for providers/models that support prompt caching.
+     */
+    cacheCreationInputTokens?: string;
   } | null;
 
   /**


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Re: https://vercel.slack.com/archives/C099VQB75TP/p1755977985474589?thread_ts=1755977765.274169&cid=C099VQB75TP

## Summary

Added cache pricing fields in the model metadata schema

## Manual Verification

Tested with an example script that printed the metadata for each model, and I verified that cache pricing was printed (not for every model, many don't support it).

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [X] I have reviewed this pull request (self-review)