### PR TITLE
fix(provider/amazon-bedrock): ensure reasoningConfig works with additionalModelRequestFields

### DIFF
--- a/.changeset/fair-adults-cheer.md
+++ b/.changeset/fair-adults-cheer.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Fix reasoning with Bedrock when additionalModelRequestFields is used

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -257,8 +257,11 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       await convertToBedrockChatMessages(filteredPrompt);
 
     // Filter out reasoningConfig from providerOptions.bedrock to prevent sending it to Bedrock API
-    const { reasoningConfig: _, ...filteredBedrockOptions } =
-      providerOptions?.bedrock || {};
+    const {
+      reasoningConfig: _,
+      additionalModelRequestFields: __,
+      ...filteredBedrockOptions
+    } = providerOptions?.bedrock || {};
 
     return {
       command: {


### PR DESCRIPTION
## Background

Spreading providerOptions.bedrock into the request allowed user additionalModelRequestFields to overwrite the computed map that includes thinking derived from reasoningConfig.

## Summary

Excluded both reasoningConfig and additionalModelRequestFields from the spread into the Bedrock request. Always use the internally merged bedrockOptions.additionalModelRequestFields, which combines user fields with the derived thinking (derived values take precedence on conflict).

## Manual Verification

Used the repro script in #9312 and added two tests:
- doGenerate: merges user additionalModelRequestFields with derived thinking.
- doStream: merges user additionalModelRequestFields with derived thinking.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #9312