### PR TITLE
docs: use `inputSchema` instead of `parameters` for tools

### DIFF
--- a/content/docs/03-agents/01-overview.mdx
+++ b/content/docs/03-agents/01-overview.mdx
@@ -46,7 +46,7 @@ const result = await generateText({
   tools: {
     weather: tool({
       description: 'Get the weather in a location',
-      parameters: z.object({
+      inputSchema: z.object({
         location: z.string().describe('The location to get the weather for'),
       }),
       execute: async ({ location }) => ({
@@ -74,7 +74,7 @@ const result = await generateText({
   tools: {
     weather: tool({
       description: 'Get the weather in a location (in Fahrenheit)',
-      parameters: z.object({
+      inputSchema: z.object({
         location: z.string().describe('The location to get the weather for'),
       }),
       execute: async ({ location }) => ({
@@ -84,7 +84,7 @@ const result = await generateText({
     }),
     convertFahrenheitToCelsius: tool({
       description: 'Convert temperature from Fahrenheit to Celsius',
-      parameters: z.object({
+      inputSchema: z.object({
         temperature: z.number().describe('Temperature in Fahrenheit'),
       }),
       execute: async ({ temperature }) => {


### PR DESCRIPTION
The `parameters` key does not exists.

https://ai-sdk.dev/docs/reference/ai-sdk-core/tool