### PR TITLE
fix(ai): add missing agent settings

### DIFF
--- a/.changeset/orange-trains-destroy.md
+++ b/.changeset/orange-trains-destroy.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): add missing agent settings

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -7,7 +7,7 @@ import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
 import { PrepareStepFunction } from '../generate-text/prepare-step';
 import { StopCondition } from '../generate-text/stop-condition';
-import { streamText } from '../generate-text/stream-text';
+import { streamText, StreamTextTransform } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
 import { ToolSet } from '../generate-text/tool-set';
@@ -86,6 +86,15 @@ A function that attempts to repair a tool call that failed to parse.
   experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
 
   /**
+   * Optional stream transformations.
+   * They are applied in the order they are provided.
+   * The stream transformations must maintain the stream structure for streamText to work correctly.
+   */
+  experimental_transform?:
+    | StreamTextTransform<TOOLS>
+    | Array<StreamTextTransform<TOOLS>>;
+
+  /**
   Callback that is called when each step (LLM call) is finished, including intermediate steps.
   */
   onStepFinish?: GenerateTextOnStepFinishCallback<NoInfer<TOOLS>>;
@@ -98,6 +107,19 @@ A function that attempts to repair a tool call that failed to parse.
    * @default undefined
    */
   experimental_context?: unknown;
+
+  /**
+   * Additional provider-specific metadata. They are passed through
+   * from the provider to the AI SDK and enable provider-specific
+   * results that can be fully encapsulated in the provider.
+   */
+  providerMetadata?: ProviderMetadata;
+  /**
+   * Additional provider-specific metadata. They are passed through
+   *  to the provider from the AI SDK and enable provider-specific
+   * functionality that can be fully encapsulated in the provider.
+   */
+  providerOptions?: ProviderOptions;
 
   /**
    * Internal. For test use only. May change without notice.


### PR DESCRIPTION
## Background

Agents already support packaging up the provider model but it was odd that you could not also package up the provider settings with the Agent

## Summary

Added `providerOptions`, `providerMetadata`, and `experimental_transform` settings to the agent.  They can still be overwritten at the time when `stream` or `respond` is called.  I aslo cleaned up some doc comments while I was in this file

## Manual Verification

Tested in my PoC project

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

There are probably more missing settings that others may want to bundle up with the Agent

## Related Issues

N/A
