### PR TITLE
chore(docs): Update anthropic provider page with `disableParallelToolUse` provider option

### DIFF
--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -159,6 +159,12 @@ Without this header, tool inputs and structured outputs may arrive all at once a
 
 The following optional provider options are available for Anthropic models:
 
+- `disableParallelToolUse` _boolean_
+
+  Optional. Disables the use of parallel tool calls. Defaults to `false`.
+
+  When set to `true`, the model will only call one tool at a time instead of potentially calling multiple tools in parallel.
+
 - `sendReasoning` _boolean_
 
   Optional. Include reasoning content in requests sent to the model. Defaults to `true`.


### PR DESCRIPTION
## Background

The Anthropic provider supports a `disableParallelToolUse` option (similar to OpenAI's `parallelToolCalls`), but it wasn't documented on the provider page.

OpenAI has: 
<img width="671" height="102" alt="Screenshot 2025-10-17 at 12 59 25 PM" src="https://github.com/user-attachments/assets/7a1df869-fe15-406e-a8df-60c14a98db2d" />

## Summary

Added documentation for the `disableParallelToolUse` provider option to the Anthropic provider page. This matches the style used in the OpenAI provider docs where `parallelToolCalls` is documented.

The option allows users to disable parallel tool calling, forcing the model to only call one tool at a time instead of potentially calling multiple tools in parallel.