### PR TITLE
feat(provider/anthropic): default and limit maxTokens based on model

### DIFF
--- a/.changeset/metal-doors-search.md
+++ b/.changeset/metal-doors-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(provider/anthropic): default and limit maxTokens based on model

--- a/examples/ai-core/src/stream-text/anthropic.ts
+++ b/examples/ai-core/src/stream-text/anthropic.ts
@@ -12,5 +12,11 @@ run(async () => {
     process.stdout.write(textPart);
   }
 
+  console.log();
+  console.log();
+  console.log('Request body:');
   console.dir((await result.request).body, { depth: Infinity });
+  console.log();
+  console.log('Warnings:');
+  console.dir(await result.warnings, { depth: Infinity });
 });

--- a/examples/ai-core/src/stream-text/anthropic.ts
+++ b/examples/ai-core/src/stream-text/anthropic.ts
@@ -1,10 +1,10 @@
 import { anthropic } from '@ai-sdk/anthropic';
 import { streamText } from 'ai';
-import 'dotenv/config';
+import { run } from '../lib/run';
 
-async function main() {
+run(async () => {
   const result = streamText({
-    model: anthropic('claude-3-5-sonnet-20240620'),
+    model: anthropic('claude-haiku-4-5'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 
@@ -12,9 +12,5 @@ async function main() {
     process.stdout.write(textPart);
   }
 
-  console.log();
-  console.log('Token usage:', await result.usage);
-  console.log('Finish reason:', await result.finishReason);
-}
-
-main().catch(console.error);
+  console.dir((await result.request).body, { depth: Infinity });
+});

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -111,7 +111,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           content: [{ type: 'text', text: 'Hello, World!' }],
         });
 
-        const result = await model.doGenerate({
+        const result = await provider('claude-sonnet-4-5').doGenerate({
           prompt: TEST_PROMPT,
           temperature: 0.5,
           topP: 0.7,
@@ -123,17 +123,27 @@ describe('AnthropicMessagesLanguageModel', () => {
           },
         });
 
-        expect(await server.calls[0].requestBodyJson).toStrictEqual({
-          model: 'claude-3-haiku-20240307',
-          messages: [
-            {
-              role: 'user',
-              content: [{ type: 'text', text: 'Hello' }],
+        expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+          {
+            "max_tokens": 64000,
+            "messages": [
+              {
+                "content": [
+                  {
+                    "text": "Hello",
+                    "type": "text",
+                  },
+                ],
+                "role": "user",
+              },
+            ],
+            "model": "claude-sonnet-4-5",
+            "thinking": {
+              "budget_tokens": 1000,
+              "type": "enabled",
             },
-          ],
-          max_tokens: 4096 + 1000,
-          thinking: { type: 'enabled', budget_tokens: 1000 },
-        });
+          }
+        `);
 
         expect(result.warnings).toStrictEqual([
           {

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -113,6 +113,7 @@ describe('AnthropicMessagesLanguageModel', () => {
 
         const result = await provider('claude-sonnet-4-5').doGenerate({
           prompt: TEST_PROMPT,
+          maxOutputTokens: 20000,
           temperature: 0.5,
           topP: 0.7,
           topK: 0.1,
@@ -125,7 +126,7 @@ describe('AnthropicMessagesLanguageModel', () => {
 
         expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
           {
-            "max_tokens": 64000,
+            "max_tokens": 21000,
             "messages": [
               {
                 "content": [

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -483,7 +483,7 @@ describe('AnthropicMessagesLanguageModel', () => {
     it('should send the model id and settings', async () => {
       prepareJsonResponse({});
 
-      await model.doGenerate({
+      const { warnings } = await model.doGenerate({
         prompt: TEST_PROMPT,
         temperature: 0.5,
         maxOutputTokens: 100,
@@ -493,17 +493,78 @@ describe('AnthropicMessagesLanguageModel', () => {
         frequencyPenalty: 0.15,
       });
 
-      expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'claude-3-haiku-20240307',
-        max_tokens: 100,
-        stop_sequences: ['abc', 'def'],
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "max_tokens": 100,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-3-haiku-20240307",
+          "stop_sequences": [
+            "abc",
+            "def",
+          ],
+          "temperature": 0.5,
+          "top_k": 0.1,
+          "top_p": 0.9,
+        }
+      `);
+
+      expect(warnings).toMatchInlineSnapshot(`
+        [
+          {
+            "setting": "frequencyPenalty",
+            "type": "unsupported-setting",
+          },
+        ]
+      `);
+    });
+
+    it('should limit max output tokens to the model max and warn', async () => {
+      prepareJsonResponse({});
+
+      const { warnings } = await provider('claude-haiku-4-5').doGenerate({
+        prompt: TEST_PROMPT,
         temperature: 0.5,
-        top_k: 0.1,
-        top_p: 0.9,
-        messages: [
-          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
-        ],
+        maxOutputTokens: 999999,
       });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "max_tokens": 64000,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-haiku-4-5",
+          "temperature": 0.5,
+        }
+      `);
+
+      expect(warnings).toMatchInlineSnapshot(`
+        [
+          {
+            "details": "999999 (maxOutputTokens + thinkingBudget) is greater than claude-haiku-4-5 64000 max output tokens. The max output tokens have been limited to 64000.",
+            "setting": "maxOutputTokens",
+            "type": "unsupported-setting",
+          },
+        ]
+      `);
     });
 
     it('should pass tools and toolChoice', async () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -263,10 +263,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
         });
       }
 
-      // adjust max tokens to account for thinking if maxOutputTokens is provided:
+      // adjust max tokens to account for thinking if maxOutputTokens is provided
       if (maxOutputTokens != null) {
         baseArgs.max_tokens = maxOutputTokens + thinkingBudget;
       }
+    }
 
     const {
       tools: anthropicTools,

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -271,13 +271,14 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
     // limit to max output tokens for model to enable model switching without breakages:
     if (baseArgs.max_tokens > maxOutputTokensForModel) {
-      // only warn if max output tokens is provided:
+      // only warn if max output tokens is provided as input:
       if (maxOutputTokens != null) {
         warnings.push({
           type: 'unsupported-setting',
           setting: 'maxOutputTokens',
           details:
-            "maxTokens (maxOutputTokens + thinkingBudget) is greater than the model's max output tokens",
+            `${maxTokens} (maxOutputTokens + thinkingBudget) is greater than ${this.modelId} ${maxOutputTokensForModel} max output tokens. ` +
+            `The max output tokens have been limited to ${maxOutputTokensForModel}.`,
         });
       }
       baseArgs.max_tokens = maxOutputTokensForModel;

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -39,7 +39,6 @@ import {
 import { prepareTools } from './anthropic-prepare-tools';
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
-import { codeExecution_20250825OutputSchema } from './tool/code-execution_20250825';
 
 function createCitationSource(
   citation: Citation,

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -126,7 +126,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
   private async getArgs({
     prompt,
-    maxOutputTokens = 4096, // 4096: max model output tokens TODO update default in v5
+    maxOutputTokens,
     temperature,
     topP,
     topK,
@@ -263,9 +263,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
         });
       }
 
-      // adjust max tokens to account for thinking:
-      baseArgs.max_tokens = maxOutputTokens + thinkingBudget;
-    }
+      // adjust max tokens to account for thinking if maxOutputTokens is provided:
+      if (maxOutputTokens != null) {
+        baseArgs.max_tokens = maxOutputTokens + thinkingBudget;
+      }
 
     const {
       tools: anthropicTools,


### PR DESCRIPTION
## Background

The default max output tokens for Anthropic models is 4096 for historic reasons, which leads to errors on newer models (see #9540 ).

## Summary

The default max output tokens depend on the chosen Anthropic model.

## Manual Verification

- [x] run `examples/ai-core/src/stream-text/anthropic.ts`

## Future Work

When new Anthropic models are being added, their max output tokens need to be added to `getMaxOutputTokensForModel`.

## Related Issues

Fixes #9540