### PR TITLE
fix(provider/anthropic): correct maxOutputTokens warning message

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -277,7 +277,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
           type: 'unsupported-setting',
           setting: 'maxOutputTokens',
           details:
-            `${maxTokens} (maxOutputTokens + thinkingBudget) is greater than ${this.modelId} ${maxOutputTokensForModel} max output tokens. ` +
+            `${baseArgs.max_tokens} (maxOutputTokens + thinkingBudget) is greater than ${this.modelId} ${maxOutputTokensForModel} max output tokens. ` +
             `The max output tokens have been limited to ${maxOutputTokensForModel}.`,
         });
       }


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/pull/9546#discussion_r2435141985

## Summary

Fix warning message.