### PR TITLE
ci(load-time): bump permitted load time for `@ai-sdk/openai-compatible` from 60 to 65ms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           - module: '@ai-sdk/openai'
             max-load-time: 60
           - module: '@ai-sdk/openai-compatible'
-            max-load-time: 60
+            max-load-time: 65
           - module: '@ai-sdk/anthropic'
             max-load-time: 60
           - module: '@ai-sdk/google'


### PR DESCRIPTION
addresses https://github.com/vercel/ai/actions/runs/18471791880/job/52627185276?pr=9455