### PR TITLE
Adds support for OpenAI remote MCP tool calls

### DIFF
--- a/.changeset/metal-bulldogs-shop.md
+++ b/.changeset/metal-bulldogs-shop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': minor
+---
+
+Adds remote mcp calling support for OpenAI

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -96,7 +96,12 @@ async function doParseToolCall<TOOLS extends ToolSet>({
   toolCall: LanguageModelV2ToolCall;
   tools: TOOLS;
 }): Promise<TypedToolCall<TOOLS>> {
-  const toolName = toolCall.toolName as keyof TOOLS & string;
+  let toolName = toolCall.toolName as keyof TOOLS & string;
+
+  // This indicates that we have an MCP tool for the OpenAI provider
+  if (toolCall.providerMetadata?.openai?.isMcp) {
+    toolName = toolCall.providerMetadata.openai.serverLabel as string;
+  }
 
   const tool = tools[toolName];
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -93,6 +93,7 @@ npx @ai-sdk/codemod v5/rename-format-stream-part .
 | `v5/move-provider-options`                                            | Transforms v5/move provider options                                            |
 | `v5/move-react-to-ai-sdk`                                             | Transforms v5/move react to ai sdk                                             |
 | `v5/move-ui-utils-to-ai`                                              | Transforms v5/move ui utils to ai                                              |
+| `v5/not-implemented/pattern`                                          | Transforms v5/not implemented/pattern                                          |
 | `v5/remove-experimental-wrap-language-model`                          | Transforms v5/remove experimental wrap language model                          |
 | `v5/remove-get-ui-text`                                               | Transforms v5/remove get ui text                                               |
 | `v5/remove-openai-compatibility`                                      | Transforms v5/remove openai compatibility                                      |

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -1,9 +1,11 @@
 import { codeInterpreter } from './tool/code-interpreter';
 import { fileSearch } from './tool/file-search';
+import { mcp } from './tool/mcp';
 import { webSearchPreview } from './tool/web-search-preview';
 
 export const openaiTools = {
   codeInterpreter,
   fileSearch,
   webSearchPreview,
+  mcp
 };

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -7,5 +7,5 @@ export const openaiTools = {
   codeInterpreter,
   fileSearch,
   webSearchPreview,
-  mcp
+  mcp,
 };

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -133,7 +133,7 @@ export type OpenAIResponsesTool =
       server_label?: string;
       require_approval?: any;
       headers?: Record<string, string>;
-      allowed_tools?: string[];
+      allowed_tools?: any;
     };
 
 export type OpenAIResponsesReasoning = {

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -37,6 +37,7 @@ export type OpenAIResponsesAssistantMessage = {
     | OpenAIWebSearchCall
     | OpenAIComputerCall
     | OpenAIFileSearchCall
+    | OpenAIMCPCall
   >;
   id?: string;
 };
@@ -69,6 +70,12 @@ export type OpenAIComputerCall = {
 
 export type OpenAIFileSearchCall = {
   type: 'file_search_call';
+  id: string;
+  status?: string;
+};
+
+export type OpenAIMCPCall = {
+  type: 'mcp_call';
   id: string;
   status?: string;
 };
@@ -115,6 +122,15 @@ export type OpenAIResponsesTool =
             type: 'and' | 'or';
             filters: any[];
           };
+    }
+  | {
+      type: 'mcp';
+      server_url: string;
+      server_description?: string;
+      server_label?: string;
+      require_approval: any;
+      headers?: Record<string, string>;
+      allowed_tools?: string[];
     };
 
 export type OpenAIResponsesReasoning = {

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -128,7 +128,7 @@ export type OpenAIResponsesTool =
       server_url: string;
       server_description?: string;
       server_label?: string;
-      require_approval: any;
+      require_approval?: any;
       headers?: Record<string, string>;
       allowed_tools?: string[];
     };

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -11,7 +11,8 @@ export type OpenAIResponsesMessage =
   | OpenAIWebSearchCall
   | OpenAIComputerCall
   | OpenAIFileSearchCall
