### PR TITLE
feat(provider/anthropic): memory tool

### DIFF
--- a/.changeset/weak-bulldogs-remain.md
+++ b/.changeset/weak-bulldogs-remain.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(provider/anthropic): memory tool

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -297,6 +297,30 @@ Parameters:
 - `command` (string): The bash command to run. Required unless the tool is being restarted.
 - `restart` (boolean, optional): Specifying true will restart this tool.
 
+<Note>
+  The bash tool must have the name `bash`. Only certain Claude versions are
+  supported.
+</Note>
+
+### Memory Tool
+
+The [Memory Tool](https://docs.claude.com/en/docs/agents-and-tools/tool-use/memory-tool) allows Claude to use a local memory, e.g. in the filesystem.
+Here's how to create it:
+
+```ts
+const memory = anthropic.tools.memory_20250818({
+  execute: async action => {
+    // Implement your memory command execution logic here
+    // Return the result of the command execution
+  },
+});
+```
+
+<Note>
+  The memory tool must have the name `memory`. Only certain Claude versions are
+  supported.
+</Note>
+
 ### Text Editor Tool
 
 The Text Editor Tool provides functionality for viewing and editing text files.

--- a/examples/ai-core/.gitignore
+++ b/examples/ai-core/.gitignore
@@ -1,2 +1,2 @@
 output
-
+memory

--- a/examples/ai-core/src/generate-text/anthropic-memory-20250818.ts
+++ b/examples/ai-core/src/generate-text/anthropic-memory-20250818.ts
@@ -1,0 +1,23 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { stepCountIs, generateText } from 'ai';
+import { run } from '../lib/run';
+import { anthropicLocalFsMemoryTool } from '../lib/anthropic-local-fs-memory-tool';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5'),
+    prompt: `Please remember these [MEM] facts for future turns.
+Acknowledge by saying "stored".
+[MEM] Name: Alex Rivera
+[MEM] Role: PM at Nova Robotics`,
+    tools: {
+      memory: anthropicLocalFsMemoryTool({ basePath: './memory' }),
+    },
+    stopWhen: stepCountIs(10),
+  });
+
+  console.dir(
+    result.steps.flatMap(step => step.content),
+    { depth: Infinity },
+  );
+});

--- a/examples/ai-core/src/generate-text/anthropic-memory-20250818.ts
+++ b/examples/ai-core/src/generate-text/anthropic-memory-20250818.ts
@@ -16,8 +16,5 @@ Acknowledge by saying "stored".
     stopWhen: stepCountIs(10),
   });
 
-  console.dir(
-    result.steps.flatMap(step => step.content),
-    { depth: Infinity },
-  );
+  console.log(JSON.stringify(result.steps[0].response.body));
 });

