### PR TITLE
feat(provider/google): add gemini 2.5 flash image preview model support

### DIFF
--- a/.changeset/shaggy-wasps-smash.md
+++ b/.changeset/shaggy-wasps-smash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): add gemini 2.5 flash image preview model support

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -593,7 +593,8 @@ const result = await generateText({
   providerOptions: {
     google: { responseModalities: ['TEXT', 'IMAGE'] },
   },
-  prompt: 'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
+  prompt:
+    'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
 });
 
 for (const file of result.files) {

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -581,7 +581,7 @@ const urlContextMetadata = metadata?.urlContextMetadata;
 
 ### Image Outputs
 
-Gemini models with image generation capabilities (`gemini-2.0-flash-preview-image-generation`, `gemini-2.5-flash-image-preview`) support image generation. Images are exposed as files in the response.
+Gemini models with image generation capabilities (`gemini-2.5-flash-image-preview`) support image generation. Images are exposed as files in the response.
 You need to enable image output in the provider options using the `responseModalities` option.
 
 ```ts

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -581,7 +581,7 @@ const urlContextMetadata = metadata?.urlContextMetadata;
 
 ### Image Outputs
 
-The model `gemini-2.0-flash-preview-image-generation` supports image generation. Images are exposed as files in the response.
+Gemini models with image generation capabilities (`gemini-2.0-flash-preview-image-generation`, `gemini-2.5-flash-image-preview`) support image generation. Images are exposed as files in the response.
 You need to enable image output in the provider options using the `responseModalities` option.
 
 ```ts
@@ -589,16 +589,16 @@ import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 
 const result = await generateText({
-  model: google('gemini-2.0-flash-preview-image-generation'),
+  model: google('gemini-2.5-flash-image-preview'),
   providerOptions: {
     google: { responseModalities: ['TEXT', 'IMAGE'] },
   },
-  prompt: 'Generate an image of a comic cat',
+  prompt: 'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
 });
 
 for (const file of result.files) {
   if (file.mediaType.startsWith('image/')) {
-    // show the image
+    console.log('Generated image:', file);
   }
 }
 ```

--- a/examples/ai-core/src/generate-image/google-gemini-editing.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-editing.ts
@@ -10,18 +10,22 @@ async function main() {
     providerOptions: {
       google: { responseModalities: ['TEXT', 'IMAGE'] },
     },
-    prompt: 'A photorealistic picture of a fluffy ginger cat sitting on a wooden table',
+    prompt:
+      'A photorealistic picture of a fluffy ginger cat sitting on a wooden table',
   });
 
   let baseImageData: Uint8Array | null = null;
   const timestamp = Date.now();
-  
+
   fs.mkdirSync('output', { recursive: true });
-  
+
   for (const file of baseResult.files) {
     if (file.mediaType.startsWith('image/')) {
       baseImageData = file.uint8Array;
-      await fs.promises.writeFile(`output/cat-base-${timestamp}.png`, file.uint8Array);
+      await fs.promises.writeFile(
+        `output/cat-base-${timestamp}.png`,
+        file.uint8Array,
+      );
       console.log(`Saved base image: output/cat-base-${timestamp}.png`);
       break;
     }
@@ -57,7 +61,10 @@ async function main() {
 
   for (const file of editResult.files) {
     if (file.mediaType.startsWith('image/')) {
-      await fs.promises.writeFile(`output/cat-wizard-${timestamp}.png`, file.uint8Array);
+      await fs.promises.writeFile(
+        `output/cat-wizard-${timestamp}.png`,
+        file.uint8Array,
+      );
       console.log(`Saved edited image: output/cat-wizard-${timestamp}.png`);
     }
   }

--- a/examples/ai-core/src/generate-image/google-gemini-editing.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-editing.ts
@@ -1,0 +1,66 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+import 'dotenv/config';
+
+async function main() {
+  console.log('Generating base cat image...');
+  const baseResult = await generateText({
+    model: google('gemini-2.5-flash-image-preview'),
+    providerOptions: {
+      google: { responseModalities: ['TEXT', 'IMAGE'] },
+    },
+    prompt: 'A photorealistic picture of a fluffy ginger cat sitting on a wooden table',
+  });
+
+  let baseImageData: Uint8Array | null = null;
+  const timestamp = Date.now();
+  
+  fs.mkdirSync('output', { recursive: true });
+  
+  for (const file of baseResult.files) {
+    if (file.mediaType.startsWith('image/')) {
+      baseImageData = file.uint8Array;
+      await fs.promises.writeFile(`output/cat-base-${timestamp}.png`, file.uint8Array);
+      console.log(`Saved base image: output/cat-base-${timestamp}.png`);
+      break;
+    }
+  }
+
+  if (!baseImageData) {
+    throw new Error('No base image generated');
+  }
+
+  console.log('Adding wizard hat...');
+  const editResult = await generateText({
+    model: google('gemini-2.5-flash-image-preview'),
+    providerOptions: {
+      google: { responseModalities: ['TEXT', 'IMAGE'] },
+    },
+    prompt: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Add a small wizard hat to this cat. Keep everything else the same.',
+          },
+          {
+            type: 'file',
+            data: baseImageData,
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ],
+  });
+
+  for (const file of editResult.files) {
+    if (file.mediaType.startsWith('image/')) {
+      await fs.promises.writeFile(`output/cat-wizard-${timestamp}.png`, file.uint8Array);
+      console.log(`Saved edited image: output/cat-wizard-${timestamp}.png`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-image/google-gemini-image.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-image.ts
@@ -1,0 +1,28 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: google('gemini-2.5-flash-image-preview'),
+    providerOptions: {
+      google: { responseModalities: ['TEXT', 'IMAGE'] },
+    },
+    prompt: 'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
+  });
+
+  for (const file of result.files) {
+    if (file.mediaType.startsWith('image/')) {
+      const timestamp = Date.now();
+      const fileName = `nano-banana-${timestamp}.png`;
+      
+      fs.mkdirSync('output', { recursive: true });
+      await fs.promises.writeFile(`output/${fileName}`, file.uint8Array);
+      
+      console.log(`Generated and saved image: output/${fileName}`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-image/google-gemini-image.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-image.ts
@@ -9,17 +9,18 @@ async function main() {
     providerOptions: {
       google: { responseModalities: ['TEXT', 'IMAGE'] },
     },
-    prompt: 'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
+    prompt:
+      'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
   });
 
   for (const file of result.files) {
     if (file.mediaType.startsWith('image/')) {
       const timestamp = Date.now();
       const fileName = `nano-banana-${timestamp}.png`;
-      
+
       fs.mkdirSync('output', { recursive: true });
       await fs.promises.writeFile(`output/${fileName}`, file.uint8Array);
-      
+
       console.log(`Generated and saved image: output/${fileName}`);
     }
   }

--- a/examples/ai-core/src/generate-image/google-gemini-minimal.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-minimal.ts
@@ -1,0 +1,17 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+const { files } = await generateText({
+  model: google('gemini-2.5-flash-image-preview'),
+  providerOptions: {
+    google: { responseModalities: ['TEXT', 'IMAGE'] },
+  },
+  prompt: 'A nano banana in a fancy restaurant',
+});
+
+  console.log(`Generated ${files.length} image files`);
+}
+
+main();

--- a/examples/ai-core/src/generate-image/google-gemini-minimal.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-minimal.ts
@@ -14,4 +14,4 @@ async function main() {
   console.log(`Generated ${files.length} image files`);
 }
 
-main();
+main().catch(console.error);

--- a/examples/ai-core/src/generate-image/google-gemini-minimal.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-minimal.ts
@@ -3,13 +3,13 @@ import { generateText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-const { files } = await generateText({
-  model: google('gemini-2.5-flash-image-preview'),
-  providerOptions: {
-    google: { responseModalities: ['TEXT', 'IMAGE'] },
-  },
-  prompt: 'A nano banana in a fancy restaurant',
-});
+  const { files } = await generateText({
+    model: google('gemini-2.5-flash-image-preview'),
+    providerOptions: {
+      google: { responseModalities: ['TEXT', 'IMAGE'] },
+    },
+    prompt: 'A nano banana in a fancy restaurant',
+  });
 
   console.log(`Generated ${files.length} image files`);
 }

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -24,6 +24,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.5-pro'
   | 'gemini-2.5-flash'
   | 'gemini-2.5-flash-lite'
+  | 'gemini-2.5-flash-image-preview'
   // Experimental models
   // https://ai.google.dev/gemini-api/docs/models/experimental-models
   | 'gemini-2.5-pro-exp-03-25'


### PR DESCRIPTION
## background

google released gemini 2.5 flash image preview (aka nano-banana) which supports advanced image generation and editing through the language model api. users need access to this model for conversational image creation and editing capabilities.

## summary

- added gemini-2.5-flash-image-preview to language model options
- created examples for basic generation and image editing
- updated documentation with correct usage patterns
- it is a multi model reason why it uses streamText() not generateImage()

## verification

all tests pass. created examples in ai-core showing text-to-image and image editing

## tasks

- [x] added gemini-2.5-flash-image-preview to language model options
- [x] created basic image generation example
- [x] created image editing example
- [x] updated google provider documentation