### PR TITLE
feat(provider-utils): add needsApproval support to provider-defined tools

### DIFF
--- a/.changeset/kind-chicken-share.md
+++ b/.changeset/kind-chicken-share.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+feat(provider-utils): add needsApproval support to provider-defined tools

--- a/examples/next-openai/agent/openai-local-shell-agent.ts
+++ b/examples/next-openai/agent/openai-local-shell-agent.ts
@@ -1,0 +1,40 @@
+import { openai } from '@ai-sdk/openai';
+import { Sandbox } from '@vercel/sandbox';
+import { Agent, InferAgentUIMessage } from 'ai';
+
+// warning: this is a demo sandbox that is shared across chats on localhost
+let globalSandboxId: string | null = null;
+async function getSandbox(): Promise<Sandbox> {
+  if (globalSandboxId) {
+    return await Sandbox.get({ sandboxId: globalSandboxId });
+  }
+  const sandbox = await Sandbox.create();
+  globalSandboxId = sandbox.sandboxId;
+  return sandbox;
+}
+
+export const openaiLocalShellAgent = new Agent({
+  model: openai('gpt-5-codex'),
+  system: 'You are an agent with access to a shell environment.',
+  tools: {
+    local_shell: openai.tools.localShell({
+      needsApproval: true,
+      execute: async ({ action }) => {
+        const [cmd, ...args] = action.command;
+
+        const sandbox = await getSandbox();
+        const command = await sandbox.runCommand({
+          cmd,
+          args,
+          cwd: action.workingDirectory,
+        });
+
+        return { output: await command.stdout() };
+      },
+    }),
+  },
+});
+
+export type OpenAILocalShellMessage = InferAgentUIMessage<
+  typeof openaiLocalShellAgent
+>;

--- a/examples/next-openai/app/api/chat-openai-local-shell/route.ts
+++ b/examples/next-openai/app/api/chat-openai-local-shell/route.ts
@@ -1,51 +1,10 @@
-import { openai } from '@ai-sdk/openai';
-import { Sandbox } from '@vercel/sandbox';
-import {
-  Agent,
-  InferAgentUIMessage,
-  stepCountIs,
-  validateUIMessages,
-} from 'ai';
-
-// warning: this is a demo sandbox that is shared across chats on localhost
-let globalSandboxId: string | null = null;
-async function getSandbox(): Promise<Sandbox> {
-  if (globalSandboxId) {
-    return await Sandbox.get({ sandboxId: globalSandboxId });
-  }
-  const sandbox = await Sandbox.create();
-  globalSandboxId = sandbox.sandboxId;
-  return sandbox;
-}
-
-const sandboxAgent = new Agent({
-  model: openai('gpt-5-codex'),
-  system: 'You are a helpful assistant.',
-  tools: {
-    local_shell: openai.tools.localShell({
-      execute: async ({ action }) => {
-        const [cmd, ...args] = action.command;
-
-        const sandbox = await getSandbox();
-        const command = await sandbox.runCommand({
-          cmd,
-          args,
-          cwd: action.workingDirectory,
-        });
-
-        return { output: await command.stdout() };
-      },
-    }),
-  },
-  stopWhen: stepCountIs(10),
-});
-
-export type OpenAILocalShellMessage = InferAgentUIMessage<typeof sandboxAgent>;
+import { openaiLocalShellAgent } from '@/agent/openai-local-shell-agent';
+import { validateUIMessages } from 'ai';
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
-  return sandboxAgent.respond({
+  return openaiLocalShellAgent.respond({
     messages: await validateUIMessages({ messages }),
   });
 }

--- a/examples/next-openai/app/test-openai-local-shell/page.tsx
+++ b/examples/next-openai/app/test-openai-local-shell/page.tsx
@@ -1,22 +1,28 @@
 'use client';
 
 import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport } from 'ai';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+} from 'ai';
 import ChatInput from '@/component/chat-input';
