### PR TITLE
run prettier on automerge

### DIFF
--- a/.github/workflows/prettier-on-automerge.yml
+++ b/.github/workflows/prettier-on-automerge.yml
@@ -1,0 +1,74 @@
+name: Prettier on Auto-merge
+
+on:
+  pull_request_target:
+    types: [auto_merge_enabled]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  prettier:
+    name: Run Prettier
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    
+    steps:
+      - name: Create access token for GitHub App
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
+
+      - name: Get GitHub App User ID
+        id: app-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git user for GitHub App
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Prettier
+        run: pnpm prettier-fix
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git add -A
+          if git diff --staged --quiet; then
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes detected"
+          else
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected"
+          fi
+
+      - name: Commit and push changes
+        if: steps.git-check.outputs.has-changes == 'true'
+        run: |
+          git commit -m "style: prettier"
+          git push

--- a/packages/openai/src/openai-provider.test.ts
+++ b/packages/openai/src/openai-provider.test.ts
@@ -1,6 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createOpenAI } from './openai-provider';
-import { afterEach } from 'node:test';
 
 vi.mock('./version', () => ({
   VERSION: '0.0.0-test',


### PR DESCRIPTION
I have seen our team asking contributors to run `prettier-fix` in order to make the CI pass. We can automate that. With this workflow, each time we activate the auto-merge feature, prettier is run, and if there are any changes, they are pushed back to the pull request, which should resolve any CI error due to the prettier check, and save all of us some time.