### PR TITLE
fix(openai-compatible): prevent redundant reasoningEffort field

### DIFF
--- a/.changeset/proud-phones-join.md
+++ b/.changeset/proud-phones-join.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Prevent redundant reasoningEffort field in request body (in favor of reasoning_effort)

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -28,6 +28,7 @@ import { mapOpenAICompatibleFinishReason } from './map-openai-compatible-finish-
 import {
   OpenAICompatibleChatModelId,
   openaiCompatibleProviderOptions,
+  OpenAICompatibleProviderOptions,
 } from './openai-compatible-chat-options';
 import {
   defaultOpenAICompatibleErrorStructure,
@@ -184,7 +185,14 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
 
         stop: stopSequences,
         seed,
-        ...providerOptions?.[this.providerOptionsName],
+        ...Object.fromEntries(
+          Object.entries(
+            providerOptions?.[this.providerOptionsName] ?? {},
+          ).filter(
+            ([key]) =>
+              !Object.keys(openaiCompatibleProviderOptions.shape).includes(key),
+          ),
+        ),
 
         reasoning_effort: compatibleOptions.reasoningEffort,
 


### PR DESCRIPTION
Prevent redundant `reasoningEffort` field alongside `reasoning_effort` in request body.

Fixes #8372

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

See #8372. Some OpenAI compatible backends (like LiteLLM proxying to Azure, which is what I can personally test) are tripping over the `reasoningEffort` field with errors like:

```
AzureException BadRequestError - Unknown parameter: 'reasoningEffort'
```

## Summary

I decided to NOT forward (spread) any of the "known" `openaiCompatibleProviderOptions` to avoid duplication. The idea is that these are already added to the correct part of the request body anyway. Why else would they be parsed out?

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] ~Documentation has been added / updated (for bug fixes / features)~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

—

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

Fixes #8372
