### PR TITLE
chore(agent): rename BasicAgent to ToolLoopAgent

### DIFF
--- a/.changeset/thin-comics-rescue.md
+++ b/.changeset/thin-comics-rescue.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(agent): rename BasicAgent to ToolLoopAgent

--- a/content/docs/03-agents/01-overview.mdx
+++ b/content/docs/03-agents/01-overview.mdx
@@ -15,15 +15,15 @@ These components work together:
   - **Context management** - Maintaining conversation history and deciding what the model sees (input) at each step
   - **Stopping conditions** - Determining when the loop (task) is complete
 
-## Agent Class
+## ToolLoopAgent Class
 
-The Agent class handles these three components. Here's an agent that uses multiple tools in a loop to accomplish a task:
+The ToolLoopAgent class handles these three components. Here's an agent that uses multiple tools in a loop to accomplish a task:
 
 ```ts
-import { Agent, stepCountIs, tool } from 'ai';
+import { ToolLoopAgent, stepCountIs, tool } from 'ai';
 import { z } from 'zod';
 
-const weatherAgent = new Agent({
+const weatherAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     weather: tool({

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -7,7 +7,7 @@ description: Complete guide to creating agents with the Agent class.
 
 The Agent class provides a structured way to encapsulate LLM configuration, tools, and behavior into reusable components. It handles the agent loop for you, allowing the LLM to call tools multiple times in sequence to accomplish complex tasks. Define agents once and use them across your application.
 
-## Why Use the Agent Class?
+## Why Use the ToolLoopAgent Class?
 
 When building AI applications, you often need to:
 
@@ -16,16 +16,16 @@ When building AI applications, you often need to:
 - **Simplify API routes** - Reduce boilerplate in your endpoints
 - **Type safety** - Get full TypeScript support for your agent's tools and outputs
 
-The Agent class provides a single place to define your agent's behavior.
+The ToolLoopAgent class provides a single place to define your agent's behavior.
 
 ## Creating an Agent
 
-Define an agent by instantiating the Agent class with your desired configuration:
+Define an agent by instantiating the ToolLoopAgent class with your desired configuration:
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const myAgent = new Agent({
+const myAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: 'You are a helpful assistant.',
   tools: {
@@ -41,9 +41,9 @@ The Agent class accepts all the same settings as `generateText` and `streamText`
 ### Model and System Prompt
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: 'You are an expert software engineer.',
 });
@@ -54,10 +54,10 @@ const agent = new Agent({
 Provide tools that the agent can use to accomplish tasks:
 
 ```ts
-import { Agent, tool } from 'ai';
+import { ToolLoopAgent, tool } from 'ai';
 import { z } from 'zod';
 
