### PR TITLE
feat(ai): rootSpan flag for telemetry options

### DIFF
--- a/.changeset/clean-deers-pull.md
+++ b/.changeset/clean-deers-pull.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): rootSpan flag for telemetry options

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -121,6 +121,7 @@ Only applicable for HTTP-based providers.
       },
     }),
     tracer,
+    root: telemetry?.rootSpan,
     fn: async span => {
       const [maxEmbeddingsPerCall, supportsParallelCalls] = await Promise.all([
         model.maxEmbeddingsPerCall,

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -104,6 +104,7 @@ Only applicable for HTTP-based providers.
       },
     }),
     tracer,
+    root: telemetry?.rootSpan,
     fn: async span => {
       const { embedding, usage, response, providerMetadata } = await retry(() =>
         // nested spans to align with the embedMany telemetry data:

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -298,6 +298,7 @@ Default and recommended: 'auto' (best mode for the model).
         },
       }),
       tracer,
+      root: telemetry?.rootSpan,
       fn: async span => {
         let result: string;
         let finishReason: FinishReason;

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -491,6 +491,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
         },
       }),
       tracer,
+      root: telemetry?.rootSpan,
       endWhenDone: false,
       fn: async rootSpan => {
         const standardizedPrompt = await standardizePrompt({

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -328,6 +328,7 @@ A function that attempts to repair a tool call that failed to parse.
         },
       }),
       tracer,
+      root: telemetry?.rootSpan,
       fn: async span => {
         const initialMessages = initialPrompt.messages;
         const responseMessages: Array<ResponseMessage> = [];

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1057,6 +1057,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
         },
       }),
       tracer,
+      root: telemetry?.rootSpan,
       endWhenDone: false,
       fn: async rootSpanArg => {
         rootSpan = rootSpanArg;

--- a/packages/ai/src/telemetry/record-span.ts
+++ b/packages/ai/src/telemetry/record-span.ts
@@ -3,17 +3,19 @@ import { Attributes, Span, Tracer, SpanStatusCode } from '@opentelemetry/api';
 export function recordSpan<T>({
   name,
   tracer,
+  root,
   attributes,
   fn,
   endWhenDone = true,
 }: {
   name: string;
   tracer: Tracer;
+  root?: boolean;
   attributes: Attributes;
   fn: (span: Span) => Promise<T>;
   endWhenDone?: boolean;
 }) {
-  return tracer.startActiveSpan(name, { attributes }, async span => {
+  return tracer.startActiveSpan(name, { attributes, root }, async span => {
     try {
       const result = await fn(span);
 

--- a/packages/ai/src/telemetry/telemetry-settings.ts
+++ b/packages/ai/src/telemetry/telemetry-settings.ts
@@ -41,4 +41,9 @@ export type TelemetrySettings = {
    * A custom tracer to use for the telemetry data.
    */
   tracer?: Tracer;
+
+  /**
+   * Whether to create a root span for the operation.
+   */
+  rootSpan?: boolean;
 };


### PR DESCRIPTION
## Background

The reason to propose this is that currently I'm having a hard time getting telemetry to show up correctly in langfuse while using effect.

Because the stream returned by stream operations exists outside the lifecycle of the calling function, traces get reported out of order, and ultimately certain attributes that should be made available to the root span never make it.

So forcing the ai traces to be isolated isi the only way I've been able to sort of solve it.

## Summary

Adds a new flag `rootSpan` to `experimental_telemetry` that instructs to create a root span (detached from any parent) during the execution. Defaults to false keeping the current behavior.

## Manual Verification

Tested a local build with my existing app

## Checklist
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work


## Related Issues
