### PR TITLE
feat(ai): gracefully handle ui message validation in output-error scenarios

### DIFF
--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -941,6 +941,50 @@ describe('validateUIMessages', () => {
       `);
     });
 
+    it('should not validate tool input when state is output-error and input schema was error cause', async () => {
+      const messages = await validateUIMessages<TestMessage>({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-foo',
+                toolCallId: '1',
+                state: 'output-error',
+                rawInput: { bar: 'baz' },
+                errorText: 'Input did not match schema',
+              },
+            ],
+          },
+        ],
+        tools: {
+          foo: testTool,
+        },
+      });
+
+      expectTypeOf(messages).toEqualTypeOf<Array<TestMessage>>();
+      expect(messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "parts": [
+              {
+                "errorText": "Input did not match schema",
+                "rawInput": {
+                  "bar": "baz",
+                },
+                "state": "output-error",
+                "toolCallId": "1",
+                "type": "tool-foo",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
     it('should throw error when no tool schema is found', async () => {
       await expect(
         validateUIMessages<TestMessage>({

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -115,6 +115,7 @@ const toolUIPartSchemas = [
     input: z.unknown().optional(),
     output: z.never().optional(),
     errorText: z.never().optional(),
+    providerExecuted: z.boolean().optional(),
   }),
   z.object({
     type: z.string().startsWith('tool-'),
@@ -124,6 +125,7 @@ const toolUIPartSchemas = [
     output: z.never().optional(),
     errorText: z.never().optional(),
     callProviderMetadata: providerMetadataSchema.optional(),
+    providerExecuted: z.boolean().optional(),
   }),
   z.object({
     type: z.string().startsWith('tool-'),
@@ -134,15 +136,18 @@ const toolUIPartSchemas = [
     errorText: z.never().optional(),
     callProviderMetadata: providerMetadataSchema.optional(),
     preliminary: z.boolean().optional(),
+    providerExecuted: z.boolean().optional(),
   }),
   z.object({
     type: z.string().startsWith('tool-'),
     toolCallId: z.string(),
     state: z.literal('output-error'),
-    input: z.unknown(),
+    input: z.unknown().optional(),
+    rawInput: z.unknown().optional(),
     output: z.never().optional(),
     errorText: z.string(),
     callProviderMetadata: providerMetadataSchema.optional(),
+    providerExecuted: z.boolean().optional(),
   }),
 ];
 
@@ -252,13 +257,21 @@ export async function validateUIMessages<UI_MESSAGE extends UIMessage>({
 
         if (
           toolPart.state === 'input-available' ||
-          toolPart.state === 'output-available' ||
-          toolPart.state === 'output-error'
+          toolPart.state === 'output-available'
         ) {
           await validateTypes({
             value: toolPart.input,
             schema: tool.inputSchema,
           });
+        }
+
+        if (toolPart.state === 'output-error') {
+          if (toolPart.input !== undefined) {
+            await validateTypes({
+              value: toolPart.input,
+              schema: tool.inputSchema,
+            });
+          }
         }
 
         if (toolPart.state === 'output-available' && tool.outputSchema) {


### PR DESCRIPTION
## Background

The `validateUIMessages` utility function does not cover the potential `input`
and `rawInput` states for `output-error` scenarios properly. In the case that a
tool fails due to a schematic error in `input`, the validation of that
`ToolUIPart` of `{ state: "output-error" }` fails its schematic check against
the tool's `inputSchema`, creating an invalid messages array despite the array
being technically valid based on it's type. [see ToolUIPart](https://github.com/vercel/ai/blob/main/packages/ai/src/ui/ui-messages.ts#L201)

The main reason this happens is due to:

1. the schemas defined in the validation aren't directly covering all possible scenarios
that the type defines
2. the `output-error` scenario still forces a schematic check on the input, even if the
input does not exist. In these scenarios, the part returned actually uses the `rawInput`
property to portray that failed input.

The tests for this function do not cover this particular state, which allows the
test-suite to pass gracefully despite this potential state occurring in real-world
scenarios.

## Manual Verification

* test the scenario where unhandled, yet valid, input scenarios fail the test suite
* ensure the schema is only checked when it makes sense for `output-error`'s.

## Tasks

- [x] add additional test case for scenario
- [x] A _patch_ changeset for relevant packages has been added
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)