-  | OpenAIResponsesReasoning;
+  | OpenAIResponsesReasoning
+  | OpenAIMCPCall;
 
 export type OpenAIResponsesSystemMessage = {
   role: 'system' | 'developer';
@@ -78,6 +79,7 @@ export type OpenAIMCPCall = {
   type: 'mcp_call';
   id: string;
   status?: string;
+  dynamic: true;
 };
 
 export type OpenAIResponsesTool =
@@ -125,7 +127,8 @@ export type OpenAIResponsesTool =
     }
   | {
       type: 'mcp';
-      server_url: string;
+      server_url?: string;
+      connector_id?: string;
       server_description?: string;
       server_label?: string;
       require_approval?: any;

--- a/packages/openai/src/responses/openai-responses-api-types.ts
+++ b/packages/openai/src/responses/openai-responses-api-types.ts
@@ -38,7 +38,6 @@ export type OpenAIResponsesAssistantMessage = {
     | OpenAIWebSearchCall
     | OpenAIComputerCall
     | OpenAIFileSearchCall
-    | OpenAIMCPCall
   >;
   id?: string;
 };
@@ -79,7 +78,7 @@ export type OpenAIMCPCall = {
   type: 'mcp_call';
   id: string;
   status?: string;
-  dynamic: true;
+  name: string;
 };
 
 export type OpenAIResponsesTool =

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1265,6 +1265,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               name: 'anmcp',
               args: {
                 serverUrl: 'https://mcp.example.com/mcp',
+                serverLabel: 'an_mcp_label',
               },
             },
           ],
@@ -1287,6 +1288,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             "model": "gpt-4o",
             "tools": [
               {
+                "server_label": "an_mcp_label",
                 "server_url": "https://mcp.example.com/mcp",
                 "type": "mcp",
               },

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1203,6 +1203,100 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send mcp tool', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.mcp',
+              name: 'anmcp',
+              args: {
+                serverUrl: 'https://mcp.example.com/mcp',
+                serverLabel: 'randommcp',
+                requireApproval: 'never',
+                headers: {
+                  Authorization: 'Bearer token',
+                  Random: 'Value',
+                },
+              },
+            },
+          ],
+          prompt: TEST_PROMPT,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "gpt-4o",
+            "tools": [
+              {
+                "headers": {
+                  "Authorization": "Bearer token",
+                  "Random": "Value",
+                },
+                "require_approval": "never",
+                "server_label": "randommcp",
+                "server_url": "https://mcp.example.com/mcp",
+                "type": "mcp",
+              },
+            ],
+          }
+        `);
+
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should send mcp tool with minimal args', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.mcp',
+              name: 'anmcp',
+              args: {
+                serverUrl: 'https://mcp.example.com/mcp',
+              },
+            },
+          ],
+          prompt: TEST_PROMPT,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "input": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "input_text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "gpt-4o",
+            "tools": [
+              {
+                "server_url": "https://mcp.example.com/mcp",
+                "type": "mcp",
+              },
+            ],
+          }
+        `);
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should warn about unsupported settings', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -434,7 +434,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               }),
               z.object({
                 id: z.string(),
-                type: z.literal('mcp_tool_call'),
+                type: z.literal('mcp_call'),
                 approval_request_id: z.string().nullable(),
                 arguments: z.string().nullable(),
                 error: z.string().nullable(),
@@ -631,7 +631,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
           break;
         }
 
-        case 'mcp_tool_call': {
+        case 'mcp_call': {
           content.push({
             type: 'tool-result',
             toolCallId: part.id,

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -203,4 +203,35 @@ describe('prepareResponsesTools', () => {
       expect(result.toolWarnings).toEqual([]);
     });
   });
+
+  describe('mcp', () => {
+    it('should prepare mcp tool with only server url', () => {
+      const result = prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'openai.mcp',
+            name: 'mcp',
+            args: {
+              serverUrl: 'https://mcp.server.com',
+            },
+          },
+        ],
+        strictJsonSchema: false,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'mcp',
+          server_url: 'https://mcp.server.com',
+          server_label: undefined,
+          server_description: undefined,
+          require_approval: undefined,
+          headers: undefined,
+          allowed_tools: undefined,
+        },
+      ]);
+      expect(result.toolWarnings).toEqual([]);
+    });
+  });
 });

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -235,5 +235,133 @@ describe('prepareResponsesTools', () => {
       ]);
       expect(result.toolWarnings).toEqual([]);
     });
