### PR TITLE
feat(provider/anthropic): expose container from response in provider metadata

### DIFF
--- a/.changeset/silly-maps-thank.md
+++ b/.changeset/silly-maps-thank.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(provider/anthropic): expose container from response in provider metadata

--- a/examples/ai-core/src/generate-text/anthropic-skills.ts
+++ b/examples/ai-core/src/generate-text/anthropic-skills.ts
@@ -22,4 +22,6 @@ run(async () => {
   });
 
   print('content', result.content);
+
+  console.log(JSON.stringify(result.response.body));
 });

--- a/examples/ai-core/src/generate-text/anthropic-skills.ts
+++ b/examples/ai-core/src/generate-text/anthropic-skills.ts
@@ -1,4 +1,8 @@
-import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import {
+  anthropic,
+  AnthropicMessageMetadata,
+  AnthropicProviderOptions,
+} from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 import { run } from '../lib/run';
 import { print } from '../lib/print';
@@ -21,7 +25,10 @@ run(async () => {
     },
   });
 
-  print('content', result.content);
+  const anthropicContainer = (
+    result.providerMetadata?.anthropic as unknown as AnthropicMessageMetadata
+  )?.container;
 
-  console.log(JSON.stringify(result.response.body));
+  print('content', result.content);
+  print('container', anthropicContainer);
 });

--- a/examples/ai-core/src/generate-text/anthropic-skills.ts
+++ b/examples/ai-core/src/generate-text/anthropic-skills.ts
@@ -4,8 +4,8 @@ import {
   AnthropicProviderOptions,
 } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
-import { run } from '../lib/run';
 import { print } from '../lib/print';
