### PR TITLE
test: auto update fixture output

### DIFF
--- a/.changeset/tidy-ears-buy.md
+++ b/.changeset/tidy-ears-buy.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+allow auto updating test output files

--- a/.changeset/tidy-ears-buy.md
+++ b/.changeset/tidy-ears-buy.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/codemod': patch
----
-
-allow auto updating test output files

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -16,6 +16,7 @@
     "prettier-check": "prettier --check \"./**/*.ts*\"",
     "test": "vitest --config vitest.config.ts --run",
     "test:watch": "vitest",
+    "test:update": "UPDATE_SNAPSHOT=true vitest -u --run",
     "scaffold": "tsx scripts/scaffold-codemod.ts",
     "generate-readme": "tsx scripts/generate-readme.ts"
   },

--- a/packages/codemod/src/test/rename-message-to-ui-message.test.ts
+++ b/packages/codemod/src/test/rename-message-to-ui-message.test.ts
@@ -1,40 +1,9 @@
-import { join } from 'path';
-import { readFileSync } from 'fs';
-import jscodeshift from 'jscodeshift';
-import transform from '../codemods/v5/rename-message-to-ui-message';
-import { describe, it, expect } from 'vitest';
-
-function trim(str: string) {
-  return str.replace(/^\s+|\s+$/, '');
-}
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v5/rename-message-to-ui-message';
+import { testTransform } from './test-utils';
 
 describe('rename-message-to-ui-message', () => {
-  it('transforms Message and CreateMessage to UIMessage and CreateUIMessage', () => {
-    const input = readFileSync(
-      join(__dirname, '__testfixtures__/rename-message-to-ui-message.input.ts'),
-      'utf8',
-    );
-    const expected = readFileSync(
-      join(
-        __dirname,
-        '__testfixtures__/rename-message-to-ui-message.output.ts',
-      ),
-      'utf8',
-    );
-
-    const j = jscodeshift.withParser('tsx');
-
-    const result = transform(
-      { source: input, path: 'test.ts' },
-      {
-        jscodeshift: j,
-        j: j,
-        stats: () => {},
-        report: () => {},
-      },
-      {},
-    );
-
-    expect(trim(result || '')).toEqual(trim(expected));
+  it('transforms correctly', () => {
+    testTransform(transformer, 'rename-message-to-ui-message');
   });
 });

--- a/packages/codemod/src/test/replace-generatetext-text-property.test.ts
+++ b/packages/codemod/src/test/replace-generatetext-text-property.test.ts
@@ -1,41 +1,9 @@
-import { join } from 'path';
-import { readFileSync } from 'fs';
-import jscodeshift from 'jscodeshift';
-import transform from '../codemods/v5/replace-generatetext-text-property';
-
-function trim(str: string) {
-  return str.replace(/^\s+|\s+$/, '');
-}
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v5/replace-generatetext-text-property';
+import { testTransform } from './test-utils';
 
 describe('replace-generatetext-text-property', () => {
-  it('transforms generateText result.text to result.text.text', () => {
-    const input = readFileSync(
-      join(
-        __dirname,
-        '__testfixtures__/replace-generatetext-text-property.input.ts',
-      ),
-      'utf8',
-    );
-    const expected = readFileSync(
-      join(
-        __dirname,
-        '__testfixtures__/replace-generatetext-text-property.output.ts',
-      ),
-      'utf8',
-    );
-
-    const result = transform(
-      { source: input, path: 'test.ts' },
-      {
-        jscodeshift,
-        j: jscodeshift,
-        stats: () => {},
-        report: () => {},
-      },
-      {},
-    );
-
-    expect(trim(result || '')).toEqual(trim(expected));
+  it('transforms correctly', () => {
+    testTransform(transformer, 'replace-generatetext-text-property');
   });
 });

--- a/packages/codemod/src/test/test-utils.test.ts
+++ b/packages/codemod/src/test/test-utils.test.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
   readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
 }));
 
 vi.mock('path', () => ({

--- a/packages/codemod/src/test/test-utils.ts
+++ b/packages/codemod/src/test/test-utils.ts
@@ -1,7 +1,7 @@
 import { API, FileInfo } from 'jscodeshift';
 import jscodeshift from 'jscodeshift';
 import { join } from 'path';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import ts from 'typescript';
 import { expect } from 'vitest';
 
@@ -236,6 +236,16 @@ export function testTransform(
   // Validate that output code is syntactically correct
   validateSyntax(actualOutput, outputExt);
 
-  // Compare actual output to expected output
-  expect(actualOutput).toBe(expectedOutput);
+  if (process.env.UPDATE_SNAPSHOT) {
+    // Update the expected output fixture if the environment variable is set
+    const outputPath = join(
+      __dirname,
+      '__testfixtures__',
+      `${fixtureName}.output${outputExt}`,
+    );
+    writeFileSync(outputPath, actualOutput, 'utf8');
+  } else {
+    // Compare actual output to expected output
+    expect(actualOutput).toBe(expectedOutput);
+  }
 }

--- a/packages/codemod/turbo.json
+++ b/packages/codemod/turbo.json
@@ -1,12 +1,12 @@
 {
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": [
-        "**/dist/**"
-      ]
+      "outputs": ["**/dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^build", "build"],
+      "env": ["UPDATE_SNAPSHOT"]
     }
   }
 }


### PR DESCRIPTION
## Background

Everytime we update the input files, we need to manually update the output file. This pr adds a new npm script named `test:update` that updates the output file instead of checking similar to how snapshot update works

## Summary

This pr adds auto update test fixture outputs. This pr also changes the test files to use test-utils

## Manual Verification

I run all tests and they all passed

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] n/a ~~A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)~~
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)