### PR TITLE
ci(release): remove v5 branch targets from github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, v5]
+    branches: [main]
   pull_request:
-    branches: [main, v5]
+    branches: [main]
 
 jobs:
   build-examples:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v5
     paths:
       - '.changeset/**'
       - '.github/workflows/release.yml'


### PR DESCRIPTION
## Summary

remove v5 branch targets from github actions