### PR TITLE
fix(ai): download files when intermediate file cannot be downloaded

### DIFF
--- a/.changeset/tall-terms-smash.md
+++ b/.changeset/tall-terms-smash.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): download files when intermediate file cannot be downloaded

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -682,13 +682,13 @@ describe('convertToLanguageModelPrompt', () => {
       const mockDownload = vi.fn().mockResolvedValue([
         {
           url: new URL(imageUrlA),
-          data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]), // empty png
+          data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0]), // empty png and 0
           mediaType: 'image/png',
         },
         null,
         {
           url: new URL(imageUrlB),
-          data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]), // empty png
+          data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1]), // empty png and 1
           mediaType: 'image/png',
         },
       ]);
@@ -730,6 +730,7 @@ describe('convertToLanguageModelPrompt', () => {
                   10,
                   26,
                   10,
+                  0,
                 ],
                 "filename": undefined,
                 "mediaType": "image/png",
@@ -753,6 +754,7 @@ describe('convertToLanguageModelPrompt', () => {
                   10,
                   26,
                   10,
+                  1,
                 ],
                 "filename": undefined,
                 "mediaType": "image/png",

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -245,18 +245,15 @@ async function downloadAssets(
 
   return Object.fromEntries(
     downloadedFiles
-      .filter(
-        (
-          downloadedFile,
-        ): downloadedFile is {
-          mediaType: string | undefined;
-          data: Uint8Array;
-        } => downloadedFile?.data != null,
+      .map((file, index) =>
+        file == null
+          ? null
+          : [
+              plannedDownloads[index].url.toString(),
+              { data: file.data, mediaType: file.mediaType },
+            ],
       )
-      .map(({ data, mediaType }, index) => [
-        plannedDownloads[index].url.toString(),
-        { data, mediaType },
-      ]),
+      .filter(file => file != null),
   );
 }
 


### PR DESCRIPTION
## Background

Files where not correctly downloaded when provided items where a mix of supported and unsupported URLs/media types

## Summary

Map before filtering to retain correct index

## Manual Verification

Verified by testing original bug submit from our security bug bounty program

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

closes #8881