### PR TITLE
feat(ai): add onFinish to Agent

### DIFF
--- a/.changeset/poor-bats-sell.md
+++ b/.changeset/poor-bats-sell.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add onFinish to Agent

--- a/examples/ai-core/src/agent/openai-generate-on-finish.ts
+++ b/examples/ai-core/src/agent/openai-generate-on-finish.ts
@@ -3,16 +3,15 @@ import { Agent } from 'ai';
 import { run } from '../lib/run';
 
 const agent = new Agent({
-  model: openai('gpt-5'),
+  model: openai('gpt-4o'),
   system: 'You are a helpful assistant.',
 });
 
 run(async () => {
-  const result = agent.stream({
+  await agent.generate({
     prompt: 'Invent a new holiday and describe its traditions.',
+    onFinish(event) {
+      console.dir(event, { depth: Infinity });
+    },
   });
-
-  for await (const textPart of result.textStream) {
-    process.stdout.write(textPart);
-  }
 });

--- a/examples/ai-core/src/agent/openai-generate-on-finish.ts
+++ b/examples/ai-core/src/agent/openai-generate-on-finish.ts
@@ -5,8 +5,8 @@ import { run } from '../lib/run';
 const agent = new Agent({
   model: openai('gpt-4o'),
   system: 'You are a helpful assistant.',
-  onFinish(event) {
-    console.dir(event, { depth: Infinity });
+  onFinish({ text }) {
+    console.log(text);
   },
 });
 

--- a/examples/ai-core/src/agent/openai-generate-on-finish.ts
+++ b/examples/ai-core/src/agent/openai-generate-on-finish.ts
@@ -5,13 +5,13 @@ import { run } from '../lib/run';
 const agent = new Agent({
   model: openai('gpt-4o'),
   system: 'You are a helpful assistant.',
+  onFinish(event) {
+    console.dir(event, { depth: Infinity });
+  },
 });
 
 run(async () => {
   await agent.generate({
     prompt: 'Invent a new holiday and describe its traditions.',
-    onFinish(event) {
-      console.dir(event, { depth: Infinity });
-    },
   });
 });

--- a/examples/ai-core/src/agent/openai-generate.ts
+++ b/examples/ai-core/src/agent/openai-generate.ts
@@ -1,20 +1,16 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent } from 'ai';
-import 'dotenv/config';
+import { run } from '../lib/run';
 
-async function main() {
-  const agent = new Agent({
-    model: openai('gpt-4o'),
-    system: 'You are a helpful assistant.',
-  });
+const agent = new Agent({
+  model: openai('gpt-4o'),
+  system: 'You are a helpful assistant.',
+});
 
-  const { text, usage } = await agent.generate({
+run(async () => {
+  const { text } = await agent.generate({
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
   console.log(text);
-  console.log();
-  console.log('Usage:', usage);
-}
-
-main().catch(console.error);
+});

--- a/examples/ai-core/src/agent/openai-stream-tools.ts
+++ b/examples/ai-core/src/agent/openai-stream-tools.ts
@@ -1,26 +1,26 @@
 import { openai } from '@ai-sdk/openai';
 import { Agent, tool } from 'ai';
-import 'dotenv/config';
+import { run } from '../lib/run';
 import { z } from 'zod';
 
-async function main() {
-  const agent = new Agent({
-    model: openai('gpt-5'),
-    system: 'You are a helpful that answers questions about the weather.',
-    tools: {
-      weather: tool({
-        description: 'Get the weather in a location',
-        inputSchema: z.object({
-          location: z.string().describe('The location to get the weather for'),
-        }),
-        execute: ({ location }) => ({
-          location,
-          temperature: 72 + Math.floor(Math.random() * 21) - 10,
-        }),
+const agent = new Agent({
+  model: openai('gpt-5'),
+  system: 'You are a helpful that answers questions about the weather.',
+  tools: {
+    weather: tool({
+      description: 'Get the weather in a location',
+      inputSchema: z.object({
+        location: z.string().describe('The location to get the weather for'),
       }),
-    },
-  });
+      execute: ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+  },
+});
 
+run(async () => {
   const result = agent.stream({
     prompt: 'What is the weather in Tokyo?',
   });
@@ -28,10 +28,4 @@ async function main() {
   for await (const textPart of result.textStream) {
     process.stdout.write(textPart);
   }
-
-  console.log();
-  console.log('Token usage:', await result.usage);
-  console.log('Finish reason:', await result.finishReason);
-}
-
-main().catch(console.error);
+});

--- a/packages/ai/src/agent/agent-on-finish-callback.ts
+++ b/packages/ai/src/agent/agent-on-finish-callback.ts
@@ -1,0 +1,22 @@
+import { StepResult } from '../generate-text/step-result';
+import { ToolSet } from '../generate-text/tool-set';
+import { LanguageModelUsage } from '../types/usage';
+
+/**
+Callback that is set using the `onFinish` option.
+
+@param event - The event that is passed to the callback.
+ */
+export type AgentOnFinishCallback<TOOLS extends ToolSet> = (
+  event: StepResult<TOOLS> & {
+    /**
+Details for all steps.
+   */
+    readonly steps: StepResult<TOOLS>[];
+
+    /**
+Total usage for all steps. This is the sum of the usage of all steps.
+     */
+    readonly totalUsage: LanguageModelUsage;
+  },
+) => PromiseLike<void> | void;

--- a/packages/ai/src/agent/agent-settings.ts
+++ b/packages/ai/src/agent/agent-settings.ts
@@ -7,6 +7,7 @@ import { ToolSet } from '../generate-text/tool-set';
 import { CallSettings } from '../prompt/call-settings';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { LanguageModel, ToolChoice } from '../types/language-model';
+import { AgentOnFinishCallback } from './agent-on-finish-callback';
 import { AgentOnStepFinishCallback } from './agent-on-step-finish-callback';
 
 /**
@@ -84,9 +85,14 @@ A function that attempts to repair a tool call that failed to parse.
   experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<TOOLS>>;
 
   /**
-  Callback that is called when each step (LLM call) is finished, including intermediate steps.
-  */
+   * Callback that is called when each step (LLM call) is finished, including intermediate steps.
+   */
   onStepFinish?: AgentOnStepFinishCallback<NoInfer<TOOLS>>;
+
+  /**
+   * Callback that is called when all steps are finished and the response is complete.
+   */
+  onFinish?: AgentOnFinishCallback<NoInfer<TOOLS>>;
 
   /**
 Additional provider-specific options. They are passed through

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -6,6 +6,7 @@ export {
    */
   Agent as Experimental_Agent,
 } from './agent';
+export { type AgentOnFinishCallback } from './agent-on-finish-callback';
 export { type AgentOnStepFinishCallback } from './agent-on-step-finish-callback';
 export {
   type AgentSettings,


### PR DESCRIPTION
## Background

Both `streamText` and `generateText` support `onFinish`.

## Summary

Add `onFinish` callback to `Agent`.

## Manual Verification

- [x] Run `examples/ai-core/src/agent/openai-generate-on-finish.ts`

## Future Work

- add `onAbort` callback
- documentation @nicoalbanese 

## Related Issues

Builds on #9235 