### PR TITLE
Baseten provider Kimi K2 0711, Llama 4 Maverick and Llama 4 Scout Model APIs deprecation

### DIFF
--- a/packages/baseten/src/baseten-chat-options.ts
+++ b/packages/baseten/src/baseten-chat-options.ts
@@ -2,9 +2,9 @@
 // Below is the current list of models supported by Baseten model APIs.
 // Ohter dedicated models are also supported, but not listed here.
 export type BasetenChatModelId =
-  | 'deepseek-ai/DeepSeek-V3.1'
   | 'deepseek-ai/DeepSeek-R1-0528'
   | 'deepseek-ai/DeepSeek-V3-0324'
+  | 'deepseek-ai/DeepSeek-V3.1'
   | 'moonshotai/Kimi-K2-Instruct-0905'
   | 'Qwen/Qwen3-235B-A22B-Instruct-2507'
   | 'Qwen/Qwen3-Coder-480B-A35B-Instruct'

--- a/packages/baseten/src/baseten-chat-options.ts
+++ b/packages/baseten/src/baseten-chat-options.ts
@@ -2,11 +2,10 @@
 // Below is the current list of models supported by Baseten model APIs.
 // Ohter dedicated models are also supported, but not listed here.
 export type BasetenChatModelId =
+  | 'deepseek-ai/DeepSeek-V3.1'
   | 'deepseek-ai/DeepSeek-R1-0528'
   | 'deepseek-ai/DeepSeek-V3-0324'
-  | 'meta-llama/Llama-4-Maverick-17B-128E-Instruct'
-  | 'meta-llama/Llama-4-Scout-17B-16E-Instruct'
-  | 'moonshotai/Kimi-K2-Instruct'
+  | 'moonshotai/Kimi-K2-Instruct-0905'
   | 'Qwen/Qwen3-235B-A22B-Instruct-2507'
   | 'Qwen/Qwen3-Coder-480B-A35B-Instruct'
   | 'openai/gpt-oss-120b'


### PR DESCRIPTION
In light of the newer kimik2 version and the lack of usage from the llama4 series models, Baseten will be deprecating the Kimi K2 0711, Llama 4 Maverick and Llama 4 Scout endpoints: https://www.baseten.co/resources/changelog/model-api-deprecation-notice-kimi-k2-0711-scout-maverick/. This PR removes these models from the list of supported models in `baseten-chat-options.ts`