### PR TITLE
fix(provider/anthropic): disable parallel tool use when using json output tool for structured responses

### DIFF
--- a/.changeset/cold-plants-listen.md
+++ b/.changeset/cold-plants-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(provider/anthropic): disable parallel tool use when using json output tool for structured responses

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -208,6 +208,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             ],
             "model": "claude-3-haiku-20240307",
             "tool_choice": {
+              "disable_parallel_tool_use": true,
               "name": "json",
               "type": "tool",
             },
@@ -1739,6 +1740,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "model": "claude-3-haiku-20240307",
             "stream": true,
             "tool_choice": {
+              "disable_parallel_tool_use": true,
               "name": "json",
               "type": "tool",
             },

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -332,7 +332,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
         ? {
             tools: [jsonResponseTool],
             toolChoice: { type: 'tool', toolName: jsonResponseTool.name },
-            disableParallelToolUse: anthropicOptions?.disableParallelToolUse,
+            disableParallelToolUse: true,
           }
         : {
             tools: tools ?? [],


### PR DESCRIPTION
## Background

There was a chance that multiple json tools were called when using structured outputs with Anthropic.

## Summary

disable parallel tool use when using json output tool for structured responses