### PR TITLE
docs: update migration guide with tool parts helper

### DIFF
--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -880,6 +880,74 @@ Tool UI parts now use more granular states that better represent the streaming l
 - `result` → `output-available` (tool execution successful)
 - New: `output-error` (tool execution failed)
 
+#### Rendering Tool Invocations
+
+In v4, you typically rendered tool invocations using a catch-all `tool-invocation` type. In v5, you need to use helper functions `isToolUIPart` and `getToolName` to handle tool parts in a default case.
+
+```tsx filename="AI SDK 4.0"
+{
+  message.parts.map((part, index) => {
+    switch (part.type) {
+      case 'text':
+        return <div key={index}>{part.text}</div>;
+      case 'tool-invocation':
+        const { toolInvocation } = part;
+        return (
+          <details key={`tool-${toolInvocation.toolCallId}`}>
+            <summary>
+              <span>{toolInvocation.toolName}</span>
+              {toolInvocation.state === 'result' ? (
+                <span>Click to expand</span>
+              ) : (
+                <span>calling...</span>
+              )}
+            </summary>
+            {toolInvocation.state === 'result' ? (
+              <div>
+                <pre>{JSON.stringify(toolInvocation.result, null, 2)}</pre>
+              </div>
+            ) : null}
+          </details>
+        );
+    }
+  });
+}
+```
+
+```tsx filename="AI SDK 5.0"
+import { isToolUIPart, getToolName } from 'ai';
+
+{
+  message.parts.map((part, index) => {
+    switch (part.type) {
+      case 'text':
+        return <div key={index}>{part.text}</div>;
+      default:
+        if (isToolUIPart(part)) {
+          const toolInvocation = part;
+          return (
+            <details key={`tool-${toolInvocation.toolCallId}`}>
+              <summary>
+                <span>{getToolName(toolInvocation)}</span>
+                {toolInvocation.state === 'output-available' ? (
+                  <span>Click to expand</span>
+                ) : (
+                  <span>calling...</span>
+                )}
+              </summary>
+              {toolInvocation.state === 'output-available' ? (
+                <div>
+                  <pre>{JSON.stringify(toolInvocation.output, null, 2)}</pre>
+                </div>
+              ) : null}
+            </details>
+          );
+        }
+    }
+  });
+}
+```
+
 #### Media Type Standardization
 
 `mimeType` has been renamed to `mediaType` for consistency. Both image and file types are supported in model messages.
@@ -2806,6 +2874,13 @@ await generateText({
 ```
 
 ## Message Persistence Changes
+
+<Note>
+  For a comprehensive guide on migrating your persisted message data from v4 to
+  v5, including database schema changes and zero-downtime migration strategies,
+  see the [Data Migration
+  Guide](/docs/migration-guides/migration-guide-5-0-data).
+</Note>
 
 In v4, you would typically use helper functions like `appendResponseMessages` or `appendClientMessage` to format messages in the `onFinish` callback of `streamText`:
 

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -880,9 +880,9 @@ Tool UI parts now use more granular states that better represent the streaming l
 - `result` → `output-available` (tool execution successful)
 - New: `output-error` (tool execution failed)
 
-#### Rendering Tool Invocations
+#### Rendering Tool Invocations (Catch-All Pattern)
 
-In v4, you typically rendered tool invocations using a catch-all `tool-invocation` type. In v5, you need to use helper functions `isToolUIPart` and `getToolName` to handle tool parts in a default case.
+In v4, you typically rendered tool invocations using a catch-all `tool-invocation` type. In v5, the recommended approach is to handle each tool specifically using its typed part name (e.g., `tool-getWeather`). However, if you need a catch-all pattern for rendering all tool invocations the same way, you can use the `isToolUIPart` and `getToolName` helper functions as a fallback.
 
 ```tsx filename="AI SDK 4.0"
 {

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -882,7 +882,7 @@ Tool UI parts now use more granular states that better represent the streaming l
 
 #### Rendering Tool Invocations (Catch-All Pattern)
 
-In v4, you typically rendered tool invocations using a catch-all `tool-invocation` type. In v5, the recommended approach is to handle each tool specifically using its typed part name (e.g., `tool-getWeather`). However, if you need a catch-all pattern for rendering all tool invocations the same way, you can use the `isToolUIPart` and `getToolName` helper functions as a fallback.
+In v4, you typically rendered tool invocations using a catch-all `tool-invocation` type. In v5, the **recommended approach is to handle each tool specifically using its typed part name (e.g., `tool-getWeather`)**. However, if you need a catch-all pattern for rendering all tool invocations the same way, you can use the `isToolUIPart` and `getToolName` helper functions as a fallback.
 
 ```tsx filename="AI SDK 4.0"
 {

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -2875,13 +2875,6 @@ await generateText({
 
 ## Message Persistence Changes
 
-<Note>
-  For a comprehensive guide on migrating your persisted message data from v4 to
-  v5, including database schema changes and zero-downtime migration strategies,
-  see the [Data Migration
-  Guide](/docs/migration-guides/migration-guide-5-0-data).
-</Note>
-
 In v4, you would typically use helper functions like `appendResponseMessages` or `appendClientMessage` to format messages in the `onFinish` callback of `streamText`:
 
 ```tsx filename="AI SDK 4.0"


### PR DESCRIPTION
## Background
This common UI pattern could benefit from having a direct example in v5. Also missing documentation for isToolUIPart and getToolName.

## Summary
Added example to v5 migration guide.
