### PR TITLE
chore (provider/google): Add preview modelIds for gemini 2.5 flash and lite

### DIFF
--- a/.changeset/witty-items-rest.md
+++ b/.changeset/witty-items-rest.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/google': patch
+---
+
+chore (provider/google): Add preview modelIds for gemini 2.5 flash and lite

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -22,6 +22,8 @@ export type GoogleVertexModelId =
   | 'gemini-1.0-pro-002'
   // Preview models
   | 'gemini-2.0-flash-lite-preview-02-05'
+  | 'gemini-2.5-flash-preview-09-2025'
+  | 'gemini-2.5-flash-lite-preview-09-2025'
   // Experimental models
   | 'gemini-2.0-pro-exp-02-05'
   | 'gemini-2.0-flash-exp'

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -22,8 +22,8 @@ export type GoogleVertexModelId =
   | 'gemini-1.0-pro-002'
   // Preview models
   | 'gemini-2.0-flash-lite-preview-02-05'
-  | 'gemini-2.5-flash-preview-09-2025'
   | 'gemini-2.5-flash-lite-preview-09-2025'
+  | 'gemini-2.5-flash-preview-09-2025'
   // Experimental models
   | 'gemini-2.0-pro-exp-02-05'
   | 'gemini-2.0-flash-exp'

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -23,14 +23,14 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.0-flash-exp'
   | 'gemini-2.5-pro'
   | 'gemini-2.5-flash'
-  | 'gemini-2.5-flash-lite'
   | 'gemini-2.5-flash-image-preview'
+  | 'gemini-2.5-flash-lite'
+  | 'gemini-2.5-flash-lite-preview-09-2025'
+  | 'gemini-2.5-flash-preview-04-17'
+  | 'gemini-2.5-flash-preview-09-2025'
   // Experimental models
   // https://ai.google.dev/gemini-api/docs/models/experimental-models
   | 'gemini-2.5-pro-exp-03-25'
-  | 'gemini-2.5-flash-preview-04-17'
-  | 'gemini-2.5-flash-preview-09-2025'
-  | 'gemini-2.5-flash-lite-preview-09-2025'
   | 'gemini-exp-1206'
   | 'gemma-3-12b-it'
   | 'gemma-3-27b-it'

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -29,6 +29,8 @@ export type GoogleGenerativeAIModelId =
   // https://ai.google.dev/gemini-api/docs/models/experimental-models
   | 'gemini-2.5-pro-exp-03-25'
   | 'gemini-2.5-flash-preview-04-17'
+  | 'gemini-2.5-flash-preview-09-2025'
+  | 'gemini-2.5-flash-lite-preview-09-2025'
   | 'gemini-exp-1206'
   | 'gemma-3-12b-it'
   | 'gemma-3-27b-it'


### PR DESCRIPTION
Updates the modelIds for gemini and vertex to include the two new preview models for flash and lite from today: https://developers.googleblog.com/en/continuing-to-bring-you-our-latest-models-with-an-improved-gemini-2-5-flash-and-flash-lite-release/