### PR TITLE
(feat): add getGeneration() method for gateway provider

### DIFF
--- a/.changeset/young-drinks-enjoy.md
+++ b/.changeset/young-drinks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+add getGeneration() method on gateway provider

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -225,6 +225,25 @@ The `getCredits()` method returns your team's credit information based on the au
 - **balance** _number_ - Your team's current available credit balance
 - **total_used** _number_ - Total credits consumed by your team
 
+## Generation Data
+
+You can retrieve detailed information about a specific generation using its `generationId`:
+
+```ts
+import { gateway } from 'ai';
+
+const generationData = await gateway.getGeneration('gen_01234567890123456789012345');
+
+console.log(`Provider: ${generationData.provider}`);
+console.log(`Model: ${generationData.model}`);
+console.log(`Cost: $${generationData.cost}`);
+console.log(`Input tokens: ${generationData.inputTokens}`);
+console.log(`Output tokens: ${generationData.outputTokens}`);
+console.log(`Request duration: ${generationData.requestDurationMs}ms`);
+console.log(`Time to first token: ${generationData.timeToFirstTokenMs}`);
+console.log(`Token throughput: ${generationData.tokenThroughput}`);
+```
+
 ## Examples
 
 ### Basic Text Generation

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -20,6 +20,43 @@ export interface GatewayCreditsResponse {
   total_used: string;
 }
 
+export interface GatewayGenerationResponse {
+  timestamp: string;
+  projectId: string;
+  ownerId: string;
+  referrerUrl: string;
+  appName: string;
+  environment: string;
+  deploymentId: string;
+  gatewayModelId: string;
+  model: string;
+  modelType: string;
+  provider: string;
+  currency: string;
+  marketCostCurrency: string;
+  cachedInputTokensCurrency: string;
+  cacheCreationInputTokensCurrency: string;
+  responseStatusCode: number;
+  inputCostPerToken: number;
+  inputCostPerTokenCurrency: string;
+  outputCostPerToken: number;
+  outputCostPerTokenCurrency: string;
+  gatewayTimestamp: string;
+  isFreeTier: string;
+  isByok: string;
+  generationId: string;
+  cost: number;
+  marketCost: number;
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  cacheCreationInputTokens: number;
+  reasoningTokens: number;
+  requestDurationMs: number;
+  timeToFirstTokenMs: number;
+  tokenThroughput: number;
+}
+
 export class GatewayFetchMetadata {
   constructor(private readonly config: GatewayFetchMetadataConfig) {}
 
@@ -54,6 +91,31 @@ export class GatewayFetchMetadata {
         headers: await resolve(this.config.headers()),
         successfulResponseHandler:
           createJsonResponseHandler(gatewayCreditsSchema),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        fetch: this.config.fetch,
+      });
+
+      return value;
+    } catch (error) {
+      throw asGatewayError(error);
+    }
+  }
+
+  async getGeneration(
+    generationId: string,
+  ): Promise<GatewayGenerationResponse> {
+    try {
+      const baseUrl = new URL(this.config.baseURL);
+
+      const { value } = await getFromApi({
+        url: `${baseUrl.origin}/v1/generation?id=${encodeURIComponent(generationId)}`,
+        headers: await resolve(this.config.headers()),
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewayGenerationSchema,
+        ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
           errorToMessage: data => data,
@@ -106,4 +168,41 @@ const gatewayFetchMetadataSchema = z.object({
 const gatewayCreditsSchema = z.object({
   balance: z.string(),
   total_used: z.string(),
+});
+
+const gatewayGenerationSchema = z.object({
+  timestamp: z.string(),
+  projectId: z.string(),
+  ownerId: z.string(),
+  referrerUrl: z.string(),
+  appName: z.string(),
+  environment: z.string(),
+  deploymentId: z.string(),
+  gatewayModelId: z.string(),
+  model: z.string(),
+  modelType: z.string(),
+  provider: z.string(),
+  currency: z.string(),
+  marketCostCurrency: z.string(),
+  cachedInputTokensCurrency: z.string(),
+  cacheCreationInputTokensCurrency: z.string(),
+  responseStatusCode: z.number(),
+  inputCostPerToken: z.number(),
+  inputCostPerTokenCurrency: z.string(),
+  outputCostPerToken: z.number(),
+  outputCostPerTokenCurrency: z.string(),
+  gatewayTimestamp: z.string(),
+  isFreeTier: z.string(),
+  isByok: z.string(),
+  generationId: z.string(),
+  cost: z.number(),
+  marketCost: z.number(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cachedInputTokens: z.number(),
+  cacheCreationInputTokens: z.number(),
+  reasoningTokens: z.number(),
+  requestDurationMs: z.number(),
+  timeToFirstTokenMs: z.number(),
+  tokenThroughput: z.number(),
 });

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -13,6 +13,7 @@ import {
   GatewayFetchMetadata,
   type GatewayFetchMetadataResponse,
   type GatewayCreditsResponse,
+  type GatewayGenerationResponse,
 } from './gateway-fetch-metadata';
 import { GatewayLanguageModel } from './gateway-language-model';
 import { GatewayEmbeddingModel } from './gateway-embedding-model';
@@ -42,6 +43,11 @@ Returns available providers and models for use with the remote provider.
 Returns credit information for the authenticated user.
  */
   getCredits(): Promise<GatewayCreditsResponse>;
+
+  /**
+Returns generation information for a specific generation ID.
+ */
+  getGeneration(generationId: string): Promise<GatewayGenerationResponse>;
 
   /**
 Creates a model for generating text embeddings.
@@ -192,6 +198,18 @@ export function createGatewayProvider(
       });
   };
 
+  const getGeneration = async (generationId: string) => {
+    return new GatewayFetchMetadata({
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    })
+      .getGeneration(generationId)
+      .catch(async (error: unknown) => {
+        throw asGatewayError(error, parseAuthMethod(await getHeaders()));
+      });
+  };
+
   const provider = function (modelId: GatewayModelId) {
     if (new.target) {
       throw new Error(
@@ -204,6 +222,7 @@ export function createGatewayProvider(
 
   provider.getAvailableModels = getAvailableModels;
   provider.getCredits = getCredits;
+  provider.getGeneration = getGeneration;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -3,7 +3,10 @@ export type {
   GatewayLanguageModelEntry,
   GatewayLanguageModelSpecification,
 } from './gateway-model-entry';
-export type { GatewayCreditsResponse } from './gateway-fetch-metadata';
+export type {
+  GatewayCreditsResponse,
+  GatewayGenerationResponse,
+} from './gateway-fetch-metadata';
 export type { GatewayLanguageModelEntry as GatewayModelEntry } from './gateway-model-entry';
 export {
   createGatewayProvider,


### PR DESCRIPTION
## Summary

This PR adds a `getGeneration(id)` method to the gateway provider that calls the new `/v1/generation` gateway endpoint

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)