### PR TITLE
Feat(anthropic) container uploads for messages

### DIFF
--- a/.changeset/good-dancers-give.md
+++ b/.changeset/good-dancers-give.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/anthropic': minor
+'@ai-sdk/provider': minor
+---
+
+Support for container uploads for claude

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -577,6 +577,37 @@ const result = await generateText({
 });
 ```
 
+#### Container Uploads
+
+You can also add files for code execution using container uploads. For example,
+
+```ts
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+const codeExecutionTool = anthropic.tools.codeExecution_20250522();
+const result = await generateText({
+  model: anthropic('claude-opus-4-20250514'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Analyze this csv file',
+        },
+        {
+          type: 'container_upload',
+          file_id: 'file-123',
+        },
+      ],
+    },
+  ],
+  tools: {
+    code_execution: codeExecutionTool,
+  },
+});
+```
+
 #### Error Handling
 
 Code execution errors are handled differently depending on whether you're using streaming or non-streaming:

--- a/packages/anthropic/src/anthropic-api-types.ts
+++ b/packages/anthropic/src/anthropic-api-types.ts
@@ -18,6 +18,7 @@ export interface AnthropicUserMessage {
     | AnthropicImageContent
     | AnthropicDocumentContent
     | AnthropicToolResultContent
+    | AnthropicContainerUploadContent
   >;
 }
 
@@ -38,6 +39,11 @@ export interface AnthropicTextContent {
   type: 'text';
   text: string;
   cache_control: AnthropicCacheControl | undefined;
+}
+
+export interface AnthropicContainerUploadContent {
+  type: 'container_upload';
+  file_id: string;
 }
 
 export interface AnthropicThinkingContent {

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
 import { LanguageModelV2CallWarning } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 
 describe('system messages', () => {
@@ -1611,5 +1611,35 @@ describe('citations', () => {
         },
       }
     `);
+  });
+
+  it('should convert container upload message parts into anthropic container uploads', async () => {
+    const result = await convertToAnthropicMessagesPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'container_upload',
+              file_id: 'file-123',
+            },
+          ],
+        },
+      ],
+      sendReasoning: false,
+      warnings: [],
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'container_upload', file_id: 'file-123' }],
+          },
+        ],
+      },
+      betas: new Set(),
+    });
   });
 });

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -16,8 +16,8 @@ import {
 import { anthropicReasoningMetadataSchema } from './anthropic-messages-language-model';
 import { anthropicFilePartProviderOptions } from './anthropic-messages-options';
 import { getCacheControl } from './get-cache-control';
-import { webSearch_20250305OutputSchema } from './tool/web-search_20250305';
 import { codeExecution_20250522OutputSchema } from './tool/code-execution_20250522';
+import { webSearch_20250305OutputSchema } from './tool/web-search_20250305';
 
 function convertToString(data: LanguageModelV2DataContent): string {
   if (typeof data === 'string') {
@@ -226,6 +226,13 @@ export async function convertToAnthropicMessagesPrompt({
                     }
 
                     break;
+                  }
+
+                  case 'container_upload': {
+                    anthropicContent.push({
+                      type: 'container_upload',
+                      file_id: part.file_id,
+                    });
                   }
                 }
               }

--- a/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts
@@ -233,6 +233,7 @@ export async function convertToAnthropicMessagesPrompt({
                       type: 'container_upload',
                       file_id: part.file_id,
                     });
+                    break;
                   }
                 }
               }

--- a/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-prompt.ts
@@ -24,7 +24,11 @@ export type LanguageModelV2Message =
       }
     | {
         role: 'user';
-        content: Array<LanguageModelV2TextPart | LanguageModelV2FilePart>;
+        content: Array<
+          | LanguageModelV2TextPart
+          | LanguageModelV2FilePart
+          | LanguageModelV2ContainerUploadPart
+        >;
       }
     | {
         role: 'assistant';
@@ -59,6 +63,25 @@ export interface LanguageModelV2TextPart {
 The text content.
    */
   text: string;
+
+  /**
+   * Additional provider-specific options. They are passed through
+   * to the provider from the AI SDK and enable provider-specific
+   * functionality that can be fully encapsulated in the provider.
+   */
+  providerOptions?: SharedV2ProviderOptions;
+}
+
+/**
+Container uploads content part. Supported by Anthropic API. 
+ */
+export interface LanguageModelV2ContainerUploadPart {
+  type: 'container_upload';
+
+  /**
+   * The file id
+   */
+  file_id: string;
 
   /**
    * Additional provider-specific options. They are passed through


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

After realizing that I could not add files to messages for code interpreter using claude, I decided this little change was needed to add support for the container uploads feature that anthropic sdk provides. 

## Summary

<!-- What did you change? -->
Added extra case for handling container_upload type of the message content part. 

## Manual Verification
Use any claude  model that supports code interpreter, and add files to message history using message content type 'container_upload', providing anthropic file id. 

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->
One of my projects that I am working on required file analysis using code interpreter, and I verified by using it in my project. The code interpreter was able to access the uploaded files. Requires users to add beta headers for files api and code interpreter. 

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
Similar changes to other packages including openai are needed to support container uploads for their code interpreters. 

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
