### PR TITLE
fix(provider/anthropic): add `cacheControl` to `AnthropicProviderOptions`

### DIFF
--- a/.changeset/gorgeous-pets-tie.md
+++ b/.changeset/gorgeous-pets-tie.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(provider/anthorpic): add cacheControl to AnthropicProviderOptions

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -234,18 +234,13 @@ const result = await generateText({
 
 #### Longer cache TTL
 
-Anthropic also supports a longer 1-hour cache duration. At time of writing,
-[this is currently in beta](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#1-hour-cache-duration),
-so you must pass a `'anthropic-beta'` header set to `'extended-cache-ttl-2025-04-11'`.
+Anthropic also supports a longer 1-hour cache duration.
 
 Here's an example:
 
 ```ts
 const result = await generateText({
   model: anthropic('claude-3-5-haiku-latest'),
-  headers: {
-    'anthropic-beta': 'extended-cache-ttl-2025-04-11',
-  },
   messages: [
     {
       role: 'user',

--- a/examples/ai-core/src/generate-text/anthropic-cache-control-beta-1h.ts
+++ b/examples/ai-core/src/generate-text/anthropic-cache-control-beta-1h.ts
@@ -1,4 +1,4 @@
-import { anthropic } from '@ai-sdk/anthropic';
+import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 import 'dotenv/config';
 import fs from 'node:fs';
@@ -26,8 +26,8 @@ async function main() {
             text: cachedMessage,
             providerOptions: {
               anthropic: {
-                cacheControl: { type: 'ephemeral', ttl: '1h' },
-              },
+                cacheControl: { type: 'ephemeral', ttl: '1h'},
+              } satisfies AnthropicProviderOptions,
             },
           },
           {

--- a/examples/ai-core/src/generate-text/anthropic-cache-control-beta-1h.ts
+++ b/examples/ai-core/src/generate-text/anthropic-cache-control-beta-1h.ts
@@ -26,7 +26,7 @@ async function main() {
             text: cachedMessage,
             providerOptions: {
               anthropic: {
-                cacheControl: { type: 'ephemeral', ttl: '1h'},
+                cacheControl: { type: 'ephemeral', ttl: '1h' },
               } satisfies AnthropicProviderOptions,
             },
           },

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -679,9 +679,6 @@ describe('AnthropicMessagesLanguageModel', () => {
       const model = provider('claude-3-haiku-20240307');
 
       const result = await model.doGenerate({
-        headers: {
-          'anthropic-beta': 'extended-cache-ttl-2025-04-11',
-        },
         prompt: [
           {
             role: 'user',
@@ -2534,9 +2531,6 @@ describe('AnthropicMessagesLanguageModel', () => {
 
       const { stream } = await model.doStream({
         prompt: TEST_PROMPT,
-        headers: {
-          'anthropic-beta': 'extended-cache-ttl-2025-04-11',
-        },
       });
 
       expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -553,7 +553,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             providerOptions: {
               anthropic: {
                 cacheControl: { type: 'ephemeral' },
-              },
+              } satisfies AnthropicProviderOptions,
             },
           },
         ],
@@ -689,7 +689,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             providerOptions: {
               anthropic: {
                 cacheControl: { type: 'ephemeral', ttl: '1h' },
-              },
+              } satisfies AnthropicProviderOptions,
             },
           },
         ],

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -67,6 +67,17 @@ export const anthropicProviderOptions = z.object({
    * When set to true, Claude will use at most one tool per response.
    */
   disableParallelToolUse: z.boolean().optional(),
+
+  /**
+   * Cache control settings for this message.
+   * See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+   */
+  cacheControl: z
+    .object({
+      type: z.literal('ephemeral'),
+      ttl: z.union([z.literal('5m'), z.literal('1h')]).optional(),
+    })
+    .optional(),
 });
 
 export type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;


### PR DESCRIPTION
## Background

Follow up to #7526 which I think aimed at implementing support for the `cache_control` input argument, but didn't fix it correctly

## Summary

This was already implemented and tested, but we lacked the type for `AnthropicProviderOptions`

## Manual Verification

`examples/ai-core/src/generate-text/anthropic-cache-control-beta-1h.ts`

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

#7526
