### PR TITLE
fix(ai): Add missing `LoadSettingError` export

### DIFF
--- a/.changeset/fresh-drinks-explain.md
+++ b/.changeset/fresh-drinks-explain.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): add missing export for `LoadSettingError`

--- a/packages/ai/src/error/index.ts
+++ b/packages/ai/src/error/index.ts
@@ -6,12 +6,12 @@ export {
   InvalidResponseDataError,
   JSONParseError,
   LoadAPIKeyError,
+  LoadSettingError,
   NoContentGeneratedError,
   NoSuchModelError,
   TooManyEmbeddingValuesForCallError,
   TypeValidationError,
   UnsupportedFunctionalityError,
-  LoadSettingError,
 } from '@ai-sdk/provider';
 
 export { InvalidArgumentError } from './invalid-argument-error';

--- a/packages/ai/src/error/index.ts
+++ b/packages/ai/src/error/index.ts
@@ -11,6 +11,7 @@ export {
   TooManyEmbeddingValuesForCallError,
   TypeValidationError,
   UnsupportedFunctionalityError,
+  LoadSettingError,
 } from '@ai-sdk/provider';
 
 export { InvalidArgumentError } from './invalid-argument-error';


### PR DESCRIPTION
This PR re-exports `@ai-sdk/provider`'s `LoadSettingError` from `ai`, like other errors.

## Checklist

- [x] Documentation has been added / updated (for bug fixes / features)
	- It was already documented as such: https://ai-sdk.dev/docs/reference/ai-sdk-errors/ai-load-setting-error 
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)