+import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({

--- a/examples/ai-core/src/lib/print-full-stream.ts
+++ b/examples/ai-core/src/lib/print-full-stream.ts
@@ -1,0 +1,34 @@
+import { StreamTextResult } from 'ai';
+
+export async function printFullStream({
+  result,
+}: {
+  result: StreamTextResult<any, any>;
+}) {
+  for await (const chunk of result.fullStream) {
+    switch (chunk.type) {
+      case 'text-delta': {
+        process.stdout.write(chunk.text);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(
+          `\x1b[32m\x1b[1mTool call:\x1b[22m ${JSON.stringify(chunk, null, 2)}\x1b[0m`,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        console.log(
+          `\x1b[32m\x1b[1mTool result:\x1b[22m ${JSON.stringify(chunk, null, 2)}\x1b[0m`,
+        );
+        break;
+      }
+
+      case 'error':
+        console.error('Error:', chunk.error);
+        break;
+    }
+  }
+}

--- a/examples/ai-core/src/lib/print-full-stream.ts
+++ b/examples/ai-core/src/lib/print-full-stream.ts
@@ -14,14 +14,14 @@ export async function printFullStream({
 
       case 'tool-call': {
         console.log(
-          `\x1b[32m\x1b[1mTool call:\x1b[22m ${JSON.stringify(chunk, null, 2)}\x1b[0m`,
+          `\n\x1b[32m\x1b[1mTOOL CALL:\x1b[22m\n${JSON.stringify(chunk, null, 2)}\x1b[0m`,
         );
         break;
       }
 
       case 'tool-result': {
         console.log(
-          `\x1b[32m\x1b[1mTool result:\x1b[22m ${JSON.stringify(chunk, null, 2)}\x1b[0m`,
+          `\n\x1b[32m\x1b[1mTOOL RESULT:\x1b[22m\n${JSON.stringify(chunk, null, 2)}\x1b[0m`,
         );
         break;
       }

--- a/examples/ai-core/src/stream-text/anthropic-mcp.ts
+++ b/examples/ai-core/src/stream-text/anthropic-mcp.ts
@@ -2,6 +2,7 @@ import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { streamText } from 'ai';
 import { run } from '../lib/run';
 import { print } from '../lib/print';
+import { printFullStream } from '../lib/print-full-stream';
 
 run(async () => {
   const result = streamText({
@@ -20,32 +21,7 @@ run(async () => {
     },
   });
 
-  for await (const chunk of result.fullStream) {
-    switch (chunk.type) {
-      case 'text-delta': {
-        process.stdout.write(chunk.text);
-        break;
-      }
-
-      case 'tool-call': {
-        console.log(
-          `\x1b[32m\x1b[1mTool call:\x1b[22m ${JSON.stringify(chunk, null, 2)}\x1b[0m`,
-        );
-        break;
-      }
-
-      case 'tool-result': {
-        console.log(
-          `\x1b[32m\x1b[1mTool result:\x1b[22m ${JSON.stringify(chunk, null, 2)}\x1b[0m`,
-        );
-        break;
-      }
-
-      case 'error':
-        console.error('Error:', chunk.error);
-        break;
-    }
-  }
+  await printFullStream({ result });
 
   console.log();
   print('Request body:', (await result.request).body);

--- a/examples/ai-core/src/stream-text/anthropic-skills.ts
+++ b/examples/ai-core/src/stream-text/anthropic-skills.ts
@@ -1,0 +1,26 @@
+import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+import { saveRawChunks } from '../lib/save-raw-chunks';
+
+run(async () => {
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-5'),
+    tools: {
+      code_execution: anthropic.tools.codeExecution_20250825(),
+    },
+    prompt:
+      'Create a presentation about renewable energy sources with 4 slides. ' +
+      'Include: 1) Title slide, 2) Solar power, 3) Wind energy, 4) Conclusion.',
+    providerOptions: {
+      anthropic: {
+        container: {
+          skills: [{ type: 'anthropic', skillId: 'pptx' }],
+        },
+      } satisfies AnthropicProviderOptions,
+    },
+    includeRawChunks: true,
+  });
+
+  saveRawChunks({ result, filename: 'anthropic-skills' });
+});

--- a/examples/ai-core/src/stream-text/anthropic-skills.ts
+++ b/examples/ai-core/src/stream-text/anthropic-skills.ts
@@ -1,7 +1,12 @@
-import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import {
+  anthropic,
+  AnthropicMessageMetadata,
+  AnthropicProviderOptions,
+} from '@ai-sdk/anthropic';
 import { streamText } from 'ai';
+import { print } from '../lib/print';
+import { printFullStream } from '../lib/print-full-stream';
 import { run } from '../lib/run';
-import { saveRawChunks } from '../lib/save-raw-chunks';
 
 run(async () => {
   const result = streamText({
@@ -19,8 +24,14 @@ run(async () => {
         },
       } satisfies AnthropicProviderOptions,
     },
-    includeRawChunks: true,
   });
 
-  saveRawChunks({ result, filename: 'anthropic-skills' });
+  await printFullStream({ result });
+
+  const anthropicContainer = (
+    (await result.providerMetadata)
+      ?.anthropic as unknown as AnthropicMessageMetadata
+  )?.container;
+
+  print('container', anthropicContainer);
 });

--- a/packages/anthropic/src/__fixtures__/anthropic-code-execution-20250825.pptx-skill.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-code-execution-20250825.pptx-skill.chunks.txt
@@ -1,0 +1,691 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01Bu3u6DZfwcuhDWUQMQJz39","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":2751,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":2,"service_tier":"standard"}}}
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I nee"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d to create a PowerPoint presentation about renewable"}}
+{"type":"ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" energy sources. Let me first read the"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" PPTX skill file to understand the proper approach"}}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}}
+{"type":"content_block_stop","index":0}
+{"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"co"}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"mmand\": \""}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"view\""}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":", \"path\": \""}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"/skills"}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"/pptx/"}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"SKILL"}}
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":".md\"}"}}
+{"type":"content_block_stop","index":1}
+{"type":"content_block_start","index":2,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK","content":{"type":"text_editor_code_execution_view_result","file_type":"text","content":"---\nname: PowerPoint Suite\ndescription: Presentation creation, editing, and analysis.\nwhen_to_use: \"When Claude needs to work with presentations (.pptx files) for: (1) Creating new presentations, (2) Modifying or editing content, (3) Working with layouts, (4) Adding comments or speaker notes, or any other presentation tasks\"\nversion: 0.0.3\n---\n\n# PPTX creation, editing, and analysis\n\n## Overview\n\nA user may ask you to create, edit, or analyze the contents of a .pptx file. A .pptx file is essentially a ZIP archive containing XML files and other resources that you can read or edit. You have different tools and workflows available for different tasks.\n\n## Reading and analyzing content\n\n### Text extraction\nIf you just need to read the text contents of a presentation, you should convert the document to markdown:\n\n```bash\n# Convert document to markdown\npython -m markitdown path-to-file.pptx\n```\n\n### Raw XML access\nYou need raw XML access for: comments, speaker notes, slide layouts, animations, design elements, and complex formatting. For any of these ....*: `npm install -g sharp` (for SVG rasterization and image processing)\n- **LibreOffice**: `sudo apt-get install libreoffice` (for PDF conversion)\n- **Poppler**: `sudo apt-get install poppler-utils` (for pdftoppm to convert PDF to images)","num_lines":484,"start_line":1,"total_lines":484}}}
+{"type":"content_block_stop","index":2}
+{"type":"content_block_start","index":3,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":"Now"}}
+{"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":" let me read the html2pptx.md file to understand the detaile"}}
+{"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":"d syntax and best practices for creating presentations:"}}
+{"type":"content_block_stop","index":3}
+{"type":"content_block_start","index":4,"content_block":{"type":"server_tool_use","id":"srvtoolu_016RuxHyUU862TQjFkNrKNVS","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":"{\"command\": "}}
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":"\"view\""}}
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":", \"path"}}
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":"\": \"/"}}
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":"skills/"}}
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":"pptx/htm"}}
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":"l2pptx.md\"}"}}
+{"type":"content_block_stop","index":4}
+{"type":"content_block_start","index":5,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_016RuxHyUU862TQjFkNrKNVS","content":{"type":"text_editor_code_execution_view_result","file_type":"text","content":"# HTML to PowerPoint Guide\n\nConvert HTML slides to PowerPoint presentations with accurate positioning using the `html2pptx.js` library.\n\n## Table of Contents\n\n1. [Creating HTML Slides](#creating-html-slides)\n2. [Using the html2pptx Library](#using-the-html2pptx-library)\n3. [Using PptxGenJS](#using-pptxgenjs)\n\n---\n\n## Creating HTML Slides\n\nEvery HTML slide must include proper body dimensions:\n\n### Layout Dimensions\n\n- **16:9** (default): `width: 720pt; height: 405pt`\n- **4:3**: `width: 720pt; height: 540pt`\n- **16:10**: `width: 720pt; height: 450pt`\n\n### Supported Elements\n\n- `<p>`, `<h1>`-`<h6>` - Text with styling\n- `<ul>`, `<ol>` - Lists (never use manual bullets •, -, *)\n- `<b>`, `<strong>` - Bold text (inline formatting)\n- `<i>`, `<em>` - Italic text (inline formatting)\n- `<u>` - Underlined text (inline formatting)\n- `<span>` - Inline formatting with CSS styles (bold, italic, underline, color)\n- `<div>` with bg/border - Becomes .....e\n- `colW` - Array of column widths (in inches)\n- `rowH` - Array of row heights (in inches)\n- `border` - Border style: `{ pt: 1, color: \"999999\" }`\n- `fill` - Background color (no # prefix)\n- `align` - Text alignment: \"left\", \"center\", \"right\"\n- `valign` - Vertical alignment: \"top\", \"middle\", \"bottom\"\n- `fontSize` - Text size\n- `autoPage` - Auto-create new slides if content overflows","num_lines":626,"start_line":1,"total_lines":626}}}
+{"type":"content_block_stop","index":5}
+{"type":"content_block_start","index":6,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"Perfect"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"! Now I'll create a"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":" presentation about renewable energy sources. Let me think"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":" about the design approach first:\n\n**"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"Design Approach:**\nFor"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":" a renewable energy presentation, I'll use:"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"\n- **Color Palette**: \""}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"Sage & Terracotta\" with"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":" earthy tones -"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":" Sage (#87A96B) for renewable"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"/nature, terracotta (#E07A"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"5F) for solar/energy, cream"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":" (#F4F1DE), and charcoal (#2C2"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"C2C) for text\n- **Typography**: Arial for"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":" clarity and professionalism\n- **Layout**:"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":" Clean, modern design with strong visual hierarchy\n- **Style"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"**: Use color blocks and simple shapes to create visual interest"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"\n\nNow let me create the HTML slides and convert them to Power"}}
+{"type":"content_block_delta","index":6,"delta":{"type":"text_delta","text":"Point:"}}
+{"type":"content_block_stop","index":6}
+{"type":"content_block_start","index":7,"content_block":{"type":"server_tool_use","id":"srvtoolu_0114p62tPzsq7C8QCbZteakb","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"{\"comma"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"nd\": \"c"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"reate\""}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":", \"path\": \""}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"/tmp/slide"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"1."}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"html\""}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":", \"file_"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"tex"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"t\": \""}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"<!DO"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"CTYPE h"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"tml>"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"\\n<html>\\"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"n<"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"head"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":">\\n"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"<style>\\"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"nhtm"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"l "}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"ng"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":" a Sustaina"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"ble Future"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"</p>\\n</div>"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"\\n"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"</body>\\n</"}}
+{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"html>\\n\"}"}}
+{"type":"content_block_stop","index":7}
+{"type":"content_block_start","index":8,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_0114p62tPzsq7C8QCbZteakb","content":{"type":"text_editor_code_execution_create_result","is_file_update":false}}}
+{"type":"content_block_stop","index":8}
+{"type":"content_block_start","index":9,"content_block":{"type":"server_tool_use","id":"srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"{\"comman"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"d\": \"creat"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"e\""}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":", \"path\":"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":" \""}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"/tmp/sl"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"ide2.h"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"tml\""}}
+{"type":"ping"}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":", \"fil"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"e_"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"text\": \"<!DO"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"right"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"-col\\\">\\n"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"    <h"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"2>Key Be"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"nefits</h"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"2>\\n   "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":" <ul"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":">\\n     "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":" <li>Zero gr"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"eenho"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"use gas"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":" emiss"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"ions</li>"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"\\n   "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"   "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"<li>Redu"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"ce"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"s "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"electricity "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"bi"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"lls</li>\\n  "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"    "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"<l"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"i>Low maint"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"en"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"ance c"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"osts</li>\\n"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"   "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"   <li>Scal"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"able f"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"rom "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"homes to lar"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"ge "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"farms</li>"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"\\n      <"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"li>Te"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"chnology "}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"costs decli"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"ning ra"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"pidly</li>\\"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"n    </u"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"l>\\n  </div>"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"\\n</div>\\n<"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"/body>\\n"}}
+{"type":"content_block_delta","index":9,"delta":{"type":"input_json_delta","partial_json":"</html>\\n\"}"}}
+{"type":"content_block_stop","index":9}
+{"type":"content_block_start","index":10,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8","content":{"type":"text_editor_code_execution_create_result","is_file_update":false}}}
+{"type":"content_block_stop","index":10}
+{"type":"content_block_start","index":11,"content_block":{"type":"server_tool_use","id":"srvtoolu_01SKYyUuGjiukko1ScoaPXjC","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"{\""}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"co"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"mmand\": \"cr"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"eate\""}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":", \"path\": \"/"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"tmp/slide3."}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"html"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"\""}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":", \"f"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"ile_t"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"ex"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"t\": \"<!DOC"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"TYPE html>"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"\\n"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"<html>\\"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"n<head"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":">\\n<st"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"yle>"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"\\nh"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"tml { back"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"ground"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":": #ffff"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"ff; }\\n"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"body {"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"\\n  wi"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"dth: "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"720pt"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"; heig"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"ht: 405pt;"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":" marg"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"in: "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"0; padding:"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":" 0;\\n  backg"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"in: 0 "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"0 "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"25pt 0;\\"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"n  "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"line-height"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":": 1.5;\\n"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"}\\nul "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"{\\n  color"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":": #2"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"C2C2C;"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"\\n  font"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"-size: 15p"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"t;\\n  lin"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"e-height: "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"1.8;\\n  ma"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"rgin: "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"0;\\"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"n  "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"paddi"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"ng-left: 20p"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"t;\\n}\\n"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":".highlight"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":" {\\n  backg"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"round: #E07A"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"  "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"    <li>Mi"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"nimal la"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"nd fo"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"otprint</li"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":">\\"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"n      "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"<l"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"i>Offsh"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"or"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"e potentia"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"l is en"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"ormous</"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"li>"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"\\n  "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"  "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"</ul>\\n "}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":" </d"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"iv>\\n</div"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":">\\n</bod"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"y>\\n<"}}
+{"type":"content_block_delta","index":11,"delta":{"type":"input_json_delta","partial_json":"/html>\\n\"}"}}
+{"type":"content_block_stop","index":11}
+{"type":"content_block_start","index":12,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_01SKYyUuGjiukko1ScoaPXjC","content":{"type":"text_editor_code_execution_create_result","is_file_update":false}}}
+{"type":"content_block_stop","index":12}
+{"type":"content_block_start","index":13,"content_block":{"type":"server_tool_use","id":"srvtoolu_01DpSG6m7PmLBK91rfdnJZmf","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"{\"command"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"\": "}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"\"cr"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"eate\""}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":", \""}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"path"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"\": \"/"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"tmp/slide4."}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"html\""}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":", \"file"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"_text\": "}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"\"<!DOCTYPE "}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"e create"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":" a "}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"healthi"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"er"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":" p"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"lanet for "}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"generations "}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"to come."}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"</p>\\"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"n  </div"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":">\\n  <div cl"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"ass=\\\"a"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"cce"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"nt-line\\"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"\"></div>\\n  "}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"<p class=\\\""}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"footer-tex"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"t\\\">The Fu"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"ture "}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"is Renewabl"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"e</p>\\n<"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"/di"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"v>\\n</bo"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"dy>"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"\\n</"}}
+{"type":"content_block_delta","index":13,"delta":{"type":"input_json_delta","partial_json":"html>\\n\"}"}}
+{"type":"content_block_stop","index":13}
+{"type":"content_block_start","index":14,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_01DpSG6m7PmLBK91rfdnJZmf","content":{"type":"text_editor_code_execution_create_result","is_file_update":false}}}
+{"type":"content_block_stop","index":14}
+{"type":"content_block_start","index":15,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":15,"delta":{"type":"text_delta","text":"Now"}}
+{"type":"content_block_delta","index":15,"delta":{"type":"text_delta","text":" let me create the JavaScript file to convert these"}}
+{"type":"content_block_delta","index":15,"delta":{"type":"text_delta","text":" HTML slides to PowerPoint:"}}
+{"type":"content_block_stop","index":15}
+{"type":"content_block_start","index":16,"content_block":{"type":"server_tool_use","id":"srvtoolu_01R8QVDsdupbwxGHwSH31k8c","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"ping"}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"{\"comma"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"nd\": \""}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"crea"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"te\""}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":", \"path\": \"/"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"tmp/cr"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"eate_present"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"at"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"ion.js\""}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":", \"file_text"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"\": "}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"\"con"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"st pp"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"txgen = requ"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"ir"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"e('pp"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"txgenjs');\\n"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"ed success"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"fully!'"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":");\\n}\\n"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"\\ncrea"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"tePresent"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"ation"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"()."}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"catch("}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"co"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"nso"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"le.err"}}
+{"type":"content_block_delta","index":16,"delta":{"type":"input_json_delta","partial_json":"or);\\n\"}"}}
+{"type":"content_block_stop","index":16}
+{"type":"content_block_start","index":17,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_01R8QVDsdupbwxGHwSH31k8c","content":{"type":"text_editor_code_execution_create_result","is_file_update":false}}}
+{"type":"content_block_stop","index":17}
+{"type":"content_block_start","index":18,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":18,"delta":{"type":"text_delta","text":"Now"}}
+{"type":"content_block_delta","index":18,"delta":{"type":"text_delta","text":" let's run the script to create the presentation:"}}
+{"type":"content_block_stop","index":18}
+{"type":"content_block_start","index":19,"content_block":{"type":"server_tool_use","id":"srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg","name":"bash_code_execution","input":{}}}
+{"type":"content_block_delta","index":19,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":19,"delta":{"type":"input_json_delta","partial_json":"{\"command\""}}
+{"type":"content_block_delta","index":19,"delta":{"type":"input_json_delta","partial_json":": \"cd /tmp &"}}
+{"type":"content_block_delta","index":19,"delta":{"type":"input_json_delta","partial_json":"& node "}}
+{"type":"content_block_delta","index":19,"delta":{"type":"input_json_delta","partial_json":"create_"}}
+{"type":"content_block_delta","index":19,"delta":{"type":"input_json_delta","partial_json":"presentat"}}
+{"type":"content_block_delta","index":19,"delta":{"type":"input_json_delta","partial_json":"ion.js\"}"}}
+{"type":"content_block_stop","index":19}
+{"type":"content_block_start","index":20,"content_block":{"type":"bash_code_execution_tool_result","tool_use_id":"srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg","content":{"type":"bash_code_execution_result","stdout":"","stderr":"Error: /tmp/slide4.html: Text box \"The Future is Renewable\" ends too close to bottom edge (0.06\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create_presentation.js:20:5)\n","return_code":0,"content":[]}}}
+{"type":"content_block_stop","index":20}
+{"type":"content_block_start","index":21,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":21,"delta":{"type":"text_delta","text":"I"}}
+{"type":"content_block_delta","index":21,"delta":{"type":"text_delta","text":" need to fix the spacing issue on slide 4. Let me adjust the margins"}}
+{"type":"content_block_delta","index":21,"delta":{"type":"text_delta","text":":"}}
+{"type":"content_block_stop","index":21}
+{"type":"content_block_start","index":22,"content_block":{"type":"server_tool_use","id":"srvtoolu_019LmqPHLi2gTLpQYqwPC9tE","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"{\"comm"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"and\":"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":" \""}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"str_repla"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"ce\""}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":", \"path\""}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":": \"/tmp/slid"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"e4.ht"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"ml\""}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":", \"old"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"_str\":"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":" \".cont"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"ai"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"ne"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"r {\\n  margi"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"n: 60pt;\\n  "}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"text-ali"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"gn: center;\\"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"n}\""}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":", \"n"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"ew_str\":"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":" \".container"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":" {\\n  margin"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":": 50pt "}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"60pt 60pt 60"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"pt;\\n  te"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"xt-"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"align:"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":" c"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":"enter"}}
+{"type":"content_block_delta","index":22,"delta":{"type":"input_json_delta","partial_json":";\\n}\"}"}}
+{"type":"content_block_stop","index":22}
+{"type":"content_block_start","index":23,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_019LmqPHLi2gTLpQYqwPC9tE","content":{"type":"text_editor_code_execution_str_replace_result","old_start":9,"old_lines":7,"new_start":9,"new_lines":7,"lines":["   display: flex; align-items: center; justify-content: center;"," }"," .container {","-  margin: 60pt;","+  margin: 50pt 60pt 60pt 60pt;","   text-align: center;"," }"," h1 {"]}}}
+{"type":"content_block_stop","index":23}
+{"type":"content_block_start","index":24,"content_block":{"type":"server_tool_use","id":"srvtoolu_0161GS82gFRYsaNcv3o3KxPf","name":"bash_code_execution","input":{}}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":"{\""}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":"command"}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":"\": \"cd"}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":" /tmp &&"}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":" node cre"}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":"ate_"}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":"presentatio"}}
+{"type":"content_block_delta","index":24,"delta":{"type":"input_json_delta","partial_json":"n.js\"}"}}
+{"type":"content_block_stop","index":24}
+{"type":"content_block_start","index":25,"content_block":{"type":"bash_code_execution_tool_result","tool_use_id":"srvtoolu_0161GS82gFRYsaNcv3o3KxPf","content":{"type":"bash_code_execution_result","stdout":"","stderr":"Error: /tmp/slide4.html: Text box \"The Future is Renewable\" ends too close to bottom edge (0.13\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create_presentation.js:20:5)\n","return_code":0,"content":[]}}}
+{"type":"content_block_stop","index":25}
+{"type":"content_block_start","index":26,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":26,"delta":{"type":"text_delta","text":"I need more"}}
+{"type":"content_block_delta","index":26,"delta":{"type":"text_delta","text":" spacing. Let me adjust further:"}}
+{"type":"content_block_stop","index":26}
+{"type":"content_block_start","index":27,"content_block":{"type":"server_tool_use","id":"srvtoolu_0183xLGyGvh952zbapjNZD7i","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"{\"command"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"\": \"str_repl"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"ace\""}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":", \"path\": "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"\"/tmp/"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"slide4"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":".html\""}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":", \""}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"old_str\":"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":" \".foot"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"er-text {"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"\\n"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"  color: #8"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"7A96"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"B;\\n  "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"font-size: "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"20p"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"t;\\n  marg"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"in:"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":" 0"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":";\\n  fo"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"nt-w"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"eight: "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"bold;\\n}\\"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"n.ac"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"cent-line {\\"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"n  width: 10"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"0pt"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":";\\n"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"  he"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"igh"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"t: 4pt;\\n  "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"backg"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"rou"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"nd: "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"#E07A5F;\\n "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":" margi"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"n: "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"20pt a"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"uto;\\n}\""}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":", "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"\"n"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"ew_str\": \""}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":".footer"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"-te"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"xt {\\n  col"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"or: #87"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"A96"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"B;\\n  f"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"ont-size: 20"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"pt;\\n  "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"margi"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"n: 0"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":" 0 3"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"0pt"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":" 0;\\n  font-"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"weigh"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"t: bol"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"d;\\n}\\n"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":".accent-li"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"ne {\\n  wi"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"dth: 10"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"0pt;"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"\\n  heig"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"ht: 4pt;\\n  "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"backgro"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"und: #E0"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"7A5F;\\n "}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":" margi"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":"n: 15pt"}}
+{"type":"content_block_delta","index":27,"delta":{"type":"input_json_delta","partial_json":" auto;\\n}\"}"}}
+{"type":"content_block_stop","index":27}
+{"type":"content_block_start","index":28,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_0183xLGyGvh952zbapjNZD7i","content":{"type":"text_editor_code_execution_str_replace_result","old_start":36,"old_lines":14,"new_start":36,"new_lines":14,"lines":[" .footer-text {","   color: #87A96B;","   font-size: 20pt;","-  margin: 0;","+  margin: 0 0 30pt 0;","   font-weight: bold;"," }"," .accent-line {","   width: 100pt;","   height: 4pt;","   background: #E07A5F;","-  margin: 20pt auto;","+  margin: 15pt auto;"," }"," </style>"," </head>"]}}}
+{"type":"content_block_stop","index":28}
+{"type":"content_block_start","index":29,"content_block":{"type":"server_tool_use","id":"srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB","name":"bash_code_execution","input":{}}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":"{\"command"}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":"\": \"c"}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":"d /tmp"}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":" &&"}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":" n"}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":"ode create"}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":"_presentatio"}}
+{"type":"content_block_delta","index":29,"delta":{"type":"input_json_delta","partial_json":"n.js\"}"}}
+{"type":"content_block_stop","index":29}
+{"type":"ping"}
+{"type":"content_block_start","index":30,"content_block":{"type":"bash_code_execution_tool_result","tool_use_id":"srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB","content":{"type":"bash_code_execution_result","stdout":"","stderr":"Error: /tmp/slide4.html: Multiple validation errors found:\n  1. HTML content overflows body by 2.3pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n  2. Text box \"The Future is Renewable\" ends too close to bottom edge (0.37\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create_presentation.js:20:5)\n","return_code":0,"content":[]}}}
+{"type":"content_block_stop","index":30}
+{"type":"content_block_start","index":31,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":31,"delta":{"type":"text_delta","text":"Let"}}
+{"type":"content_block_delta","index":31,"delta":{"type":"text_delta","text":" me reduce the overall content size to fit within the slide"}}
+{"type":"content_block_delta","index":31,"delta":{"type":"text_delta","text":" properly:"}}
+{"type":"content_block_stop","index":31}
+{"type":"content_block_start","index":32,"content_block":{"type":"server_tool_use","id":"srvtoolu_0124fFTYi7kr5TekwB1uX2Te","name":"text_editor_code_execution","input":{}}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"{\"comm"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"and\": \"st"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"r_repla"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ce\""}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":", \"path\":"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" \"/"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"tmp/s"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"lide4.ht"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ml\""}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":", \"old"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"_str\": \".con"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"taine"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"r {"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"\\n  ma"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"rgin"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":": 50pt "}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"60pt 60pt 6"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"0pt;\\n"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"  text-al"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ign: cen"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ter;\\n}\\nh1 "}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"{\\n "}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" color:"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" #"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ffffff;\\n  "}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"fo"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"nt-size"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":": 48"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"pt"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":";\\n "}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" margin: 0 0"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" 30pt 0;\\"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"n  font"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"-w"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"eight:"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" bold;\\n}\\n"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":".con"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"tent-bo"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"x {\\n "}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" backgrou"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"nd:"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" #ffffff;\\"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"n  padding:"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" 35pt"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" 40pt;\\n  bo"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"rder-radiu"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"s: "}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"8pt;\\n  ma"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"rgin-b"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ottom: 30p"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"t;\\n}\\n.cont"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ent-box"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" p {\\n  co"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"lor: #2"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"C2C2C;\\n"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"  fo"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"nt-si"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ze: 18p"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"t;\\n  mar"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"gin: 0 0 20"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"pt 0;\\n  li"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ne-heig"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ht: 1"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":".6;\\n}"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"\\n.content-b"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ox p:last"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"-child"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" {\\n  margi"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"n: 0;\\n}\\n"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":".footer-"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"text {\\n  c"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"line {"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"\\n  widt"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"h: "}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"100p"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"t;\\n  he"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"igh"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"t: 4pt;\\n  b"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"ackg"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"round"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":": #E07A"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"5F"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":";\\n  margin"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":": 15pt"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":" aut"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"o;\\n"}}
+{"type":"content_block_delta","index":32,"delta":{"type":"input_json_delta","partial_json":"}\"}"}}
+{"type":"content_block_stop","index":32}
+{"type":"content_block_start","index":33,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_0124fFTYi7kr5TekwB1uX2Te","content":{"type":"text_editor_code_execution_str_replace_result","old_start":9,"old_lines":34,"new_start":9,"new_lines":34,"lines":["   display: flex; align-items: center; justify-content: center;"," }"," .container {","-  margin: 50pt 60pt 60pt 60pt;","+  margin: 45pt 60pt 50pt 60pt;","   text-align: center;"," }"," h1 {","   color: #ffffff;","-  font-size: 48pt;","-  margin: 0 0 30pt 0;","+  font-size: 44pt;","+  margin: 0 0 25pt 0;","   font-weight: bold;"," }"," .content-box {","   background: #ffffff;","-  padding: 35pt 40pt;","+  padding: 30pt 40pt;","   border-radius: 8pt;","-  margin-bottom: 30pt;","+  margin-bottom: 25pt;"," }"," .content-box p {","   color: #2C2C2C;","-  font-size: 18pt;","-  margin: 0 0 20pt 0;","-  line-height: 1.6;","+  font-size: 17pt;","+  margin: 0 0 18pt 0;","+  line-height: 1.5;"," }"," .content-box p:last-child {","   margin: 0;"," }"," .footer-text {","   color: #87A96B;","-  font-size: 20pt;","-  margin: 0 0 30pt 0;","+  font-size: 19pt;","+  margin: 0;","   font-weight: bold;"," }"," .accent-line {"]}}}
+{"type":"content_block_stop","index":33}
+{"type":"content_block_start","index":34,"content_block":{"type":"server_tool_use","id":"srvtoolu_019qRxtfSXCNeyhPeLAR67H3","name":"bash_code_execution","input":{}}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":"{\"comman"}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":"d\": \"cd /tm"}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":"p && no"}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":"de cre"}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":"ate_pre"}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":"sentation"}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":".j"}}
+{"type":"content_block_delta","index":34,"delta":{"type":"input_json_delta","partial_json":"s\"}"}}
+{"type":"content_block_stop","index":34}
+{"type":"content_block_start","index":35,"content_block":{"type":"bash_code_execution_tool_result","tool_use_id":"srvtoolu_019qRxtfSXCNeyhPeLAR67H3","content":{"type":"bash_code_execution_result","stdout":"Presentation created successfully!\n","stderr":"","return_code":0,"content":[]}}}
+{"type":"content_block_stop","index":35}
+{"type":"content_block_start","index":36,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":36,"delta":{"type":"text_delta","text":"Great"}}
+{"type":"content_block_delta","index":36,"delta":{"type":"text_delta","text":"! The presentation was created successfully. Now"}}
+{"type":"content_block_delta","index":36,"delta":{"type":"text_delta","text":" let me create thumbnails to"}}
+{"type":"content_block_delta","index":36,"delta":{"type":"text_delta","text":" validate the visual layout:"}}
+{"type":"content_block_stop","index":36}
+{"type":"content_block_start","index":37,"content_block":{"type":"server_tool_use","id":"srvtoolu_01CwLPrEurEQ4ruCJua94vHC","name":"bash_code_execution","input":{}}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"{\"co"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"mmand\""}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":": \"cd"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":" /tmp &"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"& pyt"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"hon /skill"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"s/pptx/scri"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"pts/thumbna"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"il.p"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"y renewable_"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"energy.pp"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"tx"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":" thumb"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"nails -"}}
+{"type":"content_block_delta","index":37,"delta":{"type":"input_json_delta","partial_json":"-cols 4\"}"}}
+{"type":"content_block_stop","index":37}
+{"type":"content_block_start","index":38,"content_block":{"type":"bash_code_execution_tool_result","tool_use_id":"srvtoolu_01CwLPrEurEQ4ruCJua94vHC","content":{"type":"bash_code_execution_result","stdout":"Processing: renewable_energy.pptx\nAnalyzing presentation...\nTotal slides: 4\nConverting to PDF...\nError: PDF conversion failed\n","stderr":"","return_code":1,"content":[]}}}
+{"type":"content_block_stop","index":38}
+{"type":"content_block_start","index":39,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":39,"delta":{"type":"text_delta","text":"Let"}}
+{"type":"content_block_delta","index":39,"delta":{"type":"text_delta","text":" me try a different approach and copy the file"}}
+{"type":"content_block_delta","index":39,"delta":{"type":"text_delta","text":" to the output directory:"}}
+{"type":"content_block_stop","index":39}
+{"type":"content_block_start","index":40,"content_block":{"type":"server_tool_use","id":"srvtoolu_01AHZTbXCnWcLhc3My3nNYPT","name":"bash_code_execution","input":{}}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"{\"comman"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"d\": \"cp /t"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"mp/renewab"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"le_e"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"nergy.pp"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"tx"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":" $OUTP"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"UT_DIR/"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"renew"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"able_energy."}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"pptx &"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"& ls"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":" -lh"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":" $"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"OUT"}}
+{"type":"content_block_delta","index":40,"delta":{"type":"input_json_delta","partial_json":"PUT_DIR/\"}"}}
+{"type":"content_block_stop","index":40}
+{"type":"ping"}
+{"type":"content_block_start","index":41,"content_block":{"type":"bash_code_execution_tool_result","tool_use_id":"srvtoolu_01AHZTbXCnWcLhc3My3nNYPT","content":{"type":"bash_code_execution_result","stdout":"total 80K\n-rw-r--r-- 1 root root 80K Oct 20 11:27 renewable_energy.pptx\n","stderr":"","return_code":0,"content":[{"type":"bash_code_execution_output","file_id":"file_011CUJNRcxM3JHxL8b5QGrNT"}]}}}
+{"type":"content_block_stop","index":41}
+{"type":"content_block_start","index":42,"content_block":{"type":"text","text":""}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"Perfect"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"! I've successfully created your"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" presentation about renewable energy sources. Here"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"'s what I've delivered:\n\n##"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" Presentation Overview\n\n**Title:** Renewable Energy Sources"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"\n**Format:** PowerPoint (."}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"pptx)\n**Slides:** 4 slides as"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" requested\n\n### Design Approach\nI"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" chose a **Sage & Ter"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"racotta** color palette that reflects"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" the natural, earth-friendly theme of renewable energy:"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"\n- **Sage green (#87"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"A96B)** - represents nature an"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"d sustainability\n- **Terracotta (#E07A5F)**"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" - represents solar energy and warmth\n- **Cream"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" (#F4F1DE)** - neutral"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" background for readability\n- **Charcoal (#2C2C2"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"C)** - professional text color\n\n###"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" Slide Contents\n\n1. **Slide 1 - Title"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" Slide**: \n   - Bold title \"Renewable Energy Sources\""}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"\n   - Subtitle \"Powering"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" a Sustainable Future\"\n   - Clean"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" design with sage green background and accent bar"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"\n\n2. **Slide 2 - Solar Power**:\n   "}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"- Description of solar energy technology\n   - Key"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" benefits including zero emissions, cost savings, and scal"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"ability\n   - Two-column layout with highlighte"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"d callout box\n\n3. **Slide 3"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" - Wind Energy**:\n   "}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"- Explanation of wind turbine technology\n   - Benefits including"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" clean energy, cost-competitiveness, and job creation\n   "}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"- Similar two-column layout maintaining design"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" consistency\n\n4. **Slide "}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"4 - Conclusion**:"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"\n   - Summary of the importance of renewable energy\n   - Call to"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" action about building a sustainable future\n   - Dark"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" background with impactful message"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":"\n\nThe presentation has"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" been exported and is"}}
+{"type":"content_block_delta","index":42,"delta":{"type":"text_delta","text":" ready for use!"}}
+{"type":"content_block_stop","index":42}
+{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"container":{"id":"container_011CUJNGs88jcQ8KEiZguEUo","expires_at":"2025-10-20T12:27:25.107823Z","skills":[{"type":"anthropic","skill_id":"pptx","version":"20251013"}]}},"usage":{"input_tokens":320032,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5558,"server_tool_use":{"web_search_requests":0,"web_fetch_requests":0}}}
+{"type":"message_stop"}

