### PR TITLE
feat(ai): add support for v2 specs in transcription and speech models

### DIFF
--- a/.changeset/lemon-cherries-clap.md
+++ b/.changeset/lemon-cherries-clap.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add support for v2 specs in transcription and speech models

--- a/packages/ai/src/generate-speech/generate-speech.ts
+++ b/packages/ai/src/generate-speech/generate-speech.ts
@@ -119,13 +119,6 @@ Only applicable for HTTP-based providers.
   if (!resolvedModel) {
     throw new Error('Model could not be resolved');
   }
-  if (resolvedModel.specificationVersion !== 'v3') {
-    throw new UnsupportedModelVersionError({
-      version: resolvedModel.specificationVersion,
-      provider: resolvedModel.provider,
-      modelId: resolvedModel.modelId,
-    });
-  }
 
   const headersWithUserAgent = withUserAgentSuffix(
     headers ?? {},

--- a/packages/ai/src/generate-speech/generate-speech.ts
+++ b/packages/ai/src/generate-speech/generate-speech.ts
@@ -1,7 +1,6 @@
 import { JSONValue } from '@ai-sdk/provider';
 import { ProviderOptions, withUserAgentSuffix } from '@ai-sdk/provider-utils';
 import { NoSpeechGeneratedError } from '../error/no-speech-generated-error';
-import { UnsupportedModelVersionError } from '../error/unsupported-model-version-error';
 import { logWarnings } from '../logger/log-warnings';
 import { SpeechWarning, SpeechModel } from '../types/speech-model';
 import { SpeechModelResponseMetadata } from '../types/speech-model-response-metadata';

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -5,10 +5,16 @@ import {
   LanguageModelV2,
   LanguageModelV3,
   ProviderV3,
+  SpeechModelV2,
+  SpeechModelV3,
+  TranscriptionModelV2,
+  TranscriptionModelV3,
 } from '@ai-sdk/provider';
 import { UnsupportedModelVersionError } from '../error';
 import { EmbeddingModel } from '../types/embedding-model';
 import { LanguageModel } from '../types/language-model';
+import { SpeechModel } from '../types/speech-model';
+import { TranscriptionModel } from '../types/transcription-model';
 
 function transformToV3LanguageModel(model: LanguageModelV2): LanguageModelV3 {
   return new Proxy(model, {
@@ -28,6 +34,28 @@ function transformToV3EmbeddingModel<VALUE>(
       return target[prop];
     },
   }) as unknown as EmbeddingModelV3<VALUE>;
+}
+
+function transformToV3TranscriptionModel(
+  model: TranscriptionModelV2,
+): TranscriptionModelV3 {
+  return new Proxy(model, {
+    get(target, prop: keyof TranscriptionModelV2) {
+      if (prop === 'specificationVersion') return 'v3';
+      return target[prop];
+    },
+  }) as unknown as TranscriptionModelV3;
+}
+
+function transformToV3SpeechModel(
+  model: SpeechModelV2,
+): SpeechModelV3 {
+  return new Proxy(model, {
+    get(target, prop: keyof SpeechModelV2) {
+      if (prop === 'specificationVersion') return 'v3';
+      return target[prop];
+    },
+  }) as unknown as SpeechModelV3;
 }
 
 export function resolveLanguageModel(model: LanguageModel): LanguageModelV3 {
@@ -78,6 +106,52 @@ export function resolveEmbeddingModel<VALUE = string>(
   return getGlobalProvider().textEmbeddingModel(
     model,
   ) as EmbeddingModelV3<VALUE>;
+}
+
+export function resolveTranscriptionModel(
+  model: TranscriptionModel,
+): TranscriptionModelV3 {
+  if (typeof model !== 'string') {
+    if (
+      model.specificationVersion !== 'v3' &&
+      model.specificationVersion !== 'v2'
+    ) {
+      const unsupportedModel: any = model;
+      throw new UnsupportedModelVersionError({
+        version: unsupportedModel.specificationVersion,
+        provider: unsupportedModel.provider,
+        modelId: unsupportedModel.modelId,
+      });
+    }
+    if (model.specificationVersion === 'v2') {
+      return transformToV3TranscriptionModel(model);
+    }
+    return model;
+  }
+
+  return getGlobalProvider().transcriptionModel(model);
+}
+
+export function resolveSpeechModel(model: SpeechModel): SpeechModelV3 {
+  if (typeof model !== 'string') {
+    if (
+      model.specificationVersion !== 'v3' &&
+      model.specificationVersion !== 'v2'
+    ) {
+      const unsupportedModel: any = model;
+      throw new UnsupportedModelVersionError({
+        version: unsupportedModel.specificationVersion,
+        provider: unsupportedModel.provider,
+        modelId: unsupportedModel.modelId,
+      });
+    }
+    if (model.specificationVersion === 'v2') {
+      return transformToV3SpeechModel(model);
+    }
+    return model;
+  }
+
+  return getGlobalProvider().speechModel(model);
 }
 
 function getGlobalProvider(): ProviderV3 {

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -47,9 +47,7 @@ function transformToV3TranscriptionModel(
   }) as unknown as TranscriptionModelV3;
 }
 
-function transformToV3SpeechModel(
-  model: SpeechModelV2,
-): SpeechModelV3 {
+function transformToV3SpeechModel(model: SpeechModelV2): SpeechModelV3 {
   return new Proxy(model, {
     get(target, prop: keyof SpeechModelV2) {
       if (prop === 'specificationVersion') return 'v3';

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -108,7 +108,7 @@ export function resolveEmbeddingModel<VALUE = string>(
 
 export function resolveTranscriptionModel(
   model: TranscriptionModel,
-): TranscriptionModelV3 {
+): TranscriptionModelV3 | undefined {
   if (typeof model !== 'string') {
     if (
       model.specificationVersion !== 'v3' &&
@@ -127,10 +127,10 @@ export function resolveTranscriptionModel(
     return model;
   }
 
-  return getGlobalProvider().transcriptionModel(model);
+  return getGlobalProvider().transcriptionModel?.(model);
 }
 
-export function resolveSpeechModel(model: SpeechModel): SpeechModelV3 {
+export function resolveSpeechModel(model: SpeechModel): SpeechModelV3 | undefined {
   if (typeof model !== 'string') {
     if (
       model.specificationVersion !== 'v3' &&
@@ -149,7 +149,7 @@ export function resolveSpeechModel(model: SpeechModel): SpeechModelV3 {
     return model;
   }
 
-  return getGlobalProvider().speechModel(model);
+  return getGlobalProvider().speechModel?.(model);
 }
 
 function getGlobalProvider(): ProviderV3 {

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -130,7 +130,9 @@ export function resolveTranscriptionModel(
   return getGlobalProvider().transcriptionModel?.(model);
 }
 
-export function resolveSpeechModel(model: SpeechModel): SpeechModelV3 | undefined {
+export function resolveSpeechModel(
+  model: SpeechModel,
+): SpeechModelV3 | undefined {
   if (typeof model !== 'string') {
     if (
       model.specificationVersion !== 'v3' &&

--- a/packages/ai/src/transcribe/transcribe.ts
+++ b/packages/ai/src/transcribe/transcribe.ts
@@ -1,11 +1,10 @@
-import { JSONValue, TranscriptionModelV3 } from '@ai-sdk/provider';
+import { JSONValue } from '@ai-sdk/provider';
 import { ProviderOptions, withUserAgentSuffix } from '@ai-sdk/provider-utils';
 import { NoTranscriptGeneratedError } from '../error/no-transcript-generated-error';
-import { UnsupportedModelVersionError } from '../error/unsupported-model-version-error';
 import { logWarnings } from '../logger/log-warnings';
 import { DataContent } from '../prompt';
 import { convertDataContentToUint8Array } from '../prompt/data-content';
-import { TranscriptionWarning } from '../types/transcription-model';
+import { TranscriptionWarning, TranscriptionModel } from '../types/transcription-model';
 import { TranscriptionModelResponseMetadata } from '../types/transcription-model-response-metadata';
 import {
   audioMediaTypeSignatures,
@@ -15,6 +14,7 @@ import { download } from '../util/download/download';
 import { prepareRetries } from '../util/prepare-retries';
 import { TranscriptionResult } from './transcribe-result';
 import { VERSION } from '../version';
+import { resolveTranscriptionModel } from '../model/resolve-model';
 /**
 Generates transcripts using a transcription model.
 
@@ -39,7 +39,7 @@ export async function transcribe({
   /**
 The transcription model to use.
      */
-  model: TranscriptionModelV3;
+  model: TranscriptionModel;
 
   /**
 The audio data to transcribe.
@@ -80,13 +80,10 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<TranscriptionResult> {
-  if (model.specificationVersion !== 'v3') {
-    throw new UnsupportedModelVersionError({
-      version: model.specificationVersion,
-      provider: model.provider,
-      modelId: model.modelId,
-    });
-  }
+  const resolvedModel = resolveTranscriptionModel(model);
+  if (!resolvedModel) {
+    throw new Error('Model could not be resolved');
+     }
 
   const { retry } = prepareRetries({
     maxRetries: maxRetriesArg,
@@ -104,7 +101,7 @@ Only applicable for HTTP-based providers.
       : convertDataContentToUint8Array(audio);
 
   const result = await retry(() =>
-    model.doGenerate({
+    resolvedModel.doGenerate({
       audio: audioData,
       abortSignal,
       headers: headersWithUserAgent,

--- a/packages/ai/src/transcribe/transcribe.ts
+++ b/packages/ai/src/transcribe/transcribe.ts
@@ -4,7 +4,10 @@ import { NoTranscriptGeneratedError } from '../error/no-transcript-generated-err
 import { logWarnings } from '../logger/log-warnings';
 import { DataContent } from '../prompt';
 import { convertDataContentToUint8Array } from '../prompt/data-content';
-import { TranscriptionWarning, TranscriptionModel } from '../types/transcription-model';
+import {
+  TranscriptionWarning,
+  TranscriptionModel,
+} from '../types/transcription-model';
 import { TranscriptionModelResponseMetadata } from '../types/transcription-model-response-metadata';
 import {
   audioMediaTypeSignatures,
@@ -83,7 +86,7 @@ Only applicable for HTTP-based providers.
   const resolvedModel = resolveTranscriptionModel(model);
   if (!resolvedModel) {
     throw new Error('Model could not be resolved');
-     }
+  }
 
   const { retry } = prepareRetries({
     maxRetries: maxRetriesArg,

--- a/packages/ai/src/types/speech-model.ts
+++ b/packages/ai/src/types/speech-model.ts
@@ -1,9 +1,13 @@
-import { SpeechModelV3, SpeechModelV3CallWarning } from '@ai-sdk/provider';
+import {
+  SpeechModelV2,
+  SpeechModelV3,
+  SpeechModelV3CallWarning,
+} from '@ai-sdk/provider';
 
 /**
 Speech model that is used by the AI SDK Core functions.
   */
-export type SpeechModel = SpeechModelV3;
+export type SpeechModel = string | SpeechModelV3 | SpeechModelV2;
 
 /**
 Warning from the model provider for this call. The call will proceed, but e.g.

--- a/packages/ai/src/types/transcription-model.ts
+++ b/packages/ai/src/types/transcription-model.ts
@@ -1,4 +1,5 @@
 import {
+  TranscriptionModelV2,
   TranscriptionModelV3,
   TranscriptionModelV3CallWarning,
 } from '@ai-sdk/provider';
@@ -6,7 +7,7 @@ import {
 /**
 Transcription model that is used by the AI SDK Core functions.
   */
-export type TranscriptionModel = TranscriptionModelV3;
+export type TranscriptionModel = string | TranscriptionModelV3 | TranscriptionModelV2;
 
 /**
 Warning from the model provider for this call. The call will proceed, but e.g.

--- a/packages/ai/src/types/transcription-model.ts
+++ b/packages/ai/src/types/transcription-model.ts
@@ -7,7 +7,10 @@ import {
 /**
 Transcription model that is used by the AI SDK Core functions.
   */
-export type TranscriptionModel = string | TranscriptionModelV3 | TranscriptionModelV2;
+export type TranscriptionModel =
+  | string
+  | TranscriptionModelV3
+  | TranscriptionModelV2;
 
 /**
 Warning from the model provider for this call. The call will proceed, but e.g.


### PR DESCRIPTION
## Background

To allow for community providers to still work with V2 specs

## Summary

Added support for V2 specs for TranscriptionModel and SpeechModel

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
