### PR TITLE
feat(ai): throw InvalidArgumentError when messages argument is not provided

### DIFF
--- a/.changeset/early-pumpkins-swim.md
+++ b/.changeset/early-pumpkins-swim.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): throw InvalidArgumentError when messages is not provided

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -4,6 +4,28 @@ import { validateUIMessages } from './validate-ui-messages';
 import { describe, it, expect, expectTypeOf } from 'vitest';
 
 describe('validateUIMessages', () => {
+  describe('parameter validation', () => {
+    it('should throw InvalidArgumentError when messages parameter is null', async () => {
+      await expect(
+        validateUIMessages({
+          messages: null,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [AI_InvalidArgumentError: Invalid argument for parameter messages: messages parameter must be provided]
+      `);
+    });
+
+    it('should throw InvalidArgumentError when messages parameter is undefined', async () => {
+      await expect(
+        validateUIMessages({
+          messages: undefined,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [AI_InvalidArgumentError: Invalid argument for parameter messages: messages parameter must be provided]
+      `);
+    });
+  });
+
   describe('metadata', () => {
     it('should validate a user message with metadata when no metadata schema is provided', async () => {
       type TestMessage = UIMessage<{ foo: string }>;

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -14,6 +14,7 @@ import {
   ToolUIPart,
   UIMessage,
 } from './ui-messages';
+import { InvalidArgumentError } from '../error';
 
 const textUIPartSchema = z.object({
   type: z.literal('text'),
@@ -194,6 +195,14 @@ export async function validateUIMessages<UI_MESSAGE extends UIMessage>({
     >;
   };
 }): Promise<Array<UI_MESSAGE>> {
+  if (messages == null) {
+    throw new InvalidArgumentError({
+      parameter: 'messages',
+      value: messages,
+      message: 'messages parameter must be provided',
+    });
+  }
+
   const validatedMessages = await validateTypes({
     value: messages,
     schema: z.array(uiMessageSchema),


### PR DESCRIPTION
## Background

In Next.js, the request body has type `any` by default, making it hard to detect the mistake of passing messages as the main argument vs. a messages property into `validateUIMessages`, which then adds types.

## Summary

Validate and throw dedicated error when `messages` is not passed into `validateUIMessages`.
