### PR TITLE
feat (provider/openai+anthropic): update jsdoc of provider-defined tools

### DIFF
--- a/.changeset/soft-brooms-cross.md
+++ b/.changeset/soft-brooms-cross.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat (provider/openai): add jsdoc for openai tools

--- a/.changeset/strong-lemons-pretend.md
+++ b/.changeset/strong-lemons-pretend.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat (provider/anthropic): update jsdoc of anthropic tools

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -10,43 +10,44 @@ import { codeExecution_20250522 } from './tool/code-execution_20250522';
 
 export const anthropicTools = {
   /**
-   * Creates a tool for running a bash command. Must have name "bash".
+   * The bash tool enables Claude to execute shell commands in a persistent bash session,
+   * allowing system operations, script execution, and command-line automation.
    *
    * Image results are supported.
    *
-   * @param execute - The function to execute the tool. Optional.
+   * Tool name must be `bash`.
    */
   bash_20241022,
 
   /**
-   * Creates a tool for running a bash command. Must have name "bash".
+   * The bash tool enables Claude to execute shell commands in a persistent bash session,
+   * allowing system operations, script execution, and command-line automation.
    *
    * Image results are supported.
    *
-   * @param execute - The function to execute the tool. Optional.
+   * Tool name must be `bash`.
    */
   bash_20250124,
 
   /**
-   * Creates a tool for editing text. Must have name "str_replace_editor".
+   * Claude can analyze data, create visualizations, perform complex calculations,
+   * run system commands, create and edit files, and process uploaded files directly within
+   * the API conversation.
+   *
+   * The code execution tool allows Claude to run Bash commands and manipulate files,
+   * including writing code, in a secure, sandboxed environment.
+   *
+   * Tool name must be `code_execution`.
    */
-  textEditor_20241022,
+  codeExecution_20250522,
 
   /**
-   * Creates a tool for editing text. Must have name "str_replace_editor".
-   */
-  textEditor_20250124,
-
-  /**
-   * Creates a tool for editing text. Must have name "str_replace_based_edit_tool".
-   * Note: This version does not support the "undo_edit" command.
-   */
-  textEditor_20250429,
-
-  /**
-   * Creates a tool for executing actions on a computer. Must have name "computer".
+   * Claude can interact with computer environments through the computer use tool, which
+   * provides screenshot capabilities and mouse/keyboard control for autonomous desktop interaction.
    *
    * Image results are supported.
+   *
+   * Tool name must be `computer`.
    *
    * @param displayWidthPx - The width of the display being controlled by the model in pixels.
    * @param displayHeightPx - The height of the display being controlled by the model in pixels.
@@ -55,20 +56,52 @@ export const anthropicTools = {
   computer_20241022,
 
   /**
-   * Creates a tool for executing actions on a computer. Must have name "computer".
+   * Claude can interact with computer environments through the computer use tool, which
+   * provides screenshot capabilities and mouse/keyboard control for autonomous desktop interaction.
    *
    * Image results are supported.
+   *
+   * Tool name must be `computer`.
    *
    * @param displayWidthPx - The width of the display being controlled by the model in pixels.
    * @param displayHeightPx - The height of the display being controlled by the model in pixels.
    * @param displayNumber - The display number to control (only relevant for X11 environments). If specified, the tool will be provided a display number in the tool definition.
-   * @param execute - The function to execute the tool. Optional.
    */
   computer_20250124,
 
   /**
+   * Claude can use an Anthropic-defined text editor tool to view and modify text files,
+   * helping you debug, fix, and improve your code or other text documents. This allows Claude
+   * to directly interact with your files, providing hands-on assistance rather than just suggesting changes.
+   *
+   * Tool name must be `str_replace_editor`.
+   */
+  textEditor_20241022,
+
+  /**
+   * Claude can use an Anthropic-defined text editor tool to view and modify text files,
+   * helping you debug, fix, and improve your code or other text documents. This allows Claude
+   * to directly interact with your files, providing hands-on assistance rather than just suggesting changes.
+   *
+   * Tool name must be `str_replace_editor`.
+   */
+  textEditor_20250124,
+
+  /**
+   * Claude can use an Anthropic-defined text editor tool to view and modify text files,
+   * helping you debug, fix, and improve your code or other text documents. This allows Claude
+   * to directly interact with your files, providing hands-on assistance rather than just suggesting changes.
+   *
+   * Note: This version does not support the "undo_edit" command.
+   *
+   * Tool name must be `str_replace_editor`.
+   */
+  textEditor_20250429,
+
+  /**
    * Creates a web search tool that gives Claude direct access to real-time web content.
-   * Must have name "web_search".
+   *
+   * Tool name must be `web_search`.
    *
    * @param maxUses - Maximum number of web searches Claude can perform during the conversation.
    * @param allowedDomains - Optional list of domains that Claude is allowed to search.
@@ -76,9 +109,4 @@ export const anthropicTools = {
    * @param userLocation - Optional user location information to provide geographically relevant search results.
    */
   webSearch_20250305,
-
-  /**
-   * Creates a tool for executing Python code. Must have name "code_execution".
-   */
-  codeExecution_20250522,
 };

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -94,7 +94,7 @@ export const anthropicTools = {
    *
    * Note: This version does not support the "undo_edit" command.
    *
-   * Tool name must be `str_replace_editor`.
+   * Tool name must be `str_replace_based_edit_tool`.
    */
   textEditor_20250429,
 

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -29,6 +29,28 @@ export const openaiTools = {
    */
   fileSearch,
 
+  /**
+   * Web search allows models to access up-to-date information from the internet
+   * and provide answers with sourced citations.
+   *
+   * Must have name `web_search_preview`.
+   *
+   * @param searchContextSize - The search context size to use for the web search.
+   * @param userLocation - The user location to use for the web search.
+   *
+   * @deprecated Use `webSearch` instead.
+   */
   webSearchPreview,
+
+  /**
+   * Web search allows models to access up-to-date information from the internet
+   * and provide answers with sourced citations.
+   *
+   * Must have name `web_search`.
+   *
+   * @param filters - The filters to use for the web search.
+   * @param searchContextSize - The search context size to use for the web search.
+   * @param userLocation - The user location to use for the web search.
+   */
   webSearch,
 };

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -4,8 +4,31 @@ import { webSearch } from './tool/web-search';
 import { webSearchPreview } from './tool/web-search-preview';
 
 export const openaiTools = {
+  /**
+   * The Code Interpreter tool allows models to write and run Python code in a
+   * sandboxed environment to solve complex problems in domains like data analysis,
+   * coding, and math.
+   *
+   * @param container - The container to use for the code interpreter.
+   *
+   * Must have name `code_interpreter`.
+   */
   codeInterpreter,
+
+  /**
+   * File search is a tool available in the Responses API. It enables models to
+   * retrieve information in a knowledge base of previously uploaded files through
+   * semantic and keyword search.
+   *
+   * Must have name `file_search`.
+   *
+   * @param vectorStoreIds - The vector store IDs to use for the file search.
+   * @param maxNumResults - The maximum number of results to return.
+   * @param ranking - The ranking options to use for the file search.
+   * @param filters - The filters to use for the file search.
+   */
   fileSearch,
+
   webSearchPreview,
   webSearch,
 };

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -1,7 +1,6 @@
 import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
-// Filter schemas
 const comparisonFilterSchema = z.object({
   key: z.string(),
   type: z.enum(['eq', 'ne', 'gt', 'gte', 'lt', 'lte']),
@@ -17,30 +16,14 @@ const compoundFilterSchema: z.ZodType<any> = z.object({
 
 const filtersSchema = z.union([comparisonFilterSchema, compoundFilterSchema]);
 
-// Args validation schema
 export const fileSearchArgsSchema = z.object({
-  /**
-   * List of vector store IDs to search through. If not provided, searches all available vector stores.
-   */
   vectorStoreIds: z.array(z.string()).optional(),
-
-  /**
-   * Maximum number of search results to return. Defaults to 10.
-   */
   maxNumResults: z.number().optional(),
-
-  /**
-   * Ranking options for the search.
-   */
   ranking: z
     .object({
       ranker: z.enum(['auto', 'default-2024-08-21']).optional(),
     })
     .optional(),
-
-  /**
-   * A filter to apply based on file attributes.
-   */
   filters: filtersSchema.optional(),
 });
 


### PR DESCRIPTION
## Background

The JSDoc comments for the openai and anthropic provider defined tools were incomplete.

## Summary

* update and add documentation
* sort anthropic tools alphabetically