### PR TITLE
feat(ai): set default stopWhen on Agent to stepCountIs(20)

### DIFF
--- a/.changeset/sour-carrots-reflect.md
+++ b/.changeset/sour-carrots-reflect.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): set default stopWhen on Agent to stepCountIs(20)

--- a/content/docs/07-reference/01-ai-sdk-core/05-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-agent.mdx
@@ -68,7 +68,7 @@ To see `Agent` in action, check out [these examples](#examples).
       name: 'stopWhen',
       type: 'StopCondition | StopCondition[]',
       description:
-        'Condition for stopping the generation when there are tool results in the last step. Default: stepCountIs(1)',
+        'Condition for stopping the generation when there are tool results in the last step. Default: stepCountIs(20)',
     },
     {
       name: 'activeTools',

--- a/examples/ai-core/src/agent/openai-stream-tools.ts
+++ b/examples/ai-core/src/agent/openai-stream-tools.ts
@@ -1,11 +1,11 @@
 import { openai } from '@ai-sdk/openai';
-import { Agent, stepCountIs, tool } from 'ai';
+import { Agent, tool } from 'ai';
 import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
   const agent = new Agent({
-    model: openai('gpt-3.5-turbo'),
+    model: openai('gpt-5'),
     system: 'You are a helpful that answers questions about the weather.',
     tools: {
       weather: tool({
@@ -19,7 +19,6 @@ async function main() {
         }),
       }),
     },
-    stopWhen: stepCountIs(5),
   });
 
   const result = agent.stream({

--- a/examples/ai-core/src/agent/openai-stream.ts
+++ b/examples/ai-core/src/agent/openai-stream.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 
 async function main() {
   const agent = new Agent({
-    model: openai('gpt-3.5-turbo'),
+    model: openai('gpt-5'),
     system: 'You are a helpful assistant.',
   });
 

--- a/examples/next-agent/agent/weather-agent.ts
+++ b/examples/next-agent/agent/weather-agent.ts
@@ -1,6 +1,6 @@
 import { weatherTool } from '@/tool/weather-tool';
 import { openai } from '@ai-sdk/openai';
-import { Agent, InferAgentUIMessage, stepCountIs } from 'ai';
+import { Agent, InferAgentUIMessage } from 'ai';
 
 export const weatherAgent = new Agent({
   model: openai('gpt-4o'),
@@ -8,7 +8,6 @@ export const weatherAgent = new Agent({
   tools: {
     weather: weatherTool,
   },
-  stopWhen: stepCountIs(10),
 });
 
 export type WeatherAgentUIMessage = InferAgentUIMessage<typeof weatherAgent>;

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -6,7 +6,7 @@ import {
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
 import { PrepareStepFunction } from '../generate-text/prepare-step';
-import { StopCondition } from '../generate-text/stop-condition';
+import { stepCountIs, StopCondition } from '../generate-text/stop-condition';
 import { streamText } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
@@ -52,7 +52,7 @@ The tool choice strategy. Default: 'auto'.
 Condition for stopping the generation when there are tool results in the last step.
 When the condition is an array, any of the conditions can be met to stop the generation.
 
-@default stepCountIs(1)
+@default stepCountIs(20)
    */
   stopWhen?:
     | StopCondition<NoInfer<TOOLS>>
@@ -154,11 +154,19 @@ export class Agent<
   }
 
   async generate(options: Prompt): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
-    return generateText({ ...this.settings, ...options });
+    return generateText({
+      ...this.settings,
+      stopWhen: this.settings.stopWhen ?? stepCountIs(20),
+      ...options,
+    });
   }
 
   stream(options: Prompt): StreamTextResult<TOOLS, OUTPUT_PARTIAL> {
-    return streamText({ ...this.settings, ...options });
+    return streamText({
+      ...this.settings,
+      stopWhen: this.settings.stopWhen ?? stepCountIs(20),
+      ...options,
+    });
   }
 
   /**


### PR DESCRIPTION
## Background

Agents should loop by default.

## Summary

Set the default number of steps to 20. We rolled a D20 and surprisingly a 20 came out.