### PR TITLE
feat(ai): Effect schema support

### DIFF
--- a/.changeset/eight-countries-draw.md
+++ b/.changeset/eight-countries-draw.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+feat(ai): Effect schema support

--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -44,6 +44,7 @@
     "ai": "workspace:*",
     "arktype": "2.1.22",
     "dotenv": "16.4.5",
+    "effect": "3.18.4",
     "image-type": "^5.2.0",
     "mathjs": "14.0.0",
     "sharp": "^0.33.5",

--- a/examples/ai-core/src/generate-object/anthropic-effect.ts
+++ b/examples/ai-core/src/generate-object/anthropic-effect.ts
@@ -1,0 +1,27 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateObject } from 'ai';
+import { Schema } from 'effect';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateObject({
+    model: anthropic('claude-3-7-sonnet-latest'),
+    schema: Schema.standardSchemaV1(
+      Schema.Struct({
+        recipe: Schema.Struct({
+          name: Schema.String,
+          ingredients: Schema.Array(
+            Schema.Struct({
+              name: Schema.String,
+              amount: Schema.String,
+            }),
+          ),
+          steps: Schema.Array(Schema.String),
+        }),
+      }),
+    ),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.dir(result.object.recipe, { depth: Infinity });
+});

--- a/examples/ai-core/src/generate-object/anthropic-valibot.ts
+++ b/examples/ai-core/src/generate-object/anthropic-valibot.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateObject({
-    model: anthropic('claude-3-5-sonnet-20240620'),
+    model: anthropic('claude-3-7-sonnet-latest'),
     schema: v.object({
       recipe: v.object({
         name: v.string(),

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -48,6 +48,7 @@
     "@valibot/to-json-schema": "^1.3.0",
     "@vercel/ai-tsconfig": "workspace:*",
     "arktype": "^2.1.22",
+    "effect": "^3.18.4",
     "msw": "2.7.0",
     "tsup": "^8",
     "typescript": "5.8.3",
@@ -56,11 +57,15 @@
   },
   "peerDependencies": {
     "arktype": "^2.1.22",
+    "effect": "^3.18.4",
     "zod": "^3.25.76 || ^4.1.8",
     "@valibot/to-json-schema": "^1.3.0"
   },
   "peerDependenciesMeta": {
     "arktype": {
+      "optional": true
+    },
+    "effect": {
       "optional": true
     },
     "@valibot/to-json-schema": {

--- a/packages/provider-utils/src/__snapshots__/schema.test.ts.snap
+++ b/packages/provider-utils/src/__snapshots__/schema.test.ts.snap
@@ -19,6 +19,26 @@ exports[`standardSchema > arktype > should create a schema with simple types 1`]
 }
 `;
 
+exports[`standardSchema > effect > should create a schema with simple types 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "number": {
+      "type": "number",
+    },
+    "text": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "text",
+    "number",
+  ],
+  "type": "object",
+}
+`;
+
 exports[`standardSchema > valibot > should create a schema with simple types 1`] = `
 {
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -1,9 +1,10 @@
+import { type } from 'arktype';
+import { Schema as EffectSchema } from 'effect';
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 import * as z4 from 'zod/v4';
 import { safeParseJSON } from './parse-json';
 import { standardSchema, zodSchema } from './schema';
-import { type } from 'arktype';
 
 describe('zodSchema', () => {
   describe('zod/v4', () => {
@@ -200,6 +201,21 @@ describe('standardSchema', () => {
           text: 'string',
           number: 'number',
         }),
+      );
+
+      expect(await schema.jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('effect', () => {
+    it('should create a schema with simple types', async () => {
+      const schema = standardSchema(
+        EffectSchema.standardSchemaV1(
+          EffectSchema.Struct({
+            text: EffectSchema.String,
+            number: EffectSchema.Number,
+          }),
+        ),
       );
 
       expect(await schema.jsonSchema).toMatchSnapshot();

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -3,6 +3,7 @@ import { StandardSchemaV1 } from '@standard-schema/spec';
 import * as z3 from 'zod/v3';
 import * as z4 from 'zod/v4';
 import { arktypeToJsonSchema } from './to-json-schema/arktype-to-json-schema';
+import { effectToJsonSchema } from './to-json-schema/effect-to-json-schema';
 import { valibotToJsonSchema } from './to-json-schema/valibot-to-json-schema';
 import { Validator, validatorSymbol, type ValidationResult } from './validator';
 import zodToJsonSchema from './zod-to-json-schema';
@@ -144,6 +145,13 @@ export function standardSchema<OBJECT>(
       return standardSchemaWithJsonSchemaResolver(
         standardSchema,
         arktypeToJsonSchema,
+      );
+    }
+
+    case 'effect': {
+      return standardSchemaWithJsonSchemaResolver(
+        standardSchema,
+        effectToJsonSchema,
       );
     }
 

--- a/packages/provider-utils/src/to-json-schema/effect-to-json-schema.ts
+++ b/packages/provider-utils/src/to-json-schema/effect-to-json-schema.ts
@@ -1,0 +1,13 @@
+import { JSONSchema7 } from '@ai-sdk/provider';
+
+export const effectToJsonSchema = async (
+  schema: unknown,
+): Promise<JSONSchema7> => {
+  try {
+    const { JSONSchema } = await import('effect');
+    return JSONSchema.make(schema as any) as JSONSchema7;
+  } catch {
+    // TODO dedicated error class
+    throw new Error(`Failed to import module 'effect'`);
+  }
+};

--- a/packages/provider-utils/src/to-json-schema/valibot-to-json-schema.ts
+++ b/packages/provider-utils/src/to-json-schema/valibot-to-json-schema.ts
@@ -8,6 +8,6 @@ export const valibotToJsonSchema = async (
     return toJsonSchema(schema as any);
   } catch {
     // TODO dedicated error class
-    throw new Error(`Failed to import @valibot/to-json-schema`);
+    throw new Error(`Failed to import module '@valibot/to-json-schema'`);
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2398,6 +2398,9 @@ importers:
       arktype:
         specifier: ^2.1.22
         version: 2.1.22
+      effect:
+        specifier: ^3.18.4
+        version: 3.18.4
       msw:
         specifier: 2.7.0
         version: 2.7.0(@types/node@20.17.24)(typescript@5.8.3)
@@ -11443,6 +11446,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.18.4:
+    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -11934,6 +11940,10 @@ packages:
 
   externality@1.0.2:
     resolution: {integrity: sha512-LyExtJWKxtgVzmgtEHyQtLFpw1KFhQphF9nTG8TpAIVkiI/xQ3FJh75tRFLYl4hkn7BNIIdLJInuDAavX35pMw==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -28695,6 +28705,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.18.4:
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      fast-check: 3.23.2
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.2
@@ -29138,7 +29153,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.1)
       eslint-plugin-react: 7.34.1(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -29226,8 +29241,8 @@ snapshots:
       debug: 4.4.1(supports-color@9.4.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.3
       get-tsconfig: 4.8.1
       is-core-module: 2.16.1
@@ -29277,7 +29292,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -29353,7 +29368,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -29363,7 +29378,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -29894,6 +29909,10 @@ snapshots:
       mlly: 1.7.3
       pathe: 1.1.2
       ufo: 1.5.4
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-decode-uri-component@1.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
+      effect:
+        specifier: 3.18.4
+        version: 3.18.4
       image-type:
         specifier: ^5.2.0
         version: 5.2.0


### PR DESCRIPTION
## Background

Only Zod schemas can currently be passed into generateObject/streamObject and tools. With Standard Schema, it is possible to use other validation libraries directly as well, as long as we provide a way to generate json schemas for them.

## Summary

Add Effect Schema support.

## Manual Verification

- [x] run `examples/ai-core/src/generate-object/anthropic-effect.ts`

## Tasks

- [x] implementation
- [x] changeset
- [x] example
- [x] test

## Related Issues

Builds on #9338 