### PR TITLE
docs: clarify `stepCountIs()`

### DIFF
--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -94,7 +94,7 @@ const { text, steps } = await generateText({
       }),
     }),
   },
-  stopWhen: stepCountIs(5), // stop after 5 steps if tools were called
+  stopWhen: stepCountIs(5), // stop after a maximum of 5 steps if tools were called
   prompt: 'What is the weather in San Francisco?',
 });
 ```


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

A friend was reading the AI SDK docs and let me know that there was a small point of confusion because the naming of `stopWhen` and `stepCountIs(5)` doesn't make it clear that it's a maximum of 5 steps, not that it will take exactly 5 steps every time. His message to me:

> the info tag actually does explain it, but you kind have to assume that a text stop reason will cause the execution loop to terminate (which seems obvious now but it didn’t click for some reason). i think the comment in the codeblock + the naming of the utilities is the primary source of confusion, but probably just changing comment in the codeblock to “// stop after a maximum of 5 steps if tools were called” works.
>
> i would probably make the interface { stopCondition: stepCountMax(i: number) } but thats prolly not worth it

## Summary

Makes this more clear in the docs

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [X] I have reviewed this pull request (self-review)