### PR TITLE
feat: tool execution approval for dynamic tools

### DIFF
--- a/.changeset/lemon-gorillas-begin.md
+++ b/.changeset/lemon-gorillas-begin.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+feat: tool execution approval for dynamic tools

--- a/examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts
@@ -4,8 +4,8 @@ import {
   generateText,
   ModelMessage,
   stepCountIs,
-  tool,
   ToolApprovalResponse,
+  ToolSet,
 } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod/v4';
@@ -28,6 +28,9 @@ const weatherTool = dynamicTool({
   needsApproval: true,
 });
 
+// type as generic ToolSet (tools are not known at development time)
+const tools: ToolSet = { weather: weatherTool };
+
 run(async () => {
   const messages: ModelMessage[] = [];
   let approvals: ToolApprovalResponse[] = [];
@@ -48,7 +51,7 @@ run(async () => {
       system:
         'When a tool execution is not approved by the user, do not retry it.' +
         'Just say that the tool execution was not approved.',
-      tools: { weather: weatherTool },
+      tools,
       messages,
       stopWhen: stepCountIs(5),
     });

--- a/examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts
@@ -1,0 +1,84 @@
+import { openai } from '@ai-sdk/openai';
+import {
+  dynamicTool,
+  generateText,
+  ModelMessage,
+  stepCountIs,
+  tool,
+  ToolApprovalResponse,
+} from 'ai';
+import * as readline from 'node:readline/promises';
+import { z } from 'zod/v4';
+import { run } from '../lib/run';
+
+const terminal = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const weatherTool = dynamicTool({
+  description: 'Get the weather in a location',
+  inputSchema: z.object({
+    location: z.string().describe('The location to get the weather for'),
+  }),
+  execute: async input => ({
+    location: (input as { location: string }).location,
+    temperature: 72 + Math.floor(Math.random() * 21) - 10,
+  }),
+  needsApproval: true,
+});
+
+run(async () => {
+  const messages: ModelMessage[] = [];
+  let approvals: ToolApprovalResponse[] = [];
+
+  while (true) {
+    messages.push(
+      approvals.length > 0
+        ? { role: 'tool', content: approvals }
+        : { role: 'user', content: await terminal.question('You:\n') },
+    );
+
+    approvals = [];
+
+    const result = await generateText({
+      model: openai('gpt-5-mini'),
+      // context engineering required to make sure the model does not retry
+      // the tool execution if it is not approved:
+      system:
+        'When a tool execution is not approved by the user, do not retry it.' +
+        'Just say that the tool execution was not approved.',
+      tools: { weather: weatherTool },
+      messages,
+      stopWhen: stepCountIs(5),
+    });
+
+    process.stdout.write(`\nAssistant:\n`);
+    for (const part of result.content) {
+      if (part.type === 'text') {
+        process.stdout.write(part.text);
+      }
+
+      if (part.type === 'tool-approval-request') {
+        if (part.toolCall.toolName === 'weather') {
+          const input = part.toolCall.input as { location: string };
+
+          const answer = await terminal.question(
+            `\nCan I retrieve the weather for ${input.location} (y/n)?`,
+          );
+
+          approvals.push({
+            type: 'tool-approval-response',
+            approvalId: part.approvalId,
+            approved:
+              answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes',
+          });
+        }
+      }
+    }
+
+    process.stdout.write('\n\n');
+
+    messages.push(...result.response.messages);
+  }
+});

--- a/examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts
@@ -29,7 +29,7 @@ const weatherTool = dynamicTool({
 });
 
 // type as generic ToolSet (tools are not known at development time)
-const tools: ToolSet = { weather: weatherTool };
+const tools: {} = { weather: weatherTool } satisfies ToolSet;
 
 run(async () => {
   const messages: ModelMessage[] = [];

--- a/examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts
+++ b/examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts
@@ -63,11 +63,10 @@ run(async () => {
       }
 
       if (part.type === 'tool-approval-request') {
-        if (part.toolCall.toolName === 'weather') {
-          const input = part.toolCall.input as { location: string };
-
+        if (part.toolCall.dynamic) {
           const answer = await terminal.question(
-            `\nCan I retrieve the weather for ${input.location} (y/n)?`,
+            `\nCan I retrieve execute the tool "${part.toolCall.toolName}" ` +
+              `with input ${JSON.stringify(part.toolCall.input)} (y/n)?`,
           );
 
           approvals.push({

--- a/examples/ai-core/src/stream-text/openai-tool-approval-dynamic-tool.ts
+++ b/examples/ai-core/src/stream-text/openai-tool-approval-dynamic-tool.ts
@@ -30,7 +30,7 @@ const weatherTool = dynamicTool({
 });
 
 // type as generic ToolSet (tools are not known at development time)
-const tools: ToolSet = { weather: weatherTool };
+const tools: {} = { weather: weatherTool } satisfies ToolSet;
 
 run(async () => {
   const messages: ModelMessage[] = [];

--- a/examples/next-openai/agent/dynamic-weather-with-approval-agent.ts
+++ b/examples/next-openai/agent/dynamic-weather-with-approval-agent.ts
@@ -1,0 +1,46 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { BasicAgent, dynamicTool, InferAgentUIMessage, ToolSet } from 'ai';
+import { z } from 'zod';
+
+function randomWeather() {
+  const weatherOptions = ['sunny', 'cloudy', 'rainy', 'windy'];
+  return weatherOptions[Math.floor(Math.random() * weatherOptions.length)];
+}
+
+const weatherTool = dynamicTool({
+  description: 'Get the weather in a location',
+  inputSchema: z.object({ city: z.string() }),
+  needsApproval: true,
+  async *execute() {
+    yield { state: 'loading' as const };
+
+    // Add artificial delay of 2 seconds
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    yield {
+      state: 'ready' as const,
+      temperature: 72,
+      weather: randomWeather(),
+    };
+  },
+});
+
+// type as generic ToolSet (tools are not known at development time)
+const tools: {} = { weather: weatherTool } satisfies ToolSet;
+
+export const dynamicWeatherWithApprovalAgent = new BasicAgent({
+  model: anthropic('claude-sonnet-4-5'),
+  // context engineering required to make sure the model does not retry
+  // the tool execution if it is not approved:
+  system:
+    'When a tool execution is not approved by the user, do not retry it.' +
+    'Just say that the tool execution was not approved.',
+  tools,
+  onStepFinish: ({ request }) => {
+    console.log(JSON.stringify(request.body, null, 2));
+  },
+});
+
+export type DynamicWeatherWithApprovalAgentUIMessage = InferAgentUIMessage<
+  typeof dynamicWeatherWithApprovalAgent
+>;

--- a/examples/next-openai/app/api/chat-tool-approval-dynamic/route.ts
+++ b/examples/next-openai/app/api/chat-tool-approval-dynamic/route.ts
@@ -1,0 +1,12 @@
+import { dynamicWeatherWithApprovalAgent } from '@/agent/dynamic-weather-with-approval-agent';
+import { validateUIMessages } from 'ai';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+
+  console.dir(body.messages, { depth: Infinity });
+
+  return dynamicWeatherWithApprovalAgent.respond({
+    messages: await validateUIMessages({ messages: body.messages }),
+  });
+}

--- a/examples/next-openai/app/test-tool-approval-dynamic/page.tsx
+++ b/examples/next-openai/app/test-tool-approval-dynamic/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { DynamicWeatherWithApprovalAgentUIMessage } from '@/agent/dynamic-weather-with-approval-agent';
+import ChatInput from '@/components/chat-input';
+import DynamicToolWithApprovalView from '@/components/tool/dynamic-tool-with-approval-view';
+import { useChat } from '@ai-sdk/react';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+} from 'ai';
+
+export default function TestToolApproval() {
+  const { status, sendMessage, messages, addToolApprovalResponse } =
+    useChat<DynamicWeatherWithApprovalAgentUIMessage>({
+      transport: new DefaultChatTransport({
+        api: '/api/chat-tool-approval-dynamic',
+      }),
+      sendAutomaticallyWhen:
+        lastAssistantMessageIsCompleteWithApprovalResponses,
+    });
+
+  console.log(structuredClone(messages));
+
+  return (
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
+      <h1 className="mb-4 text-xl font-bold">Tool Approval Test</h1>
+
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap">
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) => {
+            switch (part.type) {
+              case 'text':
+                return <div key={index}>{part.text}</div>;
+              case 'dynamic-tool':
+                return (
+                  <DynamicToolWithApprovalView
+                    key={index}
+                    invocation={part}
+                    addToolApprovalResponse={addToolApprovalResponse}
+                  />
+                );
+            }
+          })}
+        </div>
+      ))}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/examples/next-openai/components/tool/dynamic-tool-with-approval-view.tsx
+++ b/examples/next-openai/components/tool/dynamic-tool-with-approval-view.tsx
@@ -1,0 +1,69 @@
+import type { ChatAddToolApproveResponseFunction, DynamicToolUIPart } from 'ai';
+
+export default function WeatherWithApprovalView({
+  invocation,
+  addToolApprovalResponse,
+}: {
+  invocation: DynamicToolUIPart;
+  addToolApprovalResponse: ChatAddToolApproveResponseFunction;
+}) {
+  switch (invocation.state) {
+    case 'approval-requested':
+      return (
+        <div className="text-gray-500">
+          Can I execute the tool &quot;{invocation.toolName}&quot; with input{' '}
+          {JSON.stringify(invocation.input)}?
+          <div>
+            <button
+              className="px-4 py-2 mr-2 text-white bg-blue-500 rounded transition-colors hover:bg-blue-600"
+              onClick={() =>
+                addToolApprovalResponse({
+                  id: invocation.approval.id,
+                  approved: true,
+                })
+              }
+            >
+              Approve
+            </button>
+            <button
+              className="px-4 py-2 text-white bg-red-500 rounded transition-colors hover:bg-red-600"
+              onClick={() =>
+                addToolApprovalResponse({
+                  id: invocation.approval.id,
+                  approved: false,
+                })
+              }
+            >
+              Deny
+            </button>
+          </div>
+        </div>
+      );
+    case 'approval-responded':
+      return (
+        <div className="text-gray-500">
+          Can I execute the tool &quot;{invocation.toolName}&quot; with input{' '}
+          {JSON.stringify(invocation.input)}?
+          <div>{invocation.approval.approved ? 'Approved' : 'Denied'}</div>
+        </div>
+      );
+
+    case 'output-available':
+      return (
+        <div className="text-gray-500">
+          Tool {invocation.toolName} with input{' '}
+          {JSON.stringify(invocation.input)} executed. Output:{' '}
+          {JSON.stringify(invocation.output)}
+        </div>
+      );
+    case 'output-denied':
+      return (
+        <div className="text-red-500">
+          Tool {invocation.toolName} with input{' '}
+          {JSON.stringify(invocation.input)} execution denied.
+        </div>
+      );
+    case 'output-error':
+      return <div className="text-red-500">Error: {invocation.errorText}</div>;
+  }
+}

--- a/packages/ai/src/generate-text/tool-set.ts
+++ b/packages/ai/src/generate-text/tool-set.ts
@@ -5,6 +5,10 @@ export type ToolSet = Record<
   (Tool<never, never> | Tool<any, any> | Tool<any, never> | Tool<never, any>) &
     Pick<
       Tool<any, any>,
-      'execute' | 'onInputAvailable' | 'onInputStart' | 'onInputDelta'
+      | 'execute'
+      | 'onInputAvailable'
+      | 'onInputStart'
+      | 'onInputDelta'
+      | 'needsApproval'
     >
 >;

--- a/packages/ai/src/prompt/content-part.ts
+++ b/packages/ai/src/prompt/content-part.ts
@@ -108,6 +108,10 @@ export const outputSchema: z.ZodType<LanguageModelV3ToolResultOutput> =
       value: jsonValueSchema,
     }),
     z.object({
+      type: z.literal('execution-denied'),
+      reason: z.string().optional(),
+    }),
+    z.object({
       type: z.literal('error-text'),
       value: z.string(),
     }),

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -439,7 +439,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       const updatePart = (
         part: UIMessagePart<UIDataTypes, UITools>,
       ): UIMessagePart<UIDataTypes, UITools> =>
-        isToolUIPart(part) &&
+        isToolOrDynamicToolUIPart(part) &&
         part.state === 'approval-requested' &&
         part.approval.id === id
           ? {

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -694,7 +694,10 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     }
 
     // automatically send the message if the sendAutomaticallyWhen function returns true
-    if (this.sendAutomaticallyWhen?.({ messages: this.state.messages })) {
+    if (
+      this.sendAutomaticallyWhen?.({ messages: this.state.messages }) &&
+      !isError
+    ) {
       await this.makeRequest({
         trigger: 'submit-message',
         messageId: this.lastMessage?.id,

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -1186,7 +1186,7 @@ describe('convertToModelMessages', () => {
   });
 
   describe('when converting tool approval request responses', () => {
-    it('should convert an approved tool approval request', () => {
+    it('should convert an approved tool approval request (static tool)', () => {
       const result = convertToModelMessages([
         {
           parts: [
@@ -1265,7 +1265,86 @@ describe('convertToModelMessages', () => {
       `);
     });
 
-    it('should convert a denied tool approval request and follow up text', () => {
+    it('should convert an approved tool approval request (dynamic tool)', () => {
+      const result = convertToModelMessages([
+        {
+          parts: [
+            {
+              text: 'What is the weather in Tokyo?',
+              type: 'text',
+            },
+          ],
+          role: 'user',
+        },
+        {
+          parts: [
+            {
+              type: 'step-start',
+            },
+            {
+              approval: {
+                approved: true,
+                id: 'approval-1',
+                reason: undefined,
+              },
+              input: {
+                city: 'Tokyo',
+              },
+              state: 'approval-responded',
+              toolCallId: 'call-1',
+              type: 'dynamic-tool',
+              toolName: 'weather',
+            },
+          ],
+          role: 'assistant',
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "What is the weather in Tokyo?",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "city": "Tokyo",
+                },
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-call",
+              },
+              {
+                "approvalId": "approval-1",
+                "toolCallId": "call-1",
+                "type": "tool-approval-request",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "approvalId": "approval-1",
+                "approved": true,
+                "reason": undefined,
+                "type": "tool-approval-response",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+    });
+
+    it('should convert a denied tool approval request and follow up text (static tool)', () => {
       const result = convertToModelMessages([
         {
           parts: [
@@ -1359,7 +1438,101 @@ describe('convertToModelMessages', () => {
       `);
     });
 
-    it('should convert tool output denied', () => {
+    it('should convert a denied tool approval request and follow up text (dynamic tool)', () => {
+      const result = convertToModelMessages([
+        {
+          parts: [
+            {
+              text: 'What is the weather in Tokyo?',
+              type: 'text',
+            },
+          ],
+          role: 'user',
+        },
+        {
+          parts: [
+            {
+              type: 'step-start',
+            },
+            {
+              approval: {
+                approved: false,
+                id: 'approval-1',
+                reason: "I don't want to approve this",
+              },
+              input: {
+                city: 'Tokyo',
+              },
+              state: 'approval-responded',
+              toolCallId: 'call-1',
+              type: 'dynamic-tool',
+              toolName: 'weather',
+            },
+            { type: 'step-start' },
+            {
+              type: 'text',
+              text: 'I was not able to retrieve the weather.',
+              state: 'done',
+            },
+          ],
+          role: 'assistant',
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "What is the weather in Tokyo?",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "city": "Tokyo",
+                },
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-call",
+              },
+              {
+                "approvalId": "approval-1",
+                "toolCallId": "call-1",
+                "type": "tool-approval-request",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "approvalId": "approval-1",
+                "approved": false,
+                "reason": "I don't want to approve this",
+                "type": "tool-approval-response",
+              },
+            ],
+            "role": "tool",
+          },
+          {
+            "content": [
+              {
+                "text": "I was not able to retrieve the weather.",
+                "type": "text",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+    });
+
+    it('should convert tool output denied (static tool)', () => {
       const result = convertToModelMessages([
         {
           parts: [
@@ -1447,7 +1620,95 @@ describe('convertToModelMessages', () => {
       `);
     });
 
-    it('should convert tool output result with approval and follow up text', () => {
+    it('should convert tool output denied (dynamic tool)', () => {
+      const result = convertToModelMessages([
+        {
+          parts: [
+            {
+              text: 'What is the weather in Tokyo?',
+              type: 'text',
+            },
+          ],
+          role: 'user',
+        },
+        {
+          parts: [
+            {
+              type: 'step-start',
+            },
+            {
+              approval: {
+                approved: false,
+                id: 'approval-1',
+                reason: "I don't want to approve this",
+              },
+              input: {
+                city: 'Tokyo',
+              },
+              state: 'output-denied',
+              toolCallId: 'call-1',
+              type: 'dynamic-tool',
+              toolName: 'weather',
+            },
+          ],
+          role: 'assistant',
+        },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "What is the weather in Tokyo?",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "content": [
+              {
+                "input": {
+                  "city": "Tokyo",
+                },
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-call",
+              },
+              {
+                "approvalId": "approval-1",
+                "toolCallId": "call-1",
+                "type": "tool-approval-request",
+              },
+            ],
+            "role": "assistant",
+          },
+          {
+            "content": [
+              {
+                "approvalId": "approval-1",
+                "approved": false,
+                "reason": "I don't want to approve this",
+                "type": "tool-approval-response",
+              },
+              {
+                "output": {
+                  "type": "error-text",
+                  "value": "I don't want to approve this",
+                },
+                "toolCallId": "call-1",
+                "toolName": "weather",
+                "type": "tool-result",
+              },
+            ],
+            "role": "tool",
+          },
+        ]
+      `);
+    });
+
+    it('should convert tool output result with approval and follow up text (static tool)', () => {
       const result = convertToModelMessages([
         {
           parts: [
@@ -1554,7 +1815,7 @@ describe('convertToModelMessages', () => {
       `);
     });
 
-    it('should convert tool error result with approval and follow up text', () => {
+    it('should convert tool error result with approval and follow up text (static tool)', () => {
       const result = convertToModelMessages([
         {
           parts: [

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -11,6 +11,7 @@ import {
   DynamicToolUIPart,
   FileUIPart,
   getToolName,
+  getToolOrDynamicToolName,
   isToolOrDynamicToolUIPart,
   isToolUIPart,
   ReasoningUIPart,
@@ -254,7 +255,7 @@ export function convertToModelMessages(
                         outputs.push({
                           type: 'tool-result',
                           toolCallId: toolPart.toolCallId,
-                          toolName: getToolName(toolPart),
+                          toolName: getToolOrDynamicToolName(toolPart),
                           output: {
                             type: 'error-text' as const,
                             value:
@@ -268,11 +269,7 @@ export function convertToModelMessages(
 
                       case 'output-error':
                       case 'output-available': {
-                        const toolName =
-                          toolPart.type === 'dynamic-tool'
-                            ? toolPart.toolName
-                            : getToolName(toolPart);
-
+                        const toolName = getToolOrDynamicToolName(toolPart);
                         outputs.push({
                           type: 'tool-result',
                           toolCallId: toolPart.toolCallId,

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -162,6 +162,14 @@ export function convertToModelMessages(
                       : {}),
                   });
                 }
+
+                if (part.approval != null) {
+                  content.push({
+                    type: 'tool-approval-request' as const,
+                    approvalId: part.approval.id,
+                    toolCallId: part.toolCallId,
+                  });
+                }
               } else if (isToolUIPart(part)) {
                 const toolName = getToolName(part);
 
@@ -238,10 +246,7 @@ export function convertToModelMessages(
                     > = [];
 
                     // add approval response for approved tool calls:
-                    if (
-                      toolPart.type !== 'dynamic-tool' &&
-                      toolPart.approval?.approved != null
-                    ) {
+                    if (toolPart.approval?.approved != null) {
                       outputs.push({
                         type: 'tool-approval-response' as const,
                         approvalId: toolPart.approval.id,
@@ -305,8 +310,7 @@ export function convertToModelMessages(
               part.type === 'text' ||
               part.type === 'reasoning' ||
               part.type === 'file' ||
-              part.type === 'dynamic-tool' ||
-              isToolUIPart(part)
+              isToolOrDynamicToolUIPart(part)
             ) {
               block.push(part);
             } else if (part.type === 'step-start') {

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -5915,7 +5915,7 @@ describe('processUIMessageStream', () => {
     });
   });
 
-  describe('tool approval requests', () => {
+  describe('tool approval requests (static tool)', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([
         {
@@ -6042,6 +6042,137 @@ describe('processUIMessageStream', () => {
             "state": "approval-requested",
             "toolCallId": "call-1",
             "type": "tool-tool1",
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('tool approval requests (dynamic tool)', () => {
+    beforeEach(async () => {
+      const stream = createUIMessageStream([
+        {
+          type: 'start',
+        },
+        {
+          type: 'start-step',
+        },
+        {
+          input: {
+            value: 'value',
+          },
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          type: 'tool-input-available',
+          dynamic: true,
+        },
+        {
+          approvalId: 'id-1',
+          toolCallId: 'call-1',
+          type: 'tool-approval-request',
+        },
+        {
+          type: 'finish-step',
+        },
+        {
+          type: 'finish',
+        },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+    });
+
+    it('should call the update function with the correct arguments', async () => {
+      expect(writeCalls).toMatchInlineSnapshot(`
+        [
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "errorText": undefined,
+                  "input": {
+                    "value": "value",
+                  },
+                  "output": undefined,
+                  "preliminary": undefined,
+                  "state": "input-available",
+                  "toolCallId": "call-1",
+                  "toolName": "tool1",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+          {
+            "message": {
+              "id": "msg-123",
+              "metadata": undefined,
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "approval": {
+                    "id": "id-1",
+                  },
+                  "errorText": undefined,
+                  "input": {
+                    "value": "value",
+                  },
+                  "output": undefined,
+                  "preliminary": undefined,
+                  "state": "approval-requested",
+                  "toolCallId": "call-1",
+                  "toolName": "tool1",
+                  "type": "dynamic-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          },
+        ]
+      `);
+    });
+
+    it('should have the correct final message state', async () => {
+      expect(state!.message.parts).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "step-start",
+          },
+          {
+            "approval": {
+              "id": "id-1",
+            },
+            "errorText": undefined,
+            "input": {
+              "value": "value",
+            },
+            "output": undefined,
+            "preliminary": undefined,
+            "state": "approval-requested",
+            "toolCallId": "call-1",
+            "toolName": "tool1",
+            "type": "dynamic-tool",
           },
         ]
       `);

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -1,8 +1,4 @@
-import {
-  StandardSchemaV1,
-  validateTypes,
-  FlexibleSchema,
-} from '@ai-sdk/provider-utils';
+import { FlexibleSchema, validateTypes } from '@ai-sdk/provider-utils';
 import { ProviderMetadata } from '../types';
 import {
   DataUIMessageChunk,

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -505,10 +505,8 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 
             case 'tool-approval-request': {
               const toolInvocation = getToolInvocation(chunk.toolCallId);
-
               toolInvocation.state = 'approval-requested';
               toolInvocation.approval = { id: chunk.approvalId };
-
               write();
               break;
             }

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -385,6 +385,7 @@ export type DynamicToolUIPart = {
     }
 );
 
+// TODO AI SDK 6: rename to isStaticToolUIPart
 export function isToolUIPart<TOOLS extends UITools>(
   part: UIMessagePart<UIDataTypes, TOOLS>,
 ): part is ToolUIPart<TOOLS> {
@@ -397,18 +398,21 @@ export function isDynamicToolUIPart(
   return part.type === 'dynamic-tool';
 }
 
+// TODO AI SDK 6: rename to isToolUIPart
 export function isToolOrDynamicToolUIPart<TOOLS extends UITools>(
   part: UIMessagePart<UIDataTypes, TOOLS>,
 ): part is ToolUIPart<TOOLS> | DynamicToolUIPart {
   return isToolUIPart(part) || isDynamicToolUIPart(part);
 }
 
+// TODO AI SDK 6: rename to getStaticToolName
 export function getToolName<TOOLS extends UITools>(
   part: ToolUIPart<TOOLS>,
 ): keyof TOOLS {
   return part.type.split('-').slice(1).join('-') as keyof TOOLS;
 }
 
+// TODO AI SDK 6: rename to getToolName
 export function getToolOrDynamicToolName(
   part: ToolUIPart<UITools> | DynamicToolUIPart,
 ): string {

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -312,6 +312,7 @@ export type DynamicToolUIPart = {
       input: unknown | undefined;
       output?: never;
       errorText?: never;
+      approval?: never;
     }
   | {
       state: 'input-available';
@@ -319,6 +320,31 @@ export type DynamicToolUIPart = {
       output?: never;
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
+      approval?: never;
+    }
+  | {
+      state: 'approval-requested';
+      input: unknown;
+      output?: never;
+      errorText?: never;
+      callProviderMetadata?: ProviderMetadata;
+      approval: {
+        id: string;
+        approved?: never;
+        reason?: never;
+      };
+    }
+  | {
+      state: 'approval-responded';
+      input: unknown;
+      output?: never;
+      errorText?: never;
+      callProviderMetadata?: ProviderMetadata;
+      approval: {
+        id: string;
+        approved: boolean;
+        reason?: string;
+      };
     }
   | {
       state: 'output-available';
@@ -327,6 +353,11 @@ export type DynamicToolUIPart = {
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
       preliminary?: boolean;
+      approval?: {
+        id: string;
+        approved: true;
+        reason?: string;
+      };
     }
   | {
       state: 'output-error'; // TODO AI SDK 6: change to 'error' state
@@ -334,6 +365,23 @@ export type DynamicToolUIPart = {
       output?: never;
       errorText: string;
       callProviderMetadata?: ProviderMetadata;
+      approval?: {
+        id: string;
+        approved: true;
+        reason?: string;
+      };
+    }
+  | {
+      state: 'output-denied';
+      input: unknown;
+      output?: never;
+      errorText?: never;
+      callProviderMetadata?: ProviderMetadata;
+      approval: {
+        id: string;
+        approved: false;
+        reason?: string;
+      };
     }
 );
 

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -77,6 +77,7 @@ const uiMessagesSchema = lazySchema(() =>
               input: z.unknown().optional(),
               output: z.never().optional(),
               errorText: z.never().optional(),
+              approval: z.never().optional(),
             }),
             z.object({
               type: z.literal('dynamic-tool'),
@@ -87,6 +88,37 @@ const uiMessagesSchema = lazySchema(() =>
               output: z.never().optional(),
               errorText: z.never().optional(),
               callProviderMetadata: providerMetadataSchema.optional(),
+              approval: z.never().optional(),
+            }),
+            z.object({
+              type: z.literal('dynamic-tool'),
+              toolName: z.string(),
+              toolCallId: z.string(),
+              state: z.literal('approval-requested'),
+              input: z.unknown(),
+              output: z.never().optional(),
+              errorText: z.never().optional(),
+              callProviderMetadata: providerMetadataSchema.optional(),
+              approval: z.object({
+                id: z.string(),
+                approved: z.never().optional(),
+                reason: z.never().optional(),
+              }),
+            }),
+            z.object({
+              type: z.literal('dynamic-tool'),
+              toolName: z.string(),
+              toolCallId: z.string(),
+              state: z.literal('approval-responded'),
+              input: z.unknown(),
+              output: z.never().optional(),
+              errorText: z.never().optional(),
+              callProviderMetadata: providerMetadataSchema.optional(),
+              approval: z.object({
+                id: z.string(),
+                approved: z.boolean(),
+                reason: z.string().optional(),
+              }),
             }),
             z.object({
               type: z.literal('dynamic-tool'),
@@ -98,6 +130,13 @@ const uiMessagesSchema = lazySchema(() =>
               errorText: z.never().optional(),
               callProviderMetadata: providerMetadataSchema.optional(),
               preliminary: z.boolean().optional(),
+              approval: z
+                .object({
+                  id: z.string(),
+                  approved: z.literal(true),
+                  reason: z.string().optional(),
+                })
+                .optional(),
             }),
             z.object({
               type: z.literal('dynamic-tool'),
@@ -108,6 +147,28 @@ const uiMessagesSchema = lazySchema(() =>
               output: z.never().optional(),
               errorText: z.string(),
               callProviderMetadata: providerMetadataSchema.optional(),
+              approval: z
+                .object({
+                  id: z.string(),
+                  approved: z.literal(true),
+                  reason: z.string().optional(),
+                })
+                .optional(),
+            }),
+            z.object({
+              type: z.literal('dynamic-tool'),
+              toolName: z.string(),
+              toolCallId: z.string(),
+              state: z.literal('output-denied'),
+              input: z.unknown(),
+              output: z.never().optional(),
+              errorText: z.never().optional(),
+              callProviderMetadata: providerMetadataSchema.optional(),
+              approval: z.object({
+                id: z.string(),
+                approved: z.literal(false),
+                reason: z.string().optional(),
+              }),
             }),
             z.object({
               type: z.string().startsWith('tool-'),

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -23,6 +23,7 @@ export {
   type Tool,
   type ToolCallOptions,
   type ToolExecuteFunction,
+  type ToolNeedsApprovalFunction,
 } from './tool';
 export type { ToolApprovalRequest } from './tool-approval-request';
 export type { ToolApprovalResponse } from './tool-approval-response';

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -32,6 +32,32 @@ export interface ToolCallOptions {
   experimental_context?: unknown;
 }
 
+/**
+ * Function that is called to determine if the tool needs approval before it can be executed.
+ */
+export type ToolNeedsApprovalFunction<INPUT> = (
+  input: INPUT,
+  options: {
+    /**
+     * The ID of the tool call. You can use it e.g. when sending tool-call related information with stream data.
+     */
+    toolCallId: string;
+
+    /**
+     * Messages that were sent to the language model to initiate the response that contained the tool call.
+     * The messages **do not** include the system prompt nor the assistant response that contained the tool call.
+     */
+    messages: ModelMessage[];
+
+    /**
+     * Additional context.
+     *
+     * Experimental (can break in patch releases).
+     */
+    experimental_context?: unknown;
+  },
+) => boolean | PromiseLike<boolean>;
+
 export type ToolExecuteFunction<INPUT, OUTPUT> = (
   input: INPUT,
   options: ToolCallOptions,
@@ -102,29 +128,7 @@ Whether the tool needs approval before it can be executed.
    */
   needsApproval?:
     | boolean
-    | ((
-        input: [INPUT] extends [never] ? unknown : INPUT,
-        options: {
-          /**
-           * The ID of the tool call. You can use it e.g. when sending tool-call related information with stream data.
-           */
-          toolCallId: string;
-
-          /**
-           * Messages that were sent to the language model to initiate the response that contained the tool call.
-           * The messages **do not** include the system prompt nor the assistant response that contained the tool call.
-           */
-          messages: ModelMessage[];
-
-          /**
-           * Additional context.
-           *
-           * Experimental (can break in patch releases).
-           */
-          experimental_context?: unknown;
-        },
-      ) => boolean | PromiseLike<boolean>);
-
+    | ToolNeedsApprovalFunction<[INPUT] extends [never] ? unknown : INPUT>;
   /**
    * Optional function that is called when the argument streaming starts.
    * Only called when the tool is used in a streaming context.
@@ -233,6 +237,11 @@ export function dynamicTool(tool: {
   inputSchema: FlexibleSchema<unknown>;
   execute: ToolExecuteFunction<unknown, unknown>;
   toModelOutput?: (output: unknown) => LanguageModelV3ToolResultPart['output'];
+
+  /**
+Whether the tool needs approval before it can be executed.
+   */
+  needsApproval?: boolean | ToolNeedsApprovalFunction<unknown>;
 }): Tool<unknown, unknown> & {
   type: 'dynamic';
 } {

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -229,7 +229,7 @@ export function tool(tool: any): any {
 }
 
 /**
-Helper function for defining a dynamic tool.
+ * Defines a dynamic tool.
  */
 export function dynamicTool(tool: {
   description?: string;
@@ -239,7 +239,7 @@ export function dynamicTool(tool: {
   toModelOutput?: (output: unknown) => LanguageModelV3ToolResultPart['output'];
 
   /**
-Whether the tool needs approval before it can be executed.
+   * Whether the tool needs approval before it can be executed.
    */
   needsApproval?: boolean | ToolNeedsApprovalFunction<unknown>;
 }): Tool<unknown, unknown> & {


### PR DESCRIPTION
## Background

Tool execution approvals were introduced for static tools in #8541 . Dynamic tools need to support tool execution approvals as well, in particular in preparation for provider-executed MCP servers.

## Summary

Add tool execution approval support for dynamic tools.

## Manual Verification

- [x] run `examples/ai-core/src/generate-text/openai-tool-approval-dynamic-tool.ts`
   - [x] with positive approval responses and follow up message
   - [x] with negative approval responses and follow up message
- [x] run `examples/ai-core/src/stream-text/openai-tool-approval-dynamic-tool.ts`
   - [x] with positive approval responses and follow up message
   - [x] with negative approval responses and follow up message
- [x] run UI test `next-openai` http://localhost:3000/test-tool-approval-dynamic
   - [x] approved with follow up message
   - [x] denied with follow up message
   - [x] multiple approvals in one message

## Tasks

- [x] add generateText example
- [x] change dynamic tool signatures
- [x] fix invalid prompt error for generate with negative response and follow up message
- [x] add streamText example
- [x] add UI example
- [x] add approval UI message states to dynamic tool parts
- [x] process ui stream: parse dynamic tool approvals
- [x] chat submission
- [x] ui message validation
- [x] convert to model messages
- [x] changeset

## Related Issues

Builds on #8541