### PR TITLE
fix(provider/openai): end reasoning parts earlier

### DIFF
--- a/.changeset/smart-yaks-exercise.md
+++ b/.changeset/smart-yaks-exercise.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(provider/openai): end reasoning parts earlier

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -732,9 +732,9 @@ describe('convertToOpenAIResponsesInput', () => {
       ]);
     });
 
-    describe('reasoning messages', () => {
-      describe('basic conversion', () => {
-        it('should convert single reasoning part with text (store: false)', async () => {
+    describe('reasoning messages (store: false)', () => {
+      describe('single summary part', () => {
+        it('should convert single reasoning part with text', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -773,7 +773,7 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.warnings).toHaveLength(0);
         });
 
-        it('should convert single reasoning part with encrypted content (store: false)', async () => {
+        it('should convert single reasoning part with encrypted content', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -813,7 +813,7 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.warnings).toHaveLength(0);
         });
 
-        it('should convert single reasoning part with null encrypted content (store: false)', async () => {
+        it('should convert single reasoning part with null encrypted content', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -854,8 +854,8 @@ describe('convertToOpenAIResponsesInput', () => {
         });
       });
 
-      describe('empty text handling', () => {
-        it('should create empty summary for initial empty text (store: false)', async () => {
+      describe('single summary part with empty text', () => {
+        it('should create empty summary for initial empty text', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -889,7 +889,7 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.warnings).toHaveLength(0);
         });
 
-        it('should create empty summary for initial empty text with encrypted content (store: false)', async () => {
+        it('should create empty summary for initial empty text with encrypted content', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -924,7 +924,7 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.warnings).toHaveLength(0);
         });
 
-        it('should warn when appending empty text to existing sequence (store: false)', async () => {
+        it('should warn when appending empty text to existing sequence', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -981,7 +981,7 @@ describe('convertToOpenAIResponsesInput', () => {
       });
 
       describe('merging and sequencing', () => {
-        it('should merge consecutive parts with same reasoning ID (store: false)', async () => {
+        it('should merge consecutive parts with same reasoning ID', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -1002,6 +1002,8 @@ describe('convertToOpenAIResponsesInput', () => {
                     providerOptions: {
                       openai: {
                         itemId: 'reasoning_001',
+                        // encrypted content is stored in the last summary part
+                        reasoningEncryptedContent: 'encrypted_content_001',
                       },
                     },
                   },
@@ -1012,28 +1014,30 @@ describe('convertToOpenAIResponsesInput', () => {
             store: false,
           });
 
-          expect(result.input).toEqual([
-            {
-              type: 'reasoning',
-              id: 'reasoning_001',
-              encrypted_content: undefined,
-              summary: [
-                {
-                  type: 'summary_text',
-                  text: 'First reasoning step',
-                },
-                {
-                  type: 'summary_text',
-                  text: 'Second reasoning step',
-                },
-              ],
-            },
-          ]);
+          expect(result.input).toMatchInlineSnapshot(`
+            [
+              {
+                "encrypted_content": "encrypted_content_001",
+                "id": "reasoning_001",
+                "summary": [
+                  {
+                    "text": "First reasoning step",
+                    "type": "summary_text",
+                  },
+                  {
+                    "text": "Second reasoning step",
+                    "type": "summary_text",
+                  },
+                ],
+                "type": "reasoning",
+              },
+            ]
+          `);
 
           expect(result.warnings).toHaveLength(0);
         });
 
-        it('should create separate messages for different reasoning IDs (store: false)', async () => {
+        it('should create separate messages for different reasoning IDs', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -1092,7 +1096,7 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.warnings).toHaveLength(0);
         });
 
-        it('should handle reasoning across multiple assistant messages (store: true)', async () => {
+        it('should handle reasoning across multiple assistant messages', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -1201,7 +1205,7 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.warnings).toMatchInlineSnapshot(`[]`);
         });
 
-        it('should handle reasoning across multiple assistant messages (store: false)', async () => {
+        it('should handle reasoning across multiple assistant messages', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -1304,7 +1308,7 @@ describe('convertToOpenAIResponsesInput', () => {
           expect(result.warnings).toHaveLength(0);
         });
 
-        it('should handle complex reasoning sequences with tool interactions (store: false)', async () => {
+        it('should handle complex reasoning sequences with tool interactions', async () => {
           const result = await convertToOpenAIResponsesInput({
             prompt: [
               {
@@ -1522,7 +1526,7 @@ describe('convertToOpenAIResponsesInput', () => {
               },
             ],
             systemMessageMode: 'system',
-            store: true,
+            store: false,
           });
 
           expect(result.input).toHaveLength(0);
@@ -1558,7 +1562,7 @@ describe('convertToOpenAIResponsesInput', () => {
               },
             ],
             systemMessageMode: 'system',
-            store: true,
+            store: false,
           });
 
           expect(result.input).toHaveLength(0);

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -236,8 +236,9 @@ export async function convertToOpenAIResponsesInput({
                 const reasoningMessage = reasoningMessages[reasoningId];
 
                 if (store) {
+                  // use item references to refer to reasoning (single reference)
+                  // when the first part is encountered
                   if (reasoningMessage === undefined) {
-                    // use item references to refer to reasoning (single reference)
                     input.push({ type: 'item_reference', id: reasoningId });
 
                     // store unused reasoning message to mark id as used
@@ -276,6 +277,12 @@ export async function convertToOpenAIResponsesInput({
                     input.push(reasoningMessages[reasoningId]);
                   } else {
                     reasoningMessage.summary.push(...summaryParts);
+
+                    // updated encrypted content to enable setting it in the last summary part:
+                    if (providerOptions?.reasoningEncryptedContent != null) {
+                      reasoningMessage.encrypted_content =
+                        providerOptions.reasoningEncryptedContent;
+                    }
                   }
                 }
               } else {

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -487,6 +487,11 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
         delta: z.string(),
       }),
       z.object({
+        type: z.literal('response.reasoning_summary_part.done'),
+        item_id: z.string(),
+        summary_index: z.number(),
+      }),
+      z.object({
         type: z.literal('error'),
         code: z.string(),
         message: z.string(),

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -3638,6 +3638,15 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "reasoning-delta",
               },
               {
+                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
+                  },
+                },
+                "type": "reasoning-end",
+              },
+              {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
@@ -3668,16 +3677,6 @@ describe('OpenAIResponsesLanguageModel', () => {
                   },
                 },
                 "type": "reasoning-delta",
-              },
-              {
-                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
-                "providerMetadata": {
-                  "openai": {
-                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoningEncryptedContent": null,
-                  },
-                },
-                "type": "reasoning-end",
               },
               {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
@@ -3932,6 +3931,15 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "reasoning-delta",
               },
               {
+                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
+                  },
+                },
+                "type": "reasoning-end",
+              },
+              {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
@@ -3962,16 +3970,6 @@ describe('OpenAIResponsesLanguageModel', () => {
                   },
                 },
                 "type": "reasoning-delta",
-              },
-              {
-                "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:0",
-                "providerMetadata": {
-                  "openai": {
-                    "itemId": "rs_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoningEncryptedContent": "encrypted_reasoning_data_final_def456",
-                  },
-                },
-                "type": "reasoning-end",
               },
               {
                 "id": "rs_6808709f6fcc8191ad2e2fdd784017b3:1",
@@ -4242,6 +4240,15 @@ describe('OpenAIResponsesLanguageModel', () => {
                 "type": "reasoning-delta",
               },
               {
+                "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:0",
+                "providerMetadata": {
+                  "openai": {
+                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
+                  },
+                },
+                "type": "reasoning-end",
+              },
+              {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:1",
                 "providerMetadata": {
                   "openai": {
@@ -4272,16 +4279,6 @@ describe('OpenAIResponsesLanguageModel', () => {
                   },
                 },
                 "type": "reasoning-delta",
-              },
-              {
-                "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:0",
-                "providerMetadata": {
-                  "openai": {
-                    "itemId": "rs_first_6808709f6fcc8191ad2e2fdd784017b3",
-                    "reasoningEncryptedContent": null,
-                  },
-                },
-                "type": "reasoning-end",
               },
               {
                 "id": "rs_first_6808709f6fcc8191ad2e2fdd784017b3:1",


### PR DESCRIPTION
## Background

OpenAI reasoning parts were not finished until the parent reasoning item was finished (to store encrypted reasoning). This led to ongoing spinners in the UI.

## Summary

- when `store: true`: immediately send reasoning end for summary parts
- when `store: false`: send reasoning end for finished summary parts when a new part starts (last summary part under reasoning item contains encrypted reasoning)

## Manual Verification

- [x] test `examples/next-openai` http://localhost:3000/chat-openai-web-search with `store: true`
- [x] test `examples/next-openai` http://localhost:3000/chat-openai-web-search with `store: false`