### PR TITLE
feat(provider/amazon-bedrock,provider/azure): export provider options types for bedrock and azure

### DIFF
--- a/packages/amazon-bedrock/src/index.ts
+++ b/packages/amazon-bedrock/src/index.ts
@@ -1,6 +1,4 @@
-export type {
-  AnthropicProviderOptions,
-} from '@ai-sdk/anthropic';
+export type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 
 export type { BedrockProviderOptions } from './bedrock-chat-options';
 export { bedrock, createAmazonBedrock } from './bedrock-provider';

--- a/packages/amazon-bedrock/src/index.ts
+++ b/packages/amazon-bedrock/src/index.ts
@@ -1,3 +1,7 @@
+export type {
+  AnthropicProviderOptions,
+} from '@ai-sdk/anthropic';
+
 export type { BedrockProviderOptions } from './bedrock-chat-options';
 export { bedrock, createAmazonBedrock } from './bedrock-provider';
 export type {

--- a/packages/azure/src/index.ts
+++ b/packages/azure/src/index.ts
@@ -1,3 +1,8 @@
+export type {
+  OpenAIResponsesProviderOptions,
+  OpenAIChatLanguageModelOptions,
+} from '@ai-sdk/openai';
+
 export { azure, createAzure } from './azure-openai-provider';
 export type {
   AzureOpenAIProvider,


### PR DESCRIPTION
Wasn't sure whether to PR this against release-v5.0 or the main branch, let me know if I should switch it to main


<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Using amazon-bedrock and azure it's difficult to know what you can pass into the providerOptions since it's not really typed, plus the packages do not export the types that it accepts. This just re-exports the types these wrappers use (anthropic and azure)

## Summary

Export upstream provider options types from Amazon Bedrock and Azure packages to enable consumers to access configuration types when using these providers.

- Export AnthropicProviderOptions from @ai-sdk/anthropic in amazon-bedrock
- Export OpenAIResponsesProviderOptions and OpenAIChatLanguageModelOptions from @ai-sdk/openai in azure

