### PR TITLE
Backport feat(provider/gateway): Add DeepSeek V3.2 Exp to Gateway language model settings

### DIFF
--- a/.changeset/itchy-boxes-hang.md
+++ b/.changeset/itchy-boxes-hang.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): Add DeepSeek V3.2 Exp to Gateway language model settings

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -31,6 +31,8 @@ export type GatewayModelId =
   | 'deepseek/deepseek-v3.1'
   | 'deepseek/deepseek-v3.1-base'
   | 'deepseek/deepseek-v3.1-thinking'
+  | 'deepseek/deepseek-v3.1-terminus'
+  | 'deepseek/deepseek-v3.2-exp'
   | 'google/gemini-2.0-flash'
   | 'google/gemini-2.0-flash-lite'
   | 'google/gemini-2.5-flash'


### PR DESCRIPTION
Backport #9038