### PR TITLE
feat(anthropic): handle `pause_turn` as value for `stop_reason`

### DIFF
--- a/.changeset/eighty-phones-rest.md
+++ b/.changeset/eighty-phones-rest.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(anthropic): handle `pause_turn` as value for `stop_reason`

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -2640,6 +2640,54 @@ describe('AnthropicMessagesLanguageModel', () => {
       `);
     });
 
+    it('should handle handle stop_reason:pause_turn', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_01KfpJoAEabmH2iHRRFjQMAG","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", "}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"World!"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"pause_turn","stop_sequence":null},"usage":{"output_tokens":227}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const result = await model.doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      // consume stream
+      const chunks = await convertReadableStreamToArray(result.stream);
+
+      expect(chunks.filter(chunk => chunk.type === 'finish'))
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "finishReason": "stop",
+            "providerMetadata": {
+              "anthropic": {
+                "cacheCreationInputTokens": null,
+                "usage": {
+                  "input_tokens": 17,
+                  "output_tokens": 1,
+                },
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "cachedInputTokens": undefined,
+              "inputTokens": 17,
+              "outputTokens": 227,
+              "totalTokens": 244,
+            },
+          },
+        ]
+      `);
+    });
+
     describe('raw chunks', () => {
       it('should include raw chunks when includeRawChunks is enabled', async () => {
         server.urls['https://api.anthropic.com/v1/messages'].response = {

--- a/packages/anthropic/src/map-anthropic-stop-reason.ts
+++ b/packages/anthropic/src/map-anthropic-stop-reason.ts
@@ -1,5 +1,8 @@
 import { LanguageModelV2FinishReason } from '@ai-sdk/provider';
 
+/**
+ * @see https://docs.anthropic.com/en/api/messages#response-stop-reason
+ */
 export function mapAnthropicStopReason({
   finishReason,
   isJsonResponseFromTool,
@@ -8,6 +11,7 @@ export function mapAnthropicStopReason({
   isJsonResponseFromTool?: boolean;
 }): LanguageModelV2FinishReason {
   switch (finishReason) {
+    case 'pause_turn':
     case 'end_turn':
     case 'stop_sequence':
       return 'stop';


### PR DESCRIPTION
## Background

We currently implement:

https://github.com/vercel/ai/blob/3b67c6244d1227087e71e4bb620ff1e6ebb0a194/packages/anthropic/src/map-anthropic-stop-reason.ts#L11-L21

But Anthropic also supports `pause_turn`:
https://docs.anthropic.com/en/api/messages#response-stop-reason

## Summary

Map `pause_turn` to `ai`'s `stop`

## Manual Verification

Not sure how.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future work

handle continuation:

https://docs.anthropic.com/en/api/handling-stop-reasons#pause-turn

## Related Issues

Fixes #8420 