### PR TITLE
ci: auto-merge-release-prs

### DIFF
--- a/.github/workflows/auto-merge-release-prs.yml
+++ b/.github/workflows/auto-merge-release-prs.yml
@@ -26,10 +26,10 @@ jobs:
           app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
 
-      - name: Enable auto-merge
+      - name: merge pull request
         run: |
           gh pr merge ${{ github.event.pull_request.number }} --auto --squash
+          gh pr review ${{ github.event.pull_request.number }} --approve
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-

--- a/.github/workflows/auto-merge-release-prs.yml
+++ b/.github/workflows/auto-merge-release-prs.yml
@@ -1,0 +1,35 @@
+name: Auto-merge Release PRs
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    name: Enable Auto-merge for Release PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only run if PR is created by vercel-ai-sdk[bot] and branch starts with changeset-release/
+    if: |
+      github.event.pull_request.user.login == 'vercel-ai-sdk[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+    
+    steps:
+      - name: Create access token for GitHub App
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.VERCEL_AI_SDK_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERCEL_AI_SDK_GITHUB_APP_PRIVATE_KEY_PKCS8 }}
+
+      - name: Enable auto-merge
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} --auto --squash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+


### PR DESCRIPTION
if we ever wanted to disable the auto-merge behavior for "Version Packages" pull requests, go to the "actions" tab, select the "Auto-merge Release PRs" action in the sidebar, then click on the <kbd>⋯</kbd> button on the top right, select `Disable workflow`

<img width="1074" height="468" alt="image" src="https://github.com/user-attachments/assets/4e1557fc-df16-4b9b-a89a-7dbf2578f2c9" />
