### PR TITLE
fix(provider/fal): handle null width/height in image response schema

### DIFF
--- a/.changeset/forty-terms-invent.md
+++ b/.changeset/forty-terms-invent.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fal': patch
+---
+
+fix: handle null width/height values in image response schema

--- a/packages/fal/src/fal-image-model.test.ts
+++ b/packages/fal/src/fal-image-model.test.ts
@@ -472,5 +472,49 @@ describe('FalImageModel', () => {
         seed: 235205040,
       });
     });
+
+    it('should handle null width and height values with images array only', async () => {
+      server.urls['https://api.example.com/fal-ai/qwen-image'].response = {
+        type: 'json-value',
+        body: {
+          images: [
+            {
+              url: 'https://api.example.com/image.png',
+              content_type: 'image/png',
+              file_name: 'output.png',
+              file_size: 663399,
+              width: null,
+              height: null,
+            },
+          ],
+          description: 'here is an image with null width and height',
+        },
+      };
+
+      const model = createBasicModel();
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        providerOptions: {},
+        size: undefined,
+        seed: undefined,
+        aspectRatio: undefined,
+      });
+
+      expect(result.images).toHaveLength(1);
+      expect(result.images[0]).toBeInstanceOf(Uint8Array);
+      expect(result.providerMetadata?.fal).toMatchObject({
+        images: [
+          {
+            width: null,
+            height: null,
+            contentType: 'image/png',
+            fileName: 'output.png',
+            fileSize: 663399,
+          },
+        ],
+        description: 'here is an image with null width and height',
+      });
+    });
   });
 });

--- a/packages/fal/src/fal-image-model.ts
+++ b/packages/fal/src/fal-image-model.ts
@@ -214,14 +214,14 @@ const falErrorSchema = z.union([falValidationErrorSchema, falHttpErrorSchema]);
 
 const falImageSchema = z.object({
   url: z.string(),
-  width: z.number().nullable().optional(),
-  height: z.number().nullable().optional(),
+  width: z.number().nullish(),
+  height: z.number().nullish(),
   // e.g. https://fal.ai/models/fal-ai/fashn/tryon/v1.6/api#schema-output
-  content_type: z.string().nullable().optional(),
+  content_type: z.string().nullish(),
   // e.g. https://fal.ai/models/fal-ai/flowedit/api#schema-output
-  file_name: z.string().nullable().optional(),
+  file_name: z.string().nullish(),
   file_data: z.string().optional(),
-  file_size: z.number().nullable().optional(),
+  file_size: z.number().nullish(),
 });
 
 // https://fal.ai/models/fal-ai/lora/api#type-File

--- a/packages/fal/src/fal-image-model.ts
+++ b/packages/fal/src/fal-image-model.ts
@@ -214,8 +214,8 @@ const falErrorSchema = z.union([falValidationErrorSchema, falHttpErrorSchema]);
 
 const falImageSchema = z.object({
   url: z.string(),
-  width: z.number().optional(),
-  height: z.number().optional(),
+  width: z.number().nullable().optional(),
+  height: z.number().nullable().optional(),
   // e.g. https://fal.ai/models/fal-ai/fashn/tryon/v1.6/api#schema-output
   content_type: z.string().nullable().optional(),
   // e.g. https://fal.ai/models/fal-ai/flowedit/api#schema-output


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The Fal provider's `gemini-25-flash-image` model returns `null` values for `width` and `height` fields in the response, causing JSON validation errors in AI SDK v5.

<!-- Why was this change necessary? -->

## Summary

<!-- What did you change? -->
Updated the Fal image response schema to accept nullable values for `width` and `height` fields, matching the existing pattern used for other nullable fields (`file_name`, `file_size`, `content_type`).

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->
Tested with the exact response format returned by `fal-ai/gemini-25-flash-image`:
- Added test case with null width/height values
- All existing tests pass
- Verified schema now accepts both number and null values


## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
