### PR TITLE
feat(agent): change output generics

### DIFF
--- a/.changeset/big-geese-vanish.md
+++ b/.changeset/big-geese-vanish.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(agent): change output generics

--- a/examples/ai-core/src/agent/openai-generate-json.ts
+++ b/examples/ai-core/src/agent/openai-generate-json.ts
@@ -1,0 +1,35 @@
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { Output, ToolLoopAgent } from 'ai';
+import { run } from '../lib/run';
+import { z } from 'zod';
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-4o'),
+  experimental_output: Output.object({
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({
+            name: z.string(),
+            amount: z.string(),
+          }),
+        ),
+        steps: z.array(z.string()),
+      }),
+    }),
+  }),
+  providerOptions: {
+    openai: {
+      strictJsonSchema: true,
+    } satisfies OpenAIResponsesProviderOptions,
+  },
+});
+
+run(async () => {
+  const { experimental_output: output } = await agent.generate({
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.dir(output, { depth: Infinity });
+});

--- a/examples/ai-core/src/agent/openai-stream-json.ts
+++ b/examples/ai-core/src/agent/openai-stream-json.ts
@@ -1,7 +1,7 @@
 import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
 import { Output, ToolLoopAgent } from 'ai';
-import { run } from '../lib/run';
 import { z } from 'zod';
+import { run } from '../lib/run';
 
 const agent = new ToolLoopAgent({
   model: openai('gpt-4o'),
@@ -27,9 +27,13 @@ const agent = new ToolLoopAgent({
 });
 
 run(async () => {
-  const { experimental_output: output } = await agent.generate({
+  // types wrong
+  const result = agent.stream({
     prompt: 'Generate a lasagna recipe.',
   });
 
-  console.dir(output, { depth: Infinity });
+  for await (const partialObject of result.experimental_partialOutputStream) {
+    console.clear();
+    console.dir(partialObject, { depth: Infinity });
+  }
 });

--- a/examples/ai-core/src/agent/openai-stream-json.ts
+++ b/examples/ai-core/src/agent/openai-stream-json.ts
@@ -27,7 +27,6 @@ const agent = new ToolLoopAgent({
 });
 
 run(async () => {
-  // types wrong
   const result = agent.stream({
     prompt: 'Generate a lasagna recipe.',
   });

--- a/examples/ai-core/src/stream-object/openai.ts
+++ b/examples/ai-core/src/stream-object/openai.ts
@@ -23,10 +23,8 @@ async function main() {
 
   for await (const partialObject of result.partialObjectStream) {
     console.clear();
-    console.log(partialObject);
+    console.dir(partialObject, { depth: Infinity });
   }
-
-  console.log(JSON.stringify((await result.request).body, null, 2));
 }
 
 main().catch(console.error);

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,4 +1,5 @@
 import { GenerateTextResult } from '../generate-text/generate-text-result';
+import { InferStreamOutput, Output } from '../generate-text/output';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 import { Prompt } from '../prompt/prompt';
@@ -12,8 +13,7 @@ import { Prompt } from '../prompt/prompt';
  */
 export interface Agent<
   TOOLS extends ToolSet = {},
-  OUTPUT = never,
-  OUTPUT_PARTIAL = never,
+  OUTPUT extends Output = never,
 > {
   /**
    * The specification version of the agent interface. This will enable
@@ -39,5 +39,5 @@ export interface Agent<
   /**
    * Streams an output from the agent (streaming).
    */
-  stream(options: Prompt): StreamTextResult<TOOLS, OUTPUT_PARTIAL>;
+  stream(options: Prompt): StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>>;
 }

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,5 +1,9 @@
 import { GenerateTextResult } from '../generate-text/generate-text-result';
-import { InferStreamOutput, Output } from '../generate-text/output';
+import {
+  InferGenerateOutput,
+  InferStreamOutput,
+  Output,
+} from '../generate-text/output';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 import { Prompt } from '../prompt/prompt';
@@ -34,7 +38,9 @@ export interface Agent<
   /**
    * Generates an output from the agent (non-streaming).
    */
-  generate(options: Prompt): PromiseLike<GenerateTextResult<TOOLS, OUTPUT>>;
+  generate(
+    options: Prompt,
+  ): PromiseLike<GenerateTextResult<TOOLS, InferGenerateOutput<OUTPUT>>>;
 
   /**
    * Streams an output from the agent (streaming).

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -1,4 +1,5 @@
 import { UIMessageStreamOptions } from '../generate-text';
+import { Output } from '../generate-text/output';
 import { ToolSet } from '../generate-text/tool-set';
 import { createUIMessageStreamResponse } from '../ui-message-stream';
 import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
@@ -16,8 +17,7 @@ import { createAgentUIStream } from './create-agent-ui-stream';
  */
 export async function createAgentUIStreamResponse<
   TOOLS extends ToolSet = {},
-  OUTPUT = never,
-  OUTPUT_PARTIAL = never,
+  OUTPUT extends Output = never,
 >({
   headers,
   status,
@@ -25,7 +25,7 @@ export async function createAgentUIStreamResponse<
   consumeSseStream,
   ...options
 }: {
-  agent: Agent<TOOLS, OUTPUT, OUTPUT_PARTIAL>;
+  agent: Agent<TOOLS, OUTPUT>;
   messages: unknown[];
 } & UIMessageStreamResponseInit &
   UIMessageStreamOptions<

--- a/packages/ai/src/agent/create-agent-ui-stream.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream.ts
@@ -1,4 +1,5 @@
 import { UIMessageStreamOptions } from '../generate-text';
+import { Output } from '../generate-text/output';
 import { ToolSet } from '../generate-text/tool-set';
 import { InferUIMessageChunk } from '../ui-message-stream';
 import { convertToModelMessages } from '../ui/convert-to-model-messages';
@@ -17,14 +18,13 @@ import { Agent } from './agent';
  */
 export async function createAgentUIStream<
   TOOLS extends ToolSet = {},
-  OUTPUT = never,
-  OUTPUT_PARTIAL = never,
+  OUTPUT extends Output = never,
 >({
   agent,
   messages,
   ...uiMessageStreamOptions
 }: {
-  agent: Agent<TOOLS, OUTPUT, OUTPUT_PARTIAL>;
+  agent: Agent<TOOLS, OUTPUT>;
   messages: unknown[];
 } & UIMessageStreamOptions<
   UIMessage<never, never, InferUITools<TOOLS>>

--- a/packages/ai/src/agent/infer-agent-tools.ts
+++ b/packages/ai/src/agent/infer-agent-tools.ts
@@ -4,4 +4,4 @@ import { Agent } from './agent';
  * Infer the type of the tools of an agent.
  */
 export type InferAgentTools<AGENT> =
-  AGENT extends Agent<infer TOOLS, any, any> ? TOOLS : never;
+  AGENT extends Agent<infer TOOLS, never> ? TOOLS : never;

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -1,5 +1,6 @@
 import { ServerResponse } from 'node:http';
 import { UIMessageStreamOptions } from '../generate-text';
+import { Output } from '../generate-text/output';
 import { ToolSet } from '../generate-text/tool-set';
 import { pipeUIMessageStreamToResponse } from '../ui-message-stream';
 import { UIMessageStreamResponseInit } from '../ui-message-stream/ui-message-stream-response-init';
@@ -15,8 +16,7 @@ import { createAgentUIStream } from './create-agent-ui-stream';
  */
 export async function pipeAgentUIStreamToResponse<
   TOOLS extends ToolSet = {},
-  OUTPUT = never,
-  OUTPUT_PARTIAL = never,
+  OUTPUT extends Output = never,
 >({
   response,
   headers,
@@ -26,7 +26,7 @@ export async function pipeAgentUIStreamToResponse<
   ...options
 }: {
   response: ServerResponse;
-  agent: Agent<TOOLS, OUTPUT, OUTPUT_PARTIAL>;
+  agent: Agent<TOOLS, OUTPUT>;
   messages: unknown[];
 } & UIMessageStreamResponseInit &
   UIMessageStreamOptions<

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -15,8 +15,7 @@ import { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-fin
  */
 export type ToolLoopAgentSettings<
   TOOLS extends ToolSet = {},
-  OUTPUT = never,
-  OUTPUT_PARTIAL = never,
+  OUTPUT extends Output = never,
 > = CallSettings & {
   /**
    * The id of the agent.
@@ -67,7 +66,7 @@ changing the tool call and result types in the result.
   /**
 Optional specification for parsing structured outputs from the LLM response.
    */
-  experimental_output?: Output<OUTPUT, OUTPUT_PARTIAL>;
+  experimental_output?: OUTPUT;
 
   /**
    * @deprecated Use `prepareStep` instead.

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -1,0 +1,49 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod';
+import { Output } from '../generate-text';
+import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
+import { ToolLoopAgent } from './tool-loop-agent';
+import { AsyncIterableStream } from '../util/async-iterable-stream';
+import { DeepPartial } from '../util/deep-partial';
+
+describe('ToolLoopAgent', () => {
+  describe('generate', () => {
+    it('should infer output type', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3(),
+        experimental_output: Output.object({
+          schema: z.object({ value: z.string() }),
+        }),
+      });
+
+      const generateResult = await agent.generate({
+        prompt: 'Hello, world!',
+      });
+
+      const output = generateResult.experimental_output;
+
+      expectTypeOf<typeof output>().toEqualTypeOf<{ value: string }>();
+    });
+  });
+
+  describe('stream', () => {
+    it('should infer output type', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3(),
+        experimental_output: Output.object({
+          schema: z.object({ value: z.string() }),
+        }),
+      });
+
+      const streamResult = agent.stream({
+        prompt: 'Hello, world!',
+      });
+
+      const partialOutputStream = streamResult.experimental_partialOutputStream;
+
+      expectTypeOf<typeof partialOutputStream>().toEqualTypeOf<
+        AsyncIterableStream<DeepPartial<{ value: string }>>
+      >();
+    });
+  });
+});

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,5 +1,6 @@
 import { generateText } from '../generate-text/generate-text';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
+import { InferStreamOutput, Output } from '../generate-text/output';
 import { stepCountIs } from '../generate-text/stop-condition';
 import { streamText } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
@@ -21,19 +22,14 @@ import { ToolLoopAgentSettings } from './tool-loop-agent-settings';
  */
 export class ToolLoopAgent<
   TOOLS extends ToolSet = {},
-  OUTPUT = never,
-  OUTPUT_PARTIAL = never,
-> implements Agent<TOOLS, OUTPUT, OUTPUT_PARTIAL>
+  OUTPUT extends Output = never,
+> implements Agent<TOOLS, OUTPUT>
 {
   readonly version = 'agent-v1';
 
-  private readonly settings: ToolLoopAgentSettings<
-    TOOLS,
-    OUTPUT,
-    OUTPUT_PARTIAL
-  >;
+  private readonly settings: ToolLoopAgentSettings<TOOLS, OUTPUT>;
 
-  constructor(settings: ToolLoopAgentSettings<TOOLS, OUTPUT, OUTPUT_PARTIAL>) {
+  constructor(settings: ToolLoopAgentSettings<TOOLS, OUTPUT>) {
     this.settings = settings;
   }
 
@@ -65,7 +61,7 @@ export class ToolLoopAgent<
   /**
    * Streams an output from the agent (streaming).
    */
-  stream(options: Prompt): StreamTextResult<TOOLS, OUTPUT_PARTIAL> {
+  stream(options: Prompt): StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>> {
     return streamText({
       ...this.settings,
       stopWhen: this.settings.stopWhen ?? stepCountIs(20),

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,6 +1,10 @@
 import { generateText } from '../generate-text/generate-text';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
-import { InferStreamOutput, Output } from '../generate-text/output';
+import {
+  InferGenerateOutput,
+  InferStreamOutput,
+  Output,
+} from '../generate-text/output';
 import { stepCountIs } from '../generate-text/stop-condition';
 import { streamText } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
@@ -50,7 +54,9 @@ export class ToolLoopAgent<
   /**
    * Generates an output from the agent (non-streaming).
    */
-  async generate(options: Prompt): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
+  async generate(
+    options: Prompt,
+  ): Promise<GenerateTextResult<TOOLS, InferGenerateOutput<OUTPUT>>> {
     return generateText({
       ...this.settings,
       stopWhen: this.settings.stopWhen ?? stepCountIs(20),

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -13,7 +13,7 @@ import { LanguageModelUsage } from '../types/usage';
 import { DeepPartial } from '../util/deep-partial';
 import { parsePartialJson } from '../util/parse-partial-json';
 
-export interface Output<OUTPUT = never, PARTIAL = never> {
+export interface Output<OUTPUT = any, PARTIAL = any> {
   readonly type: 'object' | 'text';
 
   responseFormat: PromiseLike<LanguageModelV3CallOptions['responseFormat']>;

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -126,7 +126,7 @@ export const object = <OUTPUT>({
 };
 
 export type InferGenerateOutput<OUTPUT extends Output> =
-  OUTPUT extends Output<infer T, never> ? T : never;
+  OUTPUT extends Output<infer T, any> ? T : never;
 
 export type InferStreamOutput<OUTPUT extends Output> =
-  OUTPUT extends Output<never, infer P> ? P : never;
+  OUTPUT extends Output<any, infer P> ? P : never;

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -1,4 +1,4 @@
-import { JSONSchema7, LanguageModelV3CallOptions } from '@ai-sdk/provider';
+import { LanguageModelV3CallOptions } from '@ai-sdk/provider';
 import {
   asSchema,
   FlexibleSchema,
@@ -13,7 +13,7 @@ import { LanguageModelUsage } from '../types/usage';
 import { DeepPartial } from '../util/deep-partial';
 import { parsePartialJson } from '../util/parse-partial-json';
 
-export interface Output<OUTPUT, PARTIAL> {
+export interface Output<OUTPUT = never, PARTIAL = never> {
   readonly type: 'object' | 'text';
 
   responseFormat: PromiseLike<LanguageModelV3CallOptions['responseFormat']>;
@@ -124,3 +124,9 @@ export const object = <OUTPUT>({
     },
   };
 };
+
+export type InferGenerateOutput<OUTPUT extends Output> =
+  OUTPUT extends Output<infer T, never> ? T : never;
+
+export type InferStreamOutput<OUTPUT extends Output> =
+  OUTPUT extends Output<never, infer P> ? P : never;


### PR DESCRIPTION
## Background

The `OUTPUT` and `PARTIAL_OUTPUT` generics in `Agent` are related.

## Summary

Use a single `OUTPUT` generic instead.

## Manual Verification

- [x] generate example
- [x] stream example

## Tasks

- [x] fix stream types
- [x] changeset
- [x] add type tests