### PR TITLE
chore (provider/vertex): update GoogleVertexModelId

### DIFF
--- a/.changeset/ninety-scissors-pay.md
+++ b/.changeset/ninety-scissors-pay.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+chore (provider/vertex): update GoogleVertexModelId

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -1,8 +1,13 @@
-// https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#supported-models
+// https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions
 // Note preview and experimental models may only be detailed in AI Studio:
 // https://console.cloud.google.com/vertex-ai/studio/
 export type GoogleVertexModelId =
   // Stable models
+  | 'gemini-2.5-pro'
+  | 'gemini-2.5-flash'
+  | 'gemini-2.5-flash-lite'
+  | 'gemini-2.0-flash-lite'
+  | 'gemini-2.0-flash'
   | 'gemini-2.0-flash-001'
   | 'gemini-1.5-flash'
   | 'gemini-1.5-flash-001'


### PR DESCRIPTION
Simply updates the `GoogleVertexModelId` with the more recent stable models: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions

I'll do my best to make sure Vertex docs and such get some love 🥹 