### PR TITLE
fix(docs): update/add loop stop information

### DIFF
--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -91,7 +91,9 @@ const agent = new Agent({
 
 Each step represents one generation (which results in either text or a tool call). The loop continues until:
 
-- The model generates text instead of calling a tool, or
+- A finish reasoning other than tool-calls is returned, or
+- A tool that is invoked does not have an execute function, or
+- A tool call needs approval, or
 - A stop condition is met
 
 You can combine multiple conditions:

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -5,7 +5,14 @@ description: Control agent execution with built-in loop management using stopWhe
 
 # Loop Control
 
-You can control both the execution flow and the settings at each step of the agent loop. The AI SDK provides built-in loop control through two parameters: `stopWhen` for defining stopping conditions and `prepareStep` for modifying settings (model, tools, messages, and more) between steps.
+You can control both the execution flow and the settings at each step of the agent loop. The loop continues until:
+
+- A finish reasoning other than tool-calls is returned, or
+- A tool that is invoked does not have an execute function, or
+- A tool call needs approval, or
+- A stop condition is met
+
+The AI SDK provides built-in loop control through two parameters: `stopWhen` for defining stopping conditions and `prepareStep` for modifying settings (model, tools, messages, and more) between steps.
 
 ## Stop Conditions
 


### PR DESCRIPTION
## Background

Users kept asking about how to stop agents, and other users recommended bad patterns in response, pointing to a larger misunderstanding of the loop stop concepts.

## Summary

Clarify loop stop reasons. Add loop stop information to loop control page as well.