### PR TITLE
feat(agent): add optional description property to agent

### DIFF
--- a/.changeset/nervous-deers-boil.md
+++ b/.changeset/nervous-deers-boil.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(agent): add optional description property to agent

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -29,6 +29,11 @@ export type AgentSettings<
   name?: string;
 
   /**
+   * The description of what the agent does.
+   */
+  description?: string;
+
+  /**
    * The system prompt to use.
    */
   system?: string;
@@ -144,6 +149,13 @@ export class Agent<
    */
   get name(): string | undefined {
     return this.settings.name;
+  }
+
+  /**
+   * The description of what the agent does.
+   */
+  get description(): string | undefined {
+    return this.settings.description;
   }
 
   /**


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Just like tools already support a `description` field to improve discovery and clarify their purpose, agents may also expose a description.  

Also it may be used for UI/UX purposes.

## Summary

Add a `description` property to the Agent class as an optional field, consistent with the existing `name` field.

