### PR TITLE
feat (provider/gateway): improve auth error messages

### DIFF
--- a/.changeset/honest-nails-perform.md
+++ b/.changeset/honest-nails-perform.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): improve auth error messages

--- a/packages/gateway/src/errors/create-gateway-error.test.ts
+++ b/packages/gateway/src/errors/create-gateway-error.test.ts
@@ -442,7 +442,8 @@ describe('authentication_error with authMethod context', () => {
     });
 
     expect(error).toBeInstanceOf(GatewayAuthenticationError);
-    expect(error.message).toContain('Invalid API key provided');
+    expect(error.message).toContain('Invalid API key');
+    expect(error.message).toContain('vercel.com/d?to=');
     expect(error.statusCode).toBe(401);
   });
 
@@ -459,7 +460,8 @@ describe('authentication_error with authMethod context', () => {
     });
 
     expect(error).toBeInstanceOf(GatewayAuthenticationError);
-    expect(error.message).toContain('Invalid OIDC token provided');
+    expect(error.message).toContain('Invalid OIDC token');
+    expect(error.message).toContain('npx vercel link');
     expect(error.statusCode).toBe(401);
   });
 

--- a/packages/gateway/src/errors/gateway-authentication-error.ts
+++ b/packages/gateway/src/errors/gateway-authentication-error.ts
@@ -48,35 +48,26 @@ export class GatewayAuthenticationError extends GatewayError {
     let contextualMessage: string;
 
     if (apiKeyProvided) {
-      contextualMessage = `AI Gateway authentication failed: Invalid API key provided.
+      contextualMessage = `AI Gateway authentication failed: Invalid API key.
 
-The token is expected to be provided via the 'apiKey' option or 'AI_GATEWAY_API_KEY' environment variable.`;
+Create a new API key: https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%2Fapi-keys
+
+Provide via 'apiKey' option or 'AI_GATEWAY_API_KEY' environment variable.`;
     } else if (oidcTokenProvided) {
-      contextualMessage = `AI Gateway authentication failed: Invalid OIDC token provided.
+      contextualMessage = `AI Gateway authentication failed: Invalid OIDC token.
 
-The token is expected to be provided via the 'VERCEL_OIDC_TOKEN' environment variable. It expires every 12 hours.
-- make sure your Vercel project settings have OIDC enabled
-- if running locally with 'vercel dev', the token is automatically obtained and refreshed
-- if running locally with your own dev server, run 'vercel env pull' to fetch the token
-- in production/preview, the token is automatically obtained and refreshed
+Run 'npx vercel link' to link your project, then 'vc env pull' to fetch the token.
 
-Alternative: Provide an API key via 'apiKey' option or 'AI_GATEWAY_API_KEY' environment variable.`;
+Alternatively, use an API key: https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%2Fapi-keys`;
     } else {
       contextualMessage = `AI Gateway authentication failed: No authentication provided.
 
-Provide either an API key or OIDC token.
+Option 1 - API key:
+Create an API key: https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%2Fapi-keys
+Provide via 'apiKey' option or 'AI_GATEWAY_API_KEY' environment variable.
 
-API key instructions:
-
-The token is expected to be provided via the 'apiKey' option or 'AI_GATEWAY_API_KEY' environment variable.
-
-OIDC token instructions:
-
-The token is expected to be provided via the 'VERCEL_OIDC_TOKEN' environment variable. It expires every 12 hours.
-- make sure your Vercel project settings have OIDC enabled
-- if running locally with 'vercel dev', the token is automatically obtained and refreshed
-- if running locally with your own dev server, run 'vercel env pull' to fetch the token
-- in production/preview, the token is automatically obtained and refreshed`;
+Option 2 - OIDC token:
+Run 'npx vercel link' to link your project, then 'vc env pull' to fetch the token.`;
     }
 
     return new GatewayAuthenticationError({

--- a/packages/gateway/src/errors/gateway-error-types.test.ts
+++ b/packages/gateway/src/errors/gateway-error-types.test.ts
@@ -51,7 +51,8 @@ describe('GatewayAuthenticationError', () => {
         oidcTokenProvided: false,
       });
 
-      expect(error.message).toContain('Invalid API key provided');
+      expect(error.message).toContain('Invalid API key');
+      expect(error.message).toContain('vercel.com/d?to=');
       expect(error.statusCode).toBe(401);
     });
 
@@ -61,7 +62,8 @@ describe('GatewayAuthenticationError', () => {
         oidcTokenProvided: true,
       });
 
-      expect(error.message).toContain('Invalid OIDC token provided');
+      expect(error.message).toContain('Invalid OIDC token');
+      expect(error.message).toContain('npx vercel link');
       expect(error.statusCode).toBe(401);
     });
 
@@ -72,7 +74,8 @@ describe('GatewayAuthenticationError', () => {
       });
 
       expect(error.message).toContain('No authentication provided');
-      expect(error.message).toContain('VERCEL_OIDC_TOKEN');
+      expect(error.message).toContain('Option 1');
+      expect(error.message).toContain('Option 2');
       expect(error.statusCode).toBe(401);
     });
 
@@ -82,7 +85,8 @@ describe('GatewayAuthenticationError', () => {
         oidcTokenProvided: true,
       });
 
-      expect(error.message).toContain('Invalid API key provided');
+      expect(error.message).toContain('Invalid API key');
+      expect(error.message).toContain('vercel.com/d?to=');
       expect(error.statusCode).toBe(401);
     });
 
@@ -93,7 +97,8 @@ describe('GatewayAuthenticationError', () => {
       });
 
       expect(error.message).toContain('No authentication provided');
-      expect(error.message).toContain('VERCEL_OIDC_TOKEN');
+      expect(error.message).toContain('Option 1');
+      expect(error.message).toContain('Option 2');
       expect(error.statusCode).toBe(401);
     });
   });

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -213,7 +213,8 @@ describe('GatewayLanguageModel', () => {
       } catch (error) {
         expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
         const authError = error as GatewayAuthenticationError;
-        expect(authError.message).toContain('Invalid API key provided');
+        expect(authError.message).toContain('Invalid API key');
+        expect(authError.message).toContain('vercel.com/d?to=');
         expect(authError.statusCode).toBe(401);
         expect(authError.type).toBe('authentication_error');
       }
@@ -755,7 +756,8 @@ describe('GatewayLanguageModel', () => {
       } catch (error) {
         expect(GatewayAuthenticationError.isInstance(error)).toBe(true);
         const authError = error as GatewayAuthenticationError;
-        expect(authError.message).toContain('Invalid API key provided');
+        expect(authError.message).toContain('Invalid API key');
+        expect(authError.message).toContain('vercel.com/d?to=');
         expect(authError.statusCode).toBe(401);
         expect(authError.type).toBe('authentication_error');
       }


### PR DESCRIPTION
# Improve Auth Error Messages for AI Gateway

## Background

Authentication error messages in the AI Gateway were verbose and lacked clear guidance on how to resolve authentication issues. This change improves the user experience by providing more concise error messages with direct links and commands to help users resolve authentication problems.

## Summary

This PR enhances authentication error messages in the AI Gateway by:

- Adding direct links to create API keys
- Including specific commands like `npx vercel link` and `vc env pull` to guide users
- Simplifying error messages with clearer instructions for both API key and OIDC token authentication
- Organizing the "no authentication" error message into clear numbered options
- Removing unnecessary verbose explanations while keeping essential information

## Manual Verification

Verified that the updated error messages appear correctly when authentication fails, and that the links and commands provided are accurate.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)