### PR TITLE
feat(provider/openai): add conversations api support for persistent conversation management

### DIFF
--- a/.changeset/polite-rivers-argue.md
+++ b/.changeset/polite-rivers-argue.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add conversations api support for persistent conversation management

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1388,7 +1388,7 @@ const result = await generateSpeech({
 ## Conversations
 
 OpenAI provides a conversations API for managing persisted conversation state across Responses API calls.
-You can access it using the `.conversations` property:
+You can access it using the `.conversations` property on the OpenAI provider instance:
 
 ```ts
 import { openai } from '@ai-sdk/openai';

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1387,7 +1387,7 @@ const result = await generateSpeech({
 
 ## Conversations
 
-OpenAI provides a conversations API for managing persistent conversation state across Response API calls.
+OpenAI provides a conversations API for managing persisted conversation state across Responses API calls.
 You can access it using the `.conversations` property:
 
 ```ts

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1411,4 +1411,4 @@ const updated = await openai.conversations.update(conversation.id, {
 });
 ```
 
-For more information, see the [OpenAI API reference](https://platform.openai.com/docs/api-reference/conversations).
+For more platform-specific information, see the [OpenAI Conversation API reference](https://platform.openai.com/docs/api-reference/conversations).

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1384,3 +1384,31 @@ const result = await generateSpeech({
 | `tts-1`           | <Check size={18} /> |
 | `tts-1-hd`        | <Check size={18} /> |
 | `gpt-4o-mini-tts` | <Check size={18} /> |
+
+## Conversations
+
+OpenAI provides a conversations API for managing persistent conversation state across Response API calls.
+You can access it using the `.conversations` property:
+
+```ts
+import { openai } from '@ai-sdk/openai';
+
+// create conversation
+const conversation = await openai.conversations.create({
+  metadata: { topic: 'demo' },
+  items: [{ type: 'message', role: 'user', content: 'Hello!' }],
+});
+
+// manage conversation items
+const items = await openai.conversations.items.create(conversation.id, {
+  items: [{ type: 'message', role: 'user', content: 'How are you?' }],
+});
+
+// retrieve and update
+const retrieved = await openai.conversations.retrieve(conversation.id);
+const updated = await openai.conversations.update(conversation.id, {
+  metadata: { topic: 'updated', status: 'active' },
+});
+```
+
+For more information, see the [OpenAI API reference](https://platform.openai.com/docs/api-reference/conversations).

--- a/examples/ai-core/src/conversations/openai-full-conversations.ts
+++ b/examples/ai-core/src/conversations/openai-full-conversations.ts
@@ -85,7 +85,9 @@ async function main() {
 
   // finally, delete the entire conversation
   console.log('\nDeleting entire conversation...');
-  const deletedConversation = await openai.conversations.delete(conversation.id);
+  const deletedConversation = await openai.conversations.delete(
+    conversation.id,
+  );
   console.log('Deleted conversation:', deletedConversation);
 
   console.log('\nFull conversation management demo complete!');

--- a/examples/ai-core/src/conversations/openai-full-conversations.ts
+++ b/examples/ai-core/src/conversations/openai-full-conversations.ts
@@ -1,0 +1,94 @@
+import { openai } from '@ai-sdk/openai';
+import 'dotenv/config';
+
+async function main() {
+  // create a conversation
+  console.log('Creating conversation...');
+  const conversation = await openai.conversations.create({
+    metadata: { topic: 'ai-sdk-demo' },
+    items: [
+      {
+        type: 'message',
+        role: 'user',
+        content: 'Hello! How can you help me?',
+      },
+    ],
+  });
+
+  console.log('Created conversation:', conversation);
+
+  // add more items to the conversation
+  console.log('\nAdding items to conversation...');
+  const items = await openai.conversations.items.create(conversation.id, {
+    items: [
+      {
+        type: 'message',
+        role: 'user',
+        content: 'Tell me about the AI SDK.',
+      },
+      {
+        type: 'message',
+        role: 'user',
+        content: 'What providers does it support?',
+      },
+    ],
+  });
+
+  console.log('Added items:', items.data.length);
+
+  // list all conversation items
+  console.log('\nListing conversation items...');
+  const allItems = await openai.conversations.items.list(conversation.id, {
+    limit: 20,
+  });
+
+  console.log('Total items:', allItems.data.length);
+  console.log('Has more:', allItems.has_more);
+
+  // retrieve the conversation
+  console.log('\nRetrieving conversation...');
+  const retrieved = await openai.conversations.retrieve(conversation.id);
+  console.log('Retrieved conversation metadata:', retrieved.metadata);
+
+  // update conversation metadata
+  console.log('\nUpdating conversation metadata...');
+  const updated = await openai.conversations.update(conversation.id, {
+    metadata: { topic: 'ai-sdk-demo', status: 'active' },
+  });
+
+  console.log('Updated metadata:', updated.metadata);
+
+  // retrieve a specific item
+  if (allItems.data.length > 0) {
+    console.log('\nRetrieving specific item...');
+    const item = await openai.conversations.items.retrieve(
+      conversation.id,
+      allItems.data[0].id!,
+    );
+    console.log('Retrieved item type:', item.type);
+  }
+
+  // delete a conversation item
+  if (allItems.data.length > 1) {
+    console.log('\nDeleting a conversation item...');
+    const updatedConversation = await openai.conversations.items.delete(
+      conversation.id,
+      allItems.data[1].id!,
+    );
+    console.log('Item deleted, conversation still exists');
+  }
+
+  // list items again to see the change
+  console.log('\nListing items after deletion...');
+  const finalItems = await openai.conversations.items.list(conversation.id);
+  console.log('Remaining items:', finalItems.data.length);
+
+  // finally, delete the entire conversation
+  console.log('\nDeleting entire conversation...');
+  const deletedConversation = await openai.conversations.delete(conversation.id);
+  console.log('Deleted conversation:', deletedConversation);
+
+  console.log('\nFull conversation management demo complete!');
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/conversations/openai.ts
+++ b/examples/ai-core/src/conversations/openai.ts
@@ -1,0 +1,15 @@
+import { openai } from '@ai-sdk/openai';
+import 'dotenv/config';
+
+
+async function main() {
+  const conversation = await openai.conversations.create({
+  metadata: { topic: "demo" },
+  items: [
+    { type: "message", role: "user", content: "Hello!" }
+  ],
+});
+console.log(conversation);
+}
+
+main();

--- a/examples/ai-core/src/conversations/openai.ts
+++ b/examples/ai-core/src/conversations/openai.ts
@@ -1,15 +1,12 @@
 import { openai } from '@ai-sdk/openai';
 import 'dotenv/config';
 
-
 async function main() {
   const conversation = await openai.conversations.create({
-  metadata: { topic: "demo" },
-  items: [
-    { type: "message", role: "user", content: "Hello!" }
-  ],
-});
-console.log(conversation);
+    metadata: { topic: 'demo' },
+    items: [{ type: 'message', role: 'user', content: 'Hello!' }],
+  });
+  console.log(conversation);
 }
 
 main();

--- a/packages/openai/src/conversations/openai-conversations-items.ts
+++ b/packages/openai/src/conversations/openai-conversations-items.ts
@@ -23,7 +23,9 @@ export class OpenAIConversationItems {
   constructor(private readonly config: OpenAIConfig) {}
 
   private getUrl(path: string): string {
-    const baseUrl = this.config.url({ path: '', modelId: '' }).replace(/\/$/, '');
+    const baseUrl = this.config
+      .url({ path: '', modelId: '' })
+      .replace(/\/$/, '');
     return `${baseUrl}${path}`;
   }
 
@@ -158,7 +160,9 @@ export class OpenAIConversationItems {
       this.getUrl(`/conversations/${conversationId}/items/${itemId}`),
       {
         method: 'DELETE',
-        headers: removeUndefinedEntries(combineHeaders(this.config.headers(), options.headers)),
+        headers: removeUndefinedEntries(
+          combineHeaders(this.config.headers(), options.headers),
+        ),
         signal: options.abortSignal,
       },
     );
@@ -172,6 +176,6 @@ export class OpenAIConversationItems {
       throw errorHandler.value;
     }
 
-    return await response.json() as Conversation;
+    return (await response.json()) as Conversation;
   }
 }

--- a/packages/openai/src/conversations/openai-conversations-items.ts
+++ b/packages/openai/src/conversations/openai-conversations-items.ts
@@ -1,0 +1,177 @@
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  getFromApi,
+  postJsonToApi,
+  removeUndefinedEntries,
+} from '@ai-sdk/provider-utils';
+import { OpenAIConfig } from '../openai-config';
+import { openaiFailedResponseHandler } from '../openai-error';
+import {
+  Conversation,
+  ConversationItem,
+  ConversationItemList,
+  CreateItemsRequest,
+  ListItemsOptions,
+  RetrieveItemOptions,
+  conversationItemListSchema,
+  conversationItemSchema,
+  conversationSchema,
+} from './openai-conversations-types';
+
+export class OpenAIConversationItems {
+  constructor(private readonly config: OpenAIConfig) {}
+
+  private getUrl(path: string): string {
+    const baseUrl = this.config.url({ path: '', modelId: '' }).replace(/\/$/, '');
+    return `${baseUrl}${path}`;
+  }
+
+  async list(
+    conversationId: string,
+    options: ListItemsOptions & {
+      headers?: Record<string, string>;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<ConversationItemList> {
+    const { headers, abortSignal, ...listOptions } = options;
+
+    const searchParams = new URLSearchParams();
+    if (listOptions.after) searchParams.set('after', listOptions.after);
+    if (listOptions.limit !== undefined)
+      searchParams.set('limit', listOptions.limit.toString());
+    if (listOptions.order) searchParams.set('order', listOptions.order);
+    if (listOptions.include) {
+      listOptions.include.forEach(include =>
+        searchParams.append('include', include),
+      );
+    }
+
+    const url = `${this.getUrl(`/conversations/${conversationId}/items`)}${
+      searchParams.toString() ? `?${searchParams.toString()}` : ''
+    }`;
+
+    const { value: response } = await getFromApi({
+      url,
+      headers: combineHeaders(this.config.headers(), headers),
+      failedResponseHandler: openaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        conversationItemListSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return response;
+  }
+
+  async create(
+    conversationId: string,
+    request: CreateItemsRequest,
+    options: {
+      include?: Array<
+        | 'code_interpreter_call.outputs'
+        | 'computer_call_output.output.image_url'
+        | 'file_search_call.results'
+        | 'message.input_image.image_url'
+        | 'message.output_text.logprobs'
+        | 'reasoning.encrypted_content'
+      >;
+      headers?: Record<string, string>;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<ConversationItemList> {
+    const { headers, abortSignal, include } = options;
+
+    const searchParams = new URLSearchParams();
+    if (include) {
+      include.forEach(includeItem =>
+        searchParams.append('include', includeItem),
+      );
+    }
+
+    const url = `${this.getUrl(`/conversations/${conversationId}/items`)}${
+      searchParams.toString() ? `?${searchParams.toString()}` : ''
+    }`;
+
+    const { value: response } = await postJsonToApi({
+      url,
+      headers: combineHeaders(this.config.headers(), headers),
+      body: {
+        items: request.items,
+      },
+      failedResponseHandler: openaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        conversationItemListSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return response;
+  }
+
+  async retrieve(
+    conversationId: string,
+    itemId: string,
+    options: RetrieveItemOptions & {
+      headers?: Record<string, string>;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<ConversationItem> {
+    const { headers, abortSignal, ...retrieveOptions } = options;
+
+    const searchParams = new URLSearchParams();
+    if (retrieveOptions.include) {
+      retrieveOptions.include.forEach(include =>
+        searchParams.append('include', include),
+      );
+    }
+
+    const url = `${this.getUrl(`/conversations/${conversationId}/items/${itemId}`)}${
+      searchParams.toString() ? `?${searchParams.toString()}` : ''
+    }`;
+
+    const { value: response } = await getFromApi({
+      url,
+      headers: combineHeaders(this.config.headers(), headers),
+      failedResponseHandler: openaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        conversationItemSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return response;
+  }
+
+  async delete(
+    conversationId: string,
+    itemId: string,
+    options: {
+      headers?: Record<string, string>;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<Conversation> {
+    const response = await (this.config.fetch ?? fetch)(
+      this.getUrl(`/conversations/${conversationId}/items/${itemId}`),
+      {
+        method: 'DELETE',
+        headers: removeUndefinedEntries(combineHeaders(this.config.headers(), options.headers)),
+        signal: options.abortSignal,
+      },
+    );
+
+    if (!response.ok) {
+      const errorHandler = await openaiFailedResponseHandler({
+        response,
+        url: this.getUrl(`/conversations/${conversationId}/items/${itemId}`),
+        requestBodyValues: {},
+      });
+      throw errorHandler.value;
+    }
+
+    return await response.json() as Conversation;
+  }
+}

--- a/packages/openai/src/conversations/openai-conversations-types.ts
+++ b/packages/openai/src/conversations/openai-conversations-types.ts
@@ -9,14 +9,16 @@ export const conversationSchema = z.object({
 
 export type Conversation = z.infer<typeof conversationSchema>;
 
-export const conversationItemSchema = z.object({
-  type: z.string(),
-  id: z.string().optional(),
-  status: z.string().optional(),
-  role: z.string().optional(),
-  content: z.union([z.string(), z.array(z.unknown())]).optional(),
-  created_at: z.number().optional(),
-}).passthrough();
+export const conversationItemSchema = z
+  .object({
+    type: z.string(),
+    id: z.string().optional(),
+    status: z.string().optional(),
+    role: z.string().optional(),
+    content: z.union([z.string(), z.array(z.unknown())]).optional(),
+    created_at: z.number().optional(),
+  })
+  .passthrough();
 
 export type ConversationItem = z.infer<typeof conversationItemSchema>;
 

--- a/packages/openai/src/conversations/openai-conversations-types.ts
+++ b/packages/openai/src/conversations/openai-conversations-types.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod/v4';
+
+export const conversationSchema = z.object({
+  id: z.string(),
+  object: z.literal('conversation'),
+  created_at: z.number(),
+  metadata: z.record(z.string(), z.string()).optional(),
+});
+
+export type Conversation = z.infer<typeof conversationSchema>;
+
+export const conversationItemSchema = z.object({
+  type: z.string(),
+  id: z.string().optional(),
+  status: z.string().optional(),
+  role: z.string().optional(),
+  content: z.union([z.string(), z.array(z.unknown())]).optional(),
+  created_at: z.number().optional(),
+}).passthrough();
+
+export type ConversationItem = z.infer<typeof conversationItemSchema>;
+
+export const conversationItemListSchema = z.object({
+  object: z.literal('list'),
+  data: z.array(conversationItemSchema),
+  first_id: z.string().optional(),
+  last_id: z.string().optional(),
+  has_more: z.boolean(),
+});
+
+export type ConversationItemList = z.infer<typeof conversationItemListSchema>;
+
+export const deletedConversationSchema = z.object({
+  id: z.string(),
+  object: z.literal('conversation.deleted'),
+  deleted: z.boolean(),
+});
+
+export type DeletedConversation = z.infer<typeof deletedConversationSchema>;
+
+export interface CreateConversationRequest {
+  items?: Array<{
+    type: 'message';
+    role: 'user' | 'assistant' | 'system' | 'developer';
+    content: string | Array<unknown>;
+  }>;
+  metadata?: Record<string, string>;
+}
+
+export interface UpdateConversationRequest {
+  metadata: Record<string, string>;
+}
+
+export interface ListItemsOptions {
+  after?: string;
+  include?: Array<
+    | 'code_interpreter_call.outputs'
+    | 'computer_call_output.output.image_url'
+    | 'file_search_call.results'
+    | 'message.input_image.image_url'
+    | 'message.output_text.logprobs'
+    | 'reasoning.encrypted_content'
+  >;
+  limit?: number;
+  order?: 'asc' | 'desc';
+}
+
+export interface CreateItemsRequest {
+  items: Array<{
+    type: 'message';
+    role: 'user' | 'assistant' | 'system' | 'developer';
+    content: string | Array<unknown>;
+  }>;
+}
+
+export interface RetrieveItemOptions {
+  include?: Array<
+    | 'code_interpreter_call.outputs'
+    | 'computer_call_output.output.image_url'
+    | 'file_search_call.results'
+    | 'message.input_image.image_url'
+    | 'message.output_text.logprobs'
+    | 'reasoning.encrypted_content'
+  >;
+}

--- a/packages/openai/src/conversations/openai-conversations.test.ts
+++ b/packages/openai/src/conversations/openai-conversations.test.ts
@@ -26,9 +26,7 @@ describe('OpenAIConversations', () => {
 
       const result = await conversations.create({
         metadata: { topic: 'demo' },
-        items: [
-          { type: 'message', role: 'user', content: 'Hello!' },
-        ],
+        items: [{ type: 'message', role: 'user', content: 'Hello!' }],
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -67,15 +65,16 @@ describe('OpenAIConversations', () => {
 
   describe('retrieve', () => {
     it('should retrieve a conversation', async () => {
-      server.urls['https://api.openai.com/v1/conversations/conv_123'].response = {
-        type: 'json-value',
-        body: {
-          id: 'conv_123',
-          object: 'conversation',
-          created_at: 1741900000,
-          metadata: { topic: 'demo' },
-        },
-      };
+      server.urls['https://api.openai.com/v1/conversations/conv_123'].response =
+        {
+          type: 'json-value',
+          body: {
+            id: 'conv_123',
+            object: 'conversation',
+            created_at: 1741900000,
+            metadata: { topic: 'demo' },
+          },
+        };
 
       const result = await conversations.retrieve('conv_123');
 
@@ -94,15 +93,16 @@ describe('OpenAIConversations', () => {
 
   describe('update', () => {
     it('should update conversation metadata', async () => {
-      server.urls['https://api.openai.com/v1/conversations/conv_123'].response = {
-        type: 'json-value',
-        body: {
-          id: 'conv_123',
-          object: 'conversation',
-          created_at: 1741900000,
-          metadata: { topic: 'project-x' },
-        },
-      };
+      server.urls['https://api.openai.com/v1/conversations/conv_123'].response =
+        {
+          type: 'json-value',
+          body: {
+            id: 'conv_123',
+            object: 'conversation',
+            created_at: 1741900000,
+            metadata: { topic: 'project-x' },
+          },
+        };
 
       const result = await conversations.update('conv_123', {
         metadata: { topic: 'project-x' },
@@ -123,14 +123,15 @@ describe('OpenAIConversations', () => {
 
   describe('delete', () => {
     it('should delete a conversation', async () => {
-      server.urls['https://api.openai.com/v1/conversations/conv_123'].response = {
-        type: 'json-value',
-        body: {
-          id: 'conv_123',
-          object: 'conversation.deleted',
-          deleted: true,
-        },
-      };
+      server.urls['https://api.openai.com/v1/conversations/conv_123'].response =
+        {
+          type: 'json-value',
+          body: {
+            id: 'conv_123',
+            object: 'conversation.deleted',
+            deleted: true,
+          },
+        };
 
       const result = await conversations.delete('conv_123');
 
@@ -147,7 +148,9 @@ describe('OpenAIConversations', () => {
   describe('items', () => {
     describe('list', () => {
       it('should list conversation items', async () => {
-        server.urls['https://api.openai.com/v1/conversations/conv_123/items'].response = {
+        server.urls[
+          'https://api.openai.com/v1/conversations/conv_123/items'
+        ].response = {
           type: 'json-value',
           body: {
             object: 'list',
@@ -166,7 +169,9 @@ describe('OpenAIConversations', () => {
           },
         };
 
-        const result = await conversations.items.list('conv_123', { limit: 10 });
+        const result = await conversations.items.list('conv_123', {
+          limit: 10,
+        });
 
         expect(result).toMatchInlineSnapshot(`
           {
@@ -190,7 +195,9 @@ describe('OpenAIConversations', () => {
 
     describe('create', () => {
       it('should create conversation items', async () => {
-        server.urls['https://api.openai.com/v1/conversations/conv_123/items'].response = {
+        server.urls[
+          'https://api.openai.com/v1/conversations/conv_123/items'
+        ].response = {
           type: 'json-value',
           body: {
             object: 'list',
@@ -260,7 +267,9 @@ describe('OpenAIConversations', () => {
 
     describe('retrieve', () => {
       it('should retrieve a conversation item', async () => {
-        server.urls['https://api.openai.com/v1/conversations/conv_123/items/msg_456'].response = {
+        server.urls[
+          'https://api.openai.com/v1/conversations/conv_123/items/msg_456'
+        ].response = {
           type: 'json-value',
           body: {
             type: 'message',
@@ -271,7 +280,10 @@ describe('OpenAIConversations', () => {
           },
         };
 
-        const result = await conversations.items.retrieve('conv_123', 'msg_456');
+        const result = await conversations.items.retrieve(
+          'conv_123',
+          'msg_456',
+        );
 
         expect(result).toMatchInlineSnapshot(`
           {
@@ -287,7 +299,9 @@ describe('OpenAIConversations', () => {
 
     describe('delete', () => {
       it('should delete a conversation item', async () => {
-        server.urls['https://api.openai.com/v1/conversations/conv_123/items/msg_456'].response = {
+        server.urls[
+          'https://api.openai.com/v1/conversations/conv_123/items/msg_456'
+        ].response = {
           type: 'json-value',
           body: {
             id: 'conv_123',

--- a/packages/openai/src/conversations/openai-conversations.test.ts
+++ b/packages/openai/src/conversations/openai-conversations.test.ts
@@ -1,0 +1,315 @@
+import { createTestServer } from '@ai-sdk/provider-utils/test';
+import { createOpenAI } from '../openai-provider';
+
+const provider = createOpenAI({ apiKey: 'test-api-key' });
+const conversations = provider.conversations;
+
+const server = createTestServer({
+  'https://api.openai.com/v1/conversations': {},
+  'https://api.openai.com/v1/conversations/conv_123': {},
+  'https://api.openai.com/v1/conversations/conv_123/items': {},
+  'https://api.openai.com/v1/conversations/conv_123/items/msg_456': {},
+});
+
+describe('OpenAIConversations', () => {
+  describe('create', () => {
+    it('should create a conversation with metadata', async () => {
+      server.urls['https://api.openai.com/v1/conversations'].response = {
+        type: 'json-value',
+        body: {
+          id: 'conv_123',
+          object: 'conversation',
+          created_at: 1741900000,
+          metadata: { topic: 'demo' },
+        },
+      };
+
+      const result = await conversations.create({
+        metadata: { topic: 'demo' },
+        items: [
+          { type: 'message', role: 'user', content: 'Hello!' },
+        ],
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "created_at": 1741900000,
+          "id": "conv_123",
+          "metadata": {
+            "topic": "demo",
+          },
+          "object": "conversation",
+        }
+      `);
+    });
+
+    it('should create a conversation without initial items', async () => {
+      server.urls['https://api.openai.com/v1/conversations'].response = {
+        type: 'json-value',
+        body: {
+          id: 'conv_456',
+          object: 'conversation',
+          created_at: 1741900000,
+        },
+      };
+
+      const result = await conversations.create();
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "created_at": 1741900000,
+          "id": "conv_456",
+          "object": "conversation",
+        }
+      `);
+    });
+  });
+
+  describe('retrieve', () => {
+    it('should retrieve a conversation', async () => {
+      server.urls['https://api.openai.com/v1/conversations/conv_123'].response = {
+        type: 'json-value',
+        body: {
+          id: 'conv_123',
+          object: 'conversation',
+          created_at: 1741900000,
+          metadata: { topic: 'demo' },
+        },
+      };
+
+      const result = await conversations.retrieve('conv_123');
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "created_at": 1741900000,
+          "id": "conv_123",
+          "metadata": {
+            "topic": "demo",
+          },
+          "object": "conversation",
+        }
+      `);
+    });
+  });
+
+  describe('update', () => {
+    it('should update conversation metadata', async () => {
+      server.urls['https://api.openai.com/v1/conversations/conv_123'].response = {
+        type: 'json-value',
+        body: {
+          id: 'conv_123',
+          object: 'conversation',
+          created_at: 1741900000,
+          metadata: { topic: 'project-x' },
+        },
+      };
+
+      const result = await conversations.update('conv_123', {
+        metadata: { topic: 'project-x' },
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "created_at": 1741900000,
+          "id": "conv_123",
+          "metadata": {
+            "topic": "project-x",
+          },
+          "object": "conversation",
+        }
+      `);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a conversation', async () => {
+      server.urls['https://api.openai.com/v1/conversations/conv_123'].response = {
+        type: 'json-value',
+        body: {
+          id: 'conv_123',
+          object: 'conversation.deleted',
+          deleted: true,
+        },
+      };
+
+      const result = await conversations.delete('conv_123');
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "deleted": true,
+          "id": "conv_123",
+          "object": "conversation.deleted",
+        }
+      `);
+    });
+  });
+
+  describe('items', () => {
+    describe('list', () => {
+      it('should list conversation items', async () => {
+        server.urls['https://api.openai.com/v1/conversations/conv_123/items'].response = {
+          type: 'json-value',
+          body: {
+            object: 'list',
+            data: [
+              {
+                type: 'message',
+                id: 'msg_abc',
+                status: 'completed',
+                role: 'user',
+                content: 'Hello!',
+              },
+            ],
+            first_id: 'msg_abc',
+            last_id: 'msg_abc',
+            has_more: false,
+          },
+        };
+
+        const result = await conversations.items.list('conv_123', { limit: 10 });
+
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "data": [
+              {
+                "content": "Hello!",
+                "id": "msg_abc",
+                "role": "user",
+                "status": "completed",
+                "type": "message",
+              },
+            ],
+            "first_id": "msg_abc",
+            "has_more": false,
+            "last_id": "msg_abc",
+            "object": "list",
+          }
+        `);
+      });
+    });
+
+    describe('create', () => {
+      it('should create conversation items', async () => {
+        server.urls['https://api.openai.com/v1/conversations/conv_123/items'].response = {
+          type: 'json-value',
+          body: {
+            object: 'list',
+            data: [
+              {
+                type: 'message',
+                id: 'msg_abc',
+                status: 'completed',
+                role: 'user',
+                content: 'Hello!',
+              },
+              {
+                type: 'message',
+                id: 'msg_def',
+                status: 'completed',
+                role: 'user',
+                content: 'How are you?',
+              },
+            ],
+            first_id: 'msg_abc',
+            last_id: 'msg_def',
+            has_more: false,
+          },
+        };
+
+        const result = await conversations.items.create('conv_123', {
+          items: [
+            {
+              type: 'message',
+              role: 'user',
+              content: 'Hello!',
+            },
+            {
+              type: 'message',
+              role: 'user',
+              content: 'How are you?',
+            },
+          ],
+        });
+
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "data": [
+              {
+                "content": "Hello!",
+                "id": "msg_abc",
+                "role": "user",
+                "status": "completed",
+                "type": "message",
+              },
+              {
+                "content": "How are you?",
+                "id": "msg_def",
+                "role": "user",
+                "status": "completed",
+                "type": "message",
+              },
+            ],
+            "first_id": "msg_abc",
+            "has_more": false,
+            "last_id": "msg_def",
+            "object": "list",
+          }
+        `);
+      });
+    });
+
+    describe('retrieve', () => {
+      it('should retrieve a conversation item', async () => {
+        server.urls['https://api.openai.com/v1/conversations/conv_123/items/msg_456'].response = {
+          type: 'json-value',
+          body: {
+            type: 'message',
+            id: 'msg_abc',
+            status: 'completed',
+            role: 'user',
+            content: 'Hello!',
+          },
+        };
+
+        const result = await conversations.items.retrieve('conv_123', 'msg_456');
+
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "content": "Hello!",
+            "id": "msg_abc",
+            "role": "user",
+            "status": "completed",
+            "type": "message",
+          }
+        `);
+      });
+    });
+
+    describe('delete', () => {
+      it('should delete a conversation item', async () => {
+        server.urls['https://api.openai.com/v1/conversations/conv_123/items/msg_456'].response = {
+          type: 'json-value',
+          body: {
+            id: 'conv_123',
+            object: 'conversation',
+            created_at: 1741900000,
+            metadata: { topic: 'demo' },
+          },
+        };
+
+        const result = await conversations.items.delete('conv_123', 'msg_456');
+
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "created_at": 1741900000,
+            "id": "conv_123",
+            "metadata": {
+              "topic": "demo",
+            },
+            "object": "conversation",
+          }
+        `);
+      });
+    });
+  });
+});

--- a/packages/openai/src/conversations/openai-conversations.ts
+++ b/packages/openai/src/conversations/openai-conversations.ts
@@ -1,0 +1,126 @@
+import {
+  combineHeaders,
+  createJsonResponseHandler,
+  getFromApi,
+  postJsonToApi,
+  removeUndefinedEntries,
+} from '@ai-sdk/provider-utils';
+import { OpenAIConfig } from '../openai-config';
+import { openaiFailedResponseHandler } from '../openai-error';
+import { OpenAIConversationItems } from './openai-conversations-items';
+import {
+  Conversation,
+  CreateConversationRequest,
+  DeletedConversation,
+  UpdateConversationRequest,
+  conversationSchema,
+  deletedConversationSchema,
+} from './openai-conversations-types';
+
+export class OpenAIConversations {
+  private readonly config: OpenAIConfig;
+  readonly items: OpenAIConversationItems;
+
+  constructor(config: OpenAIConfig) {
+    this.config = config;
+    this.items = new OpenAIConversationItems(config);
+  }
+
+  private getUrl(path: string): string {
+    const baseUrl = this.config.url({ path: '', modelId: '' }).replace(/\/$/, '');
+    return `${baseUrl}${path}`;
+  }
+
+  async create(
+    request: CreateConversationRequest = {},
+    options: {
+      headers?: Record<string, string>;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<Conversation> {
+    const { value: response } = await postJsonToApi({
+      url: this.getUrl('/conversations'),
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body: {
+        ...(request.items && { items: request.items }),
+        ...(request.metadata && { metadata: request.metadata }),
+      },
+      failedResponseHandler: openaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(conversationSchema),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return response;
+  }
+
+  async retrieve(
+    conversationId: string,
+    options: {
+      headers?: Record<string, string>;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<Conversation> {
+    const { value: response } = await getFromApi({
+      url: this.getUrl(`/conversations/${conversationId}`),
+      headers: combineHeaders(this.config.headers(), options.headers),
+      failedResponseHandler: openaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(conversationSchema),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return response;
+  }
+
+  async update(
+    conversationId: string,
+    request: UpdateConversationRequest,
+    options: {
+      headers?: Record<string, string>;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<Conversation> {
+    const { value: response } = await postJsonToApi({
+      url: this.getUrl(`/conversations/${conversationId}`),
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body: {
+        metadata: request.metadata,
+      },
+      failedResponseHandler: openaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(conversationSchema),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return response;
+  }
+
+  async delete(
+    conversationId: string,
+    options: {
+      headers?: Record<string, string>;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<DeletedConversation> {
+    const response = await (this.config.fetch ?? fetch)(
+      this.getUrl(`/conversations/${conversationId}`),
+      {
+        method: 'DELETE',
+        headers: removeUndefinedEntries(combineHeaders(this.config.headers(), options.headers)),
+        signal: options.abortSignal,
+      },
+    );
+
+    if (!response.ok) {
+      const errorHandler = await openaiFailedResponseHandler({
+        response,
+        url: this.getUrl(`/conversations/${conversationId}`),
+        requestBodyValues: {},
+      });
+      throw errorHandler.value;
+    }
+
+    return await response.json() as DeletedConversation;
+  }
+}

--- a/packages/openai/src/conversations/openai-conversations.ts
+++ b/packages/openai/src/conversations/openai-conversations.ts
@@ -27,7 +27,9 @@ export class OpenAIConversations {
   }
 
   private getUrl(path: string): string {
-    const baseUrl = this.config.url({ path: '', modelId: '' }).replace(/\/$/, '');
+    const baseUrl = this.config
+      .url({ path: '', modelId: '' })
+      .replace(/\/$/, '');
     return `${baseUrl}${path}`;
   }
 
@@ -107,7 +109,9 @@ export class OpenAIConversations {
       this.getUrl(`/conversations/${conversationId}`),
       {
         method: 'DELETE',
-        headers: removeUndefinedEntries(combineHeaders(this.config.headers(), options.headers)),
+        headers: removeUndefinedEntries(
+          combineHeaders(this.config.headers(), options.headers),
+        ),
         signal: options.abortSignal,
       },
     );
@@ -121,6 +125,6 @@ export class OpenAIConversations {
       throw errorHandler.value;
     }
 
-    return await response.json() as DeletedConversation;
+    return (await response.json()) as DeletedConversation;
   }
 }

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -19,6 +19,7 @@ import { OpenAIEmbeddingModel } from './embedding/openai-embedding-model';
 import { OpenAIEmbeddingModelId } from './embedding/openai-embedding-options';
 import { OpenAIImageModel } from './image/openai-image-model';
 import { OpenAIImageModelId } from './image/openai-image-options';
+import { OpenAIConversations } from './conversations/openai-conversations';
 import { openaiTools } from './openai-tools';
 import { OpenAIResponsesLanguageModel } from './responses/openai-responses-language-model';
 import { OpenAIResponsesModelId } from './responses/openai-responses-settings';
@@ -89,6 +90,11 @@ Creates a model for speech generation.
 OpenAI-specific tools.
    */
   tools: typeof openaiTools;
+
+  /**
+OpenAI conversations API.
+   */
+  conversations: OpenAIConversations;
 }
 
 export interface OpenAIProviderSettings {
@@ -219,6 +225,15 @@ export function createOpenAI(
     });
   };
 
+  const createConversations = () => {
+    return new OpenAIConversations({
+      provider: `${providerName}.conversations`,
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
   const provider = function (modelId: OpenAIResponsesModelId) {
     return createLanguageModel(modelId);
   };
@@ -241,6 +256,8 @@ export function createOpenAI(
   provider.speechModel = createSpeechModel;
 
   provider.tools = openaiTools;
+
+  provider.conversations = createConversations();
 
   return provider as OpenAIProvider;
 }


### PR DESCRIPTION
## background

openai released a conversations api to replace assistants api threads. this provides stateful conversation management across response api calls, allowing developers to maintain conversation context without manual state handling

## summary

- added conversations api support for create/retrieve/update/delete operations
- implemented conversation items management with pagination
- integrated conversations into openai provider following existing patterns
- added tests and examples

## verification

all tests pass. created src/conversations/ folder with openai-conversations.ts, openai-conversations-items.ts, openai-conversations-types.ts, and tests

## tasks

- [x] created conversations api types and zod schemas
- [x] implemented openai conversations class with create/retrieve/update/delete
- [x] implemented conversation items management class
- [x] added conversations to openai provider using factory pattern
- [x] added tests following existing patterns
- [x] created working examples in ai-core (basic and full demos)