### PR TITLE
feat(mcp): Add an optional fetch property to MCPTransportConfig

### DIFF
--- a/.changeset/forty-files-approve.md
+++ b/.changeset/forty-files-approve.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Add an optional fetch property to MCPTransportConfig

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -108,6 +108,13 @@ It currently does not support accepting notifications from an MCP server, and cu
                       description:
                         'Optional OAuth provider for authorization to access protected remote MCP servers.',
                     },
+                    {
+                      name: 'fetch',
+                      type: 'FetchFunction',
+                      isOptional: true,
+                      description:
+                        'Custom fetch implementation. You can use it as a middleware to intercept requests, or to provide a custom fetch implementation for e.g. testing.',
+                    },
                   ],
                 },
               ],

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -43,6 +43,7 @@ Available examples/folders:
 - `elicitation` - MCP elicitation example
 - `elicitation-multi-step` - MCP multi-step elicitation example
 - `elicitation-ui` - MCP elicitation with UI (server only)
+- `sse-custom-fetch` - SSE Transport with custom fetch (Legacy)
 
 Example usage:
 
@@ -64,3 +65,17 @@ pnpm server:elicitation-ui
 ```
 
 and then start the dev server in a new terminal in `examples/next-openai` and navigate to `localhost:3000/mcp-elicitation`
+
+## SSE Transport with custom fetch (Legacy)
+
+Start server
+
+```sh
+pnpm server:sse
+```
+
+Run example:
+
+```sh
+pnpm client:sse-custom-fetch
+```

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "server:sse": "tsx src/sse/server.ts",
     "client:sse": "tsx src/sse/client.ts",
+    "client:sse-custom-fetch": "tsx src/sse-custom-fetch/client.ts",
     "server:http": "tsx src/http/server.ts",
     "client:http": "tsx src/http/client.ts",
     "server:mcp-with-auth": "tsx src/mcp-with-auth/server.ts",
@@ -28,6 +29,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "3.0.1",
+    "@ai-sdk/provider-utils": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.24.0",
     "ai": "6.0.3",
     "dotenv": "16.4.5",

--- a/examples/mcp/src/sse-custom-fetch/client.ts
+++ b/examples/mcp/src/sse-custom-fetch/client.ts
@@ -1,0 +1,37 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, stepCountIs } from 'ai';
+import { experimental_createMCPClient } from '@ai-sdk/mcp';
+import 'dotenv/config';
+import { createDumpFetch } from './dump-fetch';
+
+async function main() {
+  const mcpClient = await experimental_createMCPClient({
+    transport: {
+      type: 'sse',
+      url: 'http://localhost:8080/sse',
+      headers: {
+        example: 'header',
+      },
+      fetch: createDumpFetch(),
+    },
+  });
+
+  const tools = await mcpClient.tools();
+
+  const { text: answer } = await generateText({
+    model: openai('gpt-4o-mini'),
+    tools,
+    stopWhen: stepCountIs(10),
+    onStepFinish: async ({ toolResults }) => {
+      console.log(`STEP RESULTS: ${JSON.stringify(toolResults, null, 2)}`);
+    },
+    system: 'You are a helpful chatbot',
+    prompt: 'List all products, then find availability for Product 1.',
+  });
+
+  await mcpClient.close();
+
+  console.log(`FINAL ANSWER: ${answer}`);
+}
+
+main().catch(console.error);

--- a/examples/mcp/src/sse-custom-fetch/dump-fetch.ts
+++ b/examples/mcp/src/sse-custom-fetch/dump-fetch.ts
@@ -1,0 +1,34 @@
+import 'dotenv/config';
+import { FetchFunction } from '@ai-sdk/provider-utils';
+import { createWriteStream, mkdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+
+/**
+ * Creates a fetch function that dumps the response body into a file in the format "fetch_<timestamp>.dump".
+ */
+export function createDumpFetch() {
+  const fetch: FetchFunction = async (input, init) => {
+    const response = await globalThis.fetch(input, init);
+    if (response.body != null) {
+      const filePath = resolve(__dirname, 'dist', `fetch_${Date.now()}.dump`);
+      mkdirSync(dirname(filePath), { recursive: true });
+      const writer = createWriteStream(filePath);
+      return new Response(
+        response.body.pipeThrough(
+          new TransformStream({
+            transform(chunk, controller) {
+              writer.write(chunk);
+              controller.enqueue(chunk);
+            },
+            flush() {
+              writer.close();
+            },
+          }),
+        ),
+        response,
+      );
+    }
+    return response;
+  };
+  return fetch;
+}

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -1,3 +1,4 @@
+import { FetchFunction } from '@ai-sdk/provider-utils';
 import { MCPClientError } from '../error/mcp-client-error';
 import { JSONRPCMessage } from './json-rpc-message';
 import { SseMCPTransport } from './mcp-sse-transport';
@@ -58,6 +59,12 @@ export type MCPTransportConfig = {
    * An optional OAuth client provider to use for authentication for MCP servers.
    */
   authProvider?: OAuthClientProvider;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
 };
 
 export function createMcpTransport(config: MCPTransportConfig): MCPTransport {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
       '@ai-sdk/openai':
         specifier: 3.0.1
         version: link:../../packages/openai
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../../packages/provider-utils
       '@modelcontextprotocol/sdk':
         specifier: ^1.24.0
         version: 1.24.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)


### PR DESCRIPTION
## Background

When running some unit tests, I can provide a custom fetch function for the providers I'm using but not for the MCP client. (And I don't want to move my project and install [`@modelcontextprotocol/sdk` just for this](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/client/sse.ts#L54))

## Summary

Adding `fetch` as an optional property on `MCPTransportConfig` and the logic / tests necessary.

## Manual Verification

Not manually verified apart from unit tests.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)