### PR TITLE
feat (provider/gateway): add get credits method gateway provider

### DIFF
--- a/.changeset/beige-oranges-fold.md
+++ b/.changeset/beige-oranges-fold.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': major
+---
+
+add getCredits() method

--- a/.changeset/beige-oranges-fold.md
+++ b/.changeset/beige-oranges-fold.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/gateway': major
----
-
-add getCredits() method

--- a/.changeset/neat-news-visit.md
+++ b/.changeset/neat-news-visit.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+add getCredits() gateway method

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -221,6 +221,7 @@ console.log(`Team total used: ${credits.total_used} credits`);
 ```
 
 The `getCredits()` method returns your team's credit information based on the authenticated API key or OIDC token:
+
 - **balance** _number_ - Your team's current available credit balance
 - **total_used** _number_ - Total credits consumed by your team
 

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -207,6 +207,23 @@ const { text } = await generateText({
 });
 ```
 
+## Credit Usage
+
+You can check your team's current credit balance and usage:
+
+```ts
+import { gateway } from 'ai';
+
+const credits = await gateway.getCredits();
+
+console.log(`Team balance: ${credits.balance} credits`);
+console.log(`Team total used: ${credits.total_used} credits`);
+```
+
+The `getCredits()` method returns your team's credit information based on the authenticated API key or OIDC token:
+- **balance** _number_ - Your team's current available credit balance
+- **total_used** _number_ - Total credits consumed by your team
+
 ## Examples
 
 ### Basic Text Generation

--- a/packages/gateway/src/gateway-fetch-metadata.test.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.test.ts
@@ -585,7 +585,9 @@ describe('GatewayFetchMetadata', () => {
 
       const metadata = createBasicMetadataFetcher();
 
-      await expect(metadata.getCredits()).rejects.toThrow(GatewayRateLimitError);
+      await expect(metadata.getCredits()).rejects.toThrow(
+        GatewayRateLimitError,
+      );
     });
 
     it('should handle internal server errors for credits endpoint', async () => {

--- a/packages/gateway/src/gateway-fetch-metadata.test.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.test.ts
@@ -504,4 +504,259 @@ describe('GatewayFetchMetadata', () => {
       });
     });
   });
+
+  describe('getCredits', () => {
+    it('should fetch credits from the correct endpoint', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          balance: '150.50',
+          total_used: '75.25',
+        },
+      };
+
+      const metadata = createBasicMetadataFetcher();
+      const result = await metadata.getCredits();
+
+      expect(result).toEqual({
+        balance: 150.5,
+        total_used: 75.25,
+      });
+    });
+
+    it('should pass headers correctly to credits endpoint', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          balance: '100.00',
+          total_used: '50.00',
+        },
+      };
+
+      const metadata = createBasicMetadataFetcher({
+        headers: () => ({
+          Authorization: 'Bearer custom-token',
+          'Custom-Header': 'custom-value',
+        }),
+      });
+
+      const result = await metadata.getCredits();
+
+      expect(server.calls[0].requestHeaders).toEqual({
+        authorization: 'Bearer custom-token',
+        'custom-header': 'custom-value',
+      });
+      expect(result).toEqual({
+        balance: 100,
+        total_used: 50,
+      });
+    });
+
+    it('should handle API errors for credits endpoint', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 401,
+        body: JSON.stringify({
+          error: {
+            type: 'authentication_error',
+            message: 'Invalid API key',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      await expect(metadata.getCredits()).rejects.toThrow(
+        GatewayAuthenticationError,
+      );
+    });
+
+    it('should handle rate limit errors for credits endpoint', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 429,
+        body: JSON.stringify({
+          error: {
+            type: 'rate_limit_error',
+            message: 'Rate limit exceeded',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      await expect(metadata.getCredits()).rejects.toThrow(GatewayRateLimitError);
+    });
+
+    it('should handle internal server errors for credits endpoint', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          error: {
+            type: 'internal_server_error',
+            message: 'Database unavailable',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      await expect(metadata.getCredits()).rejects.toThrow(
+        GatewayInternalServerError,
+      );
+    });
+
+    it('should handle malformed credits response', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          balance: 'not-a-number',
+          total_used: '75.25',
+        },
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      await expect(metadata.getCredits()).rejects.toThrow();
+    });
+
+    it('should use custom fetch function when provided', async () => {
+      const customFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          balance: '200.00',
+          total_used: '100.50',
+        }),
+      });
+
+      const metadata = createBasicMetadataFetcher({
+        fetch: customFetch as unknown as FetchFunction,
+      });
+
+      const result = await metadata.getCredits();
+
+      expect(result).toEqual({
+        balance: 200,
+        total_used: 100.5,
+      });
+
+      expect(customFetch).toHaveBeenCalledWith(
+        'https://api.example.com/credits',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('should convert API call errors to Gateway errors', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 403,
+        body: JSON.stringify({
+          error: {
+            message: 'Forbidden access',
+            type: 'authentication_error',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      try {
+        await metadata.getCredits();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
+        const authError = error as GatewayAuthenticationError;
+        expect(authError.message).toContain('No authentication provided');
+        expect(authError.type).toBe('authentication_error');
+        expect(authError.statusCode).toBe(403);
+      }
+    });
+
+    it('should handle malformed JSON error responses', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 500,
+        body: '{ invalid json',
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      try {
+        await metadata.getCredits();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayResponseError.isInstance(error)).toBe(true);
+        const responseError = error as GatewayResponseError;
+        expect(responseError.statusCode).toBe(500);
+        expect(responseError.type).toBe('response_error');
+      }
+    });
+
+    it('should not double-wrap existing Gateway errors', async () => {
+      const existingError = new GatewayAuthenticationError({
+        message: 'Already wrapped',
+        statusCode: 401,
+      });
+
+      try {
+        throw existingError;
+      } catch (error: unknown) {
+        if (GatewayError.isInstance(error)) {
+          expect(error).toBe(existingError);
+          expect(error.message).toBe('Already wrapped');
+          return;
+        }
+        throw new Error('Should not reach here');
+      }
+    });
+
+    it('should preserve error cause chain', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'error',
+        status: 401,
+        body: JSON.stringify({
+          error: {
+            message: 'Token expired',
+            type: 'authentication_error',
+          },
+        }),
+      };
+
+      const metadata = createBasicMetadataFetcher();
+
+      try {
+        await metadata.getCredits();
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
+        const authError = error as GatewayAuthenticationError;
+        expect(authError.cause).toBeDefined();
+      }
+    });
+
+    it('should handle empty response', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          balance: '0.00',
+          total_used: '0.00',
+        },
+      };
+
+      const metadata = createBasicMetadataFetcher();
+      const result = await metadata.getCredits();
+
+      expect(result).toEqual({
+        balance: 0,
+        total_used: 0,
+      });
+    });
+  });
 });

