### PR TITLE
fix(provider/elevenlabs): `experimental_transcribe` fails with valid Buffer

### DIFF
--- a/.changeset/violet-taxis-doubt.md
+++ b/.changeset/violet-taxis-doubt.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/elevenlabs': patch
+---
+
+fix(provider/elevenlabs): `experimental_transcribe` fails with valid buffer`

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -7,6 +7,7 @@ import {
   combineHeaders,
   convertBase64ToUint8Array,
   createJsonResponseHandler,
+  mediaTypeToExtension,
   parseProviderOptions,
   postFormDataToApi,
 } from '@ai-sdk/provider-utils';
@@ -73,7 +74,12 @@ export class ElevenLabsTranscriptionModel implements TranscriptionModelV2 {
         : new Blob([convertBase64ToUint8Array(audio)]);
 
     formData.append('model_id', this.modelId);
-    formData.append('file', new File([blob], 'audio', { type: mediaType }));
+    const fileExtension = mediaTypeToExtension(mediaType);
+    formData.append(
+      'file',
+      new File([blob], 'audio', { type: mediaType }),
+      `audio.${fileExtension}`,
+    );
     formData.append('diarize', 'true');
 
     // Add provider-specific options


### PR DESCRIPTION
## Background

`experimental_transcribe` fails with valid Buffer input after upgrading to [ai@5.x](/)

## Summary

[Set `filename`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append#filename) when uploading audio blob to Elevenlabs's transcribe API

## Manual Verification

Ran test file `examples/ai-core/src/transcribe/elevenlabs.ts`

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

Apply the same fix to other places where we upload a blob without defining a file name

```
packages/gladia/src/gladia-transcription-model.ts:
  502        'audio',
  503:       new File([blob], 'audio', { type: options.mediaType }),
  504      );

packages/openai/src/transcription/openai-transcription-model.ts:
  131      formData.append('model', this.modelId);
  132:     formData.append('file', new File([blob], 'audio', { type: mediaType }));
  133  

packages/revai/src/revai-transcription-model.ts:
  254  
  255:     formData.append('media', new File([blob], 'audio', { type: mediaType }));
  256      const transcriptionModelOptions: RevaiTranscriptionAPITypes = {
```

## Related Issues

Fixes #8405 
