### PR TITLE
fix(ai): update `uiMessageChunkSchema` to satisfy the `UIMessageChunk` type

### DIFF
--- a/.changeset/great-eels-mate.md
+++ b/.changeset/great-eels-mate.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Update `uiMessageChunkSchema` to properly satisfy the `UIMessageChunk` type

--- a/.changeset/great-eels-mate.md
+++ b/.changeset/great-eels-mate.md
@@ -2,4 +2,4 @@
 'ai': patch
 ---
 
-Update `uiMessageChunkSchema` to properly satisfy the `UIMessageChunk` type
+fix(ai): update `uiMessageChunkSchema` to satisfy the `UIMessageChunk` type

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.test-d.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.test-d.ts
@@ -1,0 +1,14 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { UIMessageChunk, uiMessageChunkSchema } from './ui-message-chunks';
+
+describe('UI message chunks type', () => {
+  it('should work with fixed inputSchema', () => {
+    const chunk = uiMessageChunkSchema.parse({
+      type: 'text-delta',
+      delta: 'Hello, world!',
+      id: '123',
+    });
+
+    expectTypeOf(chunk).toEqualTypeOf<UIMessageChunk>();
+  });
+});

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -1,317 +1,317 @@
-import { z } from "zod/v4";
+import { z } from 'zod/v4';
 import {
-	ProviderMetadata,
-	providerMetadataSchema,
-} from "../types/provider-metadata";
+  ProviderMetadata,
+  providerMetadataSchema,
+} from '../types/provider-metadata';
 import {
-	InferUIMessageData,
-	InferUIMessageMetadata,
-	UIDataTypes,
-	UIMessage,
-} from "../ui/ui-messages";
-import { ValueOf } from "../util/value-of";
+  InferUIMessageData,
+  InferUIMessageMetadata,
+  UIDataTypes,
+  UIMessage,
+} from '../ui/ui-messages';
+import { ValueOf } from '../util/value-of';
 
 export const uiMessageChunkSchema = z.union([
-	z.strictObject({
-		type: z.literal("text-start"),
-		id: z.string(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("text-delta"),
-		id: z.string(),
-		delta: z.string(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("text-end"),
-		id: z.string(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("error"),
-		errorText: z.string(),
-	}),
-	z.strictObject({
-		type: z.literal("tool-input-start"),
-		toolCallId: z.string(),
-		toolName: z.string(),
-		providerExecuted: z.boolean().optional(),
-		dynamic: z.boolean().optional(),
-	}),
-	z.strictObject({
-		type: z.literal("tool-input-delta"),
-		toolCallId: z.string(),
-		inputTextDelta: z.string(),
-	}),
-	z.strictObject({
-		type: z.literal("tool-input-available"),
-		toolCallId: z.string(),
-		toolName: z.string(),
-		input: z.unknown(),
-		providerExecuted: z.boolean().optional(),
-		providerMetadata: providerMetadataSchema.optional(),
-		dynamic: z.boolean().optional(),
-	}),
-	z.strictObject({
-		type: z.literal("tool-input-error"),
-		toolCallId: z.string(),
-		toolName: z.string(),
-		input: z.unknown(),
-		providerExecuted: z.boolean().optional(),
-		providerMetadata: providerMetadataSchema.optional(),
-		dynamic: z.boolean().optional(),
-		errorText: z.string(),
-	}),
-	z.strictObject({
-		type: z.literal("tool-output-available"),
-		toolCallId: z.string(),
-		output: z.unknown(),
-		providerExecuted: z.boolean().optional(),
-		dynamic: z.boolean().optional(),
-		preliminary: z.boolean().optional(),
-	}),
-	z.strictObject({
-		type: z.literal("tool-output-error"),
-		toolCallId: z.string(),
-		errorText: z.string(),
-		providerExecuted: z.boolean().optional(),
-		dynamic: z.boolean().optional(),
-	}),
-	z.strictObject({
-		type: z.literal("reasoning"),
-		text: z.string(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("reasoning-start"),
-		id: z.string(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("reasoning-delta"),
-		id: z.string(),
-		delta: z.string(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("reasoning-end"),
-		id: z.string(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("reasoning-part-finish"),
-	}),
-	z.strictObject({
-		type: z.literal("source-url"),
-		sourceId: z.string(),
-		url: z.string(),
-		title: z.string().optional(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("source-document"),
-		sourceId: z.string(),
-		mediaType: z.string(),
-		title: z.string(),
-		filename: z.string().optional(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.literal("file"),
-		url: z.string(),
-		mediaType: z.string(),
-		providerMetadata: providerMetadataSchema.optional(),
-	}),
-	z.strictObject({
-		type: z.custom<`data-${string}`>(
-			(val): val is `data-${string}` =>
-				typeof val === "string" && val.startsWith("data-"),
-			{ message: 'Type must start with "data-"' },
-		),
-		id: z.string().optional(),
-		data: z.unknown(),
-		transient: z.boolean().optional(),
-	}),
-	z.strictObject({
-		type: z.literal("start-step"),
-	}),
-	z.strictObject({
-		type: z.literal("finish-step"),
-	}),
-	z.strictObject({
-		type: z.literal("start"),
-		messageId: z.string().optional(),
-		messageMetadata: z.unknown().optional(),
-	}),
-	z.strictObject({
-		type: z.literal("finish"),
-		messageMetadata: z.unknown().optional(),
-	}),
-	z.strictObject({
-		type: z.literal("abort"),
-	}),
-	z.strictObject({
-		type: z.literal("message-metadata"),
-		messageMetadata: z.unknown(),
-	}),
+  z.strictObject({
+    type: z.literal('text-start'),
+    id: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('text-delta'),
+    id: z.string(),
+    delta: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('text-end'),
+    id: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('error'),
+    errorText: z.string(),
+  }),
+  z.strictObject({
+    type: z.literal('tool-input-start'),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    providerExecuted: z.boolean().optional(),
+    dynamic: z.boolean().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('tool-input-delta'),
+    toolCallId: z.string(),
+    inputTextDelta: z.string(),
+  }),
+  z.strictObject({
+    type: z.literal('tool-input-available'),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    input: z.unknown(),
+    providerExecuted: z.boolean().optional(),
+    providerMetadata: providerMetadataSchema.optional(),
+    dynamic: z.boolean().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('tool-input-error'),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    input: z.unknown(),
+    providerExecuted: z.boolean().optional(),
+    providerMetadata: providerMetadataSchema.optional(),
+    dynamic: z.boolean().optional(),
+    errorText: z.string(),
+  }),
+  z.strictObject({
+    type: z.literal('tool-output-available'),
+    toolCallId: z.string(),
+    output: z.unknown(),
+    providerExecuted: z.boolean().optional(),
+    dynamic: z.boolean().optional(),
+    preliminary: z.boolean().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('tool-output-error'),
+    toolCallId: z.string(),
+    errorText: z.string(),
+    providerExecuted: z.boolean().optional(),
+    dynamic: z.boolean().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('reasoning'),
+    text: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('reasoning-start'),
+    id: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('reasoning-delta'),
+    id: z.string(),
+    delta: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('reasoning-end'),
+    id: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('reasoning-part-finish'),
+  }),
+  z.strictObject({
+    type: z.literal('source-url'),
+    sourceId: z.string(),
+    url: z.string(),
+    title: z.string().optional(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('source-document'),
+    sourceId: z.string(),
+    mediaType: z.string(),
+    title: z.string(),
+    filename: z.string().optional(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal('file'),
+    url: z.string(),
+    mediaType: z.string(),
+    providerMetadata: providerMetadataSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.custom<`data-${string}`>(
+      (val): val is `data-${string}` =>
+        typeof val === 'string' && val.startsWith('data-'),
+      { message: 'Type must start with "data-"' },
+    ),
+    id: z.string().optional(),
+    data: z.unknown(),
+    transient: z.boolean().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('start-step'),
+  }),
+  z.strictObject({
+    type: z.literal('finish-step'),
+  }),
+  z.strictObject({
+    type: z.literal('start'),
+    messageId: z.string().optional(),
+    messageMetadata: z.unknown().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('finish'),
+    messageMetadata: z.unknown().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('abort'),
+  }),
+  z.strictObject({
+    type: z.literal('message-metadata'),
+    messageMetadata: z.unknown(),
+  }),
 ]);
 
 export type DataUIMessageChunk<DATA_TYPES extends UIDataTypes> = ValueOf<{
-	[NAME in keyof DATA_TYPES & string]: {
-		type: `data-${NAME}`;
-		id?: string;
-		data: DATA_TYPES[NAME];
-		transient?: boolean;
-	};
+  [NAME in keyof DATA_TYPES & string]: {
+    type: `data-${NAME}`;
+    id?: string;
+    data: DATA_TYPES[NAME];
+    transient?: boolean;
+  };
 }>;
 
 export type UIMessageChunk<
-	METADATA = unknown,
-	DATA_TYPES extends UIDataTypes = UIDataTypes,
+  METADATA = unknown,
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
 > =
-	| {
-			type: "text-start";
-			id: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "text-delta";
-			delta: string;
-			id: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "text-end";
-			id: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "reasoning-start";
-			id: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "reasoning-delta";
-			id: string;
-			delta: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "reasoning-end";
-			id: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "reasoning";
-			text: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "reasoning-part-finish";
-	  }
-	| {
-			type: "error";
-			errorText: string;
-	  }
-	| {
-			type: "tool-input-available";
-			toolCallId: string;
-			toolName: string;
-			input: unknown;
-			providerExecuted?: boolean;
-			providerMetadata?: ProviderMetadata;
-			dynamic?: boolean;
-	  }
-	| {
-			type: "tool-input-error";
-			toolCallId: string;
-			toolName: string;
-			input: unknown;
-			providerExecuted?: boolean;
-			providerMetadata?: ProviderMetadata;
-			dynamic?: boolean;
-			errorText: string;
-	  }
-	| {
-			type: "tool-output-available";
-			toolCallId: string;
-			output: unknown;
-			providerExecuted?: boolean;
-			dynamic?: boolean;
-			preliminary?: boolean;
-	  }
-	| {
-			type: "tool-output-error";
-			toolCallId: string;
-			errorText: string;
-			providerExecuted?: boolean;
-			dynamic?: boolean;
-	  }
-	| {
-			type: "tool-input-start";
-			toolCallId: string;
-			toolName: string;
-			providerExecuted?: boolean;
-			dynamic?: boolean;
-	  }
-	| {
-			type: "tool-input-delta";
-			toolCallId: string;
-			inputTextDelta: string;
-	  }
-	| {
-			type: "source-url";
-			sourceId: string;
-			url: string;
-			title?: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "source-document";
-			sourceId: string;
-			mediaType: string;
-			title: string;
-			filename?: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| {
-			type: "file";
-			url: string;
-			mediaType: string;
-			providerMetadata?: ProviderMetadata;
-	  }
-	| DataUIMessageChunk<DATA_TYPES>
-	| {
-			type: "start-step";
-	  }
-	| {
-			type: "finish-step";
-	  }
-	| {
-			type: "start";
-			messageId?: string;
-			messageMetadata?: METADATA;
-	  }
-	| {
-			type: "finish";
-			messageMetadata?: METADATA;
-	  }
-	| {
-			type: "abort";
-	  }
-	| {
-			type: "message-metadata";
-			messageMetadata: METADATA;
-	  };
+  | {
+      type: 'text-start';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'text-delta';
+      delta: string;
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'text-end';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'reasoning-start';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'reasoning-delta';
+      id: string;
+      delta: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'reasoning-end';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'reasoning';
+      text: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'reasoning-part-finish';
+    }
+  | {
+      type: 'error';
+      errorText: string;
+    }
+  | {
+      type: 'tool-input-available';
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      providerExecuted?: boolean;
+      providerMetadata?: ProviderMetadata;
+      dynamic?: boolean;
+    }
+  | {
+      type: 'tool-input-error';
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      providerExecuted?: boolean;
+      providerMetadata?: ProviderMetadata;
+      dynamic?: boolean;
+      errorText: string;
+    }
+  | {
+      type: 'tool-output-available';
+      toolCallId: string;
+      output: unknown;
+      providerExecuted?: boolean;
+      dynamic?: boolean;
+      preliminary?: boolean;
+    }
+  | {
+      type: 'tool-output-error';
+      toolCallId: string;
+      errorText: string;
+      providerExecuted?: boolean;
+      dynamic?: boolean;
+    }
+  | {
+      type: 'tool-input-start';
+      toolCallId: string;
+      toolName: string;
+      providerExecuted?: boolean;
+      dynamic?: boolean;
+    }
+  | {
+      type: 'tool-input-delta';
+      toolCallId: string;
+      inputTextDelta: string;
+    }
+  | {
+      type: 'source-url';
+      sourceId: string;
+      url: string;
+      title?: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'source-document';
+      sourceId: string;
+      mediaType: string;
+      title: string;
+      filename?: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | {
+      type: 'file';
+      url: string;
+      mediaType: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | DataUIMessageChunk<DATA_TYPES>
+  | {
+      type: 'start-step';
+    }
+  | {
+      type: 'finish-step';
+    }
+  | {
+      type: 'start';
+      messageId?: string;
+      messageMetadata?: METADATA;
+    }
+  | {
+      type: 'finish';
+      messageMetadata?: METADATA;
+    }
+  | {
+      type: 'abort';
+    }
+  | {
+      type: 'message-metadata';
+      messageMetadata: METADATA;
+    };
 
 export function isDataUIMessageChunk(
-	chunk: UIMessageChunk,
+  chunk: UIMessageChunk,
 ): chunk is DataUIMessageChunk<UIDataTypes> {
-	return chunk.type.startsWith("data-");
+  return chunk.type.startsWith('data-');
 }
 
 export type InferUIMessageChunk<T extends UIMessage> = UIMessageChunk<
-	InferUIMessageMetadata<T>,
-	InferUIMessageData<T>
+  InferUIMessageMetadata<T>,
+  InferUIMessageData<T>
 >;

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -79,11 +79,6 @@ export const uiMessageChunkSchema = z.union([
     dynamic: z.boolean().optional(),
   }),
   z.strictObject({
-    type: z.literal('reasoning'),
-    text: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
     type: z.literal('reasoning-start'),
     id: z.string(),
     providerMetadata: providerMetadataSchema.optional(),
@@ -98,9 +93,6 @@ export const uiMessageChunkSchema = z.union([
     type: z.literal('reasoning-end'),
     id: z.string(),
     providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('reasoning-part-finish'),
   }),
   z.strictObject({
     type: z.literal('source-url'),
@@ -201,14 +193,6 @@ export type UIMessageChunk<
       type: 'reasoning-end';
       id: string;
       providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'reasoning';
-      text: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'reasoning-part-finish';
     }
   | {
       type: 'error';

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -117,8 +117,8 @@ export const uiMessageChunkSchema = z.union([
   }),
   z.strictObject({
     type: z.custom<`data-${string}`>(
-      (val): val is `data-${string}` =>
-        typeof val === 'string' && val.startsWith('data-'),
+      (value): value is `data-${string}` =>
+        typeof value === 'string' && value.startsWith('data-'),
       { message: 'Type must start with "data-"' },
     ),
     id: z.string().optional(),

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -1,304 +1,317 @@
-import { z } from 'zod/v4';
+import { z } from "zod/v4";
 import {
-  ProviderMetadata,
-  providerMetadataSchema,
-} from '../types/provider-metadata';
+	ProviderMetadata,
+	providerMetadataSchema,
+} from "../types/provider-metadata";
 import {
-  InferUIMessageData,
-  InferUIMessageMetadata,
-  UIDataTypes,
-  UIMessage,
-} from '../ui/ui-messages';
-import { ValueOf } from '../util/value-of';
+	InferUIMessageData,
+	InferUIMessageMetadata,
+	UIDataTypes,
+	UIMessage,
+} from "../ui/ui-messages";
+import { ValueOf } from "../util/value-of";
 
 export const uiMessageChunkSchema = z.union([
-  z.strictObject({
-    type: z.literal('text-start'),
-    id: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('text-delta'),
-    id: z.string(),
-    delta: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('text-end'),
-    id: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('error'),
-    errorText: z.string(),
-  }),
-  z.strictObject({
-    type: z.literal('tool-input-start'),
-    toolCallId: z.string(),
-    toolName: z.string(),
-    providerExecuted: z.boolean().optional(),
-    dynamic: z.boolean().optional(),
-  }),
-  z.strictObject({
-    type: z.literal('tool-input-delta'),
-    toolCallId: z.string(),
-    inputTextDelta: z.string(),
-  }),
-  z.strictObject({
-    type: z.literal('tool-input-available'),
-    toolCallId: z.string(),
-    toolName: z.string(),
-    input: z.unknown(),
-    providerExecuted: z.boolean().optional(),
-    providerMetadata: providerMetadataSchema.optional(),
-    dynamic: z.boolean().optional(),
-  }),
-  z.strictObject({
-    type: z.literal('tool-input-error'),
-    toolCallId: z.string(),
-    toolName: z.string(),
-    input: z.unknown(),
-    providerExecuted: z.boolean().optional(),
-    providerMetadata: providerMetadataSchema.optional(),
-    dynamic: z.boolean().optional(),
-    errorText: z.string(),
-  }),
-  z.strictObject({
-    type: z.literal('tool-output-available'),
-    toolCallId: z.string(),
-    output: z.unknown(),
-    providerExecuted: z.boolean().optional(),
-    dynamic: z.boolean().optional(),
-    preliminary: z.boolean().optional(),
-  }),
-  z.strictObject({
-    type: z.literal('tool-output-error'),
-    toolCallId: z.string(),
-    errorText: z.string(),
-    providerExecuted: z.boolean().optional(),
-    dynamic: z.boolean().optional(),
-  }),
-  z.strictObject({
-    type: z.literal('reasoning'),
-    text: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('reasoning-start'),
-    id: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('reasoning-delta'),
-    id: z.string(),
-    delta: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('reasoning-end'),
-    id: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('reasoning-part-finish'),
-  }),
-  z.strictObject({
-    type: z.literal('source-url'),
-    sourceId: z.string(),
-    url: z.string(),
-    title: z.string().optional(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('source-document'),
-    sourceId: z.string(),
-    mediaType: z.string(),
-    title: z.string(),
-    filename: z.string().optional(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.literal('file'),
-    url: z.string(),
-    mediaType: z.string(),
-    providerMetadata: providerMetadataSchema.optional(),
-  }),
-  z.strictObject({
-    type: z.string().startsWith('data-'),
-    id: z.string().optional(),
-    data: z.unknown(),
-    transient: z.boolean().optional(),
-  }),
-  z.strictObject({
-    type: z.literal('start-step'),
-  }),
-  z.strictObject({
-    type: z.literal('finish-step'),
-  }),
-  z.strictObject({
-    type: z.literal('start'),
-    messageId: z.string().optional(),
-    messageMetadata: z.unknown().optional(),
-  }),
-  z.strictObject({
-    type: z.literal('finish'),
-    messageMetadata: z.unknown().optional(),
-  }),
-  z.strictObject({
-    type: z.literal('abort'),
-  }),
-  z.strictObject({
-    type: z.literal('message-metadata'),
-    messageMetadata: z.unknown(),
-  }),
+	z.strictObject({
+		type: z.literal("text-start"),
+		id: z.string(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("text-delta"),
+		id: z.string(),
+		delta: z.string(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("text-end"),
+		id: z.string(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("error"),
+		errorText: z.string(),
+	}),
+	z.strictObject({
+		type: z.literal("tool-input-start"),
+		toolCallId: z.string(),
+		toolName: z.string(),
+		providerExecuted: z.boolean().optional(),
+		dynamic: z.boolean().optional(),
+	}),
+	z.strictObject({
+		type: z.literal("tool-input-delta"),
+		toolCallId: z.string(),
+		inputTextDelta: z.string(),
+	}),
+	z.strictObject({
+		type: z.literal("tool-input-available"),
+		toolCallId: z.string(),
+		toolName: z.string(),
+		input: z.unknown(),
+		providerExecuted: z.boolean().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+		dynamic: z.boolean().optional(),
+	}),
+	z.strictObject({
+		type: z.literal("tool-input-error"),
+		toolCallId: z.string(),
+		toolName: z.string(),
+		input: z.unknown(),
+		providerExecuted: z.boolean().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+		dynamic: z.boolean().optional(),
+		errorText: z.string(),
+	}),
+	z.strictObject({
+		type: z.literal("tool-output-available"),
+		toolCallId: z.string(),
+		output: z.unknown(),
+		providerExecuted: z.boolean().optional(),
+		dynamic: z.boolean().optional(),
+		preliminary: z.boolean().optional(),
+	}),
+	z.strictObject({
+		type: z.literal("tool-output-error"),
+		toolCallId: z.string(),
+		errorText: z.string(),
+		providerExecuted: z.boolean().optional(),
+		dynamic: z.boolean().optional(),
+	}),
+	z.strictObject({
+		type: z.literal("reasoning"),
+		text: z.string(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("reasoning-start"),
+		id: z.string(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("reasoning-delta"),
+		id: z.string(),
+		delta: z.string(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("reasoning-end"),
+		id: z.string(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("reasoning-part-finish"),
+	}),
+	z.strictObject({
+		type: z.literal("source-url"),
+		sourceId: z.string(),
+		url: z.string(),
+		title: z.string().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("source-document"),
+		sourceId: z.string(),
+		mediaType: z.string(),
+		title: z.string(),
+		filename: z.string().optional(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.literal("file"),
+		url: z.string(),
+		mediaType: z.string(),
+		providerMetadata: providerMetadataSchema.optional(),
+	}),
+	z.strictObject({
+		type: z.custom<`data-${string}`>(
+			(val): val is `data-${string}` =>
+				typeof val === "string" && val.startsWith("data-"),
+			{ message: 'Type must start with "data-"' },
+		),
+		id: z.string().optional(),
+		data: z.unknown(),
+		transient: z.boolean().optional(),
+	}),
+	z.strictObject({
+		type: z.literal("start-step"),
+	}),
+	z.strictObject({
+		type: z.literal("finish-step"),
+	}),
+	z.strictObject({
+		type: z.literal("start"),
+		messageId: z.string().optional(),
+		messageMetadata: z.unknown().optional(),
+	}),
+	z.strictObject({
+		type: z.literal("finish"),
+		messageMetadata: z.unknown().optional(),
+	}),
+	z.strictObject({
+		type: z.literal("abort"),
+	}),
+	z.strictObject({
+		type: z.literal("message-metadata"),
+		messageMetadata: z.unknown(),
+	}),
 ]);
 
 export type DataUIMessageChunk<DATA_TYPES extends UIDataTypes> = ValueOf<{
-  [NAME in keyof DATA_TYPES & string]: {
-    type: `data-${NAME}`;
-    id?: string;
-    data: DATA_TYPES[NAME];
-    transient?: boolean;
-  };
+	[NAME in keyof DATA_TYPES & string]: {
+		type: `data-${NAME}`;
+		id?: string;
+		data: DATA_TYPES[NAME];
+		transient?: boolean;
+	};
 }>;
 
 export type UIMessageChunk<
-  METADATA = unknown,
-  DATA_TYPES extends UIDataTypes = UIDataTypes,
+	METADATA = unknown,
+	DATA_TYPES extends UIDataTypes = UIDataTypes,
 > =
-  | {
-      type: 'text-start';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'text-delta';
-      delta: string;
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'text-end';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'reasoning-start';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'reasoning-delta';
-      id: string;
-      delta: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'reasoning-end';
-      id: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'error';
-      errorText: string;
-    }
-  | {
-      type: 'tool-input-available';
-      toolCallId: string;
-      toolName: string;
-      input: unknown;
-      providerExecuted?: boolean;
-      providerMetadata?: ProviderMetadata;
-      dynamic?: boolean;
-    }
-  | {
-      type: 'tool-input-error';
-      toolCallId: string;
-      toolName: string;
-      input: unknown;
-      providerExecuted?: boolean;
-      providerMetadata?: ProviderMetadata;
-      dynamic?: boolean;
-      errorText: string;
-    }
-  | {
-      type: 'tool-output-available';
-      toolCallId: string;
-      output: unknown;
-      providerExecuted?: boolean;
-      dynamic?: boolean;
-      preliminary?: boolean;
-    }
-  | {
-      type: 'tool-output-error';
-      toolCallId: string;
-      errorText: string;
-      providerExecuted?: boolean;
-      dynamic?: boolean;
-    }
-  | {
-      type: 'tool-input-start';
-      toolCallId: string;
-      toolName: string;
-      providerExecuted?: boolean;
-      dynamic?: boolean;
-    }
-  | {
-      type: 'tool-input-delta';
-      toolCallId: string;
-      inputTextDelta: string;
-    }
-  | {
-      type: 'source-url';
-      sourceId: string;
-      url: string;
-      title?: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'source-document';
-      sourceId: string;
-      mediaType: string;
-      title: string;
-      filename?: string;
-      providerMetadata?: ProviderMetadata;
-    }
-  | {
-      type: 'file';
-      url: string;
-      mediaType: string;
-    }
-  | DataUIMessageChunk<DATA_TYPES>
-  | {
-      type: 'start-step';
-    }
-  | {
-      type: 'finish-step';
-    }
-  | {
-      type: 'start';
-      messageId?: string;
-      messageMetadata?: METADATA;
-    }
-  | {
-      type: 'finish';
-      messageMetadata?: METADATA;
-    }
-  | {
-      type: 'abort';
-    }
-  | {
-      type: 'message-metadata';
-      messageMetadata: METADATA;
-    };
+	| {
+			type: "text-start";
+			id: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "text-delta";
+			delta: string;
+			id: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "text-end";
+			id: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "reasoning-start";
+			id: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "reasoning-delta";
+			id: string;
+			delta: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "reasoning-end";
+			id: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "reasoning";
+			text: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "reasoning-part-finish";
+	  }
+	| {
+			type: "error";
+			errorText: string;
+	  }
+	| {
+			type: "tool-input-available";
+			toolCallId: string;
+			toolName: string;
+			input: unknown;
+			providerExecuted?: boolean;
+			providerMetadata?: ProviderMetadata;
+			dynamic?: boolean;
+	  }
+	| {
+			type: "tool-input-error";
+			toolCallId: string;
+			toolName: string;
+			input: unknown;
+			providerExecuted?: boolean;
+			providerMetadata?: ProviderMetadata;
+			dynamic?: boolean;
+			errorText: string;
+	  }
+	| {
+			type: "tool-output-available";
+			toolCallId: string;
+			output: unknown;
+			providerExecuted?: boolean;
+			dynamic?: boolean;
+			preliminary?: boolean;
+	  }
+	| {
+			type: "tool-output-error";
+			toolCallId: string;
+			errorText: string;
+			providerExecuted?: boolean;
+			dynamic?: boolean;
+	  }
+	| {
+			type: "tool-input-start";
+			toolCallId: string;
+			toolName: string;
+			providerExecuted?: boolean;
+			dynamic?: boolean;
+	  }
+	| {
+			type: "tool-input-delta";
+			toolCallId: string;
+			inputTextDelta: string;
+	  }
+	| {
+			type: "source-url";
+			sourceId: string;
+			url: string;
+			title?: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "source-document";
+			sourceId: string;
+			mediaType: string;
+			title: string;
+			filename?: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| {
+			type: "file";
+			url: string;
+			mediaType: string;
+			providerMetadata?: ProviderMetadata;
+	  }
+	| DataUIMessageChunk<DATA_TYPES>
+	| {
+			type: "start-step";
+	  }
+	| {
+			type: "finish-step";
+	  }
+	| {
+			type: "start";
+			messageId?: string;
+			messageMetadata?: METADATA;
+	  }
+	| {
+			type: "finish";
+			messageMetadata?: METADATA;
+	  }
+	| {
+			type: "abort";
+	  }
+	| {
+			type: "message-metadata";
+			messageMetadata: METADATA;
+	  };
 
 export function isDataUIMessageChunk(
-  chunk: UIMessageChunk,
+	chunk: UIMessageChunk,
 ): chunk is DataUIMessageChunk<UIDataTypes> {
-  return chunk.type.startsWith('data-');
+	return chunk.type.startsWith("data-");
 }
 
 export type InferUIMessageChunk<T extends UIMessage> = UIMessageChunk<
-  InferUIMessageMetadata<T>,
-  InferUIMessageData<T>
+	InferUIMessageMetadata<T>,
+	InferUIMessageData<T>
 >;


### PR DESCRIPTION
## Background

The `uiMessageChunkSchema` seems to be out of date with the TypeScript `UIMessageChunk` type. Consider the following code:

```ts
import { type UIMessageChunk, uiMessageChunkSchema } from "ai";

const m: UIMessageChunk = uiMessageChunkSchema.parse({
	type: "text-delta",
	delta: "Hello, world!",
	id: "123",
});
```

This was producing the following TypeScript error:

```
Type '{ type: "text-start"; id: string; providerMetadata?: SharedV2ProviderMetadata | undefined; } | { type: "text-delta"; id: string; delta: string; providerMetadata?: SharedV2ProviderMetadata | undefined; } | ... 22 more ... | { ...; }' is not assignable to type 'UIMessageChunk'.
  Type '{ type: "reasoning"; text: string; providerMetadata?: SharedV2ProviderMetadata | undefined; }' is not assignable to type 'UIMessageChunk'.
    Type '{ type: "reasoning"; text: string; providerMetadata?: SharedV2ProviderMetadata | undefined; }' is missing the following properties from type '{ type: "source-document"; sourceId: string; mediaType: string; title: string; filename?: string | undefined; providerMetadata?: SharedV2ProviderMetadata | undefined; }': sourceId, mediaType, titlets(2322)
```

## Summary

* remove unused types from schema
* add provider metadata for file
* update data type parsing to support template string

## Manual Testing

- [x] test UI example with reasoning (2 steps, OpenAI)

## Tasks

- [x] add type test
- [x] investigate expected behavior