### PR TITLE
feat(ai): enable experimental_context override in prepareStep

### DIFF
--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -401,6 +401,9 @@ A function that attempts to repair a tool call that failed to parse.
             messages: stepInputMessages,
           });
 
+          const stepExperimentalContext =
+            prepareStepResult?.experimental_context ?? experimental_context;
+
           const promptMessages = await convertToLanguageModelPrompt({
             prompt: {
               system: prepareStepResult?.system ?? initialPrompt.system,
@@ -565,7 +568,7 @@ A function that attempts to repair a tool call that failed to parse.
                 toolCallId: toolCall.toolCallId,
                 messages: stepInputMessages,
                 abortSignal,
-                experimental_context,
+                experimental_context: stepExperimentalContext,
               });
             }
 
@@ -574,7 +577,7 @@ A function that attempts to repair a tool call that failed to parse.
                 tool,
                 toolCall,
                 messages: stepInputMessages,
-                experimental_context,
+                experimental_context: stepExperimentalContext,
               })
             ) {
               toolApprovalRequests[toolCall.toolCallId] = {
@@ -622,7 +625,7 @@ A function that attempts to repair a tool call that failed to parse.
                 telemetry,
                 messages: stepInputMessages,
                 abortSignal,
-                experimental_context,
+                experimental_context: stepExperimentalContext,
               })),
             );
           }

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -31,5 +31,6 @@ export type PrepareStepResult<
       activeTools?: Array<keyof NoInfer<TOOLS>>;
       system?: string;
       messages?: Array<ModelMessage>;
+      experimental_context?: unknown;
     }
   | undefined;

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1182,6 +1182,9 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
             messages: stepInputMessages,
           });
 
+          const stepExperimentalContext =
+            prepareStepResult?.experimental_context ?? experimental_context;
+
           const promptMessages = await convertToLanguageModelPrompt({
             prompt: {
               system: prepareStepResult?.system ?? initialPrompt.system,
@@ -1278,7 +1281,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
             messages: stepInputMessages,
             repairToolCall,
             abortSignal,
-            experimental_context,
+            experimental_context: stepExperimentalContext,
             generateId,
           });
 
@@ -1449,7 +1452,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                           toolCallId: chunk.id,
                           messages: stepInputMessages,
                           abortSignal,
-                          experimental_context,
+                          experimental_context: stepExperimentalContext,
                         });
                       }
 
@@ -1476,7 +1479,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
                           toolCallId: chunk.id,
                           messages: stepInputMessages,
                           abortSignal,
-                          experimental_context,
+                          experimental_context: stepExperimentalContext,
                         });
                       }
 


### PR DESCRIPTION
## Problem
Currently, `experimental_context` cannot be overridden in prepareStep(), unlike other properties such as model, toolChoice, and activeTools. This prevents dynamic context injection per step.

## Use Case
At [Twenty](https://github.com/twentyhq/twenty), we're building multi-agent systems where each agent has a unique role with different permissions (field access, row-level filtering, object access, etc.). With dozens of agents and hundreds of fields or millions of rows, we can't pre-generate all possible tool combinations. Instead, we use generic tools (e.g., createCompany, createLead) and inject role-specific context at runtime based on the intersection of the agent role and user role. I tried to find a better option than this but using `experimental_context`  was the best lead I could find to pass the agent's role dynamically to the function call.

## Solution
Added experimental_context to PrepareStepResult type, allowing it to be overridden per step:
