### PR TITLE
feat(ai): add tool output scoring system (POC)

### DIFF
--- a/examples/ai-core/src/stream-text/gateway-scorers.ts
+++ b/examples/ai-core/src/stream-text/gateway-scorers.ts
@@ -1,0 +1,94 @@
+import { streamText, ModelMessage, ToolCallPart, ToolResultPart } from 'ai';
+import 'dotenv/config';
+import { weatherTool } from '../tools/weather-tool';
+
+const messages: ModelMessage[] = [];
+
+async function main() {
+  let toolResponseAvailable = false;
+
+  const result = streamText({
+    model: 'openai/gpt-5-nano',
+    maxOutputTokens: 512,
+    tools: {
+      weather: weatherTool,
+    },
+    toolChoice: 'required',
+    prompt:
+      'What is the weather in San Francisco and what attractions should I visit?',
+    scorers: [
+      {
+        name: 'weather tool',
+        tool: 'weather',
+        scorer: (output: { location: string; temperature: number }) => {
+          let score = 0;
+
+          if (output?.location.includes('Francisco')) score += 0.5;
+          if (output?.temperature > 50) score += 0.5;
+
+          return score;
+        },
+      },
+    ],
+    onStepFinish: ({ scorers }) => {
+      console.log('scorers', scorers);
+    },
+  });
+
+  let fullResponse = '';
+  const toolCalls: ToolCallPart[] = [];
+  const toolResponses: ToolResultPart[] = [];
+
+  for await (const delta of result.fullStream) {
+    switch (delta.type) {
+      case 'text-delta': {
+        fullResponse += delta.text;
+        process.stdout.write(delta.text);
+        break;
+      }
+
+      case 'tool-call': {
+        toolCalls.push(delta);
+
+        process.stdout.write(
+          `\nTool call: '${delta.toolName}' ${JSON.stringify(delta.input)}`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        if (delta.dynamic) {
+          continue;
+        }
+
+        const transformedDelta: ToolResultPart = {
+          ...delta,
+          output: { type: 'json', value: delta.output },
+        };
+        toolResponses.push(transformedDelta);
+
+        process.stdout.write(
+          `\nTool response: '${delta.toolName}' ${JSON.stringify(
+            delta.output,
+          )}`,
+        );
+        break;
+      }
+    }
+  }
+  process.stdout.write('\n\n');
+
+  messages.push({
+    role: 'assistant',
+    content: [{ type: 'text', text: fullResponse }, ...toolCalls],
+  });
+
+  if (toolResponses.length > 0) {
+    messages.push({ role: 'tool', content: toolResponses });
+  }
+
+  toolResponseAvailable = toolCalls.length > 0;
+  console.log('Messages:', messages[0].content);
+}
+
+main().catch(console.error);

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -554,6 +554,7 @@ A function that attempts to repair a tool call that failed to parse.
               // deep clone msgs to avoid mutating past messages in multi-step:
               messages: structuredClone(responseMessages),
             },
+            scorers: undefined,
           });
 
           logWarnings(currentModelResponse.warnings ?? []);

--- a/packages/ai/src/generate-text/scorer.ts
+++ b/packages/ai/src/generate-text/scorer.ts
@@ -1,0 +1,23 @@
+export type Scorer<T = any> = {
+  name: string;
+  tool: string;
+  scorer: (output: T) => number;
+};
+
+export type ScorerResult = {
+  name: Scorer['name'];
+  tool: Scorer['tool'];
+  result: number;
+};
+
+export function createScorer<T>(scorer: {
+  name: string;
+  tool: string;
+  scorer: (output: T) => number;
+}): Scorer<T> {
+  return scorer;
+}
+
+export function executeScorer<T>(scorer: Scorer<T>['scorer'], output: T) {
+  return scorer(output);
+}

--- a/packages/ai/src/generate-text/step-result.ts
+++ b/packages/ai/src/generate-text/step-result.ts
@@ -18,6 +18,7 @@ import {
   TypedToolResult,
 } from './tool-result';
 import { ToolSet } from './tool-set';
+import { ScorerResult } from './scorer';
 
 /**
  * The result of a single step in the generation process.
@@ -126,6 +127,10 @@ from the provider to the AI SDK and enable provider-specific
 results that can be fully encapsulated in the provider.
    */
   readonly providerMetadata: ProviderMetadata | undefined;
+  /**
+Results from scoring tool outputs.
+  */
+  readonly scorers: ScorerResult[] | undefined;
 };
 
 export class DefaultStepResult<TOOLS extends ToolSet>
@@ -138,6 +143,7 @@ export class DefaultStepResult<TOOLS extends ToolSet>
   readonly request: StepResult<TOOLS>['request'];
   readonly response: StepResult<TOOLS>['response'];
   readonly providerMetadata: StepResult<TOOLS>['providerMetadata'];
+  readonly scorers: StepResult<TOOLS>['scorers'];
 
   constructor({
     content,
@@ -147,6 +153,7 @@ export class DefaultStepResult<TOOLS extends ToolSet>
     request,
     response,
     providerMetadata,
+    scorers,
   }: {
     content: StepResult<TOOLS>['content'];
     finishReason: StepResult<TOOLS>['finishReason'];
@@ -155,6 +162,7 @@ export class DefaultStepResult<TOOLS extends ToolSet>
     request: StepResult<TOOLS>['request'];
     response: StepResult<TOOLS>['response'];
     providerMetadata: StepResult<TOOLS>['providerMetadata'];
+    scorers: StepResult<TOOLS>['scorers'];
   }) {
     this.content = content;
     this.finishReason = finishReason;
@@ -163,6 +171,7 @@ export class DefaultStepResult<TOOLS extends ToolSet>
     this.request = request;
     this.response = response;
     this.providerMetadata = providerMetadata;
+    this.scorers = scorers;
   }
 
   get text() {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Validating LLM outputs isn't only about correctness, it's about extracting signals. Scorers make that possible

this implementation:
- includes scoring results in the final step response
- helps when running evals (e.g. [Evalite scorers](https://www.evalite.dev/guides/scorers))
- makes it easier to validate interaction + user intention across agent <> tools
- opens the door to using other LLMs as evaluators [paper](https://arxiv.org/abs/2406.02863)

## Summary

- adds a first version of scorers support in `streamText`
- runs defined scorers on `tool-result` parts
- results are exposed in `onStepFinish({ scorers })`
- includes an example (examples/ai-core/src/stream-text/gateway-scorers.ts)

this is a poc, only wired into `streamText` and still missing docs, tests, and broader integration

## Manual Verification

`bun run ./stream-text/gateway-scorers.ts`

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
