### PR TITLE
docs: update braintrust guide

### DIFF
--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -33,7 +33,6 @@ export function register() {
 
 Traced LLM calls will appear under the Braintrust project or experiment provided in the `parent` field.
 
-
 When you call the AI SDK, make sure to set `experimental_telemetry`:
 
 ```typescript

--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -13,7 +13,7 @@ Braintrust natively supports OpenTelemetry and works out of the box with the AI 
 
 ### Next.js
 
-If you are using Next.js, you can use the Braintrust exporter with `@vercel/otel` for the cleanest setup:
+If you are using Next.js, use the Braintrust exporter with `@vercel/otel`:
 
 ```typescript
 import { registerOTel } from '@vercel/otel';
@@ -31,14 +31,8 @@ export function register() {
 }
 ```
 
-Or set the following environment variables in your app's `.env` file, with your API key and project ID:
+Traced LLM calls will appear under the Braintrust project or experiment provided in the `parent` field.
 
-```
-OTEL_EXPORTER_OTLP_ENDPOINT=https://api.braintrust.dev/otel
-OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <Your API Key>, x-bt-parent=project_id:<Your Project ID>"
-```
-
-Traced LLM calls will appear under the Braintrust project or experiment provided in the `x-bt-parent` header.
 
 When you call the AI SDK, make sure to set `experimental_telemetry`:
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Improving documentation. When specifying both the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` and a `traceExporter: new BraintrustExporter`, the braintrust exporter alongside it's configuration is overriden - the exporter used is the auto-configured one from Vercel. 


## Summary

This PR removes the environment variable approach from the Braintrust documentation to make the preferred method more clear and prevent people from doing both configuration paths which leads to confusing behavior. 
 
## Manual Verification

This docs change aligns with the docs on the Braintrust website https://www.braintrust.dev/docs/start/frameworks/opentelemetry#nextjs


<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
