### PR TITLE
Add image detail to XAI chat message conversion

### DIFF
--- a/packages/xai/src/convert-to-xai-chat-messages.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.ts
@@ -47,6 +47,9 @@ export function convertToXaiChatMessages(prompt: LanguageModelV3Prompt): {
                         part.data instanceof URL
                           ? part.data.toString()
                           : `data:${mediaType};base64,${convertToBase64(part.data)}`,
+                      
+                      // https://docs.x.ai/docs/guides/image-understanding
+                      detail: part.providerOptions?.xai?.imageDetail,
                     },
                   };
                 } else {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Current xAI provider doesn't support propagating custom imageDetail to xAI's API. Relevant docs: https://ai-sdk.dev/providers/ai-sdk-providers/xai

## Summary

Added new provider options "imageDetail" for xAI to specify image quality when using xAI based model

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

- Update https://ai-sdk.dev/providers/ai-sdk-providers/xai to add section regarding image detail