-import { OpenAILocalShellMessage } from '@/app/api/chat-openai-local-shell/route';
+import { OpenAILocalShellMessage } from '@/agent/openai-local-shell-agent';
 import LocalShellView from '@/component/openai-local-shell-view';
 
 export default function TestOpenAIWebSearch() {
-  const { status, sendMessage, messages } = useChat<OpenAILocalShellMessage>({
-    transport: new DefaultChatTransport({
-      api: '/api/chat-openai-local-shell',
-    }),
-  });
+  const { status, sendMessage, messages, addToolApprovalResponse } =
+    useChat<OpenAILocalShellMessage>({
+      transport: new DefaultChatTransport({
+        api: '/api/chat-openai-local-shell',
+      }),
+      sendAutomaticallyWhen:
+        lastAssistantMessageIsCompleteWithApprovalResponses,
+    });
 
   return (
     <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
       <h1 className="mb-2 text-xl font-bold">OpenAI Local Shell Test</h1>
-      <h2 className="mb-4 border-b pb-2">
+      <h2 className="pb-2 mb-4 border-b">
         Note: This example requires a Vercel OIDC Token to run the Code Shell
         with Vercel Sandbox
       </h2>
@@ -30,7 +36,13 @@ export default function TestOpenAIWebSearch() {
                 case 'text':
                   return <div key={index}>{part.text}</div>;
                 case 'tool-local_shell':
-                  return <LocalShellView key={index} invocation={part} />;
+                  return (
+                    <LocalShellView
+                      key={index}
+                      invocation={part}
+                      addToolApprovalResponse={addToolApprovalResponse}
+                    />
+                  );
               }
             })}
           </div>

--- a/examples/next-openai/component/openai-local-shell-view.tsx
+++ b/examples/next-openai/component/openai-local-shell-view.tsx
@@ -1,93 +1,112 @@
 import { openai } from '@ai-sdk/openai';
