### PR TITLE
feat(provider/openai): Adds service tier to OpenAI responses provider metadata

### DIFF
--- a/.changeset/silver-lizards-jam.md
+++ b/.changeset/silver-lizards-jam.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add serviceTier to provider metadata for OpenAI responses

--- a/examples/ai-core/src/stream-text/openai-responses-service-tier.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-service-tier.ts
@@ -1,0 +1,28 @@
+import 'dotenv/config';
+import { openai } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+
+async function main() {
+  const result = streamText({
+    model: openai('gpt-5-nano'),
+    prompt: 'What color is the sky in one word?',
+    providerOptions: {
+      openai: {
+        serviceTier: 'flex',
+      },
+    },
+  });
+
+  await result.consumeStream();
+  const providerMetadata = await result.providerMetadata;
+
+  console.log('Provider metadata:', providerMetadata);
+  // Provider metadata: {
+  //   openai: {
+  //     responseId: '...',
+  //     serviceTier: 'flex'
+  //   }
+  // }
+}
+
+main().catch(console.error);

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -3351,7 +3351,7 @@ describe('OpenAIResponsesLanguageModel', () => {
       `);
     });
 
-    it('should should handle logprops', async () => {
+    it('should should handle logprobs and service tier', async () => {
       server.urls['https://api.openai.com/v1/responses'].response = {
         type: 'stream-chunks',
         chunks: [
@@ -3441,6 +3441,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                   ],
                 ],
                 "responseId": "resp_689cec4cf608819583c56813ccb0f5040f92af1765dd5aad",
+                "serviceTier": "default",
               },
             },
             "type": "finish",

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -3351,7 +3351,105 @@ describe('OpenAIResponsesLanguageModel', () => {
       `);
     });
 
