### PR TITLE
fix(agent): move provider options to main agent config

### DIFF
--- a/.changeset/odd-goats-punch.md
+++ b/.changeset/odd-goats-punch.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(agent): move provider options to main agent config

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -15,7 +15,6 @@ import { CallSettings } from '../prompt/call-settings';
 import { Prompt } from '../prompt/prompt';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { LanguageModel, ToolChoice } from '../types/language-model';
-import { ProviderMetadata } from '../types/provider-metadata';
 import { convertToModelMessages } from '../ui/convert-to-model-messages';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
 
@@ -91,6 +90,13 @@ A function that attempts to repair a tool call that failed to parse.
   onStepFinish?: GenerateTextOnStepFinishCallback<NoInfer<TOOLS>>;
 
   /**
+Additional provider-specific options. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+         */
+  providerOptions?: ProviderOptions;
+
+  /**
    * Context that is passed into tool calls.
    *
    * Experimental (can break in patch releases).
@@ -123,41 +129,11 @@ export class Agent<
     return this.settings.tools as TOOLS;
   }
 
-  async generate(
-    options: Prompt & {
-      /**
-Additional provider-specific metadata. They are passed through
-from the provider to the AI SDK and enable provider-specific
-results that can be fully encapsulated in the provider.
-   */
-      providerMetadata?: ProviderMetadata;
-      /**
-Additional provider-specific metadata. They are passed through
-to the provider from the AI SDK and enable provider-specific
-functionality that can be fully encapsulated in the provider.
-         */
-      providerOptions?: ProviderOptions;
-    },
-  ): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
+  async generate(options: Prompt): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
     return generateText({ ...this.settings, ...options });
   }
 
-  stream(
-    options: Prompt & {
-      /**
-Additional provider-specific metadata. They are passed through
-from the provider to the AI SDK and enable provider-specific
-results that can be fully encapsulated in the provider.
-   */
-      providerMetadata?: ProviderMetadata;
-      /**
-Additional provider-specific metadata. They are passed through
-to the provider from the AI SDK and enable provider-specific
-functionality that can be fully encapsulated in the provider.
-         */
-      providerOptions?: ProviderOptions;
-    },
-  ): StreamTextResult<TOOLS, OUTPUT_PARTIAL> {
+  stream(options: Prompt): StreamTextResult<TOOLS, OUTPUT_PARTIAL> {
     return streamText({ ...this.settings, ...options });
   }
 


### PR DESCRIPTION
## Background

`providerOptions` and `providerMetadata` were incorrectly implemented on `Agent`.

## Summary

- remove provider metadata (not needed on input)
- move provider options to agent state (similar to the rest)

Note: breaking change to experimental code, no backport.