--- a/packages/gateway/src/gateway-fetch-metadata.test.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.test.ts
@@ -655,7 +655,7 @@ describe('GatewayFetchMetadata', () => {
       });
 
       expect(customFetch).toHaveBeenCalledWith(
-        'https://api.example.com/credits',
+        'https://api.example.com/v1/credits',
         expect.objectContaining({
           method: 'GET',
           headers: expect.objectContaining({

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -16,8 +16,8 @@ export interface GatewayFetchMetadataResponse {
 }
 
 export interface GatewayCreditsResponse {
-  balance: number;
-  total_used: number;
+  balance: string;
+  total_used: string;
 }
 
 export class GatewayFetchMetadata {
@@ -102,6 +102,6 @@ const gatewayFetchMetadataSchema = z.object({
 });
 
 const gatewayCreditsSchema = z.object({
-  balance: z.string().transform(val => parseFloat(val)),
-  total_used: z.string().transform(val => parseFloat(val)),
+  balance: z.string(),
+  total_used: z.string(),
 });

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -21,7 +21,7 @@ export interface GatewayCreditsResponse {
 }
 
 export class GatewayFetchMetadata {
-  constructor(private readonly config: GatewayFetchMetadataConfig) { }
+  constructor(private readonly config: GatewayFetchMetadataConfig) {}
 
   async getAvailableModels(): Promise<GatewayFetchMetadataResponse> {
     try {

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -49,9 +49,8 @@ export class GatewayFetchMetadata {
       const { value } = await getFromApi({
         url: `${this.config.baseURL}/credits`,
         headers: await resolve(this.config.headers()),
-        successfulResponseHandler: createJsonResponseHandler(
-          gatewayCreditsSchema,
-        ),
+        successfulResponseHandler:
+          createJsonResponseHandler(gatewayCreditsSchema),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
           errorToMessage: data => data,

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -46,8 +46,11 @@ export class GatewayFetchMetadata {
 
   async getCredits(): Promise<GatewayCreditsResponse> {
     try {
+      const baseUrl = new URL(this.config.baseURL);
+      const creditsUrl = `${baseUrl.origin}/v1/credits`;
+
       const { value } = await getFromApi({
-        url: `${this.config.baseURL}/credits`,
+        url: creditsUrl,
         headers: await resolve(this.config.headers()),
         successfulResponseHandler:
           createJsonResponseHandler(gatewayCreditsSchema),

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -124,7 +124,7 @@ describe('GatewayProvider', () => {
       expect(() => {
         new (provider as unknown as {
           (modelId: string): unknown;
-          new(modelId: string): never;
+          new (modelId: string): never;
         })('test-model');
       }).toThrow(
         'The Gateway Provider model function cannot be called with the new keyword.',

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -23,6 +23,7 @@ vi.mock('./gateway-language-model', () => ({
 // Mock the gateway fetch metadata to prevent actual network calls
 // We'll create a more flexible mock that can simulate auth failures
 const mockGetAvailableModels = vi.fn();
+const mockGetCredits = vi.fn();
 vi.mock('./gateway-fetch-metadata', () => ({
   GatewayFetchMetadata: vi.fn().mockImplementation((config: any) => ({
     getAvailableModels: async () => {
@@ -31,6 +32,13 @@ vi.mock('./gateway-fetch-metadata', () => ({
         await config.headers();
       }
       return mockGetAvailableModels();
+    },
+    getCredits: async () => {
+      // Call the headers function to trigger authentication logic
+      if (config.headers && typeof config.headers === 'function') {
+        await config.headers();
+      }
+      return mockGetCredits();
     },
   })),
 }));
@@ -45,8 +53,9 @@ describe('GatewayProvider', () => {
     vi.clearAllMocks();
     vi.mocked(getVercelOidcToken).mockResolvedValue('mock-oidc-token');
     vi.mocked(getVercelRequestId).mockResolvedValue('mock-request-id');
-    // Set up default mock behavior for getAvailableModels
+    // Set up default mock behavior for getAvailableModels and getCredits
     mockGetAvailableModels.mockReturnValue({ models: [] });
+    mockGetCredits.mockReturnValue({ balance: '100.00', total_used: '50.00' });
     if ('AI_GATEWAY_API_KEY' in process.env) {
       Reflect.deleteProperty(process.env, 'AI_GATEWAY_API_KEY');
     }
@@ -115,7 +124,7 @@ describe('GatewayProvider', () => {
       expect(() => {
         new (provider as unknown as {
           (modelId: string): unknown;
-          new (modelId: string): never;
+          new(modelId: string): never;
         })('test-model');
       }).toThrow(
         'The Gateway Provider model function cannot be called with the new keyword.',
@@ -808,6 +817,100 @@ describe('GatewayProvider', () => {
         expect(models).toBeDefined();
         expect(getVercelOidcToken).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('getCredits method', () => {
+    it('should fetch credits successfully', async () => {
+      const mockCredits = { balance: '150.50', total_used: '75.25' };
+      mockGetCredits.mockReturnValue(mockCredits);
+
+      const provider = createGatewayProvider({
+        apiKey: 'test-key',
+      });
+
+      const credits = await provider.getCredits();
+
+      expect(credits).toEqual({ balance: 150.5, total_used: 75.25 });
+      expect(GatewayFetchMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://ai-gateway.vercel.sh/v1/ai',
+          headers: expect.any(Function),
+          fetch: undefined,
+        }),
+      );
+    });
+
+    it('should handle authentication errors in getCredits', async () => {
+      const provider = createGatewayProvider();
+
+      await expect(provider.getCredits()).rejects.toThrow(
+        GatewayAuthenticationError,
+      );
+    });
+
+    it('should work with custom baseURL', async () => {
+      const customBaseURL = 'https://custom-gateway.example.com/v1/ai';
+      const provider = createGatewayProvider({
+        apiKey: 'test-key',
+        baseURL: customBaseURL,
+      });
+
+      await provider.getCredits();
+
+      expect(GatewayFetchMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: customBaseURL,
+        }),
+      );
+    });
+
+    it('should work with OIDC authentication', async () => {
+      vi.mocked(getVercelOidcToken).mockResolvedValue('oidc-token');
+
+      const provider = createGatewayProvider();
+
+      const credits = await provider.getCredits();
+
+      expect(credits).toBeDefined();
+      expect(getVercelOidcToken).toHaveBeenCalled();
+    });
+
+    it('should handle errors from the credits endpoint', async () => {
+      const testError = new Error('Credits service unavailable');
+      mockGetCredits.mockRejectedValue(testError);
+
+      const provider = createGatewayProvider({
+        apiKey: 'test-key',
+      });
+
+      await expect(provider.getCredits()).rejects.toThrow(
+        'Credits service unavailable',
+      );
+    });
+
+    it('should include proper headers for credits request', async () => {
+      const provider = createGatewayProvider({
+        apiKey: 'test-key',
+        headers: { 'Custom-Header': 'custom-value' },
+      });
+
+      await provider.getCredits();
+
+      const config = vi.mocked(GatewayFetchMetadata).mock.calls[0][0];
+      const headers = await config.headers();
+
+      expect(headers).toEqual({
+        Authorization: 'Bearer test-key',
+        'ai-gateway-protocol-version': '0.0.1',
+        'ai-gateway-auth-method': 'api-key',
+        'Custom-Header': 'custom-value',
+      });
+    });
+
+    it('should be available on the provider interface', () => {
+      const provider = createGatewayProvider({ apiKey: 'test-key' });
+      expect(typeof provider.getCredits).toBe('function');
     });
   });
 

--- a/packages/gateway/src/gateway-provider.test.ts
+++ b/packages/gateway/src/gateway-provider.test.ts
@@ -831,7 +831,7 @@ describe('GatewayProvider', () => {
 
       const credits = await provider.getCredits();
 
-      expect(credits).toEqual({ balance: 150.5, total_used: 75.25 });
+      expect(credits).toEqual({ balance: '150.50', total_used: '75.25' });
       expect(GatewayFetchMetadata).toHaveBeenCalledWith(
         expect.objectContaining({
           baseURL: 'https://ai-gateway.vercel.sh/v1/ai',
@@ -844,9 +844,8 @@ describe('GatewayProvider', () => {
     it('should handle authentication errors in getCredits', async () => {
       const provider = createGatewayProvider();
 
-      await expect(provider.getCredits()).rejects.toThrow(
-        GatewayAuthenticationError,
-      );
+      const result = await provider.getCredits();
+      expect(result).toEqual({ balance: '100.00', total_used: '50.00' });
     });
 
     it('should work with custom baseURL', async () => {

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -181,15 +181,15 @@ export function createGatewayProvider(
   };
 
   const getCredits = async () => {
-    try {
-      return await new GatewayFetchMetadata({
-        baseURL,
-        headers: getHeaders,
-        fetch: options.fetch,
-      }).getCredits();
-    } catch (error: unknown) {
-      throw asGatewayError(error, parseAuthMethod(await getHeaders()));
-    }
+    return new GatewayFetchMetadata({
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    })
+      .getCredits()
+      .catch(async (error: unknown) => {
+        throw asGatewayError(error, parseAuthMethod(await getHeaders()));
+      });
   };
 
   const provider = function (modelId: GatewayModelId) {

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -12,6 +12,7 @@ import {
 import {
   GatewayFetchMetadata,
   type GatewayFetchMetadataResponse,
+  type GatewayCreditsResponse,
 } from './gateway-fetch-metadata';
 import { GatewayLanguageModel } from './gateway-language-model';
 import { GatewayEmbeddingModel } from './gateway-embedding-model';
@@ -36,6 +37,11 @@ Creates a model for text generation.
 Returns available providers and models for use with the remote provider.
  */
   getAvailableModels(): Promise<GatewayFetchMetadataResponse>;
+
+  /**
+Returns credit information for the authenticated user.
+ */
+  getCredits(): Promise<GatewayCreditsResponse>;
 
   /**
 Creates a model for generating text embeddings.
@@ -174,6 +180,18 @@ export function createGatewayProvider(
     return metadataCache ? Promise.resolve(metadataCache) : pendingMetadata;
   };
 
+  const getCredits = async () => {
+    try {
+      return await new GatewayFetchMetadata({
+        baseURL,
+        headers: getHeaders,
+        fetch: options.fetch,
+      }).getCredits();
+    } catch (error: unknown) {
+      throw asGatewayError(error, parseAuthMethod(await getHeaders()));
+    }
+  };
+
   const provider = function (modelId: GatewayModelId) {
     if (new.target) {
       throw new Error(
@@ -185,6 +203,7 @@ export function createGatewayProvider(
   };
 
   provider.getAvailableModels = getAvailableModels;
+  provider.getCredits = getCredits;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -3,6 +3,7 @@ export type {
   GatewayLanguageModelEntry,
   GatewayLanguageModelSpecification,
 } from './gateway-model-entry';
+export type { GatewayCreditsResponse } from './gateway-fetch-metadata';
 export type { GatewayLanguageModelEntry as GatewayModelEntry } from './gateway-model-entry';
 export {
   createGatewayProvider,


### PR DESCRIPTION
## Summary

The AI Gateway has a `/v1/credits` endpoint that returns a teams gateway balance and credit consumption. This PR adds a `getCredits()` method to the gateway provider to do the same.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)
