### PR TITLE
docs: re-add Smithery to toolkit documentation

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -108,6 +108,7 @@ There are several providers that offer pre-built tools as **toolkits** that you 
 - **[JigsawStack](http://www.jigsawstack.com/docs/integration/vercel)** - JigsawStack provides over 30+ small custom fine tuned models available for specific uses.
 - **[AI Tools Registry](https://ai-tools-registry.vercel.app)** - A Shadcn compatible tool definitions and components registry for the AI SDK.
 - **[DeepAgent](https://deepagent.amardeep.space/docs/vercel-ai-sdk)** - A powerful suite of 50+ AI tools and integrations, seamlessly connecting with APIs like Tavily, E2B, Airtable and [more](https://deepagent.amardeep.space/docs) to build enterprise-ready AI agents.
+- **[Smithery](https://smithery.ai/docs/integrations/vercel_ai_sdk)** - Smithery provides an open marketplace of 6K+ MCPs, including [Browserbase](https://browserbase.com/) and [Exa](https://exa.ai/).
 
 <Note>
   Do you have open source tools or tool libraries that are compatible with the


### PR DESCRIPTION
## Background

Smithery was previously removed from the toolkit listing in commit ad759cbe7 (PR #8414) due to lack of AI SDK-specific documentation/integration and attribution concerns. Smithery now properly attributes the Vercel AI SDK in their documentation.

## Summary

Re-adds Smithery to the toolkit documentation listing in `content/docs/02-foundations/04-tools.mdx` with updated documentation link: https://smithery.ai/docs/integrations/vercel_ai_sdk

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

- Original removal: https://github.com/vercel/ai/pull/8414