### PR TITLE
fix: revert zod import change

### DIFF
--- a/.changeset/hungry-ladybugs-peel.md
+++ b/.changeset/hungry-ladybugs-peel.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix: revert zod import change

--- a/.changeset/hungry-ladybugs-peel.md
+++ b/.changeset/hungry-ladybugs-peel.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/provider-utils': patch
----
-
-fix: revert zod import change

--- a/.changeset/young-beans-melt.md
+++ b/.changeset/young-beans-melt.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix: revert zod import change

--- a/.changeset/young-beans-melt.md
+++ b/.changeset/young-beans-melt.md
@@ -1,5 +1,6 @@
 ---
 '@ai-sdk/gateway': patch
+'@ai-sdk/provider-utils': patch
 ---
 
 fix: revert zod import change

--- a/packages/ai/src/generate-object/generate-object.test-d.ts
+++ b/packages/ai/src/generate-object/generate-object.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'vitest';
 import { generateObject } from './generate-object';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { JSONValue } from '@ai-sdk/provider';
 import { describe, it } from 'vitest';
 

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -15,7 +15,7 @@ import {
   vitest,
   vi,
 } from 'vitest';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { verifyNoObjectGeneratedError as originalVerifyNoObjectGeneratedError } from '../error/verify-no-object-generated-error';
 import * as logWarningsModule from '../logger/log-warnings';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';

--- a/packages/ai/src/generate-object/stream-object.test-d.ts
+++ b/packages/ai/src/generate-object/stream-object.test-d.ts
@@ -1,6 +1,6 @@
 import { JSONValue } from '@ai-sdk/provider';
 import { expectTypeOf } from 'vitest';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { FinishReason } from '../types';
 import { streamObject } from './stream-object';

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@ai-sdk/provider-utils/test';
 import assert, { fail } from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { NoObjectGeneratedError } from '../error/no-object-generated-error';
 import { verifyNoObjectGeneratedError } from '../error/verify-no-object-generated-error';
 import * as logWarningsModule from '../logger/log-warnings';

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -25,7 +25,7 @@ import {
   vi,
   vitest,
 } from 'vitest';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { Output } from '.';
 import * as logWarningsModule from '../logger/log-warnings';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';

--- a/packages/ai/src/generate-text/output.test.ts
+++ b/packages/ai/src/generate-text/output.test.ts
@@ -1,5 +1,5 @@
 import { fail } from 'assert';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { verifyNoObjectGeneratedError } from '../error/verify-no-object-generated-error';
 import { object } from './output';
 import { FinishReason } from '../types';

--- a/packages/ai/src/generate-text/parse-tool-call.test.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.test.ts
@@ -1,5 +1,5 @@
 import { dynamicTool, tool } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
 import { ToolCallRepairError } from '../error/tool-call-repair-error';

--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -6,7 +6,7 @@ import {
   mockId,
 } from '@ai-sdk/provider-utils/test';
 import { describe, expect, it } from 'vitest';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { NoSuchToolError } from '../error/no-such-tool-error';
 import { MockTracer } from '../test/mock-tracer';
 import { runToolsTransformation } from './run-tools-transformation';

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -35,7 +35,7 @@ import {
   vi,
   vitest,
 } from 'vitest';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import * as logWarningsModule from '../logger/log-warnings';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
 import { createMockServerResponse } from '../test/mock-server-response';

