### PR TITLE
feat (provider/gateway): add user and tags provider options

### DIFF
--- a/.changeset/ninety-starfishes-end.md
+++ b/.changeset/ninety-starfishes-end.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add user and tags provider options

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -289,6 +289,7 @@ const { text } = await generateText({
 Track usage per end-user and categorize requests with tags:
 
 ```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -298,7 +299,7 @@ const { text } = await generateText({
     gateway: {
       user: 'user-abc-123', // Track usage for this specific end-user
       tags: ['document-summary', 'premium-feature'], // Categorize for reporting
-    },
+    } satisfies GatewayProviderOptions,
   },
 });
 ```
@@ -318,6 +319,7 @@ The AI Gateway provider accepts provider options that control routing behavior a
 You can use the `gateway` key in `providerOptions` to control how AI Gateway routes requests:
 
 ```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -327,7 +329,7 @@ const { text } = await generateText({
     gateway: {
       order: ['vertex', 'anthropic'], // Try Vertex AI first, then Anthropic
       only: ['vertex', 'anthropic'], // Only use these providers
-    },
+    } satisfies GatewayProviderOptions,
   },
 });
 ```
@@ -361,6 +363,7 @@ The following gateway provider options are available:
 You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -370,7 +373,7 @@ const { text } = await generateText({
     gateway: {
       order: ['vertex'], // Prefer Vertex AI
       only: ['anthropic', 'vertex'], // Only allow these providers
-    },
+    } satisfies GatewayProviderOptions,
   },
 });
 ```
@@ -380,6 +383,8 @@ const { text } = await generateText({
 When using provider-specific options through AI Gateway, use the actual provider name (e.g. `anthropic`, `openai`, not `gateway`) as the key:
 
 ```ts
+import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
@@ -388,10 +393,10 @@ const { text } = await generateText({
   providerOptions: {
     gateway: {
       order: ['vertex', 'anthropic'],
-    },
+    } satisfies GatewayProviderOptions,
     anthropic: {
       thinking: { type: 'enabled', budgetTokens: 12000 },
-    },
+    } satisfies AnthropicProviderOptions,
   },
 });
 ```

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -284,6 +284,31 @@ const { text } = await generateText({
 });
 ```
 
+### Usage Tracking with User and Tags
+
+Track usage per end-user and categorize requests with tags:
+
+```ts
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'openai/gpt-5',
+  prompt: 'Summarize this document...',
+  providerOptions: {
+    gateway: {
+      user: 'user-abc-123', // Track usage for this specific end-user
+      tags: ['document-summary', 'premium-feature'], // Categorize for reporting
+    },
+  },
+});
+```
+
+This allows you to:
+
+- View usage and costs broken down by end-user in your analytics
+- Filter and analyze spending by feature or use case using tags
+- Track which users or features are driving the most AI usage
+
 ## Provider Options
 
 The AI Gateway provider accepts provider options that control routing behavior and provider-specific configurations.
@@ -321,7 +346,19 @@ The following gateway provider options are available:
 
   Example: `only: ['anthropic', 'vertex']` will only allow routing to Anthropic or Vertex AI.
 
-You can combine both options to have fine-grained control over routing:
+- **user** _string_
+
+  Optional identifier for the end user on whose behalf the request is being made. This is used for spend tracking and attribution purposes, allowing you to track usage per end-user in your application.
+
+  Example: `user: 'user-123'` will associate this request with end-user ID "user-123" in usage reports.
+
+- **tags** _string[]_
+
+  Optional array of tags for categorizing and filtering usage in reports. Useful for tracking spend by feature, prompt version, or any other dimension relevant to your application.
+
+  Example: `tags: ['chat', 'v2']` will tag this request with "chat" and "v2" for filtering in usage analytics.
+
+You can combine these options to have fine-grained control over routing and tracking:
 
 ```ts
 import { generateText } from 'ai';

--- a/examples/ai-core/src/stream-text/gateway-provider-options-tags.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-tags.ts
@@ -1,3 +1,4 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { streamText } from 'ai';
 import 'dotenv/config';
 
@@ -9,7 +10,7 @@ async function main() {
       gateway: {
         user: 'user-123',
         tags: ['chat', 'v2'],
-      },
+      } satisfies GatewayProviderOptions,
     },
   });
 

--- a/examples/ai-core/src/stream-text/gateway-provider-options-tags.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-tags.ts
@@ -1,0 +1,26 @@
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'anthropic/claude-4-sonnet',
+    prompt: 'Invent a new holiday and describe its traditions.',
+    providerOptions: {
+      gateway: {
+        user: 'user-123',
+        tags: ['chat', 'v2'],
+      },
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Provider metadata:', await result.providerMetadata);
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -17,6 +17,20 @@ const gatewayProviderOptions = lazySchema(() =>
        * Example: `['bedrock', 'anthropic']` will try Amazon Bedrock first, then Anthropic as fallback.
        */
       order: z.array(z.string()).optional(),
+      /**
+       * The unique identifier for the end user on behalf of whom the request was made.
+       *
+       * Used for spend tracking and attribution purposes.
+       */
+      user: z.string().optional(),
+      /**
+       * User-specified tags for use in reporting and filtering usage.
+       *
+       * For example, spend tracking reporting by feature or prompt version.
+       *
+       * Example: `['chat', 'v2']`
+       */
+      tags: z.array(z.string()).optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Background

Added user tracking and request tagging capabilities to the AI Gateway provider to enable better usage analytics and cost attribution.

## Summary

- Added `user` option to track requests by end-user identifier
- Added `tags` option to categorize requests for reporting and filtering
- Updated documentation with examples showing how to use these new tracking features
- Added a changeset for the patch update to `@ai-sdk/gateway`

## Manual Verification

Verified that the new options are properly passed through to the AI Gateway.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)