### PR TITLE
Docs: Update streamText() documentation with correct types/descriptions for LanguageModelUsage

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -964,27 +964,39 @@ To see `streamText` in action, check out [these examples](#examples).
             },
             {
               name: 'usage',
-              type: 'TokenUsage',
+              type: 'LanguageModelUsage',
               description: 'The token usage of the step.',
               properties: [
                 {
-                  type: 'TokenUsage',
+                  type: 'LanguageModelUsage',
                   parameters: [
                     {
                       name: 'inputTokens',
-                      type: 'number',
-                      description: 'The total number of tokens in the prompt.',
+                      type: 'number | undefined',
+                      description: 'The number of input (prompt) tokens used.',
                     },
                     {
                       name: 'outputTokens',
-                      type: 'number',
-                      description:
-                        'The total number of tokens in the completion.',
+                      type: 'number | undefined',
+                      description: 'The number of output (completion) tokens used.',
                     },
                     {
                       name: 'totalTokens',
-                      type: 'number',
-                      description: 'The total number of tokens generated.',
+                      type: 'number | undefined',
+                      description:
+                        'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of reasoning tokens used.',
+                    },
+                    {
+                      name: 'cachedInputTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of cached input tokens.',
                     },
                   ],
                 },
@@ -1157,27 +1169,39 @@ To see `streamText` in action, check out [these examples](#examples).
             },
             {
               name: 'usage',
-              type: 'TokenUsage',
+              type: 'LanguageModelUsage',
               description: 'The token usage of the generated text.',
               properties: [
                 {
-                  type: 'TokenUsage',
+                  type: 'LanguageModelUsage',
                   parameters: [
                     {
                       name: 'inputTokens',
-                      type: 'number',
-                      description: 'The total number of tokens in the prompt.',
+                      type: 'number | undefined',
+                      description: 'The number of input (prompt) tokens used.',
                     },
                     {
                       name: 'outputTokens',
-                      type: 'number',
-                      description:
-                        'The total number of tokens in the completion.',
+                      type: 'number | undefined',
+                      description: 'The number of output (completion) tokens used.',
                     },
                     {
                       name: 'totalTokens',
-                      type: 'number',
-                      description: 'The total number of tokens generated.',
+                      type: 'number | undefined',
+                      description:
+                        'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of reasoning tokens used.',
+                    },
+                    {
+                      name: 'cachedInputTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of cached input tokens.',
                     },
                   ],
                 },
@@ -1431,19 +1455,32 @@ To see `streamText` in action, check out [these examples](#examples).
           type: 'LanguageModelUsage',
           parameters: [
             {
-              name: 'promptTokens',
-              type: 'number',
-              description: 'The total number of tokens in the prompt.',
+              name: 'inputTokens',
+              type: 'number | undefined',
+              description: 'The number of input (prompt) tokens used.',
             },
             {
-              name: 'completionTokens',
-              type: 'number',
-              description: 'The total number of tokens in the completion.',
+              name: 'outputTokens',
+              type: 'number | undefined',
+              description: 'The number of output (completion) tokens used.',
             },
             {
               name: 'totalTokens',
-              type: 'number',
-              description: 'The total number of tokens generated.',
+              type: 'number | undefined',
+              description:
+                'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+            },
+            {
+              name: 'reasoningTokens',
+              type: 'number | undefined',
+              isOptional: true,
+              description: 'The number of reasoning tokens used.',
+            },
+            {
+              name: 'cachedInputTokens',
+              type: 'number | undefined',
+              isOptional: true,
+              description: 'The number of cached input tokens.',
             },
           ],
         },
@@ -1458,19 +1495,32 @@ To see `streamText` in action, check out [these examples](#examples).
           type: 'LanguageModelUsage',
           parameters: [
             {
-              name: 'promptTokens',
-              type: 'number',
-              description: 'The total number of tokens in the prompt.',
+              name: 'inputTokens',
+              type: 'number | undefined',
+              description: 'The number of input (prompt) tokens used.',
             },
             {
-              name: 'completionTokens',
-              type: 'number',
-              description: 'The total number of tokens in the completion.',
+              name: 'outputTokens',
+              type: 'number | undefined',
+              description: 'The number of output (completion) tokens used.',
             },
             {
               name: 'totalTokens',
-              type: 'number',
-              description: 'The total number of tokens generated.',
+              type: 'number | undefined',
+              description:
+                'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+            },
+            {
+              name: 'reasoningTokens',
+              type: 'number | undefined',
+              isOptional: true,
+              description: 'The number of reasoning tokens used.',
+            },
+            {
+              name: 'cachedInputTokens',
+              type: 'number | undefined',
+              isOptional: true,
+              description: 'The number of cached input tokens.',
             },
           ],
         },
@@ -1784,19 +1834,31 @@ To see `streamText` in action, check out [these examples](#examples).
                   parameters: [
                     {
                       name: 'inputTokens',
-                      type: 'number',
-                      description: 'The total number of tokens in the prompt.',
+                      type: 'number | undefined',
+                      description: 'The number of input (prompt) tokens used.',
                     },
                     {
                       name: 'outputTokens',
-                      type: 'number',
-                      description:
-                        'The total number of tokens in the completion.',
+                      type: 'number | undefined',
+                      description: 'The number of output (completion) tokens used.',
                     },
                     {
                       name: 'totalTokens',
-                      type: 'number',
-                      description: 'The total number of tokens generated.',
+                      type: 'number | undefined',
+                      description:
+                        'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of reasoning tokens used.',
+                    },
+                    {
+                      name: 'cachedInputTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of cached input tokens.',
                     },
                   ],
                 },
@@ -2215,19 +2277,31 @@ To see `streamText` in action, check out [these examples](#examples).
                   parameters: [
                     {
                       name: 'inputTokens',
-                      type: 'number',
-                      description: 'The total number of tokens in the prompt.',
+                      type: 'number | undefined',
+                      description: 'The number of input (prompt) tokens used.',
                     },
                     {
                       name: 'outputTokens',
-                      type: 'number',
-                      description:
-                        'The total number of tokens in the completion.',
+                      type: 'number | undefined',
+                      description: 'The number of output (completion) tokens used.',
                     },
                     {
                       name: 'totalTokens',
-                      type: 'number',
-                      description: 'The total number of tokens generated.',
+                      type: 'number | undefined',
+                      description:
+                        'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of reasoning tokens used.',
+                    },
+                    {
+                      name: 'cachedInputTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of cached input tokens.',
                     },
                   ],
                 },
@@ -2280,19 +2354,31 @@ To see `streamText` in action, check out [these examples](#examples).
                   parameters: [
                     {
                       name: 'inputTokens',
-                      type: 'number',
-                      description: 'The total number of tokens in the prompt.',
+                      type: 'number | undefined',
+                      description: 'The number of input (prompt) tokens used.',
                     },
                     {
                       name: 'outputTokens',
-                      type: 'number',
-                      description:
-                        'The total number of tokens in the completion.',
+                      type: 'number | undefined',
+                      description: 'The number of output (completion) tokens used.',
                     },
                     {
                       name: 'totalTokens',
-                      type: 'number',
-                      description: 'The total number of tokens generated.',
+                      type: 'number | undefined',
+                      description:
+                        'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of reasoning tokens used.',
+                    },
+                    {
+                      name: 'cachedInputTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of cached input tokens.',
                     },
                   ],
                 },


### PR DESCRIPTION
@lgrammel / @dancer / @gr2m Please take a look!

The documentation for streamText() was out of date/out of sync with the documentation for generateText/generateObject/streamObject.

The only change here is bringing the type/description/properties of `LanguageModelUsage` verbatim from the other docs to match the actual interface definition