### PR TITLE
Include missing `providerExecuted` and `providerMetadata` to invalid `tool-call` chunks

### DIFF
--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -82,6 +82,8 @@ export async function parseToolCall<TOOLS extends ToolSet>({
       toolCallId: toolCall.toolCallId,
       toolName: toolCall.toolName,
       input,
+      providerExecuted: toolCall.providerExecuted,
+      providerMetadata: toolCall.providerMetadata,
       dynamic: true,
       invalid: true,
       error,


### PR DESCRIPTION
This PR adds the missing  `providerExecuted` and `providerMetadata` to invalid `tool-call` chunks. I don't fully understand why a `tool-call` chunk is enqueued instead of `tool-error` chunk when parsing the tool input fails (would love an explanation @lgrammel), but I noticed that `providerExecuted` and `providerMetadata` were missing on those chunks.