### PR TITLE
feat(agent): introduce version property

### DIFF
--- a/.changeset/strong-otters-lie.md
+++ b/.changeset/strong-otters-lie.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(agent): introduce version property

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -17,14 +17,20 @@ export interface Agent<
   OUTPUT_PARTIAL = never,
 > {
   /**
+   * The specification version of the agent interface. This will enable
+   * us to evolve the agent interface and retain backwards compatibility.
+   */
+  readonly version: 'agent-v1';
+
+  /**
    * The id of the agent.
    */
-  id: string | undefined;
+  readonly id: string | undefined;
 
   /**
    * The tools that the agent can use.
    */
-  tools: TOOLS;
+  readonly tools: TOOLS;
 
   /**
    * Generates an output from the agent (non-streaming).

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -27,6 +27,8 @@ export class ToolLoopAgent<
   OUTPUT_PARTIAL = never,
 > implements Agent<TOOLS, OUTPUT, OUTPUT_PARTIAL>
 {
+  readonly version = 'agent-v1';
+
   private readonly settings: ToolLoopAgentSettings<
     TOOLS,
     OUTPUT,


### PR DESCRIPTION
## Background

We need to support for evolutions of the `Agent` interface while retaining backwards compatibility.

## Summary

Introduce `version` property with value `agent-v1` to enable future versioning and discriminated unions for backwards compatibility.