### PR TITLE
docs: import MyUIMessage as a type

### DIFF
--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -766,7 +766,7 @@ Then, on the client, you can access the message-level metadata.
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { MyUIMessage } from './api/chat/route';
+import type { MyUIMessage } from './api/chat/route';
 import { DefaultChatTransport } from 'ai';
 
 export default function Chat() {
@@ -804,7 +804,7 @@ You can also access your metadata from the `onFinish` callback of `useChat`:
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { MyUIMessage } from './api/chat/route';
+import type { MyUIMessage } from './api/chat/route';
 import { DefaultChatTransport } from 'ai';
 
 export default function Chat() {
@@ -1253,7 +1253,7 @@ Pass the custom type to `useChat` or `createUIMessageStream`:
 ```tsx
 import { useChat } from '@ai-sdk/react';
 import { createUIMessageStream } from 'ai';
-import { MyUIMessage } from './types';
+import type { MyUIMessage } from './types';
 
 // With useChat
 const { messages } = useChat<MyUIMessage>();

--- a/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
+++ b/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
@@ -54,7 +54,7 @@ import {
   streamText,
   convertToModelMessages,
 } from 'ai';
-import { MyUIMessage } from '@/ai/types';
+import type { MyUIMessage } from '@/ai/types';
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
@@ -199,7 +199,7 @@ The `onData` callback is essential for handling streaming data, especially trans
 
 ```tsx filename="page.tsx"
 import { useChat } from '@ai-sdk/react';
-import { MyUIMessage } from '@/ai/types';
+import type { MyUIMessage } from '@/ai/types';
 
 const { messages } = useChat<MyUIMessage>({
   api: '/api/chat',
@@ -274,7 +274,7 @@ const result = (
 
 import { useChat } from '@ai-sdk/react';
 import { useState } from 'react';
-import { MyUIMessage } from '@/ai/types';
+import type { MyUIMessage } from '@/ai/types';
 
 export default function Chat() {
   const [input, setInput] = useState('');

--- a/content/docs/04-ai-sdk-ui/25-message-metadata.mdx
+++ b/content/docs/04-ai-sdk-ui/25-message-metadata.mdx
@@ -43,7 +43,7 @@ Use the `messageMetadata` callback in `toUIMessageStreamResponse` to send metada
 ```ts filename="app/api/chat/route.ts" highlight="11-20"
 import { openai } from '@ai-sdk/openai';
 import { convertToModelMessages, streamText } from 'ai';
-import { MyUIMessage } from '@/types';
+import type { MyUIMessage } from '@/types';
 
 export async function POST(req: Request) {
   const { messages }: { messages: MyUIMessage[] } = await req.json();
@@ -89,7 +89,7 @@ Access metadata through the `message.metadata` property:
 
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
-import { MyUIMessage } from '@/types';
+import type { MyUIMessage } from '@/types';
 
 export default function Chat() {
   const { messages } = useChat<MyUIMessage>({

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1681,7 +1681,7 @@ Then, on the client, you can access the message-level metadata.
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { MyUIMessage } from './api/chat/route';
+import type { MyUIMessage } from './api/chat/route';
 import { DefaultChatTransport } from 'ai';
 
 export default function Chat() {
@@ -1719,7 +1719,7 @@ You can also access your metadata from the `onFinish` callback of `useChat`:
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { MyUIMessage } from './api/chat/route';
+import type { MyUIMessage } from './api/chat/route';
 import { DefaultChatTransport } from 'ai';
 
 export default function Chat() {

--- a/examples/next/app/api/chat/route.ts
+++ b/examples/next/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { MyUIMessage } from '@/util/chat-schema';
+import type { MyUIMessage } from '@/util/chat-schema';
 import { openai } from '@ai-sdk/openai';
 import { readChat, saveChat } from '@util/chat-store';
 import { convertToModelMessages, generateId, streamText } from 'ai';

--- a/examples/next/app/chat/[chatId]/chat.tsx
+++ b/examples/next/app/chat/[chatId]/chat.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { invalidateRouterCache } from '@/app/actions';
-import { MyUIMessage } from '@/util/chat-schema';
+import type { MyUIMessage } from '@/util/chat-schema';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 import { useEffect, useRef } from 'react';

--- a/examples/next/app/chat/[chatId]/message.tsx
+++ b/examples/next/app/chat/[chatId]/message.tsx
@@ -1,4 +1,4 @@
-import { MyUIMessage } from '@/util/chat-schema';
+import type { MyUIMessage } from '@/util/chat-schema';
 import { ChatStatus } from 'ai';
 
 export default function Message({


### PR DESCRIPTION
## Background

Importing by default creates a code dependency from frontend to backend. `import type` avoid this to some degree.

## Summary

Change example code to `import type` when custom ui messages are used.