### PR TITLE
docs(anthropic): add highlighting to reasoning example

### DIFF
--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -119,7 +119,7 @@ Anthropic has reasoning support for `claude-opus-4-20250514`, `claude-sonnet-4-2
 You can enable it using the `thinking` provider option
 and specifying a thinking budget in tokens.
 
-```ts
+```ts highlight="4,8-10"
 import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Issue #8872


## Summary

<!-- What did you change? -->

Added highlighting to the reasoning example in the Anthropic provider documentation (`content/providers/01-ai-sdk-providers/05-anthropic.mdx`):
- Line 4: highlights the reasoning-specific return values (`text`, `reasoning`, `reasoningDetails`)
- Lines 8-10: highlights the `thinking` provider option configuration (the core feature)

This follows the same highlighting pattern used in the cache control example on line 155 of the same file.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

N/A - Documentation change only. The highlighting will be visible once deployed to ai-sdk.dev.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->

Fixes #8872