### PR TITLE
feat(ai): export PartialObject from util to fix TS declaration consumers error

### DIFF
--- a/.changeset/rare-cycles-scream.md
+++ b/.changeset/rare-cycles-scream.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+export PartialObject from util to fix TS declaration consumers error

--- a/packages/ai/src/util/deep-partial.ts
+++ b/packages/ai/src/util/deep-partial.ts
@@ -82,6 +82,6 @@ type PartialReadonlyMap<KeyType, ValueType> = {} & ReadonlyMap<
 
 type PartialReadonlySet<T> = {} & ReadonlySet<DeepPartialInternal<T>>;
 
-type PartialObject<ObjectType extends object> = {
+export type PartialObject<ObjectType extends object> = {
   [KeyType in keyof ObjectType]?: DeepPartialInternal<ObjectType[KeyType]>;
 };

--- a/packages/ai/src/util/index.ts
+++ b/packages/ai/src/util/index.ts
@@ -2,7 +2,7 @@ export type { AsyncIterableStream } from './async-iterable-stream';
 export { consumeStream } from './consume-stream';
 export { cosineSimilarity } from './cosine-similarity';
 export { getTextFromDataUrl } from './data-url';
-export type { DeepPartial } from './deep-partial';
+export type { DeepPartial, PartialObject } from './deep-partial';
 export type { DownloadFunction as Experimental_DownloadFunction } from './download/download-function';
 export { type ErrorHandler } from './error-handler';
 export { isDeepEqualData } from './is-deep-equal-data';


### PR DESCRIPTION
## Background

This PR exports PartialObject from the AI SDK public util index to avoid TypeScript declaration naming errors when consumer projects enable declaration output.

When using the AI SDK in a project with declaration: true, TypeScript may emit:

```log
Return type of public method from exported class has or is using name PartialObject from external module "/node_modules/ai/dist/index" but cannot be named.
```

## Summary

Expose PartialObject alongside DeepPartial in packages/ai/src/util/index.ts.

## Manual Verification

Repo builds, lints, and tests succeed locally. No runtime behavior changes; this is a type-only surface export.

## Tasks

- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)
