### PR TITLE
fix(ai): response headers are not being sent in writeToServerResponse

### DIFF
--- a/.changeset/red-pens-enjoy.md
+++ b/.changeset/red-pens-enjoy.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix call to node's writeHead

--- a/packages/ai/src/util/write-to-server-response.ts
+++ b/packages/ai/src/util/write-to-server-response.ts
@@ -16,7 +16,8 @@ export function writeToServerResponse({
   headers?: Record<string, string | number | string[]>;
   stream: ReadableStream<Uint8Array>;
 }): void {
-  response.writeHead(status ?? 200, statusText, headers);
+  if (statusText) response.writeHead(status ?? 200, statusText, headers);
+  else response.writeHead(status ?? 200, headers);
 
   const reader = stream.getReader();
   const read = async () => {


### PR DESCRIPTION
## Background

When passing `undefined` `statusText`, Node mistakenly interprets that as `undefined` headers, so

```
export const UI_MESSAGE_STREAM_HEADERS = {
  'content-type': 'text/event-stream',
  'cache-control': 'no-cache',
  connection: 'keep-alive',
  'x-vercel-ai-ui-message-stream': 'v1',
  'x-accel-buffering': 'no', // disable nginx buffering
};
```
are not sent.

## Summary

<!-- What did you change? -->

## Manual Verification

Verified that the headers are correctly sent after this fix.

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
