### PR TITLE
fix(codemod): `delta.textDelta` -> `delta.text` is currently also replacing the value of `delta.type` from `'text-delta'` to `'text'`

### DIFF
--- a/.changeset/ten-stingrays-greet.md
+++ b/.changeset/ten-stingrays-greet.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+fix(codemod): Do not replace `delta.type` value from `'text-delta'` to `'text'`

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -2213,7 +2213,7 @@ const result = streamText({
   prompt: 'Write a story',
   onChunk({ chunk }) {
     switch (chunk.type) {
-      case 'text': {
+      case 'text-delta': {
         // Text chunks now use single 'text' type
         console.log('Text chunk:', chunk.text);
         break;
@@ -3143,7 +3143,7 @@ The chunk types in `fullStream` have been renamed for consistency with UI stream
 ```tsx filename="AI SDK 5.0 (before beta.26)"
 for await (const chunk of result.fullStream) {
   switch (chunk.type) {
-    case 'text': {
+    case 'text-delta': {
       process.stdout.write(chunk.text);
       break;
     }

--- a/packages/codemod/src/codemods/v5/replace-textdelta-with-text.ts
+++ b/packages/codemod/src/codemods/v5/replace-textdelta-with-text.ts
@@ -35,35 +35,60 @@ export default createTransformer((fileInfo, api, options, context) => {
       context.hasChanges = true;
     });
 
-  // Replace the case 'text-delta' with case 'text'
+  // Find all ObjectProperty nodes in object patterns where key is 'textDelta'
   root
-    .find(j.SwitchCase)
+    .find(j.ObjectProperty)
     .filter(path => {
-      const node = path.node;
+      const prop = path.node;
 
-      // Check if the test is a string literal with value 'text-delta'
-      if (j.Literal.check(node.test) && node.test.value === 'text-delta') {
+      // Must be a property with key 'textDelta'
+      if (!j.Identifier.check(prop.key) || prop.key.name !== 'textDelta') {
+        return false;
+      }
+
+      // Must be inside an ObjectPattern
+      const parent = path.parent;
+      if (!j.ObjectPattern.check(parent.node)) {
+        return false;
+      }
+
+      // For variable declarations, check if destructuring from delta
+      const grandParent = parent.parent;
+      if (j.VariableDeclarator.check(grandParent.node)) {
+        return (
+          j.Identifier.check(grandParent.node.init) &&
+          grandParent.node.init.name === 'delta'
+        );
+      }
+
+      // For function parameters, allow transformation
+      // (we can't easily check the source, so we'll transform all textDelta in function params)
+      if (
+        j.Function.check(grandParent.node) ||
+        j.ArrowFunctionExpression.check(grandParent.node)
+      ) {
         return true;
       }
 
       return false;
     })
     .forEach(path => {
-      // Replace 'text-delta' with 'text'
-      path.node.test = j.literal('text');
-      context.hasChanges = true;
-    });
+      const prop = path.node;
 
-  // Replace string literal 'text-delta' with 'text' in direct comparisons
-  root
-    .find(j.Literal)
-    .filter(path => {
-      const node = path.node;
-      return node.value === 'text-delta';
-    })
-    .forEach(path => {
-      // Replace 'text-delta' with 'text'
-      path.node.value = 'text';
+      // Handle different destructuring patterns
+      if (prop.shorthand) {
+        // Case: { textDelta } → { text: textDelta }
+        if (j.Identifier.check(prop.key)) {
+          prop.key.name = 'text';
+          prop.shorthand = false;
+        }
+      } else {
+        // Case: { textDelta: customName } → { text: customName }
+        if (j.Identifier.check(prop.key)) {
+          prop.key.name = 'text';
+        }
+      }
+
       context.hasChanges = true;
     });
 });

--- a/packages/codemod/src/codemods/v5/replace-textdelta-with-text.ts
+++ b/packages/codemod/src/codemods/v5/replace-textdelta-with-text.ts
@@ -1,5 +1,11 @@
 import { createTransformer } from '../lib/create-transformer';
 
+/**
+ * Codemod to replace all instances of `delta.textDelta` with `delta.text`
+ * and to update destructuring patterns accordingly.
+ *
+ * @see https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0#onchunk-callback-changes
+ */
 export default createTransformer((fileInfo, api, options, context) => {
   const { j, root } = context;
 

--- a/packages/codemod/src/test/__testfixtures__/replace-textdelta-with-text.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/replace-textdelta-with-text.input.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+// Test file for replace-textdelta-with-text codemod
+
+// 1. Member expression cases
+const content = delta.textDelta; // Should be transformed
+const otherContent = delta.text; // Should NOT be transformed  
+const wrongObject = other.textDelta; // Should NOT be transformed (wrong object)
+const wrongProperty = delta.otherProperty; // Should NOT be transformed (wrong property)
+
+// 2. Switch case transformations
+function handleStreamPart(part: any) {
+  switch (part.type) {
+    case 'text-delta':
+      return processTextDelta(part);
+    case 'other-delta':
+      return processOther(part);
+  }
+}
+
+// 3. String literal transformations
+const partType = 'text-delta'; // Should be transformed
+const otherType = 'text'; // Should NOT be transformed
+const anotherType = 'other-delta'; // Should NOT be transformed
+
+// 4. Conditional checks
+if (part.type === 'text-delta') { // Should be transformed
+  handleTextDelta();
+}
+
+if (part.type === 'text') { // Should NOT be transformed
+  handleText();
+}
+
+// 5. Complex expressions combining multiple patterns
+function processStream(parts: any[]) {
+  return parts.map(part => {
+    if (part.type === 'text-delta') {
+      return {
+        ...part,
+        content: delta.textDelta,
+        type: 'text' // This 'text' should NOT be transformed (not 'text-delta')
+      };
+    }
+    return part;
+  });
+}

--- a/packages/codemod/src/test/__testfixtures__/replace-textdelta-with-text.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/replace-textdelta-with-text.input.ts
@@ -7,40 +7,23 @@ const otherContent = delta.text; // Should NOT be transformed
 const wrongObject = other.textDelta; // Should NOT be transformed (wrong object)
 const wrongProperty = delta.otherProperty; // Should NOT be transformed (wrong property)
 
-// 2. Switch case transformations
-function handleStreamPart(part: any) {
-  switch (part.type) {
-    case 'text-delta':
-      return processTextDelta(part);
-    case 'other-delta':
-      return processOther(part);
-  }
+// 1.1. Destructuring cases
+const { textDelta } = delta; // Should be transformed
+const { text: existingText } = delta; // Should NOT be transformed
+const { textDelta: renamedDelta } = delta; // Should be transformed
+const { text: renamedText } = delta; // Should NOT be transformed
+const { textDelta: deltaContent, otherProp } = delta; // Should transform textDelta only
+const { text: textContent, anotherProp } = delta; // Should NOT be transformed
+const { wrongProp } = other; // Should NOT be transformed (wrong object)
+
+// Function parameter destructuring
+function processTextDelta({ textDelta }: any) { // Should be transformed
+  return textDelta;
+}
+function processText({ text }: any) { // Should NOT be transformed
+  return text;
 }
 
-// 3. String literal transformations
-const partType = 'text-delta'; // Should be transformed
-const otherType = 'text'; // Should NOT be transformed
-const anotherType = 'other-delta'; // Should NOT be transformed
-
-// 4. Conditional checks
-if (part.type === 'text-delta') { // Should be transformed
-  handleTextDelta();
-}
-
-if (part.type === 'text') { // Should NOT be transformed
-  handleText();
-}
-
-// 5. Complex expressions combining multiple patterns
-function processStream(parts: any[]) {
-  return parts.map(part => {
-    if (part.type === 'text-delta') {
-      return {
-        ...part,
-        content: delta.textDelta,
-        type: 'text' // This 'text' should NOT be transformed (not 'text-delta')
-      };
-    }
-    return part;
-  });
-}
+// Nested destructuring
+const { data: { textDelta: nestedTextDelta } } = someObject; // Should NOT be transformed (not direct delta destructuring)
+const { delta: { textDelta: deepTextDelta } } = someObject; // Should NOT be transformed (not direct delta destructuring)

--- a/packages/codemod/src/test/__testfixtures__/replace-textdelta-with-text.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/replace-textdelta-with-text.output.ts
@@ -7,40 +7,23 @@ const otherContent = delta.text; // Should NOT be transformed
 const wrongObject = other.textDelta; // Should NOT be transformed (wrong object)
 const wrongProperty = delta.otherProperty; // Should NOT be transformed (wrong property)
 
-// 2. Switch case transformations
-function handleStreamPart(part: any) {
-  switch (part.type) {
-    case 'text':
-      return processTextDelta(part);
-    case 'other-delta':
-      return processOther(part);
-  }
+// 1.1. Destructuring cases
+const { text: textDelta } = delta; // Should be transformed
+const { text: existingText } = delta; // Should NOT be transformed
+const { text: renamedDelta } = delta; // Should be transformed
+const { text: renamedText } = delta; // Should NOT be transformed
+const { text: deltaContent, otherProp } = delta; // Should transform textDelta only
+const { text: textContent, anotherProp } = delta; // Should NOT be transformed
+const { wrongProp } = other; // Should NOT be transformed (wrong object)
+
+// Function parameter destructuring
+function processTextDelta({ text: textDelta }: any) { // Should be transformed
+  return textDelta;
+}
+function processText({ text }: any) { // Should NOT be transformed
+  return text;
 }
 
-// 3. String literal transformations
-const partType = 'text'; // Should be transformed
-const otherType = 'text'; // Should NOT be transformed
-const anotherType = 'other-delta'; // Should NOT be transformed
-
-// 4. Conditional checks
-if (part.type === 'text') { // Should be transformed
-  handleTextDelta();
-}
-
-if (part.type === 'text') { // Should NOT be transformed
-  handleText();
-}
-
-// 5. Complex expressions combining multiple patterns
-function processStream(parts: any[]) {
-  return parts.map(part => {
-    if (part.type === 'text') {
-      return {
-        ...part,
-        content: delta.text,
-        type: 'text' // This 'text' should NOT be transformed (not 'text-delta')
-      };
-    }
-    return part;
-  });
-}
+// Nested destructuring
+const { data: { textDelta: nestedTextDelta } } = someObject; // Should NOT be transformed (not direct delta destructuring)
+const { delta: { textDelta: deepTextDelta } } = someObject; // Should NOT be transformed (not direct delta destructuring)

--- a/packages/codemod/src/test/__testfixtures__/replace-textdelta-with-text.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/replace-textdelta-with-text.output.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+// Test file for replace-textdelta-with-text codemod
+
+// 1. Member expression cases
+const content = delta.text; // Should be transformed
+const otherContent = delta.text; // Should NOT be transformed  
+const wrongObject = other.textDelta; // Should NOT be transformed (wrong object)
+const wrongProperty = delta.otherProperty; // Should NOT be transformed (wrong property)
+
+// 2. Switch case transformations
+function handleStreamPart(part: any) {
+  switch (part.type) {
+    case 'text':
+      return processTextDelta(part);
+    case 'other-delta':
+      return processOther(part);
+  }
+}
+
+// 3. String literal transformations
+const partType = 'text'; // Should be transformed
+const otherType = 'text'; // Should NOT be transformed
+const anotherType = 'other-delta'; // Should NOT be transformed
+
+// 4. Conditional checks
+if (part.type === 'text') { // Should be transformed
+  handleTextDelta();
+}
+
+if (part.type === 'text') { // Should NOT be transformed
+  handleText();
+}
+
+// 5. Complex expressions combining multiple patterns
+function processStream(parts: any[]) {
+  return parts.map(part => {
+    if (part.type === 'text') {
+      return {
+        ...part,
+        content: delta.text,
+        type: 'text' // This 'text' should NOT be transformed (not 'text-delta')
+      };
+    }
+    return part;
+  });
+}

--- a/packages/codemod/src/test/replace-textdelta-with-text.test.ts
+++ b/packages/codemod/src/test/replace-textdelta-with-text.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v5/replace-textdelta-with-text';
+import { testTransform } from './test-utils';
+
+describe('replace-textdelta-with-text', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'replace-textdelta-with-text');
+  });
+});


### PR DESCRIPTION
## Background

See https://github.com/vercel/ai/issues/8335

## Summary

1. Updated tests 73095a7b9715baf3269da58d994e998b0ae3da6a
2. Implemented fix d2e2de6de8a2cf46860d1f4c0c7b2234aa124501

## Manual Verification

```
/Users/gr2m/code/vercel/ai/packages/codemod/dist/bin/codemod.js v5/replace-textdelta-with-text .
```


## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

closes #8335
towards #6552