### PR TITLE
fix(provider/google): lazy schema loading

### DIFF
--- a/.changeset/nervous-beans-relax.md
+++ b/.changeset/nervous-beans-relax.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): lazy schema loading
+
+import time improved by 12.5% (22.3ms ➡️ 19.5ms)

--- a/examples/ai-core/src/benchmark/anthropic-load-time.ts
+++ b/examples/ai-core/src/benchmark/anthropic-load-time.ts
@@ -1,9 +1,0 @@
-async function main() {
-  const t0 = performance.now();
-  await import('@ai-sdk/anthropic');
-  const t1 = performance.now();
-
-  console.log(`Import @ai-sdk/anthropic: ${(t1 - t0).toFixed(1)} ms`);
-}
-
-main().catch(console.error);

--- a/examples/ai-core/src/benchmark/provider-load-time.ts
+++ b/examples/ai-core/src/benchmark/provider-load-time.ts
@@ -3,7 +3,9 @@ import { spawn } from 'child_process';
 const provider = process.argv[2];
 
 if (!provider) {
-  console.error('Please provide a provider name as an argument, e.g., "anthropic"');
+  console.error(
+    'Please provide a provider name as an argument, e.g., "anthropic"',
+  );
   process.exit(1);
 }
 
@@ -23,15 +25,15 @@ console.log(t1 - t0);
     ]);
 
     let output = '';
