### PR TITLE
fix(cerebras): enable structured outputs support in language model creation

### DIFF
--- a/content/providers/01-ai-sdk-providers/40-cerebras.mdx
+++ b/content/providers/01-ai-sdk-providers/40-cerebras.mdx
@@ -67,6 +67,10 @@ You can use the following optional settings to customize the Cerebras provider i
 
   Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
 
+- **supportsStructuredOutputs** _boolean_
+
+  Whether the model supports structured outputs. This config gets passed onto the `OpenAICompatibleChatLanguageModel`.
+
 ## Language Models
 
 You can create language models using a provider instance:

--- a/examples/ai-core/src/generate-object/cerebras.ts
+++ b/examples/ai-core/src/generate-object/cerebras.ts
@@ -1,0 +1,33 @@
+import { createCerebras } from '@ai-sdk/cerebras';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod/v4';
+
+async function main() {
+  const cerebras = createCerebras({
+    supportsStructuredOutputs: true,
+  });
+  const result = await generateObject({
+    model: cerebras('gpt-oss-120b'),
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({
+            name: z.string(),
+            amount: z.string(),
+          }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log(JSON.stringify(result.object, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -46,6 +46,10 @@ Custom fetch implementation. You can use it as a middleware to intercept request
 or to provide a custom fetch implementation for e.g. testing.
 */
   fetch?: FetchFunction;
+  /**
+Whether the model supports structured outputs.
+*/
+  supportsStructuredOutputs?: boolean;
 }
 
 export interface CerebrasProvider extends ProviderV2 {
@@ -87,7 +91,7 @@ export function createCerebras(
       headers: getHeaders,
       fetch: options.fetch,
       errorStructure: cerebrasErrorStructure,
-      supportsStructuredOutputs: true
+      supportsStructuredOutputs: options.supportsStructuredOutputs ?? false,
     });
   };
 

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -87,6 +87,7 @@ export function createCerebras(
       headers: getHeaders,
       fetch: options.fetch,
       errorStructure: cerebrasErrorStructure,
+      supportsStructuredOutputs: true
     });
   };
 


### PR DESCRIPTION
## Background

According to [Cerebras docs](https://inference-docs.cerebras.ai/capabilities/structured-outputs#json-mode), there is support for structured outputs. There seems to be issues (https://github.com/vercel/ai/issues/8475) with simple json mode for some models by Cerebras's API, so we need to enable structured output.

## Summary

Enable structured output as this is supported by Cerebras's API.

## Manual Verification

JSON object received from output instead of the generic error found in https://github.com/vercel/ai/issues/8475
Cerebras example
<img width="1344" height="806" alt="Screenshot 2025-09-08 at 12 14 29 PM" src="https://github.com/user-attachments/assets/22621da6-3a9c-4625-9faa-05f56a0c49c9" />


## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

## Related Issues

Fixes https://github.com/vercel/ai/issues/8475
