### PR TITLE
feat (provider/cerebras): enable structured outputs

### DIFF
--- a/.changeset/grumpy-actors-sleep.md
+++ b/.changeset/grumpy-actors-sleep.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cerebras': patch
+---
+
+feat (provider/cerebras): enable structured outputs

--- a/examples/ai-core/src/generate-object/cerebras.ts
+++ b/examples/ai-core/src/generate-object/cerebras.ts
@@ -1,0 +1,30 @@
+import { cerebras } from '@ai-sdk/cerebras';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await generateObject({
+    model: cerebras('gpt-oss-120b'),
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({
+            name: z.string(),
+            amount: z.string(),
+          }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log(JSON.stringify(result.object.recipe, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-object/cerebras.ts
+++ b/examples/ai-core/src/stream-object/cerebras.ts
@@ -1,0 +1,33 @@
+import { cerebras } from '@ai-sdk/cerebras';
+import { streamObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = streamObject({
+    model: cerebras('gpt-oss-120b'),
+    schema: z.object({
+      characters: z.array(
+        z.object({
+          name: z.string(),
+          class: z
+            .string()
+            .describe('Character class, e.g. warrior, mage, or thief.'),
+          description: z.string(),
+        }),
+      ),
+    }),
+    prompt:
+      'Generate 3 character descriptions for a fantasy role playing game.',
+  });
+
+  for await (const partialObject of result.partialObjectStream) {
+    console.clear();
+    console.log(partialObject);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+}
+
+main().catch(console.error);

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -87,6 +87,7 @@ export function createCerebras(
       headers: getHeaders,
       fetch: options.fetch,
       errorStructure: cerebrasErrorStructure,
+      supportsStructuredOutputs: true,
     });
   };
 


### PR DESCRIPTION
## Background

Cerebras supports structured outputs in at least some models now per https://inference-docs.cerebras.ai/capabilities/structured-outputs

In https://github.com/nvie/ai/commit/c79511dd62bcc3b884727e084970f32a7a54716b we added a provider setting to `openai-compatible` to allow derived providers to enable the feature when available.

## Summary

Enable `supportsStructuredOutputs` in the Cerebras provider and add example scripts to demonstrate successful operation.

## Manual Verification

Ran the scripts.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future work

Investigate better error handling of

> [AI_NoObjectGeneratedError]: No object generated: response did not match schema.

Instead make clear that the problem is that the model does not support structured output

## Related Issues

Fixes https://github.com/vercel/ai/issues/8475