### PR TITLE
fix(provider/openai): file search tool optional query

### DIFF
--- a/.changeset/gold-zoos-smell.md
+++ b/.changeset/gold-zoos-smell.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Fix openai file_search query param to make it optional

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -32,7 +32,7 @@ export const fileSearch = createProviderDefinedToolFactory<
     /**
      * The search query to execute.
      */
-    query: string;
+    query?: string;
   },
   {
     /**
@@ -70,6 +70,6 @@ export const fileSearch = createProviderDefinedToolFactory<
   id: 'openai.file_search',
   name: 'file_search',
   inputSchema: z.object({
-    query: z.string(),
+    query: z.string().optional(),
   }),
 });


### PR DESCRIPTION
## Background

When the `query` param isn't included, `tool-output-error` chunk is thrown despite the tool executing correctly. Is triggering `stopWhen` conditions to run until expiry (30 runs for example when `stopWhen: stepCountIs(30)`)

When the search query is not included, the provider determines it.

## Summary

Made the `query` param optional in the `file_search` openai tool.

## Manual Verification

Using this fix in an internal version with positive results.

## Tasks

<!--
This task list is intended to help you keep track of what you need to do.
Feel free to add tasks and remove unnecessary tasks or this section as needed.

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

Fixes https://github.com/vercel/ai/issues/8479
