### PR TITLE
fix: use `{ stream }` instead of `stream` when calling `createUIMessageStreamResponse` in example

### DIFF
--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -379,7 +379,7 @@ export async function POST(req: Request) {
     },
   });
 
-  return createUIMessageStreamResponse(stream);
+  return createUIMessageStreamResponse({ stream });
 }
 
 async function executeWeatherTool({ city }: { city: string }) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Doc should provide correct example for users to learn and run. Original doc pass wrong param when calling `createUIMessageStreamResponse`.

## Summary

<!-- What did you change? -->

How param is passed when calling `createUIMessageStreamResponse`.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

I ran the code locally and it went well.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

Nope.