### PR TITLE
chore(agent): limit agent call parameters

### DIFF
--- a/.changeset/breezy-masks-occur.md
+++ b/.changeset/breezy-masks-occur.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(agent): limit agent call parameters

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -8,37 +8,14 @@ import {
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 
-export type AgentCallParameters =
-  | {
-      /**
-       * A prompt. It can be either a text prompt or a list of messages.
-       *
-       * You can either use `prompt` or `messages` but not both.
-       */
-      prompt: string | Array<ModelMessage>;
-
-      /**
-       * A list of messages.
-       *
-       * You can either use `prompt` or `messages` but not both.
-       */
-      messages?: never;
-    }
-  | {
-      /**
-       * A list of messages.
-       *
-       * You can either use `prompt` or `messages` but not both.
-       */
-      messages: Array<ModelMessage>;
-
-      /**
-       * A prompt. It can be either a text prompt or a list of messages.
-       *
-       * You can either use `prompt` or `messages` but not both.
-       */
-      prompt?: never;
-    };
+export type AgentCallParameters = {
+  /**
+   * A prompt. It can be either a text prompt or a list of messages.
+   *
+   * You can either use `prompt` or `messages` but not both.
+   */
+  prompt: string | Array<ModelMessage>;
+};
 
 /**
  * An Agent receives a prompt (text or messages) and generates or streams an output

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,3 +1,4 @@
+import { ModelMessage } from '@ai-sdk/provider-utils';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import {
   InferGenerateOutput,
@@ -6,7 +7,38 @@ import {
 } from '../generate-text/output';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
-import { Prompt } from '../prompt/prompt';
+
+export type AgentCallParameters =
+  | {
+      /**
+       * A prompt. It can be either a text prompt or a list of messages.
+       *
+       * You can either use `prompt` or `messages` but not both.
+       */
+      prompt: string | Array<ModelMessage>;
+
+      /**
+       * A list of messages.
+       *
+       * You can either use `prompt` or `messages` but not both.
+       */
+      messages?: never;
+    }
+  | {
+      /**
+       * A list of messages.
+       *
+       * You can either use `prompt` or `messages` but not both.
+       */
+      messages: Array<ModelMessage>;
+
+      /**
+       * A prompt. It can be either a text prompt or a list of messages.
+       *
+       * You can either use `prompt` or `messages` but not both.
+       */
+      prompt?: never;
+    };
 
 /**
  * An Agent receives a prompt (text or messages) and generates or streams an output
@@ -39,11 +71,13 @@ export interface Agent<
    * Generates an output from the agent (non-streaming).
    */
   generate(
-    options: Prompt,
+    options: AgentCallParameters,
   ): PromiseLike<GenerateTextResult<TOOLS, InferGenerateOutput<OUTPUT>>>;
 
   /**
    * Streams an output from the agent (streaming).
    */
-  stream(options: Prompt): StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>>;
+  stream(
+    options: AgentCallParameters,
+  ): StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>>;
 }

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -8,14 +8,37 @@ import {
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 
-export type AgentCallParameters = {
-  /**
-   * A prompt. It can be either a text prompt or a list of messages.
-   *
-   * You can either use `prompt` or `messages` but not both.
-   */
-  prompt: string | Array<ModelMessage>;
-};
+export type AgentCallParameters =
+  | {
+      /**
+       * A prompt. It can be either a text prompt or a list of messages.
+       *
+       * You can either use `prompt` or `messages` but not both.
+       */
+      prompt: string | Array<ModelMessage>;
+
+      /**
+       * A list of messages.
+       *
+       * You can either use `prompt` or `messages` but not both.
+       */
+      messages?: never;
+    }
+  | {
+      /**
+       * A list of messages.
+       *
+       * You can either use `prompt` or `messages` but not both.
+       */
+      messages: Array<ModelMessage>;
+
+      /**
+       * A prompt. It can be either a text prompt or a list of messages.
+       *
+       * You can either use `prompt` or `messages` but not both.
+       */
+      prompt?: never;
+    };
 
 /**
  * An Agent receives a prompt (text or messages) and generates or streams an output

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -8,6 +8,18 @@ import { DeepPartial } from '../util/deep-partial';
 
 describe('ToolLoopAgent', () => {
   describe('generate', () => {
+    it('should not allow system prompt', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3(),
+      });
+
+      await agent.generate({
+        // @ts-expect-error - system prompt is not allowed
+        system: '123',
+        prompt: 'Hello, world!',
+      });
+    });
+
     it('should infer output type', async () => {
       const agent = new ToolLoopAgent({
         model: new MockLanguageModelV3(),
@@ -27,6 +39,18 @@ describe('ToolLoopAgent', () => {
   });
 
   describe('stream', () => {
+    it('should not allow system prompt', () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3(),
+      });
+
+      agent.stream({
+        // @ts-expect-error - system prompt is not allowed
+        system: '123',
+        prompt: 'Hello, world!',
+      });
+    });
+
     it('should infer output type', async () => {
       const agent = new ToolLoopAgent({
         model: new MockLanguageModelV3(),

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -10,7 +10,7 @@ import { streamText } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 import { Prompt } from '../prompt/prompt';
-import { Agent } from './agent';
+import { Agent, AgentCallParameters } from './agent';
 import { ToolLoopAgentSettings } from './tool-loop-agent-settings';
 
 /**
@@ -55,7 +55,7 @@ export class ToolLoopAgent<
    * Generates an output from the agent (non-streaming).
    */
   async generate(
-    options: Prompt,
+    options: AgentCallParameters,
   ): Promise<GenerateTextResult<TOOLS, InferGenerateOutput<OUTPUT>>> {
     return generateText({
       ...this.settings,
@@ -67,7 +67,9 @@ export class ToolLoopAgent<
   /**
    * Streams an output from the agent (streaming).
    */
-  stream(options: Prompt): StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>> {
+  stream(
+    options: AgentCallParameters,
+  ): StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>> {
     return streamText({
       ...this.settings,
       stopWhen: this.settings.stopWhen ?? stepCountIs(20),


### PR DESCRIPTION
## Background

It was possible to call agents with a system parameter. This should not be possible. The instructions / system prompt of the agent should be controlled separately, some agent implementations may not even support this.

## Summary

Limit agent call parameters to messages and prompt.