-    child.stdout.on('data', (data) => {
+    child.stdout.on('data', data => {
       output += data.toString();
     });
 
-    child.stderr.on('data', (data) => {
+    child.stderr.on('data', data => {
       console.error('Error:', data.toString());
     });
 
-    child.on('close', (code) => {
+    child.on('close', code => {
       if (code !== 0) {
         reject(new Error(`Child process exited with code ${code}`));
       } else {

--- a/examples/ai-core/src/benchmark/provider-load-time.ts
+++ b/examples/ai-core/src/benchmark/provider-load-time.ts
@@ -1,0 +1,67 @@
+import { spawn } from 'child_process';
+
+const provider = process.argv[2];
+
+if (!provider) {
+  console.error('Please provide a provider name as an argument, e.g., "anthropic"');
+  process.exit(1);
+}
+
+const moduleName = `@ai-sdk/${provider}`;
+
+async function runInSeparateProcess(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [
+      '--input-type=module',
+      '--eval',
+      `
+const t0 = performance.now();
+await import('${moduleName}');
+const t1 = performance.now();
+console.log(t1 - t0);
+      `.trim(),
+    ]);
+
+    let output = '';
+    child.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      console.error('Error:', data.toString());
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Child process exited with code ${code}`));
+      } else {
+        resolve(parseFloat(output.trim()));
+      }
+    });
+  });
+}
+
+async function main() {
+  const times: number[] = [];
+  const iterations = 10;
+
+  console.log(`Running import benchmark 10 times for ${moduleName}...\n`);
+
+  for (let i = 0; i < iterations; i++) {
+    const time = await runInSeparateProcess();
+    console.log(`Run ${i + 1}: ${time.toFixed(1)} ms`);
+    times.push(time);
+  }
+
+  const average = times.reduce((a, b) => a + b, 0) / times.length;
+  const min = Math.min(...times);
+  const max = Math.max(...times);
+
+  console.log(`\n--- Statistics ---`);
+  console.log(`Average: ${average.toFixed(1)} ms`);
+  console.log(`Min: ${min.toFixed(1)} ms`);
+  console.log(`Max: ${max.toFixed(1)} ms`);
+  console.log(`Range: ${(max - min).toFixed(1)} ms`);
+}
+
+main().catch(console.error);

--- a/packages/google/src/google-error.ts
+++ b/packages/google/src/google-error.ts
@@ -1,15 +1,24 @@
-import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import {
+  createJsonErrorResponseHandler,
+  type InferValidator,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
 
-const googleErrorDataSchema = z.object({
-  error: z.object({
-    code: z.number().nullable(),
-    message: z.string(),
-    status: z.string(),
-  }),
-});
+const googleErrorDataSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      error: z.object({
+        code: z.number().nullable(),
+        message: z.string(),
+        status: z.string(),
+      }),
+    }),
+  ),
+);
 
-export type GoogleErrorData = z.infer<typeof googleErrorDataSchema>;
+export type GoogleErrorData = InferValidator<typeof googleErrorDataSchema>;
 
 export const googleFailedResponseHandler = createJsonErrorResponseHandler({
   errorSchema: googleErrorDataSchema,

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -6,9 +6,11 @@ import {
   combineHeaders,
   createJsonResponseHandler,
   FetchFunction,
+  lazySchema,
   parseProviderOptions,
   postJsonToApi,
   resolve,
+  zodSchema,
 } from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
 import { googleFailedResponseHandler } from './google-error';
@@ -139,11 +141,19 @@ export class GoogleGenerativeAIEmbeddingModel
 
 // minimal version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const googleGenerativeAITextEmbeddingResponseSchema = z.object({
-  embeddings: z.array(z.object({ values: z.array(z.number()) })),
-});
+const googleGenerativeAITextEmbeddingResponseSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      embeddings: z.array(z.object({ values: z.array(z.number()) })),
+    }),
+  ),
+);
 
 // Schema for single embedding response
-const googleGenerativeAISingleEmbeddingResponseSchema = z.object({
-  embedding: z.object({ values: z.array(z.number()) }),
-});
+const googleGenerativeAISingleEmbeddingResponseSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      embedding: z.object({ values: z.array(z.number()) }),
+    }),
+  ),
+);

--- a/packages/google/src/google-generative-ai-embedding-options.ts
+++ b/packages/google/src/google-generative-ai-embedding-options.ts
@@ -1,3 +1,8 @@
+import {
+  type InferValidator,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
 
 export type GoogleGenerativeAIEmbeddingModelId =
@@ -5,39 +10,43 @@ export type GoogleGenerativeAIEmbeddingModelId =
   | 'text-embedding-004'
   | (string & {});
 
-export const googleGenerativeAIEmbeddingProviderOptions = z.object({
-  /**
-   * Optional. Optional reduced dimension for the output embedding.
-   * If set, excessive values in the output embedding are truncated from the end.
-   */
-  outputDimensionality: z.number().optional(),
+export const googleGenerativeAIEmbeddingProviderOptions = lazySchema(() =>
+  zodSchema(
+    z.object({
+      /**
+       * Optional. Optional reduced dimension for the output embedding.
+       * If set, excessive values in the output embedding are truncated from the end.
+       */
+      outputDimensionality: z.number().optional(),
 
-  /**
-   * Optional. Specifies the task type for generating embeddings.
-   * Supported task types:
-   * - SEMANTIC_SIMILARITY: Optimized for text similarity.
-   * - CLASSIFICATION: Optimized for text classification.
-   * - CLUSTERING: Optimized for clustering texts based on similarity.
-   * - RETRIEVAL_DOCUMENT: Optimized for document retrieval.
-   * - RETRIEVAL_QUERY: Optimized for query-based retrieval.
-   * - QUESTION_ANSWERING: Optimized for answering questions.
-   * - FACT_VERIFICATION: Optimized for verifying factual information.
-   * - CODE_RETRIEVAL_QUERY: Optimized for retrieving code blocks based on natural language queries.
-   */
-  taskType: z
-    .enum([
-      'SEMANTIC_SIMILARITY',
-      'CLASSIFICATION',
-      'CLUSTERING',
-      'RETRIEVAL_DOCUMENT',
-      'RETRIEVAL_QUERY',
-      'QUESTION_ANSWERING',
-      'FACT_VERIFICATION',
-      'CODE_RETRIEVAL_QUERY',
-    ])
-    .optional(),
-});
+      /**
+       * Optional. Specifies the task type for generating embeddings.
+       * Supported task types:
+       * - SEMANTIC_SIMILARITY: Optimized for text similarity.
+       * - CLASSIFICATION: Optimized for text classification.
+       * - CLUSTERING: Optimized for clustering texts based on similarity.
+       * - RETRIEVAL_DOCUMENT: Optimized for document retrieval.
+       * - RETRIEVAL_QUERY: Optimized for query-based retrieval.
+       * - QUESTION_ANSWERING: Optimized for answering questions.
+       * - FACT_VERIFICATION: Optimized for verifying factual information.
+       * - CODE_RETRIEVAL_QUERY: Optimized for retrieving code blocks based on natural language queries.
+       */
+      taskType: z
+        .enum([
+          'SEMANTIC_SIMILARITY',
+          'CLASSIFICATION',
+          'CLUSTERING',
+          'RETRIEVAL_DOCUMENT',
+          'RETRIEVAL_QUERY',
+          'QUESTION_ANSWERING',
+          'FACT_VERIFICATION',
+          'CODE_RETRIEVAL_QUERY',
+        ])
+        .optional(),
+    }),
+  ),
+);
 
-export type GoogleGenerativeAIEmbeddingProviderOptions = z.infer<
+export type GoogleGenerativeAIEmbeddingProviderOptions = InferValidator<
   typeof googleGenerativeAIEmbeddingProviderOptions
 >;

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -50,8 +50,8 @@ const provider = createGoogleGenerativeAI({
 });
 const model = provider.chat('gemini-pro');
 
-const groundingMetadataSchema = getGroundingMetadataSchema()
-const urlContextMetadataSchema = getUrlContextMetadataSchema()
+const groundingMetadataSchema = getGroundingMetadataSchema();
+const urlContextMetadataSchema = getUrlContextMetadataSchema();
 
 describe('groundingMetadataSchema', () => {
   it('validates complete grounding metadata with web search results', () => {

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -11,8 +11,8 @@ import {
   GoogleGenerativeAIUrlContextMetadata,
 } from './google-generative-ai-prompt';
 import { createGoogleGenerativeAI } from './google-provider';
-import { groundingMetadataSchema } from './tool/google-search';
-import { urlContextMetadataSchema } from './tool/url-context';
+// import { groundingMetadataSchema } from './tool/google-search';
+// import { urlContextMetadataSchema } from './tool/url-context';
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('./version', () => ({
@@ -48,135 +48,135 @@ const provider = createGoogleGenerativeAI({
 });
 const model = provider.chat('gemini-pro');
 
-describe('groundingMetadataSchema', () => {
-  it('validates complete grounding metadata with web search results', () => {
-    const metadata = {
-      webSearchQueries: ["What's the weather in Chicago this weekend?"],
-      searchEntryPoint: {
-        renderedContent: 'Sample rendered content for search results',
-      },
-      groundingChunks: [
-        {
-          web: {
-            uri: 'https://example.com/weather',
-            title: 'Chicago Weather Forecast',
-          },
-        },
-      ],
-      groundingSupports: [
-        {
-          segment: {
-            startIndex: 0,
-            endIndex: 65,
-            text: 'Chicago weather changes rapidly, so layers let you adjust easily.',
-          },
-          groundingChunkIndices: [0],
-          confidenceScores: [0.99],
-        },
-      ],
-      retrievalMetadata: {
-        webDynamicRetrievalScore: 0.96879,
-      },
-    };
+// describe('groundingMetadataSchema', () => {
+//   it('validates complete grounding metadata with web search results', () => {
+//     const metadata = {
+//       webSearchQueries: ["What's the weather in Chicago this weekend?"],
+//       searchEntryPoint: {
+//         renderedContent: 'Sample rendered content for search results',
+//       },
+//       groundingChunks: [
+//         {
+//           web: {
+//             uri: 'https://example.com/weather',
+//             title: 'Chicago Weather Forecast',
+//           },
+//         },
+//       ],
+//       groundingSupports: [
+//         {
+//           segment: {
+//             startIndex: 0,
+//             endIndex: 65,
+//             text: 'Chicago weather changes rapidly, so layers let you adjust easily.',
+//           },
+//           groundingChunkIndices: [0],
+//           confidenceScores: [0.99],
+//         },
+//       ],
+//       retrievalMetadata: {
+//         webDynamicRetrievalScore: 0.96879,
+//       },
+//     };
 
-    const result = groundingMetadataSchema.safeParse(metadata);
-    expect(result.success).toBe(true);
-  });
+//     const result = groundingMetadataSchema.safeParse(metadata);
+//     expect(result.success).toBe(true);
+//   });
 
-  it('validates complete grounding metadata with Vertex AI Search results', () => {
-    const metadata = {
-      retrievalQueries: ['How to make appointment to renew driving license?'],
-      groundingChunks: [
-        {
-          retrievedContext: {
-            uri: 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/AXiHM.....QTN92V5ePQ==',
-            title: 'dmv',
-          },
-        },
-      ],
-      groundingSupports: [
-        {
-          segment: {
-            startIndex: 25,
-            endIndex: 147,
-          },
-          segment_text: 'ipsum lorem ...',
-          supportChunkIndices: [1, 2],
-          confidenceScore: [0.9541752, 0.97726375],
-        },
-      ],
-    };
+//   it('validates complete grounding metadata with Vertex AI Search results', () => {
+//     const metadata = {
+//       retrievalQueries: ['How to make appointment to renew driving license?'],
+//       groundingChunks: [
+//         {
+//           retrievedContext: {
+//             uri: 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/AXiHM.....QTN92V5ePQ==',
+//             title: 'dmv',
+//           },
+//         },
+//       ],
+//       groundingSupports: [
+//         {
+//           segment: {
+//             startIndex: 25,
+//             endIndex: 147,
+//           },
+//           segment_text: 'ipsum lorem ...',
+//           supportChunkIndices: [1, 2],
+//           confidenceScore: [0.9541752, 0.97726375],
+//         },
+//       ],
+//     };
 
-    const result = groundingMetadataSchema.safeParse(metadata);
-    expect(result.success).toBe(true);
-  });
+//     const result = groundingMetadataSchema.safeParse(metadata);
+//     expect(result.success).toBe(true);
+//   });
 
-  it('validates partial grounding metadata', () => {
-    const metadata = {
-      webSearchQueries: ['sample query'],
-      // Missing other optional fields
-    };
+//   it('validates partial grounding metadata', () => {
+//     const metadata = {
+//       webSearchQueries: ['sample query'],
+//       // Missing other optional fields
+//     };
 
-    const result = groundingMetadataSchema.safeParse(metadata);
-    expect(result.success).toBe(true);
-  });
+//     const result = groundingMetadataSchema.safeParse(metadata);
+//     expect(result.success).toBe(true);
+//   });
 
-  it('validates empty grounding metadata', () => {
-    const metadata = {};
+//   it('validates empty grounding metadata', () => {
+//     const metadata = {};
 
-    const result = groundingMetadataSchema.safeParse(metadata);
-    expect(result.success).toBe(true);
-  });
+//     const result = groundingMetadataSchema.safeParse(metadata);
+//     expect(result.success).toBe(true);
+//   });
 
-  it('validates metadata with empty retrievalMetadata', () => {
-    const metadata = {
-      webSearchQueries: ['sample query'],
-      retrievalMetadata: {},
-    };
+//   it('validates metadata with empty retrievalMetadata', () => {
+//     const metadata = {
+//       webSearchQueries: ['sample query'],
+//       retrievalMetadata: {},
+//     };
 
-    const result = groundingMetadataSchema.safeParse(metadata);
-    expect(result.success).toBe(true);
-  });
+//     const result = groundingMetadataSchema.safeParse(metadata);
+//     expect(result.success).toBe(true);
+//   });
 
-  it('rejects invalid data types', () => {
-    const metadata = {
-      webSearchQueries: 'not an array', // Should be an array
-      groundingSupports: [
-        {
-          confidenceScores: 'not an array', // Should be an array of numbers
-        },
-      ],
-    };
+//   it('rejects invalid data types', () => {
+//     const metadata = {
+//       webSearchQueries: 'not an array', // Should be an array
+//       groundingSupports: [
+//         {
+//           confidenceScores: 'not an array', // Should be an array of numbers
+//         },
+//       ],
+//     };
 
-    const result = groundingMetadataSchema.safeParse(metadata);
-    expect(result.success).toBe(false);
-  });
-});
+//     const result = groundingMetadataSchema.safeParse(metadata);
+//     expect(result.success).toBe(false);
+//   });
+// });
 
-describe('urlContextMetadata', () => {
-  it('validates complete url context output', () => {
-    const output = {
-      urlMetadata: [
-        {
-          retrievedUrl: 'https://example.com/weather',
-          urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS',
-        },
-      ],
-    };
+// describe('urlContextMetadata', () => {
+//   it('validates complete url context output', () => {
+//     const output = {
+//       urlMetadata: [
+//         {
+//           retrievedUrl: 'https://example.com/weather',
+//           urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS',
+//         },
+//       ],
+//     };
 
-    const result = urlContextMetadataSchema.safeParse(output);
-    expect(result.success).toBe(true);
-  });
+//     const result = urlContextMetadataSchema.safeParse(output);
+//     expect(result.success).toBe(true);
+//   });
 
-  it('validates empty url context output', () => {
-    const output = {
-      urlMetadata: [],
-    };
+//   it('validates empty url context output', () => {
+//     const output = {
+//       urlMetadata: [],
+//     };
 
-    const result = urlContextMetadataSchema.safeParse(output);
-    expect(result.success).toBe(true);
-  });
-});
+//     const result = urlContextMetadataSchema.safeParse(output);
+//     expect(result.success).toBe(true);
+//   });
+// });
 
 describe('doGenerate', () => {
   const TEST_URL_GEMINI_PRO =

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -697,103 +697,98 @@ function extractSources({
     }));
 }
 
-// const groundingMetadataSchema = lazySchema(() =>
-//   zodSchema(
-//     z.object({
-//       webSearchQueries: z.array(z.string()).nullish(),
-//       retrievalQueries: z.array(z.string()).nullish(),
-//       searchEntryPoint: z.object({ renderedContent: z.string() }).nullish(),
-//       groundingChunks: z
-//         .array(
-//           z.object({
-//             web: z.object({ uri: z.string(), title: z.string() }).nullish(),
-//             retrievedContext: z
-//               .object({ uri: z.string(), title: z.string() })
-//               .nullish(),
-//           }),
-//         )
-//         .nullish(),
-//       groundingSupports: z
-//         .array(
-//           z.object({
-//             segment: z.object({
-//               startIndex: z.number().nullish(),
-//               endIndex: z.number().nullish(),
-//               text: z.string().nullish(),
-//             }),
-//             segment_text: z.string().nullish(),
-//             groundingChunkIndices: z.array(z.number()).nullish(),
-//             supportChunkIndices: z.array(z.number()).nullish(),
-//             confidenceScores: z.array(z.number()).nullish(),
-//             confidenceScore: z.array(z.number()).nullish(),
-//           }),
-//         )
-//         .nullish(),
-//       retrievalMetadata: z
-//         .union([
-//           z.object({
-//             webDynamicRetrievalScore: z.number(),
-//           }),
-//           z.object({}),
-//         ])
-//         .nullish(),
-//     }),
-//   ),
-// );
+export const getGroundingMetadataSchema = () =>
+  z.object({
+    webSearchQueries: z.array(z.string()).nullish(),
+    retrievalQueries: z.array(z.string()).nullish(),
+    searchEntryPoint: z.object({ renderedContent: z.string() }).nullish(),
+    groundingChunks: z
+      .array(
+        z.object({
+          web: z.object({ uri: z.string(), title: z.string() }).nullish(),
+          retrievedContext: z
+            .object({ uri: z.string(), title: z.string() })
+            .nullish(),
+        }),
+      )
+      .nullish(),
+    groundingSupports: z
+      .array(
+        z.object({
+          segment: z.object({
+            startIndex: z.number().nullish(),
+            endIndex: z.number().nullish(),
+            text: z.string().nullish(),
+          }),
+          segment_text: z.string().nullish(),
+          groundingChunkIndices: z.array(z.number()).nullish(),
+          supportChunkIndices: z.array(z.number()).nullish(),
+          confidenceScores: z.array(z.number()).nullish(),
+          confidenceScore: z.array(z.number()).nullish(),
+        }),
+      )
+      .nullish(),
+    retrievalMetadata: z
+      .union([
+        z.object({
+          webDynamicRetrievalScore: z.number(),
+        }),
+        z.object({}),
+      ])
+      .nullish(),
+  });
 
-// const contentSchema = lazySchema(() =>
-//   zodSchema(
-//     z.object({
-//       parts: z
-//         .array(
-//           z.union([
-//             // note: order matters since text can be fully empty
-//             z.object({
-//               functionCall: z.object({
-//                 name: z.string(),
-//                 args: z.unknown(),
-//               }),
-//               thoughtSignature: z.string().nullish(),
-//             }),
-//             z.object({
-//               inlineData: z.object({
-//                 mimeType: z.string(),
-//                 data: z.string(),
-//               }),
-//             }),
-//             z.object({
-//               executableCode: z
-//                 .object({
-//                   language: z.string(),
-//                   code: z.string(),
-//                 })
-//                 .nullish(),
-//               codeExecutionResult: z
-//                 .object({
-//                   outcome: z.string(),
-//                   output: z.string(),
-//                 })
-//                 .nullish(),
-//               text: z.string().nullish(),
-//               thought: z.boolean().nullish(),
-//               thoughtSignature: z.string().nullish(),
-//             }),
-//           ]),
-//         )
-//         .nullish(),
-//     }),
-//   ),
-// );
+const getContentSchema = () =>
+  z.object({
+    parts: z
+      .array(
+        z.union([
+          // note: order matters since text can be fully empty
+          z.object({
+            functionCall: z.object({
+              name: z.string(),
+              args: z.unknown(),
+            }),
+            thoughtSignature: z.string().nullish(),
+          }),
+          z.object({
+            inlineData: z.object({
+              mimeType: z.string(),
+              data: z.string(),
+            }),
+          }),
+          z.object({
+            executableCode: z
+              .object({
+                language: z.string(),
+                code: z.string(),
+              })
+              .nullish(),
+            codeExecutionResult: z
+              .object({
+                outcome: z.string(),
+                output: z.string(),
+              })
+              .nullish(),
+            text: z.string().nullish(),
+            thought: z.boolean().nullish(),
+            thoughtSignature: z.string().nullish(),
+          }),
+        ]),
+      )
+      .nullish(),
+  });
 
 // https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters
-export const safetyRatingSchema = z.object({
-  category: z.string().nullish(),
-  probability: z.string().nullish(),
-  probabilityScore: z.number().nullish(),
-  severity: z.string().nullish(),
-  severityScore: z.number().nullish(),
-  blocked: z.boolean().nullish(),
-});
+const getSafetyRatingSchema = () =>
+  z.object({
+    category: z.string().nullish(),
+    probability: z.string().nullish(),
+    probabilityScore: z.number().nullish(),
+    severity: z.string().nullish(),
+    severityScore: z.number().nullish(),
+    blocked: z.boolean().nullish(),
+  });
 
 const usageSchema = z.object({
   cachedContentTokenCount: z.number().nullish(),
@@ -804,130 +799,33 @@ const usageSchema = z.object({
 });
 
 // https://ai.google.dev/api/generate-content#UrlRetrievalMetadata
-// const urlContextMetadataSchema = lazySchema(() =>
-//   zodSchema(
-//     z.object({
-//       urlMetadata: z.array(
-//         z.object({
-//           retrievedUrl: z.string(),
-//           urlRetrievalStatus: z.string(),
-//         }),
-//       ),
-//     }),
-//   ),
-// );
+export const getUrlContextMetadataSchema = () =>
+  z.object({
+    urlMetadata: z.array(
+      z.object({
+        retrievedUrl: z.string(),
+        urlRetrievalStatus: z.string(),
+      }),
+    ),
+  });
 
 const responseSchema = lazySchema(() =>
   zodSchema(
     z.object({
       candidates: z.array(
         z.object({
-          content: z
-            .object({
-              parts: z
-                .array(
-                  z.union([
-                    // note: order matters since text can be fully empty
-                    z.object({
-                      functionCall: z.object({
-                        name: z.string(),
-                        args: z.unknown(),
-                      }),
-                      thoughtSignature: z.string().nullish(),
-                    }),
-                    z.object({
-                      inlineData: z.object({
-                        mimeType: z.string(),
-                        data: z.string(),
-                      }),
-                    }),
-                    z.object({
-                      executableCode: z
-                        .object({
-                          language: z.string(),
-                          code: z.string(),
-                        })
-                        .nullish(),
-                      codeExecutionResult: z
-                        .object({
-                          outcome: z.string(),
-                          output: z.string(),
-                        })
-                        .nullish(),
-                      text: z.string().nullish(),
-                      thought: z.boolean().nullish(),
-                      thoughtSignature: z.string().nullish(),
-                    }),
-                  ]),
-                )
-                .nullish(),
-            })
-            .nullish()
-            .or(z.object({}).strict()),
+          content: getContentSchema().nullish().or(z.object({}).strict()),
           finishReason: z.string().nullish(),
-          safetyRatings: z.array(safetyRatingSchema).nullish(),
-          groundingMetadata: z
-            .object({
-              webSearchQueries: z.array(z.string()).nullish(),
-              retrievalQueries: z.array(z.string()).nullish(),
-              searchEntryPoint: z
-                .object({ renderedContent: z.string() })
-                .nullish(),
-              groundingChunks: z
-                .array(
-                  z.object({
-                    web: z
-                      .object({ uri: z.string(), title: z.string() })
-                      .nullish(),
-                    retrievedContext: z
-                      .object({ uri: z.string(), title: z.string() })
-                      .nullish(),
-                  }),
-                )
-                .nullish(),
-              groundingSupports: z
-                .array(
-                  z.object({
-                    segment: z.object({
-                      startIndex: z.number().nullish(),
-                      endIndex: z.number().nullish(),
-                      text: z.string().nullish(),
-                    }),
-                    segment_text: z.string().nullish(),
-                    groundingChunkIndices: z.array(z.number()).nullish(),
-                    supportChunkIndices: z.array(z.number()).nullish(),
-                    confidenceScores: z.array(z.number()).nullish(),
-                    confidenceScore: z.array(z.number()).nullish(),
-                  }),
-                )
-                .nullish(),
-              retrievalMetadata: z
-                .union([
-                  z.object({
-                    webDynamicRetrievalScore: z.number(),
-                  }),
-                  z.object({}),
-                ])
-                .nullish(),
-            })
-            .nullish(),
-          urlContextMetadata: z
-            .object({
-              urlMetadata: z.array(
-                z.object({
-                  retrievedUrl: z.string(),
-                  urlRetrievalStatus: z.string(),
-                }),
-              ),
-            })
-            .nullish(),
+          safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
+          groundingMetadata: getGroundingMetadataSchema().nullish(),
+          urlContextMetadata: getUrlContextMetadataSchema().nullish(),
         }),
       ),
       usageMetadata: usageSchema.nullish(),
       promptFeedback: z
         .object({
           blockReason: z.string().nullish(),
-          safetyRatings: z.array(safetyRatingSchema).nullish(),
+          safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
         })
         .nullish(),
     }),
@@ -937,7 +835,6 @@ const responseSchema = lazySchema(() =>
 type ContentSchema = NonNullable<
   InferValidator<typeof responseSchema>['candidates'][number]['content']
 >;
-export type SafetyRatingSchema = z.infer<typeof safetyRatingSchema>;
 export type GroundingMetadataSchema = NonNullable<
   InferValidator<
     typeof responseSchema
@@ -954,6 +851,10 @@ export type UrlContextMetadataSchema = NonNullable<
   >['candidates'][number]['urlContextMetadata']
 >;
 
+export type SafetyRatingSchema = NonNullable<
+  InferValidator<typeof responseSchema>['candidates'][number]['safetyRatings']
+>[number];
+
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
 const chunkSchema = lazySchema(() =>
@@ -962,104 +863,11 @@ const chunkSchema = lazySchema(() =>
       candidates: z
         .array(
           z.object({
-            content: z
-              .object({
-                parts: z
-                  .array(
-                    z.union([
-                      // note: order matters since text can be fully empty
-                      z.object({
-                        functionCall: z.object({
-                          name: z.string(),
-                          args: z.unknown(),
-                        }),
-                        thoughtSignature: z.string().nullish(),
-                      }),
-                      z.object({
-                        inlineData: z.object({
-                          mimeType: z.string(),
-                          data: z.string(),
-                        }),
-                      }),
-                      z.object({
-                        executableCode: z
-                          .object({
-                            language: z.string(),
-                            code: z.string(),
-                          })
-                          .nullish(),
-                        codeExecutionResult: z
-                          .object({
-                            outcome: z.string(),
-                            output: z.string(),
-                          })
-                          .nullish(),
-                        text: z.string().nullish(),
-                        thought: z.boolean().nullish(),
-                        thoughtSignature: z.string().nullish(),
-                      }),
-                    ]),
-                  )
-                  .nullish(),
-              })
-              .nullish(),
+            content: getContentSchema().nullish(),
             finishReason: z.string().nullish(),
-            safetyRatings: z.array(safetyRatingSchema).nullish(),
-            groundingMetadata: z
-              .object({
-                webSearchQueries: z.array(z.string()).nullish(),
-                retrievalQueries: z.array(z.string()).nullish(),
-                searchEntryPoint: z
-                  .object({ renderedContent: z.string() })
-                  .nullish(),
-                groundingChunks: z
-                  .array(
-                    z.object({
-                      web: z
-                        .object({ uri: z.string(), title: z.string() })
-                        .nullish(),
-                      retrievedContext: z
-                        .object({ uri: z.string(), title: z.string() })
-                        .nullish(),
-                    }),
-                  )
-                  .nullish(),
-                groundingSupports: z
-                  .array(
-                    z.object({
-                      segment: z.object({
-                        startIndex: z.number().nullish(),
-                        endIndex: z.number().nullish(),
-                        text: z.string().nullish(),
-                      }),
-                      segment_text: z.string().nullish(),
-                      groundingChunkIndices: z.array(z.number()).nullish(),
-                      supportChunkIndices: z.array(z.number()).nullish(),
-                      confidenceScores: z.array(z.number()).nullish(),
-                      confidenceScore: z.array(z.number()).nullish(),
-                    }),
-                  )
-                  .nullish(),
-                retrievalMetadata: z
-                  .union([
-                    z.object({
-                      webDynamicRetrievalScore: z.number(),
-                    }),
-                    z.object({}),
-                  ])
-                  .nullish(),
-              })
-              .nullish(),
-            urlContextMetadata: z
-              .object({
-                urlMetadata: z.array(
-                  z.object({
-                    retrievedUrl: z.string(),
-                    urlRetrievalStatus: z.string(),
-                  }),
-                ),
-              })
-              .nullish(),
+            safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
+            groundingMetadata: getGroundingMetadataSchema().nullish(),
+            urlContextMetadata: getUrlContextMetadataSchema().nullish(),
           }),
         )
         .nullish(),
@@ -1067,7 +875,7 @@ const chunkSchema = lazySchema(() =>
       promptFeedback: z
         .object({
           blockReason: z.string().nullish(),
-          safetyRatings: z.array(safetyRatingSchema).nullish(),
+          safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
         })
         .nullish(),
     }),

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -10,15 +10,18 @@ import {
 } from '@ai-sdk/provider';
 import {
   FetchFunction,
+  InferValidator,
   ParseResult,
   Resolvable,
   combineHeaders,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
+  lazySchema,
   parseProviderOptions,
   postJsonToApi,
   resolve,
+  zodSchema,
 } from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
 import { convertJSONSchemaToOpenAPISchema } from './convert-json-schema-to-openapi-schema';
@@ -32,11 +35,6 @@ import {
 } from './google-generative-ai-options';
 import { prepareTools } from './google-prepare-tools';
 import { mapGoogleGenerativeAIFinishReason } from './map-google-generative-ai-finish-reason';
-import {
-  groundingChunkSchema,
-  groundingMetadataSchema,
-} from './tool/google-search';
-import { urlContextMetadataSchema } from './tool/url-context';
 
 type GoogleGenerativeAIConfig = {
   provider: string;
@@ -358,7 +356,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
     return {
       stream: response.pipeThrough(
         new TransformStream<
-          ParseResult<z.infer<typeof chunkSchema>>,
+          ParseResult<ChunkSchema>,
           LanguageModelV3StreamPart
         >({
           start(controller) {
@@ -640,7 +638,7 @@ function getToolCallsFromParts({
   parts,
   generateId,
 }: {
-  parts: z.infer<typeof contentSchema>['parts'];
+  parts: ContentSchema['parts'];
   generateId: () => string;
 }) {
   const functionCallParts = parts?.filter(
@@ -665,7 +663,7 @@ function getToolCallsFromParts({
       }));
 }
 
-function getInlineDataParts(parts: z.infer<typeof contentSchema>['parts']) {
+function getInlineDataParts(parts: ContentSchema['parts']) {
   return parts?.filter(
     (
       part,
@@ -679,14 +677,14 @@ function extractSources({
   groundingMetadata,
   generateId,
 }: {
-  groundingMetadata: z.infer<typeof groundingMetadataSchema> | undefined | null;
+  groundingMetadata: GroundingMetadataSchema | undefined | null;
   generateId: () => string;
 }): undefined | LanguageModelV3Source[] {
   return groundingMetadata?.groundingChunks
     ?.filter(
       (
         chunk,
-      ): chunk is z.infer<typeof groundingChunkSchema> & {
+      ): chunk is GroundingChunkSchema & {
         web: { uri: string; title?: string };
       } => chunk.web != null,
     )
@@ -699,45 +697,93 @@ function extractSources({
     }));
 }
 
-const contentSchema = z.object({
-  parts: z
-    .array(
-      z.union([
-        // note: order matters since text can be fully empty
-        z.object({
-          functionCall: z.object({
-            name: z.string(),
-            args: z.unknown(),
-          }),
-          thoughtSignature: z.string().nullish(),
-        }),
-        z.object({
-          inlineData: z.object({
-            mimeType: z.string(),
-            data: z.string(),
-          }),
-        }),
-        z.object({
-          executableCode: z
-            .object({
-              language: z.string(),
-              code: z.string(),
-            })
-            .nullish(),
-          codeExecutionResult: z
-            .object({
-              outcome: z.string(),
-              output: z.string(),
-            })
-            .nullish(),
-          text: z.string().nullish(),
-          thought: z.boolean().nullish(),
-          thoughtSignature: z.string().nullish(),
-        }),
-      ]),
-    )
-    .nullish(),
-});
+// const groundingMetadataSchema = lazySchema(() =>
+//   zodSchema(
+//     z.object({
+//       webSearchQueries: z.array(z.string()).nullish(),
+//       retrievalQueries: z.array(z.string()).nullish(),
+//       searchEntryPoint: z.object({ renderedContent: z.string() }).nullish(),
+//       groundingChunks: z
+//         .array(
+//           z.object({
+//             web: z.object({ uri: z.string(), title: z.string() }).nullish(),
+//             retrievedContext: z
+//               .object({ uri: z.string(), title: z.string() })
+//               .nullish(),
+//           }),
+//         )
+//         .nullish(),
+//       groundingSupports: z
+//         .array(
+//           z.object({
+//             segment: z.object({
+//               startIndex: z.number().nullish(),
+//               endIndex: z.number().nullish(),
+//               text: z.string().nullish(),
+//             }),
+//             segment_text: z.string().nullish(),
+//             groundingChunkIndices: z.array(z.number()).nullish(),
+//             supportChunkIndices: z.array(z.number()).nullish(),
+//             confidenceScores: z.array(z.number()).nullish(),
+//             confidenceScore: z.array(z.number()).nullish(),
+//           }),
+//         )
+//         .nullish(),
+//       retrievalMetadata: z
+//         .union([
+//           z.object({
+//             webDynamicRetrievalScore: z.number(),
+//           }),
+//           z.object({}),
+//         ])
+//         .nullish(),
+//     }),
+//   ),
+// );
+
+// const contentSchema = lazySchema(() =>
+//   zodSchema(
+//     z.object({
+//       parts: z
+//         .array(
+//           z.union([
+//             // note: order matters since text can be fully empty
+//             z.object({
+//               functionCall: z.object({
+//                 name: z.string(),
+//                 args: z.unknown(),
+//               }),
+//               thoughtSignature: z.string().nullish(),
+//             }),
+//             z.object({
+//               inlineData: z.object({
+//                 mimeType: z.string(),
+//                 data: z.string(),
+//               }),
+//             }),
+//             z.object({
+//               executableCode: z
+//                 .object({
+//                   language: z.string(),
+//                   code: z.string(),
+//                 })
+//                 .nullish(),
+//               codeExecutionResult: z
+//                 .object({
+//                   outcome: z.string(),
+//                   output: z.string(),
+//                 })
+//                 .nullish(),
+//               text: z.string().nullish(),
+//               thought: z.boolean().nullish(),
+//               thoughtSignature: z.string().nullish(),
+//             }),
+//           ]),
+//         )
+//         .nullish(),
+//     }),
+//   ),
+// );
 
 // https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters
 export const safetyRatingSchema = z.object({
@@ -757,44 +803,275 @@ const usageSchema = z.object({
   totalTokenCount: z.number().nullish(),
 });
 
-const responseSchema = z.object({
-  candidates: z.array(
+// https://ai.google.dev/api/generate-content#UrlRetrievalMetadata
+// const urlContextMetadataSchema = lazySchema(() =>
+//   zodSchema(
+//     z.object({
+//       urlMetadata: z.array(
+//         z.object({
+//           retrievedUrl: z.string(),
+//           urlRetrievalStatus: z.string(),
+//         }),
+//       ),
+//     }),
+//   ),
+// );
+
+const responseSchema = lazySchema(() =>
+  zodSchema(
     z.object({
-      content: contentSchema.nullish().or(z.object({}).strict()),
-      finishReason: z.string().nullish(),
-      safetyRatings: z.array(safetyRatingSchema).nullish(),
-      groundingMetadata: groundingMetadataSchema.nullish(),
-      urlContextMetadata: urlContextMetadataSchema.nullish(),
+      candidates: z.array(
+        z.object({
+          content: z
+            .object({
+              parts: z
+                .array(
+                  z.union([
+                    // note: order matters since text can be fully empty
+                    z.object({
+                      functionCall: z.object({
+                        name: z.string(),
+                        args: z.unknown(),
+                      }),
+                      thoughtSignature: z.string().nullish(),
+                    }),
+                    z.object({
+                      inlineData: z.object({
+                        mimeType: z.string(),
+                        data: z.string(),
+                      }),
+                    }),
+                    z.object({
+                      executableCode: z
+                        .object({
+                          language: z.string(),
+                          code: z.string(),
+                        })
+                        .nullish(),
+                      codeExecutionResult: z
+                        .object({
+                          outcome: z.string(),
+                          output: z.string(),
+                        })
+                        .nullish(),
+                      text: z.string().nullish(),
+                      thought: z.boolean().nullish(),
+                      thoughtSignature: z.string().nullish(),
+                    }),
+                  ]),
+                )
+                .nullish(),
+            })
+            .nullish()
+            .or(z.object({}).strict()),
+          finishReason: z.string().nullish(),
+          safetyRatings: z.array(safetyRatingSchema).nullish(),
+          groundingMetadata: z
+            .object({
+              webSearchQueries: z.array(z.string()).nullish(),
+              retrievalQueries: z.array(z.string()).nullish(),
+              searchEntryPoint: z
+                .object({ renderedContent: z.string() })
+                .nullish(),
+              groundingChunks: z
+                .array(
+                  z.object({
+                    web: z
+                      .object({ uri: z.string(), title: z.string() })
+                      .nullish(),
+                    retrievedContext: z
+                      .object({ uri: z.string(), title: z.string() })
+                      .nullish(),
+                  }),
+                )
+                .nullish(),
+              groundingSupports: z
+                .array(
+                  z.object({
+                    segment: z.object({
+                      startIndex: z.number().nullish(),
+                      endIndex: z.number().nullish(),
+                      text: z.string().nullish(),
+                    }),
+                    segment_text: z.string().nullish(),
+                    groundingChunkIndices: z.array(z.number()).nullish(),
+                    supportChunkIndices: z.array(z.number()).nullish(),
+                    confidenceScores: z.array(z.number()).nullish(),
+                    confidenceScore: z.array(z.number()).nullish(),
+                  }),
+                )
+                .nullish(),
+              retrievalMetadata: z
+                .union([
+                  z.object({
+                    webDynamicRetrievalScore: z.number(),
+                  }),
+                  z.object({}),
+                ])
+                .nullish(),
+            })
+            .nullish(),
+          urlContextMetadata: z
+            .object({
+              urlMetadata: z.array(
+                z.object({
+                  retrievedUrl: z.string(),
+                  urlRetrievalStatus: z.string(),
+                }),
+              ),
+            })
+            .nullish(),
+        }),
+      ),
+      usageMetadata: usageSchema.nullish(),
+      promptFeedback: z
+        .object({
+          blockReason: z.string().nullish(),
+          safetyRatings: z.array(safetyRatingSchema).nullish(),
+        })
+        .nullish(),
     }),
   ),
-  usageMetadata: usageSchema.nullish(),
-  promptFeedback: z
-    .object({
-      blockReason: z.string().nullish(),
-      safetyRatings: z.array(safetyRatingSchema).nullish(),
-    })
-    .nullish(),
-});
+);
+
+type ContentSchema = NonNullable<
+  InferValidator<typeof responseSchema>['candidates'][number]['content']
+>;
+export type SafetyRatingSchema = z.infer<typeof safetyRatingSchema>;
+export type GroundingMetadataSchema = NonNullable<
+  InferValidator<
+    typeof responseSchema
+  >['candidates'][number]['groundingMetadata']
+>;
+
+type GroundingChunkSchema = NonNullable<
+  GroundingMetadataSchema['groundingChunks']
+>[number];
+
+export type UrlContextMetadataSchema = NonNullable<
+  InferValidator<
+    typeof responseSchema
+  >['candidates'][number]['urlContextMetadata']
+>;
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const chunkSchema = z.object({
-  candidates: z
-    .array(
-      z.object({
-        content: contentSchema.nullish(),
-        finishReason: z.string().nullish(),
-        safetyRatings: z.array(safetyRatingSchema).nullish(),
-        groundingMetadata: groundingMetadataSchema.nullish(),
-        urlContextMetadata: urlContextMetadataSchema.nullish(),
-      }),
-    )
-    .nullish(),
-  usageMetadata: usageSchema.nullish(),
-  promptFeedback: z
-    .object({
-      blockReason: z.string().nullish(),
-      safetyRatings: z.array(safetyRatingSchema).nullish(),
-    })
-    .nullish(),
-});
+const chunkSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      candidates: z
+        .array(
+          z.object({
+            content: z
+              .object({
+                parts: z
+                  .array(
+                    z.union([
+                      // note: order matters since text can be fully empty
+                      z.object({
+                        functionCall: z.object({
+                          name: z.string(),
+                          args: z.unknown(),
+                        }),
+                        thoughtSignature: z.string().nullish(),
+                      }),
+                      z.object({
+                        inlineData: z.object({
+                          mimeType: z.string(),
+                          data: z.string(),
+                        }),
+                      }),
+                      z.object({
+                        executableCode: z
+                          .object({
+                            language: z.string(),
+                            code: z.string(),
+                          })
+                          .nullish(),
+                        codeExecutionResult: z
+                          .object({
+                            outcome: z.string(),
+                            output: z.string(),
+                          })
+                          .nullish(),
+                        text: z.string().nullish(),
+                        thought: z.boolean().nullish(),
+                        thoughtSignature: z.string().nullish(),
+                      }),
+                    ]),
+                  )
+                  .nullish(),
+              })
+              .nullish(),
+            finishReason: z.string().nullish(),
+            safetyRatings: z.array(safetyRatingSchema).nullish(),
+            groundingMetadata: z
+              .object({
+                webSearchQueries: z.array(z.string()).nullish(),
+                retrievalQueries: z.array(z.string()).nullish(),
+                searchEntryPoint: z
+                  .object({ renderedContent: z.string() })
+                  .nullish(),
+                groundingChunks: z
+                  .array(
+                    z.object({
+                      web: z
+                        .object({ uri: z.string(), title: z.string() })
+                        .nullish(),
+                      retrievedContext: z
+                        .object({ uri: z.string(), title: z.string() })
+                        .nullish(),
+                    }),
+                  )
+                  .nullish(),
+                groundingSupports: z
+                  .array(
+                    z.object({
+                      segment: z.object({
+                        startIndex: z.number().nullish(),
+                        endIndex: z.number().nullish(),
+                        text: z.string().nullish(),
+                      }),
+                      segment_text: z.string().nullish(),
+                      groundingChunkIndices: z.array(z.number()).nullish(),
+                      supportChunkIndices: z.array(z.number()).nullish(),
+                      confidenceScores: z.array(z.number()).nullish(),
+                      confidenceScore: z.array(z.number()).nullish(),
+                    }),
+                  )
+                  .nullish(),
+                retrievalMetadata: z
+                  .union([
+                    z.object({
+                      webDynamicRetrievalScore: z.number(),
+                    }),
+                    z.object({}),
+                  ])
+                  .nullish(),
+              })
+              .nullish(),
+            urlContextMetadata: z
+              .object({
+                urlMetadata: z.array(
+                  z.object({
+                    retrievedUrl: z.string(),
+                    urlRetrievalStatus: z.string(),
+                  }),
+                ),
+              })
+              .nullish(),
+          }),
+        )
+        .nullish(),
+      usageMetadata: usageSchema.nullish(),
+      promptFeedback: z
+        .object({
+          blockReason: z.string().nullish(),
+          safetyRatings: z.array(safetyRatingSchema).nullish(),
+        })
+        .nullish(),
+    }),
+  ),
+);
+
+type ChunkSchema = InferValidator<typeof chunkSchema>;

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -1,3 +1,8 @@
+import {
+  type InferValidator,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
 
 export type GoogleGenerativeAIModelId =
@@ -41,99 +46,103 @@ export type GoogleGenerativeAIModelId =
   | 'gemma-3-27b-it'
   | (string & {});
 
-export const googleGenerativeAIProviderOptions = z.object({
-  responseModalities: z.array(z.enum(['TEXT', 'IMAGE'])).optional(),
+export const googleGenerativeAIProviderOptions = lazySchema(() =>
+  zodSchema(
+    z.object({
+      responseModalities: z.array(z.enum(['TEXT', 'IMAGE'])).optional(),
 
-  thinkingConfig: z
-    .object({
-      thinkingBudget: z.number().optional(),
-      includeThoughts: z.boolean().optional(),
-    })
-    .optional(),
+      thinkingConfig: z
+        .object({
+          thinkingBudget: z.number().optional(),
+          includeThoughts: z.boolean().optional(),
+        })
+        .optional(),
 
-  /**
-Optional.
-The name of the cached content used as context to serve the prediction.
-Format: cachedContents/{cachedContent}
-   */
-  cachedContent: z.string().optional(),
+      /**
+       * Optional.
+       * The name of the cached content used as context to serve the prediction.
+       * Format: cachedContents/{cachedContent}
+       */
+      cachedContent: z.string().optional(),
 
-  /**
-   * Optional. Enable structured output. Default is true.
-   *
-   * This is useful when the JSON Schema contains elements that are
-   * not supported by the OpenAPI schema version that
-   * Google Generative AI uses. You can use this to disable
-   * structured outputs if you need to.
-   */
-  structuredOutputs: z.boolean().optional(),
+      /**
+       * Optional. Enable structured output. Default is true.
+       *
+       * This is useful when the JSON Schema contains elements that are
+       * not supported by the OpenAPI schema version that
+       * Google Generative AI uses. You can use this to disable
+       * structured outputs if you need to.
+       */
+      structuredOutputs: z.boolean().optional(),
 
-  /**
-Optional. A list of unique safety settings for blocking unsafe content.
- */
-  safetySettings: z
-    .array(
-      z.object({
-        category: z.enum([
-          'HARM_CATEGORY_UNSPECIFIED',
-          'HARM_CATEGORY_HATE_SPEECH',
-          'HARM_CATEGORY_DANGEROUS_CONTENT',
-          'HARM_CATEGORY_HARASSMENT',
-          'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-          'HARM_CATEGORY_CIVIC_INTEGRITY',
-        ]),
-        threshold: z.enum([
+      /**
+       * Optional. A list of unique safety settings for blocking unsafe content.
+       */
+      safetySettings: z
+        .array(
+          z.object({
+            category: z.enum([
+              'HARM_CATEGORY_UNSPECIFIED',
+              'HARM_CATEGORY_HATE_SPEECH',
+              'HARM_CATEGORY_DANGEROUS_CONTENT',
+              'HARM_CATEGORY_HARASSMENT',
+              'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+              'HARM_CATEGORY_CIVIC_INTEGRITY',
+            ]),
+            threshold: z.enum([
+              'HARM_BLOCK_THRESHOLD_UNSPECIFIED',
+              'BLOCK_LOW_AND_ABOVE',
+              'BLOCK_MEDIUM_AND_ABOVE',
+              'BLOCK_ONLY_HIGH',
+              'BLOCK_NONE',
+              'OFF',
+            ]),
+          }),
+        )
+        .optional(),
+
+      threshold: z
+        .enum([
           'HARM_BLOCK_THRESHOLD_UNSPECIFIED',
           'BLOCK_LOW_AND_ABOVE',
           'BLOCK_MEDIUM_AND_ABOVE',
           'BLOCK_ONLY_HIGH',
           'BLOCK_NONE',
           'OFF',
-        ]),
-      }),
-    )
-    .optional(),
+        ])
+        .optional(),
 
-  threshold: z
-    .enum([
-      'HARM_BLOCK_THRESHOLD_UNSPECIFIED',
-      'BLOCK_LOW_AND_ABOVE',
-      'BLOCK_MEDIUM_AND_ABOVE',
-      'BLOCK_ONLY_HIGH',
-      'BLOCK_NONE',
-      'OFF',
-    ])
-    .optional(),
+      /**
+       * Optional. Enables timestamp understanding for audio-only files.
+       *
+       * https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding
+       */
+      audioTimestamp: z.boolean().optional(),
 
-  /**
-   * Optional. Enables timestamp understanding for audio-only files.
-   *
-   * https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding
-   */
-  audioTimestamp: z.boolean().optional(),
+      /**
+       * Optional. Defines labels used in billing reports. Available on Vertex AI only.
+       *
+       * https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls
+       */
+      labels: z.record(z.string(), z.string()).optional(),
 
-  /**
-   * Optional. Defines labels used in billing reports. Available on Vertex AI only.
-   *
-   * https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls
-   */
-  labels: z.record(z.string(), z.string()).optional(),
+      /**
+       * Optional. If specified, the media resolution specified will be used.
+       *
+       * https://ai.google.dev/api/generate-content#MediaResolution
+       */
+      mediaResolution: z
+        .enum([
+          'MEDIA_RESOLUTION_UNSPECIFIED',
+          'MEDIA_RESOLUTION_LOW',
+          'MEDIA_RESOLUTION_MEDIUM',
+          'MEDIA_RESOLUTION_HIGH',
+        ])
+        .optional(),
+    }),
+  ),
+);
 
-  /**
-   * Optional. If specified, the media resolution specified will be used.
-   *
-   * https://ai.google.dev/api/generate-content#MediaResolution
-   */
-  mediaResolution: z
-    .enum([
-      'MEDIA_RESOLUTION_UNSPECIFIED',
-      'MEDIA_RESOLUTION_LOW',
-      'MEDIA_RESOLUTION_MEDIUM',
-      'MEDIA_RESOLUTION_HIGH',
-    ])
-    .optional(),
-});
-
-export type GoogleGenerativeAIProviderOptions = z.infer<
+export type GoogleGenerativeAIProviderOptions = InferValidator<
   typeof googleGenerativeAIProviderOptions
 >;

--- a/packages/google/src/google-generative-ai-prompt.ts
+++ b/packages/google/src/google-generative-ai-prompt.ts
@@ -1,7 +1,8 @@
-import * as z from 'zod/v4';
-import { groundingMetadataSchema } from './tool/google-search';
-import { urlContextMetadataSchema } from './tool/url-context';
-import { safetyRatingSchema } from './google-generative-ai-language-model';
+import {
+  GroundingMetadataSchema,
+  UrlContextMetadataSchema,
+} from './google-generative-ai-language-model';
+import { type SafetyRatingSchema } from './google-generative-ai-language-model';
 
 export type GoogleGenerativeAIPrompt = {
   systemInstruction?: GoogleGenerativeAISystemInstruction;
@@ -24,15 +25,11 @@ export type GoogleGenerativeAIContentPart =
   | { functionResponse: { name: string; response: unknown } }
   | { fileData: { mimeType: string; fileUri: string } };
 
-export type GoogleGenerativeAIGroundingMetadata = z.infer<
-  typeof groundingMetadataSchema
->;
+export type GoogleGenerativeAIGroundingMetadata = GroundingMetadataSchema;
 
-export type GoogleGenerativeAIUrlContextMetadata = z.infer<
-  typeof urlContextMetadataSchema
->;
+export type GoogleGenerativeAIUrlContextMetadata = UrlContextMetadataSchema;
 
-export type GoogleGenerativeAISafetyRating = z.infer<typeof safetyRatingSchema>;
+export type GoogleGenerativeAISafetyRating = SafetyRatingSchema;
 
 export interface GoogleGenerativeAIProviderMetadata {
   groundingMetadata: GoogleGenerativeAIGroundingMetadata | null;

--- a/packages/google/src/tool/google-search.ts
+++ b/packages/google/src/tool/google-search.ts
@@ -1,45 +1,13 @@
-import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
+import {
+  createProviderDefinedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
 
 // https://ai.google.dev/gemini-api/docs/google-search
 // https://ai.google.dev/api/generate-content#GroundingSupport
 // https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-search
-
-export const groundingChunkSchema = z.object({
-  web: z.object({ uri: z.string(), title: z.string() }).nullish(),
-  retrievedContext: z.object({ uri: z.string(), title: z.string() }).nullish(),
-});
-
-export const groundingMetadataSchema = z.object({
-  webSearchQueries: z.array(z.string()).nullish(),
-  retrievalQueries: z.array(z.string()).nullish(),
-  searchEntryPoint: z.object({ renderedContent: z.string() }).nullish(),
-  groundingChunks: z.array(groundingChunkSchema).nullish(),
-  groundingSupports: z
-    .array(
-      z.object({
-        segment: z.object({
-          startIndex: z.number().nullish(),
-          endIndex: z.number().nullish(),
-          text: z.string().nullish(),
-        }),
-        segment_text: z.string().nullish(),
-        groundingChunkIndices: z.array(z.number()).nullish(),
-        supportChunkIndices: z.array(z.number()).nullish(),
-        confidenceScores: z.array(z.number()).nullish(),
-        confidenceScore: z.array(z.number()).nullish(),
-      }),
-    )
-    .nullish(),
-  retrievalMetadata: z
-    .union([
-      z.object({
-        webDynamicRetrievalScore: z.number(),
-      }),
-      z.object({}),
-    ])
-    .nullish(),
-});
 
 export const googleSearch = createProviderDefinedToolFactory<
   {},
@@ -60,10 +28,14 @@ export const googleSearch = createProviderDefinedToolFactory<
 >({
   id: 'google.google_search',
   name: 'google_search',
-  inputSchema: z.object({
-    mode: z
-      .enum(['MODE_DYNAMIC', 'MODE_UNSPECIFIED'])
-      .default('MODE_UNSPECIFIED'),
-    dynamicThreshold: z.number().default(1),
-  }),
+  inputSchema: lazySchema(() =>
+    zodSchema(
+      z.object({
+        mode: z
+          .enum(['MODE_DYNAMIC', 'MODE_UNSPECIFIED'])
+          .default('MODE_UNSPECIFIED'),
+        dynamicThreshold: z.number().default(1),
+      }),
+    ),
+  ),
 });

--- a/packages/google/src/tool/url-context.ts
+++ b/packages/google/src/tool/url-context.ts
@@ -1,15 +1,9 @@
-import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
+import {
+  createProviderDefinedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
-
-// https://ai.google.dev/api/generate-content#UrlRetrievalMetadata
-const urlMetadataSchema = z.object({
-  retrievedUrl: z.string(),
-  urlRetrievalStatus: z.string(),
-});
-
-export const urlContextMetadataSchema = z.object({
-  urlMetadata: z.array(urlMetadataSchema),
-});
 
 export const urlContext = createProviderDefinedToolFactory<
   {
@@ -19,5 +13,5 @@ export const urlContext = createProviderDefinedToolFactory<
 >({
   id: 'google.url_context',
   name: 'url_context',
-  inputSchema: z.object({}),
+  inputSchema: lazySchema(() => zodSchema(z.object({}))),
 });


### PR DESCRIPTION
## Background

- https://github.com/vercel/ai/issues/9339

## Summary

- replaced `examples/ai-core/src/benchmark/anthropic-load-time.ts` with `examples/ai-core/src/benchmark/provider-load-time.ts` for provider-agnostic bechmarks with average from 10 isolated imports
- updated schemas for Google to use lazy schemas
- import time improved by 12.5% (22.3ms ➡️ 19.5ms)

## Manual Verification

```
cd examples/ai-core
pnpm tsx /Users/gr2m/code/vercel/ai/examples/ai-core/src/benchmark/provider-load-time.ts google
```

Searched for `z.infer()` in `packages/google` - no results

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

- closes #9340 
