### PR TITLE
feat (ai): export gateway provider

### DIFF
--- a/.changeset/metal-gifts-walk.md
+++ b/.changeset/metal-gifts-walk.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ai): export gateway provider

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,4 +1,5 @@
 // re-exports:
+export { gateway } from '@ai-sdk/gateway';
 export {
   asSchema,
   createIdGenerator,


### PR DESCRIPTION
## Background

To use gateway model id autocomplete, the `gateway` provider function needs to be called. However, this requires adding a dependency on the gateway provider package.

## Summary

Export the gateway provider from `ai`.