### PR TITLE
chore: remove response modalities from gemini flash image examples and docs

### DIFF
--- a/content/docs/03-ai-sdk-core/35-image-generation.mdx
+++ b/content/docs/03-ai-sdk-core/35-image-generation.mdx
@@ -231,7 +231,7 @@ try {
 
 ## Generating Images with Language Models
 
-Some language models such as Google `gemini-2.0-flash-exp` support multi-modal outputs including images.
+Some language models such as Google `gemini-2.5-flash-image-preview` support multi-modal outputs including images.
 With such models, you can access the generated images using the `files` property of the response.
 
 ```ts
@@ -239,10 +239,7 @@ import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 
 const result = await generateText({
-  model: google('gemini-2.0-flash-exp'),
-  providerOptions: {
-    google: { responseModalities: ['TEXT', 'IMAGE'] },
-  },
+  model: google('gemini-2.5-flash-image-preview'),
   prompt: 'Generate an image of a comic cat',
 });
 

--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -960,7 +960,7 @@ messages.map(message => (
 
 ## Image Generation
 
-Some models such as Google `gemini-2.0-flash-exp` support image generation.
+Some models such as Google `gemini-2.5-flash-image-preview` support image generation.
 When images are generated, they are exposed as files to the client.
 On the client side, you can access file parts of the message object
 and render them as images.

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -110,7 +110,6 @@ await generateText({
           threshold: 'BLOCK_LOW_AND_ABOVE',
         },
       ],
-      responseModalities: ['TEXT', 'IMAGE'],
     },
   },
 });
@@ -582,7 +581,6 @@ const urlContextMetadata = metadata?.urlContextMetadata;
 ### Image Outputs
 
 Gemini models with image generation capabilities (`gemini-2.5-flash-image-preview`) support image generation. Images are exposed as files in the response.
-You need to enable image output in the provider options using the `responseModalities` option.
 
 ```ts
 import { google } from '@ai-sdk/google';
@@ -590,9 +588,6 @@ import { generateText } from 'ai';
 
 const result = await generateText({
   model: google('gemini-2.5-flash-image-preview'),
-  providerOptions: {
-    google: { responseModalities: ['TEXT', 'IMAGE'] },
-  },
   prompt:
     'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
 });

--- a/examples/ai-core/src/generate-image/google-gemini-editing.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-editing.ts
@@ -7,9 +7,6 @@ async function main() {
   console.log('Generating base cat image...');
   const baseResult = await generateText({
     model: google('gemini-2.5-flash-image-preview'),
-    providerOptions: {
-      google: { responseModalities: ['TEXT', 'IMAGE'] },
-    },
     prompt:
       'A photorealistic picture of a fluffy ginger cat sitting on a wooden table',
   });
@@ -38,9 +35,6 @@ async function main() {
   console.log('Adding wizard hat...');
   const editResult = await generateText({
     model: google('gemini-2.5-flash-image-preview'),
-    providerOptions: {
-      google: { responseModalities: ['TEXT', 'IMAGE'] },
-    },
     prompt: [
       {
         role: 'user',

--- a/examples/ai-core/src/generate-image/google-gemini-image.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-image.ts
@@ -6,9 +6,6 @@ import 'dotenv/config';
 async function main() {
   const result = await generateText({
     model: google('gemini-2.5-flash-image-preview'),
-    providerOptions: {
-      google: { responseModalities: ['TEXT', 'IMAGE'] },
-    },
     prompt:
       'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
   });

--- a/examples/ai-core/src/generate-image/google-gemini-minimal.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-minimal.ts
@@ -5,9 +5,6 @@ import 'dotenv/config';
 async function main() {
   const { files } = await generateText({
     model: google('gemini-2.5-flash-image-preview'),
-    providerOptions: {
-      google: { responseModalities: ['TEXT', 'IMAGE'] },
-    },
     prompt: 'A nano banana in a fancy restaurant',
   });
 

--- a/examples/ai-core/src/generate-text/google-image-output.ts
+++ b/examples/ai-core/src/generate-text/google-image-output.ts
@@ -7,9 +7,6 @@ async function main() {
   const result = await generateText({
     model: google('gemini-2.0-flash-exp'),
     prompt: 'Generate an image of a comic cat',
-    providerOptions: {
-      google: { responseModalities: ['TEXT', 'IMAGE'] },
-    },
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/google-image.ts
+++ b/examples/ai-core/src/generate-text/google-image.ts
@@ -1,4 +1,4 @@
-import { google, GoogleGenerativeAIProviderOptions } from '@ai-sdk/google';
+import { google } from '@ai-sdk/google';
 import { generateText } from 'ai';
 import 'dotenv/config';
 import fs from 'node:fs';

--- a/examples/ai-core/src/generate-text/google-image.ts
+++ b/examples/ai-core/src/generate-text/google-image.ts
@@ -15,11 +15,6 @@ async function main() {
         ],
       },
     ],
-    providerOptions: {
-      google: {
-        responseModalities: ['TEXT', 'IMAGE'],
-      } satisfies GoogleGenerativeAIProviderOptions,
-    },
   });
 
   console.log(result.content);

--- a/examples/ai-core/src/stream-text/google-chatbot-image-output.ts
+++ b/examples/ai-core/src/stream-text/google-chatbot-image-output.ts
@@ -17,9 +17,6 @@ async function main() {
 
     const result = streamText({
       model: google('gemini-2.0-flash-exp'),
-      providerOptions: {
-        google: { responseModalities: ['TEXT', 'IMAGE'] },
-      },
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/google-gemini-2.5-flash-image-preview-chatbot.ts
+++ b/examples/ai-core/src/stream-text/google-gemini-2.5-flash-image-preview-chatbot.ts
@@ -17,9 +17,6 @@ async function main() {
 
     const result = streamText({
       model: google('gemini-2.5-flash-image-preview'),
-      providerOptions: {
-        google: { responseModalities: ['TEXT', 'IMAGE'] },
-      },
       messages,
     });
 

--- a/examples/ai-core/src/stream-text/google-image-output.ts
+++ b/examples/ai-core/src/stream-text/google-image-output.ts
@@ -7,9 +7,6 @@ async function main() {
   const result = streamText({
     model: google('gemini-2.0-flash-exp'),
     prompt: 'Generate an image of a comic cat',
-    providerOptions: {
-      google: { responseModalities: ['TEXT', 'IMAGE'] },
-    },
   });
 
   for await (const part of result.fullStream) {

--- a/examples/ai-core/src/stream-text/vertex-gemini-2.5-flash-image-preview-chatbot.ts
+++ b/examples/ai-core/src/stream-text/vertex-gemini-2.5-flash-image-preview-chatbot.ts
@@ -17,9 +17,6 @@ async function main() {
 
     const result = streamText({
       model: vertex('gemini-2.5-flash-image-preview'),
-      providerOptions: {
-        google: { responseModalities: ['TEXT', 'IMAGE'] },
-      },
       messages,
     });
 

--- a/examples/next-openai/app/api/use-chat-image-output/route.ts
+++ b/examples/next-openai/app/api/use-chat-image-output/route.ts
@@ -8,9 +8,6 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: google('gemini-2.0-flash-exp'),
-    providerOptions: {
-      google: { responseModalities: ['TEXT', 'IMAGE'] },
-    },
     messages: convertToModelMessages(messages),
   });
 


### PR DESCRIPTION
Passing response modalities in provider options is no longer required with gemini flash image.