--- a/packages/anthropic/src/__fixtures__/anthropic-code-execution-20250825.pptx-skill.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-code-execution-20250825.pptx-skill.json
@@ -1,0 +1,1801 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_01Gdvr7KcANJw63niKbzQGwQ",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "I'll help you create a presentation about renewable energy sources. Let me first read the PowerPoint skill file to ensure I follow the correct procedures."
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01JotqRPYCFJo4ErykSm8MbD",
+      "name": "text_editor_code_execution",
+      "input": { "command": "view", "path": "/skills/pptx/SKILL.md" }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01JotqRPYCFJo4ErykSm8MbD",
+      "content": {
+        "type": "text_editor_code_execution_view_result",
+        "file_type": "text",
+        "content": "---\nname: PowerPoint Suite\ndescription: ...",
+        "num_lines": 484,
+        "start_line": 1,
+        "total_lines": 484
+      }
+    },
+    {
+      "type": "text",
+      "text": "Now let me read the html2pptx.md file as instructed:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01YKVmXubUhZys88NLDzTvdk",
+      "name": "text_editor_code_execution",
+      "input": { "command": "view", "path": "/skills/pptx/html2pptx.md" }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01YKVmXubUhZys88NLDzTvdk",
+      "content": {
+        "type": "text_editor_code_execution_view_result",
+        "file_type": "text",
+        "content": "# HTML to PowerPoint Guide\n\nConvert HTML...",
+        "num_lines": 626,
+        "start_line": 1,
+        "total_lines": 626
+      }
+    },
+    {
+      "type": "text",
+      "text": "Now I'll create a presentation about renewable energy sources following the guidelines. Let me start by designing the presentation with appropriate colors and layout.\n\nBased on the content (renewable energy sources), I'll use an **eco-friendly color palette** with greens, blues, and earthy tones to reflect nature and sustainability:\n\n**Design approach:**\n- **Color palette**: Sage & Terracotta - Sage green (#87A96B), Terracotta (#E07A5F), Cream (#F4F1DE), Charcoal (#2C2C2C)\n- **Typography**: Clean, modern Arial font with strong hierarchy\n- **Layout**: Two-column layout for content slides (text + visuals)\n- **Visual elements**: Rounded shapes, subtle shadows for depth\n\nLet me create the HTML slides:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01SFUXZu5BV8FdvCND6R4rmh",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "create",
+        "path": "/tmp/slide1-title.html",
+        "file_text": "<!DOCTYPE html>\n<html>\n<head>\n<style>\nhtml ...\n"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01398595rMmYudXtThVf4qBV",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "create",
+        "path": "/tmp/slide2-solar.html",
+        "file_text": "<!DOCTYPE html>\n<html>\n<head>\n<style>\nhtml { background: #ffffff; }...\n</html>\n"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01R5ESdsU329J4NgCP8mDEsc",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "create",
+        "path": "/tmp/slide3-wind.html",
+        "file_text": "<!DOCTYPE html>\n<html>\n<head>\n<style>\nhtml { background: #ffffff; }...\n</html>\n"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_015yqpaajYDKf47b487wDJBh",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "create",
+        "path": "/tmp/slide4-conclusion.html",
+        "file_text": "<!DOCTYPE html>\n<html>\n<head>\n<style>\nhtml { background: #ffffff; }...\n</html>\n"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01SFUXZu5BV8FdvCND6R4rmh",
+      "content": {
+        "type": "text_editor_code_execution_create_result",
+        "is_file_update": false
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01398595rMmYudXtThVf4qBV",
+      "content": {
+        "type": "text_editor_code_execution_create_result",
+        "is_file_update": false
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01R5ESdsU329J4NgCP8mDEsc",
+      "content": {
+        "type": "text_editor_code_execution_create_result",
+        "is_file_update": false
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_015yqpaajYDKf47b487wDJBh",
+      "content": {
+        "type": "text_editor_code_execution_create_result",
+        "is_file_update": false
+      }
+    },
+    {
+      "type": "text",
+      "text": "Now let me create the JavaScript file to convert the HTML slides to PowerPoint:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01S6fJ2B2qiefihhZdCCdbrY",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "create",
+        "path": "/tmp/create-presentation.js",
+        "file_text": "const pptxgen = require('pptxgenjs');\nconst html2....);\n"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01S6fJ2B2qiefihhZdCCdbrY",
+      "content": {
+        "type": "text_editor_code_execution_create_result",
+        "is_file_update": false
+      }
+    },
+    {
+      "type": "text",
+      "text": "Now let me run the JavaScript file to create the presentation:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01CNNt7J1q1GUmbQiBwo5Msj",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01CNNt7J1q1GUmbQiBwo5Msj",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide2-solar.html: Multiple validation errors found:\n  1. HTML content overflows body by 101.3pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n  2. Text box \"Converts sunlight into electricity using photovolt...\" ends too close to bottom edge (0.26\" from bottom, minimum 0.5\" required)\n  3. Text box \"25+ years\" ends too close to bottom edge (-0.42\" from bottom, minimum 0.5\" required)\n  4. Text box \"Typical panel lifespan\" ends too close to bottom edge (-0.72\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:14:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "I need to fix the overflow issues in the slides. Let me adjust the layout and spacing:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01EVQmjJxtSsy2C6pojb8pnc",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".content {\n  display: flex;\n  padding: 30pt 40pt;\n  gap: 30pt;\n  flex: 1;\n}",
+        "new_str": ".content {\n  display: flex;\n  padding: 20pt 40pt 40pt 40pt;\n  gap: 25pt;\n  flex: 1;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_012GFHjEKwiEz6GaqkeYU7UG",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".list-item {\n  color: #2C2C2C;\n  font-size: 16pt;\n  margin: 12pt 0;\n  line-height: 1.4;\n}",
+        "new_str": ".list-item {\n  color: #2C2C2C;\n  font-size: 15pt;\n  margin: 8pt 0;\n  line-height: 1.3;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01SGNzkPDCFWnRQMMGbk2VmG",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".visual-column {\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  gap: 15pt;\n}",
+        "new_str": ".visual-column {\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  gap: 12pt;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_0196HcEE5XayzPzTziin8uL2",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".stat-box {\n  background: #FFFFFF;\n  padding: 20pt;\n  border-radius: 12pt;\n  border-left: 8pt solid #E07A5F;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}",
+        "new_str": ".stat-box {\n  background: #FFFFFF;\n  padding: 15pt;\n  border-radius: 12pt;\n  border-left: 8pt solid #E07A5F;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01JRdj7cQHWxytYT3NSUTHoa",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".stat-number {\n  color: #E07A5F;\n  font-size: 36pt;\n  font-weight: bold;\n  margin: 0;\n}",
+        "new_str": ".stat-number {\n  color: #E07A5F;\n  font-size: 32pt;\n  font-weight: bold;\n  margin: 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01Lm95pRQhLZrf6k8xMp2u7C",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".stat-label {\n  color: #2C2C2C;\n  font-size: 14pt;\n  margin: 5pt 0 0 0;\n}",
+        "new_str": ".stat-label {\n  color: #2C2C2C;\n  font-size: 13pt;\n  margin: 3pt 0 0 0;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01EVQmjJxtSsy2C6pojb8pnc",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 22,
+        "old_lines": 8,
+        "new_start": 22,
+        "new_lines": 8,
+        "lines": [
+          " }",
+          " .content {",
+          "   display: flex;",
+          "-  padding: 30pt 40pt;",
+          "-  gap: 30pt;",
+          "+  padding: 20pt 40pt 40pt 40pt;",
+          "+  gap: 25pt;",
+          "   flex: 1;",
+          " }",
+          " .text-column {"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_012GFHjEKwiEz6GaqkeYU7UG",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 37,
+        "old_lines": 9,
+        "new_start": 37,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " .list-item {",
+          "   color: #2C2C2C;",
+          "-  font-size: 16pt;",
+          "-  margin: 12pt 0;",
+          "-  line-height: 1.4;",
+          "+  font-size: 15pt;",
+          "+  margin: 8pt 0;",
+          "+  line-height: 1.3;",
+          " }",
+          " .visual-column {",
+          "   flex: 1;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01SGNzkPDCFWnRQMMGbk2VmG",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 45,
+        "old_lines": 7,
+        "new_start": 45,
+        "new_lines": 7,
+        "lines": [
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;",
+          "-  gap: 15pt;",
+          "+  gap: 12pt;",
+          " }",
+          " .stat-box {",
+          "   background: #FFFFFF;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_0196HcEE5XayzPzTziin8uL2",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 49,
+        "old_lines": 7,
+        "new_start": 49,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .stat-box {",
+          "   background: #FFFFFF;",
+          "-  padding: 20pt;",
+          "+  padding: 15pt;",
+          "   border-radius: 12pt;",
+          "   border-left: 8pt solid #E07A5F;",
+          "   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01JRdj7cQHWxytYT3NSUTHoa",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 56,
+        "old_lines": 7,
+        "new_start": 56,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .stat-number {",
+          "   color: #E07A5F;",
+          "-  font-size: 36pt;",
+          "+  font-size: 32pt;",
+          "   font-weight: bold;",
+          "   margin: 0;",
+          " }"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01Lm95pRQhLZrf6k8xMp2u7C",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 62,
+        "old_lines": 8,
+        "new_start": 62,
+        "new_lines": 8,
+        "lines": [
+          " }",
+          " .stat-label {",
+          "   color: #2C2C2C;",
+          "-  font-size: 14pt;",
+          "-  margin: 5pt 0 0 0;",
+          "+  font-size: 13pt;",
+          "+  margin: 3pt 0 0 0;",
+          " }",
+          " </style>",
+          " </head>"
+        ]
+      }
+    },
+    { "type": "text", "text": "Now let me apply the same fixes to slide 3:" },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_014cgidRz89qahhLzPw73A9j",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".content {\n  display: flex;\n  padding: 30pt 40pt;\n  gap: 30pt;\n  flex: 1;\n}",
+        "new_str": ".content {\n  display: flex;\n  padding: 20pt 40pt 40pt 40pt;\n  gap: 25pt;\n  flex: 1;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01SfsTPtnmJzQUjBLXfmLmQT",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".list-item {\n  color: #2C2C2C;\n  font-size: 16pt;\n  margin: 12pt 0;\n  line-height: 1.4;\n}",
+        "new_str": ".list-item {\n  color: #2C2C2C;\n  font-size: 15pt;\n  margin: 8pt 0;\n  line-height: 1.3;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01QVDzRTzqqLTVXXRkb5vyyD",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".visual-column {\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  gap: 15pt;\n}",
+        "new_str": ".visual-column {\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  gap: 12pt;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_0173BQwp6SLEd3vHSwtFrZdW",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".stat-box {\n  background: #FFFFFF;\n  padding: 20pt;\n  border-radius: 12pt;\n  border-left: 8pt solid #E07A5F;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}",
+        "new_str": ".stat-box {\n  background: #FFFFFF;\n  padding: 15pt;\n  border-radius: 12pt;\n  border-left: 8pt solid #E07A5F;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01SKyW29FDqqaCieYY7w3wuu",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".stat-number {\n  color: #E07A5F;\n  font-size: 36pt;\n  font-weight: bold;\n  margin: 0;\n}",
+        "new_str": ".stat-number {\n  color: #E07A5F;\n  font-size: 32pt;\n  font-weight: bold;\n  margin: 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_012Jxx6zP8MZ5EL1nTAJzb1d",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".stat-label {\n  color: #2C2C2C;\n  font-size: 14pt;\n  margin: 5pt 0 0 0;\n}",
+        "new_str": ".stat-label {\n  color: #2C2C2C;\n  font-size: 13pt;\n  margin: 3pt 0 0 0;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_014cgidRz89qahhLzPw73A9j",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 22,
+        "old_lines": 8,
+        "new_start": 22,
+        "new_lines": 8,
+        "lines": [
+          " }",
+          " .content {",
+          "   display: flex;",
+          "-  padding: 30pt 40pt;",
+          "-  gap: 30pt;",
+          "+  padding: 20pt 40pt 40pt 40pt;",
+          "+  gap: 25pt;",
+          "   flex: 1;",
+          " }",
+          " .text-column {"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01SfsTPtnmJzQUjBLXfmLmQT",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 37,
+        "old_lines": 9,
+        "new_start": 37,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " .list-item {",
+          "   color: #2C2C2C;",
+          "-  font-size: 16pt;",
+          "-  margin: 12pt 0;",
+          "-  line-height: 1.4;",
+          "+  font-size: 15pt;",
+          "+  margin: 8pt 0;",
+          "+  line-height: 1.3;",
+          " }",
+          " .visual-column {",
+          "   flex: 1;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01QVDzRTzqqLTVXXRkb5vyyD",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 45,
+        "old_lines": 7,
+        "new_start": 45,
+        "new_lines": 7,
+        "lines": [
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;",
+          "-  gap: 15pt;",
+          "+  gap: 12pt;",
+          " }",
+          " .stat-box {",
+          "   background: #FFFFFF;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_0173BQwp6SLEd3vHSwtFrZdW",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 49,
+        "old_lines": 7,
+        "new_start": 49,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .stat-box {",
+          "   background: #FFFFFF;",
+          "-  padding: 20pt;",
+          "+  padding: 15pt;",
+          "   border-radius: 12pt;",
+          "   border-left: 8pt solid #E07A5F;",
+          "   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01SKyW29FDqqaCieYY7w3wuu",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 56,
+        "old_lines": 7,
+        "new_start": 56,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .stat-number {",
+          "   color: #E07A5F;",
+          "-  font-size: 36pt;",
+          "+  font-size: 32pt;",
+          "   font-weight: bold;",
+          "   margin: 0;",
+          " }"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_012Jxx6zP8MZ5EL1nTAJzb1d",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 62,
+        "old_lines": 8,
+        "new_start": 62,
+        "new_lines": 8,
+        "lines": [
+          " }",
+          " .stat-label {",
+          "   color: #2C2C2C;",
+          "-  font-size: 14pt;",
+          "-  margin: 5pt 0 0 0;",
+          "+  font-size: 13pt;",
+          "+  margin: 3pt 0 0 0;",
+          " }",
+          " </style>",
+          " </head>"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "text": "Now let me run the presentation creation again:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01GTbY5XGVT8fruhrCkmyWJn",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01GTbY5XGVT8fruhrCkmyWJn",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide2-solar.html: Multiple validation errors found:\n  1. HTML content overflows body by 43.5pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n  2. Text box \"25+ years\" ends too close to bottom edge (0.41\" from bottom, minimum 0.5\" required)\n  3. Text box \"Typical panel lifespan\" ends too close to bottom edge (0.15\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:14:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "I need to further reduce the spacing. Let me adjust:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_011HqujSHHybdYQHsBaAXnFx",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": "h2 {\n  color: #2C2C2C;\n  font-size: 24pt;\n  font-weight: bold;\n  margin: 0 0 15pt 0;\n}",
+        "new_str": "h2 {\n  color: #2C2C2C;\n  font-size: 22pt;\n  font-weight: bold;\n  margin: 0 0 12pt 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01AysZ8K7fjqjvCqDc7VnaoB",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".stat-box {\n  background: #FFFFFF;\n  padding: 15pt;\n  border-radius: 12pt;\n  border-left: 8pt solid #E07A5F;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}",
+        "new_str": ".stat-box {\n  background: #FFFFFF;\n  padding: 12pt;\n  border-radius: 12pt;\n  border-left: 8pt solid #E07A5F;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_011YzGFZUoGASSgELxxtwRSC",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".stat-number {\n  color: #E07A5F;\n  font-size: 32pt;\n  font-weight: bold;\n  margin: 0;\n}",
+        "new_str": ".stat-number {\n  color: #E07A5F;\n  font-size: 28pt;\n  font-weight: bold;\n  margin: 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_013GUqXR9u9KyWYhAqqHCnsR",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".visual-column {\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  gap: 12pt;\n}",
+        "new_str": ".visual-column {\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  gap: 10pt;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_011HqujSHHybdYQHsBaAXnFx",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 31,
+        "old_lines": 9,
+        "new_start": 31,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " h2 {",
+          "   color: #2C2C2C;",
+          "-  font-size: 24pt;",
+          "+  font-size: 22pt;",
+          "   font-weight: bold;",
+          "-  margin: 0 0 15pt 0;",
+          "+  margin: 0 0 12pt 0;",
+          " }",
+          " .list-item {",
+          "   color: #2C2C2C;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01AysZ8K7fjqjvCqDc7VnaoB",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 49,
+        "old_lines": 7,
+        "new_start": 49,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .stat-box {",
+          "   background: #FFFFFF;",
+          "-  padding: 15pt;",
+          "+  padding: 12pt;",
+          "   border-radius: 12pt;",
+          "   border-left: 8pt solid #E07A5F;",
+          "   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_011YzGFZUoGASSgELxxtwRSC",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 56,
+        "old_lines": 7,
+        "new_start": 56,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .stat-number {",
+          "   color: #E07A5F;",
+          "-  font-size: 32pt;",
+          "+  font-size: 28pt;",
+          "   font-weight: bold;",
+          "   margin: 0;",
+          " }"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_013GUqXR9u9KyWYhAqqHCnsR",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 45,
+        "old_lines": 7,
+        "new_start": 45,
+        "new_lines": 7,
+        "lines": [
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;",
+          "-  gap: 12pt;",
+          "+  gap: 10pt;",
+          " }",
+          " .stat-box {",
+          "   background: #FFFFFF;"
+        ]
+      }
+    },
+    { "type": "text", "text": "Apply the same changes to slide 3:" },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_011f8d8J1yrrbHvufaRAoWBM",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": "h2 {\n  color: #2C2C2C;\n  font-size: 24pt;\n  font-weight: bold;\n  margin: 0 0 15pt 0;\n}",
+        "new_str": "h2 {\n  color: #2C2C2C;\n  font-size: 22pt;\n  font-weight: bold;\n  margin: 0 0 12pt 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_015HVTHMGhWexondG6XCQrgD",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".stat-box {\n  background: #FFFFFF;\n  padding: 15pt;\n  border-radius: 12pt;\n  border-left: 8pt solid #E07A5F;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}",
+        "new_str": ".stat-box {\n  background: #FFFFFF;\n  padding: 12pt;\n  border-radius: 12pt;\n  border-left: 8pt solid #E07A5F;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_015rYYLoHCFNbi8v6KarsXTh",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".stat-number {\n  color: #E07A5F;\n  font-size: 32pt;\n  font-weight: bold;\n  margin: 0;\n}",
+        "new_str": ".stat-number {\n  color: #E07A5F;\n  font-size: 28pt;\n  font-weight: bold;\n  margin: 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01XtTopNnzL7wW8TaXbuWpBN",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".visual-column {\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  gap: 12pt;\n}",
+        "new_str": ".visual-column {\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  gap: 10pt;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_011f8d8J1yrrbHvufaRAoWBM",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 31,
+        "old_lines": 9,
+        "new_start": 31,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " h2 {",
+          "   color: #2C2C2C;",
+          "-  font-size: 24pt;",
+          "+  font-size: 22pt;",
+          "   font-weight: bold;",
+          "-  margin: 0 0 15pt 0;",
+          "+  margin: 0 0 12pt 0;",
+          " }",
+          " .list-item {",
+          "   color: #2C2C2C;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_015HVTHMGhWexondG6XCQrgD",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 49,
+        "old_lines": 7,
+        "new_start": 49,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .stat-box {",
+          "   background: #FFFFFF;",
+          "-  padding: 15pt;",
+          "+  padding: 12pt;",
+          "   border-radius: 12pt;",
+          "   border-left: 8pt solid #E07A5F;",
+          "   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_015rYYLoHCFNbi8v6KarsXTh",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 56,
+        "old_lines": 7,
+        "new_start": 56,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .stat-number {",
+          "   color: #E07A5F;",
+          "-  font-size: 32pt;",
+          "+  font-size: 28pt;",
+          "   font-weight: bold;",
+          "   margin: 0;",
+          " }"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01XtTopNnzL7wW8TaXbuWpBN",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 45,
+        "old_lines": 7,
+        "new_start": 45,
+        "new_lines": 7,
+        "lines": [
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;",
+          "-  gap: 12pt;",
+          "+  gap: 10pt;",
+          " }",
+          " .stat-box {",
+          "   background: #FFFFFF;"
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "text": "Now let me run the presentation creation again:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01BKUEoFsPjtHmRDxgdVEKQ9",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01BKUEoFsPjtHmRDxgdVEKQ9",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide2-solar.html: HTML content overflows body by 8.3pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:14:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Close! Let me make a small adjustment to the header padding:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01VHjWJoNzk72aaVwno78vd6",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide2-solar.html",
+        "old_str": ".header {\n  background: #87A96B;\n  padding: 30pt 40pt;\n  border-bottom-right-radius: 20pt;\n}",
+        "new_str": ".header {\n  background: #87A96B;\n  padding: 25pt 40pt;\n  border-bottom-right-radius: 20pt;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01WtJKZ9855a8HP6b29rZA1P",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide3-wind.html",
+        "old_str": ".header {\n  background: #87A96B;\n  padding: 30pt 40pt;\n  border-bottom-right-radius: 20pt;\n}",
+        "new_str": ".header {\n  background: #87A96B;\n  padding: 25pt 40pt;\n  border-bottom-right-radius: 20pt;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01VHjWJoNzk72aaVwno78vd6",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 11,
+        "old_lines": 7,
+        "new_start": 11,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .header {",
+          "   background: #87A96B;",
+          "-  padding: 30pt 40pt;",
+          "+  padding: 25pt 40pt;",
+          "   border-bottom-right-radius: 20pt;",
+          " }",
+          " h1 {"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01WtJKZ9855a8HP6b29rZA1P",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 11,
+        "old_lines": 7,
+        "new_start": 11,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .header {",
+          "   background: #87A96B;",
+          "-  padding: 30pt 40pt;",
+          "+  padding: 25pt 40pt;",
+          "   border-bottom-right-radius: 20pt;",
+          " }",
+          " h1 {"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_016u3VigcCA2HvhyqDMa8bdb",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_016u3VigcCA2HvhyqDMa8bdb",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide4-conclusion.html: Multiple validation errors found:\n  1. HTML content overflows body by 263.3pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n  2. Text box \"Reduced carbon emissions and environmental impact\" ends too close to bottom edge (-1.19\" from bottom, minimum 0.5\" required)\n  3. Text box \"Together, we can power a cleaner, more sustainable...\" ends too close to bottom edge (-2.77\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:20:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Good progress! Now I need to fix slide 4. Let me adjust the conclusion slide:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01NwSKiCEUiY1aWa8hCAWiaN",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".header {\n  background: #87A96B;\n  padding: 30pt 40pt;\n  border-bottom-right-radius: 20pt;\n}",
+        "new_str": ".header {\n  background: #87A96B;\n  padding: 25pt 40pt;\n  border-bottom-right-radius: 20pt;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01X9FCwX1ffqV9xwNFQjW9iB",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".content {\n  padding: 40pt 60pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}",
+        "new_str": ".content {\n  padding: 20pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_0118529s29G8d8CyuwkryDep",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": "h2 {\n  color: #2C2C2C;\n  font-size: 28pt;\n  font-weight: bold;\n  margin: 0 0 20pt 0;\n}",
+        "new_str": "h2 {\n  color: #2C2C2C;\n  font-size: 24pt;\n  font-weight: bold;\n  margin: 0 0 12pt 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01V8FeuEXfwXBdW7znE1EVPW",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".conclusion-text {\n  color: #2C2C2C;\n  font-size: 18pt;\n  line-height: 1.6;\n  margin: 15pt 0;\n}",
+        "new_str": ".conclusion-text {\n  color: #2C2C2C;\n  font-size: 15pt;\n  line-height: 1.4;\n  margin: 8pt 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01NHn7K4bT9BRd34GsDvMRuK",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".highlight-box {\n  background: #87A96B;\n  padding: 25pt 30pt;\n  border-radius: 12pt;\n  margin-top: 30pt;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}",
+        "new_str": ".highlight-box {\n  background: #87A96B;\n  padding: 20pt 25pt;\n  border-radius: 12pt;\n  margin-top: 15pt;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_013EhzoLZheUH7dy1JXwYNjm",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".highlight-text {\n  color: #FFFFFF;\n  font-size: 20pt;\n  font-weight: bold;\n  margin: 0;\n  text-align: center;\n}",
+        "new_str": ".highlight-text {\n  color: #FFFFFF;\n  font-size: 18pt;\n  font-weight: bold;\n  margin: 0;\n  text-align: center;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01NwSKiCEUiY1aWa8hCAWiaN",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 11,
+        "old_lines": 7,
+        "new_start": 11,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .header {",
+          "   background: #87A96B;",
+          "-  padding: 30pt 40pt;",
+          "+  padding: 25pt 40pt;",
+          "   border-bottom-right-radius: 20pt;",
+          " }",
+          " h1 {"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01X9FCwX1ffqV9xwNFQjW9iB",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 21,
+        "old_lines": 7,
+        "new_start": 21,
+        "new_lines": 7,
+        "lines": [
+          "   margin: 0;",
+          " }",
+          " .content {",
+          "-  padding: 40pt 60pt;",
+          "+  padding: 20pt 50pt 40pt 50pt;",
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_0118529s29G8d8CyuwkryDep",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 29,
+        "old_lines": 9,
+        "new_start": 29,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " h2 {",
+          "   color: #2C2C2C;",
+          "-  font-size: 28pt;",
+          "+  font-size: 24pt;",
+          "   font-weight: bold;",
+          "-  margin: 0 0 20pt 0;",
+          "+  margin: 0 0 12pt 0;",
+          " }",
+          " .conclusion-text {",
+          "   color: #2C2C2C;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01V8FeuEXfwXBdW7znE1EVPW",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 35,
+        "old_lines": 9,
+        "new_start": 35,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " .conclusion-text {",
+          "   color: #2C2C2C;",
+          "-  font-size: 18pt;",
+          "-  line-height: 1.6;",
+          "-  margin: 15pt 0;",
+          "+  font-size: 15pt;",
+          "+  line-height: 1.4;",
+          "+  margin: 8pt 0;",
+          " }",
+          " .highlight-box {",
+          "   background: #87A96B;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01NHn7K4bT9BRd34GsDvMRuK",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 41,
+        "old_lines": 9,
+        "new_start": 41,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " .highlight-box {",
+          "   background: #87A96B;",
+          "-  padding: 25pt 30pt;",
+          "+  padding: 20pt 25pt;",
+          "   border-radius: 12pt;",
+          "-  margin-top: 30pt;",
+          "+  margin-top: 15pt;",
+          "   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);",
+          " }",
+          " .highlight-text {"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_013EhzoLZheUH7dy1JXwYNjm",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 48,
+        "old_lines": 7,
+        "new_start": 48,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .highlight-text {",
+          "   color: #FFFFFF;",
+          "-  font-size: 20pt;",
+          "+  font-size: 18pt;",
+          "   font-weight: bold;",
+          "   margin: 0;",
+          "   text-align: center;"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_016ASiFShroCzcd9MLrgzBso",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_016ASiFShroCzcd9MLrgzBso",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide4-conclusion.html: Multiple validation errors found:\n  1. HTML content overflows body by 75.0pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n  2. Text box \"Together, we can power a cleaner, more sustainable...\" ends too close to bottom edge (-0.21\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:20:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Still need to reduce more. Let me adjust the list items spacing:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_015YN8Cwu1orGyVrRkLYV6eR",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".conclusion-text {\n  color: #2C2C2C;\n  font-size: 15pt;\n  line-height: 1.4;\n  margin: 8pt 0;\n}",
+        "new_str": ".conclusion-text {\n  color: #2C2C2C;\n  font-size: 14pt;\n  line-height: 1.3;\n  margin: 6pt 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01JH2yY5dMU8PPgWomTCXTuP",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".highlight-box {\n  background: #87A96B;\n  padding: 20pt 25pt;\n  border-radius: 12pt;\n  margin-top: 15pt;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}",
+        "new_str": ".highlight-box {\n  background: #87A96B;\n  padding: 18pt 25pt;\n  border-radius: 12pt;\n  margin-top: 12pt;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01VbwxrfFf5t6727bwSyAYGy",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".highlight-text {\n  color: #FFFFFF;\n  font-size: 18pt;\n  font-weight: bold;\n  margin: 0;\n  text-align: center;\n}",
+        "new_str": ".highlight-text {\n  color: #FFFFFF;\n  font-size: 16pt;\n  font-weight: bold;\n  margin: 0;\n  text-align: center;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_015YN8Cwu1orGyVrRkLYV6eR",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 35,
+        "old_lines": 9,
+        "new_start": 35,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " .conclusion-text {",
+          "   color: #2C2C2C;",
+          "-  font-size: 15pt;",
+          "-  line-height: 1.4;",
+          "-  margin: 8pt 0;",
+          "+  font-size: 14pt;",
+          "+  line-height: 1.3;",
+          "+  margin: 6pt 0;",
+          " }",
+          " .highlight-box {",
+          "   background: #87A96B;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01JH2yY5dMU8PPgWomTCXTuP",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 41,
+        "old_lines": 9,
+        "new_start": 41,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " .highlight-box {",
+          "   background: #87A96B;",
+          "-  padding: 20pt 25pt;",
+          "+  padding: 18pt 25pt;",
+          "   border-radius: 12pt;",
+          "-  margin-top: 15pt;",
+          "+  margin-top: 12pt;",
+          "   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);",
+          " }",
+          " .highlight-text {"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01VbwxrfFf5t6727bwSyAYGy",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 48,
+        "old_lines": 7,
+        "new_start": 48,
+        "new_lines": 7,
+        "lines": [
+          " }",
+          " .highlight-text {",
+          "   color: #FFFFFF;",
+          "-  font-size: 18pt;",
+          "+  font-size: 16pt;",
+          "   font-weight: bold;",
+          "   margin: 0;",
+          "   text-align: center;"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01CvZR9dFiNPp551DcudcCh4",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01CvZR9dFiNPp551DcudcCh4",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide4-conclusion.html: Multiple validation errors found:\n  1. HTML content overflows body by 34.5pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n  2. Text box \"Together, we can power a cleaner, more sustainable...\" ends too close to bottom edge (0.31\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:20:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Almost there! Let me adjust the content padding a bit more:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01CYW7C1vpdkWduDhYv4f5aB",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".content {\n  padding: 20pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}",
+        "new_str": ".content {\n  padding: 15pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01XTqWQwYA7V6s8VRBxw6yJB",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": "h2 {\n  color: #2C2C2C;\n  font-size: 24pt;\n  font-weight: bold;\n  margin: 0 0 12pt 0;\n}",
+        "new_str": "h2 {\n  color: #2C2C2C;\n  font-size: 22pt;\n  font-weight: bold;\n  margin: 0 0 10pt 0;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01CYW7C1vpdkWduDhYv4f5aB",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 21,
+        "old_lines": 7,
+        "new_start": 21,
+        "new_lines": 7,
+        "lines": [
+          "   margin: 0;",
+          " }",
+          " .content {",
+          "-  padding: 20pt 50pt 40pt 50pt;",
+          "+  padding: 15pt 50pt 40pt 50pt;",
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01XTqWQwYA7V6s8VRBxw6yJB",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 29,
+        "old_lines": 9,
+        "new_start": 29,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " h2 {",
+          "   color: #2C2C2C;",
+          "-  font-size: 24pt;",
+          "+  font-size: 22pt;",
+          "   font-weight: bold;",
+          "-  margin: 0 0 12pt 0;",
+          "+  margin: 0 0 10pt 0;",
+          " }",
+          " .conclusion-text {",
+          "   color: #2C2C2C;"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01SYhX2THtcmSYETnYPx3dtT",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01SYhX2THtcmSYETnYPx3dtT",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide4-conclusion.html: Multiple validation errors found:\n  1. HTML content overflows body by 25.5pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n  2. Text box \"Together, we can power a cleaner, more sustainable...\" ends too close to bottom edge (0.44\" from bottom, minimum 0.5\" required)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:20:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Just a little bit more. Let me reduce the margin on the conclusion text items slightly:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01APA4NR872CroiUHetsiHkx",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".conclusion-text {\n  color: #2C2C2C;\n  font-size: 14pt;\n  line-height: 1.3;\n  margin: 6pt 0;\n}",
+        "new_str": ".conclusion-text {\n  color: #2C2C2C;\n  font-size: 14pt;\n  line-height: 1.3;\n  margin: 5pt 0;\n}"
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_019JQf96nqYeScMeVkhXH8EN",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".highlight-box {\n  background: #87A96B;\n  padding: 18pt 25pt;\n  border-radius: 12pt;\n  margin-top: 12pt;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}",
+        "new_str": ".highlight-box {\n  background: #87A96B;\n  padding: 16pt 25pt;\n  border-radius: 12pt;\n  margin-top: 10pt;\n  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01APA4NR872CroiUHetsiHkx",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 37,
+        "old_lines": 7,
+        "new_start": 37,
+        "new_lines": 7,
+        "lines": [
+          "   color: #2C2C2C;",
+          "   font-size: 14pt;",
+          "   line-height: 1.3;",
+          "-  margin: 6pt 0;",
+          "+  margin: 5pt 0;",
+          " }",
+          " .highlight-box {",
+          "   background: #87A96B;"
+        ]
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_019JQf96nqYeScMeVkhXH8EN",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 41,
+        "old_lines": 9,
+        "new_start": 41,
+        "new_lines": 9,
+        "lines": [
+          " }",
+          " .highlight-box {",
+          "   background: #87A96B;",
+          "-  padding: 18pt 25pt;",
+          "+  padding: 16pt 25pt;",
+          "   border-radius: 12pt;",
+          "-  margin-top: 12pt;",
+          "+  margin-top: 10pt;",
+          "   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);",
+          " }",
+          " .highlight-text {"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01NpDkw7LEMF53inS3HT7ijZ",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01NpDkw7LEMF53inS3HT7ijZ",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide4-conclusion.html: HTML content overflows body by 12.0pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:20:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Very close! Let me make one more small adjustment:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01PfEcaECLEh9ihQfiyxh8vH",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".content {\n  padding: 15pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}",
+        "new_str": ".content {\n  padding: 12pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01PfEcaECLEh9ihQfiyxh8vH",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 21,
+        "old_lines": 7,
+        "new_start": 21,
+        "new_lines": 7,
+        "lines": [
+          "   margin: 0;",
+          " }",
+          " .content {",
+          "-  padding: 15pt 50pt 40pt 50pt;",
+          "+  padding: 12pt 50pt 40pt 50pt;",
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01EpB6SVGN75ZQ7a8JWkxnNe",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01EpB6SVGN75ZQ7a8JWkxnNe",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide4-conclusion.html: HTML content overflows body by 9.0pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:20:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    { "type": "text", "text": "Let me try reducing the margin a bit more:" },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01NLMx59q9xosT7xpCUuDA3t",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".conclusion-text {\n  color: #2C2C2C;\n  font-size: 14pt;\n  line-height: 1.3;\n  margin: 5pt 0;\n}",
+        "new_str": ".conclusion-text {\n  color: #2C2C2C;\n  font-size: 14pt;\n  line-height: 1.3;\n  margin: 4pt 0;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01NLMx59q9xosT7xpCUuDA3t",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 37,
+        "old_lines": 7,
+        "new_start": 37,
+        "new_lines": 7,
+        "lines": [
+          "   color: #2C2C2C;",
+          "   font-size: 14pt;",
+          "   line-height: 1.3;",
+          "-  margin: 5pt 0;",
+          "+  margin: 4pt 0;",
+          " }",
+          " .highlight-box {",
+          "   background: #87A96B;"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01KXWBNv1oYQvDoWNbQ9s3QG",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01KXWBNv1oYQvDoWNbQ9s3QG",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide4-conclusion.html: HTML content overflows body by 2.3pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:20:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Almost there! Just 2.3pt more. Let me make a final tiny adjustment:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01DM3GXt6McbmydAdonWFwhQ",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".content {\n  padding: 12pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}",
+        "new_str": ".content {\n  padding: 10pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01DM3GXt6McbmydAdonWFwhQ",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 21,
+        "old_lines": 7,
+        "new_start": 21,
+        "new_lines": 7,
+        "lines": [
+          "   margin: 0;",
+          " }",
+          " .content {",
+          "-  padding: 12pt 50pt 40pt 50pt;",
+          "+  padding: 10pt 50pt 40pt 50pt;",
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_011MV62mdB7bYwf8ejukmMyX",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_011MV62mdB7bYwf8ejukmMyX",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "",
+        "stderr": "Error: /tmp/slide4-conclusion.html: HTML content overflows body by 0.8pt vertically (Remember: leave 0.5\" margin at bottom of slide)\n    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)\n    at async createPresentation (/tmp/create-presentation.js:20:5)\n",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "So close! Let me adjust the top padding slightly more:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01XDsMMNMWKrVR7hrauyK15m",
+      "name": "text_editor_code_execution",
+      "input": {
+        "command": "str_replace",
+        "path": "/tmp/slide4-conclusion.html",
+        "old_str": ".content {\n  padding: 10pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}",
+        "new_str": ".content {\n  padding: 9pt 50pt 40pt 50pt;\n  flex: 1;\n  display: flex;\n  flex-direction: column;\n  justify-content: center;\n}"
+      }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01XDsMMNMWKrVR7hrauyK15m",
+      "content": {
+        "type": "text_editor_code_execution_str_replace_result",
+        "old_start": 21,
+        "old_lines": 7,
+        "new_start": 21,
+        "new_lines": 7,
+        "lines": [
+          "   margin: 0;",
+          " }",
+          " .content {",
+          "-  padding: 10pt 50pt 40pt 50pt;",
+          "+  padding: 9pt 50pt 40pt 50pt;",
+          "   flex: 1;",
+          "   display: flex;",
+          "   flex-direction: column;"
+        ]
+      }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01Be5EUZboEypgMRzWR1GRmd",
+      "name": "bash_code_execution",
+      "input": { "command": "cd /tmp && node create-presentation.js" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01Be5EUZboEypgMRzWR1GRmd",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "Presentation created successfully!\n",
+        "stderr": "",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Excellent! The presentation has been created successfully. Now let me create thumbnail grids to visually validate the presentation:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01AtPDhjepTnMGtN86chNHH2",
+      "name": "bash_code_execution",
+      "input": {
+        "command": "cd /tmp && python /skills/pptx/scripts/thumbnail.py renewable-energy.pptx thumbnails --cols 4"
+      }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01AtPDhjepTnMGtN86chNHH2",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "Processing: renewable-energy.pptx\nAnalyzing presentation...\nTotal slides: 4\nConverting to PDF...\nError: PDF conversion failed\n",
+        "stderr": "",
+        "return_code": 1,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "Let me try converting to PDF manually and then creating thumbnails:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_016Qi1t4i5F4YD59bwW6nKQ7",
+      "name": "bash_code_execution",
+      "input": {
+        "command": "cd /tmp && soffice --headless --convert-to pdf renewable-energy.pptx 2>&1"
+      }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_016Qi1t4i5F4YD59bwW6nKQ7",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "Warning: failed to launch javaldx - java may not function correctly\n/usr/lib/libreoffice/program/soffice.bin X11 error: Can't open display: \n   Set DISPLAY environment variable, use -display option\n   or check permissions of your X-Server\n   (See \"man X\" resp. \"man xhost\" for details)\n",
+        "stderr": "",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    {
+      "type": "text",
+      "text": "LibreOffice needs a display server. Let me just copy the presentation to the output directory so you can download and view it:"
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01Bvsh2yfTLC1BD9SbkXKYVj",
+      "name": "bash_code_execution",
+      "input": {
+        "command": "cp /tmp/renewable-energy.pptx $OUTPUT_DIR/renewable-energy.pptx && ls -lh $OUTPUT_DIR/"
+      }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01Bvsh2yfTLC1BD9SbkXKYVj",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "total 94K\n-rw-r--r-- 1 root root 94K Oct 20 10:48 renewable-energy.pptx\n",
+        "stderr": "",
+        "return_code": 0,
+        "content": [
+          {
+            "type": "bash_code_execution_output",
+            "file_id": "file_011CUJKUp367cjQUB9qr74Es"
+          }
+        ]
+      }
+    },
+    {
+      "type": "text",
+      "text": "Perfect! I've successfully created a PowerPoint presentation about renewable energy sources. Here's what I created:\n\n## Presentation Summary\n\n**Design Approach:** \n- **Color palette**: Sage & Terracotta - eco-friendly colors reflecting sustainability\n  - Sage green (#87A96B) - primary accent color\n  - Terracotta (#E07A5F) - secondary accent for stats\n  - Cream (#F4F1DE) - warm background\n  - Charcoal (#2C2C2C) - text color\n- **Layout**: Clean, modern design with two-column layouts for content slides\n- **Typography**: Arial with strong hierarchy and clear readability\n\n**4 Slides:**\n\n1. **Title Slide**: \"Renewable Energy Sources\" with subtitle \"Powering a Sustainable Future\" - centered design with a decorative accent line\n\n2. **Solar Power**: \n   - Left column: Key features including photovoltaic cells, zero emissions, low maintenance, scalability, and cost-competitiveness\n   - Right column: Three statistic boxes showing:\n     - 173,000 TW of solar energy reaching Earth\n     - 85% cost reduction since 2010\n     - 25+ years typical panel lifespan\n\n3. **Wind Energy**:\n   - Left column: Key features including turbine technology, clean energy, onshore/offshore installations, minimal footprint, and job creation\n   - Right column: Three statistic boxes showing:\n     - 743 GW global installed capacity\n     - 7% of global electricity generation\n     - 20-25 years typical turbine lifespan\n\n4. **Conclusion**: \"Building a Sustainable Energy Future\"\n   - Summary of key benefits (reduced emissions, energy independence, economic growth, declining costs)\n   - Highlight box with inspiring message: \"Together, we can power a cleaner, more sustainable world\"\n\nThe presentation has been saved and is ready for download!"
+    }
+  ],
+  "container": {
+    "id": "container_011CUJKA7aVjWm5XJL9ozHGS",
+    "expires_at": "2025-10-20T11:48:47.798310Z",
+    "skills": [
+      { "type": "anthropic", "skill_id": "pptx", "version": "20251013" }
+    ]
+  },
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 950648,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 13856,
+    "service_tier": "standard",
+    "server_tool_use": { "web_search_requests": 0, "web_fetch_requests": 0 }
+  }
+}

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -4,6 +4,17 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should exp
 {
   "anthropic": {
     "cacheCreationInputTokens": 0,
+    "container": {
+      "expiresAt": "2025-10-20T11:48:47.798310Z",
+      "id": "container_011CUJKA7aVjWm5XJL9ozHGS",
+      "skills": [
+        {
+          "skillId": "pptx",
+          "type": "anthropic",
+          "version": "20251013",
+        },
+      ],
+    },
     "stopSequence": null,
     "usage": {
       "cache_creation": {
@@ -14,6 +25,35 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should exp
       "cache_read_input_tokens": 0,
       "input_tokens": 950648,
       "output_tokens": 13856,
+      "server_tool_use": {
+        "web_fetch_requests": 0,
+        "web_search_requests": 0,
+      },
+      "service_tier": "standard",
+    },
+  },
+}
+`;
+
+exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 > should expose container information as provider metadata 1`] = `
+{
+  "anthropic": {
+    "cacheCreationInputTokens": 0,
+    "container": {
+      "expiresAt": "2025-10-14T10:28:40.590791Z",
+      "id": "container_011CU6rVteVhydYXRyNs6G1M",
+      "skills": null,
+    },
+    "stopSequence": null,
+    "usage": {
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 0,
+        "ephemeral_5m_input_tokens": 0,
+      },
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "input_tokens": 7881,
+      "output_tokens": 608,
       "server_tool_use": {
         "web_fetch_requests": 0,
         "web_search_requests": 0,

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -1,5 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should expose container information as provider metadata 1`] = `
+{
+  "anthropic": {
+    "cacheCreationInputTokens": 0,
+    "stopSequence": null,
+    "usage": {
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 0,
+        "ephemeral_5m_input_tokens": 0,
+      },
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "input_tokens": 950648,
+      "output_tokens": 13856,
+      "server_tool_use": {
+        "web_fetch_requests": 0,
+        "web_search_requests": 0,
+      },
+      "service_tier": "standard",
+    },
+  },
+}
+`;
+
 exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 > should include code execution tool call and result in content 1`] = `
 [
   {

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -4337,6 +4337,17 @@ The presentation has",
     "providerMetadata": {
       "anthropic": {
         "cacheCreationInputTokens": 0,
+        "container": {
+          "expiresAt": "2025-10-20T12:27:25.107823Z",
+          "id": "container_011CUJNGs88jcQ8KEiZguEUo",
+          "skills": [
+            {
+              "skillId": "pptx",
+              "type": "anthropic",
+              "version": "20251013",
+            },
+          ],
+        },
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -5626,6 +5637,11 @@ The Fibonacci sequence starts with 0, ",
     "providerMetadata": {
       "anthropic": {
         "cacheCreationInputTokens": 0,
+        "container": {
+          "expiresAt": "2025-10-14T10:02:00.044495Z",
+          "id": "container_011CU6pTr2hLT47seQ5Xs4yj",
+          "skills": null,
+        },
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -5730,6 +5746,7 @@ It simply echoed back",
     "providerMetadata": {
       "anthropic": {
         "cacheCreationInputTokens": 0,
+        "container": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -6128,6 +6145,7 @@ The page also discusses",
     "providerMetadata": {
       "anthropic": {
         "cacheCreationInputTokens": 0,
+        "container": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -6862,6 +6880,7 @@ The main tech story today appears to be Apple's significant",
     "providerMetadata": {
       "anthropic": {
         "cacheCreationInputTokens": 0,
+        "container": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -653,6 +653,3719 @@ For the most current breaking tech news today, I'd recommend checking major tech
 ]
 `;
 
+exports[`AnthropicMessagesLanguageModel > doStream > raw chunks > agent skills > should stream code execution tool results 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "msg_01Bu3u6DZfwcuhDWUQMQJz39",
+    "modelId": "claude-sonnet-4-5-20250929",
+    "type": "response-metadata",
+  },
+  {
+    "id": "0",
+    "type": "text-start",
+  },
+  {
+    "delta": "I nee",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": "d to create a PowerPoint presentation about renewable",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": " energy sources. Let me first read the",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": " PPTX skill file to understand the proper approach",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "delta": ".",
+    "id": "0",
+    "type": "text-delta",
+  },
+  {
+    "id": "0",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","co",
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "mmand": "",
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "view"",
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path": "",
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "/skills",
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "/pptx/",
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "SKILL",
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".md"}",
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "view", "path": "/skills/pptx/SKILL.md"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": "---
+name: PowerPoint Suite
+description: Presentation creation, editing, and analysis.
+when_to_use: "When Claude needs to work with presentations (.pptx files) for: (1) Creating new presentations, (2) Modifying or editing content, (3) Working with layouts, (4) Adding comments or speaker notes, or any other presentation tasks"
+version: 0.0.3
+---
+
+# PPTX creation, editing, and analysis
+
+## Overview
+
+A user may ask you to create, edit, or analyze the contents of a .pptx file. A .pptx file is essentially a ZIP archive containing XML files and other resources that you can read or edit. You have different tools and workflows available for different tasks.
+
+## Reading and analyzing content
+
+### Text extraction
+If you just need to read the text contents of a presentation, you should convert the document to markdown:
+
+\`\`\`bash
+# Convert document to markdown
+python -m markitdown path-to-file.pptx
+\`\`\`
+
+### Raw XML access
+You need raw XML access for: comments, speaker notes, slide layouts, animations, design elements, and complex formatting. For any of these ....*: \`npm install -g sharp\` (for SVG rasterization and image processing)
+- **LibreOffice**: \`sudo apt-get install libreoffice\` (for PDF conversion)
+- **Poppler**: \`sudo apt-get install poppler-utils\` (for pdftoppm to convert PDF to images)",
+      "file_type": "text",
+      "num_lines": 484,
+      "start_line": 1,
+      "total_lines": 484,
+      "type": "text_editor_code_execution_view_result",
+    },
+    "toolCallId": "srvtoolu_01Cq5HzojbaLrsQTvdHW4VNK",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "3",
+    "type": "text-start",
+  },
+  {
+    "delta": "Now",
+    "id": "3",
+    "type": "text-delta",
+  },
+  {
+    "delta": " let me read the html2pptx.md file to understand the detaile",
+    "id": "3",
+    "type": "text-delta",
+  },
+  {
+    "delta": "d syntax and best practices for creating presentations:",
+    "id": "3",
+    "type": "text-delta",
+  },
+  {
+    "id": "3",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","command": ",
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""view"",
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path",
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "": "/",
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "skills/",
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "pptx/htm",
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "l2pptx.md"}",
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "view", "path": "/skills/pptx/html2pptx.md"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": "# HTML to PowerPoint Guide
+
+Convert HTML slides to PowerPoint presentations with accurate positioning using the \`html2pptx.js\` library.
+
+## Table of Contents
+
+1. [Creating HTML Slides](#creating-html-slides)
+2. [Using the html2pptx Library](#using-the-html2pptx-library)
+3. [Using PptxGenJS](#using-pptxgenjs)
+
+---
+
+## Creating HTML Slides
+
+Every HTML slide must include proper body dimensions:
+
+### Layout Dimensions
+
+- **16:9** (default): \`width: 720pt; height: 405pt\`
+- **4:3**: \`width: 720pt; height: 540pt\`
+- **16:10**: \`width: 720pt; height: 450pt\`
+
+### Supported Elements
+
+- \`<p>\`, \`<h1>\`-\`<h6>\` - Text with styling
+- \`<ul>\`, \`<ol>\` - Lists (never use manual bullets •, -, *)
+- \`<b>\`, \`<strong>\` - Bold text (inline formatting)
+- \`<i>\`, \`<em>\` - Italic text (inline formatting)
+- \`<u>\` - Underlined text (inline formatting)
+- \`<span>\` - Inline formatting with CSS styles (bold, italic, underline, color)
+- \`<div>\` with bg/border - Becomes .....e
+- \`colW\` - Array of column widths (in inches)
+- \`rowH\` - Array of row heights (in inches)
+- \`border\` - Border style: \`{ pt: 1, color: "999999" }\`
+- \`fill\` - Background color (no # prefix)
+- \`align\` - Text alignment: "left", "center", "right"
+- \`valign\` - Vertical alignment: "top", "middle", "bottom"
+- \`fontSize\` - Text size
+- \`autoPage\` - Auto-create new slides if content overflows",
+      "file_type": "text",
+      "num_lines": 626,
+      "start_line": 1,
+      "total_lines": 626,
+      "type": "text_editor_code_execution_view_result",
+    },
+    "toolCallId": "srvtoolu_016RuxHyUU862TQjFkNrKNVS",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "6",
+    "type": "text-start",
+  },
+  {
+    "delta": "Perfect",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "! Now I'll create a",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " presentation about renewable energy sources. Let me think",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " about the design approach first:
+
+**",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "Design Approach:**
+For",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " a renewable energy presentation, I'll use:",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+- **Color Palette**: "",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "Sage & Terracotta" with",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " earthy tones -",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " Sage (#87A96B) for renewable",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "/nature, terracotta (#E07A",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "5F) for solar/energy, cream",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " (#F4F1DE), and charcoal (#2C2",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "C2C) for text
+- **Typography**: Arial for",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " clarity and professionalism
+- **Layout**:",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": " Clean, modern design with strong visual hierarchy
+- **Style",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "**: Use color blocks and simple shapes to create visual interest",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+
+Now let me create the HTML slides and convert them to Power",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "delta": "Point:",
+    "id": "6",
+    "type": "text-delta",
+  },
+  {
+    "id": "6",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","comma",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nd": "c",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "reate"",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path": "",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "/tmp/slide",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "1.",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "html"",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "file_",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tex",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t": "",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "<!DO",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "CTYPE h",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tml>",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n<html>\\",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n<",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "head",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ">\\n",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "<style>\\",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nhtm",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "l ",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ng",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " a Sustaina",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ble Future",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "</p>\\n</div>",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "</body>\\n</",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "html>\\n"}",
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "create", "path": "/tmp/slide1.html", "file_text": "<!DOCTYPE html>\\n<html>\\n<head>\\n<style>\\nhtml ng a Sustainable Future</p>\\n</div>\\n</body>\\n</html>\\n"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "is_file_update": false,
+      "type": "text_editor_code_execution_create_result",
+    },
+    "toolCallId": "srvtoolu_0114p62tPzsq7C8QCbZteakb",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","comman",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "d": "creat",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e"",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path":",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " "",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "/tmp/sl",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ide2.h",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tml"",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "fil",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e_",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "text": "<!DO",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "right",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "-col\\">\\n",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    <h",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "2>Key Be",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nefits</h",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "2>\\n   ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " <ul",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ">\\n     ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " <li>Zero gr",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "eenho",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "use gas",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " emiss",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ions</li>",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n   ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "   ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "<li>Redu",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ce",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "s ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "electricity ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "bi",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "lls</li>\\n  ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "<l",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "i>Low maint",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "en",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ance c",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "osts</li>\\n",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "   ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "   <li>Scal",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "able f",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rom ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "homes to lar",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ge ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "farms</li>",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n      <",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "li>Te",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "chnology ",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "costs decli",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ning ra",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "pidly</li>\\",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n    </u",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "l>\\n  </div>",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n</div>\\n<",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "/body>\\n",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "</html>\\n"}",
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "create", "path": "/tmp/slide2.html", "file_text": "<!DOright-col\\">\\n    <h2>Key Benefits</h2>\\n    <ul>\\n      <li>Zero greenhouse gas emissions</li>\\n      <li>Reduces electricity bills</li>\\n      <li>Low maintenance costs</li>\\n      <li>Scalable from homes to large farms</li>\\n      <li>Technology costs declining rapidly</li>\\n    </ul>\\n  </div>\\n</div>\\n</body>\\n</html>\\n"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "is_file_update": false,
+      "type": "text_editor_code_execution_create_result",
+    },
+    "toolCallId": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "co",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "mmand": "cr",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "eate"",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path": "/",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tmp/slide3.",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "html",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": """,
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "f",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ile_t",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ex",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t": "<!DOC",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "TYPE html>",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "<html>\\",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n<head",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ">\\n<st",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "yle>",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\nh",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tml { back",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ground",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": #ffff",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ff; }\\n",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "body {",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n  wi",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "dth: ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "720pt",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "; heig",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ht: 405pt;",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " marg",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "in: ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0; padding:",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 0;\\n  backg",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "in: 0 ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0 ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "25pt 0;\\",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n  ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "line-height",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": 1.5;\\n",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "}\\nul ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "{\\n  color",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": #2",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "C2C2C;",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n  font",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "-size: 15p",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t;\\n  lin",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e-height: ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "1.8;\\n  ma",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rgin: ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0;\\",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n  ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "paddi",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ng-left: 20p",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t;\\n}\\n",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".highlight",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " {\\n  backg",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "round: #E07A",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "    <li>Mi",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nimal la",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nd fo",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "otprint</li",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ">\\",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n      ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "<l",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "i>Offsh",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "or",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e potentia",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "l is en",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ormous</",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "li>",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n  ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "</ul>\\n ",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " </d",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "iv>\\n</div",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ">\\n</bod",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "y>\\n<",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "/html>\\n"}",
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "create", "path": "/tmp/slide3.html", "file_text": "<!DOCTYPE html>\\n<html>\\n<head>\\n<style>\\nhtml { background: #ffffff; }\\nbody {\\n  width: 720pt; height: 405pt; margin: 0; padding: 0;\\n  backgin: 0 0 25pt 0;\\n  line-height: 1.5;\\n}\\nul {\\n  color: #2C2C2C;\\n  font-size: 15pt;\\n  line-height: 1.8;\\n  margin: 0;\\n  padding-left: 20pt;\\n}\\n.highlight {\\n  background: #E07A      <li>Minimal land footprint</li>\\n      <li>Offshore potential is enormous</li>\\n    </ul>\\n  </div>\\n</div>\\n</body>\\n</html>\\n"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "is_file_update": false,
+      "type": "text_editor_code_execution_create_result",
+    },
+    "toolCallId": "srvtoolu_01SKYyUuGjiukko1ScoaPXjC",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","command",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "": ",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""cr",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "eate"",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "path",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "": "/",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tmp/slide4.",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "html"",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "file",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "_text": ",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""<!DOCTYPE ",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e create",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " a ",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "healthi",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "er",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " p",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "lanet for ",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "generations ",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "to come.",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "</p>\\",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n  </div",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ">\\n  <div cl",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ass=\\"a",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "cce",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nt-line\\",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""></div>\\n  ",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "<p class=\\"",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "footer-tex",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t\\">The Fu",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ture ",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "is Renewabl",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e</p>\\n<",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "/di",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "v>\\n</bo",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "dy>",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n</",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "html>\\n"}",
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "create", "path": "/tmp/slide4.html", "file_text": "<!DOCTYPE e create a healthier planet for generations to come.</p>\\n  </div>\\n  <div class=\\"accent-line\\"></div>\\n  <p class=\\"footer-text\\">The Future is Renewable</p>\\n</div>\\n</body>\\n</html>\\n"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "is_file_update": false,
+      "type": "text_editor_code_execution_create_result",
+    },
+    "toolCallId": "srvtoolu_01DpSG6m7PmLBK91rfdnJZmf",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "15",
+    "type": "text-start",
+  },
+  {
+    "delta": "Now",
+    "id": "15",
+    "type": "text-delta",
+  },
+  {
+    "delta": " let me create the JavaScript file to convert these",
+    "id": "15",
+    "type": "text-delta",
+  },
+  {
+    "delta": " HTML slides to PowerPoint:",
+    "id": "15",
+    "type": "text-delta",
+  },
+  {
+    "id": "15",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","comma",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nd": "",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "crea",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "te"",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path": "/",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tmp/cr",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "eate_present",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "at",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ion.js"",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "file_text",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "": ",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""con",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "st pp",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "txgen = requ",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ir",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e('pp",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "txgenjs');\\n",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ed success",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "fully!'",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ");\\n}\\n",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\ncrea",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tePresent",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ation",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "().",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "catch(",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "co",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nso",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "le.err",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "or);\\n"}",
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "create", "path": "/tmp/create_presentation.js", "file_text": "const pptxgen = require('pptxgenjs');\\ned successfully!');\\n}\\n\\ncreatePresentation().catch(console.error);\\n"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "is_file_update": false,
+      "type": "text_editor_code_execution_create_result",
+    },
+    "toolCallId": "srvtoolu_01R8QVDsdupbwxGHwSH31k8c",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "18",
+    "type": "text-start",
+  },
+  {
+    "delta": "Now",
+    "id": "18",
+    "type": "text-delta",
+  },
+  {
+    "delta": " let's run the script to create the presentation:",
+    "id": "18",
+    "type": "text-delta",
+  },
+  {
+    "id": "18",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "bash_code_execution","command"",
+    "id": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": "cd /tmp &",
+    "id": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "& node ",
+    "id": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "create_",
+    "id": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "presentat",
+    "id": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ion.js"}",
+    "id": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "bash_code_execution","command": "cd /tmp && node create_presentation.js"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": [],
+      "return_code": 0,
+      "stderr": "Error: /tmp/slide4.html: Text box "The Future is Renewable" ends too close to bottom edge (0.06" from bottom, minimum 0.5" required)
+    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)
+    at async createPresentation (/tmp/create_presentation.js:20:5)
+",
+      "stdout": "",
+      "type": "bash_code_execution_result",
+    },
+    "toolCallId": "srvtoolu_01S5SVmuCHt4vjbgt8AWwdZg",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "21",
+    "type": "text-start",
+  },
+  {
+    "delta": "I",
+    "id": "21",
+    "type": "text-delta",
+  },
+  {
+    "delta": " need to fix the spacing issue on slide 4. Let me adjust the margins",
+    "id": "21",
+    "type": "text-delta",
+  },
+  {
+    "delta": ":",
+    "id": "21",
+    "type": "text-delta",
+  },
+  {
+    "id": "21",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","comm",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "and":",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " "",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "str_repla",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ce"",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path"",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": "/tmp/slid",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "e4.ht",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ml"",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "old",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "_str":",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " ".cont",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ai",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ne",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "r {\\n  margi",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n: 60pt;\\n  ",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "text-ali",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "gn: center;\\",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n}"",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "n",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ew_str":",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " ".container",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " {\\n  margin",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": 50pt ",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "60pt 60pt 60",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "pt;\\n  te",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "xt-",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "align:",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " c",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "enter",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ";\\n}"}",
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "str_replace", "path": "/tmp/slide4.html", "old_str": ".container {\\n  margin: 60pt;\\n  text-align: center;\\n}", "new_str": ".container {\\n  margin: 50pt 60pt 60pt 60pt;\\n  text-align: center;\\n}"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "lines": [
+        "   display: flex; align-items: center; justify-content: center;",
+        " }",
+        " .container {",
+        "-  margin: 60pt;",
+        "+  margin: 50pt 60pt 60pt 60pt;",
+        "   text-align: center;",
+        " }",
+        " h1 {",
+      ],
+      "new_lines": 7,
+      "new_start": 9,
+      "old_lines": 7,
+      "old_start": 9,
+      "type": "text_editor_code_execution_str_replace_result",
+    },
+    "toolCallId": "srvtoolu_019LmqPHLi2gTLpQYqwPC9tE",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "bash_code_execution","",
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "command",
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "": "cd",
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " /tmp &&",
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " node cre",
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ate_",
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "presentatio",
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n.js"}",
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "bash_code_execution","command": "cd /tmp && node create_presentation.js"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": [],
+      "return_code": 0,
+      "stderr": "Error: /tmp/slide4.html: Text box "The Future is Renewable" ends too close to bottom edge (0.13" from bottom, minimum 0.5" required)
+    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)
+    at async createPresentation (/tmp/create_presentation.js:20:5)
+",
+      "stdout": "",
+      "type": "bash_code_execution_result",
+    },
+    "toolCallId": "srvtoolu_0161GS82gFRYsaNcv3o3KxPf",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "26",
+    "type": "text-start",
+  },
+  {
+    "delta": "I need more",
+    "id": "26",
+    "type": "text-delta",
+  },
+  {
+    "delta": " spacing. Let me adjust further:",
+    "id": "26",
+    "type": "text-delta",
+  },
+  {
+    "id": "26",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","command",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "": "str_repl",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ace"",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path": ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""/tmp/",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "slide4",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".html"",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "old_str":",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " ".foot",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "er-text {",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  color: #8",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "7A96",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "B;\\n  ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "font-size: ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "20p",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t;\\n  marg",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "in:",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 0",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ";\\n  fo",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nt-w",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "eight: ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "bold;\\n}\\",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n.ac",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "cent-line {\\",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n  width: 10",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0pt",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ";\\n",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  he",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "igh",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t: 4pt;\\n  ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "backg",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rou",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nd: ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "#E07A5F;\\n ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " margi",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n: ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "20pt a",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "uto;\\n}"",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ""n",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ew_str": "",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".footer",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "-te",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "xt {\\n  col",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "or: #87",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "A96",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "B;\\n  f",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ont-size: 20",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "pt;\\n  ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "margi",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n: 0",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 0 3",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0pt",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 0;\\n  font-",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "weigh",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t: bol",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "d;\\n}\\n",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".accent-li",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ne {\\n  wi",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "dth: 10",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0pt;",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n  heig",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ht: 4pt;\\n  ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "backgro",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "und: #E0",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "7A5F;\\n ",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " margi",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n: 15pt",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " auto;\\n}"}",
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "str_replace", "path": "/tmp/slide4.html", "old_str": ".footer-text {\\n  color: #87A96B;\\n  font-size: 20pt;\\n  margin: 0;\\n  font-weight: bold;\\n}\\n.accent-line {\\n  width: 100pt;\\n  height: 4pt;\\n  background: #E07A5F;\\n  margin: 20pt auto;\\n}", "new_str": ".footer-text {\\n  color: #87A96B;\\n  font-size: 20pt;\\n  margin: 0 0 30pt 0;\\n  font-weight: bold;\\n}\\n.accent-line {\\n  width: 100pt;\\n  height: 4pt;\\n  background: #E07A5F;\\n  margin: 15pt auto;\\n}"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "lines": [
+        " .footer-text {",
+        "   color: #87A96B;",
+        "   font-size: 20pt;",
+        "-  margin: 0;",
+        "+  margin: 0 0 30pt 0;",
+        "   font-weight: bold;",
+        " }",
+        " .accent-line {",
+        "   width: 100pt;",
+        "   height: 4pt;",
+        "   background: #E07A5F;",
+        "-  margin: 20pt auto;",
+        "+  margin: 15pt auto;",
+        " }",
+        " </style>",
+        " </head>",
+      ],
+      "new_lines": 14,
+      "new_start": 36,
+      "old_lines": 14,
+      "old_start": 36,
+      "type": "text_editor_code_execution_str_replace_result",
+    },
+    "toolCallId": "srvtoolu_0183xLGyGvh952zbapjNZD7i",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "bash_code_execution","command",
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "": "c",
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "d /tmp",
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " &&",
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " n",
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ode create",
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "_presentatio",
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n.js"}",
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "bash_code_execution","command": "cd /tmp && node create_presentation.js"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": [],
+      "return_code": 0,
+      "stderr": "Error: /tmp/slide4.html: Multiple validation errors found:
+  1. HTML content overflows body by 2.3pt vertically (Remember: leave 0.5" margin at bottom of slide)
+  2. Text box "The Future is Renewable" ends too close to bottom edge (0.37" from bottom, minimum 0.5" required)
+    at html2pptx (/skills/pptx/scripts/html2pptx.js:989:13)
+    at async createPresentation (/tmp/create_presentation.js:20:5)
+",
+      "stdout": "",
+      "type": "bash_code_execution_result",
+    },
+    "toolCallId": "srvtoolu_01Gra9rbVSy1AVBMRBWUdpLB",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "31",
+    "type": "text-start",
+  },
+  {
+    "delta": "Let",
+    "id": "31",
+    "type": "text-delta",
+  },
+  {
+    "delta": " me reduce the overall content size to fit within the slide",
+    "id": "31",
+    "type": "text-delta",
+  },
+  {
+    "delta": " properly:",
+    "id": "31",
+    "type": "text-delta",
+  },
+  {
+    "id": "31",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "text_editor_code_execution","comm",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "and": "st",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "r_repla",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ce"",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "path":",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " "/",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tmp/s",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "lide4.ht",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ml"",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ", "old",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "_str": ".con",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "taine",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "r {",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n  ma",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rgin",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": 50pt ",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "60pt 60pt 6",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "0pt;\\n",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  text-al",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ign: cen",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ter;\\n}\\nh1 ",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "{\\n ",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " color:",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " #",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ffffff;\\n  ",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "fo",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nt-size",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": 48",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "pt",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ";\\n ",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " margin: 0 0",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 30pt 0;\\",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n  font",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "-w",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "eight:",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " bold;\\n}\\n",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".con",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tent-bo",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "x {\\n ",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " backgrou",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nd:",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " #ffffff;\\",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n  padding:",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 35pt",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " 40pt;\\n  bo",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rder-radiu",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "s: ",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "8pt;\\n  ma",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "rgin-b",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ottom: 30p",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t;\\n}\\n.cont",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ent-box",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " p {\\n  co",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "lor: #2",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "C2C2C;\\n",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "  fo",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nt-si",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ze: 18p",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t;\\n  mar",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "gin: 0 0 20",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "pt 0;\\n  li",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ne-heig",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ht: 1",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".6;\\n}",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n.content-b",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ox p:last",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "-child",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " {\\n  margi",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "n: 0;\\n}\\n",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".footer-",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "text {\\n  c",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "line {",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "\\n  widt",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "h: ",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "100p",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t;\\n  he",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "igh",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "t: 4pt;\\n  b",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ackg",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "round",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": #E07A",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "5F",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ";\\n  margin",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": 15pt",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " aut",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "o;\\n",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "}"}",
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "text_editor_code_execution","command": "str_replace", "path": "/tmp/slide4.html", "old_str": ".container {\\n  margin: 50pt 60pt 60pt 60pt;\\n  text-align: center;\\n}\\nh1 {\\n  color: #ffffff;\\n  font-size: 48pt;\\n  margin: 0 0 30pt 0;\\n  font-weight: bold;\\n}\\n.content-box {\\n  background: #ffffff;\\n  padding: 35pt 40pt;\\n  border-radius: 8pt;\\n  margin-bottom: 30pt;\\n}\\n.content-box p {\\n  color: #2C2C2C;\\n  font-size: 18pt;\\n  margin: 0 0 20pt 0;\\n  line-height: 1.6;\\n}\\n.content-box p:last-child {\\n  margin: 0;\\n}\\n.footer-text {\\n  cline {\\n  width: 100pt;\\n  height: 4pt;\\n  background: #E07A5F;\\n  margin: 15pt auto;\\n}"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "lines": [
+        "   display: flex; align-items: center; justify-content: center;",
+        " }",
+        " .container {",
+        "-  margin: 50pt 60pt 60pt 60pt;",
+        "+  margin: 45pt 60pt 50pt 60pt;",
+        "   text-align: center;",
+        " }",
+        " h1 {",
+        "   color: #ffffff;",
+        "-  font-size: 48pt;",
+        "-  margin: 0 0 30pt 0;",
+        "+  font-size: 44pt;",
+        "+  margin: 0 0 25pt 0;",
+        "   font-weight: bold;",
+        " }",
+        " .content-box {",
+        "   background: #ffffff;",
+        "-  padding: 35pt 40pt;",
+        "+  padding: 30pt 40pt;",
+        "   border-radius: 8pt;",
+        "-  margin-bottom: 30pt;",
+        "+  margin-bottom: 25pt;",
+        " }",
+        " .content-box p {",
+        "   color: #2C2C2C;",
+        "-  font-size: 18pt;",
+        "-  margin: 0 0 20pt 0;",
+        "-  line-height: 1.6;",
+        "+  font-size: 17pt;",
+        "+  margin: 0 0 18pt 0;",
+        "+  line-height: 1.5;",
+        " }",
+        " .content-box p:last-child {",
+        "   margin: 0;",
+        " }",
+        " .footer-text {",
+        "   color: #87A96B;",
+        "-  font-size: 20pt;",
+        "-  margin: 0 0 30pt 0;",
+        "+  font-size: 19pt;",
+        "+  margin: 0;",
+        "   font-weight: bold;",
+        " }",
+        " .accent-line {",
+      ],
+      "new_lines": 34,
+      "new_start": 9,
+      "old_lines": 34,
+      "old_start": 9,
+      "type": "text_editor_code_execution_str_replace_result",
+    },
+    "toolCallId": "srvtoolu_0124fFTYi7kr5TekwB1uX2Te",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "bash_code_execution","comman",
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "d": "cd /tm",
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "p && no",
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "de cre",
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "ate_pre",
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "sentation",
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ".j",
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "s"}",
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "bash_code_execution","command": "cd /tmp && node create_presentation.js"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": [],
+      "return_code": 0,
+      "stderr": "",
+      "stdout": "Presentation created successfully!
+",
+      "type": "bash_code_execution_result",
+    },
+    "toolCallId": "srvtoolu_019qRxtfSXCNeyhPeLAR67H3",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "36",
+    "type": "text-start",
+  },
+  {
+    "delta": "Great",
+    "id": "36",
+    "type": "text-delta",
+  },
+  {
+    "delta": "! The presentation was created successfully. Now",
+    "id": "36",
+    "type": "text-delta",
+  },
+  {
+    "delta": " let me create thumbnails to",
+    "id": "36",
+    "type": "text-delta",
+  },
+  {
+    "delta": " validate the visual layout:",
+    "id": "36",
+    "type": "text-delta",
+  },
+  {
+    "id": "36",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "bash_code_execution","co",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "mmand"",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": ": "cd",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " /tmp &",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "& pyt",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "hon /skill",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "s/pptx/scri",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "pts/thumbna",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "il.p",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "y renewable_",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "energy.pp",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tx",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " thumb",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nails -",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "-cols 4"}",
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "bash_code_execution","command": "cd /tmp && python /skills/pptx/scripts/thumbnail.py renewable_energy.pptx thumbnails --cols 4"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": [],
+      "return_code": 1,
+      "stderr": "",
+      "stdout": "Processing: renewable_energy.pptx
+Analyzing presentation...
+Total slides: 4
+Converting to PDF...
+Error: PDF conversion failed
+",
+      "type": "bash_code_execution_result",
+    },
+    "toolCallId": "srvtoolu_01CwLPrEurEQ4ruCJua94vHC",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "39",
+    "type": "text-start",
+  },
+  {
+    "delta": "Let",
+    "id": "39",
+    "type": "text-delta",
+  },
+  {
+    "delta": " me try a different approach and copy the file",
+    "id": "39",
+    "type": "text-delta",
+  },
+  {
+    "delta": " to the output directory:",
+    "id": "39",
+    "type": "text-delta",
+  },
+  {
+    "id": "39",
+    "type": "text-end",
+  },
+  {
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "providerExecuted": true,
+    "toolName": "code_execution",
+    "type": "tool-input-start",
+  },
+  {
+    "delta": "{"type": "bash_code_execution","comman",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "d": "cp /t",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "mp/renewab",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "le_e",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "nergy.pp",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "tx",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " $OUTP",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "UT_DIR/",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "renew",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "able_energy.",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "pptx &",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "& ls",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " -lh",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": " $",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "OUT",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "delta": "PUT_DIR/"}",
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-delta",
+  },
+  {
+    "id": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "type": "tool-input-end",
+  },
+  {
+    "input": "{"type": "bash_code_execution","command": "cp /tmp/renewable_energy.pptx $OUTPUT_DIR/renewable_energy.pptx && ls -lh $OUTPUT_DIR/"}",
+    "providerExecuted": true,
+    "toolCallId": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "toolName": "code_execution",
+    "type": "tool-call",
+  },
+  {
+    "providerExecuted": true,
+    "result": {
+      "content": [
+        {
+          "file_id": "file_011CUJNRcxM3JHxL8b5QGrNT",
+          "type": "bash_code_execution_output",
+        },
+      ],
+      "return_code": 0,
+      "stderr": "",
+      "stdout": "total 80K
+-rw-r--r-- 1 root root 80K Oct 20 11:27 renewable_energy.pptx
+",
+      "type": "bash_code_execution_result",
+    },
+    "toolCallId": "srvtoolu_01AHZTbXCnWcLhc3My3nNYPT",
+    "toolName": "code_execution",
+    "type": "tool-result",
+  },
+  {
+    "id": "42",
+    "type": "text-start",
+  },
+  {
+    "delta": "Perfect",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "! I've successfully created your",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " presentation about renewable energy sources. Here",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "'s what I've delivered:
+
+##",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " Presentation Overview
+
+**Title:** Renewable Energy Sources",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+**Format:** PowerPoint (.",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "pptx)
+**Slides:** 4 slides as",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " requested
+
+### Design Approach
+I",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " chose a **Sage & Ter",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "racotta** color palette that reflects",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " the natural, earth-friendly theme of renewable energy:",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+- **Sage green (#87",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "A96B)** - represents nature an",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "d sustainability
+- **Terracotta (#E07A5F)**",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " - represents solar energy and warmth
+- **Cream",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " (#F4F1DE)** - neutral",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " background for readability
+- **Charcoal (#2C2C2",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "C)** - professional text color
+
+###",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " Slide Contents
+
+1. **Slide 1 - Title",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " Slide**: 
+   - Bold title "Renewable Energy Sources"",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+   - Subtitle "Powering",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " a Sustainable Future"
+   - Clean",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " design with sage green background and accent bar",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+
+2. **Slide 2 - Solar Power**:
+   ",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "- Description of solar energy technology
+   - Key",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " benefits including zero emissions, cost savings, and scal",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "ability
+   - Two-column layout with highlighte",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "d callout box
+
+3. **Slide 3",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " - Wind Energy**:
+   ",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "- Explanation of wind turbine technology
+   - Benefits including",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " clean energy, cost-competitiveness, and job creation
+   ",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "- Similar two-column layout maintaining design",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " consistency
+
+4. **Slide ",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "4 - Conclusion**:",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+   - Summary of the importance of renewable energy
+   - Call to",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " action about building a sustainable future
+   - Dark",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " background with impactful message",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": "
+
+The presentation has",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " been exported and is",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "delta": " ready for use!",
+    "id": "42",
+    "type": "text-delta",
+  },
+  {
+    "id": "42",
+    "type": "text-end",
+  },
+  {
+    "finishReason": "stop",
+    "providerMetadata": {
+      "anthropic": {
+        "cacheCreationInputTokens": 0,
+        "stopSequence": null,
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0,
+          },
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 320032,
+          "output_tokens": 5558,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0,
+          },
+          "service_tier": "standard",
+        },
+      },
+    },
+    "type": "finish",
+    "usage": {
+      "cachedInputTokens": 0,
+      "inputTokens": 2751,
+      "outputTokens": 5558,
+      "totalTokens": 8309,
+    },
+  },
+]
+`;
+
 exports[`AnthropicMessagesLanguageModel > doStream > raw chunks > code execution 20250825 tool > should stream code execution tool results 1`] = `
 [
   {

--- a/packages/anthropic/src/anthropic-message-metadata.ts
+++ b/packages/anthropic/src/anthropic-message-metadata.ts
@@ -6,15 +6,42 @@ export interface AnthropicMessageMetadata {
   // (use value in usage object instead)
   cacheCreationInputTokens: number | null;
   stopSequence: string | null;
+
+  /**
+   * Information about the container used in this request.
+   *
+   * This will be non-null if a container tool (e.g., code execution) was used.
+   * Information about the container used in the request (for the code execution tool).
+   */
   container: {
+    /**
+     * The time at which the container will expire (RFC3339 timestamp).
+     */
     expiresAt: string;
+
+    /**
+     * Identifier for the container used in this request.
+     */
     id: string;
-    skills:
-      | {
-          type: 'anthropic' | 'custom';
-          skillId: string;
-          version: string;
-        }[]
-      | null;
+
+    /**
+     * Skills loaded in the container.
+     */
+    skills: Array<{
+      /**
+       * Type of skill: either 'anthropic' (built-in) or 'custom' (user-defined).
+       */
+      type: 'anthropic' | 'custom';
+
+      /**
+       * Skill ID (1-64 characters).
+       */
+      skillId: string;
+
+      /**
+       * Skill version or 'latest' for most recent version (1-64 characters).
+       */
+      version: string;
+    }> | null;
   } | null;
 }

--- a/packages/anthropic/src/anthropic-message-metadata.ts
+++ b/packages/anthropic/src/anthropic-message-metadata.ts
@@ -1,0 +1,20 @@
+import { JSONObject } from '@ai-sdk/provider';
+
+export interface AnthropicMessageMetadata {
+  usage: JSONObject;
+  // TODO remove cacheCreationInputTokens in AI SDK 6
+  // (use value in usage object instead)
+  cacheCreationInputTokens: number | null;
+  stopSequence: string | null;
+  container: {
+    expiresAt: string;
+    id: string;
+    skills:
+      | {
+          type: 'anthropic' | 'custom';
+          skillId: string;
+          version: string;
+        }[]
+      | null;
+  } | null;
+}

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -833,6 +833,24 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
         delta: z.object({
           stop_reason: z.string().nullish(),
           stop_sequence: z.string().nullish(),
+          container: z
+            .object({
+              expires_at: z.string(),
+              id: z.string(),
+              skills: z
+                .array(
+                  z.object({
+                    type: z.union([
+                      z.literal('anthropic'),
+                      z.literal('custom'),
+                    ]),
+                    skill_id: z.string(),
+                    version: z.string(),
+                  }),
+                )
+                .nullish(),
+            })
+            .nullish(),
         }),
         usage: z.looseObject({
           output_tokens: z.number(),

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -567,6 +567,21 @@ export const anthropicMessagesResponseSchema = lazySchema(() =>
         cache_creation_input_tokens: z.number().nullish(),
         cache_read_input_tokens: z.number().nullish(),
       }),
+      container: z
+        .object({
+          expires_at: z.string(),
+          id: z.string(),
+          skills: z
+            .array(
+              z.object({
+                type: z.union([z.literal('anthropic'), z.literal('custom')]),
+                skill_id: z.string(),
+                version: z.string(),
+              }),
+            )
+            .nullish(),
+        })
+        .nullish(),
     }),
   ),
 );

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -2583,6 +2583,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "providerMetadata": {
                 "anthropic": {
                   "cacheCreationInputTokens": null,
+                  "container": null,
                   "stopSequence": null,
                   "usage": {
                     "input_tokens": 441,
@@ -2661,6 +2662,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "providerMetadata": {
               "anthropic": {
                 "cacheCreationInputTokens": null,
+                "container": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 17,
@@ -2759,6 +2761,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "providerMetadata": {
               "anthropic": {
                 "cacheCreationInputTokens": null,
+                "container": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 17,
@@ -2839,6 +2842,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "providerMetadata": {
               "anthropic": {
                 "cacheCreationInputTokens": null,
+                "container": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 17,
@@ -2905,6 +2909,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "providerMetadata": {
               "anthropic": {
                 "cacheCreationInputTokens": null,
+                "container": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 17,
@@ -3039,6 +3044,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "providerMetadata": {
               "anthropic": {
                 "cacheCreationInputTokens": null,
+                "container": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 441,
@@ -3247,6 +3253,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "providerMetadata": {
               "anthropic": {
                 "cacheCreationInputTokens": 10,
+                "container": null,
                 "stopSequence": null,
                 "usage": {
                   "cache_creation_input_tokens": 10,
@@ -3320,6 +3327,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "providerMetadata": {
               "anthropic": {
                 "cacheCreationInputTokens": 10,
+                "container": null,
                 "stopSequence": null,
                 "usage": {
                   "cache_creation": {
@@ -3423,6 +3431,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "providerMetadata": {
                 "anthropic": {
                   "cacheCreationInputTokens": null,
+                  "container": null,
                   "stopSequence": null,
                   "usage": {
                     "input_tokens": 17,
@@ -3470,6 +3479,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "providerMetadata": {
                 "anthropic": {
                   "cacheCreationInputTokens": null,
+                  "container": null,
                   "stopSequence": "STOP",
                   "usage": {
                     "input_tokens": 17,
@@ -3704,6 +3714,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "providerMetadata": {
                 "anthropic": {
                   "cacheCreationInputTokens": null,
+                  "container": null,
                   "stopSequence": null,
                   "usage": {
                     "input_tokens": 17,

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -1801,7 +1801,9 @@ describe('AnthropicMessagesLanguageModel', () => {
 
     describe('agent skills', () => {
       it('should send request body with skills in container', async () => {
-        prepareJsonResponse({});
+        prepareJsonFixtureResponse(
+          'anthropic-code-execution-20250825.pptx-skill',
+        );
 
         const result = await model.doGenerate({
           prompt: TEST_PROMPT,
@@ -1877,7 +1879,9 @@ describe('AnthropicMessagesLanguageModel', () => {
       });
 
       it('should add a warning when the code execution tool is not present', async () => {
-        prepareJsonResponse({});
+        prepareJsonFixtureResponse(
+          'anthropic-code-execution-20250825.pptx-skill',
+        );
 
         const result = await model.doGenerate({
           prompt: TEST_PROMPT,
@@ -1946,7 +1950,9 @@ describe('AnthropicMessagesLanguageModel', () => {
       });
 
       it('should include beta headers when skills are configured', async () => {
-        prepareJsonResponse({});
+        prepareJsonFixtureResponse(
+          'anthropic-code-execution-20250825.pptx-skill',
+        );
 
         await model.doGenerate({
           prompt: TEST_PROMPT,
@@ -1981,6 +1987,39 @@ describe('AnthropicMessagesLanguageModel', () => {
             "x-api-key": "test-api-key",
           }
         `);
+      });
+
+      it('should expose container information as provider metadata', async () => {
+        prepareJsonFixtureResponse(
+          'anthropic-code-execution-20250825.pptx-skill',
+        );
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'anthropic.code_execution_20250825',
+              name: 'code_execution',
+              args: {},
+            },
+          ],
+          providerOptions: {
+            anthropic: {
+              container: {
+                skills: [
+                  {
+                    type: 'anthropic',
+                    skillId: 'pptx',
+                    version: 'latest',
+                  },
+                ],
+              },
+            } satisfies AnthropicProviderOptions,
+          },
+        });
+
+        expect(result.providerMetadata).toMatchSnapshot();
       });
     });
 

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -446,6 +446,7 @@ describe('AnthropicMessagesLanguageModel', () => {
         {
           "anthropic": {
             "cacheCreationInputTokens": null,
+            "container": null,
             "stopSequence": "STOP",
             "usage": {
               "input_tokens": 4,
@@ -732,6 +733,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           "providerMetadata": {
             "anthropic": {
               "cacheCreationInputTokens": 10,
+              "container": null,
               "stopSequence": null,
               "usage": {
                 "cache_creation_input_tokens": 10,
@@ -866,6 +868,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           "providerMetadata": {
             "anthropic": {
               "cacheCreationInputTokens": 10,
+              "container": null,
               "stopSequence": null,
               "usage": {
                 "cache_creation": {
@@ -2158,6 +2161,24 @@ describe('AnthropicMessagesLanguageModel', () => {
         });
 
         expect(result.content).toMatchSnapshot();
+      });
+
+      it('should expose container information as provider metadata', async () => {
+        prepareJsonFixtureResponse('anthropic-code-execution-20250825.1');
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider-defined',
+              id: 'anthropic.code_execution_20250825',
+              name: 'code_execution',
+              args: {},
+            },
+          ],
+        });
+
+        expect(result.providerMetadata).toMatchSnapshot();
       });
     });
 

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -3747,6 +3747,37 @@ describe('AnthropicMessagesLanguageModel', () => {
         });
       });
 
+      describe('agent skills', () => {
+        it('should stream code execution tool results', async () => {
+          prepareChunksFixtureResponse(
+            'anthropic-code-execution-20250825.pptx-skill',
+          );
+
+          const result = await model.doStream({
+            prompt: TEST_PROMPT,
+            tools: [
+              {
+                type: 'provider-defined',
+                id: 'anthropic.code_execution_20250825',
+                name: 'code_execution',
+                args: {},
+              },
+            ],
+            providerOptions: {
+              anthropic: {
+                container: {
+                  skills: [{ type: 'anthropic', skillId: 'pptx' }],
+                },
+              } satisfies AnthropicProviderOptions,
+            },
+          });
+
+          expect(
+            await convertReadableStreamToArray(result.stream),
+          ).toMatchSnapshot();
+        });
+      });
+
       describe('code execution 20250825 tool', () => {
         it('should stream code execution tool results', async () => {
           prepareChunksFixtureResponse('anthropic-code-execution-20250825.1');

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -42,6 +42,7 @@ import { prepareTools } from './anthropic-prepare-tools';
 import { convertToAnthropicMessagesPrompt } from './convert-to-anthropic-messages-prompt';
 import { CacheControlValidator } from './get-cache-control';
 import { mapAnthropicStopReason } from './map-anthropic-stop-reason';
+import { AnthropicMessageMetadata } from './anthropic-message-metadata';
 
 function createCitationSource(
   citation: Citation,
@@ -766,7 +767,19 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
           cacheCreationInputTokens:
             response.usage.cache_creation_input_tokens ?? null,
           stopSequence: response.stop_sequence ?? null,
-        },
+          container: response.container
+            ? {
+                expiresAt: response.container.expires_at,
+                id: response.container.id,
+                skills:
+                  response.container.skills?.map(skill => ({
+                    type: skill.type,
+                    skillId: skill.skill_id,
+                    version: skill.version,
+                  })) ?? null,
+              }
+            : null,
+        } satisfies AnthropicMessageMetadata,
       },
     };
   }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -831,6 +831,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     let rawUsage: JSONObject | undefined = undefined;
     let cacheCreationInputTokens: number | null = null;
     let stopSequence: string | null = null;
+    let container: AnthropicMessageMetadata['container'] | null = null;
 
     let blockType:
       | 'text'
@@ -1365,6 +1366,19 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                 });
 
                 stopSequence = value.delta.stop_sequence ?? null;
+                container =
+                  value.delta.container != null
+                    ? {
+                        expiresAt: value.delta.container.expires_at,
+                        id: value.delta.container.id,
+                        skills:
+                          value.delta.container.skills?.map(skill => ({
+                            type: skill.type,
+                            skillId: skill.skill_id,
+                            version: skill.version,
+                          })) ?? null,
+                      }
+                    : null;
 
                 rawUsage = {
                   ...rawUsage,
@@ -1381,10 +1395,11 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                   usage,
                   providerMetadata: {
                     anthropic: {
-                      usage: rawUsage ?? null,
+                      usage: (rawUsage as JSONObject) ?? null,
                       cacheCreationInputTokens,
                       stopSequence,
-                    },
+                      container,
+                    } satisfies AnthropicMessageMetadata,
                   },
                 });
                 return;

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -1,3 +1,4 @@
+export type { AnthropicMessageMetadata } from './anthropic-message-metadata';
 export type { AnthropicProviderOptions } from './anthropic-messages-options';
 export { anthropic, createAnthropic } from './anthropic-provider';
 export type {


### PR DESCRIPTION
## Background

Anthropic includes the [container information](https://docs.claude.com/en/api/messages#response-container) in the response. The container id and expiry date is required to reuse the same container in subsequent requests.

## Summary

* introduce `AnthropicMessageMetadata` type
* parse container information in `doGenerate`
* add `printFullStream` examples helper

## Manual Verification

- [x] run `examples/ai-core/src/generate-text/anthropic-skills.ts`
- [x] run `examples/ai-core/src/stream-text/anthropic-skills.ts`

## Tasks

- [x] add generate test for code execution with skills
- [x] introduce `AnthropicMessageMetadata` type
- [x] implement generate
- [x] example for generate
- [x] add stream example
- [x] add stream test for code execution with skills
- [x] implement stream
- [x] jsdoc `AnthropicMessageMetadata` type
- [x] changeset

## Future Work

- figure out how to use container from response in agents with ui

## Related Issues

Fixes #9652