### PR TITLE
docs(observability): add Sentry

### DIFF
--- a/content/providers/05-observability/index.mdx
+++ b/content/providers/05-observability/index.mdx
@@ -17,6 +17,7 @@ Several LLM observability providers offer integrations with the AI SDK telemetry
 - [Maxim](/providers/observability/maxim)
 - [HoneyHive](https://docs.honeyhive.ai/integrations/vercel)
 - [Scorecard](/providers/observability/scorecard)
+- [Sentry](https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/integrations/vercelai/)
 - [SigNoz](/providers/observability/signoz)
 - [Traceloop](/providers/observability/traceloop)
 - [Weave](/providers/observability/weave)


### PR DESCRIPTION
## Background

Sentry supports `ai` SDK out of the box :)

## Summary

* Added a link to Sentry's docs on setting up `ai` SDK with `nextjs`