### PR TITLE
chore(ai): restructure agent files

### DIFF
--- a/.changeset/forty-apricots-hug.md
+++ b/.changeset/forty-apricots-hug.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(ai): restructure agent files

--- a/packages/ai/src/agent/agent-on-step-finish-callback.ts
+++ b/packages/ai/src/agent/agent-on-step-finish-callback.ts
@@ -1,0 +1,11 @@
+import { StepResult } from '../generate-text/step-result';
+import { ToolSet } from '../generate-text/tool-set';
+
+/**
+Callback that is set using the `onStepFinish` option.
+
+@param stepResult - The result of the step.
+ */
+export type AgentOnStepFinishCallback<TOOLS extends ToolSet> = (
+  stepResult: StepResult<TOOLS>,
+) => Promise<void> | void;

--- a/packages/ai/src/agent/agent-settings.ts
+++ b/packages/ai/src/agent/agent-settings.ts
@@ -1,0 +1,106 @@
+import { ProviderOptions } from '@ai-sdk/provider-utils';
+import { Output } from '../generate-text/output';
+import { PrepareStepFunction } from '../generate-text/prepare-step';
+import { StopCondition } from '../generate-text/stop-condition';
+import { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
+import { ToolSet } from '../generate-text/tool-set';
+import { CallSettings } from '../prompt/call-settings';
+import { TelemetrySettings } from '../telemetry/telemetry-settings';
+import { LanguageModel, ToolChoice } from '../types/language-model';
+import { AgentOnStepFinishCallback } from './agent-on-step-finish-callback';
+
+/**
+ * Configuration options for an agent.
+ */
+export type AgentSettings<
+  TOOLS extends ToolSet,
+  OUTPUT = never,
+  OUTPUT_PARTIAL = never,
+> = CallSettings & {
+  /**
+   * The name of the agent.
+   */
+  name?: string;
+
+  /**
+   * The system prompt to use.
+   */
+  system?: string;
+
+  /**
+The language model to use.
+   */
+  model: LanguageModel;
+
+  /**
+The tools that the model can call. The model needs to support calling tools.
+*/
+  tools?: TOOLS;
+
+  /**
+The tool choice strategy. Default: 'auto'.
+   */
+  toolChoice?: ToolChoice<NoInfer<TOOLS>>;
+
+  /**
+Condition for stopping the generation when there are tool results in the last step.
+When the condition is an array, any of the conditions can be met to stop the generation.
+
+@default stepCountIs(20)
+   */
+  stopWhen?:
+    | StopCondition<NoInfer<TOOLS>>
+    | Array<StopCondition<NoInfer<TOOLS>>>;
+
+  /**
+Optional telemetry configuration (experimental).
+   */
+  experimental_telemetry?: TelemetrySettings;
+
+  /**
+Limits the tools that are available for the model to call without
+changing the tool call and result types in the result.
+   */
+  activeTools?: Array<keyof NoInfer<TOOLS>>;
+
+  /**
+Optional specification for parsing structured outputs from the LLM response.
+   */
+  experimental_output?: Output<OUTPUT, OUTPUT_PARTIAL>;
+
+  /**
+   * @deprecated Use `prepareStep` instead.
+   */
+  experimental_prepareStep?: PrepareStepFunction<NoInfer<TOOLS>>;
+
+  /**
+Optional function that you can use to provide different settings for a step.
+  */
+  prepareStep?: PrepareStepFunction<NoInfer<TOOLS>>;
+
+  /**
+A function that attempts to repair a tool call that failed to parse.
+   */
+  experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
+
+  /**
+  Callback that is called when each step (LLM call) is finished, including intermediate steps.
+  */
+  onStepFinish?: AgentOnStepFinishCallback<NoInfer<TOOLS>>;
+
+  /**
+Additional provider-specific options. They are passed through
+to the provider from the AI SDK and enable provider-specific
+functionality that can be fully encapsulated in the provider.
+         */
+  providerOptions?: ProviderOptions;
+
+  /**
+   * Context that is passed into tool calls.
+   *
+   * Experimental (can break in patch releases).
+   *
+   * @default undefined
+   */
+  experimental_context?: unknown;
+};

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,123 +1,13 @@
-import { IdGenerator, ProviderOptions } from '@ai-sdk/provider-utils';
-import {
-  generateText,
-  GenerateTextOnStepFinishCallback,
-} from '../generate-text/generate-text';
+import { generateText } from '../generate-text/generate-text';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
-import { Output } from '../generate-text/output';
-import { PrepareStepFunction } from '../generate-text/prepare-step';
-import { stepCountIs, StopCondition } from '../generate-text/stop-condition';
+import { stepCountIs } from '../generate-text/stop-condition';
 import { streamText } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
-import { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
 import { ToolSet } from '../generate-text/tool-set';
-import { CallSettings } from '../prompt/call-settings';
 import { Prompt } from '../prompt/prompt';
-import { TelemetrySettings } from '../telemetry/telemetry-settings';
-import { LanguageModel, ToolChoice } from '../types/language-model';
 import { convertToModelMessages } from '../ui/convert-to-model-messages';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
-
-export type AgentSettings<
-  TOOLS extends ToolSet,
-  OUTPUT = never,
-  OUTPUT_PARTIAL = never,
-> = CallSettings & {
-  /**
-   * The name of the agent.
-   */
-  name?: string;
-
-  /**
-   * The system prompt to use.
-   */
-  system?: string;
-
-  /**
-The language model to use.
-   */
-  model: LanguageModel;
-
-  /**
-The tools that the model can call. The model needs to support calling tools.
-*/
-  tools?: TOOLS;
-
-  /**
-The tool choice strategy. Default: 'auto'.
-   */
-  toolChoice?: ToolChoice<NoInfer<TOOLS>>;
-
-  /**
-Condition for stopping the generation when there are tool results in the last step.
-When the condition is an array, any of the conditions can be met to stop the generation.
-
-@default stepCountIs(20)
-   */
-  stopWhen?:
-    | StopCondition<NoInfer<TOOLS>>
-    | Array<StopCondition<NoInfer<TOOLS>>>;
-
-  /**
-Optional telemetry configuration (experimental).
-   */
-  experimental_telemetry?: TelemetrySettings;
-
-  /**
-Limits the tools that are available for the model to call without
-changing the tool call and result types in the result.
-   */
-  activeTools?: Array<keyof NoInfer<TOOLS>>;
-
-  /**
-Optional specification for parsing structured outputs from the LLM response.
-   */
-  experimental_output?: Output<OUTPUT, OUTPUT_PARTIAL>;
-
-  /**
-   * @deprecated Use `prepareStep` instead.
-   */
-  experimental_prepareStep?: PrepareStepFunction<NoInfer<TOOLS>>;
-
-  /**
-Optional function that you can use to provide different settings for a step.
-  */
-  prepareStep?: PrepareStepFunction<NoInfer<TOOLS>>;
-
-  /**
-A function that attempts to repair a tool call that failed to parse.
-   */
-  experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
-
-  /**
-  Callback that is called when each step (LLM call) is finished, including intermediate steps.
-  */
-  onStepFinish?: GenerateTextOnStepFinishCallback<NoInfer<TOOLS>>;
-
-  /**
-Additional provider-specific options. They are passed through
-to the provider from the AI SDK and enable provider-specific
-functionality that can be fully encapsulated in the provider.
-         */
-  providerOptions?: ProviderOptions;
-
-  /**
-   * Context that is passed into tool calls.
-   *
-   * Experimental (can break in patch releases).
-   *
-   * @default undefined
-   */
-  experimental_context?: unknown;
-
-  /**
-   * Internal. For test use only. May change without notice.
-   */
-  _internal?: {
-    generateId?: IdGenerator;
-    currentDate?: () => Date;
-  };
-};
+import { AgentSettings } from './agent-settings';
 
 /**
  * The Agent class provides a structured way to encapsulate LLM configuration, tools,
@@ -153,6 +43,9 @@ export class Agent<
     return this.settings.tools as TOOLS;
   }
 
+  /**
+   * Generates an output from the agent (non-streaming).
+   */
   async generate(options: Prompt): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
     return generateText({
       ...this.settings,
@@ -161,6 +54,9 @@ export class Agent<
     });
   }
 
+  /**
+   * Streams an output from the agent (streaming).
+   */
   stream(options: Prompt): StreamTextResult<TOOLS, OUTPUT_PARTIAL> {
     return streamText({
       ...this.settings,
@@ -182,15 +78,3 @@ export class Agent<
     >();
   }
 }
-
-type InferAgentTools<AGENT> =
-  AGENT extends Agent<infer TOOLS, any, any> ? TOOLS : never;
-
-/**
- * Infer the UI message type of an agent.
- */
-export type InferAgentUIMessage<AGENT> = UIMessage<
-  never,
-  never,
-  InferUITools<InferAgentTools<AGENT>>
->;

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -1,20 +1,24 @@
 export {
   Agent,
-  type AgentSettings,
-  type InferAgentUIMessage,
 
   /**
    * @deprecated Use `Agent` instead.
    */
   Agent as Experimental_Agent,
+} from './agent';
+export { type AgentOnStepFinishCallback } from './agent-on-step-finish-callback';
+export {
+  type AgentSettings,
 
   /**
    * @deprecated Use `AgentSettings` instead.
    */
   type AgentSettings as Experimental_AgentSettings,
-
+} from './agent-settings';
+export {
   /**
    * @deprecated Use `InferAgentUIMessage` instead.
    */
   type InferAgentUIMessage as Experimental_InferAgentUIMessage,
-} from './agent';
+  type InferAgentUIMessage,
+} from './infer-agent-ui-message';

--- a/packages/ai/src/agent/infer-agent-ui-message.ts
+++ b/packages/ai/src/agent/infer-agent-ui-message.ts
@@ -1,0 +1,11 @@
+import { InferUITools, UIMessage } from '../ui/ui-messages';
+import { InferAgentTools } from './inter-agent-tools';
+
+/**
+ * Infer the UI message type of an agent.
+ */
+export type InferAgentUIMessage<AGENT> = UIMessage<
+  never,
+  never,
+  InferUITools<InferAgentTools<AGENT>>
+>;

--- a/packages/ai/src/agent/inter-agent-tools.ts
+++ b/packages/ai/src/agent/inter-agent-tools.ts
@@ -1,0 +1,7 @@
+import { Agent } from './agent';
+
+/**
+ * Infer the type of the tools of an agent.
+ */
+export type InferAgentTools<AGENT> =
+  AGENT extends Agent<infer TOOLS, any, any> ? TOOLS : never;


### PR DESCRIPTION
## Background

Agent interfaces lacked JSDoc and some were taken from generateText.

## Summary

* split into separate files for different interfaces
* introduce `AgentOnStepFinishCallback` type
* add jsdoc comments