### PR TITLE
feat(ai): onFinish callback for generateText

### DIFF
--- a/.changeset/few-singers-drum.md
+++ b/.changeset/few-singers-drum.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): onFinish callback for generateText

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -80,6 +80,27 @@ console.log(JSON.stringify(result.response.headers, null, 2));
 console.log(JSON.stringify(result.response.body, null, 2));
 ```
 
+### `onFinish` callback
+
+When using `generateText`, you can provide an `onFinish` callback that is triggered after the last step is finished (
+[API Reference](/docs/reference/ai-sdk-core/generate-text#on-finish)
+).
+It contains the text, usage information, finish reason, messages, steps, total usage, and more:
+
+```tsx highlight="6-8"
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-4.1',
+  prompt: 'Invent a new holiday and describe its traditions.',
+  onFinish({ text, finishReason, usage, response, steps, totalUsage }) {
+    // your own logic, e.g. for saving the chat history or recording usage
+
+    const messages = response.messages; // messages that were generated
+  },
+});
+```
+
 ## `streamText`
 
 Depending on your model and prompt, it can take a large language model (LLM) up to a minute to finish generating its response. This delay can be unacceptable for interactive use cases such as chatbots or real-time applications, where users expect immediate responses.

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -828,6 +828,262 @@ To see `generateText` in action, check out [these examples](#examples).
         },
       ],
     },
+    {
+      name: 'onFinish',
+      type: '(result: OnFinishResult) => Promise<void> | void',
+      isOptional: true,
+      description:
+        'Callback that is called when the LLM response and all request tool executions (for tools that have an `execute` function) are finished.',
+      properties: [
+        {
+          type: 'OnFinishResult',
+          parameters: [
+            {
+              name: 'finishReason',
+              type: '"stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown"',
+              description: 'The reason the model finished generating the text.',
+            },
+            {
+              name: 'usage',
+              type: 'LanguageModelUsage',
+              description: 'The token usage of the generated text.',
+              properties: [
+                {
+                  type: 'LanguageModelUsage',
+                  parameters: [
+                    {
+                      name: 'inputTokens',
+                      type: 'number | undefined',
+                      description: 'The number of input (prompt) tokens used.',
+                    },
+                    {
+                      name: 'outputTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of output (completion) tokens used.',
+                    },
+                    {
+                      name: 'totalTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of reasoning tokens used.',
+                    },
+                    {
+                      name: 'cachedInputTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of cached input tokens.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'providerMetadata',
+              type: 'Record<string,Record<string,JSONValue>> | undefined',
+              description:
+                'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+            },
+            {
+              name: 'text',
+              type: 'string',
+              description: 'The full text that has been generated.',
+            },
+            {
+              name: 'reasoning',
+              type: 'string | undefined',
+              description:
+                'The reasoning text of the model (only available for some models).',
+            },
+            {
+              name: 'reasoningDetails',
+              type: 'Array<ReasoningDetail>',
+              description:
+                'The reasoning details of the model (only available for some models).',
+              properties: [
+                {
+                  type: 'ReasoningDetail',
+                  parameters: [
+                    {
+                      name: 'type',
+                      type: "'text'",
+                      description: 'The type of the reasoning detail.',
+                    },
+                    {
+                      name: 'text',
+                      type: 'string',
+                      description: 'The text content (only for type "text").',
+                    },
+                    {
+                      name: 'signature',
+                      type: 'string',
+                      isOptional: true,
+                      description: 'Optional signature (only for type "text").',
+                    },
+                  ],
+                },
+                {
+                  type: 'ReasoningDetail',
+                  parameters: [
+                    {
+                      name: 'type',
+                      type: "'redacted'",
+                      description: 'The type of the reasoning detail.',
+                    },
+                    {
+                      name: 'data',
+                      type: 'string',
+                      description:
+                        'The redacted data content (only for type "redacted").',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'sources',
+              type: 'Array<Source>',
+              description:
+                'Sources that have been used as input to generate the response. For multi-step generation, the sources are accumulated from all steps.',
+              properties: [
+                {
+                  type: 'Source',
+                  parameters: [
+                    {
+                      name: 'sourceType',
+                      type: "'url'",
+                      description:
+                        'A URL source. This is return by web search RAG models.',
+                    },
+                    {
+                      name: 'id',
+                      type: 'string',
+                      description: 'The ID of the source.',
+                    },
+                    {
+                      name: 'url',
+                      type: 'string',
+                      description: 'The URL of the source.',
+                    },
+                    {
+                      name: 'title',
+                      type: 'string',
+                      isOptional: true,
+                      description: 'The title of the source.',
+                    },
+                    {
+                      name: 'providerMetadata',
+                      type: 'SharedV2ProviderMetadata',
+                      isOptional: true,
+                      description:
+                        'Additional provider metadata for the source.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'files',
+              type: 'Array<GeneratedFile>',
+              description: 'Files that were generated in the final step.',
+              properties: [
+                {
+                  type: 'GeneratedFile',
+                  parameters: [
+                    {
+                      name: 'base64',
+                      type: 'string',
+                      description: 'File as a base64 encoded string.',
+                    },
+                    {
+                      name: 'uint8Array',
+                      type: 'Uint8Array',
+                      description: 'File as a Uint8Array.',
+                    },
+                    {
+                      name: 'mediaType',
+                      type: 'string',
+                      description: 'The IANA media type of the file.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'toolCalls',
+              type: 'ToolCall[]',
+              description: 'The tool calls that have been executed.',
+            },
+            {
+              name: 'toolResults',
+              type: 'ToolResult[]',
+              description: 'The tool results that have been generated.',
+            },
+            {
+              name: 'warnings',
+              type: 'Warning[] | undefined',
+              description:
+                'Warnings from the model provider (e.g. unsupported settings).',
+            },
+            {
+              name: 'response',
+              type: 'Response',
+              isOptional: true,
+              description: 'Response metadata.',
+              properties: [
+                {
+                  type: 'Response',
+                  parameters: [
+                    {
+                      name: 'id',
+                      type: 'string',
+                      description:
+                        'The response identifier. The AI SDK uses the ID from the provider response when available, and generates an ID otherwise.',
+                    },
+                    {
+                      name: 'model',
+                      type: 'string',
+                      description:
+                        'The model that was used to generate the response. The AI SDK uses the response model from the provider response when available, and the model from the function call otherwise.',
+                    },
+                    {
+                      name: 'timestamp',
+                      type: 'Date',
+                      description:
+                        'The timestamp of the response. The AI SDK uses the response timestamp from the provider response when available, and creates a timestamp otherwise.',
+                    },
+                    {
+                      name: 'headers',
+                      isOptional: true,
+                      type: 'Record<string, string>',
+                      description: 'Optional response headers.',
+                    },
+                    {
+                      name: 'messages',
+                      type: 'Array<ResponseMessage>',
+                      description:
+                        'The response messages that were generated during the call. It consists of an assistant message, potentially containing tool calls.  When there are tool results, there is an additional tool message with the tool results that are available. If there are tools that do not have execute functions, they are not included in the tool results and need to be added separately.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'steps',
+              type: 'Array<StepResult>',
+              description:
+                'Response information for every step. You can use this to get information about intermediate steps, such as the tool calls or the response headers.',
+            },
+          ],
+        },
+      ],
+    },
   ]}
 />
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -709,7 +709,48 @@ To see `generateText` in action, check out [these examples](#examples).
             {
               name: 'usage',
               type: 'LanguageModelUsage',
-              description: 'The token usage of the step.',
+              description: 'The token usage of last step.',
+              properties: [
+                {
+                  type: 'LanguageModelUsage',
+                  parameters: [
+                    {
+                      name: 'inputTokens',
+                      type: 'number | undefined',
+                      description: 'The number of input (prompt) tokens used.',
+                    },
+                    {
+                      name: 'outputTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of output (completion) tokens used.',
+                    },
+                    {
+                      name: 'totalTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of reasoning tokens used.',
+                    },
+                    {
+                      name: 'cachedInputTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of cached input tokens.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'totalUsage',
+              type: 'LanguageModelUsage',
+              description: 'The total token usage from all steps.',
               properties: [
                 {
                   type: 'LanguageModelUsage',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -978,7 +978,8 @@ To see `streamText` in action, check out [these examples](#examples).
                     {
                       name: 'outputTokens',
                       type: 'number | undefined',
-                      description: 'The number of output (completion) tokens used.',
+                      description:
+                        'The number of output (completion) tokens used.',
                     },
                     {
                       name: 'totalTokens',
@@ -1170,7 +1171,7 @@ To see `streamText` in action, check out [these examples](#examples).
             {
               name: 'usage',
               type: 'LanguageModelUsage',
-              description: 'The token usage of the generated text.',
+              description: 'The token usage of last step.',
               properties: [
                 {
                   type: 'LanguageModelUsage',
@@ -1183,7 +1184,49 @@ To see `streamText` in action, check out [these examples](#examples).
                     {
                       name: 'outputTokens',
                       type: 'number | undefined',
-                      description: 'The number of output (completion) tokens used.',
+                      description:
+                        'The number of output (completion) tokens used.',
+                    },
+                    {
+                      name: 'totalTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The total number of tokens as reported by the provider. This number might be different from the sum of inputTokens and outputTokens and e.g. include reasoning tokens or other overhead.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of reasoning tokens used.',
+                    },
+                    {
+                      name: 'cachedInputTokens',
+                      type: 'number | undefined',
+                      isOptional: true,
+                      description: 'The number of cached input tokens.',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'totalUsage',
+              type: 'LanguageModelUsage',
+              description: 'The total token usage from all steps.',
+              properties: [
+                {
+                  type: 'LanguageModelUsage',
+                  parameters: [
+                    {
+                      name: 'inputTokens',
+                      type: 'number | undefined',
+                      description: 'The number of input (prompt) tokens used.',
+                    },
+                    {
+                      name: 'outputTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of output (completion) tokens used.',
                     },
                     {
                       name: 'totalTokens',
@@ -1426,8 +1469,7 @@ To see `streamText` in action, check out [these examples](#examples).
         },
       ],
     },
-
-]}
+  ]}
 />
 
 ### Returns

--- a/examples/ai-core/src/generate-text/openai-on-finish.ts
+++ b/examples/ai-core/src/generate-text/openai-on-finish.ts
@@ -1,0 +1,13 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  await generateText({
+    model: openai('gpt-4o'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+    onFinish(event) {
+      console.dir(event, { depth: Infinity });
+    },
+  });
+});

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -1,6 +1,229 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > onStepFinish should be called for each step 1`] = `
+exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callbacks > onFinish should send correct information 1`] = `
+{
+  "content": [
+    {
+      "text": "Hello, world!",
+      "type": "text",
+    },
+  ],
+  "finishReason": "stop",
+  "providerMetadata": undefined,
+  "request": {},
+  "response": {
+    "body": undefined,
+    "headers": {
+      "custom-response-header": "response-header-value",
+    },
+    "id": "test-id-2-from-model",
+    "messages": [
+      {
+        "content": [
+          {
+            "input": {
+              "value": "value",
+            },
+            "providerExecuted": undefined,
+            "providerOptions": undefined,
+            "toolCallId": "call-1",
+            "toolName": "tool1",
+            "type": "tool-call",
+          },
+        ],
+        "role": "assistant",
+      },
+      {
+        "content": [
+          {
+            "output": {
+              "type": "text",
+              "value": "result1",
+            },
+            "toolCallId": "call-1",
+            "toolName": "tool1",
+            "type": "tool-result",
+          },
+        ],
+        "role": "tool",
+      },
+      {
+        "content": [
+          {
+            "providerOptions": undefined,
+            "text": "Hello, world!",
+            "type": "text",
+          },
+        ],
+        "role": "assistant",
+      },
+    ],
+    "modelId": "test-response-model-id",
+    "timestamp": 1970-01-01T00:00:10.000Z,
+  },
+  "steps": [
+    DefaultStepResult {
+      "content": [
+        {
+          "input": {
+            "value": "value",
+          },
+          "providerExecuted": undefined,
+          "providerMetadata": undefined,
+          "toolCallId": "call-1",
+          "toolName": "tool1",
+          "type": "tool-call",
+        },
+        {
+          "dynamic": false,
+          "input": {
+            "value": "value",
+          },
+          "output": "result1",
+          "toolCallId": "call-1",
+          "toolName": "tool1",
+          "type": "tool-result",
+        },
+      ],
+      "finishReason": "tool-calls",
+      "providerMetadata": undefined,
+      "request": {},
+      "response": {
+        "body": undefined,
+        "headers": undefined,
+        "id": "test-id-1-from-model",
+        "messages": [
+          {
+            "content": [
+              {
+                "input": {
+                  "value": "value",
+                },
+                "providerExecuted": undefined,
+                "providerOptions": undefined,
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "text",
+                  "value": "result1",
+                },
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ],
+        "modelId": "test-response-model-id",
+        "timestamp": 1970-01-01T00:00:00.000Z,
+      },
+      "usage": {
+        "cachedInputTokens": undefined,
+        "inputTokens": 10,
+        "outputTokens": 5,
+        "reasoningTokens": undefined,
+        "totalTokens": 15,
+      },
+      "warnings": [],
+    },
+    DefaultStepResult {
+      "content": [
+        {
+          "text": "Hello, world!",
+          "type": "text",
+        },
+      ],
+      "finishReason": "stop",
+      "providerMetadata": undefined,
+      "request": {},
+      "response": {
+        "body": undefined,
+        "headers": {
+          "custom-response-header": "response-header-value",
+        },
+        "id": "test-id-2-from-model",
+        "messages": [
+          {
+            "content": [
+              {
+                "input": {
+                  "value": "value",
+                },
+                "providerExecuted": undefined,
+                "providerOptions": undefined,
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-call",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "output": {
+                  "type": "text",
+                  "value": "result1",
+                },
+                "toolCallId": "call-1",
+                "toolName": "tool1",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+          {
+            "content": [
+              {
+                "providerOptions": undefined,
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ],
+        "modelId": "test-response-model-id",
+        "timestamp": 1970-01-01T00:00:10.000Z,
+      },
+      "usage": {
+        "cachedInputTokens": undefined,
+        "inputTokens": 3,
+        "outputTokens": 10,
+        "reasoningTokens": undefined,
+        "totalTokens": 13,
+      },
+      "warnings": [],
+    },
+  ],
+  "totalUsage": {
+    "cachedInputTokens": undefined,
+    "inputTokens": 13,
+    "outputTokens": 15,
+    "reasoningTokens": undefined,
+    "totalTokens": 28,
+  },
+  "usage": {
+    "cachedInputTokens": undefined,
+    "inputTokens": 3,
+    "outputTokens": 10,
+    "reasoningTokens": undefined,
+    "totalTokens": 13,
+  },
+  "warnings": [],
+}
+`;
+
+exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callbacks > onStepFinish should be called for each step 1`] = `
 [
   DefaultStepResult {
     "content": [

--- a/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
+++ b/packages/ai/src/generate-text/__snapshots__/generate-text.test.ts.snap
@@ -8,8 +8,13 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "type": "text",
     },
   ],
+  "dynamicToolCalls": [],
+  "dynamicToolResults": [],
+  "files": [],
   "finishReason": "stop",
   "providerMetadata": undefined,
+  "reasoning": [],
+  "reasoningText": undefined,
   "request": {},
   "response": {
     "body": undefined,
@@ -61,6 +66,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
     "modelId": "test-response-model-id",
     "timestamp": 1970-01-01T00:00:10.000Z,
   },
+  "sources": [],
+  "staticToolCalls": [],
+  "staticToolResults": [],
   "steps": [
     DefaultStepResult {
       "content": [
@@ -205,6 +213,9 @@ exports[`generateText > options.stopWhen > 2 steps: initial, tool-result > callb
       "warnings": [],
     },
   ],
+  "text": "Hello, world!",
+  "toolCalls": [],
+  "toolResults": [],
   "totalUsage": {
     "cachedInputTokens": undefined,
     "inputTokens": 13,

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -722,8 +722,13 @@ describe('generateText', () => {
               "type": "tool-result",
             },
           ],
+          "dynamicToolCalls": [],
+          "dynamicToolResults": [],
+          "files": [],
           "finishReason": "stop",
           "providerMetadata": undefined,
+          "reasoning": [],
+          "reasoningText": undefined,
           "request": {},
           "response": {
             "body": undefined,
@@ -770,6 +775,31 @@ describe('generateText', () => {
             "modelId": "mock-model-id",
             "timestamp": 1970-01-01T00:00:00.000Z,
           },
+          "sources": [],
+          "staticToolCalls": [
+            {
+              "input": {
+                "value": "value",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "staticToolResults": [
+            {
+              "dynamic": false,
+              "input": {
+                "value": "value",
+              },
+              "output": "value-result",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
+            },
+          ],
           "steps": [
             DefaultStepResult {
               "content": [
@@ -854,6 +884,31 @@ describe('generateText', () => {
                 "totalTokens": 13,
               },
               "warnings": [],
+            },
+          ],
+          "text": "Hello, World!",
+          "toolCalls": [
+            {
+              "input": {
+                "value": "value",
+              },
+              "providerExecuted": undefined,
+              "providerMetadata": undefined,
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-call",
+            },
+          ],
+          "toolResults": [
+            {
+              "dynamic": false,
+              "input": {
+                "value": "value",
+              },
+              "output": "value-result",
+              "toolCallId": "call-1",
+              "toolName": "tool1",
+              "type": "tool-result",
             },
           ],
           "totalUsage": {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -877,13 +877,18 @@ describe('generateText', () => {
   });
 
   describe('options.stopWhen', () => {
+    let result: GenerateTextResult<any, any>;
+    let onFinishResult: Parameters<GenerateTextOnFinishCallback<any>>[0];
+    let onStepFinishResults: StepResult<any>[];
+
+    beforeEach(() => {
+      result = undefined as any;
+      onFinishResult = undefined as any;
+      onStepFinishResults = [];
+    });
+
     describe('2 steps: initial, tool-result', () => {
-      let result: GenerateTextResult<any, any>;
-      let onStepFinishResults: StepResult<any>[];
-
       beforeEach(async () => {
-        onStepFinishResults = [];
-
         let responseCount = 0;
         result = await generateText({
           model: new MockLanguageModelV3({
@@ -974,10 +979,13 @@ describe('generateText', () => {
             }),
           },
           prompt: 'test-input',
-          stopWhen: stepCountIs(3),
+          onFinish: async event => {
+            onFinishResult = event as unknown as typeof onFinishResult;
+          },
           onStepFinish: async event => {
             onStepFinishResults.push(event);
           },
+          stopWhen: stepCountIs(3),
         });
       });
 
@@ -1025,8 +1033,14 @@ describe('generateText', () => {
         expect(result.steps).toMatchSnapshot();
       });
 
-      it('onStepFinish should be called for each step', () => {
-        expect(onStepFinishResults).toMatchSnapshot();
+      describe('callbacks', () => {
+        it('onFinish should send correct information', async () => {
+          expect(onFinishResult).toMatchSnapshot();
+        });
+
+        it('onStepFinish should be called for each step', () => {
+          expect(onStepFinishResults).toMatchSnapshot();
+        });
       });
     });
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -707,7 +707,28 @@ A function that attempts to repair a tool call that failed to parse.
           } as LanguageModelUsage,
         );
 
-        await onFinish?.({ ...lastStep, steps, totalUsage });
+        await onFinish?.({
+          finishReason: lastStep.finishReason,
+          usage: lastStep.usage,
+          content: lastStep.content,
+          text: lastStep.text,
+          reasoningText: lastStep.reasoningText,
+          reasoning: lastStep.reasoning,
+          files: lastStep.files,
+          sources: lastStep.sources,
+          toolCalls: lastStep.toolCalls,
+          staticToolCalls: lastStep.staticToolCalls,
+          dynamicToolCalls: lastStep.dynamicToolCalls,
+          toolResults: lastStep.toolResults,
+          staticToolResults: lastStep.staticToolResults,
+          dynamicToolResults: lastStep.dynamicToolResults,
+          request: lastStep.request,
+          response: lastStep.response,
+          warnings: lastStep.warnings,
+          providerMetadata: lastStep.providerMetadata,
+          steps,
+          totalUsage,
+        });
 
         return new DefaultGenerateTextResult({
           steps,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -694,6 +694,12 @@ A function that attempts to repair a tool call that failed to parse.
 
         const lastStep = steps[steps.length - 1];
 
+        await onFinish?.({
+          ...lastStep,
+          steps,
+          totalUsage: lastStep.usage, // TODO aggregate usage
+        });
+
         return new DefaultGenerateTextResult({
           steps,
           resolvedOutput: await output?.parseOutput(

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -76,6 +76,25 @@ export type GenerateTextOnStepFinishCallback<TOOLS extends ToolSet> = (
 ) => Promise<void> | void;
 
 /**
+Callback that is set using the `onFinish` option.
+
+@param event - The event that is passed to the callback.
+ */
+export type GenerateTextOnFinishCallback<TOOLS extends ToolSet> = (
+  event: StepResult<TOOLS> & {
+    /**
+Details for all steps.
+   */
+    readonly steps: StepResult<TOOLS>[];
+
+    /**
+Total usage for all steps. This is the sum of the usage of all steps.
+     */
+    readonly totalUsage: LanguageModelUsage;
+  },
+) => PromiseLike<void> | void;
+
+/**
 Generate a text and call tools for a given prompt using a language model.
 
 This function does not stream the output. If you want to stream the output, use `streamText` instead.
@@ -117,6 +136,7 @@ If set and supported by the model, calls will generate deterministic results.
 @param experimental_generateMessageId - Generate a unique ID for each message.
 
 @param onStepFinish - Callback that is called when each step (LLM call) is finished, including intermediate steps.
+@param onFinish - Callback that is called when all steps are finished and the response is complete.
 
 @returns
 A result object that contains the generated text, the results of the tool calls, and additional information.

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -171,6 +171,7 @@ export async function generateText<
     currentDate = () => new Date(),
   } = {},
   onStepFinish,
+  onFinish,
   ...settings
 }: CallSettings &
   Prompt & {
@@ -250,9 +251,14 @@ A function that attempts to repair a tool call that failed to parse.
     experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
 
     /**
-    Callback that is called when each step (LLM call) is finished, including intermediate steps.
-    */
+     * Callback that is called when each step (LLM call) is finished, including intermediate steps.
+     */
     onStepFinish?: GenerateTextOnStepFinishCallback<NoInfer<TOOLS>>;
+
+    /**
+     * Callback that is called when all steps are finished and the response is complete.
+     */
+    onFinish?: GenerateTextOnFinishCallback<NoInfer<TOOLS>>;
 
     /**
      * Context that is passed into tool execution.

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -1,5 +1,8 @@
-export { generateText } from './generate-text';
-export type { GenerateTextOnStepFinishCallback } from './generate-text';
+export {
+  generateText,
+  type GenerateTextOnFinishCallback,
+  type GenerateTextOnStepFinishCallback,
+} from './generate-text';
 export type { GenerateTextResult } from './generate-text-result';
 export type {
   GeneratedFile as Experimental_GeneratedImage, // Image for backwards compatibility, TODO remove in v5
@@ -11,13 +14,13 @@ export type { ReasoningOutput } from './reasoning-output';
 export { smoothStream, type ChunkDetector } from './smooth-stream';
 export type { StepResult } from './step-result';
 export { hasToolCall, stepCountIs, type StopCondition } from './stop-condition';
-export { streamText } from './stream-text';
-export type {
-  StreamTextOnChunkCallback,
-  StreamTextOnErrorCallback,
-  StreamTextOnFinishCallback,
-  StreamTextOnStepFinishCallback,
-  StreamTextTransform,
+export {
+  streamText,
+  type StreamTextOnChunkCallback,
+  type StreamTextOnErrorCallback,
+  type StreamTextOnFinishCallback,
+  type StreamTextOnStepFinishCallback,
+  type StreamTextTransform,
 } from './stream-text';
 export type {
   StreamTextResult,

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -43,7 +43,7 @@ import { mockValues } from '../test/mock-values';
 import { object, text } from './output';
 import { StepResult } from './step-result';
 import { stepCountIs } from './stop-condition';
-import { streamText } from './stream-text';
+import { streamText, StreamTextOnFinishCallback } from './stream-text';
 import { StreamTextResult, TextStreamPart } from './stream-text-result';
 import { ToolSet } from './tool-set';
 
@@ -4712,9 +4712,7 @@ describe('streamText', () => {
 
   describe('options.onFinish', () => {
     it('should send correct information', async () => {
-      let result!: Parameters<
-        Required<Parameters<typeof streamText>[0]>['onFinish']
-      >[0];
+      let result!: Parameters<StreamTextOnFinishCallback<any>>[0];
 
       const resultObject = streamText({
         model: createTestModel({

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -5513,24 +5513,21 @@ describe('streamText', () => {
 
   describe('options.stopWhen', () => {
     let result: StreamTextResult<any, any>;
-    let onFinishResult: Parameters<
-      Required<Parameters<typeof streamText>[0]>['onFinish']
-    >[0];
+    let onFinishResult: Parameters<StreamTextOnFinishCallback<any>>[0];
     let onStepFinishResults: StepResult<any>[];
     let tracer: MockTracer;
     let stepInputs: Array<any>;
 
     beforeEach(() => {
+      result = undefined as any;
+      onFinishResult = undefined as any;
+      onStepFinishResults = [];
       tracer = new MockTracer();
       stepInputs = [];
     });
 
     describe('2 steps: initial, tool-result', () => {
       beforeEach(async () => {
-        result = undefined as any;
-        onFinishResult = undefined as any;
-        onStepFinishResults = [];
-
         let responseCount = 0;
         result = streamText({
           model: new MockLanguageModelV3({
@@ -5603,7 +5600,6 @@ describe('streamText', () => {
           },
           prompt: 'test-input',
           onFinish: async event => {
-            expect(onFinishResult).to.be.undefined;
             onFinishResult = event as unknown as typeof onFinishResult;
           },
           onStepFinish: async event => {
@@ -6625,7 +6621,6 @@ describe('streamText', () => {
     });
 
     describe('2 steps: initial, tool-result with prepareStep', () => {
-      let result: StreamTextResult<any, any>;
       let doStreamCalls: Array<LanguageModelV3CallOptions>;
       let prepareStepCalls: Array<{
         stepNumber: number;
@@ -7227,10 +7222,6 @@ describe('streamText', () => {
         });
 
       beforeEach(async () => {
-        result = undefined as any;
-        onFinishResult = undefined as any;
-        onStepFinishResults = [];
-
         let responseCount = 0;
         result = streamText({
           model: new MockLanguageModelV3({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -216,13 +216,10 @@ If set and supported by the model, calls will generate deterministic results.
 @param abortSignal - An optional abort signal that can be used to cancel the call.
 @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
 
-@param maxSteps - Maximum number of sequential LLM calls (steps), e.g. when you use tool calls.
-
 @param onChunk - Callback that is called for each chunk of the stream. The stream processing will pause until the callback promise is resolved.
 @param onError - Callback that is called when an error occurs during streaming. You can use it to log errors.
 @param onStepFinish - Callback that is called when each step (LLM call) is finished, including intermediate steps.
-@param onFinish - Callback that is called when the LLM response and all request tool executions
-(for tools that have an `execute` function) are finished.
+@param onFinish - Callback that is called when all steps are finished and the response is complete.
 
 @return
 A result object for accessing different stream types and additional information.


### PR DESCRIPTION
## Background

Agents need an `onFinish` callback. Therefore `onFinish` needs to be supported in `generateText` first.

## Summary

Add `onFinish` callback to `generateText` with the same semantics as `streamText.onFinish`.

## Manual Verification

- [x] Run `examples/ai-core/src/generate-text/openai-on-finish.ts`

## Tasks

- [x] add interface and option
- [x] generateText version of streamText onFinish test cases
- [x] implement
- [x] aggregate usage
- [x] reference docs
- [x] guide
- [x] example
- [x] changeset

## Future Work

* add `onFinish` callback to `Agent` abstraction
* add `onAbort` callback