-const codeAgent = new Agent({
+const codeAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     runCode: tool({
@@ -81,9 +81,9 @@ By default, agents run for 20 steps (`stopWhen: stepCountIs(20)`). In each step,
 To let agents call multiple tools in sequence, configure `stopWhen` to allow more steps. After each tool execution, the agent triggers a new generation where the model can call another tool or generate text:
 
 ```ts
-import { Agent, stepCountIs } from 'ai';
+import { ToolLoopAgent, stepCountIs } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   stopWhen: stepCountIs(20), // Allow up to 20 steps
 });
@@ -99,9 +99,9 @@ Each step represents one generation (which results in either text or a tool call
 You can combine multiple conditions:
 
 ```ts
-import { Agent, stepCountIs } from 'ai';
+import { ToolLoopAgent, stepCountIs } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   stopWhen: [
     stepCountIs(20), // Maximum 20 steps
@@ -117,9 +117,9 @@ Learn more about [loop control and stop conditions](/docs/agents/loop-control).
 Control how the agent uses tools:
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     // your tools here
@@ -133,9 +133,9 @@ const agent = new Agent({
 You can also force the use of a specific tool:
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     weather: weatherTool,
@@ -153,10 +153,10 @@ const agent = new Agent({
 Define structured output schemas:
 
 ```ts
-import { Agent, Output, stepCountIs } from 'ai';
+import { ToolLoopAgent, Output, stepCountIs } from 'ai';
 import { z } from 'zod';
 
-const analysisAgent = new Agent({
+const analysisAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   experimental_output: Output.object({
     schema: z.object({
@@ -182,7 +182,7 @@ System prompts define your agent's behavior, personality, and constraints. They 
 Set the agent's role and expertise:
 
 ```ts
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system:
     'You are an expert data analyst. You provide clear insights from complex data.',
@@ -194,7 +194,7 @@ const agent = new Agent({
 Provide specific guidelines for agent behavior:
 
 ```ts
-const codeReviewAgent = new Agent({
+const codeReviewAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: `You are a senior software engineer conducting code reviews.
 
@@ -212,7 +212,7 @@ const codeReviewAgent = new Agent({
 Set boundaries and ensure consistent behavior:
 
 ```ts
-const customerSupportAgent = new Agent({
+const customerSupportAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: `You are a customer support specialist for an e-commerce platform.
 
@@ -235,7 +235,7 @@ const customerSupportAgent = new Agent({
 Guide how the agent should use available tools:
 
 ```ts
-const researchAgent = new Agent({
+const researchAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: `You are a research assistant with access to search and document tools.
 
@@ -258,7 +258,7 @@ const researchAgent = new Agent({
 Control the output format and communication style:
 
 ```ts
-const technicalWriterAgent = new Agent({
+const technicalWriterAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: `You are a technical documentation writer.
 
@@ -322,12 +322,12 @@ export async function POST(request: Request) {
 
 ## End-to-end Type Safety
 
-You can infer types for your Agent's `UIMessage`s:
+You can infer types for your agent's `UIMessage`s:
 
 ```ts
-import { Agent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-const myAgent = new Agent({
+const myAgent = new ToolLoopAgent({
   // ... configuration
 });
 

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -25,9 +25,9 @@ When you provide `stopWhen`, the agent continues executing after tool calls unti
 The AI SDK provides several built-in stopping conditions:
 
 ```ts
-import { Agent, stepCountIs } from 'ai';
+import { ToolLoopAgent, stepCountIs } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     // your tools
@@ -45,9 +45,9 @@ const result = await agent.generate({
 Combine multiple stopping conditions. The loop stops when it meets any condition:
 
 ```ts
-import { Agent, stepCountIs, hasToolCall } from 'ai';
+import { ToolLoopAgent, stepCountIs, hasToolCall } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     // your tools
@@ -68,7 +68,7 @@ const result = await agent.generate({
 Build custom stopping conditions for specific requirements:
 
 ```ts
-import { Agent, StopCondition, ToolSet } from 'ai';
+import { ToolLoopAgent, StopCondition, ToolSet } from 'ai';
 
 const tools = {
   // your tools
@@ -79,7 +79,7 @@ const hasAnswer: StopCondition<typeof tools> = ({ steps }) => {
   return steps.some(step => step.text?.includes('ANSWER:')) ?? false;
 };
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools,
   stopWhen: hasAnswer,
@@ -117,9 +117,9 @@ The `prepareStep` callback runs before each step in the loop and defaults to the
 Switch models based on step requirements:
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o-mini', // Default model
   tools: {
     // your tools
@@ -146,9 +146,9 @@ const result = await agent.generate({
 Manage growing conversation history in long-running loops:
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     // your tools
@@ -177,9 +177,9 @@ const result = await agent.generate({
 Control which tools are available at each step:
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     search: searchTool,
@@ -242,9 +242,9 @@ prepareStep: async ({ stepNumber }) => {
 Transform messages before sending them to the model:
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: {
     // your tools

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -1,18 +1,18 @@
 ---
-title: Agent
+title: ToolLoopAgent
 description: API Reference for the Agent class.
 ---
 
-# `Agent`
+# `ToolLoopAgent`
 
 Creates a reusable AI agent that can generate text, stream responses, and use tools across multiple steps.
 
 It is ideal for building autonomous AI systems that need to perform complex, multi-step tasks with tool calling capabilities. Unlike single-step functions like `generateText`, agents can iteratively call tools and make decisions based on intermediate results.
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: 'You are a helpful assistant.',
   tools: {
@@ -299,9 +299,9 @@ Returns a `Response` object that streams UI messages to the client in the format
 Infers the UI message type of an agent, useful for type-safe message handling in TypeScript applications.
 
 ```ts
-import { Agent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-const weatherAgent = new Agent({
+const weatherAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   tools: { weather: weatherTool },
 });
@@ -316,10 +316,10 @@ type WeatherAgentUIMessage = InferAgentUIMessage<typeof weatherAgent>;
 Create an agent that can use multiple tools to answer questions:
 
 ```ts
-import { Agent, stepCountIs } from 'ai';
+import { ToolLoopAgent, stepCountIs } from 'ai';
 import { weatherTool, calculatorTool } from './tools';
 
-const assistant = new Agent({
+const assistant = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: 'You are a helpful assistant.',
   tools: {
@@ -343,7 +343,7 @@ console.log(result.steps); // Array of all steps taken
 Stream responses for real-time interaction:
 
 ```ts
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: 'You are a creative storyteller.',
 });
@@ -364,7 +364,7 @@ Parse structured output from agent responses:
 ```ts
 import { z } from 'zod';
 
-const analysisAgent = new Agent({
+const analysisAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   experimental_output: {
     schema: z.object({
@@ -390,7 +390,7 @@ Use an agent in a Next.js API route:
 // app/api/chat/route.ts
 import { Agent } from 'ai';
 
-const agent = new Agent({
+const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
   system: 'You are a helpful assistant.',
   tools: {

--- a/examples/ai-core/src/agent/openai-generate-on-finish.ts
+++ b/examples/ai-core/src/agent/openai-generate-on-finish.ts
@@ -1,8 +1,8 @@
 import { openai } from '@ai-sdk/openai';
-import { BasicAgent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 import { run } from '../lib/run';
 
-const agent = new BasicAgent({
+const agent = new ToolLoopAgent({
   model: openai('gpt-4o'),
   system: 'You are a helpful assistant.',
   onFinish({ text }) {

--- a/examples/ai-core/src/agent/openai-generate.ts
+++ b/examples/ai-core/src/agent/openai-generate.ts
@@ -1,8 +1,8 @@
 import { openai } from '@ai-sdk/openai';
-import { BasicAgent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 import { run } from '../lib/run';
 
-const agent = new BasicAgent({
+const agent = new ToolLoopAgent({
   model: openai('gpt-4o'),
   system: 'You are a helpful assistant.',
 });

--- a/examples/ai-core/src/agent/openai-stream-tools.ts
+++ b/examples/ai-core/src/agent/openai-stream-tools.ts
@@ -1,9 +1,9 @@
 import { openai } from '@ai-sdk/openai';
-import { BasicAgent, tool } from 'ai';
+import { ToolLoopAgent, tool } from 'ai';
 import { run } from '../lib/run';
 import { z } from 'zod';
 
-const agent = new BasicAgent({
+const agent = new ToolLoopAgent({
   model: openai('gpt-5'),
   system: 'You are a helpful that answers questions about the weather.',
   tools: {

--- a/examples/ai-core/src/agent/openai-stream.ts
+++ b/examples/ai-core/src/agent/openai-stream.ts
@@ -1,8 +1,8 @@
 import { openai } from '@ai-sdk/openai';
-import { BasicAgent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 import { run } from '../lib/run';
 
-const agent = new BasicAgent({
+const agent = new ToolLoopAgent({
   model: openai('gpt-5'),
   system: 'You are a helpful assistant.',
 });

--- a/examples/next-agent/agent/weather-agent.ts
+++ b/examples/next-agent/agent/weather-agent.ts
@@ -1,8 +1,8 @@
 import { weatherTool } from '@/tool/weather-tool';
 import { openai } from '@ai-sdk/openai';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const weatherAgent = new BasicAgent({
+export const weatherAgent = new ToolLoopAgent({
   model: openai('gpt-4o'),
   system: 'You are a helpful assistant.',
   tools: {

--- a/examples/next-openai/agent/anthropic-code-execution-agent.ts
+++ b/examples/next-openai/agent/anthropic-code-execution-agent.ts
@@ -1,7 +1,7 @@
 import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const anthropicCodeExecutionAgent = new BasicAgent({
+export const anthropicCodeExecutionAgent = new ToolLoopAgent({
   model: anthropic('claude-sonnet-4-5'),
   tools: {
     code_execution: anthropic.tools.codeExecution_20250825(),

--- a/examples/next-openai/agent/anthropic-mcp-agent.ts
+++ b/examples/next-openai/agent/anthropic-mcp-agent.ts
@@ -1,7 +1,7 @@
 import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const anthropicMcpAgent = new BasicAgent({
+export const anthropicMcpAgent = new ToolLoopAgent({
   model: anthropic('claude-sonnet-4-5'),
   providerOptions: {
     anthropic: {

--- a/examples/next-openai/agent/dynamic-weather-with-approval-agent.ts
+++ b/examples/next-openai/agent/dynamic-weather-with-approval-agent.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { BasicAgent, dynamicTool, InferAgentUIMessage, ToolSet } from 'ai';
+import { ToolLoopAgent, dynamicTool, InferAgentUIMessage, ToolSet } from 'ai';
 import { z } from 'zod';
 
 function randomWeather() {
@@ -28,7 +28,7 @@ const weatherTool = dynamicTool({
 // type as generic ToolSet (tools are not known at development time)
 const tools: {} = { weather: weatherTool } satisfies ToolSet;
 
-export const dynamicWeatherWithApprovalAgent = new BasicAgent({
+export const dynamicWeatherWithApprovalAgent = new ToolLoopAgent({
   model: anthropic('claude-sonnet-4-5'),
   // context engineering required to make sure the model does not retry
   // the tool execution if it is not approved:

--- a/examples/next-openai/agent/openai-fetch-pdf-custom-tool-agent.ts
+++ b/examples/next-openai/agent/openai-fetch-pdf-custom-tool-agent.ts
@@ -1,8 +1,8 @@
 import { fetchPdfTool } from '@/tool/fetch-pdf-tool';
 import { openai } from '@ai-sdk/openai';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const openaiFetchPdfCustomToolAgent = new BasicAgent({
+export const openaiFetchPdfCustomToolAgent = new ToolLoopAgent({
   model: openai('gpt-5-mini'),
   tools: {
     fetchPdf: fetchPdfTool,

--- a/examples/next-openai/agent/openai-image-generation-custom-tool-agent.ts
+++ b/examples/next-openai/agent/openai-image-generation-custom-tool-agent.ts
@@ -1,8 +1,8 @@
 import { generateImageTool } from '@/tool/generate-image-tool';
 import { openai } from '@ai-sdk/openai';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const openaiImageGenerationCustomToolAgent = new BasicAgent({
+export const openaiImageGenerationCustomToolAgent = new ToolLoopAgent({
   model: openai('gpt-5-mini'),
   tools: {
     imageGeneration: generateImageTool,

--- a/examples/next-openai/agent/openai-local-shell-agent.ts
+++ b/examples/next-openai/agent/openai-local-shell-agent.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { Sandbox } from '@vercel/sandbox';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
 // warning: this is a demo sandbox that is shared across chats on localhost
 let globalSandboxId: string | null = null;
@@ -13,7 +13,7 @@ async function getSandbox(): Promise<Sandbox> {
   return sandbox;
 }
 
-export const openaiLocalShellAgent = new BasicAgent({
+export const openaiLocalShellAgent = new ToolLoopAgent({
   model: openai('gpt-5-codex'),
   system:
     'You are an agent with access to a shell environment.' +

--- a/examples/next-openai/agent/openai-web-search-agent.ts
+++ b/examples/next-openai/agent/openai-web-search-agent.ts
@@ -1,7 +1,7 @@
 import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const openaiWebSearchAgent = new BasicAgent({
+export const openaiWebSearchAgent = new ToolLoopAgent({
   model: openai('gpt-5-mini'),
   tools: {
     web_search: openai.tools.webSearch({

--- a/examples/next-openai/agent/weather-valibot-agent.ts
+++ b/examples/next-openai/agent/weather-valibot-agent.ts
@@ -1,8 +1,8 @@
 import { weatherToolValibot } from '@/tool/weather-tool-valibot';
 import { anthropic } from '@ai-sdk/anthropic';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const weatherValibotAgent = new BasicAgent({
+export const weatherValibotAgent = new ToolLoopAgent({
   model: anthropic('claude-sonnet-4-5'),
   tools: {
     weather: weatherToolValibot,

--- a/examples/next-openai/agent/weather-with-approval-agent.ts
+++ b/examples/next-openai/agent/weather-with-approval-agent.ts
@@ -1,8 +1,8 @@
 import { weatherToolWithApproval } from '@/tool/weather-tool-with-approval';
 import { anthropic } from '@ai-sdk/anthropic';
-import { BasicAgent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const weatherWithApprovalAgent = new BasicAgent({
+export const weatherWithApprovalAgent = new ToolLoopAgent({
   model: anthropic('claude-sonnet-4-5'),
   // context engineering required to make sure the model does not retry
   // the tool execution if it is not approved:

--- a/examples/next-openai/app/api/chat-openai-image-generation/route.ts
+++ b/examples/next-openai/app/api/chat-openai-image-generation/route.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
-import { BasicAgent, InferAgentUIMessage, validateUIMessages } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage, validateUIMessages } from 'ai';
 
-const imageGenerationAgent = new BasicAgent({
+const imageGenerationAgent = new ToolLoopAgent({
   model: openai('gpt-5-nano'),
   tools: {
     image_generation: openai.tools.imageGeneration({

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -69,9 +69,9 @@ const { object } = await generateObject({
 ### Agents
 
 ```ts
-import { Agent } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
-const sandboxAgent = new Agent({
+const sandboxAgent = new ToolLoopAgent({
   model: 'openai/gpt-5-codex',
   system: 'You are an agent with access to a shell environment.',
   tools: {
@@ -101,9 +101,9 @@ npm install @ai-sdk/react
 
 ```ts
 import { openai } from '@ai-sdk/openai';
-import { Agent, InferAgentUIMessage } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 
-export const imageGenerationAgent = new Agent({
+export const imageGenerationAgent = new ToolLoopAgent({
   model: openai('gpt-5'),
   tools: {
     image_generation: openai.tools.imageGeneration({

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -5,8 +5,11 @@ import { Prompt } from '../prompt/prompt';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
 
 /**
- * An agent is a reusable component that that has tools and that
- * can generate or stream content.
+ * An Agent receives a prompt (text or messages) and generates or streams an output
+ * that consists of steps, tool calls, data parts, etc.
+ *
+ * You can implement your own Agent by implementing the `Agent` interface,
+ * or use the `ToolLoopAgent` class.
  */
 export interface Agent<
   TOOLS extends ToolSet = {},

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -1,22 +1,22 @@
 export { type Agent } from './agent';
-export { type BasicAgentOnFinishCallback } from './basic-agent-on-finish-callback';
-export { type BasicAgentOnStepFinishCallback } from './basic-agent-on-step-finish-callback';
+export { type ToolLoopAgentOnFinishCallback } from './tool-loop-agent-on-finish-callback';
+export { type ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-finish-callback';
 export {
-  type BasicAgentSettings,
+  type ToolLoopAgentSettings,
 
   /**
-   * @deprecated Use `BasicAgentSettings` instead.
+   * @deprecated Use `ToolLoopAgentSettings` instead.
    */
-  type BasicAgentSettings as Experimental_AgentSettings,
-} from './basic-agent-settings';
+  type ToolLoopAgentSettings as Experimental_AgentSettings,
+} from './tool-loop-agent-settings';
 export {
-  BasicAgent,
+  ToolLoopAgent,
 
   /**
-   * @deprecated Use `BasicAgent` instead.
+   * @deprecated Use `ToolLoopAgent` instead.
    */
-  BasicAgent as Experimental_Agent,
-} from './basic-agent';
+  ToolLoopAgent as Experimental_Agent,
+} from './tool-loop-agent';
 export {
   /**
    * @deprecated Use `InferAgentUIMessage` instead.

--- a/packages/ai/src/agent/infer-agent-ui-message.test-d.ts
+++ b/packages/ai/src/agent/infer-agent-ui-message.test-d.ts
@@ -10,12 +10,12 @@ import {
   TextUIPart,
   UIMessage,
 } from '../ui/ui-messages';
-import { BasicAgent } from './basic-agent';
+import { ToolLoopAgent } from './tool-loop-agent';
 import { InferAgentUIMessage } from './infer-agent-ui-message';
 
 describe('InferAgentUIMessage', () => {
   it('should not contain arbitrary static tools when no tools are provided', () => {
-    const baseAgent = new BasicAgent({
+    const baseAgent = new ToolLoopAgent({
       model: 'openai/gpt-4o',
       // no tools
     });

--- a/packages/ai/src/agent/tool-loop-agent-on-finish-callback.ts
+++ b/packages/ai/src/agent/tool-loop-agent-on-finish-callback.ts
@@ -7,7 +7,7 @@ Callback that is set using the `onFinish` option.
 
 @param event - The event that is passed to the callback.
  */
-export type BasicAgentOnFinishCallback<TOOLS extends ToolSet = {}> = (
+export type ToolLoopAgentOnFinishCallback<TOOLS extends ToolSet = {}> = (
   event: StepResult<TOOLS> & {
     /**
 Details for all steps.

--- a/packages/ai/src/agent/tool-loop-agent-on-step-finish-callback.ts
+++ b/packages/ai/src/agent/tool-loop-agent-on-step-finish-callback.ts
@@ -6,6 +6,6 @@ Callback that is set using the `onStepFinish` option.
 
 @param stepResult - The result of the step.
  */
-export type BasicAgentOnStepFinishCallback<TOOLS extends ToolSet = {}> = (
+export type ToolLoopAgentOnStepFinishCallback<TOOLS extends ToolSet = {}> = (
   stepResult: StepResult<TOOLS>,
 ) => Promise<void> | void;

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -7,13 +7,13 @@ import { ToolSet } from '../generate-text/tool-set';
 import { CallSettings } from '../prompt/call-settings';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { LanguageModel, ToolChoice } from '../types/language-model';
-import { BasicAgentOnFinishCallback } from './basic-agent-on-finish-callback';
-import { BasicAgentOnStepFinishCallback } from './basic-agent-on-step-finish-callback';
+import { ToolLoopAgentOnFinishCallback } from './tool-loop-agent-on-finish-callback';
+import { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-finish-callback';
 
 /**
  * Configuration options for an agent.
  */
-export type BasicAgentSettings<
+export type ToolLoopAgentSettings<
   TOOLS extends ToolSet = {},
   OUTPUT = never,
   OUTPUT_PARTIAL = never,
@@ -87,12 +87,12 @@ A function that attempts to repair a tool call that failed to parse.
   /**
    * Callback that is called when each step (LLM call) is finished, including intermediate steps.
    */
-  onStepFinish?: BasicAgentOnStepFinishCallback<NoInfer<TOOLS>>;
+  onStepFinish?: ToolLoopAgentOnStepFinishCallback<NoInfer<TOOLS>>;
 
   /**
    * Callback that is called when all steps are finished and the response is complete.
    */
-  onFinish?: BasicAgentOnFinishCallback<NoInfer<TOOLS>>;
+  onFinish?: ToolLoopAgentOnFinishCallback<NoInfer<TOOLS>>;
 
   /**
 Additional provider-specific options. They are passed through

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { BasicAgent } from './basic-agent';
+import { ToolLoopAgent } from './tool-loop-agent';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
 import { LanguageModelV3CallOptions } from '@ai-sdk/provider';
 import {
@@ -9,7 +9,7 @@ import {
 import { tool } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
-describe('BasicAgent', () => {
+describe('ToolLoopAgent', () => {
   describe('respond', () => {
     describe('when using tools toModelOutput', () => {
       let recordedInputs: LanguageModelV3CallOptions[];
@@ -19,7 +19,7 @@ describe('BasicAgent', () => {
       beforeEach(async () => {
         recordedInputs = [];
 
-        const agent = new BasicAgent({
+        const agent = new ToolLoopAgent({
           model: new MockLanguageModelV3({
             doStream: async input => {
               recordedInputs.push(input);

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -7,27 +7,33 @@ import { ToolSet } from '../generate-text/tool-set';
 import { Prompt } from '../prompt/prompt';
 import { convertToModelMessages } from '../ui/convert-to-model-messages';
 import { InferUITools, UIMessage } from '../ui/ui-messages';
-import { BasicAgentSettings } from './basic-agent-settings';
+import { ToolLoopAgentSettings } from './tool-loop-agent-settings';
 import { Agent } from './agent';
 
 /**
- * The Agent class provides a structured way to encapsulate LLM configuration, tools,
- * and behavior into reusable components.
+ * A tool loop agent is an agent that runs tools in a loop. In each step,
+ * it calls the LLM, and if there are tool calls, it executes the tools
+ * and calls the LLM again in a new step with the tool results.
  *
- * It handles the agent loop for you, allowing the LLM to call tools multiple times in
- * sequence to accomplish complex tasks.
- *
- * Define agents once and use them across your application.
+ * The loop continues until:
+ * - A finish reasoning other than tool-calls is returned, or
+ * - A tool that is invoked does not have an execute function, or
+ * - A tool call needs approval, or
+ * - A stop condition is met (default stop condition is stepCountIs(20))
  */
-export class BasicAgent<
+export class ToolLoopAgent<
   TOOLS extends ToolSet = {},
   OUTPUT = never,
   OUTPUT_PARTIAL = never,
 > implements Agent<TOOLS, OUTPUT, OUTPUT_PARTIAL>
 {
-  private readonly settings: BasicAgentSettings<TOOLS, OUTPUT, OUTPUT_PARTIAL>;
+  private readonly settings: ToolLoopAgentSettings<
+    TOOLS,
+    OUTPUT,
+    OUTPUT_PARTIAL
+  >;
 
-  constructor(settings: BasicAgentSettings<TOOLS, OUTPUT, OUTPUT_PARTIAL>) {
+  constructor(settings: ToolLoopAgentSettings<TOOLS, OUTPUT, OUTPUT_PARTIAL>) {
     this.settings = settings;
   }
 


### PR DESCRIPTION
## Background

The name `BasicAgent` is not descriptive or helpful. It does not explain how this agent works. There can be different agent implementation, e.g. `OrchestratorAgent`, and it should be easy to get a mental model of what they do by reading the class name.

## Summary

Rename `BasicAgent` to `ToolLoopAgent`.
