### PR TITLE
fix(examples/express): specify versions to enable deployment

### DIFF
--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -7,8 +7,8 @@
     "type-check": "tsc --build"
   },
   "dependencies": {
-    "@ai-sdk/openai": "workspace:*",
-    "ai": "workspace:*",
+    "@ai-sdk/openai": "3.0.0-beta.29",
+    "ai": "6.0.0-beta.46",
     "dotenv": "16.4.5",
     "express": "5.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,10 +305,10 @@ importers:
   examples/express:
     dependencies:
       '@ai-sdk/openai':
-        specifier: workspace:*
+        specifier: 3.0.0-beta.29
         version: link:../../packages/openai
       ai:
-        specifier: workspace:*
+        specifier: 6.0.0-beta.46
         version: link:../../packages/ai
       dotenv:
         specifier: 16.4.5


### PR DESCRIPTION
## Background

Examples could not be deployed (see #8910 ).

## Summary

Specify versions for `examples/express`.