### PR TITLE
fix(typescript): bump compiler target from es2018 (node 10) to es2022 (Node 18)

### DIFF
--- a/.changeset/curvy-squids-relate.md
+++ b/.changeset/curvy-squids-relate.md
@@ -1,0 +1,45 @@
+---
+'ai': patch
+'amazon-bedrock': patch
+'angular': patch
+'anthropic': patch
+'assemblyai': patch
+'azure': patch
+'cerebras': patch
+'codemod': patch
+'cohere': patch
+'deepgram': patch
+'deepinfra': patch
+'deepseek': patch
+'elevenlabs': patch
+'fal': patch
+'fireworks': patch
+'gateway': patch
+'gladia': patch
+'google': patch
+'google-vertex': patch
+'groq': patch
+'hume': patch
+'langchain': patch
+'llamaindex': patch
+'lmnt': patch
+'luma': patch
+'mistral': patch
+'openai': patch
+'openai-compatible': patch
+'perplexity': patch
+'provider': patch
+'provider-utils': patch
+'react': patch
+'replicate': patch
+'revai': patch
+'rsc': patch
+'svelte': patch
+'togetherai': patch
+'valibot': patch
+'vercel': patch
+'vue': patch
+'xai': patch
+---
+
+fix: bump typescript compiler target from es2018 (node 10) to es2022 (node 18)

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@vercel/ai-tsconfig/base.json",
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "es2022",
     "stripInternal": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "types": ["@types/node", "vitest/globals"],

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@vercel/ai-tsconfig/react-library.json",
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "es2022",
     "stripInternal": true,
     "composite": true,
     "rootDir": "src",

--- a/packages/rsc/tsconfig.json
+++ b/packages/rsc/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/@vercel/ai-tsconfig/react-library.json",
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "es2022",
     "stripInternal": true,
     "rootDir": "src",
     "composite": true,

--- a/tools/tsconfig/ts-library.json
+++ b/tools/tsconfig/ts-library.json
@@ -6,10 +6,10 @@
         "lib": [
             "dom",
             "dom.iterable",
-            "ES2018"
+            "es2022"
         ],
         "module": "ESNext",
-        "target": "ES2018",
+        "target": "es2022",
         "stripInternal": true
     },
 }


### PR DESCRIPTION
bump Typescript compiler target from [es2018 (node 10)](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-10) to [es2022 (node 18)](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-18)



unblocks #8277