### PR TITLE
docs: document prompt array messages

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -46,12 +46,12 @@ To see `generateText` in action, check out [these examples](#examples).
     },
     {
       name: 'prompt',
-      type: 'string | Array<messages>',
+      type: 'string | Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage>',
       description: 'The input prompt to generate the text from.',
     },
     {
       name: 'messages',
-      type: 'Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage> | Array<UIMessage>',
+      type: 'Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage>',
       description:
         'A list of messages that represent a conversation. Automatically converts UI messages from the useChat hook.',
       properties: [

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -46,7 +46,7 @@ To see `generateText` in action, check out [these examples](#examples).
     },
     {
       name: 'prompt',
-      type: 'string',
+      type: 'string | Array<messages>',
       description: 'The input prompt to generate the text from.',
     },
     {

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -48,7 +48,7 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'prompt',
-      type: 'string',
+      type: 'string | Array<messages>',
       description: 'The input prompt to generate the text from.',
     },
     {

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -48,12 +48,12 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'prompt',
-      type: 'string | Array<messages>',
+      type: 'string | Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage>',
       description: 'The input prompt to generate the text from.',
     },
     {
       name: 'messages',
-      type: 'Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage> | Array<UIMessage>',
+      type: 'Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage>',
       description:
         'A list of messages that represent a conversation. Automatically converts UI messages from the useChat hook.',
       properties: [

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -157,12 +157,12 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
     },
     {
       name: 'prompt',
-      type: 'string | Array<messages>',
+      type: 'string | Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage>',
       description: 'The input prompt to generate the text from.',
     },
     {
       name: 'messages',
-      type: 'Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage> | Array<UIMessage>',
+      type: 'Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage>',
       description:
         'A list of messages that represent a conversation. Automatically converts UI messages from the useChat hook.',
       properties: [

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -157,7 +157,7 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
     },
     {
       name: 'prompt',
-      type: 'string',
+      type: 'string | Array<messages>',
       description: 'The input prompt to generate the text from.',
     },
     {

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -163,7 +163,7 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
     },
     {
       name: 'prompt',
-      type: 'string',
+      type: 'string | Array<messages>',
       description: 'The input prompt to generate the text from.',
     },
     {

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -163,12 +163,12 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
     },
     {
       name: 'prompt',
-      type: 'string | Array<messages>',
+      type: 'string | Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage>',
       description: 'The input prompt to generate the text from.',
     },
     {
       name: 'messages',
-      type: 'Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage> | Array<UIMessage>',
+      type: 'Array<SystemModelMessage | UserModelMessage | AssistantModelMessage | ToolModelMessage>',
       description:
         'A list of messages that represent a conversation. Automatically converts UI messages from the useChat hook.',
       properties: [


### PR DESCRIPTION
## Summary
- clarify `prompt` parameter can accept a string or array of messages

## Testing
- `pnpm exec prettier --check content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx`
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch executable doesn't exist, run `pnpm exec playwright install`)*

## Related Issues

Fixes #8363 

------
https://chatgpt.com/codex/tasks/task_b_68b5534e4ed88320b9e6b9acf2e96fc2