### PR TITLE
feat(ai): add README section for generating structured data

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -47,7 +47,26 @@ const { text } = await generateText({
 });
 ```
 
-### Agent
+### Generating Structured Data
+
+```ts
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const { object } = await generateObject({
+  model: 'openai/gpt-4.1',
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+      steps: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate a lasagna recipe.',
+});
+```
+
+### Agents
 
 ```ts
 import { Agent } from 'ai';


### PR DESCRIPTION
## Background

Generating structured data is a primary use case that was not shown in the README.

## Summary

Add README section for `generateObject`