### PR TITLE
feat(google): add support for `aspectRatio` for Gemini models

### DIFF
--- a/.changeset/sour-gifts-tie.md
+++ b/.changeset/sour-gifts-tie.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Support `imageConfig.aspectRatio` configuration for Gemini models

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -172,6 +172,25 @@ The following optional provider options are available for Google Generative AI m
 
     Optional. If set to true, thought summaries are returned, which are synthisized versions of the model's raw thoughts and offer insights into the model's internal reasoning process.
 
+  - **imageConfig** _\{ aspectRatio: string \}_
+
+    Optional. Configuration for the models image generation. Only supported by specific [Google Generative AI models](https://ai.google.dev/gemini-api/docs/image-generation).
+
+    - **aspectRatio** _string_
+
+    Model defaults to generate 1:1 squares, or to matching the output image size to that of your input image. Can be one of the following:
+
+    - 1:1
+    - 2:3
+    - 3:2
+    - 3:4
+    - 4:3
+    - 4:5
+    - 5:4
+    - 9:16
+    - 16:9
+    - 21:9
+
 ### Thinking
 
 The Gemini 2.5 series models use an internal "thinking process" that significantly improves their reasoning and multi-step planning abilities, making them highly effective for complex tasks such as coding, advanced mathematics, and data analysis. For more information see [Google Generative AI thinking documentation](https://ai.google.dev/gemini-api/docs/thinking).

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -172,24 +172,24 @@ The following optional provider options are available for Google Generative AI m
 
     Optional. If set to true, thought summaries are returned, which are synthisized versions of the model's raw thoughts and offer insights into the model's internal reasoning process.
 
-  - **imageConfig** _\{ aspectRatio: string \}_
+- **imageConfig** _\{ aspectRatio: string \}_
 
-    Optional. Configuration for the models image generation. Only supported by specific [Google Generative AI models](https://ai.google.dev/gemini-api/docs/image-generation).
+  Optional. Configuration for the models image generation. Only supported by specific [Google Generative AI models](https://ai.google.dev/gemini-api/docs/image-generation).
 
-    - **aspectRatio** _string_
+  - **aspectRatio** _string_
 
-    Model defaults to generate 1:1 squares, or to matching the output image size to that of your input image. Can be one of the following:
+  Model defaults to generate 1:1 squares, or to matching the output image size to that of your input image. Can be one of the following:
 
-    - 1:1
-    - 2:3
-    - 3:2
-    - 3:4
-    - 4:3
-    - 4:5
-    - 5:4
-    - 9:16
-    - 16:9
-    - 21:9
+  - 1:1
+  - 2:3
+  - 3:2
+  - 3:4
+  - 4:3
+  - 4:5
+  - 5:4
+  - 9:16
+  - 16:9
+  - 21:9
 
 ### Thinking
 

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1388,6 +1388,29 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass imageConfig.aspectRatio in provider options', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          imageConfig: {
+            aspectRatio: '16:9',
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      generationConfig: {
+        imageConfig: {
+          aspectRatio: '16:9',
+        },
+      },
+    });
+  });
+
   it('should include non-image inlineData parts', async () => {
     server.urls[TEST_URL_GEMINI_PRO].response = {
       type: 'json-value',

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -163,6 +163,9 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           ...(googleOptions?.mediaResolution && {
             mediaResolution: googleOptions.mediaResolution,
           }),
+          ...(googleOptions?.imageConfig && {
+            imageConfig: googleOptions.imageConfig,
+          }),
         },
         contents,
         systemInstruction: isGemmaModel ? undefined : systemInstruction,

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -141,22 +141,24 @@ export const googleGenerativeAIProviderOptions = lazySchema(() =>
        *
        * https://ai.google.dev/gemini-api/docs/image-generation#aspect_ratios
        */
-      imageConfig: z.object({
-        aspectRatio: z
-          .enum([
-            '1:1',
-            '2:3',
-            '3:2',
-            '3:4',
-            '4:3',
-            '4:5',
-            '5:4',
-            '9:16',
-            '16:9',
-            '21:9',
-          ])
-          .optional(),
-      }).optional(),
+      imageConfig: z
+        .object({
+          aspectRatio: z
+            .enum([
+              '1:1',
+              '2:3',
+              '3:2',
+              '3:4',
+              '4:3',
+              '4:5',
+              '5:4',
+              '9:16',
+              '16:9',
+              '21:9',
+            ])
+            .optional(),
+        })
+        .optional(),
     }),
   ),
 );

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -135,6 +135,28 @@ export const googleGenerativeAIProviderOptions = lazySchema(() =>
           'MEDIA_RESOLUTION_HIGH',
         ])
         .optional(),
+
+      /**
+       * Optional. Configures the image generation aspect ratio for Gemini models.
+       *
+       * https://ai.google.dev/gemini-api/docs/image-generation#aspect_ratios
+       */
+      imageConfig: z.object({
+        aspectRatio: z
+          .enum([
+            '1:1',
+            '2:3',
+            '3:2',
+            '3:4',
+            '4:3',
+            '4:5',
+            '5:4',
+            '9:16',
+            '16:9',
+            '21:9',
+          ])
+          .optional(),
+      }).optional(),
     }),
   ),
 );


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->
Google made their Gemini 2.5 Flash Image (Nano Banana) production ready and added aspect ratio for configuration. [developers.googleblog.com](https://developers.googleblog.com/en/gemini-2-5-flash-image-now-ready-for-production-with-new-aspect-ratios/)

## Summary

<!-- What did you change? -->
Extended the Google Generative AI Options to support `aspectRatio` configuration.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

I linked the package into my own project where I needed support for this functionality and did multiple generation runs to confirm it working.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

Fixes #9239