+
+    it('should prepare mcp tool with valid allowed tools array', () => {
+      const result = prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'openai.mcp',
+            name: 'mcp123',
+            args: {
+              serverUrl: 'https://mcp.server.com',
+              serverLabel: 'a_label',
+              allowedTools: ['wrench'],
+            },
+          },
+        ],
+        strictJsonSchema: false,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'mcp',
+          server_url: 'https://mcp.server.com',
+          server_label: 'a_label',
+          server_description: undefined,
+          require_approval: undefined,
+          headers: undefined,
+          connector_id: undefined,
+          allowed_tools: ['wrench'],
+        },
+      ]);
+      expect(result.toolWarnings).toEqual([]);
+    });
+
+    it('should prepare mcp tool with valid allowed tools object', () => {
+      const result = prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider-defined',
+            id: 'openai.mcp',
+            name: 'mcp123',
+            args: {
+              serverUrl: 'https://mcp.server.com',
+              serverLabel: 'a_label',
+              allowedTools: {
+                readOnly: true,
+                toolNames: ['wrench'],
+              },
+            },
+          },
+        ],
+        strictJsonSchema: false,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'mcp',
+          server_url: 'https://mcp.server.com',
+          server_label: 'a_label',
+          server_description: undefined,
+          require_approval: undefined,
+          headers: undefined,
+          connector_id: undefined,
+          allowed_tools: {
+            read_only: true,
+            tool_names: ['wrench'],
+          },
+        },
+      ]);
+      expect(result.toolWarnings).toEqual([]);
+    });
+
+    it('should throw with error if server url and provider id missing', () => {
+      expect(() =>
+        prepareResponsesTools({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.mcp',
+              name: 'mcp123',
+              args: {
+                serverLabel: 'a_label',
+              },
+            },
+          ],
+          strictJsonSchema: false,
+        }),
+      ).toThrowError('Either serverUrl or connectorId must be provided');
+    });
+
+    it('should throw with error if serverUrl and connectorId are both provided', () => {
+      expect(() =>
+        prepareResponsesTools({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.mcp',
+              name: 'mcp123',
+              args: {
+                serverLabel: 'a_label',
+                serverUrl: 'https://www.mcp.com/mcp',
+                connectorId: 'connector_123',
+              },
+            },
+          ],
+          strictJsonSchema: false,
+        }),
+      ).toThrowError('Only one of serverUrl or connectorId must be provided');
+    });
+
+    it('should have warnings if allowed tools contains invalid schema', () => {
+      expect(() =>
+        prepareResponsesTools({
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'openai.mcp',
+              name: 'mcp123',
+              args: {
+                serverUrl: 'https://www.mcp.com/mcp',
+                serverLabel: 'a_label',
+                allowedTools: [false],
+              },
+            },
+          ],
+          strictJsonSchema: false,
+        }),
+      ).toThrowError();
+    });
   });
 });

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -211,9 +211,10 @@ describe('prepareResponsesTools', () => {
           {
             type: 'provider-defined',
             id: 'openai.mcp',
-            name: 'mcp',
+            name: 'mcp123',
             args: {
               serverUrl: 'https://mcp.server.com',
+              serverLabel: 'a_label',
             },
           },
         ],
@@ -224,10 +225,11 @@ describe('prepareResponsesTools', () => {
         {
           type: 'mcp',
           server_url: 'https://mcp.server.com',
-          server_label: undefined,
+          server_label: 'a_label',
           server_description: undefined,
           require_approval: undefined,
           headers: undefined,
+          connector_id: undefined,
           allowed_tools: undefined,
         },
       ]);

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -218,7 +218,7 @@ describe('prepareResponsesTools', () => {
             },
           },
         ],
-        strictJsonSchema: false,
+        strictJsonSchema: true,
       });
 
       expect(result.tools).toEqual([
@@ -250,7 +250,7 @@ describe('prepareResponsesTools', () => {
             },
           },
         ],
-        strictJsonSchema: false,
+        strictJsonSchema: true,
       });
 
       expect(result.tools).toEqual([
@@ -285,7 +285,7 @@ describe('prepareResponsesTools', () => {
             },
           },
         ],
-        strictJsonSchema: false,
+        strictJsonSchema: true,
       });
 
       expect(result.tools).toEqual([
@@ -319,7 +319,7 @@ describe('prepareResponsesTools', () => {
               },
             },
           ],
-          strictJsonSchema: false,
+          strictJsonSchema: true,
         }),
       ).toThrowError('Either serverUrl or connectorId must be provided');
     });
@@ -339,7 +339,7 @@ describe('prepareResponsesTools', () => {
               },
             },
           ],
-          strictJsonSchema: false,
+          strictJsonSchema: true,
         }),
       ).toThrowError('Only one of serverUrl or connectorId must be provided');
     });
@@ -359,7 +359,7 @@ describe('prepareResponsesTools', () => {
               },
             },
           ],