--- a/examples/ai-core/src/lib/anthropic-local-fs-memory-tool.ts
+++ b/examples/ai-core/src/lib/anthropic-local-fs-memory-tool.ts
@@ -187,7 +187,7 @@ export const anthropicLocalFsMemoryTool = ({
             await fs.unlink(fullPath);
             return `File deleted: ${action.path}`;
           } else if (stat.isDirectory()) {
-            fs.rmdir(fullPath, { recursive: true });
+            await fs.rmdir(fullPath, { recursive: true });
             return `Directory deleted: ${action.path}`;
           } else {
             throw new Error(`Path not found: ${action.path}`);

--- a/examples/ai-core/src/lib/anthropic-local-fs-memory-tool.ts
+++ b/examples/ai-core/src/lib/anthropic-local-fs-memory-tool.ts
@@ -106,7 +106,6 @@ export const anthropicLocalFsMemoryTool = ({
 
           if (!(await exists(dir))) {
             await fs.mkdir(dir, { recursive: true });
-            throw new Error(`Path not found: ${action.path}`);
           }
 
           await fs.writeFile(fullPath, action.file_text, 'utf-8');

--- a/examples/ai-core/src/lib/anthropic-local-fs-memory-tool.ts
+++ b/examples/ai-core/src/lib/anthropic-local-fs-memory-tool.ts
@@ -1,0 +1,221 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import * as fsSync from 'fs';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+// based on
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/main/examples/tools-helpers-memory.ts
+export const anthropicLocalFsMemoryTool = ({
+  basePath = './memory',
+}: {
+  basePath: string;
+}) => {
+  const memoryRoot = path.join(basePath, 'memories');
+
+  if (!fsSync.existsSync(memoryRoot)) {
+    fsSync.mkdirSync(memoryRoot, { recursive: true });
+  }
+
+  function validatePath(memoryPath: string): string {
+    if (!memoryPath.startsWith('/memories')) {
+      throw new Error(`Path must start with /memories, got: ${memoryPath}`);
+    }
+
+    const relativePath = memoryPath
+      .slice('/memories'.length)
+      .replace(/^\//, '');
+    const fullPath = relativePath
+      ? path.join(memoryRoot, relativePath)
+      : memoryRoot;
+
+    const resolvedPath = path.resolve(fullPath);
+    const resolvedRoot = path.resolve(memoryRoot);
+    if (!resolvedPath.startsWith(resolvedRoot)) {
+      throw new Error(`Path ${memoryPath} would escape /memories directory`);
+    }
+
+    return resolvedPath;
+  }
+
+  async function exists(path: string) {
+    return await fs
+      .access(path)
+      .then(() => true)
+      .catch(() => false);
+  }
+
+  return anthropic.tools.memory_20250818({
+    execute: async action => {
+      switch (action.command) {
+        case 'view': {
+          const fullPath = validatePath(action.path);
+
+          if (!(await exists(fullPath))) {
+            throw new Error(`Path not found: ${action.path}`);
+          }
+
+          const stat = await fs.stat(fullPath);
+
+          if (stat.isDirectory()) {
+            const items: string[] = [];
+            const dirContents = await fs.readdir(fullPath);
+
+            for (const item of dirContents.sort()) {
+              if (item.startsWith('.')) {
+                continue;
+              }
+              const itemPath = path.join(fullPath, item);
+              const itemStat = await fs.stat(itemPath);
+              items.push(itemStat.isDirectory() ? `${item}/` : item);
+            }
+
+            return (
+              `Directory: ${action.path}\n` +
+              items.map(item => `- ${item}`).join('\n')
+            );
+          } else if (stat.isFile()) {
+            const content = await fs.readFile(fullPath, 'utf-8');
+            const lines = content.split('\n');
+
+            let displayLines = lines;
+            let startNum = 1;
+
+            if (action.view_range && action.view_range.length === 2) {
+              const startLine = Math.max(1, action.view_range[0]!) - 1;
+              const endLine =
+                action.view_range[1] === -1
+                  ? lines.length
+                  : action.view_range[1];
+              displayLines = lines.slice(startLine, endLine);
+              startNum = startLine + 1;
+            }
+
+            const numberedLines = displayLines.map(
+              (line, i) => `${String(i + startNum).padStart(4, ' ')}: ${line}`,
+            );
+
+            return numberedLines.join('\n');
+          } else {
+            throw new Error(`Path not found: ${action.path}`);
+          }
+        }
+
+        case 'create': {
+          const fullPath = validatePath(action.path);
+          const dir = path.dirname(fullPath);
+
+          if (!(await exists(dir))) {
+            await fs.mkdir(dir, { recursive: true });
+            throw new Error(`Path not found: ${action.path}`);
+          }
+
+          await fs.writeFile(fullPath, action.file_text, 'utf-8');
+          return `File created successfully at ${action.path}`;
+        }
+
+        case 'str_replace': {
+          const fullPath = validatePath(action.path);
+
+          if (!(await exists(fullPath))) {
+            throw new Error(`File not found: ${action.path}`);
+          }
+
+          const stat = await fs.stat(fullPath);
+          if (!stat.isFile()) {
+            throw new Error(`Path is not a file: ${action.path}`);
+          }
+
+          const content = await fs.readFile(fullPath, 'utf-8');
+          const count = content.split(action.old_str).length - 1;
+
+          if (count === 0) {
+            throw new Error(`Text not found in ${action.path}`);
+          } else if (count > 1) {
+            throw new Error(
+              `Text appears ${count} times in ${action.path}. Must be unique.`,
+            );
+          }
+
+          const newContent = content.replace(action.old_str, action.new_str);
+          await fs.writeFile(fullPath, newContent, 'utf-8');
+          return `File ${action.path} has been edited`;
+        }
+
+        case 'insert': {
+          const fullPath = validatePath(action.path);
+
+          if (!(await exists(fullPath))) {
+            throw new Error(`File not found: ${action.path}`);
+          }
+
+          const stat = await fs.stat(fullPath);
+          if (!stat.isFile()) {
+            throw new Error(`Path is not a file: ${action.path}`);
+          }
+
+          const content = await fs.readFile(fullPath, 'utf-8');
+          const lines = content.split('\n');
+
+          if (action.insert_line < 0 || action.insert_line > lines.length) {
+            throw new Error(
+              `Invalid insert_line ${action.insert_line}. Must be 0-${lines.length}`,
+            );
+          }
+
+          lines.splice(
+            action.insert_line,
+            0,
+            action.insert_text.replace(/\n$/, ''),
+          );
+          await fs.writeFile(fullPath, lines.join('\n'), 'utf-8');
+          return `Text inserted at line ${action.insert_line} in ${action.path}`;
+        }
+
+        case 'delete': {
+          const fullPath = validatePath(action.path);
+
+          if (action.path === '/memories') {
+            throw new Error('Cannot delete the /memories directory itself');
+          }
+
+          if (!(await exists(fullPath))) {
+            throw new Error(`Path not found: ${action.path}`);
+          }
+
+          const stat = await fs.stat(fullPath);
+
+          if (stat.isFile()) {
+            await fs.unlink(fullPath);
+            return `File deleted: ${action.path}`;
+          } else if (stat.isDirectory()) {
+            fs.rmdir(fullPath, { recursive: true });
+            return `Directory deleted: ${action.path}`;
+          } else {
+            throw new Error(`Path not found: ${action.path}`);
+          }
+        }
+
+        case 'rename': {
+          const oldFullPath = validatePath(action.old_path);
+          const newFullPath = validatePath(action.new_path);
+
+          if (!(await exists(oldFullPath))) {
+            throw new Error(`Source path not found: ${action.old_path}`);
+          }
+
+          if (await exists(newFullPath)) {
+            throw new Error(`Destination already exists: ${action.new_path}`);
+          }
+
+          const newDir = path.dirname(newFullPath);
+          if (!(await exists(newDir))) {
+            await fs.mkdir(newDir, { recursive: true });
+          }
+
+          await fs.rename(oldFullPath, newFullPath);
+          return `Renamed ${action.old_path} to ${action.new_path}`;
+        }
+      }
+    },
+  });
+};

--- a/examples/ai-core/src/stream-text/anthropic-memory-20250818.ts
+++ b/examples/ai-core/src/stream-text/anthropic-memory-20250818.ts
@@ -1,16 +1,19 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { streamText } from 'ai';
+import { streamText, stepCountIs } from 'ai';
 import { run } from '../lib/run';
+import { anthropicLocalFsMemoryTool } from '../lib/anthropic-local-fs-memory-tool';
 
 run(async () => {
   const result = streamText({
     model: anthropic('claude-sonnet-4-5'),
-    prompt:
-      'Write a Python script to calculate fibonacci number' +
-      ' and then execute it to find the 10th fibonacci number',
+    prompt: `Please remember these [MEM] facts for future turns.
+Acknowledge by saying "stored".
+[MEM] Name: Alex Rivera
+[MEM] Role: PM at Nova Robotics`,
     tools: {
-      code_execution: anthropic.tools.codeExecution_20250825(),
+      memory: anthropicLocalFsMemoryTool({ basePath: './memory' }),
     },
+    stopWhen: stepCountIs(10),
   });
 
   for await (const part of result.fullStream) {
@@ -22,14 +25,14 @@ run(async () => {
 
       case 'tool-call': {
         process.stdout.write(
-          `\n\nTool call: '${part.toolName}'\nInput: ${JSON.stringify(part.input, null, 2)}\n`,
+          `\x1b[32m\n\nTool call: '${part.toolName}'\nInput: ${JSON.stringify(part.input, null, 2)}\n\x1b[0m`,
         );
         break;
       }
 
       case 'tool-result': {
         process.stdout.write(
-          `\nTool result: '${part.toolName}'\nOutput: ${JSON.stringify(part.output, null, 2)}\n`,
+          `\x1b[32m\nTool result: '${part.toolName}'\nOutput: ${JSON.stringify(part.output, null, 2)}\n\x1b[0m`,
         );
         break;
       }

--- a/packages/anthropic/src/__fixtures__/anthropic-memory-20250818.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-memory-20250818.1.json
@@ -1,0 +1,28 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_01CFDwFo3hhWrKC7BRpZBzJV",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "toolu_01TvNvpwszD4hKeudmbfyWiV",
+      "name": "memory",
+      "input": { "command": "view", "path": "/memories" }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 1614,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 69,
+    "service_tier": "standard"
+  },
+  "context_management": { "applied_edits": [] }
+}

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -71,6 +71,17 @@ The script uses an iterative approach to calculate Fibonacci numbers efficiently
 ]
 `;
 
+exports[`AnthropicMessagesLanguageModel > doGenerate > memory 20250818 > should include memory tool call and result in content 1`] = `
+[
+  {
+    "input": "{"command":"view","path":"/memories"}",
+    "toolCallId": "toolu_01TvNvpwszD4hKeudmbfyWiV",
+    "toolName": "memory",
+    "type": "tool-call",
+  },
+]
+`;
+
 exports[`AnthropicMessagesLanguageModel > doGenerate > web fetch tool > text response > should include web fetch tool call and result in content 1`] = `
 [
   {

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -262,6 +262,10 @@ export type AnthropicTool =
       type: 'bash_20250124' | 'bash_20241022';
     }
   | {
+      name: string;
+      type: 'memory_20250818';
+    }
+  | {
       type: 'web_fetch_20250910';
       name: string;
       max_uses?: number;

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -1651,6 +1651,75 @@ describe('AnthropicMessagesLanguageModel', () => {
       });
     });
 
+    describe('memory 20250818', () => {
+      it('should send request body with include and tool', async () => {
+        prepareJsonFixtureResponse('anthropic-memory-20250818.1');
+
+        await model.doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'anthropic.memory_20250818',
+              name: 'memory',
+              args: {},
+            },
+          ],
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "max_tokens": 4096,
+            "messages": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "claude-3-haiku-20240307",
+            "tools": [
+              {
+                "name": "memory",
+                "type": "memory_20250818",
+              },
+            ],
+          }
+        `);
+
+        expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+          {
+            "anthropic-beta": "context-management-2025-06-27",
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+            "x-api-key": "test-api-key",
+          }
+        `);
+      });
+
+      it('should include memory tool call and result in content', async () => {
+        prepareJsonFixtureResponse('anthropic-memory-20250818.1');
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'anthropic.memory_20250818',
+              name: 'memory',
+              args: {},
+            },
+          ],
+        });
+
+        expect(result.content).toMatchSnapshot();
+      });
+    });
+
     describe('code execution 20250825', () => {
       it('should send request body with include and tool', async () => {
         prepareJsonFixtureResponse('anthropic-code-execution-20250825.1');
@@ -1688,6 +1757,15 @@ describe('AnthropicMessagesLanguageModel', () => {
                 "type": "code_execution_20250825",
               },
             ],
+          }
+        `);
+
+        expect(server.calls[0].requestHeaders).toMatchInlineSnapshot(`
+          {
+            "anthropic-beta": "code-execution-2025-08-25",
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+            "x-api-key": "test-api-key",
           }
         `);
       });

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -142,6 +142,14 @@ export async function prepareTools({
             });
             break;
           }
+          case 'anthropic.memory_20250818': {
+            betas.add('context-management-2025-06-27');
+            anthropicTools.push({
+              name: 'memory',
+              type: 'memory_20250818',
+            });
+            break;
+          }
           case 'anthropic.web_fetch_20250910': {
             betas.add('web-fetch-2025-09-10');
             const args = await validateTypes({

--- a/packages/anthropic/src/anthropic-tools.ts
+++ b/packages/anthropic/src/anthropic-tools.ts
@@ -4,6 +4,7 @@ import { codeExecution_20250522 } from './tool/code-execution_20250522';
 import { codeExecution_20250825 } from './tool/code-execution_20250825';
 import { computer_20241022 } from './tool/computer_20241022';
 import { computer_20250124 } from './tool/computer_20250124';
+import { memory_20250818 } from './tool/memory_20250818';
 import { textEditor_20241022 } from './tool/text-editor_20241022';
 import { textEditor_20250124 } from './tool/text-editor_20250124';
 import { textEditor_20250429 } from './tool/text-editor_20250429';
@@ -85,6 +86,18 @@ export const anthropicTools = {
    * @param displayNumber - The display number to control (only relevant for X11 environments). If specified, the tool will be provided a display number in the tool definition.
    */
   computer_20250124,
+
+  /**
+   * The memory tool enables Claude to store and retrieve information across conversations through a memory file directory.
+   * Claude can create, read, update, and delete files that persist between sessions,
+   * allowing it to build knowledge over time without keeping everything in the context window.
+   * The memory tool operates client-side—you control where and how the data is stored through your own infrastructure.
+   *
+   * Supported models: Claude Sonnet 4.5, Claude Sonnet 4, Claude Opus 4.1, Claude Opus 4.
+   *
+   * Tool name must be `memory`.
+   */
+  memory_20250818,
 
   /**
    * Claude can use an Anthropic-defined text editor tool to view and modify text files,

--- a/packages/anthropic/src/tool/memory_20250818.ts
+++ b/packages/anthropic/src/tool/memory_20250818.ts
@@ -7,7 +7,7 @@ import { z } from 'zod/v4';
 
 const memory_20250818InputSchema = lazySchema(() =>
   zodSchema(
-    z.discriminatedUnion('type', [
+    z.discriminatedUnion('command', [
       z.object({
         command: z.literal('view'),
         path: z.string(),

--- a/packages/anthropic/src/tool/memory_20250818.ts
+++ b/packages/anthropic/src/tool/memory_20250818.ts
@@ -1,0 +1,63 @@
+import {
+  createProviderDefinedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+const memory_20250818InputSchema = lazySchema(() =>
+  zodSchema(
+    z.discriminatedUnion('type', [
+      z.object({
+        command: z.literal('view'),
+        path: z.string(),
+        view_range: z.tuple([z.number(), z.number()]).optional(),
+      }),
+      z.object({
+        command: z.literal('create'),
+        path: z.string(),
+        file_text: z.string(),
+      }),
+      z.object({
+        command: z.literal('str_replace'),
+        path: z.string(),
+        old_str: z.string(),
+        new_str: z.string(),
+      }),
+      z.object({
+        command: z.literal('insert'),
+        path: z.string(),
+        insert_line: z.number(),
+        insert_text: z.string(),
+      }),
+      z.object({
+        command: z.literal('delete'),
+        path: z.string(),
+      }),
+      z.object({
+        command: z.literal('rename'),
+        old_path: z.string(),
+        new_path: z.string(),
+      }),
+    ]),
+  ),
+);
+
+export const memory_20250818 = createProviderDefinedToolFactory<
+  | { command: 'view'; path: string; view_range?: [number, number] }
+  | { command: 'create'; path: string; file_text: string }
+  | { command: 'str_replace'; path: string; old_str: string; new_str: string }
+  | {
+      command: 'insert';
+      path: string;
+      insert_line: number;
+      insert_text: string;
+    }
+  | { command: 'delete'; path: string }
+  | { command: 'rename'; old_path: string; new_path: string },
+  {}
+>({
+  id: 'anthropic.memory_20250818',
+  name: 'memory',
+  inputSchema: memory_20250818InputSchema,
+});


### PR DESCRIPTION
## Background

Anthropic has released a [memory tool](https://docs.claude.com/en/docs/agents-and-tools/tool-use/memory-tool).

## Summary

Add Anthropic `memory_20250818` tool.

## Manual Verification

- [x] run stream text example `examples/ai-core/src/stream-text/anthropic-memory-20250818.ts`

## Tasks

- [x] unit test generate
- [x] add examples
- [x] docs
- [x] changeset