### PR TITLE
 fix(anthropic): ensure tool_result immediately follows tool_use 

### DIFF
--- a/.changeset/bright-brooms-chew.md
+++ b/.changeset/bright-brooms-chew.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): ensure tool_result parts immediately follow corresponding tool_use (fixes #8516)
+
+- Normalize role:"tool" messages into user messages with tool_result first.
+- Reorder assistant mixed content (text before tool_use).
+- Serialize JSON outputs consistently; set is_error only for error outputs.
+
+Adds focused tests (repro + ordering edge cases).


### PR DESCRIPTION
Fixes #8516

## Description

Fixes Anthropic API error where tool_result wasn't immediately following tool_use.

The issue was that our message converter wasn't ensuring tool_result parts appear first when merging user messages. Anthropic's API strictly requires tool_result to immediately follow tool_use, but we were sometimes putting user text first.

## Changes

- Reorder content in user messages so tool_result always comes first
- Fix assistant content ordering for consistency  
- Add tests covering the exact error case from #8516

## Testing

Added reproduction test using the exact sequence from the original issue. All existing tests still pass.
