### PR TITLE
docs: update timeout on vercel troubleshooting page

### DIFF
--- a/content/docs/09-troubleshooting/06-timeout-on-vercel.mdx
+++ b/content/docs/09-troubleshooting/06-timeout-on-vercel.mdx
@@ -12,27 +12,49 @@ However, when I'm deploying to Vercel, longer responses get chopped off in the U
 
 ## Solution
 
-If you are using Next.js with the App Router, you can add the following to your route file or the page you are calling your Server Action from:
+With Vercel's [Fluid Compute](https://vercel.com/docs/fluid-compute), the default function duration is now **5 minutes (300 seconds)** across all plans. This should be sufficient for most streaming applications.
+
+If you need to extend the timeout for longer-running processes, you can increase the `maxDuration` setting:
+
+### Next.js (App Router)
+
+Add the following to your route file or the page you are calling your Server Action from:
 
 ```tsx
-export const maxDuration = 30;
+export const maxDuration = 600;
 ```
 
-This increases the maximum duration of the function to 30 seconds.
+<Note>
+  Setting `maxDuration` above 300 seconds requires a Pro or Enterprise plan.
+</Note>
 
-For other frameworks such as Svelte, you can set timeouts in your `vercel.json` file:
+### Other Frameworks
+
+For other frameworks, you can set timeouts in your `vercel.json` file:
 
 ```json
 {
   "functions": {
     "api/chat/route.ts": {
-      "maxDuration": 30
+      "maxDuration": 600
     }
   }
 }
 ```
 
+<Note>
+  Setting `maxDuration` above 300 seconds requires a Pro or Enterprise plan.
+</Note>
+
+### Maximum Duration Limits
+
+The maximum duration you can set depends on your Vercel plan:
+
+- **Hobby**: Up to 300 seconds (5 minutes)
+- **Pro**: Up to 800 seconds (~13 minutes)
+- **Enterprise**: Up to 800 seconds (~13 minutes)
+
 ## Learn more
 
+- [Fluid Compute Default Settings](https://vercel.com/docs/fluid-compute#default-settings-by-plan)
 - [Configuring Maximum Duration for Vercel Functions](https://vercel.com/docs/functions/configuring-functions/duration)
-- [Maximum Duration Limits](https://vercel.com/docs/functions/runtimes#max-duration)


### PR DESCRIPTION
## Background

This troubleshooting is no longer accurate since the release of fluid compute.

## Summary

Updated page with info on fluid compute defaults.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)