### PR TITLE
ci(release): Remove timeout from release job in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     # do not attempt running in forks
     if: github.repository_owner == 'vercel'
     steps:


### PR DESCRIPTION
should address https://github.com/vercel/ai/actions/runs/18355890738/job/52287686763

Not sure why it was canceled, but it looks like it finished all it's work. See another build for comparison:
https://github.com/vercel/ai/actions/runs/18354771668/job/52283816520#step:9:2929