### PR TITLE
fix(codemod): avoid false positive in `v5/restructure-file-stream-parts`

### DIFF
--- a/.changeset/shaggy-mangos-fail.md
+++ b/.changeset/shaggy-mangos-fail.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+fix(codemod): avoid false positive in `v5/restructure-file-stream-parts`

--- a/packages/codemod/src/codemods/v5/restructure-file-stream-parts.ts
+++ b/packages/codemod/src/codemods/v5/restructure-file-stream-parts.ts
@@ -211,9 +211,7 @@ export default createTransformer((fileInfo, api, options, context) => {
         path.node.object.type === 'Identifier' &&
         fileStreamPartIdentifiers.has(path.node.object.name) &&
         path.node.property.type === 'Identifier' &&
-        (path.node.property.name === 'mediaType' ||
-          path.node.property.name === 'mimeType' ||
-          path.node.property.name === 'data' ||
+        (path.node.property.name === 'mimeType' ||
           path.node.property.name === 'base64' ||
           path.node.property.name === 'uint8Array')
       );

--- a/packages/codemod/src/codemods/v5/restructure-file-stream-parts.ts
+++ b/packages/codemod/src/codemods/v5/restructure-file-stream-parts.ts
@@ -81,11 +81,12 @@ export default createTransformer((fileInfo, api, options, context) => {
   });
 
   // Transform object literals that represent file stream parts
+  // (not file objects in message content)
   root
     .find(j.ObjectExpression)
     .filter(path => {
-      // Look for objects with type: 'file' property
-      return path.node.properties.some(prop => {
+      // Must have type: 'file' property
+      const hasFileType = path.node.properties.some(prop => {
         if (
           (prop.type === 'ObjectProperty' || prop.type === 'Property') &&
           prop.key.type === 'Identifier' &&
@@ -97,6 +98,28 @@ export default createTransformer((fileInfo, api, options, context) => {
         }
         return false;
       });
+
+      if (!hasFileType) {
+        return false;
+      }
+
+      // Must have at least one file stream part specific property
+      // Only transform objects that have stream-specific properties like base64 or uint8Array
+      // This excludes message content files which typically only have mediaType + data
+      const fileStreamProperties = ['base64', 'uint8Array', 'mimeType'];
+
+      const hasStreamProperty = path.node.properties.some(prop => {
+        if (
+          (prop.type === 'ObjectProperty' || prop.type === 'Property') &&
+          prop.key.type === 'Identifier'
+        ) {
+          return fileStreamProperties.includes(prop.key.name);
+        }
+        return false;
+      });
+
+      // Only transform if it has file stream-specific properties
+      return hasStreamProperty;
     })
     .forEach(path => {
       const properties = path.node.properties;
@@ -124,7 +147,7 @@ export default createTransformer((fileInfo, api, options, context) => {
             prop.key.name = 'mediaType';
           }
         });
-        
+
         // Create new file object with the file properties
         const fileObject = j.objectExpression(fileProperties);
 
@@ -232,10 +255,13 @@ export default createTransformer((fileInfo, api, options, context) => {
     .forEach(path => {
       // Transform part.mediaType to part.file.mediaType
       // Also rename mimeType to mediaType
-      if (path.node.property.type === 'Identifier' && path.node.property.name === 'mimeType') {
+      if (
+        path.node.property.type === 'Identifier' &&
+        path.node.property.name === 'mimeType'
+      ) {
         path.node.property.name = 'mediaType';
       }
-      
+
       path.node.object = j.memberExpression(
         path.node.object,
         j.identifier('file'),

--- a/packages/codemod/src/codemods/v5/restructure-file-stream-parts.ts
+++ b/packages/codemod/src/codemods/v5/restructure-file-stream-parts.ts
@@ -114,6 +114,17 @@ export default createTransformer((fileInfo, api, options, context) => {
 
       // Only transform if we have file properties to move
       if (fileProperties.length > 0) {
+        // Transform mimeType to mediaType in the file properties
+        fileProperties.forEach(prop => {
+          if (
+            (prop.type === 'ObjectProperty' || prop.type === 'Property') &&
+            prop.key.type === 'Identifier' &&
+            prop.key.name === 'mimeType'
+          ) {
+            prop.key.name = 'mediaType';
+          }
+        });
+        
         // Create new file object with the file properties
         const fileObject = j.objectExpression(fileProperties);
 
@@ -211,13 +222,20 @@ export default createTransformer((fileInfo, api, options, context) => {
         path.node.object.type === 'Identifier' &&
         fileStreamPartIdentifiers.has(path.node.object.name) &&
         path.node.property.type === 'Identifier' &&
-        (path.node.property.name === 'mimeType' ||
+        (path.node.property.name === 'mediaType' ||
+          path.node.property.name === 'mimeType' ||
+          path.node.property.name === 'data' ||
           path.node.property.name === 'base64' ||
           path.node.property.name === 'uint8Array')
       );
     })
     .forEach(path => {
       // Transform part.mediaType to part.file.mediaType
+      // Also rename mimeType to mediaType
+      if (path.node.property.type === 'Identifier' && path.node.property.name === 'mimeType') {
+        path.node.property.name = 'mediaType';
+      }
+      
       path.node.object = j.memberExpression(
         path.node.object,
         j.identifier('file'),

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
@@ -39,17 +39,3 @@ const fileStreamPart = {
   base64: 'AQID',
   uint8Array: new Uint8Array([1, 2, 3])
 };
-
-// Test object without file properties (should not be transformed)
-const otherPart = {
-  type: 'text',
-  content: 'Hello world'
-};
-
-function processFile(file: any) {
-  return file;
-}
-
-function uploadFile(file: any) {
-  return file;
-}

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
@@ -13,9 +13,7 @@ for await (const part of result.fullStream) {
   switch (part.type) {
     case 'file':
       // Direct property access that should be restructured
-      console.log('Media type:', part.mediaType);
-      console.log('MIME type:', part.mimeType);
-      console.log('Data:', part.data);
+      console.log('Media type:', part.mimeType);
       console.log('Base64:', part.base64);
       console.log('Uint8Array:', part.uint8Array);
       
@@ -28,7 +26,7 @@ for await (const part of result.fullStream) {
 // Test with if statement
 for await (const delta of result.fullStream) {
   if (delta.type === 'file') {
-    console.log('File data:', delta.data);
+    console.log('Base64:', delta.base64);
     uploadFile(delta);
   }
 }

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+// Test file for restructure-file-stream-parts codemod
+
+import { streamText } from 'ai';
+
+// Test streamText usage and fullStream iteration
+const result = streamText({
+  model: openai('gpt-4'),
+  prompt: 'Generate a file',
+});
+
+for await (const part of result.fullStream) {
+  switch (part.type) {
+    case 'file':
+      // Direct property access that should be restructured
+      console.log('Media type:', part.mediaType);
+      console.log('MIME type:', part.mimeType);
+      console.log('Data:', part.data);
+      console.log('Base64:', part.base64);
+      console.log('Uint8Array:', part.uint8Array);
+      
+      // Direct identifier usage in function calls
+      processFile(part);
+      break;
+  }
+}
+
+// Test with if statement
+for await (const delta of result.fullStream) {
+  if (delta.type === 'file') {
+    console.log('File data:', delta.data);
+    uploadFile(delta);
+  }
+}
+
+// Test object literal that should be restructured
+const fileStreamPart = {
+  type: 'file',
+  mediaType: 'image/png',
+  mimeType: 'image/png',
+  data: new Uint8Array([1, 2, 3]),
+  base64: 'AQID',
+  uint8Array: new Uint8Array([1, 2, 3])
+};
+
+// Test object without file properties (should not be transformed)
+const otherPart = {
+  type: 'text',
+  content: 'Hello world'
+};
+
+function processFile(file: any) {
+  return file;
+}
+
+function uploadFile(file: any) {
+  return file;
+}

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
@@ -34,7 +34,6 @@ for await (const delta of result.fullStream) {
 // Test object literal that should be restructured
 const fileStreamPart = {
   type: 'file',
-  mediaType: 'image/png',
   mimeType: 'image/png',
   data: new Uint8Array([1, 2, 3]),
   base64: 'AQID',

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.input.ts
@@ -39,3 +39,22 @@ const fileStreamPart = {
   base64: 'AQID',
   uint8Array: new Uint8Array([1, 2, 3])
 };
+
+import type { ModelMessage } from 'ai';
+
+export const TEST_PROMPTS: Record<string, ModelMessage> = {
+  USER_IMAGE_ATTACHMENT: {
+    role: 'user',
+    content: [
+      {
+        type: 'file',
+        mediaType: '...',
+        data: '...',
+      },
+      {
+        type: 'text',
+        text: 'Who painted this?',
+      },
+    ],
+  },
+}

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
@@ -42,3 +42,22 @@ const fileStreamPart = {
     uint8Array: new Uint8Array([1, 2, 3])
   }
 };
+
+import type { ModelMessage } from 'ai';
+
+export const TEST_PROMPTS: Record<string, ModelMessage> = {
+  USER_IMAGE_ATTACHMENT: {
+    role: 'user',
+    content: [
+      {
+        type: 'file',
+        mediaType: '...',
+        data: '...',
+      },
+      {
+        type: 'text',
+        text: 'Who painted this?',
+      },
+    ],
+  },
+}

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
@@ -14,8 +14,6 @@ for await (const part of result.fullStream) {
     case 'file':
       // Direct property access that should be restructured
       console.log('Media type:', part.file.mediaType);
-      console.log('MIME type:', part.file.mimeType);
-      console.log('Data:', part.file.data);
       console.log('Base64:', part.file.base64);
       console.log('Uint8Array:', part.file.uint8Array);
       
@@ -28,7 +26,7 @@ for await (const part of result.fullStream) {
 // Test with if statement
 for await (const delta of result.fullStream) {
   if (delta.type === 'file') {
-    console.log('File data:', delta.file.data);
+    console.log('Base64:', delta.file.base64);
     uploadFile(delta.file);
   }
 }

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
@@ -42,17 +42,3 @@ const fileStreamPart = {
     uint8Array: new Uint8Array([1, 2, 3])
   }
 };
-
-// Test object without file properties (should not be transformed)
-const otherPart = {
-  type: 'text',
-  content: 'Hello world'
-};
-
-function processFile(file: any) {
-  return file;
-}
-
-function uploadFile(file: any) {
-  return file;
-}

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+// Test file for restructure-file-stream-parts codemod
+
+import { streamText } from 'ai';
+
+// Test streamText usage and fullStream iteration
+const result = streamText({
+  model: openai('gpt-4'),
+  prompt: 'Generate a file',
+});
+
+for await (const part of result.fullStream) {
+  switch (part.type) {
+    case 'file':
+      // Direct property access that should be restructured
+      console.log('Media type:', part.file.mediaType);
+      console.log('MIME type:', part.file.mimeType);
+      console.log('Data:', part.file.data);
+      console.log('Base64:', part.file.base64);
+      console.log('Uint8Array:', part.file.uint8Array);
+      
+      // Direct identifier usage in function calls
+      processFile(part.file);
+      break;
+  }
+}
+
+// Test with if statement
+for await (const delta of result.fullStream) {
+  if (delta.type === 'file') {
+    console.log('File data:', delta.file.data);
+    uploadFile(delta.file);
+  }
+}
+
+// Test object literal that should be restructured
+const fileStreamPart = {
+  type: 'file',
+
+  file: {
+    mediaType: 'image/png',
+    mimeType: 'image/png',
+    data: new Uint8Array([1, 2, 3]),
+    base64: 'AQID',
+    uint8Array: new Uint8Array([1, 2, 3])
+  }
+};
+
+// Test object without file properties (should not be transformed)
+const otherPart = {
+  type: 'text',
+  content: 'Hello world'
+};
+
+function processFile(file: any) {
+  return file;
+}
+
+function uploadFile(file: any) {
+  return file;
+}

--- a/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/restructure-file-stream-parts.output.ts
@@ -37,7 +37,6 @@ const fileStreamPart = {
 
   file: {
     mediaType: 'image/png',
-    mimeType: 'image/png',
     data: new Uint8Array([1, 2, 3]),
     base64: 'AQID',
     uint8Array: new Uint8Array([1, 2, 3])

--- a/packages/codemod/src/test/restructure-file-stream-parts.test.ts
+++ b/packages/codemod/src/test/restructure-file-stream-parts.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v5/restructure-file-stream-parts';
+import { testTransform } from './test-utils';
+
+describe('restructure-file-stream-parts', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'restructure-file-stream-parts');
+  });
+});


### PR DESCRIPTION
## Background

I ran `npx @ai-sdk/codemod upgrade` on [vercel/ai-chatbot](https://github.com/vercel/ai-chatbot) and found a false positive originating from the `v5/restructure-file-stream-parts` codemod

## Summary

- Updated fixtures to coder the false positive
- fix the codemod
- also include rename of mimeType to mediaType

## Manual Verification

Run the updated codemod locally in the `vercel/ai-chatbot` repository

```
/Users/gr2m/code/vercel/ai/packages/codemod/dist/bin/codemod.js v5/restructure-file-stream-parts .
```

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Towards #6552