### PR TITLE
examples: add gemini 2.5 flash image preview chatbot scripts

### DIFF
--- a/examples/ai-core/src/stream-text/google-gemini-2.5-flash-image-preview-chatbot.ts
+++ b/examples/ai-core/src/stream-text/google-gemini-2.5-flash-image-preview-chatbot.ts
@@ -1,0 +1,48 @@
+import { google } from '@ai-sdk/google';
+import { ModelMessage, streamText } from 'ai';
+import 'dotenv/config';
+import * as readline from 'node:readline/promises';
+import { presentImages } from '../lib/present-image';
+
+const terminal = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const messages: ModelMessage[] = [];
+
+async function main() {
+  while (true) {
+    messages.push({ role: 'user', content: await terminal.question('You: ') });
+
+    const result = streamText({
+      model: google('gemini-2.5-flash-image-preview'),
+      providerOptions: {
+        google: { responseModalities: ['TEXT', 'IMAGE'] },
+      },
+      messages,
+    });
+
+    process.stdout.write('\nAssistant: ');
+    for await (const delta of result.fullStream) {
+      switch (delta.type) {
+        case 'text-delta': {
+          process.stdout.write(delta.text);
+          break;
+        }
+
+        case 'file': {
+          if (delta.file.mediaType.startsWith('image/')) {
+            console.log(delta.file);
+            await presentImages([delta.file]);
+          }
+        }
+      }
+    }
+    process.stdout.write('\n\n');
+
+    messages.push(...(await result.response).messages);
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/vertex-gemini-2.5-flash-image-preview-chatbot.ts
+++ b/examples/ai-core/src/stream-text/vertex-gemini-2.5-flash-image-preview-chatbot.ts
@@ -1,0 +1,48 @@
+import { vertex } from '@ai-sdk/google-vertex';
+import { ModelMessage, streamText } from 'ai';
+import 'dotenv/config';
+import * as readline from 'node:readline/promises';
+import { presentImages } from '../lib/present-image';
+
+const terminal = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const messages: ModelMessage[] = [];
+
+async function main() {
+  while (true) {
+    messages.push({ role: 'user', content: await terminal.question('You: ') });
+
+    const result = streamText({
+      model: vertex('gemini-2.5-flash-image-preview'),
+      providerOptions: {
+        google: { responseModalities: ['TEXT', 'IMAGE'] },
+      },
+      messages,
+    });
+
+    process.stdout.write('\nAssistant: ');
+    for await (const delta of result.fullStream) {
+      switch (delta.type) {
+        case 'text-delta': {
+          process.stdout.write(delta.text);
+          break;
+        }
+
+        case 'file': {
+          if (delta.file.mediaType.startsWith('image/')) {
+            console.log(delta.file);
+            await presentImages([delta.file]);
+          }
+        }
+      }
+    }
+    process.stdout.write('\n\n');
+
+    messages.push(...(await result.response).messages);
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Background

Google launched new image editing models:
https://blog.google/intl/en-mena/product-updates/explore-get-answers/nano-banana-image-editing-in-gemini-just-got-a-major-upgrade/

## Summary

Added two example scripts for testing multi-turn chatbot style image generation and editing.
