### PR TITLE
ci(assign-team-pull-request): ignore bots

### DIFF
--- a/.github/workflows/assign-team-pull-request.yml
+++ b/.github/workflows/assign-team-pull-request.yml
@@ -11,7 +11,8 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     # Only assign pull requests by team members, ignore pull requests from forks
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # And only assign if pull request was created by a user, ignore bots
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type == 'User'
     steps:
       - uses: actions/checkout@v4
       - name: Assign pull request to author


### PR DESCRIPTION
This will prevent failing builds for our release PRs

<img width="975" height="145" alt="image" src="https://github.com/user-attachments/assets/f0cc0f52-4831-4913-850d-e027f9fdde9d" />
