### PR TITLE
chore(provider/gateway): lazy schema loading

### DIFF
--- a/.changeset/seven-wolves-crash.md
+++ b/.changeset/seven-wolves-crash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+chore(provider/gateway): lazy schema loading

--- a/examples/ai-core/src/benchmark/load-time.ts
+++ b/examples/ai-core/src/benchmark/load-time.ts
@@ -1,15 +1,13 @@
 import { spawn } from 'child_process';
 
-const provider = process.argv[2];
+const moduleName = process.argv[2];
 
-if (!provider) {
+if (!moduleName) {
   console.error(
-    'Please provide a provider name as an argument, e.g., "anthropic"',
+    'Please provide a module name as an argument, e.g., "@ai-sdk/anthropic"',
   );
   process.exit(1);
 }
-
-const moduleName = `@ai-sdk/${provider}`;
 
 async function runInSeparateProcess(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -45,7 +43,7 @@ console.log(t1 - t0);
 
 async function main() {
   const times: number[] = [];
-  const iterations = 10;
+  const iterations = 50;
 
   console.log(`Running import benchmark 10 times for ${moduleName}...\n`);
 

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -11,7 +11,7 @@ import {
 } from './index';
 
 describe('Valid error responses', () => {
-  it('should create GatewayAuthenticationError for authentication_error type', () => {
+  it('should create GatewayAuthenticationError for authentication_error type', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Invalid API key',
@@ -19,7 +19,7 @@ describe('Valid error responses', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 401,
     });
@@ -30,7 +30,7 @@ describe('Valid error responses', () => {
     expect(error.type).toBe('authentication_error');
   });
 
-  it('should create GatewayInvalidRequestError for invalid_request_error type', () => {
+  it('should create GatewayInvalidRequestError for invalid_request_error type', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Missing required parameter',
@@ -38,7 +38,7 @@ describe('Valid error responses', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 400,
     });
@@ -48,7 +48,7 @@ describe('Valid error responses', () => {
     expect(error.statusCode).toBe(400);
   });
 
-  it('should create GatewayRateLimitError for rate_limit_exceeded type', () => {
+  it('should create GatewayRateLimitError for rate_limit_exceeded type', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Rate limit exceeded. Try again later.',
@@ -56,7 +56,7 @@ describe('Valid error responses', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 429,
     });
@@ -66,7 +66,7 @@ describe('Valid error responses', () => {
     expect(error.statusCode).toBe(429);
   });
 
-  it('should create GatewayModelNotFoundError for model_not_found type', () => {
+  it('should create GatewayModelNotFoundError for model_not_found type', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Model not available',
@@ -75,7 +75,7 @@ describe('Valid error responses', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 404,
     });
@@ -86,7 +86,7 @@ describe('Valid error responses', () => {
     expect((error as GatewayModelNotFoundError).modelId).toBe('gpt-4-turbo');
   });
 
-  it('should create GatewayModelNotFoundError without modelId for invalid param', () => {
+  it('should create GatewayModelNotFoundError without modelId for invalid param', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Model not available',
@@ -95,7 +95,7 @@ describe('Valid error responses', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 404,
     });
@@ -104,7 +104,7 @@ describe('Valid error responses', () => {
     expect((error as GatewayModelNotFoundError).modelId).toBeUndefined();
   });
 
-  it('should create GatewayInternalServerError for internal_server_error type', () => {
+  it('should create GatewayInternalServerError for internal_server_error type', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Internal server error occurred',
@@ -112,7 +112,7 @@ describe('Valid error responses', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
     });
@@ -122,7 +122,7 @@ describe('Valid error responses', () => {
     expect(error.statusCode).toBe(500);
   });
 
-  it('should create GatewayInternalServerError for unknown error type', () => {
+  it('should create GatewayInternalServerError for unknown error type', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Unknown error occurred',
@@ -130,7 +130,7 @@ describe('Valid error responses', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
     });
@@ -142,7 +142,7 @@ describe('Valid error responses', () => {
 });
 
 describe('Error response edge cases', () => {
-  it('should preserve empty string messages from Gateway', () => {
+  it('should preserve empty string messages from Gateway', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: '',
@@ -150,7 +150,7 @@ describe('Error response edge cases', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 401,
       defaultMessage: 'Custom default message',
@@ -159,7 +159,7 @@ describe('Error response edge cases', () => {
     expect(error.message).toContain('No authentication provided'); // Uses contextual message
   });
 
-  it('should use defaultMessage when response message is null', () => {
+  it('should use defaultMessage when response message is null', async () => {
     const response = {
       error: {
         message: null,
@@ -167,7 +167,7 @@ describe('Error response edge cases', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 401,
       defaultMessage: 'Custom default message',
@@ -185,7 +185,7 @@ describe('Error response edge cases', () => {
     expect(responseError.validationError).toBeDefined();
   });
 
-  it('should handle error type as null', () => {
+  it('should handle error type as null', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Some error',
@@ -193,7 +193,7 @@ describe('Error response edge cases', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
     });
@@ -201,7 +201,7 @@ describe('Error response edge cases', () => {
     expect(error).toBeInstanceOf(GatewayInternalServerError);
   });
 
-  it('should include cause in the created error', () => {
+  it('should include cause in the created error', async () => {
     const originalCause = new Error('Original network error');
     const response: GatewayErrorResponse = {
       error: {
@@ -210,7 +210,7 @@ describe('Error response edge cases', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 504,
       cause: originalCause,
@@ -221,12 +221,12 @@ describe('Error response edge cases', () => {
 });
 
 describe('Malformed responses', () => {
-  it('should create GatewayResponseError for completely invalid response', () => {
+  it('should create GatewayResponseError for completely invalid response', async () => {
     const response = {
       invalidField: 'value',
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
     });
@@ -241,15 +241,14 @@ describe('Malformed responses', () => {
     const responseError = error as GatewayResponseError;
     expect(responseError.response).toBe(response);
     expect(responseError.validationError).toBeDefined();
-    expect(responseError.validationError?.issues).toBeDefined();
   });
 
-  it('should create GatewayResponseError for missing error field', () => {
+  it('should create GatewayResponseError for missing error field', async () => {
     const response = {
       data: 'some data',
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
       defaultMessage: 'Custom error message',
@@ -266,10 +265,10 @@ describe('Malformed responses', () => {
     expect(responseError.validationError).toBeDefined();
   });
 
-  it('should create GatewayResponseError for null response', () => {
+  it('should create GatewayResponseError for null response', async () => {
     const response = null;
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
     });
@@ -285,10 +284,10 @@ describe('Malformed responses', () => {
     expect(responseError.validationError).toBeDefined();
   });
 
-  it('should create GatewayResponseError for string response', () => {
+  it('should create GatewayResponseError for string response', async () => {
     const response = 'Error string';
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
     });
@@ -304,10 +303,10 @@ describe('Malformed responses', () => {
     expect(responseError.validationError).toBeDefined();
   });
 
-  it('should create GatewayResponseError for array response', () => {
+  it('should create GatewayResponseError for array response', async () => {
     const response = ['error', 'array'];
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
     });
@@ -325,12 +324,12 @@ describe('Malformed responses', () => {
 });
 
 describe('Object parameter validation', () => {
-  it('should use default defaultMessage when not provided', () => {
+  it('should use default defaultMessage when not provided', async () => {
     const response = {
       invalidField: 'value',
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 500,
     });
@@ -346,7 +345,7 @@ describe('Object parameter validation', () => {
     expect(responseError.validationError).toBeDefined();
   });
 
-  it('should handle undefined cause', () => {
+  it('should handle undefined cause', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Test error',
@@ -354,7 +353,7 @@ describe('Object parameter validation', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 401,
       cause: undefined,
@@ -365,7 +364,7 @@ describe('Object parameter validation', () => {
 });
 
 describe('Complex scenarios', () => {
-  it('should handle model_not_found with missing param field', () => {
+  it('should handle model_not_found with missing param field', async () => {
     const response: GatewayErrorResponse = {
       error: {
         message: 'Model not found',
@@ -374,7 +373,7 @@ describe('Complex scenarios', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 404,
     });
@@ -383,7 +382,7 @@ describe('Complex scenarios', () => {
     expect((error as GatewayModelNotFoundError).modelId).toBeUndefined();
   });
 
-  it('should handle response with extra fields', () => {
+  it('should handle response with extra fields', async () => {
     const response = {
       error: {
         message: 'Test error',
@@ -395,7 +394,7 @@ describe('Complex scenarios', () => {
       metadata: 'should be ignored',
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 401,
     });
@@ -404,7 +403,7 @@ describe('Complex scenarios', () => {
     expect(error.message).toContain('No authentication provided');
   });
 
-  it('should preserve error properties correctly', () => {
+  it('should preserve error properties correctly', async () => {
     const originalCause = new TypeError('Type error');
     const response: GatewayErrorResponse = {
       error: {
@@ -413,7 +412,7 @@ describe('Complex scenarios', () => {
       },
     };
 
-    const error = createGatewayErrorFromResponse({
+    const error = await createGatewayErrorFromResponse({
       response,
       statusCode: 429,
       defaultMessage: 'Fallback message',
@@ -430,8 +429,8 @@ describe('Complex scenarios', () => {
 });
 
 describe('authentication_error with authMethod context', () => {
-  it('should create contextual error for API key authentication failure', () => {
-    const error = createGatewayErrorFromResponse({
+  it('should create contextual error for API key authentication failure', async () => {
+    const error = await createGatewayErrorFromResponse({
       response: {
         error: {
           type: 'authentication_error',
@@ -447,8 +446,8 @@ describe('authentication_error with authMethod context', () => {
     expect(error.statusCode).toBe(401);
   });
 
-  it('should create contextual error for OIDC authentication failure', () => {
-    const error = createGatewayErrorFromResponse({
+  it('should create contextual error for OIDC authentication failure', async () => {
+    const error = await createGatewayErrorFromResponse({
       response: {
         error: {
           type: 'authentication_error',
@@ -464,8 +463,8 @@ describe('authentication_error with authMethod context', () => {
     expect(error.statusCode).toBe(401);
   });
 
-  it('should create contextual error without authMethod context', () => {
-    const error = createGatewayErrorFromResponse({
+  it('should create contextual error without authMethod context', async () => {
+    const error = await createGatewayErrorFromResponse({
       response: {
         error: {
           type: 'authentication_error',

--- a/packages/gateway/src/errors/gateway-model-not-found-error.ts
+++ b/packages/gateway/src/errors/gateway-model-not-found-error.ts
@@ -1,13 +1,18 @@
 import * as z from 'zod/v4';
 import { GatewayError } from './gateway-error';
+import { lazyValidator, zodSchema } from '@ai-sdk/provider-utils';
 
 const name = 'GatewayModelNotFoundError';
 const marker = `vercel.ai.gateway.error.${name}`;
 const symbol = Symbol.for(marker);
 
-export const modelNotFoundParamSchema = z.object({
-  modelId: z.string(),
-});
+export const modelNotFoundParamSchema = lazyValidator(() =>
+  zodSchema(
+    z.object({
+      modelId: z.string(),
+    }),
+  ),
+);
 
 /**
  * Model not found or not available

--- a/packages/gateway/src/errors/gateway-response-error.ts
+++ b/packages/gateway/src/errors/gateway-response-error.ts
@@ -1,5 +1,5 @@
+import { TypeValidationError } from '@ai-sdk/provider';
 import { GatewayError } from './gateway-error';
-import type { ZodError } from 'zod/v4';
 
 const name = 'GatewayResponseError';
 const marker = `vercel.ai.gateway.error.${name}`;
@@ -14,7 +14,7 @@ export class GatewayResponseError extends GatewayError {
   readonly name = name;
   readonly type = 'response_error';
   readonly response?: unknown;
-  readonly validationError?: ZodError;
+  readonly validationError?: TypeValidationError;
 
   constructor({
     message = 'Invalid response from Gateway',
@@ -26,7 +26,7 @@ export class GatewayResponseError extends GatewayError {
     message?: string;
     statusCode?: number;
     response?: unknown;
-    validationError?: ZodError;
+    validationError?: TypeValidationError;
     cause?: unknown;
   } = {}) {
     super({ message, statusCode, cause });

--- a/packages/gateway/src/errors/parse-auth-method.test.ts
+++ b/packages/gateway/src/errors/parse-auth-method.test.ts
@@ -12,27 +12,27 @@ describe('GATEWAY_AUTH_METHOD_HEADER', () => {
 
 describe('parseAuthMethod', () => {
   describe('valid authentication methods', () => {
-    it('should parse "api-key" auth method', () => {
+    it('should parse "api-key" auth method', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: 'api-key',
       };
 
-      const result = parseAuthMethod(headers);
+      const result = await parseAuthMethod(headers);
 
       expect(result).toBe('api-key');
     });
 
-    it('should parse "oidc" auth method', () => {
+    it('should parse "oidc" auth method', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: 'oidc',
       };
 
-      const result = parseAuthMethod(headers);
+      const result = await parseAuthMethod(headers);
 
       expect(result).toBe('oidc');
     });
 
-    it('should handle headers with other fields present', () => {
+    it('should handle headers with other fields present', async () => {
       const headers = {
         authorization: 'Bearer token',
         'content-type': 'application/json',
@@ -40,97 +40,97 @@ describe('parseAuthMethod', () => {
         'user-agent': 'test-agent',
       };
 
-      const result = parseAuthMethod(headers);
+      const result = await parseAuthMethod(headers);
 
       expect(result).toBe('api-key');
     });
   });
 
   describe('invalid authentication methods', () => {
-    it('should return undefined for invalid auth method string', () => {
+    it('should return undefined for invalid auth method string', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: 'invalid-method',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should return undefined for empty string', () => {
+    it('should return undefined for empty string', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: '',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should return undefined for numeric value', () => {
+    it('should return undefined for numeric value', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: '123',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should return undefined for boolean-like strings', () => {
+    it('should return undefined for boolean-like strings', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: 'true',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should return undefined for case-sensitive variations', () => {
+    it('should return undefined for case-sensitive variations', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: 'API-KEY',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should return undefined for OIDC case variations', () => {
+    it('should return undefined for OIDC case variations', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: 'OIDC',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
   });
 
   describe('missing or undefined headers', () => {
-    it('should return undefined when header is missing', () => {
+    it('should return undefined when header is missing', async () => {
       const headers = {
         authorization: 'Bearer token',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should return undefined when header is undefined', () => {
+    it('should return undefined when header is undefined', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: undefined,
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should return undefined when headers object is empty', () => {
+    it('should return undefined when headers object is empty', async () => {
       const headers = {};
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
   });
 
   describe('edge cases', () => {
-    it('should return undefined for whitespace-only strings', () => {
+    it('should return undefined for whitespace-only strings', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: '   ',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should return undefined for auth methods with extra whitespace', () => {
+    it('should return undefined for auth methods with extra whitespace', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: ' api-key ',
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
 
-    it('should handle null values', () => {
+    it('should handle null values', async () => {
       const headers = {
         [GATEWAY_AUTH_METHOD_HEADER]: null as any,
       };
-      expect(parseAuthMethod(headers)).toBeUndefined();
+      expect(await parseAuthMethod(headers)).toBeUndefined();
     });
   });
 });

--- a/packages/gateway/src/errors/parse-auth-method.ts
+++ b/packages/gateway/src/errors/parse-auth-method.ts
@@ -1,15 +1,23 @@
+import {
+  lazyValidator,
+  safeValidateTypes,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
 
 export const GATEWAY_AUTH_METHOD_HEADER = 'ai-gateway-auth-method' as const;
 
-export function parseAuthMethod(headers: Record<string, string | undefined>) {
-  const result = gatewayAuthMethodSchema.safeParse(
-    headers[GATEWAY_AUTH_METHOD_HEADER],
-  );
-  return result.success ? result.data : undefined;
+export async function parseAuthMethod(
+  headers: Record<string, string | undefined>,
+) {
+  const result = await safeValidateTypes({
+    value: headers[GATEWAY_AUTH_METHOD_HEADER],
+    schema: gatewayAuthMethodSchema,
+  });
+
+  return result.success ? result.value : undefined;
 }
 
-const gatewayAuthMethodSchema = z.union([
-  z.literal('api-key'),
-  z.literal('oidc'),
-]);
+const gatewayAuthMethodSchema = lazyValidator(() =>
+  zodSchema(z.union([z.literal('api-key'), z.literal('oidc')])),
+);

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -1,17 +1,21 @@
-import type { EmbeddingModelV3 } from '@ai-sdk/provider';
+import type {
+  EmbeddingModelV3,
+  SharedV3ProviderMetadata,
+} from '@ai-sdk/provider';
 import {
   combineHeaders,
-  createJsonResponseHandler,
   createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  lazyValidator,
   postJsonToApi,
   resolve,
+  zodSchema,
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
-import type { GatewayConfig } from './gateway-config';
 import { asGatewayError } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
-import type { SharedV3ProviderMetadata } from '@ai-sdk/provider';
+import type { GatewayConfig } from './gateway-config';
 
 export class GatewayEmbeddingModel implements EmbeddingModelV3<string> {
   readonly specificationVersion = 'v3';
@@ -75,7 +79,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV3<string> {
         response: { headers: responseHeaders, body: rawValue },
       };
     } catch (error) {
-      throw asGatewayError(error, parseAuthMethod(resolvedHeaders));
+      throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
     }
   }
 
@@ -91,10 +95,14 @@ export class GatewayEmbeddingModel implements EmbeddingModelV3<string> {
   }
 }
 
-const gatewayEmbeddingResponseSchema = z.object({
-  embeddings: z.array(z.array(z.number())),
-  usage: z.object({ tokens: z.number() }).nullish(),
-  providerMetadata: z
-    .record(z.string(), z.record(z.string(), z.unknown()))
-    .optional(),
-});
+const gatewayEmbeddingResponseSchema = lazyValidator(() =>
+  zodSchema(
+    z.object({
+      embeddings: z.array(z.array(z.number())),
+      usage: z.object({ tokens: z.number() }).nullish(),
+      providerMetadata: z
+        .record(z.string(), z.record(z.string(), z.unknown()))
+        .optional(),
+    }),
+  ),
+);

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -79,7 +79,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV3<string> {
         response: { headers: responseHeaders, body: rawValue },
       };
     } catch (error) {
-      throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
+      throw await asGatewayError(error, await parseAuthMethod(resolvedHeaders));
     }
   }
 

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -44,7 +44,7 @@ export class GatewayFetchMetadata {
 
       return value;
     } catch (error) {
-      throw asGatewayError(error);
+      throw await asGatewayError(error);
     }
   }
 
@@ -67,7 +67,7 @@ export class GatewayFetchMetadata {
 
       return value;
     } catch (error) {
-      throw asGatewayError(error);
+      throw await asGatewayError(error);
     }
   }
 }

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -2,12 +2,14 @@ import {
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
   getFromApi,
+  lazyValidator,
   resolve,
+  zodSchema,
 } from '@ai-sdk/provider-utils';
+import * as z from 'zod/v4';
 import { asGatewayError } from './errors';
 import type { GatewayConfig } from './gateway-config';
 import type { GatewayLanguageModelEntry } from './gateway-model-entry';
-import * as z from 'zod/v4';
 
 type GatewayFetchMetadataConfig = GatewayConfig;
 
@@ -31,7 +33,7 @@ export class GatewayFetchMetadata {
         url: `${this.config.baseURL}/config`,
         headers: await resolve(this.config.headers()),
         successfulResponseHandler: createJsonResponseHandler(
-          gatewayFetchMetadataSchema,
+          gatewayAvailableModelsResponseSchema,
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
@@ -53,8 +55,9 @@ export class GatewayFetchMetadata {
       const { value } = await getFromApi({
         url: `${baseUrl.origin}/v1/credits`,
         headers: await resolve(this.config.headers()),
-        successfulResponseHandler:
-          createJsonResponseHandler(gatewayCreditsSchema),
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewayCreditsResponseSchema,
+        ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
           errorToMessage: data => data,
@@ -69,47 +72,56 @@ export class GatewayFetchMetadata {
   }
 }
 
-const gatewayLanguageModelSpecificationSchema = z.object({
-  specificationVersion: z.literal('v3'),
-  provider: z.string(),
-  modelId: z.string(),
-});
+const gatewayAvailableModelsResponseSchema = lazyValidator(() =>
+  zodSchema(
+    z.object({
+      models: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          description: z.string().nullish(),
+          pricing: z
+            .object({
+              input: z.string(),
+              output: z.string(),
+              input_cache_read: z.string().nullish(),
+              input_cache_write: z.string().nullish(),
+            })
+            .transform(
+              ({ input, output, input_cache_read, input_cache_write }) => ({
+                input,
+                output,
+                ...(input_cache_read
+                  ? { cachedInputTokens: input_cache_read }
+                  : {}),
+                ...(input_cache_write
+                  ? { cacheCreationInputTokens: input_cache_write }
+                  : {}),
+              }),
+            )
+            .nullish(),
+          specification: z.object({
+            specificationVersion: z.literal('v3'),
+            provider: z.string(),
+            modelId: z.string(),
+          }),
+          modelType: z.enum(['language', 'embedding', 'image']).nullish(),
+        }),
+      ),
+    }),
+  ),
+);
 
-const gatewayLanguageModelPricingSchema = z
-  .object({
-    input: z.string(),
-    output: z.string(),
-    input_cache_read: z.string().nullish(),
-    input_cache_write: z.string().nullish(),
-  })
-  .transform(({ input, output, input_cache_read, input_cache_write }) => ({
-    input,
-    output,
-    ...(input_cache_read ? { cachedInputTokens: input_cache_read } : {}),
-    ...(input_cache_write
-      ? { cacheCreationInputTokens: input_cache_write }
-      : {}),
-  }));
-
-const gatewayLanguageModelEntrySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string().nullish(),
-  pricing: gatewayLanguageModelPricingSchema.nullish(),
-  specification: gatewayLanguageModelSpecificationSchema,
-  modelType: z.enum(['language', 'embedding', 'image']).nullish(),
-});
-
-const gatewayFetchMetadataSchema = z.object({
-  models: z.array(gatewayLanguageModelEntrySchema),
-});
-
-const gatewayCreditsSchema = z
-  .object({
-    balance: z.string(),
-    total_used: z.string(),
-  })
-  .transform(({ balance, total_used }) => ({
-    balance,
-    totalUsed: total_used,
-  }));
+const gatewayCreditsResponseSchema = lazyValidator(() =>
+  zodSchema(
+    z
+      .object({
+        balance: z.string(),
+        total_used: z.string(),
+      })
+      .transform(({ balance, total_used }) => ({
+        balance,
+        totalUsed: total_used,
+      })),
+  ),
+);

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -86,7 +86,7 @@ export class GatewayLanguageModel implements LanguageModelV3 {
         warnings,
       };
     } catch (error) {
-      throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
+      throw await asGatewayError(error, await parseAuthMethod(resolvedHeaders));
     }
   }
 
@@ -159,7 +159,7 @@ export class GatewayLanguageModel implements LanguageModelV3 {
         response: { headers: responseHeaders },
       };
     } catch (error) {
-      throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
+      throw await asGatewayError(error, await parseAuthMethod(resolvedHeaders));
     }
   }
 

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -86,7 +86,7 @@ export class GatewayLanguageModel implements LanguageModelV3 {
         warnings,
       };
     } catch (error) {
-      throw asGatewayError(error, parseAuthMethod(resolvedHeaders));
+      throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
     }
   }
 
@@ -159,7 +159,7 @@ export class GatewayLanguageModel implements LanguageModelV3 {
         response: { headers: responseHeaders },
       };
     } catch (error) {
-      throw asGatewayError(error, parseAuthMethod(resolvedHeaders));
+      throw asGatewayError(error, await parseAuthMethod(resolvedHeaders));
     }
   }
 

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -1,19 +1,30 @@
+import {
+  InferValidator,
+  lazyValidator,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
 import * as z from 'zod/v4';
 
 // https://vercel.com/docs/ai-gateway/provider-options
-export const gatewayProviderOptions = z.object({
-  /**
-   * Array of provider slugs that are the only ones allowed to be used.
-   *
-   * Example: `['azure', 'openai']` will only allow Azure and OpenAI to be used.
-   */
-  only: z.array(z.string()).optional(),
-  /**
-   * Array of provider slugs that specifies the sequence in which providers should be attempted.
-   *
-   * Example: `['bedrock', 'anthropic']` will try Amazon Bedrock first, then Anthropic as fallback.
-   */
-  order: z.array(z.string()).optional(),
-});
+const gatewayProviderOptions = lazyValidator(() =>
+  zodSchema(
+    z.object({
+      /**
+       * Array of provider slugs that are the only ones allowed to be used.
+       *
+       * Example: `['azure', 'openai']` will only allow Azure and OpenAI to be used.
+       */
+      only: z.array(z.string()).optional(),
+      /**
+       * Array of provider slugs that specifies the sequence in which providers should be attempted.
+       *
+       * Example: `['bedrock', 'anthropic']` will try Amazon Bedrock first, then Anthropic as fallback.
+       */
+      order: z.array(z.string()).optional(),
+    }),
+  ),
+);
 
-export type GatewayProviderOptions = z.infer<typeof gatewayProviderOptions>;
+export type GatewayProviderOptions = InferValidator<
+  typeof gatewayProviderOptions
+>;

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -178,7 +178,10 @@ export function createGatewayProvider(
           return metadata;
         })
         .catch(async (error: unknown) => {
-          throw asGatewayError(error, parseAuthMethod(await getHeaders()));
+          throw asGatewayError(
+            error,
+            await parseAuthMethod(await getHeaders()),
+          );
         });
     }
 
@@ -193,7 +196,7 @@ export function createGatewayProvider(
     })
       .getCredits()
       .catch(async (error: unknown) => {
-        throw asGatewayError(error, parseAuthMethod(await getHeaders()));
+        throw asGatewayError(error, await parseAuthMethod(await getHeaders()));
       });
   };
 

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -178,7 +178,7 @@ export function createGatewayProvider(
           return metadata;
         })
         .catch(async (error: unknown) => {
-          throw asGatewayError(
+          throw await asGatewayError(
             error,
             await parseAuthMethod(await getHeaders()),
           );

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -196,7 +196,10 @@ export function createGatewayProvider(
     })
       .getCredits()
       .catch(async (error: unknown) => {
-        throw asGatewayError(error, await parseAuthMethod(await getHeaders()));
+        throw await asGatewayError(
+          error,
+          await parseAuthMethod(await getHeaders()),
+        );
       });
   };
 


### PR DESCRIPTION
## Background

Move providers to lazy schema loading (see #9339 )

## Summary

* change `examples/ai-core/src/benchmark/provider-load-time.ts` to `examples/ai-core/src/benchmark/load-time.ts`
* updated schemas in `@ai-sdk/gateway` to use lazy loading