### PR TITLE
fix(ai): remove vitest dependency from test exports

### DIFF
--- a/.changeset/chatty-rocks-rest.md
+++ b/.changeset/chatty-rocks-rest.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): remove vitest dependency from test exports

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -1,6 +1,6 @@
+import { EmbeddingModelV2 } from '@ai-sdk/provider';
 import assert from 'node:assert';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { EmbeddingModelV2 } from '../../../provider/src/embedding-model';
 import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockTracer } from '../test/mock-tracer';
 import { Embedding, EmbeddingModelUsage } from '../types';
@@ -472,7 +472,7 @@ describe('result.providerMetadata', () => {
   });
 });
 
-export function mockEmbed<VALUE>(
+function mockEmbed<VALUE>(
   expectedValues: Array<VALUE>,
   embeddings: Array<Embedding>,
   usage?: EmbeddingModelUsage,

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  MockEmbeddingModelV2,
-  mockEmbed,
-} from '../test/mock-embedding-model-v2';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmbeddingModelV2 } from '../../../provider/src/embedding-model';
+import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockTracer } from '../test/mock-tracer';
+import { Embedding, EmbeddingModelUsage } from '../types';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { embedMany } from './embed-many';
 
@@ -472,3 +471,20 @@ describe('result.providerMetadata', () => {
     expect(result.providerMetadata).toStrictEqual(providerMetadata);
   });
 });
+
+export function mockEmbed<VALUE>(
+  expectedValues: Array<VALUE>,
+  embeddings: Array<Embedding>,
+  usage?: EmbeddingModelUsage,
+  response: Awaited<
+    ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>
+  >['response'] = { headers: {}, body: {} },
+  providerMetadata?: Awaited<
+    ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>
+  >['providerMetadata'],
+): EmbeddingModelV2<VALUE>['doEmbed'] {
+  return async ({ values }) => {
+    assert.deepStrictEqual(expectedValues, values);
+    return { embeddings, usage, response, providerMetadata };
+  };
+}

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -1,6 +1,6 @@
+import { EmbeddingModelV2 } from '@ai-sdk/provider';
 import assert from 'node:assert';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { EmbeddingModelV2 } from '../../../provider/src/embedding-model';
 import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockTracer } from '../test/mock-tracer';
 import { Embedding, EmbeddingModelUsage } from '../types';
@@ -202,7 +202,7 @@ describe('telemetry', () => {
   });
 });
 
-export function mockEmbed<VALUE>(
+function mockEmbed<VALUE>(
   expectedValues: Array<VALUE>,
   embeddings: Array<Embedding>,
   usage?: EmbeddingModelUsage,

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert';
-import { describe, it, expect, beforeEach } from 'vitest';
-import {
-  MockEmbeddingModelV2,
-  mockEmbed,
-} from '../test/mock-embedding-model-v2';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { EmbeddingModelV2 } from '../../../provider/src/embedding-model';
+import { MockEmbeddingModelV2 } from '../test/mock-embedding-model-v2';
 import { MockTracer } from '../test/mock-tracer';
+import { Embedding, EmbeddingModelUsage } from '../types';
 import { embed } from './embed';
 
 const dummyEmbedding = [0.1, 0.2, 0.3];
@@ -202,3 +201,20 @@ describe('telemetry', () => {
     expect(tracer.jsonSpans).toMatchSnapshot();
   });
 });
+
+export function mockEmbed<VALUE>(
+  expectedValues: Array<VALUE>,
+  embeddings: Array<Embedding>,
+  usage?: EmbeddingModelUsage,
+  response: Awaited<
+    ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>
+  >['response'] = { headers: {}, body: {} },
+  providerMetadata?: Awaited<
+    ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>
+  >['providerMetadata'],
+): EmbeddingModelV2<VALUE>['doEmbed'] {
+  return async ({ values }) => {
+    assert.deepStrictEqual(expectedValues, values);
+    return { embeddings, usage, response, providerMetadata };
+  };
+}

--- a/packages/ai/src/test/mock-embedding-model-v2.ts
+++ b/packages/ai/src/test/mock-embedding-model-v2.ts
@@ -1,8 +1,5 @@
 import { EmbeddingModelV2 } from '@ai-sdk/provider';
-import { Embedding } from '../types';
-import { EmbeddingModelUsage } from '../types/usage';
 import { notImplemented } from './not-implemented';
-import { assert } from 'vitest';
 
 export class MockEmbeddingModelV2<VALUE> implements EmbeddingModelV2<VALUE> {
   readonly specificationVersion = 'v2';
@@ -35,21 +32,4 @@ export class MockEmbeddingModelV2<VALUE> implements EmbeddingModelV2<VALUE> {
     this.supportsParallelCalls = supportsParallelCalls;
     this.doEmbed = doEmbed;
   }
-}
-
-export function mockEmbed<VALUE>(
-  expectedValues: Array<VALUE>,
-  embeddings: Array<Embedding>,
-  usage?: EmbeddingModelUsage,
-  response: Awaited<
-    ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>
-  >['response'] = { headers: {}, body: {} },
-  providerMetadata?: Awaited<
-    ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>
-  >['providerMetadata'],
-): EmbeddingModelV2<VALUE>['doEmbed'] {
-  return async ({ values }) => {
-    assert.deepStrictEqual(expectedValues, values);
-    return { embeddings, usage, response, providerMetadata };
-  };
 }


### PR DESCRIPTION
## Background

In `ai@5.0.27` the `ai/test` export requires vitest, leading to a breaking regression (see #8356 ).

## Summary

Remove `mockEmbed` function from `ai/test` (it should have never been exported to begin with).

## Related Issues

Fixes #8356