### PR TITLE
fix(provider/groq): track cached tokens usage

### DIFF
--- a/.changeset/wise-jobs-knock.md
+++ b/.changeset/wise-jobs-knock.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+fix(provider/groq): track cached tokens usage

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -53,6 +53,9 @@ describe('doGenerate', () => {
       prompt_tokens?: number;
       total_tokens?: number;
       completion_tokens?: number;
+      prompt_tokens_details?: {
+        cached_tokens?: number;
+      };
     };
     finish_reason?: string;
     created?: number;
@@ -134,6 +137,7 @@ describe('doGenerate', () => {
 
     expect(usage).toMatchInlineSnapshot(`
       {
+        "cachedInputTokens": undefined,
         "inputTokens": 20,
         "outputTokens": 5,
         "totalTokens": 25,
@@ -173,12 +177,40 @@ describe('doGenerate', () => {
 
     expect(usage).toMatchInlineSnapshot(`
       {
+        "cachedInputTokens": undefined,
         "inputTokens": 20,
         "outputTokens": undefined,
         "totalTokens": 20,
       }
     `);
   });
+
+  it('should extract cached input tokens', async () => {
+    prepareJsonResponse({
+      usage: {
+        prompt_tokens: 20,
+        total_tokens: 25,
+        completion_tokens: 5,
+        prompt_tokens_details: {
+          cached_tokens: 15,
+        },
+      },
+    });
+
+    const { usage } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(usage).toMatchInlineSnapshot(`
+      {
+        "cachedInputTokens": 15,
+        "inputTokens": 20,
+        "outputTokens": 5,
+        "totalTokens": 25,
+      }
+    `);
+  });
+
   it('should extract finish reason', async () => {
     prepareJsonResponse({
       finish_reason: 'stop',
@@ -812,6 +844,7 @@ describe('doStream', () => {
           "finishReason": "stop",
           "type": "finish",
           "usage": {
+            "cachedInputTokens": undefined,
             "inputTokens": 18,
             "outputTokens": 439,
             "totalTokens": 457,
@@ -895,6 +928,7 @@ describe('doStream', () => {
           "finishReason": "stop",
           "type": "finish",
           "usage": {
+            "cachedInputTokens": undefined,
             "inputTokens": 18,
             "outputTokens": 439,
             "totalTokens": 457,
@@ -1025,6 +1059,7 @@ describe('doStream', () => {
           "finishReason": "tool-calls",
           "type": "finish",
           "usage": {
+            "cachedInputTokens": undefined,
             "inputTokens": 18,
             "outputTokens": 439,
             "totalTokens": 457,
@@ -1160,6 +1195,7 @@ describe('doStream', () => {
           "finishReason": "tool-calls",
           "type": "finish",
           "usage": {
+            "cachedInputTokens": undefined,
             "inputTokens": 18,
             "outputTokens": 439,
             "totalTokens": 457,
@@ -1286,6 +1322,7 @@ describe('doStream', () => {
           "finishReason": "tool-calls",
           "type": "finish",
           "usage": {
+            "cachedInputTokens": undefined,
             "inputTokens": undefined,
             "outputTokens": undefined,
             "totalTokens": undefined,
@@ -1365,6 +1402,7 @@ describe('doStream', () => {
           "finishReason": "tool-calls",
           "type": "finish",
           "usage": {
+            "cachedInputTokens": undefined,
             "inputTokens": 18,
             "outputTokens": 439,
             "totalTokens": 457,
@@ -1405,6 +1443,7 @@ describe('doStream', () => {
           "finishReason": "error",
           "type": "finish",
           "usage": {
+            "cachedInputTokens": undefined,
             "inputTokens": undefined,
             "outputTokens": undefined,
             "totalTokens": undefined,
@@ -1443,6 +1482,7 @@ describe('doStream', () => {
             "finishReason": "error",
             "type": "finish",
             "usage": {
+              "cachedInputTokens": undefined,
               "inputTokens": undefined,
               "outputTokens": undefined,
               "totalTokens": undefined,
@@ -1643,6 +1683,7 @@ describe('doStream with raw chunks', () => {
           "finishReason": "stop",
           "type": "finish",
           "usage": {
+            "cachedInputTokens": undefined,
             "inputTokens": 10,
             "outputTokens": 5,
             "totalTokens": 15,

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -224,6 +224,8 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
         inputTokens: response.usage?.prompt_tokens ?? undefined,
         outputTokens: response.usage?.completion_tokens ?? undefined,
         totalTokens: response.usage?.total_tokens ?? undefined,
+        cachedInputTokens:
+          response.usage?.prompt_tokens_details?.cached_tokens ?? undefined,
       },
       response: {
         ...getResponseMetadata(response),
@@ -274,6 +276,7 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
       inputTokens: undefined,
       outputTokens: undefined,
       totalTokens: undefined,
+      cachedInputTokens: undefined,
     };
     let isFirstChunk = true;
     let isActiveText = false;
@@ -326,6 +329,9 @@ export class GroqChatLanguageModel implements LanguageModelV2 {
               usage.outputTokens =
                 value.x_groq.usage.completion_tokens ?? undefined;
               usage.totalTokens = value.x_groq.usage.total_tokens ?? undefined;
+              usage.cachedInputTokens =
+                value.x_groq.usage.prompt_tokens_details?.cached_tokens ??
+                undefined;
             }
 
             const choice = value.choices[0];
@@ -546,6 +552,11 @@ const groqChatResponseSchema = z.object({
       prompt_tokens: z.number().nullish(),
       completion_tokens: z.number().nullish(),
       total_tokens: z.number().nullish(),
+      prompt_tokens_details: z
+        .object({
+          cached_tokens: z.number().nullish(),
+        })
+        .nullish(),
     })
     .nullish(),
 });
@@ -589,6 +600,11 @@ const groqChatChunkSchema = z.union([
             prompt_tokens: z.number().nullish(),
             completion_tokens: z.number().nullish(),
             total_tokens: z.number().nullish(),
+            prompt_tokens_details: z
+              .object({
+                cached_tokens: z.number().nullish(),
+              })
+              .nullish(),
           })
           .nullish(),
       })


### PR DESCRIPTION

## Background

Groq now supports prompt caching for kimi-k2, we were not tracking this in `usage`.

https://console.groq.com/docs/prompt-caching#tracking-cache-usage

## Summary

Added the correct response format handling for usage.

## Manual Verification

@gr2m verified with example provided by @andrewdoro 

## Tasks

- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

fixes #8722