--- a/packages/ai/src/prompt/content-part.ts
+++ b/packages/ai/src/prompt/content-part.ts
@@ -9,7 +9,7 @@ import {
   ToolApprovalResponse,
   ToolResultPart,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { jsonValueSchema } from '../types/json-value';
 import { providerMetadataSchema } from '../types/provider-metadata';
 import { dataContentSchema } from './data-content';

--- a/packages/ai/src/prompt/data-content.ts
+++ b/packages/ai/src/prompt/data-content.ts
@@ -4,7 +4,7 @@ import {
   convertUint8ArrayToBase64,
   DataContent,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { InvalidDataContentError } from './invalid-data-content-error';
 import { splitDataUrl } from './split-data-url';
 

--- a/packages/ai/src/prompt/message.ts
+++ b/packages/ai/src/prompt/message.ts
@@ -5,7 +5,7 @@ import {
   ToolModelMessage,
   UserModelMessage,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { providerMetadataSchema } from '../types/provider-metadata';
 import {
   filePartSchema,

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { prepareToolsAndToolChoice } from './prepare-tools-and-tool-choice';
 import { Tool, tool } from '@ai-sdk/provider-utils';
 import { describe, it, expect } from 'vitest';

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -1,6 +1,6 @@
 import { InvalidPromptError } from '@ai-sdk/provider';
 import { ModelMessage, safeValidateTypes } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { modelMessageSchema } from './message';
 import { Prompt } from './prompt';
 

--- a/packages/ai/src/tool/mcp/json-rpc-message.ts
+++ b/packages/ai/src/tool/mcp/json-rpc-message.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { BaseParamsSchema, RequestSchema, ResultSchema } from './types';
 
 const JSONRPC_VERSION = '2.0';

--- a/packages/ai/src/tool/mcp/mcp-client.test.ts
+++ b/packages/ai/src/tool/mcp/mcp-client.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { MCPClientError } from '../../error/mcp-client-error';
 import { createMCPClient } from './mcp-client';
 import { MockMCPTransport } from './mock-mcp-transport';

--- a/packages/ai/src/tool/mcp/mcp-client.ts
+++ b/packages/ai/src/tool/mcp/mcp-client.ts
@@ -6,7 +6,7 @@ import {
   tool,
   ToolCallOptions,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { MCPClientError } from '../../error/mcp-client-error';
 import {
   JSONRPCError,

--- a/packages/ai/src/tool/mcp/types.ts
+++ b/packages/ai/src/tool/mcp/types.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { JSONObject } from '@ai-sdk/provider';
 import { FlexibleSchema, Tool } from '@ai-sdk/provider-utils';
 

--- a/packages/ai/src/types/json-value.ts
+++ b/packages/ai/src/types/json-value.ts
@@ -1,5 +1,5 @@
 import { JSONValue as OriginalJSONValue } from '@ai-sdk/provider';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
   z.union([

--- a/packages/ai/src/types/provider-metadata.ts
+++ b/packages/ai/src/types/provider-metadata.ts
@@ -1,5 +1,5 @@
 import { SharedV3ProviderMetadata } from '@ai-sdk/provider';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { jsonValueSchema } from './json-value';
 
 /**

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   ProviderMetadata,
   providerMetadataSchema,

--- a/packages/ai/src/ui/chat.test-d.ts
+++ b/packages/ai/src/ui/chat.test-d.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { tool } from '@ai-sdk/provider-utils';
 import { ChatInit } from './chat';
 import { ToolSet } from '../generate-text/tool-set';

--- a/packages/ai/src/ui/validate-ui-messages.test.ts
+++ b/packages/ai/src/ui/validate-ui-messages.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { InferUITool, UIMessage } from './ui-messages';
 import {
   safeValidateUIMessages,

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -7,7 +7,7 @@ import {
   Validator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { InvalidArgumentError } from '../error';
 import { providerMetadataSchema } from '../types/provider-metadata';
 import {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -9,7 +9,7 @@ import {
   BedrockRedactedReasoningContentBlock,
 } from './bedrock-api-types';
 import { anthropicTools, prepareTools } from '@ai-sdk/anthropic/internal';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const mockPrepareAnthropicTools = vi.mocked(prepareTools);
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -21,7 +21,7 @@ import {
   postJsonToApi,
   resolve,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   BEDROCK_STOP_REASONS,
   BedrockConverseInput,

--- a/packages/amazon-bedrock/src/bedrock-chat-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
 export type BedrockChatModelId =

--- a/packages/amazon-bedrock/src/bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-model.ts
@@ -17,7 +17,7 @@ import {
   bedrockEmbeddingProviderOptions,
 } from './bedrock-embedding-options';
 import { BedrockErrorSchema } from './bedrock-error';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 type BedrockEmbeddingConfig = {
   baseUrl: () => string;

--- a/packages/amazon-bedrock/src/bedrock-embedding-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-embedding-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type BedrockEmbeddingModelId =
   | 'amazon.titan-embed-text-v1'

--- a/packages/amazon-bedrock/src/bedrock-error.ts
+++ b/packages/amazon-bedrock/src/bedrock-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const BedrockErrorSchema = z.object({
   message: z.string(),

--- a/packages/amazon-bedrock/src/bedrock-event-stream-response-handler.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-event-stream-response-handler.test.ts
@@ -1,7 +1,7 @@
 import { EmptyResponseBodyError } from '@ai-sdk/provider';
 import { createBedrockEventStreamResponseHandler } from './bedrock-event-stream-response-handler';
 import { EventStreamCodec } from '@smithy/eventstream-codec';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { describe, it, expect, vi, MockInstance } from 'vitest';
 
 // Helper that constructs a properly framed message.

--- a/packages/amazon-bedrock/src/bedrock-image-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-image-model.ts
@@ -13,7 +13,7 @@ import {
   modelMaxImagesPerCall,
 } from './bedrock-image-settings';
 import { BedrockErrorSchema } from './bedrock-error';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 type BedrockImageModelConfig = {
   baseUrl: () => string;

--- a/packages/angular/src/lib/structured-object.ng.test.ts
+++ b/packages/angular/src/lib/structured-object.ng.test.ts
@@ -2,7 +2,7 @@ import {
   createTestServer,
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { StructuredObject } from './structured-object.ng';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/anthropic/src/anthropic-error.ts
+++ b/packages/anthropic/src/anthropic-error.ts
@@ -4,7 +4,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const anthropicErrorDataSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -1,6 +1,6 @@
 import { JSONSchema7 } from '@ai-sdk/provider';
 import { InferValidator, lazySchema, zodSchema } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type AnthropicMessagesPrompt = {
   system: Array<AnthropicTextContent> | undefined;

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://docs.claude.com/en/docs/about-claude/models/overview
 export type AnthropicMessagesModelId =

--- a/packages/anthropic/src/tool/bash_20241022.ts
+++ b/packages/anthropic/src/tool/bash_20241022.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const bash_20241022InputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/bash_20250124.ts
+++ b/packages/anthropic/src/tool/bash_20250124.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const bash_20250124InputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/code-execution_20250522.ts
+++ b/packages/anthropic/src/tool/code-execution_20250522.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const codeExecution_20250522OutputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/computer_20241022.ts
+++ b/packages/anthropic/src/tool/computer_20241022.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const computer_20241022InputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/computer_20250124.ts
+++ b/packages/anthropic/src/tool/computer_20250124.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const computer_20250124InputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/text-editor_20241022.ts
+++ b/packages/anthropic/src/tool/text-editor_20241022.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const textEditor_20241022InputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/text-editor_20250124.ts
+++ b/packages/anthropic/src/tool/text-editor_20250124.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const textEditor_20250124InputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/text-editor_20250429.ts
+++ b/packages/anthropic/src/tool/text-editor_20250429.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const textEditor_20250429InputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/text-editor_20250728.ts
+++ b/packages/anthropic/src/tool/text-editor_20250728.ts
@@ -1,5 +1,5 @@
 import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 
 export const textEditor_20250728ArgsSchema = lazySchema(() =>

--- a/packages/anthropic/src/tool/web-fetch-20250910.ts
+++ b/packages/anthropic/src/tool/web-fetch-20250910.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const webFetch_20250910ArgsSchema = lazySchema(() =>
   zodSchema(

--- a/packages/anthropic/src/tool/web-search_20250305.ts
+++ b/packages/anthropic/src/tool/web-search_20250305.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const webSearch_20250305ArgsSchema = lazySchema(() =>
   zodSchema(

--- a/packages/assemblyai/src/assemblyai-error.ts
+++ b/packages/assemblyai/src/assemblyai-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const assemblyaiErrorDataSchema = z.object({

--- a/packages/assemblyai/src/assemblyai-transcription-model.ts
+++ b/packages/assemblyai/src/assemblyai-transcription-model.ts
@@ -9,7 +9,7 @@ import {
   postJsonToApi,
   postToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { AssemblyAIConfig } from './assemblyai-config';
 import { assemblyaiFailedResponseHandler } from './assemblyai-error';
 import { AssemblyAITranscriptionModelId } from './assemblyai-transcription-settings';

--- a/packages/baseten/src/baseten-embedding-options.ts
+++ b/packages/baseten/src/baseten-embedding-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://www.baseten.co/library/tag/embedding/
 // Pass in the model URL directly, we won't be using the model ID

--- a/packages/baseten/src/baseten-provider.ts
+++ b/packages/baseten/src/baseten-provider.ts
@@ -15,7 +15,7 @@ import {
   withoutTrailingSlash,
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { BasetenChatModelId } from './baseten-chat-options';
 import { BasetenEmbeddingModelId } from './baseten-embedding-options';
 import { PerformanceClient } from '@basetenlabs/performance-client';

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -11,7 +11,7 @@ import {
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
 import { CerebrasChatModelId } from './cerebras-chat-options';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { ProviderErrorStructure } from '@ai-sdk/openai-compatible';
 import { VERSION } from './version';
 

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -18,7 +18,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   CohereChatModelId,
   cohereChatModelOptions,

--- a/packages/cohere/src/cohere-chat-options.ts
+++ b/packages/cohere/src/cohere-chat-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://docs.cohere.com/docs/models
 export type CohereChatModelId =

--- a/packages/cohere/src/cohere-embedding-model.ts
+++ b/packages/cohere/src/cohere-embedding-model.ts
@@ -9,7 +9,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   CohereEmbeddingModelId,
   cohereEmbeddingOptions,

--- a/packages/cohere/src/cohere-embedding-options.ts
+++ b/packages/cohere/src/cohere-embedding-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type CohereEmbeddingModelId =
   | 'embed-english-v3.0'

--- a/packages/cohere/src/cohere-error.ts
+++ b/packages/cohere/src/cohere-error.ts
@@ -1,5 +1,5 @@
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const cohereErrorDataSchema = z.object({
   message: z.string(),

--- a/packages/deepgram/src/deepgram-error.ts
+++ b/packages/deepgram/src/deepgram-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const deepgramErrorDataSchema = z.object({

--- a/packages/deepgram/src/deepgram-transcription-model.ts
+++ b/packages/deepgram/src/deepgram-transcription-model.ts
@@ -10,7 +10,7 @@ import {
   parseProviderOptions,
   postToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { DeepgramConfig } from './deepgram-config';
 import { deepgramFailedResponseHandler } from './deepgram-error';
 import { DeepgramTranscriptionModelId } from './deepgram-transcription-options';

--- a/packages/deepinfra/src/deepinfra-image-model.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.ts
@@ -7,7 +7,7 @@ import {
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
 import { DeepInfraImageModelId } from './deepinfra-image-settings';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 interface DeepInfraImageModelConfig {
   provider: string;

--- a/packages/deepseek/src/deepseek-metadata-extractor.ts
+++ b/packages/deepseek/src/deepseek-metadata-extractor.ts
@@ -1,6 +1,6 @@
 import { MetadataExtractor } from '@ai-sdk/openai-compatible';
 import { safeValidateTypes } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const buildDeepseekMetadata = (
   usage: z.infer<typeof deepSeekUsageSchema> | undefined,

--- a/packages/elevenlabs/src/elevenlabs-error.ts
+++ b/packages/elevenlabs/src/elevenlabs-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const elevenlabsErrorDataSchema = z.object({

--- a/packages/elevenlabs/src/elevenlabs-speech-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-speech-model.ts
@@ -5,7 +5,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { ElevenLabsConfig } from './elevenlabs-config';
 import { elevenlabsFailedResponseHandler } from './elevenlabs-error';
 import { ElevenLabsSpeechAPITypes } from './elevenlabs-speech-api-types';

--- a/packages/elevenlabs/src/elevenlabs-transcription-model.ts
+++ b/packages/elevenlabs/src/elevenlabs-transcription-model.ts
@@ -10,7 +10,7 @@ import {
   parseProviderOptions,
   postFormDataToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { ElevenLabsConfig } from './elevenlabs-config';
 import { elevenlabsFailedResponseHandler } from './elevenlabs-error';
 import { ElevenLabsTranscriptionModelId } from './elevenlabs-transcription-options';

--- a/packages/fal/src/fal-error.ts
+++ b/packages/fal/src/fal-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const falErrorDataSchema = z.object({

--- a/packages/fal/src/fal-image-model.ts
+++ b/packages/fal/src/fal-image-model.ts
@@ -15,7 +15,7 @@ import {
   postJsonToApi,
   resolve,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { FalImageModelId, FalImageSize } from './fal-image-settings';
 
 interface FalImageModelConfig {

--- a/packages/fal/src/fal-speech-model.ts
+++ b/packages/fal/src/fal-speech-model.ts
@@ -8,7 +8,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { FalConfig } from './fal-config';
 import { falFailedResponseHandler } from './fal-error';
 import { FAL_EMOTIONS, FAL_LANGUAGE_BOOSTS } from './fal-api-types';

--- a/packages/fal/src/fal-transcription-model.ts
+++ b/packages/fal/src/fal-transcription-model.ts
@@ -13,7 +13,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { FalConfig } from './fal-config';
 import { falErrorDataSchema, falFailedResponseHandler } from './fal-error';
 import { FalTranscriptionModelId } from './fal-transcription-options';

--- a/packages/fireworks/src/fireworks-embedding-options.ts
+++ b/packages/fireworks/src/fireworks-embedding-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // Below is just a subset of the available models.
 export type FireworksEmbeddingModelId =

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -16,7 +16,7 @@ import {
   withoutTrailingSlash,
   withUserAgentSuffix,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { FireworksChatModelId } from './fireworks-chat-options';
 import { FireworksCompletionModelId } from './fireworks-completion-options';
 import { FireworksEmbeddingModelId } from './fireworks-embedding-options';

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import type { GatewayError } from './gateway-error';
 import { GatewayAuthenticationError } from './gateway-authentication-error';
 import { GatewayInvalidRequestError } from './gateway-invalid-request-error';

--- a/packages/gateway/src/errors/gateway-model-not-found-error.ts
+++ b/packages/gateway/src/errors/gateway-model-not-found-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { GatewayError } from './gateway-error';
 import { lazyValidator, zodSchema } from '@ai-sdk/provider-utils';
 

--- a/packages/gateway/src/errors/parse-auth-method.ts
+++ b/packages/gateway/src/errors/parse-auth-method.ts
@@ -1,9 +1,9 @@
+import { z } from 'zod/v4';
 import {
   lazyValidator,
   safeValidateTypes,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
 
 export const GATEWAY_AUTH_METHOD_HEADER = 'ai-gateway-auth-method' as const;
 

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -12,7 +12,7 @@ import {
   zodSchema,
   type Resolvable,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { asGatewayError } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 import type { GatewayConfig } from './gateway-config';

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -6,7 +6,7 @@ import {
   resolve,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { asGatewayError } from './errors';
 import type { GatewayConfig } from './gateway-config';
 import type { GatewayLanguageModelEntry } from './gateway-model-entry';

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -15,7 +15,7 @@ import {
   type ParseResult,
   type Resolvable,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import type { GatewayConfig } from './gateway-config';
 import type { GatewayModelId } from './gateway-language-model-settings';
 import { asGatewayError } from './errors';

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -1,9 +1,9 @@
+import { z } from 'zod/v4';
 import {
   InferValidator,
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
 
 // https://vercel.com/docs/ai-gateway/provider-options
 const gatewayProviderOptions = lazyValidator(() =>

--- a/packages/gladia/src/gladia-error.ts
+++ b/packages/gladia/src/gladia-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const gladiaErrorDataSchema = z.object({

--- a/packages/gladia/src/gladia-transcription-model.ts
+++ b/packages/gladia/src/gladia-transcription-model.ts
@@ -14,7 +14,7 @@ import {
   postFormDataToApi,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { GladiaConfig } from './gladia-config';
 import { gladiaFailedResponseHandler } from './gladia-error';
 import { GladiaTranscriptionInitiateAPITypes } from './gladia-api-types';

--- a/packages/google-vertex/src/google-vertex-embedding-model.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-model.ts
@@ -9,7 +9,7 @@ import {
   resolve,
   parseProviderOptions,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { googleVertexFailedResponseHandler } from './google-vertex-error';
 import {
   GoogleVertexEmbeddingModelId,

--- a/packages/google-vertex/src/google-vertex-embedding-options.ts
+++ b/packages/google-vertex/src/google-vertex-embedding-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api
 export type GoogleVertexEmbeddingModelId =

--- a/packages/google-vertex/src/google-vertex-error.ts
+++ b/packages/google-vertex/src/google-vertex-error.ts
@@ -1,5 +1,5 @@
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const googleVertexErrorDataSchema = z.object({
   error: z.object({

--- a/packages/google-vertex/src/google-vertex-image-model.ts
+++ b/packages/google-vertex/src/google-vertex-image-model.ts
@@ -7,7 +7,7 @@ import {
   postJsonToApi,
   resolve,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { googleVertexFailedResponseHandler } from './google-vertex-error';
 import { GoogleVertexImageModelId } from './google-vertex-image-settings';
 

--- a/packages/google/src/google-error.ts
+++ b/packages/google/src/google-error.ts
@@ -4,7 +4,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const googleErrorDataSchema = lazySchema(() =>
   zodSchema(

--- a/packages/google/src/google-generative-ai-embedding-model.ts
+++ b/packages/google/src/google-generative-ai-embedding-model.ts
@@ -12,7 +12,7 @@ import {
   resolve,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { googleFailedResponseHandler } from './google-error';
 import {
   GoogleGenerativeAIEmbeddingModelId,

--- a/packages/google/src/google-generative-ai-embedding-options.ts
+++ b/packages/google/src/google-generative-ai-embedding-options.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type GoogleGenerativeAIEmbeddingModelId =
   | 'gemini-embedding-001'

--- a/packages/google/src/google-generative-ai-image-model.ts
+++ b/packages/google/src/google-generative-ai-image-model.ts
@@ -9,7 +9,7 @@ import {
   resolve,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { googleFailedResponseHandler } from './google-error';
 import {
   GoogleGenerativeAIImageModelId,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -23,7 +23,7 @@ import {
   resolve,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { convertJSONSchemaToOpenAPISchema } from './convert-json-schema-to-openapi-schema';
 import { convertToGoogleGenerativeAIMessages } from './convert-to-google-generative-ai-messages';
 import { getModelPath } from './get-model-path';

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type GoogleGenerativeAIModelId =
   // Stable models

--- a/packages/google/src/tool/code-execution.ts
+++ b/packages/google/src/tool/code-execution.ts
@@ -1,5 +1,5 @@
 import { createProviderDefinedToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 /**
  * A tool that enables the model to generate and run Python code.

--- a/packages/google/src/tool/google-search.ts
+++ b/packages/google/src/tool/google-search.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://ai.google.dev/gemini-api/docs/google-search
 // https://ai.google.dev/api/generate-content#GroundingSupport

--- a/packages/google/src/tool/url-context.ts
+++ b/packages/google/src/tool/url-context.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const urlContext = createProviderDefinedToolFactory<
   {

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -20,7 +20,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { convertToGroqChatMessages } from './convert-to-groq-chat-messages';
 import { getResponseMetadata } from './get-response-metadata';
 import { GroqChatModelId, groqProviderOptions } from './groq-chat-options';

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://console.groq.com/docs/models
 export type GroqChatModelId =

--- a/packages/groq/src/groq-error.ts
+++ b/packages/groq/src/groq-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const groqErrorDataSchema = z.object({

--- a/packages/groq/src/groq-transcription-model.ts
+++ b/packages/groq/src/groq-transcription-model.ts
@@ -10,7 +10,7 @@ import {
   parseProviderOptions,
   postFormDataToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { GroqConfig } from './groq-config';
 import { groqFailedResponseHandler } from './groq-error';
 import { GroqTranscriptionModelId } from './groq-transcription-options';

--- a/packages/groq/src/tool/browser-search.ts
+++ b/packages/groq/src/tool/browser-search.ts
@@ -1,5 +1,5 @@
 import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 /**
  * Browser search tool for Groq models.

--- a/packages/huggingface/src/huggingface-error.ts
+++ b/packages/huggingface/src/huggingface-error.ts
@@ -1,5 +1,5 @@
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const huggingfaceErrorDataSchema = z.object({
   error: z.object({

--- a/packages/huggingface/src/responses/huggingface-responses-language-model.ts
+++ b/packages/huggingface/src/responses/huggingface-responses-language-model.ts
@@ -16,7 +16,7 @@ import {
   ParseResult,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { HuggingFaceConfig } from '../huggingface-config';
 import { huggingfaceFailedResponseHandler } from '../huggingface-error';
 import { convertToHuggingFaceResponsesMessages } from './convert-to-huggingface-responses-messages';

--- a/packages/hume/src/hume-error.ts
+++ b/packages/hume/src/hume-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const humeErrorDataSchema = z.object({

--- a/packages/hume/src/hume-speech-model.ts
+++ b/packages/hume/src/hume-speech-model.ts
@@ -5,7 +5,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { HumeConfig } from './hume-config';
 import { humeFailedResponseHandler } from './hume-error';
 import { HumeSpeechAPITypes } from './hume-api-types';

--- a/packages/lmnt/src/lmnt-error.ts
+++ b/packages/lmnt/src/lmnt-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const lmntErrorDataSchema = z.object({

--- a/packages/lmnt/src/lmnt-speech-model.ts
+++ b/packages/lmnt/src/lmnt-speech-model.ts
@@ -5,7 +5,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { LMNTConfig } from './lmnt-config';
 import { lmntFailedResponseHandler } from './lmnt-error';
 import { LMNTSpeechModelId } from './lmnt-speech-options';

--- a/packages/luma/src/luma-image-model.ts
+++ b/packages/luma/src/luma-image-model.ts
@@ -15,7 +15,7 @@ import {
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
 import { LumaImageSettings } from './luma-image-settings';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const DEFAULT_POLL_INTERVAL_MILLIS = 500;
 const DEFAULT_MAX_POLL_ATTEMPTS = 60000 / DEFAULT_POLL_INTERVAL_MILLIS;

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -17,7 +17,7 @@ import {
   ParseResult,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { convertToMistralChatMessages } from './convert-to-mistral-chat-messages';
 import { getResponseMetadata } from './get-response-metadata';
 import { mapMistralFinishReason } from './map-mistral-finish-reason';

--- a/packages/mistral/src/mistral-chat-options.ts
+++ b/packages/mistral/src/mistral-chat-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://docs.mistral.ai/getting-started/models/models_overview/
 export type MistralChatModelId =

--- a/packages/mistral/src/mistral-embedding-model.ts
+++ b/packages/mistral/src/mistral-embedding-model.ts
@@ -8,7 +8,7 @@ import {
   FetchFunction,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { MistralEmbeddingModelId } from './mistral-embedding-options';
 import { mistralFailedResponseHandler } from './mistral-error';
 

--- a/packages/mistral/src/mistral-error.ts
+++ b/packages/mistral/src/mistral-error.ts
@@ -1,5 +1,5 @@
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const mistralErrorDataSchema = z.object({
   object: z.literal('error'),

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -21,7 +21,7 @@ import {
   postJsonToApi,
   ResponseHandler,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { convertToOpenAICompatibleChatMessages } from './convert-to-openai-compatible-chat-messages';
 import { getResponseMetadata } from './get-response-metadata';
 import { mapOpenAICompatibleFinishReason } from './map-openai-compatible-finish-reason';

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-options.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type OpenAICompatibleChatModelId = string;
 

--- a/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
@@ -18,7 +18,7 @@ import {
   postJsonToApi,
   ResponseHandler,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   defaultOpenAICompatibleErrorStructure,
   ProviderErrorStructure,

--- a/packages/openai-compatible/src/completion/openai-compatible-completion-options.ts
+++ b/packages/openai-compatible/src/completion/openai-compatible-completion-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type OpenAICompatibleCompletionModelId = string;
 

--- a/packages/openai-compatible/src/embedding/openai-compatible-embedding-model.ts
+++ b/packages/openai-compatible/src/embedding/openai-compatible-embedding-model.ts
@@ -10,7 +10,7 @@ import {
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   OpenAICompatibleEmbeddingModelId,
   openaiCompatibleEmbeddingProviderOptions,

--- a/packages/openai-compatible/src/embedding/openai-compatible-embedding-options.ts
+++ b/packages/openai-compatible/src/embedding/openai-compatible-embedding-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type OpenAICompatibleEmbeddingModelId = string;
 

--- a/packages/openai-compatible/src/image/openai-compatible-image-model.test.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { OpenAICompatibleImageModel } from './openai-compatible-image-model';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { ProviderErrorStructure } from '../openai-compatible-error';
 import { ImageModelV3CallOptions } from '@ai-sdk/provider';
 

--- a/packages/openai-compatible/src/image/openai-compatible-image-model.ts
+++ b/packages/openai-compatible/src/image/openai-compatible-image-model.ts
@@ -6,7 +6,7 @@ import {
   FetchFunction,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   defaultOpenAICompatibleErrorStructure,
   ProviderErrorStructure,

--- a/packages/openai/src/chat/openai-chat-api.ts
+++ b/packages/openai/src/chat/openai-chat-api.ts
@@ -4,7 +4,7 @@ import {
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { openaiErrorDataSchema } from '../openai-error';
 
 export interface OpenAIChatFunctionTool {

--- a/packages/openai/src/chat/openai-chat-options.ts
+++ b/packages/openai/src/chat/openai-chat-options.ts
@@ -3,7 +3,7 @@ import {
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://platform.openai.com/docs/models
 export type OpenAIChatModelId =

--- a/packages/openai/src/completion/openai-completion-api.ts
+++ b/packages/openai/src/completion/openai-completion-api.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { openaiErrorDataSchema } from '../openai-error';
 import {
   InferValidator,

--- a/packages/openai/src/completion/openai-completion-options.ts
+++ b/packages/openai/src/completion/openai-completion-options.ts
@@ -3,7 +3,7 @@ import {
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://platform.openai.com/docs/models
 export type OpenAICompletionModelId = 'gpt-3.5-turbo-instruct' | (string & {});

--- a/packages/openai/src/embedding/openai-embedding-api.ts
+++ b/packages/openai/src/embedding/openai-embedding-api.ts
@@ -1,5 +1,5 @@
 import { lazyValidator, zodSchema } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // minimal version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency

--- a/packages/openai/src/embedding/openai-embedding-options.ts
+++ b/packages/openai/src/embedding/openai-embedding-options.ts
@@ -3,7 +3,7 @@ import {
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type OpenAIEmbeddingModelId =
   | 'text-embedding-3-small'

--- a/packages/openai/src/image/openai-image-api.ts
+++ b/packages/openai/src/image/openai-image-api.ts
@@ -1,5 +1,5 @@
 import { lazyValidator, zodSchema } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // minimal version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency

--- a/packages/openai/src/openai-error.ts
+++ b/packages/openai/src/openai-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const openaiErrorDataSchema = z.object({

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -9,7 +9,7 @@ import {
   parseProviderOptions,
   validateTypes,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   localShellInputSchema,
   localShellOutputSchema,

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -4,7 +4,7 @@ import {
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type OpenAIResponsesInput = Array<OpenAIResponsesInputItem>;
 

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -3,7 +3,7 @@ import {
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 /**
  * `top_logprobs` request body argument can be set to an integer between

--- a/packages/openai/src/speech/openai-speech-options.ts
+++ b/packages/openai/src/speech/openai-speech-options.ts
@@ -3,7 +3,7 @@ import {
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type OpenAISpeechModelId =
   | 'tts-1'

--- a/packages/openai/src/tool/code-interpreter.ts
+++ b/packages/openai/src/tool/code-interpreter.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const codeInterpreterInputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   OpenAIResponsesFileSearchToolComparisonFilter,
   OpenAIResponsesFileSearchToolCompoundFilter,

--- a/packages/openai/src/tool/image-generation.ts
+++ b/packages/openai/src/tool/image-generation.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const imageGenerationArgsSchema = lazySchema(() =>
   zodSchema(

--- a/packages/openai/src/tool/local-shell.ts
+++ b/packages/openai/src/tool/local-shell.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const localShellInputSchema = lazySchema(() =>
   zodSchema(

--- a/packages/openai/src/tool/web-search-preview.ts
+++ b/packages/openai/src/tool/web-search-preview.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // Args validation schema
 export const webSearchPreviewArgsSchema = lazySchema(() =>

--- a/packages/openai/src/tool/web-search.ts
+++ b/packages/openai/src/tool/web-search.ts
@@ -3,7 +3,7 @@ import {
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const webSearchArgsSchema = lazySchema(() =>
   zodSchema(

--- a/packages/openai/src/transcription/openai-transcription-api.ts
+++ b/packages/openai/src/transcription/openai-transcription-api.ts
@@ -1,5 +1,5 @@
 import { lazyValidator, zodSchema } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export const openaiTranscriptionResponseSchema = lazyValidator(() =>
   zodSchema(

--- a/packages/openai/src/transcription/openai-transcription-options.ts
+++ b/packages/openai/src/transcription/openai-transcription-options.ts
@@ -3,7 +3,7 @@ import {
   lazyValidator,
   zodSchema,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 export type OpenAITranscriptionModelId =
   | 'whisper-1'

--- a/packages/perplexity/src/perplexity-language-model.test.ts
+++ b/packages/perplexity/src/perplexity-language-model.test.ts
@@ -7,7 +7,7 @@ import {
   convertReadableStreamToArray,
   mockId,
 } from '@ai-sdk/provider-utils/test';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   perplexityImageSchema,
   PerplexityLanguageModel,

--- a/packages/perplexity/src/perplexity-language-model.ts
+++ b/packages/perplexity/src/perplexity-language-model.ts
@@ -15,7 +15,7 @@ import {
   createJsonResponseHandler,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { convertToPerplexityMessages } from './convert-to-perplexity-messages';
 import { mapPerplexityFinishReason } from './map-perplexity-finish-reason';
 import { PerplexityLanguageModelId } from './perplexity-language-model-options';

--- a/packages/provider-utils/src/get-from-api.test.ts
+++ b/packages/provider-utils/src/get-from-api.test.ts
@@ -5,7 +5,7 @@ import {
   createJsonResponseHandler,
   createStatusCodeErrorResponseHandler,
 } from './response-handler';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { getRuntimeEnvironmentUserAgent } from './get-runtime-environment-user-agent';
 import { withUserAgentSuffix } from './with-user-agent-suffix';
 

--- a/packages/provider-utils/src/parse-json.test.ts
+++ b/packages/provider-utils/src/parse-json.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseJSON, safeParseJSON, isParsableJson } from './parse-json';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { JSONParseError, TypeValidationError } from '@ai-sdk/provider';
 
 describe('parseJSON', () => {

--- a/packages/provider-utils/src/response-handler.test.ts
+++ b/packages/provider-utils/src/response-handler.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import {
   convertArrayToReadableStream,
   convertReadableStreamToArray,

--- a/packages/provider-utils/src/types/tool.test-d.ts
+++ b/packages/provider-utils/src/types/tool.test-d.ts
@@ -1,6 +1,6 @@
 import { LanguageModelV3ToolResultPart } from '@ai-sdk/provider';
 import { describe, expectTypeOf, it } from 'vitest';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { FlexibleSchema } from '../schema';
 import { ModelMessage } from './model-message';
 import { Tool, tool, ToolExecuteFunction } from './tool';

--- a/packages/react/src/use-object.ui.test.tsx
+++ b/packages/react/src/use-object.ui.test.tsx
@@ -5,7 +5,7 @@ import {
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { experimental_useObject } from './use-object';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 

--- a/packages/replicate/src/replicate-error.ts
+++ b/packages/replicate/src/replicate-error.ts
@@ -1,5 +1,5 @@
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const replicateErrorSchema = z.object({
   detail: z.string().optional(),

--- a/packages/replicate/src/replicate-image-model.ts
+++ b/packages/replicate/src/replicate-image-model.ts
@@ -9,7 +9,7 @@ import {
   postJsonToApi,
   resolve,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { replicateFailedResponseHandler } from './replicate-error';
 import { ReplicateImageModelId } from './replicate-image-settings';
 

--- a/packages/revai/src/revai-error.ts
+++ b/packages/revai/src/revai-error.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const revaiErrorDataSchema = z.object({

--- a/packages/revai/src/revai-transcription-model.ts
+++ b/packages/revai/src/revai-transcription-model.ts
@@ -13,7 +13,7 @@ import {
   parseProviderOptions,
   postFormDataToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { RevaiConfig } from './revai-config';
 import { revaiFailedResponseHandler } from './revai-error';
 import { RevaiTranscriptionModelId } from './revai-transcription-options';

--- a/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
+++ b/packages/rsc/src/stream-ui/stream-ui.ui.test.tsx
@@ -2,7 +2,7 @@ import { delay } from '@ai-sdk/provider-utils';
 import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { LanguageModelUsage } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { streamUI } from './stream-ui';
 import { describe, it, expect, beforeEach } from 'vitest';
 

--- a/packages/svelte/src/structured-object.svelte.test.ts
+++ b/packages/svelte/src/structured-object.svelte.test.ts
@@ -3,7 +3,7 @@ import {
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
 import { render } from '@testing-library/svelte';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { StructuredObject } from './structured-object.svelte.js';
 import StructuredObjectSynchronization from './tests/structured-object-synchronization.svelte';
 import { vi, describe, beforeEach, expect, it } from 'vitest';

--- a/packages/togetherai/src/togetherai-image-model.ts
+++ b/packages/togetherai/src/togetherai-image-model.ts
@@ -7,7 +7,7 @@ import {
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
 import { TogetherAIImageModelId } from './togetherai-image-settings';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 interface TogetherAIImageModelConfig {
   provider: string;

--- a/packages/vue/src/TestUseObjectComponent.vue
+++ b/packages/vue/src/TestUseObjectComponent.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { experimental_useObject } from './use-object';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { ref, reactive } from 'vue';
 
 const onFinishCalls: Array<{

--- a/packages/vue/src/TestUseObjectCustomTransportComponent.vue
+++ b/packages/vue/src/TestUseObjectCustomTransportComponent.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { experimental_useObject } from './use-object';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { ref, reactive } from 'vue';
 
 const { object, error, submit, isLoading, stop, clear } =

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -15,7 +15,7 @@ import {
   ParseResult,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 import { convertToXaiChatMessages } from './convert-to-xai-chat-messages';
 import { getResponseMetadata } from './get-response-metadata';
 import { mapXaiFinishReason } from './map-xai-finish-reason';

--- a/packages/xai/src/xai-chat-options.ts
+++ b/packages/xai/src/xai-chat-options.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // https://console.x.ai and see "View models"
 export type XaiChatModelId =

--- a/packages/xai/src/xai-error.ts
+++ b/packages/xai/src/xai-error.ts
@@ -1,5 +1,5 @@
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
-import * as z from 'zod/v4';
+import { z } from 'zod/v4';
 
 // Add error schema and structure
 export const xaiErrorDataSchema = z.object({


### PR DESCRIPTION
## Background

Changing `import { z } from 'zod/v4';` to `import * as z from 'zod/v4';` broke AI SDK zod schemas in some environments.

## Summary

Revert import change.

## Related

- Caused by #9301
- port of #9349