### PR TITLE
Export `parseJsonEventStream` and `uiMessageChunkSchema` from "ai" package

### DIFF
--- a/.changeset/gentle-students-begin.md
+++ b/.changeset/gentle-students-begin.md
@@ -1,5 +1,5 @@
 ---
-'ai': minor
+'ai': patch
 ---
 
 Export `parseJsonEventStream` and `uiMessageChunkSchema` from "ai" package

--- a/.changeset/gentle-students-begin.md
+++ b/.changeset/gentle-students-begin.md
@@ -1,0 +1,5 @@
+---
+'ai': minor
+---
+
+Export `parseJsonEventStream` and `uiMessageChunkSchema` from "ai" package

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -6,6 +6,7 @@ export {
   dynamicTool,
   generateId,
   jsonSchema,
+  parseJsonEventStream,
   tool,
   zodSchema,
   type IdGenerator,

--- a/packages/ai/src/ui-message-stream/index.ts
+++ b/packages/ai/src/ui-message-stream/index.ts
@@ -3,7 +3,11 @@ export { createUIMessageStreamResponse } from './create-ui-message-stream-respon
 export { JsonToSseTransformStream } from './json-to-sse-transform-stream';
 export { pipeUIMessageStreamToResponse } from './pipe-ui-message-stream-to-response';
 export { readUIMessageStream } from './read-ui-message-stream';
-export type { InferUIMessageChunk, UIMessageChunk } from './ui-message-chunks';
+export {
+  uiMessageChunkSchema,
+  type InferUIMessageChunk,
+  type UIMessageChunk,
+} from './ui-message-chunks';
 export { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 export type { UIMessageStreamOnFinishCallback } from './ui-message-stream-on-finish-callback';
 export type { UIMessageStreamWriter } from './ui-message-stream-writer';


### PR DESCRIPTION
This makes it more convenient to implement custom `ChatTransport` implementations.

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

While implementing a custom `useChat` transport, I noticed these are missing from the `ai` package exports:

* The `parseJsonEventStream()` function. I could grab this from the `@ai-sdk/provider-util` package directly, but since the `ai` package is already re-exporting stuff from this package, this would be nice to have as well.
* The `uiMessageChunkSchema` zod schema is necessary for usage of `parseJsonEventStream()`.

## Summary

Re-exported `parseJsonEventStream` from `@ai-sdk/provider-util`, and exported `uiMessageChunkSchema`.
