### PR TITLE
docs: correct textEmbeddingModel method

### DIFF
--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -591,10 +591,10 @@ The following Zod features are known to not work with Google Vertex:
 
 ### Embedding Models
 
-You can create models that call the Google Vertex AI embeddings API using the `.textEmbedding()` factory method:
+You can create models that call the Google Vertex AI embeddings API using the `.textEmbeddingModel()` factory method:
 
 ```ts
-const model = vertex.textEmbedding('text-embedding-004');
+const model = vertex.textEmbeddingModel('text-embedding-004');
 ```
 
 Google Vertex AI embedding models support additional settings. You can pass them as an options argument:
@@ -603,7 +603,7 @@ Google Vertex AI embedding models support additional settings. You can pass them
 import { vertex } from '@ai-sdk/google-vertex';
 import { embed } from 'ai';
 
-const model = vertex.textEmbedding('text-embedding-004');
+const model = vertex.textEmbeddingModel('text-embedding-004');
 
 const { embedding } = await embed({
   model,


### PR DESCRIPTION
textEmbedding has changed to textEmbeddingModel in the `google-vertex` provider. Updating docs to match the code.

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Docs are out of date vs the type definitions.

## Summary

Updated the method name to use for instantiating an embedding model.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)
