### PR TITLE
fix(codemod): Language Model V2 Import

### DIFF
--- a/.changeset/few-tips-march.md
+++ b/.changeset/few-tips-march.md
@@ -1,0 +1,21 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+fix(codemod): Language Model V2 Import
+
+Migration: https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0#language-model-v2-import
+
+Codemod behavior before the fix
+
+```diff
+- import { LanguageModelV2 } from 'ai';
++ import { LanguageModelV2 } from '@ai-sdk/provider';
+```
+
+After
+
+```diff
++ import { LanguageModelV2 } from 'ai';
+- import { LanguageModelV2 } from '@ai-sdk/provider';
+```

--- a/packages/codemod/src/codemods/v5/import-LanguageModelV2-from-provider-package.ts
+++ b/packages/codemod/src/codemods/v5/import-LanguageModelV2-from-provider-package.ts
@@ -10,23 +10,30 @@ const ImportMappings: Record<string, string> = {
 export default createTransformer((fileInfo, api, options, context) => {
   const { j, root } = context;
 
-  // Find all import declarations
+  // Find all import declarations from 'ai'
   root.find(j.ImportDeclaration).forEach(importPath => {
     const node = importPath.node;
 
-    // Check if the source value is exactly '@ai-sdk/provider'
-    if (node.source.value !== '@ai-sdk/provider') return;
+    // Check if the source value is exactly 'ai'
+    if (node.source.value !== 'ai') return;
 
-    // Check if the named import includes 'LanguageModelV1' or 'LanguageModelV2'
-    const specifiers =
+    // Find specifiers that should be moved to '@ai-sdk/provider'
+    const targetSpecifiers =
       node.specifiers?.filter(
         s =>
           j.ImportSpecifier.check(s) &&
           Object.keys(ImportMappings).includes(s.imported.name),
       ) ?? [];
 
-    // Rename LanguageModelV1 to LanguageModelV2 if present
-    for (const specifier of specifiers) {
+    // If no target specifiers found, skip this import
+    if (targetSpecifiers.length === 0) return;
+
+    // Get remaining specifiers that should stay in 'ai'
+    const remainingSpecifiers =
+      node.specifiers?.filter(s => !targetSpecifiers.includes(s)) ?? [];
+
+    // Rename LanguageModelV1 to LanguageModelV2 in target specifiers
+    for (const specifier of targetSpecifiers) {
       if (
         specifier.type === 'ImportSpecifier' &&
         ImportMappings[specifier.imported.name]
@@ -38,9 +45,31 @@ export default createTransformer((fileInfo, api, options, context) => {
     // Set hasChanges to true since we will modify the AST
     context.hasChanges = true;
 
-    // Change the module source from '@ai-sdk/provider' to 'ai'
-    node.source.value = 'ai';
+    if (remainingSpecifiers.length === 0) {
+      // All specifiers should be moved, just change the source
+      node.source.value = '@ai-sdk/provider';
+      context.messages.push(`Updated import from 'ai' to '@ai-sdk/provider'`);
+    } else {
+      // Mixed imports: need to split them
+      // The current import (with comments) should become the moved import
+      // and we need to create a new import for the remaining specifiers
 
-    context.messages.push(`Updated import from '@ai-sdk/provider' to 'ai'`);
+      // Change the current import to use the new source and target specifiers
+      node.source.value = '@ai-sdk/provider';
+      node.specifiers = targetSpecifiers;
+
+      // Create new import for remaining specifiers after the current one
+      const remainingImport = j.importDeclaration(
+        remainingSpecifiers,
+        j.literal('ai'),
+      );
+
+      // Insert the remaining import after the current one
+      importPath.insertAfter(remainingImport);
+
+      context.messages.push(
+        `Split import: moved some imports from 'ai' to '@ai-sdk/provider'`,
+      );
+    }
   });
 });

--- a/packages/codemod/src/codemods/v5/import-LanguageModelV2-from-provider-package.ts
+++ b/packages/codemod/src/codemods/v5/import-LanguageModelV2-from-provider-package.ts
@@ -7,6 +7,10 @@ const ImportMappings: Record<string, string> = {
   LanguageModelV2Middleware: 'LanguageModelV2Middleware',
 };
 
+/**
+ * Codemod to update imports of LanguageModelV2 and related types from 'ai' to '@ai-sdk/provider'.
+ * @see https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0#language-model-v2-import
+ */
 export default createTransformer((fileInfo, api, options, context) => {
   const { j, root } = context;
 

--- a/packages/codemod/src/test/__testfixtures__/import-LanguageModelV2-from-provider-package.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/import-LanguageModelV2-from-provider-package.input.ts
@@ -1,9 +1,9 @@
 // @ts-nocheck
-import { LanguageModelV1 } from '@ai-sdk/provider';
-import { LanguageModelV2 } from '@ai-sdk/provider';
-import { LanguageModelV1Middleware } from '@ai-sdk/provider';
-import { LanguageModelV2Middleware } from '@ai-sdk/provider';
-import { someOtherFunction } from '@ai-sdk/provider';
+import { LanguageModelV1 } from 'ai';
+import { LanguageModelV2 } from 'ai';
+import { LanguageModelV1Middleware } from 'ai';
+import { LanguageModelV2Middleware } from 'ai';
+import { someOtherFunction } from 'ai';
 
 // Multiple imports in one declaration
 import { 
@@ -12,13 +12,13 @@ import {
   LanguageModelV1Middleware as LMV1MiddlewareMulti,
   LanguageModelV2Middleware as LMV2MiddlewareMulti,
   anotherFunction 
-} from '@ai-sdk/provider';
+} from 'ai';
 
 // Import with alias
-import { LanguageModelV1 as LMV1 } from '@ai-sdk/provider';
+import { LanguageModelV1 as LMV1 } from 'ai';
 
 // Mixed imports
-import { LanguageModelV1 as LMV1Mixed, generateText } from '@ai-sdk/provider';
+import { LanguageModelV1 as LMV1Mixed, generateText } from 'ai';
 
 // Should not affect other packages
 import { LanguageModelV1 as LMV1Other } from 'some-other-package';

--- a/packages/codemod/src/test/__testfixtures__/import-LanguageModelV2-from-provider-package.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/import-LanguageModelV2-from-provider-package.input.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import { LanguageModelV1 } from '@ai-sdk/provider';
+import { LanguageModelV2 } from '@ai-sdk/provider';
+import { LanguageModelV1Middleware } from '@ai-sdk/provider';
+import { LanguageModelV2Middleware } from '@ai-sdk/provider';
+import { someOtherFunction } from '@ai-sdk/provider';
+
+// Multiple imports in one declaration
+import { 
+  LanguageModelV1 as LMV1Multi, 
+  LanguageModelV2 as LMV2Multi, 
+  LanguageModelV1Middleware as LMV1MiddlewareMulti,
+  LanguageModelV2Middleware as LMV2MiddlewareMulti,
+  anotherFunction 
+} from '@ai-sdk/provider';
+
+// Import with alias
+import { LanguageModelV1 as LMV1 } from '@ai-sdk/provider';
+
+// Mixed imports
+import { LanguageModelV1 as LMV1Mixed, generateText } from '@ai-sdk/provider';
+
+// Should not affect other packages
+import { LanguageModelV1 as LMV1Other } from 'some-other-package';
+import { LanguageModelV2 as LMV2Other } from 'another-package';

--- a/packages/codemod/src/test/__testfixtures__/import-LanguageModelV2-from-provider-package.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/import-LanguageModelV2-from-provider-package.output.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+import { LanguageModelV2 } from 'ai';
+import { LanguageModelV2 } from 'ai';
+import { LanguageModelV2Middleware } from 'ai';
+import { LanguageModelV2Middleware } from 'ai';
+import { someOtherFunction } from 'ai';
+
+// Multiple imports in one declaration
+import { 
+  LanguageModelV2 as LMV1Multi, 
+  LanguageModelV2 as LMV2Multi, 
+  LanguageModelV2Middleware as LMV1MiddlewareMulti,
+  LanguageModelV2Middleware as LMV2MiddlewareMulti,
+  anotherFunction 
+} from 'ai';
+
+// Import with alias
+import { LanguageModelV2 as LMV1 } from 'ai';
+
+// Mixed imports
+import { LanguageModelV2 as LMV1Mixed, generateText } from 'ai';
+
+// Should not affect other packages
+import { LanguageModelV1 as LMV1Other } from 'some-other-package';
+import { LanguageModelV2 as LMV2Other } from 'another-package';

--- a/packages/codemod/src/test/__testfixtures__/import-LanguageModelV2-from-provider-package.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/import-LanguageModelV2-from-provider-package.output.ts
@@ -1,24 +1,27 @@
 // @ts-nocheck
-import { LanguageModelV2 } from 'ai';
-import { LanguageModelV2 } from 'ai';
-import { LanguageModelV2Middleware } from 'ai';
-import { LanguageModelV2Middleware } from 'ai';
+import { LanguageModelV2 } from '@ai-sdk/provider';
+import { LanguageModelV2 } from '@ai-sdk/provider';
+import { LanguageModelV2Middleware } from '@ai-sdk/provider';
+import { LanguageModelV2Middleware } from '@ai-sdk/provider';
 import { someOtherFunction } from 'ai';
 
 // Multiple imports in one declaration
-import { 
-  LanguageModelV2 as LMV1Multi, 
-  LanguageModelV2 as LMV2Multi, 
+import {
+  LanguageModelV2 as LMV1Multi,
+  LanguageModelV2 as LMV2Multi,
   LanguageModelV2Middleware as LMV1MiddlewareMulti,
   LanguageModelV2Middleware as LMV2MiddlewareMulti,
-  anotherFunction 
-} from 'ai';
+} from '@ai-sdk/provider';
+
+import { anotherFunction } from 'ai';
 
 // Import with alias
-import { LanguageModelV2 as LMV1 } from 'ai';
+import { LanguageModelV2 as LMV1 } from '@ai-sdk/provider';
 
 // Mixed imports
-import { LanguageModelV2 as LMV1Mixed, generateText } from 'ai';
+import { LanguageModelV2 as LMV1Mixed } from '@ai-sdk/provider';
+
+import { generateText } from 'ai';
 
 // Should not affect other packages
 import { LanguageModelV1 as LMV1Other } from 'some-other-package';

--- a/packages/codemod/src/test/import-LanguageModelV2-from-provider-package.test.ts
+++ b/packages/codemod/src/test/import-LanguageModelV2-from-provider-package.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v5/import-LanguageModelV2-from-provider-package';
+import { testTransform } from './test-utils';
+
+describe('import-LanguageModelV2-from-provider-package', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'import-LanguageModelV2-from-provider-package');
+  });
+});


### PR DESCRIPTION
## Background

We have an existing codemod for [Language Model V2 Import](https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0#language-model-v2-import), but it's not working the wrong way around.

Instead of 

```diff
- import { LanguageModelV2 } from 'ai';
+ import { LanguageModelV2 } from '@ai-sdk/provider';
```

it does

```diff
+ import { LanguageModelV2 } from 'ai';
- import { LanguageModelV2 } from '@ai-sdk/provider';
```

It is also eager as shown by the tests introduced in d08d0bb67bf122c1c7fa789ca105eee639d935b8

## Summary

1. Updated tests to desired behavior 125a18554000e754386bc4eab782f95231f50214
2. Implemented fix dab6739355fe1a5260b7dd3ff006eebb267c8f65

## Manual Verification

Problem surfaced by running codemod on vercel/ai-chat. Verified it no longer does the unwanted change with

```
$ cd /path/to/vercel/ai-chat
$ /path/to/packages/codemod/dist/bin/codemod.js v5/import-LanguageModelV2-from-provider-package .
```

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Towards #6552
closes #8334