### PR TITLE
Safely handles missing reasoning parts

### DIFF
--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -355,11 +355,12 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 
             case 'reasoning-end': {
               const reasoningPart = state.activeReasoningParts[chunk.id];
-              reasoningPart.providerMetadata =
-                chunk.providerMetadata ?? reasoningPart.providerMetadata;
-              reasoningPart.state = 'done';
-              delete state.activeReasoningParts[chunk.id];
-
+              if (reasoningPart){
+                reasoningPart.providerMetadata =
+                  chunk.providerMetadata ?? reasoningPart.providerMetadata;
+                reasoningPart.state = 'done';
+                delete state.activeReasoningParts[chunk.id];
+              }
               write();
               break;
             }


### PR DESCRIPTION
Adds a null check to prevent errors when processing a reasoning-end message for a non-existent or already removed reasoning part.

## Summary

Getting runtime errors when two reasoning end events come in from OpenAI. 

## Manual Verification

Added validation that the reasoning event exists.