-    it('should should handle logprobs and service tier', async () => {
+    it('Should handle service tier', async () => {
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          'data:{"type":"response.created","sequence_number":0,"response":{"id":"resp_68b08bfa71908196889e9ae5668b2ae40cd677a623b867d5","object":"response","created_at":1756400634,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-nano-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"medium","summary":null},"safety_identifier":null,"service_tier":"flex","store":true,"temperature":1,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n',
+          'data:{"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_68b08bfa71908196889e9ae5668b2ae40cd677a623b867d5","object":"response","created_at":1756400634,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-nano-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"medium","summary":null},"safety_identifier":null,"service_tier":"flex","store":true,"temperature":1,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n',
+          'data:{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_68b08bfb9f3c819682c5cff6edee6e4d0cd677a623b867d5","type":"reasoning","summary":[]}}\n\n',
+          'data:{"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"id":"rs_68b08bfb9f3c819682c5cff6edee6e4d0cd677a623b867d5","type":"reasoning","summary":[]}}\n\n',
+          'data:{"type":"response.output_item.added","sequence_number":4,"output_index":1,"item":{"id":"msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5","type":"message","status":"in_progress","content":[],"role":"assistant"}}\n\n',
+          'data:{"type":"response.content_part.added","sequence_number":5,"item_id":"msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}\n\n',
+          'data:{"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5","output_index":1,"content_index":0,"delta":"blue","logprobs":[],"obfuscation":"A3q16QVxivdK"}\n\n',
+          'data:{"type":"response.output_text.done","sequence_number":7,"item_id":"msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5","output_index":1,"content_index":0,"text":"blue","logprobs":[]}\n\n',
+          'data:{"type":"response.content_part.done","sequence_number":8,"item_id":"msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"blue"}}\n\n',
+          'data:{"type":"response.output_item.done","sequence_number":9,"output_index":1,"item":{"id":"msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"blue"}],"role":"assistant"}}\n\n',
+          'data:{"type":"response.completed","sequence_number":10,"response":{"id":"resp_68b08bfa71908196889e9ae5668b2ae40cd677a623b867d5","object":"response","created_at":1756400634,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-nano-2025-08-07","output":[{"id":"rs_68b08bfb9f3c819682c5cff6edee6e4d0cd677a623b867d5","type":"reasoning","summary":[]},{"id":"msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"blue"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"medium","summary":null},"safety_identifier":null,"service_tier":"flex","store":true,"temperature":1,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1,"truncation":"disabled","usage":{"input_tokens":15,"input_tokens_details":{"cached_tokens":0},"output_tokens":263,"output_tokens_details":{"reasoning_tokens":256},"total_tokens":278},"user":null,"metadata":{}}}\n\n',
+        ],
+      };
+
+      const { stream } = await createModel('gpt-5-nano').doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          openai: {
+            serviceTier: 'flex',
+          },
+        },
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "id": "resp_68b08bfa71908196889e9ae5668b2ae40cd677a623b867d5",
+            "modelId": "gpt-5-nano-2025-08-07",
+            "timestamp": 2025-08-28T17:03:54.000Z,
+            "type": "response-metadata",
+          },
+          {
+            "id": "rs_68b08bfb9f3c819682c5cff6edee6e4d0cd677a623b867d5:0",
+            "providerMetadata": {
+              "openai": {
+                "itemId": "rs_68b08bfb9f3c819682c5cff6edee6e4d0cd677a623b867d5",
+                "reasoningEncryptedContent": null,
+              },
+            },
+            "type": "reasoning-start",
+          },
+          {
+            "id": "rs_68b08bfb9f3c819682c5cff6edee6e4d0cd677a623b867d5:0",
+            "providerMetadata": {
+              "openai": {
+                "itemId": "rs_68b08bfb9f3c819682c5cff6edee6e4d0cd677a623b867d5",
+                "reasoningEncryptedContent": null,
+              },
+            },
+            "type": "reasoning-end",
+          },
+          {
+            "id": "msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5",
+            "providerMetadata": {
+              "openai": {
+                "itemId": "msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5",
+              },
+            },
+            "type": "text-start",
+          },
+          {
+            "delta": "blue",
+            "id": "msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5",
+            "type": "text-delta",
+          },
+          {
+            "id": "msg_68b08bfc9a548196b15465b6020b04e40cd677a623b867d5",
+            "type": "text-end",
+          },
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "openai": {
+                "responseId": "resp_68b08bfa71908196889e9ae5668b2ae40cd677a623b867d5",
+                "serviceTier": "flex",
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "cachedInputTokens": 0,
+              "inputTokens": 15,
+              "outputTokens": 263,
+              "reasoningTokens": 256,
+              "totalTokens": 278,
+            },
+          },
+        ]
+      `);
+    });
+
+    it('should handle logprobs', async () => {
       server.urls['https://api.openai.com/v1/responses'].response = {
         type: 'stream-chunks',
         chunks: [

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -417,6 +417,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               }),
             ]),
           ),
+          service_tier: z.string().nullish(),
           incomplete_details: z.object({ reason: z.string() }).nullable(),
           usage: usageSchema,
         }),
@@ -598,6 +599,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       providerMetadata.openai.logprobs = logprobs;
     }
 
+    if (typeof response.service_tier === 'string') {
+      providerMetadata.openai.serviceTier = response.service_tier;
+    }
+
     return {
       content,
       finishReason: mapOpenAIResponseFinishReason({
@@ -673,6 +678,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       }
     > = {};
 
+    const finishChunkProviderMetadata: SharedV2ProviderMetadata = {
+      openai: {},
+    };
+
     return {
       stream: response.pipeThrough(
         new TransformStream<
@@ -696,7 +705,6 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             }
 
             const value = chunk.value;
-
             if (isResponseOutputItemAddedChunk(value)) {
               if (value.item.type === 'function_call') {
                 ongoingToolCalls[value.output_index] = {
@@ -970,6 +978,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               usage.cachedInputTokens =
                 value.response.usage.input_tokens_details?.cached_tokens ??
                 undefined;
+              if (typeof value.response.service_tier === 'string') {
+                finishChunkProviderMetadata.openai.serviceTier =
+                  value.response.service_tier;
+              }
             } else if (isResponseAnnotationAddedChunk(value)) {
               if (value.annotation.type === 'url_citation') {
                 controller.enqueue({
@@ -999,21 +1011,17 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
           },
 
           flush(controller) {
-            const providerMetadata: SharedV2ProviderMetadata = {
-              openai: {
-                responseId,
-              },
-            };
+            finishChunkProviderMetadata.openai.responseId = responseId;
 
             if (logprobs.length > 0) {
-              providerMetadata.openai.logprobs = logprobs;
+              finishChunkProviderMetadata.openai.logprobs = logprobs;
             }
 
             controller.enqueue({
               type: 'finish',
               finishReason,
               usage,
-              providerMetadata,
+              providerMetadata: finishChunkProviderMetadata,
             });
           },
         }),
@@ -1055,6 +1063,7 @@ const responseFinishedChunkSchema = z.object({
   response: z.object({
     incomplete_details: z.object({ reason: z.string() }).nullish(),
     usage: usageSchema,
+    service_tier: z.string().nullish(),
   }),
 });
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1079,6 +1079,7 @@ const responseCreatedChunkSchema = z.object({
     id: z.string(),
     created_at: z.number(),
     model: z.string(),
+    service_tier: z.string().nullish(),
   }),
 });
 


### PR DESCRIPTION
## Background

There's currently no great way to get the `service_tier` out of OpenAI's response when streaming without using `fullStream` and having the user pass `includeRawChunks`. For `generate` it's possible to get this out of the response body, but it's somewhat cumbersome. This field is important for token cost tracking.

OpenAI can downgrade you depending on rate limits, so getting this info out of the request params is not enough.

## Summary

This adds `serviceTier` to the returned `providerMetadata` for OpenAI streaming (and also generate for completeness).

## Manual Verification

Ran an existing example (`ai/examples/ai-core/src/stream-text/openai-responses-reasoning-summary.ts`) and saw:

```ts
Provider metadata: {
  openai: {
    serviceTier: 'default',
    responseId: 'resp_68ae3c510d9c8195a74eed6a01736ee30fd80228337cb053'
  }
}
```

Changing to `priority` also passed this through.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)