### PR TITLE
fix(openai): convert content type tool result to function_call_output type

### DIFF
--- a/.changeset/nice-clouds-build.md
+++ b/.changeset/nice-clouds-build.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): added content type tool result support for responses api

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -68,7 +68,14 @@ export type OpenAIResponsesFunctionCall = {
 export type OpenAIResponsesFunctionCallOutput = {
   type: 'function_call_output';
   call_id: string;
-  output: string;
+  output:
+    | string
+    | Array<
+        | { type: 'input_text'; text: string }
+        | { type: 'input_image'; image_url: string }
+        | { type: 'input_file'; file_url: string }
+        | { type: 'input_file'; file_id: string }
+      >;
 };
 
 export type OpenAIResponsesComputerCall = {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

content type tool result are not handled for openai responses API. currently its serializing them into a string which leads to context overflow, rate limiting because of huge base64 tool result content.

## Summary

added conversion from content type tool result to full `function_call_output`

## Manual Verification

with this change openai reponses API models (gpt-5, etc...) able to understand image tool results 

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

https://github.com/vercel/ai/issues/8209 https://github.com/vercel/ai/issues/8014