### PR TITLE
fix(ai): do not filter zero-length text parts that have provider options

### DIFF
--- a/.changeset/silly-buses-thank.md
+++ b/.changeset/silly-buses-thank.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): do not filter zero-length text parts that have provider options

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -899,7 +899,7 @@ describe('convertToLanguageModelMessage', () => {
 
   describe('assistant message', () => {
     describe('text parts', () => {
-      it('should ignore empty text parts', async () => {
+      it('should ignore empty text parts when there are no provider options', async () => {
         const result = convertToLanguageModelMessage({
           message: {
             role: 'assistant',
@@ -930,6 +930,58 @@ describe('convertToLanguageModelMessage', () => {
             },
           ],
         });
+      });
+
+      it('should include empty text parts when there are provider options', async () => {
+        const result = convertToLanguageModelMessage({
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: '',
+                providerOptions: {
+                  'test-provider': {
+                    'key-a': 'test-value-1',
+                  },
+                },
+              },
+              {
+                type: 'tool-call',
+                toolName: 'toolName',
+                toolCallId: 'toolCallId',
+                input: {},
+              },
+            ],
+          },
+          downloadedAssets: {},
+        });
+
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "content": [
+              {
+                "providerOptions": {
+                  "test-provider": {
+                    "key-a": "test-value-1",
+                  },
+                },
+                "text": "",
+                "type": "text",
+              },
+              {
+                "input": {},
+                "providerExecuted": undefined,
+                "providerOptions": undefined,
+                "toolCallId": "toolCallId",
+                "toolName": "toolName",
+                "type": "tool-call",
+              },
+            ],
+            "providerOptions": undefined,
+            "role": "assistant",
+          }
+        `);
       });
     });
 

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -108,8 +108,11 @@ export function convertToLanguageModelMessage({
         role: 'assistant',
         content: message.content
           .filter(
-            // remove empty text parts:
-            part => part.type !== 'text' || part.text !== '',
+            // remove empty text parts (no text, and no provider options):
+            part =>
+              part.type !== 'text' ||
+              part.text !== '' ||
+              part.providerOptions != null,
           )
           .map(part => {
             const providerOptions = part.providerOptions;


### PR DESCRIPTION
## Background

Filtering out empty message parts from the OpenAI responses API can lead to `Item 'rs_...' was provided without its required following item` issues (see #8321 ).

## Summary

Limit filtering of empty message parts to cases where there are no provider options.

## Manual Verification

Verified during #8324

## Related Issues

Discovered during #8324 
Fixes one cause of #8321