### PR TITLE
docs: add troubleshooting for tool calls with generate/streamObject

### DIFF
--- a/content/docs/09-troubleshooting/14-tool-calling-with-structured-outputs.mdx
+++ b/content/docs/09-troubleshooting/14-tool-calling-with-structured-outputs.mdx
@@ -44,3 +44,5 @@ const result = await generateText({
   prompt: 'Analyze the data and provide a summary',
 });
 ```
+
+For more information about using structured outputs with `generateText` and `streamText` see [Generating Structured Data](/docs/ai-sdk-core/generating-structured-data#structured-outputs-with-generatetext-and-streamtext).

--- a/content/docs/09-troubleshooting/14-tool-calling-with-structured-outputs.mdx
+++ b/content/docs/09-troubleshooting/14-tool-calling-with-structured-outputs.mdx
@@ -1,0 +1,46 @@
+---
+title: Tool calling with generateObject and streamObject
+description: Troubleshooting tool calling when combined with generateObject and streamObject
+---
+
+# Tool calling with generateObject and streamObject (structured outputs)
+
+## Issue
+
+You may want to combine tool calling with structured output generation. While `generateObject` and `streamObject` are designed specifically for structured outputs, they don't support tool calling.
+
+## Background
+
+To use tool calling with structured outputs, use `generateText` or `streamText` with the `experimental_output` option.
+
+**Important**: When using `experimental_output` with tool calling, the structured output generation counts as an additional step in the execution flow.
+
+## Solution
+
+When using `experimental_output` with tool calling, adjust your `stopWhen` condition to account for the additional step required for structured output generation:
+
+```tsx
+const result = await generateText({
+  model: openai('gpt-4o'),
+  experimental_output: Output.object({
+    schema: z.object({
+      summary: z.string(),
+      sentiment: z.enum(['positive', 'neutral', 'negative']),
+    }),
+  }),
+  tools: {
+    analyze: tool({
+      description: 'Analyze data',
+      inputSchema: z.object({
+        data: z.string(),
+      }),
+      execute: async ({ data }) => {
+        return { result: 'analyzed' };
+      }),
+    },
+  },
+  // Add at least 1 to your intended step count to account for structured output
+  stopWhen: stepCountIs(3), // Now accounts for: tool call + tool result + structured output
+  prompt: 'Analyze the data and provide a summary',
+});
+```


### PR DESCRIPTION
## Background

Lots of folks asking about generateObject + tool calls. Solution is to use generateText with experimental_output.

## Summary

Added troubleshooting page