### PR TITLE
docs: remove formatting issues checklist from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,9 @@ Please check if the PR fulfills the following requirements:
 - [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
 - [ ] I have reviewed this pull request (self-review)
 
+
+
+
 ## Future Work
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,6 @@ Please check if the PR fulfills the following requirements:
 - [ ] Tests have been added / updated (for bug fixes / features)
 - [ ] Documentation has been added / updated (for bug fixes / features)
 - [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
-- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
 - [ ] I have reviewed this pull request (self-review)
 
 ## Future Work

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,9 +35,6 @@ Please check if the PR fulfills the following requirements:
 - [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
 - [ ] I have reviewed this pull request (self-review)
 
-
-
-
 ## Future Work
 
 <!--


### PR DESCRIPTION
We no longer need it. If all CI passes except `prettier`, enable auto-merge for the pull request, which will trigger [.github/workflows/prettier-on-automerge.yml](https://github.com/vercel/ai/blob/dff8735fbe6fa531104a79716a4670a7f168d45f/.github/workflows/prettier-on-automerge.yml) and resolve all formatting issues before merging

I simulated it in this pull request.

1. Simulated prettier error https://github.com/vercel/ai/pull/9476/commits/69a3387b873805e951d8a81bc2de3a3dd2f8a39d
2. resulted in prettier error: https://github.com/vercel/ai/actions/runs/18478059395/job/52646977667?pr=9476
3. enabled auto-merge https://github.com/vercel/ai/pull/9476#event-20255520115
4. prettier-error was fixed auto-magically via https://github.com/vercel/ai/actions/runs/18478098711/job/52647101543?pr=9476 in 51bad9e