### PR TITLE
chore(provider-utils): upgrade eventsource-parser to 3.0.5

### DIFF
--- a/.changeset/curvy-elephants-itch.md
+++ b/.changeset/curvy-elephants-itch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+chore(provider-utils): upgrade event-source parser to 3.0.5

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@ai-sdk/provider": "workspace:*",
     "@standard-schema/spec": "^1.0.0",
-    "eventsource-parser": "^3.0.3"
+    "eventsource-parser": "^3.0.5"
   },
   "devDependencies": {
     "@types/node": "20.17.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2164,8 +2164,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       eventsource-parser:
-        specifier: ^3.0.3
-        version: 3.0.3
+        specifier: ^3.0.5
+        version: 3.0.5
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -11641,8 +11641,8 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.3:
-    resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
+  eventsource-parser@3.0.5:
+    resolution: {integrity: sha512-bSRG85ZrMdmWtm7qkF9He9TNRzc/Bm99gEJMaQoHJ9E6Kv9QBbsldh2oMj7iXmYNEAVvNgvv5vPorG6W+XtBhQ==}
     engines: {node: '>=20.0.0'}
 
   eventsource@3.0.5:
@@ -29606,11 +29606,11 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.3: {}
+  eventsource-parser@3.0.5: {}
 
   eventsource@3.0.5:
     dependencies:
-      eventsource-parser: 3.0.3
+      eventsource-parser: 3.0.5
 
   execa@5.1.1:
     dependencies:


### PR DESCRIPTION
## Background

The `eventsource-parser` package contained bugfixes in 3.0.4 and 3.0.5

https://github.com/rexxars/eventsource-parser/blob/main/CHANGELOG.md

## Summary

upgrade eventsource-parser to 3.0.5