### PR TITLE
feat(provider/gateway): Add Voyage embedding models

### DIFF
--- a/.changeset/unlucky-squids-carry.md
+++ b/.changeset/unlucky-squids-carry.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): Add Voyage embedding models

--- a/packages/gateway/src/gateway-embedding-model-settings.ts
+++ b/packages/gateway/src/gateway-embedding-model-settings.ts
@@ -9,4 +9,11 @@ export type GatewayEmbeddingModelId =
   | 'openai/text-embedding-3-large'
   | 'openai/text-embedding-3-small'
   | 'openai/text-embedding-ada-002'
+  | 'voyage/voyage-3-large'
+  | 'voyage/voyage-3.5'
+  | 'voyage/voyage-3.5-lite'
+  | 'voyage/voyage-code-3'
+  | 'voyage/voyage-finance-2'
+  | 'voyage/voyage-law-2'
+  | 'voyage/voyage-code-2'
   | (string & {});


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Voyage has a list of embedding models and we'd like them on the Gateway

## Summary

Adds them to Gateway's model string autocomplete

## Manual Verification

Autocomplete works

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [X] I have reviewed this pull request (self-review)