### PR TITLE
docs: correct broken langchain-stream link to langchain-adapter

### DIFF
--- a/content/docs/07-reference/04-stream-helpers/index.mdx
+++ b/content/docs/07-reference/04-stream-helpers/index.mdx
@@ -79,7 +79,7 @@ collapsed: true
       title: 'LangChainStream',
       description:
         "Transforms the response from LangChain's language models into a readable stream.",
-      href: '/docs/reference/stream-helpers/langchain-stream',
+      href: '/docs/reference/stream-helpers/langchain-adapter',
     },
     {
       title: 'MistralStream',


### PR DESCRIPTION
## Summary
- Fixed broken documentation link from `/docs/reference/stream-helpers/langchain-stream` to `/docs/reference/stream-helpers/langchain-adapter`
- The actual documentation file is `16-langchain-adapter.mdx`, not `langchain-stream`

## Details
The link in the stream helpers index page was pointing to a non-existent path. This PR corrects it to match the actual file name and working URL path.

### Changes
- Updated `content/docs/07-reference/04-stream-helpers/index.mdx` line 82
- Changed `href: '/docs/reference/stream-helpers/langchain-stream'` to `href: '/docs/reference/stream-helpers/langchain-adapter'`

### Verification
- Broken link: https://ai-sdk.dev/docs/reference/stream-helpers/langchain-stream (404)
- Working link: https://ai-sdk.dev/docs/reference/stream-helpers/langchain-adapter (exists)