### PR TITLE
fix (provider/openai): only send tool calls finish reason for tools that are not provider-executed

### DIFF
--- a/.changeset/rude-beans-sell.md
+++ b/.changeset/rude-beans-sell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix (provider/openai): only send tool calls finish reason for tools that are not provider-executed

--- a/examples/ai-core/src/stream-text/openai-websearch-tool.ts
+++ b/examples/ai-core/src/stream-text/openai-websearch-tool.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { streamText } from 'ai';
+import { stepCountIs, streamText } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -11,12 +11,23 @@ async function main() {
       }),
     },
     prompt: 'Look up the company that owns Sonny Angel',
+    stopWhen: stepCountIs(5), // note: should stop after a single step
   });
 
   for await (const chunk of result.fullStream) {
     switch (chunk.type) {
       case 'text-delta': {
         process.stdout.write(chunk.text);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log('Tool call:', JSON.stringify(chunk, null, 2));
+        break;
+      }
+
+      case 'tool-result': {
+        console.log('Tool result:', JSON.stringify(chunk, null, 2));
         break;
       }
 

--- a/packages/openai/src/responses/map-openai-responses-finish-reason.ts
+++ b/packages/openai/src/responses/map-openai-responses-finish-reason.ts
@@ -2,20 +2,21 @@ import { LanguageModelV2FinishReason } from '@ai-sdk/provider';
 
 export function mapOpenAIResponseFinishReason({
   finishReason,
-  hasToolCalls,
+  hasFunctionCall,
 }: {
   finishReason: string | null | undefined;
-  hasToolCalls: boolean;
+  // flag that checks if there have been client-side tool calls (not executed by openai)
+  hasFunctionCall: boolean;
 }): LanguageModelV2FinishReason {
   switch (finishReason) {
     case undefined:
     case null:
-      return hasToolCalls ? 'tool-calls' : 'stop';
+      return hasFunctionCall ? 'tool-calls' : 'stop';
     case 'max_output_tokens':
       return 'length';
     case 'content_filter':
       return 'content-filter';
     default:
-      return hasToolCalls ? 'tool-calls' : 'unknown';
+      return hasFunctionCall ? 'tool-calls' : 'unknown';
   }
 }

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -3101,7 +3101,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             "input": "{"action":{"type":"search","query":"Vercel AI SDK next version features"}}",
             "providerExecuted": true,
             "toolCallId": "ws_test",
-            "toolName": "web_search_preview",
+            "toolName": "web_search",
             "type": "tool-call",
           },
           {
@@ -3110,7 +3110,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "status": "completed",
             },
             "toolCallId": "ws_test",
-            "toolName": "web_search_preview",
+            "toolName": "web_search",
             "type": "tool-result",
           },
           {
@@ -3132,7 +3132,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             "type": "text-end",
           },
           {
-            "finishReason": "tool-calls",
+            "finishReason": "stop",
             "providerMetadata": {
               "openai": {
                 "responseId": "resp_test",
@@ -3613,7 +3613,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             "input": "{}",
             "providerExecuted": true,
             "toolCallId": "ws_67cf3390e9608190869b5d45698a7067",
-            "toolName": "web_search_preview",
+            "toolName": "web_search",
             "type": "tool-call",
           },
           {
@@ -3622,7 +3622,7 @@ describe('OpenAIResponsesLanguageModel', () => {
               "status": "completed",
             },
             "toolCallId": "ws_67cf3390e9608190869b5d45698a7067",
-            "toolName": "web_search_preview",
+            "toolName": "web_search",
             "type": "tool-result",
           },
           {
@@ -3678,7 +3678,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             "type": "text-end",
           },
           {
-            "finishReason": "tool-calls",
+            "finishReason": "stop",
             "providerMetadata": {
               "openai": {
                 "responseId": "resp_67cf3390786881908b27489d7e8cfb6b",
@@ -3830,7 +3830,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "text-end",
               },
               {
-                "finishReason": "tool-calls",
+                "finishReason": "stop",
                 "providerMetadata": {
                   "openai": {
                     "responseId": "resp_67cf3390786881908b27489d7e8cfb6b",
@@ -3939,7 +3939,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "text-end",
               },
               {
-                "finishReason": "tool-calls",
+                "finishReason": "stop",
                 "providerMetadata": {
                   "openai": {
                     "responseId": "resp_67cf3390786881908b27489d7e8cfb6b",


### PR DESCRIPTION
## Background

OpenAI responses provider-executed tools had a `tool-calls` finish reason that led to looping when used with `stopWhen`.

## Summary

The `tool-calls` finish reason is for function tools that are not executed by OpenAI. Updated the finish reason mapping. Also switched to `web_search` tool result parts.

## Manual Verification

- [x] run updated `src/stream-text/openai-websearch-tool` example

## Related Issues

Discovered during #8499 