### PR TITLE
feat(provider/gateway): Fix embeddings `providerOptions`

### DIFF
--- a/.changeset/tender-months-carry.md
+++ b/.changeset/tender-months-carry.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): Fix embeddings `providerOptions`

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -129,6 +129,16 @@ describe('GatewayEmbeddingModel', () => {
       });
     });
 
+    it('should not include providerOptions when not provided', async () => {
+      prepareJsonResponse();
+
+      await createTestModel().doEmbed({ values: testValues });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toStrictEqual({ input: testValues });
+      expect('providerOptions' in body).toBe(false);
+    });
+
     it('should convert gateway error responses', async () => {
       server.urls['https://api.test.com/embedding-model'].response = {
         type: 'error',

--- a/packages/gateway/src/gateway-embedding-model.test.ts
+++ b/packages/gateway/src/gateway-embedding-model.test.ts
@@ -125,7 +125,7 @@ describe('GatewayEmbeddingModel', () => {
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
         input: testValues,
-        openai: { dimensions: 64 },
+        providerOptions: { openai: { dimensions: 64 } },
       });
     });
 

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -54,7 +54,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV2<string> {
         ),
         body: {
           input: values.length === 1 ? values[0] : values,
-          ...(providerOptions ?? {}),
+          ...(providerOptions ? { providerOptions } : {}),
         },
         successfulResponseHandler: createJsonResponseHandler(
           gatewayEmbeddingResponseSchema,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Re: https://github.com/vercel/ai/issues/8278

## Summary

Now sends `providerOptions` in the request body instead of flattening. This PR works in conjunction with https://github.com/vercel/ai-gateway/pull/373.

## Manual Verification

```
import { embed } from "ai";
const { embedding } = await embed({
    model: "google/gemini-embedding-001",
    value: "hello",
    providerOptions: {
      google: {
        outputDimensionality: 768,
        taskType: "SEMANTIC_SIMILARITY",
      },
    },
  });
```

This script now works.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

Fixes https://github.com/vercel/ai/issues/8278