### PR TITLE
feat(providers/anthropic): map 'refusal' stop reason to 'content-filter' finishReason

### DIFF
--- a/.changeset/thirty-hotels-mix.md
+++ b/.changeset/thirty-hotels-mix.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(providers/anthropic): map 'refusal' stop reason to 'content-filter' finishReason

--- a/packages/anthropic/src/map-anthropic-stop-reason.ts
+++ b/packages/anthropic/src/map-anthropic-stop-reason.ts
@@ -11,6 +11,8 @@ export function mapAnthropicStopReason({
     case 'end_turn':
     case 'stop_sequence':
       return 'stop';
+    case 'refusal':
+      return 'content-filter';
     case 'tool_use':
       return isJsonResponseFromTool ? 'stop' : 'tool-calls';
     case 'max_tokens':


### PR DESCRIPTION
## Background
- Fixes https://github.com/vercel/ai/issues/6529

## Summary

This PR adds support for the `refusal` stop reason by converting it to `content-filter`. This maps well according to Anthropic's own documentation, which says it is returned `"During streaming when content violates policies"`
<img width="746" height="131" alt="Screenshot 2025-09-02 at 11 32 07 PM" src="https://github.com/user-attachments/assets/425364a0-b515-48d1-86c9-b548dfaae1cf" />

https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals#current-refusal-types

## Manual Verification
- I have a test case for this but it is not appropriate to post publicly. Running it produces `refusal` stop reason from Anthropic which now correctly returns `content-filter` via AI-SDK