### PR TITLE
feat(ui): add isDataUIPart helper

### DIFF
--- a/.changeset/curvy-lions-accept.md
+++ b/.changeset/curvy-lions-accept.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ui): add isDataUIPart helper

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -33,6 +33,7 @@ export { TextStreamChatTransport } from './text-stream-chat-transport';
 export {
   getToolName,
   getToolOrDynamicToolName,
+  isDataUIPart,
   isToolOrDynamicToolUIPart,
   isToolUIPart,
   type DataUIPart,

--- a/packages/ai/src/ui/ui-messages.test.ts
+++ b/packages/ai/src/ui/ui-messages.test.ts
@@ -27,7 +27,6 @@ describe('getToolName', () => {
   });
 });
 
-
 describe('isDataUIPart', () => {
   it('should return true if the part is a data part', () => {
     expect(

--- a/packages/ai/src/ui/ui-messages.test.ts
+++ b/packages/ai/src/ui/ui-messages.test.ts
@@ -1,5 +1,5 @@
-import { getToolName } from './ui-messages';
 import { describe, it, expect } from 'vitest';
+import { getToolName, isDataUIPart } from './ui-messages';
 
 describe('getToolName', () => {
   it('should return the tool name after the "tool-" prefix', () => {
@@ -24,5 +24,26 @@ describe('getToolName', () => {
         output: 'some result',
       }),
     ).toBe('get-location');
+  });
+});
+
+
+describe('isDataUIPart', () => {
+  it('should return true if the part is a data part', () => {
+    expect(
+      isDataUIPart({
+        type: 'data-someDataPart',
+        data: 'some data',
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false if the part is not a data part', () => {
+    expect(
+      isDataUIPart({
+        type: 'text',
+        text: 'some text',
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -202,6 +202,9 @@ type asUITool<TOOL extends UITool | Tool> = TOOL extends Tool
   ? InferUITool<TOOL>
   : TOOL;
 
+/**
+ * Check if a message part is a data part.
+ */
 export function isDataUIPart<DATA_TYPES extends UIDataTypes>(
   part: UIMessagePart<DATA_TYPES, UITools>,
 ): part is DataUIPart<DATA_TYPES> {

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -202,6 +202,12 @@ type asUITool<TOOL extends UITool | Tool> = TOOL extends Tool
   ? InferUITool<TOOL>
   : TOOL;
 
+export function isDataUIPart<DATA_TYPES extends UIDataTypes>(
+  part: UIMessagePart<DATA_TYPES, UITools>,
+): part is DataUIPart<DATA_TYPES> {
+  return part.type.startsWith('data-');
+}
+
 /**
  * A UI tool invocation contains all the information needed to render a tool invocation in the UI.
  * It can be derived from a tool without knowing the tool name, and can be used to define


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Often, I need to tell if a part is some kind of data part. For example, if I want to have a generic renderer for all data parts. I could write `part.type.startsWith('data-')`, but it's much more convenient to import a helper.
<!-- Why was this change necessary? -->

## Summary

Added the function `isDataUiPart` as an analog to `isToolUIPart`.

<!-- What did you change? -->

## Manual Verification

I imported and used this function in my application with `pnpm i <ai package checkout path>` and validated it works as expected.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
