### PR TITLE
chore(docs): rename 'parameters' to 'inputSchema' in documentation

### DIFF
--- a/content/docs/05-ai-sdk-rsc/02-streaming-react-components.mdx
+++ b/content/docs/05-ai-sdk-rsc/02-streaming-react-components.mdx
@@ -53,7 +53,7 @@ Using tools with `streamUI` is similar to how you use tools with `generateText` 
 A tool is an object that has:
 
 - `description`: a string telling the model what the tool does and when to use it
-- `parameters`: a Zod schema describing what the tool needs in order to run
+- `inputSchema`: a Zod schema describing what the tool needs in order to run
 - `generate`: an asynchronous function that will be run if the model calls the tool. This must return a React component
 
 Let's expand the previous example to add a tool.
@@ -144,7 +144,7 @@ export async function streamComponent() {
     tools: {
       getWeather: {
         description: 'Get the weather for a location',
-        parameters: z.object({
+        inputSchema: z.object({
           location: z.string(),
         }),
         generate: async function* ({ location }) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

`parameters` no longer exists in the current tools object schema, now its named `inputSchema`. It was well-written in some other parts of the same page but some might have been forgotten

## Summary

A variable/attribute name, `parameters` -> `inputSchema`



## Tasks
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)