-import { UIToolInvocation } from 'ai';
+import { ChatAddToolApproveResponseFunction, UIToolInvocation } from 'ai';
 
 export default function LocalShellView({
   invocation,
+  addToolApprovalResponse,
 }: {
   invocation: UIToolInvocation<ReturnType<typeof openai.tools.localShell>>;
+  addToolApprovalResponse: ChatAddToolApproveResponseFunction;
 }) {
   const action = invocation.input?.action;
   const command = action?.command?.join(' ') || '';
 
-  return (
-    <div className="mb-2 bg-gray-900 rounded-xl border border-gray-600 shadow-lg p-2">
-      <div className="px-6 py-3 bg-gray-800 rounded-t-xl border-b border-gray-700">
-        <div className="overflow-hidden tracking-wide text-gray-500 whitespace-nowrap text-xxs font-small text-ellipsis">
-          Local Shell Execution
+  switch (invocation.state) {
+    case 'approval-requested':
+      return (
+        <div className="text-gray-500">
+          Can I execute the command <code>{command}</code>?
+          <div>
+            <button
+              className="px-4 py-2 mr-2 text-white bg-blue-500 rounded transition-colors hover:bg-blue-600"
+              onClick={() =>
+                addToolApprovalResponse({
+                  id: invocation.approval.id,
+                  approved: true,
+                })
+              }
+            >
+              Approve
+            </button>
+            <button
+              className="px-4 py-2 text-white bg-red-500 rounded transition-colors hover:bg-red-600"
+              onClick={() =>
+                addToolApprovalResponse({
+                  id: invocation.approval.id,
+                  approved: false,
+                })
+              }
+            >
+              Deny
+            </button>
+          </div>
         </div>
-      </div>
-
-      <div className="p-6">
-        <div className="mb-3">
-          <div className="mb-2 text-sm font-medium text-blue-400">Command:</div>
-          <pre className="overflow-x-auto p-4 text-sm text-gray-100 whitespace-pre-wrap bg-black rounded-lg">
-            {command}
-          </pre>
+      );
+    case 'approval-responded':
+      return (
+        <div className="text-gray-500">
+          Can I execute the command <code>{command}</code>?
+          <div>{invocation.approval.approved ? 'Approved' : 'Denied'}</div>
         </div>
+      );
 
-        {action?.workingDirectory && (
-          <div className="mb-3">
-            <div className="mb-2 text-sm font-medium text-gray-400">
-              Working Directory:
-            </div>
-            <div className="p-3 text-sm text-gray-300 bg-black rounded-lg font-mono">
-              {action.workingDirectory}
+    case 'output-available':
+      return (
+        <div className="p-2 mb-2 bg-gray-900 rounded-xl border border-gray-600 shadow-lg">
+          <div className="px-6 py-3 bg-gray-800 rounded-t-xl border-b border-gray-700">
+            <div className="overflow-hidden tracking-wide text-gray-500 whitespace-nowrap text-xxs font-small text-ellipsis">
+              Local Shell Execution
             </div>
           </div>
-        )}
 
-        {action?.user && (
-          <div className="mb-3">
-            <div className="mb-2 text-sm font-medium text-gray-400">User:</div>
-            <div className="p-3 text-sm text-gray-300 bg-black rounded-lg font-mono">
-              {action.user}
+          <div className="p-6">
+            <div className="mb-3">
+              <div className="mb-2 text-sm font-medium text-blue-400">
+                Command:
+              </div>
+              <pre className="overflow-x-auto p-4 text-sm text-gray-100 whitespace-pre-wrap bg-black rounded-lg">
+                {command}
+              </pre>
             </div>
-          </div>
-        )}
 
-        {action?.timeoutMs && (
-          <div className="mb-3">
-            <div className="mb-2 text-sm font-medium text-gray-400">
-              Timeout:
-            </div>
-            <div className="p-3 text-sm text-gray-300 bg-black rounded-lg font-mono">
-              {action.timeoutMs}ms
-            </div>
-          </div>
-        )}
-
-        {action?.env && Object.keys(action.env).length > 0 && (
-          <div className="mb-3">
-            <div className="mb-2 text-sm font-medium text-gray-400">
-              Environment Variables:
-            </div>
-            <div className="p-3 text-sm text-gray-300 bg-black rounded-lg font-mono">
-              {Object.entries(action.env).map(([key, value]) => (
-                <div key={key}>
-                  {key}={value}
+            {action?.workingDirectory && (
+              <div className="mb-3">
+                <div className="mb-2 text-sm font-medium text-gray-400">
+                  Working Directory:
                 </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {invocation.state === 'output-available' && (
-          <div className="mb-3">
-            <div className="mb-2 text-sm font-medium text-yellow-400">
-              Output:
-            </div>
-            <div className="space-y-2">
-              <div className="p-3 bg-black rounded-lg">
-                <div className="font-mono text-sm text-green-300">
-                  <span className="whitespace-pre-wrap">
-                    {invocation.output.output}
-                  </span>
+                <div className="p-3 font-mono text-sm text-gray-300 bg-black rounded-lg">
+                  {action.workingDirectory}
                 </div>
               </div>
-            </div>
+            )}
+
+            {invocation.state === 'output-available' && (
+              <div className="mb-3">
+                <div className="mb-2 text-sm font-medium text-yellow-400">
+                  Output:
+                </div>
+                <div className="space-y-2">
+                  <div className="p-3 bg-black rounded-lg">
+                    <div className="font-mono text-sm text-green-300">
+                      <span className="whitespace-pre-wrap">
+                        {invocation.output.output}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
-        )}
-      </div>
-    </div>
-  );
+        </div>
+      );
+
+    case 'output-denied':
+      return (
+        <div className="text-gray-500">
+          Execution of <code>{command}</code> was denied.
+        </div>
+      );
+    case 'output-error':
+      return <div className="text-red-500">Error: {invocation.errorText}</div>;
+  }
 }

--- a/packages/provider-utils/src/provider-defined-tool-factory.ts
+++ b/packages/provider-utils/src/provider-defined-tool-factory.ts
@@ -47,6 +47,7 @@ export function createProviderDefinedToolFactory<INPUT, ARGS extends object>({
       inputSchema,
       outputSchema,
       execute,
+      needsApproval,
       toModelOutput,
       onInputStart,
       onInputDelta,

--- a/packages/provider-utils/src/provider-defined-tool-factory.ts
+++ b/packages/provider-utils/src/provider-defined-tool-factory.ts
@@ -4,6 +4,7 @@ import { FlexibleSchema } from './schema';
 export type ProviderDefinedToolFactory<INPUT, ARGS extends object> = <OUTPUT>(
   options: ARGS & {
     execute?: ToolExecuteFunction<INPUT, OUTPUT>;
+    needsApproval?: Tool<INPUT, OUTPUT>['needsApproval'];
     toModelOutput?: Tool<INPUT, OUTPUT>['toModelOutput'];
     onInputStart?: Tool<INPUT, OUTPUT>['onInputStart'];
     onInputDelta?: Tool<INPUT, OUTPUT>['onInputDelta'];
@@ -23,6 +24,7 @@ export function createProviderDefinedToolFactory<INPUT, ARGS extends object>({
   return <OUTPUT>({
     execute,
     outputSchema,
+    needsApproval,
     toModelOutput,
     onInputStart,
     onInputDelta,
@@ -31,6 +33,7 @@ export function createProviderDefinedToolFactory<INPUT, ARGS extends object>({
   }: ARGS & {
     execute?: ToolExecuteFunction<INPUT, OUTPUT>;
     outputSchema?: FlexibleSchema<OUTPUT>;
+    needsApproval?: Tool<INPUT, OUTPUT>['needsApproval'];
     toModelOutput?: Tool<INPUT, OUTPUT>['toModelOutput'];
     onInputStart?: Tool<INPUT, OUTPUT>['onInputStart'];
     onInputDelta?: Tool<INPUT, OUTPUT>['onInputDelta'];
@@ -58,6 +61,7 @@ export type ProviderDefinedToolFactoryWithOutputSchema<
 > = (
   options: ARGS & {
     execute?: ToolExecuteFunction<INPUT, OUTPUT>;
+    needsApproval?: Tool<INPUT, OUTPUT>['needsApproval'];
     toModelOutput?: Tool<INPUT, OUTPUT>['toModelOutput'];
     onInputStart?: Tool<INPUT, OUTPUT>['onInputStart'];
     onInputDelta?: Tool<INPUT, OUTPUT>['onInputDelta'];
@@ -82,6 +86,7 @@ export function createProviderDefinedToolFactoryWithOutputSchema<
 }): ProviderDefinedToolFactoryWithOutputSchema<INPUT, OUTPUT, ARGS> {
   return ({
     execute,
+    needsApproval,
     toModelOutput,
     onInputStart,
     onInputDelta,
@@ -89,6 +94,7 @@ export function createProviderDefinedToolFactoryWithOutputSchema<
     ...args
   }: ARGS & {
     execute?: ToolExecuteFunction<INPUT, OUTPUT>;
+    needsApproval?: Tool<INPUT, OUTPUT>['needsApproval'];
     toModelOutput?: Tool<INPUT, OUTPUT>['toModelOutput'];
     onInputStart?: Tool<INPUT, OUTPUT>['onInputStart'];
     onInputDelta?: Tool<INPUT, OUTPUT>['onInputDelta'];
@@ -102,6 +108,7 @@ export function createProviderDefinedToolFactoryWithOutputSchema<
       inputSchema,
       outputSchema,
       execute,
+      needsApproval,
       toModelOutput,
       onInputStart,
       onInputDelta,


### PR DESCRIPTION
## Background

Tool execution approvals are useful for provider-defined tools with local execution, e.g. computer use or shell execution tools.

## Summary

Add `needsApproval` option to provider-defined tools.

## Example

<img width="479" height="614" alt="image" src="https://github.com/user-attachments/assets/2ef92a2f-0f0c-4ed0-8f04-e986ff60b010" />

## Manual Verification

- [x] test `examples/next-openai` with OpenAI local shell tool and approval http://localhost:3000/test-openai-local-shell

## Related Issues

Builds on #8541