### PR TITLE
docs(caching): normalize middleware examples to use LanguageModelV3 types

### DIFF
--- a/content/cookbook/01-next/122-caching-middleware.mdx
+++ b/content/cookbook/01-next/122-caching-middleware.mdx
@@ -67,11 +67,14 @@ You can control the initial delay and delay between chunks by adjusting the `ini
 ```tsx filename='ai/middleware.ts'
 import { Redis } from '@upstash/redis';
 import {
-  type LanguageModelV1,
-  type LanguageModelV3Middleware,
-  type LanguageModelV1StreamPart,
   simulateReadableStream,
 } from 'ai';
+
+import {
+  type LanguageModelV3,
+  type LanguageModelV3Middleware,
+  type LanguageModelV3StreamPart,
+} from '@ai-sdk/provider';
 
 const redis = new Redis({
   url: process.env.KV_URL,
@@ -83,7 +86,7 @@ export const cacheMiddleware: LanguageModelV3Middleware = {
     const cacheKey = JSON.stringify(params);
 
     const cached = (await redis.get(cacheKey)) as Awaited<
-      ReturnType<LanguageModelV1['doGenerate']>
+      ReturnType<LanguageModelV3['doGenerate']>
     > | null;
 
     if (cached !== null) {
@@ -113,7 +116,7 @@ export const cacheMiddleware: LanguageModelV3Middleware = {
     // If cached, return a simulated ReadableStream that yields the cached result
     if (cached !== null) {
       // Format the timestamps in the cached response
-      const formattedChunks = (cached as LanguageModelV1StreamPart[]).map(p => {
+      const formattedChunks = (cached as LanguageModelV3StreamPart[]).map(p => {
         if (p.type === 'response-metadata' && p.timestamp) {
           return { ...p, timestamp: new Date(p.timestamp) };
         } else return p;
@@ -130,11 +133,11 @@ export const cacheMiddleware: LanguageModelV3Middleware = {
     // If not cached, proceed with streaming
     const { stream, ...rest } = await doStream();
 
-    const fullResponse: LanguageModelV1StreamPart[] = [];
+    const fullResponse: LanguageModelV3StreamPart[] = [];
 
     const transformStream = new TransformStream<
-      LanguageModelV1StreamPart,
-      LanguageModelV1StreamPart
+      LanguageModelV3StreamPart,
+      LanguageModelV3StreamPart
     >({
       transform(chunk, controller) {
         fullResponse.push(chunk);

--- a/content/cookbook/05-node/80-local-caching-middleware.mdx
+++ b/content/cookbook/05-node/80-local-caching-middleware.mdx
@@ -38,21 +38,22 @@ The middleware handles all transformations needed to make cached responses indis
 ### Middleware
 
 ```ts
+import { simulateReadableStream, wrapLanguageModel } from 'ai';
+
 import {
-  type LanguageModelV1,
+  type LanguageModelV3,
   type LanguageModelV3Middleware,
-  LanguageModelV1Prompt,
-  type LanguageModelV1StreamPart,
-  simulateReadableStream,
-  wrapLanguageModel,
-} from 'ai';
+  type LanguageModelV3StreamPart,
+  type LanguageModelV3Prompt,
+} from '@ai-sdk/provider';
+
 import 'dotenv/config';
 import fs from 'fs';
 import path from 'path';
 
 const CACHE_FILE = path.join(process.cwd(), '.cache/ai-cache.json');
 
-export const cached = (model: LanguageModelV1) =>
+export const cached = (model: LanguageModelV3) =>
   wrapLanguageModel({
     middleware: cacheMiddleware,
     model,
@@ -96,7 +97,7 @@ const updateCache = (key: string, value: any) => {
     console.error('Failed to update cache:', error);
   }
 };
-const cleanPrompt = (prompt: LanguageModelV1Prompt) => {
+const cleanPrompt = (prompt: LanguageModelV3Prompt) => {
   return prompt.map(m => {
     if (m.role === 'assistant') {
       return m.content.map(part =>
@@ -124,7 +125,7 @@ export const cacheMiddleware: LanguageModelV3Middleware = {
     console.log('Cache Key:', cacheKey);
 
     const cached = getCachedResult(cacheKey) as Awaited<
-      ReturnType<LanguageModelV1['doGenerate']>
+      ReturnType<LanguageModelV3['doGenerate']>
     > | null;
 
     if (cached && cached !== null) {
@@ -161,7 +162,7 @@ export const cacheMiddleware: LanguageModelV3Middleware = {
     if (cached && cached !== null) {
       console.log('Cache Hit');
       // Format the timestamps in the cached response
-      const formattedChunks = (cached as LanguageModelV1StreamPart[]).map(p => {
+      const formattedChunks = (cached as LanguageModelV3StreamPart[]).map(p => {
         if (p.type === 'response-metadata' && p.timestamp) {
           return { ...p, timestamp: new Date(p.timestamp) };
         } else return p;
@@ -179,11 +180,11 @@ export const cacheMiddleware: LanguageModelV3Middleware = {
     // If not cached, proceed with streaming
     const { stream, ...rest } = await doStream();
 
-    const fullResponse: LanguageModelV1StreamPart[] = [];
+    const fullResponse: LanguageModelV3StreamPart[] = [];
 
     const transformStream = new TransformStream<
-      LanguageModelV1StreamPart,
-      LanguageModelV1StreamPart
+      LanguageModelV3StreamPart,
+      LanguageModelV3StreamPart
     >({
       transform(chunk, controller) {
         fullResponse.push(chunk);

--- a/content/docs/06-advanced/04-caching.mdx
+++ b/content/docs/06-advanced/04-caching.mdx
@@ -18,11 +18,14 @@ Let's see how you can use language model middleware to cache responses.
 ```ts filename="ai/middleware.ts"
 import { Redis } from '@upstash/redis';
 import {
+  simulateReadableStream,
+} from 'ai';
+
+import {
   type LanguageModelV3,
   type LanguageModelV3Middleware,
   type LanguageModelV3StreamPart,
-  simulateReadableStream,
-} from 'ai';
+} from '@ai-sdk/provider';
 
 const redis = new Redis({
   url: process.env.KV_URL,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

users following the caching [docs](https://ai-sdk.dev/docs/advanced/caching) were encountering ts errors when copying the middleware examples. The documentation was using outdated `LanguageModelV2` types that are no longer exported from the `ai` package, causing import errors and type mismatches with the current v3 provider specification

## Summary

- updated all caching middleware examples to use `LanguageModelV3`, `LanguageModelV3Middleware`, and `LanguageModelV3StreamPart` types
- fixed imports across caching docs to use `@ai-sdk/provider` for provider types and `ai` for utilities like `simulateReadableStream`
- consistency (v1,v2 -> v3)

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
- deploy the latest version of `@ai-sdk/provider` package to npm
- ensure all code examples across the documentation use the correct v3 types 


## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
