### PR TITLE
fix(ai): remove use of `expect()` from production code

### DIFF
--- a/.changeset/lemon-pears-stare.md
+++ b/.changeset/lemon-pears-stare.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): remove use of `expect()` from production code

--- a/packages/ai/src/error/no-object-generated-error.ts
+++ b/packages/ai/src/error/no-object-generated-error.ts
@@ -68,22 +68,3 @@ export class NoObjectGeneratedError extends AISDKError {
     return AISDKError.hasMarker(error, marker);
   }
 }
-
-export function verifyNoObjectGeneratedError(
-  error: unknown,
-  expected: {
-    message: string;
-    response: LanguageModelResponseMetadata & {
-      body?: string;
-    };
-    usage: LanguageModelUsage;
-    finishReason: FinishReason;
-  },
-) {
-  expect(NoObjectGeneratedError.isInstance(error)).toBeTruthy();
-  const noObjectGeneratedError = error as NoObjectGeneratedError;
-  expect(noObjectGeneratedError.message).toEqual(expected.message);
-  expect(noObjectGeneratedError.response).toEqual(expected.response);
-  expect(noObjectGeneratedError.usage).toEqual(expected.usage);
-  expect(noObjectGeneratedError.finishReason).toEqual(expected.finishReason);
-}

--- a/packages/ai/src/error/verify-no-object-generated-error.ts
+++ b/packages/ai/src/error/verify-no-object-generated-error.ts
@@ -1,0 +1,21 @@
+import { FinishReason, LanguageModelResponseMetadata, LanguageModelUsage } from "../types";
+import { NoObjectGeneratedError } from "./no-object-generated-error";
+
+export function verifyNoObjectGeneratedError(
+  error: unknown,
+  expected: {
+    message: string;
+    response: LanguageModelResponseMetadata & {
+      body?: string;
+    };
+    usage: LanguageModelUsage;
+    finishReason: FinishReason;
+  },
+) {
+  expect(NoObjectGeneratedError.isInstance(error)).toBeTruthy();
+  const noObjectGeneratedError = error as NoObjectGeneratedError;
+  expect(noObjectGeneratedError.message).toEqual(expected.message);
+  expect(noObjectGeneratedError.response).toEqual(expected.response);
+  expect(noObjectGeneratedError.usage).toEqual(expected.usage);
+  expect(noObjectGeneratedError.finishReason).toEqual(expected.finishReason);
+}

--- a/packages/ai/src/error/verify-no-object-generated-error.ts
+++ b/packages/ai/src/error/verify-no-object-generated-error.ts
@@ -1,5 +1,11 @@
-import { FinishReason, LanguageModelResponseMetadata, LanguageModelUsage } from "../types";
-import { NoObjectGeneratedError } from "./no-object-generated-error";
+import { expect } from 'vitest';
+
+import {
+  FinishReason,
+  LanguageModelResponseMetadata,
+  LanguageModelUsage,
+} from '../types';
+import { NoObjectGeneratedError } from './no-object-generated-error';
 
 export function verifyNoObjectGeneratedError(
   error: unknown,

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -3,7 +3,7 @@ import { jsonSchema } from '@ai-sdk/provider-utils';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import assert, { fail } from 'node:assert';
 import { z } from 'zod/v4';
-import { verifyNoObjectGeneratedError as originalVerifyNoObjectGeneratedError } from '../error/no-object-generated-error';
+import { verifyNoObjectGeneratedError as originalVerifyNoObjectGeneratedError } from '../error/verify-no-object-generated-error';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
 import { MockTracer } from '../test/mock-tracer';
 import { generateObject } from './generate-object';

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -6,10 +6,8 @@ import {
 } from '@ai-sdk/provider-utils/test';
 import assert, { fail } from 'node:assert';
 import { z } from 'zod/v4';
-import {
-  NoObjectGeneratedError,
-  verifyNoObjectGeneratedError,
-} from '../error/no-object-generated-error';
+import { NoObjectGeneratedError } from '../error/no-object-generated-error';
+import { verifyNoObjectGeneratedError } from '../error/verify-no-object-generated-error';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { MockLanguageModelV2 } from '../test/mock-language-model-v2';
 import { createMockServerResponse } from '../test/mock-server-response';

--- a/packages/ai/src/generate-text/output.test.ts
+++ b/packages/ai/src/generate-text/output.test.ts
@@ -1,6 +1,6 @@
 import { fail } from 'assert';
 import { z } from 'zod/v4';
-import { verifyNoObjectGeneratedError } from '../error/no-object-generated-error';
+import { verifyNoObjectGeneratedError } from '../error/verify-no-object-generated-error';
 import { object } from './output';
 import { FinishReason } from '../types';
 


### PR DESCRIPTION
## Background

`expect()` was used in file that is imported from production code. This slipped through because the `expect()` method is currently imported implicitly, which will change once #8277 lands.

## Summary

Move function that uses `expect()` into its own file

## Manual Verification

n/a

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- #8277
