### PR TITLE
fix(provider/revai): safe practice to include filename and fileExtension to avoid `experimental_transcribe` fails with valid Buffer

### DIFF
--- a/.changeset/dry-donkeys-protect.md
+++ b/.changeset/dry-donkeys-protect.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/revai': patch
+---
+
+fix(provider/revai): safe practice to include filename and fileExtension to avoid `experimental_transcribe` fails with valid Buffer

--- a/packages/revai/src/revai-transcription-model.ts
+++ b/packages/revai/src/revai-transcription-model.ts
@@ -7,6 +7,7 @@ import {
   combineHeaders,
   convertBase64ToUint8Array,
   createJsonResponseHandler,
+  mediaTypeToExtension,
   delay,
   getFromApi,
   parseProviderOptions,
@@ -252,7 +253,12 @@ export class RevaiTranscriptionModel implements TranscriptionModelV2 {
         ? new Blob([audio])
         : new Blob([convertBase64ToUint8Array(audio)]);
 
-    formData.append('media', new File([blob], 'audio', { type: mediaType }));
+    const fileExtension = mediaTypeToExtension(mediaType);
+    formData.append(
+      'media',
+      new File([blob], 'audio', { type: mediaType }),
+      `audio.${fileExtension}`,
+    );
     const transcriptionModelOptions: RevaiTranscriptionAPITypes = {
       transcriber: this.modelId,
     };


### PR DESCRIPTION
## Background

Adding fileExtension support to all providers (rev ai here) so that experimental_transcribe doesn't fail.

## Summary

Set `filename` when uploading audio blob to RevAI's transcribe API. Change wasn't necessary to get rid of error but still good practice

## Manual Verification

Ran test file examples/ai-core/src/transcribe/revai.ts

-->

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Related Issues

Fixes #8408 
Fixes #7757