### PR TITLE
chore(example): fix comment in weather-tool-with-approval.ts

### DIFF
--- a/examples/next-openai/tool/weather-tool-with-approval.ts
+++ b/examples/next-openai/tool/weather-tool-with-approval.ts
@@ -13,7 +13,7 @@ export const weatherToolWithApproval = tool({
   async *execute() {
     yield { state: 'loading' as const };
 
-    // Add artificial delay of 5 seconds
+    // Add artificial delay of 2 seconds
     await new Promise(resolve => setTimeout(resolve, 2000));
 
     yield {


### PR DESCRIPTION
## Background

The inline comment and the artificial delay duration were inconsistent —  
the comment stated “5 seconds” while the actual timeout was set to `2000ms` (2 seconds).

## Summary

Updated the inline comment to correctly describe the artificial delay duration as **2 seconds** in  
`examples/next-openai/tool/weather-tool-with-approval.ts`.

```diff
- // Add artificial delay of 5 seconds
+ // Add artificial delay of 2 seconds
```

No functional changes were made; this update is purely for consistency and clarity.


## Manual Verification

- Verified that the comment now correctly matches the actual delay duration.  
- No behavioral or runtime differences observed.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)