-          strictJsonSchema: false,
+          strictJsonSchema: true,
         }),
       ).toThrowError();
     });

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -97,9 +97,30 @@ export function prepareResponsesTools({
               connector_id: args.connectorId,
               server_label: args.serverLabel,
               server_description: args.serverDescription,
-              require_approval: args.requireApproval,
+              require_approval:
+                typeof args.requireApproval === 'string'
+                  ? args.requireApproval
+                  : typeof args.requireApproval === 'object'
+                    ? {
+                        always: {
+                          read_only: args.requireApproval?.always?.readOnly,
+                          tool_names: args.requireApproval?.always?.toolNames,
+                        },
+                        never: {
+                          read_only: args.requireApproval?.never?.readOnly,
+                          tool_names: args.requireApproval?.never?.toolNames,
+                        },
+                      }
+                    : undefined,
               headers: args.headers,
-              allowed_tools: args.allowedTools,
+              allowed_tools: Array.isArray(args.allowedTools)
+                ? args.allowedTools
+                : typeof args.allowedTools === 'object'
+                  ? {
+                      read_only: args.allowedTools?.readOnly,
+                      tool_names: args.allowedTools?.toolNames,
+                    }
+                  : undefined,
             });
             break;
           }

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -94,6 +94,7 @@ export function prepareResponsesTools({
             openaiTools.push({
               type: 'mcp',
               server_url: args.serverUrl,
+              connector_id: args.connectorId,
               server_label: args.serverLabel,
               server_description: args.serverDescription,
               require_approval: args.requireApproval,

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -94,16 +94,11 @@ export function prepareResponsesTools({
             openaiTools.push({
               type: 'mcp',
               server_url: args.serverUrl,
-              server_label:
-                args.serverLabel === null ? undefined : args.serverLabel,
-              server_description:
-                args.serverDescription === null
-                  ? undefined
-                  : args.serverDescription,
+              server_label: args.serverLabel,
+              server_description: args.serverDescription,
               require_approval: args.requireApproval,
-              headers: args.headers === null ? undefined : args.headers,
-              allowed_tools:
-                args.allowedTools === null ? undefined : args.allowedTools,
+              headers: args.headers,
+              allowed_tools: args.allowedTools,
             });
             break;
           }

--- a/packages/openai/src/tool/mcp.ts
+++ b/packages/openai/src/tool/mcp.ts
@@ -1,0 +1,29 @@
+import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+// Args validation schema
+export const mcpArgsSchema = z.object({
+  serverUrl: z.string(),
+  serverLabel: z.string().optional(),
+  serverDescription: z.string().optional(),
+  requireApproval: z.any().optional(),
+  allowedTools: z.array(z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+});
+
+export const mcp = createProviderDefinedToolFactory<
+  {
+    // MCP doesn't take input parameters it should be controlled by the prompt
+  },
+  {
+    server_url: string;
+    server_label?: string;
+    server_description?: string;
+    require_approval?: any;
+    headers?: Record<string, string>;
+  }
+>({
+  id: 'openai.mcp',
+  name: 'mcp',
+  inputSchema: z.object({}),
+});

--- a/packages/openai/src/tool/mcp.ts
+++ b/packages/openai/src/tool/mcp.ts
@@ -21,6 +21,7 @@ export const mcp = createProviderDefinedToolFactory<
     server_description?: string;
     require_approval?: any;
     headers?: Record<string, string>;
+    allowed_tools?: string[];
   }
 >({
   id: 'openai.mcp',

--- a/packages/openai/src/tool/mcp.ts
+++ b/packages/openai/src/tool/mcp.ts
@@ -3,8 +3,9 @@ import { z } from 'zod/v4';
 
 // Args validation schema
 export const mcpArgsSchema = z.object({
-  serverUrl: z.string(),
-  serverLabel: z.string().optional(),
+  serverUrl: z.string().optional(),
+  connectorId: z.string().optional(),
+  serverLabel: z.string(),
   serverDescription: z.string().optional(),
   requireApproval: z.any().optional(),
   allowedTools: z.array(z.string()).optional(),
@@ -16,8 +17,9 @@ export const mcp = createProviderDefinedToolFactory<
     // MCP doesn't take input parameters it should be controlled by the prompt
   },
   {
-    server_url: string;
-    server_label?: string;
+    server_url?: string;
+    connector_id?: string;
+    server_label: string;
     server_description?: string;
     require_approval?: any;
     headers?: Record<string, string>;

--- a/packages/openai/src/tool/mcp.ts
+++ b/packages/openai/src/tool/mcp.ts
@@ -53,7 +53,7 @@ export const mcp = createProviderDefinedToolFactory<
     // MCP doesn't take input parameters it should be controlled by the prompt
   },
   {
-    server_url?: string;
+    serverUrl?: string;
     connector_id?: string;
     serverLabel: string;
     serverDescription?: string;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

MCP tool calling directly from the model has been supported for some time via the responses API in OpenAI. This PR adds that support for OpenAI. 

## Summary


## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)
- [ ] Add additional unit tests for streaming and non-streaming responses
- [x] Add additional schema validation for `server_url` vs `connector_id`
- [ ] Add example usage


## Future Work

There is a lot of code that deals with schema mappings and snake case vs camel case differences that could be a result of me not understanding the patterns already used in the project. This is definitely an area where I would like to see a cleaner approach to mapping the provider specific validation and argument semantics. 

## Related Issues

Adds  #6458 
