### PR TITLE
feat: add support for generating videos via experimental_generateVideo

### DIFF
--- a/packages/ai/src/error/index.ts
+++ b/packages/ai/src/error/index.ts
@@ -20,6 +20,7 @@ export { MCPClientError } from './mcp-client-error';
 export { NoImageGeneratedError } from './no-image-generated-error';
 export { NoObjectGeneratedError } from './no-object-generated-error';
 export { NoOutputGeneratedError } from './no-output-generated-error';
+export { NoVideoGeneratedError } from './no-video-generated-error';
 export { NoOutputSpecifiedError } from './no-output-specified-error';
 export { NoSuchToolError } from './no-such-tool-error';
 export { ToolCallRepairError } from './tool-call-repair-error';

--- a/packages/ai/src/error/no-video-generated-error.ts
+++ b/packages/ai/src/error/no-video-generated-error.ts
@@ -1,0 +1,41 @@
+import { AISDKError } from '@ai-sdk/provider';
+import { VideoModelResponseMetadata } from '../types/video-model-response-metadata';
+
+const name = 'AI_NoVideoGeneratedError';
+const marker = `vercel.ai.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+Thrown when no video could be generated. This can have multiple causes:
+
+- The model failed to generate a response.
+- The model generated a response that could not be parsed.
+ */
+export class NoVideoGeneratedError extends AISDKError {
+  private readonly [symbol] = true; // used in isInstance
+
+  /**
+The response metadata for each call.
+   */
+  readonly responses: Array<VideoModelResponseMetadata> | undefined;
+
+  constructor({
+    message = 'No video generated.',
+    cause,
+    responses,
+  }: {
+    message?: string;
+    cause?: Error;
+    responses?: Array<VideoModelResponseMetadata>;
+  }) {
+    super({ name, message, cause });
+
+    this.responses = responses;
+  }
+
+  static isInstance(error: unknown): error is NoVideoGeneratedError {
+    return AISDKError.hasMarker(error, marker);
+  }
+}
+
+

--- a/packages/ai/src/generate-video/generate-video-result.ts
+++ b/packages/ai/src/generate-video/generate-video-result.ts
@@ -1,0 +1,37 @@
+import { GeneratedFile } from '../generate-text';
+import { VideoGenerationWarning } from '../types/video-model';
+import { VideoModelResponseMetadata } from '../types/video-model-response-metadata';
+
+/**
+The result of a `generateVideo` call.
+It contains the videos and additional information.
+ */
+export interface GenerateVideoResult {
+  /**
+The first video that was generated.
+   */
+  readonly video: GeneratedFile;
+
+  /**
+The videos that were generated.
+     */
+  readonly videos: Array<GeneratedFile>;
+
+  /**
+Warnings for the call, e.g. unsupported settings.
+     */
+  readonly warnings: Array<VideoGenerationWarning>;
+
+  /**
+Response metadata from the provider. There may be multiple responses if we made multiple calls to the model.
+   */
+  readonly responses: Array<VideoModelResponseMetadata>;
+
+  /**
+   * Provider-specific metadata. They are passed through from the provider to the AI SDK and enable provider-specific
+   * results that can be fully encapsulated in the provider.
+   */
+  readonly providerMetadata: Record<string, { videos: unknown[] }>;
+}
+
+

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -1,0 +1,164 @@
+import { VideoModelV2, VideoModelV2ProviderMetadata } from '@ai-sdk/provider';
+import { ProviderOptions, withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { UnsupportedModelVersionError } from '../error/unsupported-model-version-error';
+import { DefaultGeneratedFile, GeneratedFile } from '../generate-text/generated-file';
+import { prepareRetries } from '../util/prepare-retries';
+import { logWarnings } from '../logger/log-warnings';
+import { VERSION } from '../version';
+import { VideoGenerationWarning } from '../types/video-model';
+import { VideoModelResponseMetadata } from '../types/video-model-response-metadata';
+import { GenerateVideoResult } from './generate-video-result';
+import { NoVideoGeneratedError } from '../error/no-video-generated-error';
+import { detectMediaType, videoMediaTypeSignatures } from '../util/detect-media-type';
+
+const defaultVideoMediaType = 'video/mp4';
+
+export async function generateVideo({
+  model,
+  prompt,
+  n = 1,
+  maxVideosPerCall,
+  resolution,
+  aspectRatio,
+  durationSeconds,
+  fps,
+  seed,
+  providerOptions,
+  maxRetries: maxRetriesArg,
+  abortSignal,
+  headers,
+}: {
+  model: VideoModelV2;
+  prompt: string;
+  n?: number;
+  maxVideosPerCall?: number;
+  resolution?: `${number}x${number}`;
+  aspectRatio?: `${number}:${number}`;
+  durationSeconds?: number;
+  fps?: number;
+  seed?: number | string;
+  providerOptions?: ProviderOptions;
+  maxRetries?: number;
+  abortSignal?: AbortSignal;
+  headers?: Record<string, string>;
+}): Promise<GenerateVideoResult> {
+  if (model.specificationVersion !== 'v2') {
+    throw new UnsupportedModelVersionError({
+      version: model.specificationVersion,
+      provider: model.provider,
+      modelId: model.modelId,
+    });
+  }
+
+  const headersWithUserAgent = withUserAgentSuffix(headers ?? {}, `ai/${VERSION}`);
+
+  const { retry } = prepareRetries({ maxRetries: maxRetriesArg, abortSignal });
+
+  const maxVideosPerCallWithDefault =
+    maxVideosPerCall ?? (await invokeModelMaxVideosPerCall(model)) ?? 1;
+
+  const callCount = Math.ceil(n / maxVideosPerCallWithDefault);
+  const callVideoCounts = Array.from({ length: callCount }, (_, i) => {
+    if (i < callCount - 1) return maxVideosPerCallWithDefault;
+    const remainder = n % maxVideosPerCallWithDefault;
+    return remainder === 0 ? maxVideosPerCallWithDefault : remainder;
+  });
+
+  const results = await Promise.all(
+    callVideoCounts.map(async callVideoCount =>
+      retry(() =>
+        model.doGenerate({
+          prompt,
+          n: callVideoCount,
+          abortSignal,
+          headers: headersWithUserAgent,
+          resolution,
+          aspectRatio,
+          durationSeconds,
+          fps,
+          seed,
+          providerOptions: providerOptions ?? {},
+        }),
+      ),
+    ),
+  );
+
+  const videos: Array<DefaultGeneratedFile> = [];
+  const warnings: Array<VideoGenerationWarning> = [];
+  const responses: Array<VideoModelResponseMetadata> = [];
+  const providerMetadata: VideoModelV2ProviderMetadata = {} as VideoModelV2ProviderMetadata;
+
+  for (const result of results) {
+    videos.push(
+      ...result.videos.map(video =>
+        new DefaultGeneratedFile({
+          data: video,
+          mediaType:
+            detectMediaType({
+              data: video,
+              signatures: videoMediaTypeSignatures,
+            }) ?? defaultVideoMediaType,
+        }),
+      ),
+    );
+
+    warnings.push(...result.warnings);
+
+    if (result.providerMetadata) {
+      for (const [providerName] of Object.entries<{ videos: unknown }>(
+        result.providerMetadata,
+      )) {
+        providerMetadata[providerName] ??= { videos: [] } as any;
+        (providerMetadata[providerName] as any).videos.push(
+          ...(result.providerMetadata as any)[providerName].videos,
+        );
+      }
+    }
+
+    responses.push(result.response);
+  }
+
+  logWarnings(warnings);
+
+  if (!videos.length) {
+    throw new NoVideoGeneratedError({ responses });
+  }
+
+  return new DefaultGenerateVideoResult({
+    videos,
+    warnings,
+    responses,
+    providerMetadata: providerMetadata as any,
+  });
+}
+
+class DefaultGenerateVideoResult implements GenerateVideoResult {
+  readonly videos: Array<GeneratedFile>;
+  readonly warnings: Array<VideoGenerationWarning>;
+  readonly responses: Array<VideoModelResponseMetadata>;
+  readonly providerMetadata: VideoModelV2ProviderMetadata;
+
+  constructor(options: {
+    videos: Array<GeneratedFile>;
+    warnings: Array<VideoGenerationWarning>;
+    responses: Array<VideoModelResponseMetadata>;
+    providerMetadata: VideoModelV2ProviderMetadata;
+  }) {
+    this.videos = options.videos;
+    this.warnings = options.warnings;
+    this.responses = options.responses;
+    this.providerMetadata = options.providerMetadata;
+  }
+
+  get video() {
+    return this.videos[0];
+  }
+}
+
+async function invokeModelMaxVideosPerCall(model: VideoModelV2) {
+  const isFunction = model.maxVideosPerCall instanceof Function;
+  if (!isFunction) return model.maxVideosPerCall;
+  return model.maxVideosPerCall({ modelId: model.modelId });
+}
+
+

--- a/packages/ai/src/generate-video/index.ts
+++ b/packages/ai/src/generate-video/index.ts
@@ -1,0 +1,3 @@
+export { generateVideo as experimental_generateVideo } from './generate-video';
+
+

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -23,6 +23,7 @@ export * from './agent';
 export * from './embed';
 export * from './error';
 export * from './generate-image';
+export * from './generate-video';
 export * from './generate-object';
 export * from './generate-speech';
 export * from './generate-text';

--- a/packages/ai/src/logger/log-warnings.ts
+++ b/packages/ai/src/logger/log-warnings.ts
@@ -1,5 +1,6 @@
 import {
   ImageModelV3CallWarning,
+  VideoModelV2CallWarning,
   LanguageModelV2CallWarning,
   SpeechModelV2CallWarning,
   TranscriptionModelV2CallWarning,
@@ -9,7 +10,8 @@ export type Warning =
   | LanguageModelV2CallWarning
   | ImageModelV3CallWarning
   | SpeechModelV2CallWarning
-  | TranscriptionModelV2CallWarning;
+  | TranscriptionModelV2CallWarning
+  | VideoModelV2CallWarning;
 
 export type LogWarningsFunction = (warnings: Warning[]) => void;
 

--- a/packages/ai/src/types/index.ts
+++ b/packages/ai/src/types/index.ts
@@ -6,6 +6,12 @@ export type {
   ImageModelProviderMetadata,
 } from './image-model';
 export type { ImageModelResponseMetadata } from './image-model-response-metadata';
+export type {
+  VideoModel,
+  VideoGenerationWarning as VideoModelCallWarning,
+  VideoModelProviderMetadata,
+} from './video-model';
+export type { VideoModelResponseMetadata } from './video-model-response-metadata';
 export type { JSONValue } from './json-value';
 export type {
   CallWarning,

--- a/packages/ai/src/types/video-model-response-metadata.ts
+++ b/packages/ai/src/types/video-model-response-metadata.ts
@@ -1,0 +1,18 @@
+export type VideoModelResponseMetadata = {
+  /**
+  Timestamp for the start of the generated response.
+   */
+  timestamp: Date;
+
+  /**
+  The ID of the response model that was used to generate the response.
+   */
+  modelId: string;
+
+  /**
+  Response headers.
+   */
+  headers?: Record<string, string>;
+};
+
+

--- a/packages/ai/src/types/video-model.ts
+++ b/packages/ai/src/types/video-model.ts
@@ -1,0 +1,23 @@
+import {
+  VideoModelV2,
+  VideoModelV2CallWarning,
+  VideoModelV2ProviderMetadata,
+} from '@ai-sdk/provider';
+
+/**
+Video model that is used by the AI SDK Core functions.
+ */
+export type VideoModel = VideoModelV2;
+
+/**
+Warning from the model provider for this call. The call will proceed, but e.g.
+some settings might not be supported, which can lead to suboptimal results.
+ */
+export type VideoGenerationWarning = VideoModelV2CallWarning;
+
+/**
+Metadata from the model provider for this call
+ */
+export type VideoModelProviderMetadata = VideoModelV2ProviderMetadata;
+
+

--- a/packages/ai/src/util/detect-media-type.ts
+++ b/packages/ai/src/util/detect-media-type.ts
@@ -120,6 +120,24 @@ export const audioMediaTypeSignatures = [
   },
 ] as const;
 
+export const videoMediaTypeSignatures = [
+  {
+    mediaType: 'video/mp4' as const,
+    // MP4: 'ftyp' box signature starting at offset 4; we only check prefix subset here
+    bytesPrefix: [0x00, 0x00, 0x00, null, 0x66, 0x74, 0x79, 0x70],
+  },
+  {
+    mediaType: 'video/webm' as const,
+    // EBML magic number
+    bytesPrefix: [0x1a, 0x45, 0xdf, 0xa3],
+  },
+  {
+    mediaType: 'video/quicktime' as const,
+    // QuickTime: 'ftyp' then 'qt  ' brand; approximate detection via 'ftyp'
+    bytesPrefix: [0x00, 0x00, 0x00, null, 0x66, 0x74, 0x79, 0x70],
+  },
+] as const;
+
 const stripID3 = (data: Uint8Array | string) => {
   const bytes =
     typeof data === 'string' ? convertBase64ToUint8Array(data) : data;
@@ -157,7 +175,10 @@ export function detectMediaType({
   signatures,
 }: {
   data: Uint8Array | string;
-  signatures: typeof audioMediaTypeSignatures | typeof imageMediaTypeSignatures;
+  signatures:
+    | typeof audioMediaTypeSignatures
+    | typeof imageMediaTypeSignatures
+    | typeof videoMediaTypeSignatures;
 }): (typeof signatures)[number]['mediaType'] | undefined {
   const processedData = stripID3TagsIfPresent(data);
 

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,6 +1,7 @@
 export * from './embedding-model/index';
 export * from './errors/index';
 export * from './image-model/index';
+export * from './video-model/index';
 export * from './json-value/index';
 export * from './language-model-middleware/index';
 export * from './language-model/index';

--- a/packages/provider/src/provider/v2/provider-v2.ts
+++ b/packages/provider/src/provider/v2/provider-v2.ts
@@ -2,6 +2,7 @@ import { EmbeddingModelV2 } from '../../embedding-model/v2/embedding-model-v2';
 import { ImageModelV2 } from '../../image-model/v2/image-model-v2';
 import { LanguageModelV2 } from '../../language-model/v2/language-model-v2';
 import { SpeechModelV2 } from '../../speech-model/v2/speech-model-v2';
+import { VideoModelV2 } from '../../video-model/v2/video-model-v2';
 import { TranscriptionModelV2 } from '../../transcription-model/v2/transcription-model-v2';
 
 /**
@@ -41,6 +42,16 @@ The model id is then passed to the provider function to get the model.
 @returns {ImageModel} The image model associated with the id
 */
   imageModel(modelId: string): ImageModelV2;
+
+  /**
+Returns the video model with the given id.
+The model id is then passed to the provider function to get the model.
+
+@param {string} modelId - The id of the model to return.
+
+@returns {VideoModel} The video model associated with the id
+*/
+  videoModel?(modelId: string): VideoModelV2;
 
   /**
 Returns the transcription model with the given id.

--- a/packages/provider/src/video-model/index.ts
+++ b/packages/provider/src/video-model/index.ts
@@ -1,0 +1,3 @@
+export * from './v2/index';
+
+

--- a/packages/provider/src/video-model/v2/index.ts
+++ b/packages/provider/src/video-model/v2/index.ts
@@ -1,0 +1,8 @@
+export type {
+  VideoModelV2,
+  VideoModelV2ProviderMetadata,
+} from './video-model-v2';
+export type { VideoModelV2CallOptions } from './video-model-v2-call-options';
+export type { VideoModelV2CallWarning } from './video-model-v2-call-warning';
+
+

--- a/packages/provider/src/video-model/v2/video-model-v2-call-options.ts
+++ b/packages/provider/src/video-model/v2/video-model-v2-call-options.ts
@@ -1,0 +1,74 @@
+import { SharedV2ProviderOptions } from '../../shared';
+
+export type VideoModelV2CallOptions = {
+  /**
+  Prompt for the video generation.
+   */
+  prompt: string;
+
+  /**
+  Number of videos to generate.
+   */
+  n: number;
+
+  /**
+  Resolution of the videos to generate.
+  Must have the format `{width}x{height}`.
+  `undefined` will use the provider's default resolution.
+   */
+  resolution: `${number}x${number}` | undefined;
+
+  /**
+  Aspect ratio of the videos to generate.
+  Must have the format `{width}:{height}`.
+  `undefined` will use the provider's default aspect ratio.
+   */
+  aspectRatio: `${number}:${number}` | undefined;
+
+  /**
+  Duration of the generated video in seconds.
+  `undefined` will use the provider's default duration.
+   */
+  durationSeconds: number | undefined;
+
+  /**
+  Frames per second of the generated video.
+  `undefined` will use the provider's default FPS.
+   */
+  fps: number | undefined;
+
+  /**
+  Seed for the generation.
+  `undefined` will use the provider's default seed.
+   */
+  seed: number | string | undefined;
+
+  /**
+  Additional provider-specific options that are passed through to the provider
+  as body parameters.
+
+  The outer record is keyed by the provider name, and the inner
+  record is keyed by the provider-specific metadata key.
+  ```ts
+  {
+    "openai": {
+      "style": "cinematic"
+    }
+  }
+  ```
+   */
+  providerOptions: SharedV2ProviderOptions;
+
+  /**
+  Abort signal for cancelling the operation.
+   */
+  abortSignal?: AbortSignal;
+
+  /**
+  Additional HTTP headers to be sent with the request.
+  Only applicable for HTTP-based providers.
+   */
+  headers?: Record<string, string | undefined>;
+};
+
+

--- a/packages/provider/src/video-model/v2/video-model-v2-call-warning.ts
+++ b/packages/provider/src/video-model/v2/video-model-v2-call-warning.ts
@@ -1,0 +1,18 @@
+import { VideoModelV2CallOptions } from './video-model-v2-call-options';
+
+/**
+Warning from the model provider for this call. The call will proceed, but e.g.
+some settings might not be supported, which can lead to suboptimal results.
+ */
+export type VideoModelV2CallWarning =
+  | {
+      type: 'unsupported-setting';
+      setting: keyof VideoModelV2CallOptions;
+      details?: string;
+    }
+  | {
+      type: 'other';
+      message: string;
+    };
+
+

--- a/packages/provider/src/video-model/v2/video-model-v2.ts
+++ b/packages/provider/src/video-model/v2/video-model-v2.ts
@@ -1,0 +1,106 @@
+import { JSONArray, JSONValue } from '../../json-value';
+import { VideoModelV2CallOptions } from './video-model-v2-call-options';
+import { VideoModelV2CallWarning } from './video-model-v2-call-warning';
+
+export type VideoModelV2ProviderMetadata = Record<
+  string,
+  {
+    videos: JSONArray;
+  } & JSONValue
+>;
+
+type GetMaxVideosPerCallFunction = (options: {
+  modelId: string;
+}) => PromiseLike<number | undefined> | number | undefined;
+
+/**
+Video generation model specification version 2.
+ */
+export type VideoModelV2 = {
+  /**
+The video model must specify which video model interface
+version it implements. This will allow us to evolve the video
+model interface and retain backwards compatibility. The different
+implementation versions can be handled as a discriminated union
+on our side.
+   */
+  readonly specificationVersion: 'v2';
+
+  /**
+Name of the provider for logging purposes.
+   */
+  readonly provider: string;
+
+  /**
+Provider-specific model ID for logging purposes.
+   */
+  readonly modelId: string;
+
+  /**
+Limit of how many videos can be generated in a single API call.
+Can be set to a number for a fixed limit, to undefined to use
+the global limit, or a function that returns a number or undefined,
+optionally as a promise.
+   */
+  readonly maxVideosPerCall: number | undefined | GetMaxVideosPerCallFunction;
+
+  /**
+Generates an array of videos.
+   */
+  doGenerate(options: VideoModelV2CallOptions): PromiseLike<{
+    /**
+Generated videos as base64 encoded strings or binary data.
+The videos should be returned without any unnecessary conversion.
+If the API returns base64 encoded strings, the videos should be returned
+as base64 encoded strings. If the API returns binary data, the videos should
+be returned as binary data.
+     */
+    videos: Array<string> | Array<Uint8Array>;
+
+    /**
+Warnings for the call, e.g. unsupported settings.
+     */
+    warnings: Array<VideoModelV2CallWarning>;
+
+    /**
+Additional provider-specific metadata. They are passed through
+from the provider to the AI SDK and enable provider-specific
+results that can be fully encapsulated in the provider.
+
+The outer record is keyed by the provider name, and the inner
+record is provider-specific metadata. It always includes an
+`videos` key with video-specific metadata
+
+```ts
+{
+  "provider": {
+    "videos": ["revisedPrompt": "Revised prompt here."]
+  }
+}
+```
+      */
+    providerMetadata?: VideoModelV2ProviderMetadata;
+
+    /**
+Response information for telemetry and debugging purposes.
+     */
+    response: {
+      /**
+Timestamp for the start of the generated response.
+      */
+      timestamp: Date;
+
+      /**
+The ID of the response model that was used to generate the response.
+      */
+      modelId: string;
+
+      /**
+Response headers.
+      */
+      headers: Record<string, string> | undefined;
+    };
+  }>;
+};
+
+


### PR DESCRIPTION
## Background

a lot of providers do support generating videos via APIs and the logical consequence is to support this via the AI SDK, so that we can enable developers to have one place to look out for to integrating videos into their projects

## Summary

added all the required changes to make sure that `experimental_generateVideo` works, using `experimental_generateImage` as the foundation

## Manual Verification

* i extended the `@runpod/ai-sdk-provider` to be ready to generate videos
* tested `experimental_generateVideo` with the Runpod provider with a couple of different video apis

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

- implements #7541 
