### PR TITLE
fix(provider/openai) Allow `url` to be nullish in `open_page` action schema

### DIFF
--- a/packages/openai/src/tool/web-search.ts
+++ b/packages/openai/src/tool/web-search.ts
@@ -40,7 +40,7 @@ const webSearchInputSchema = lazySchema(() =>
           }),
           z.object({
             type: z.literal('open_page'),
-            url: z.string(),
+            url: z.string().nullish(),
           }),
           z.object({
             type: z.literal('find'),


### PR DESCRIPTION
Fixes https://github.com/vercel/ai/issues/9308