### PR TITLE
feat(xai): Support `parallel_function_calling` provider option for XAI provider

### DIFF
--- a/.changeset/fair-dolphins-deny.md
+++ b/.changeset/fair-dolphins-deny.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(xai): Support `parallel_function_calling` provider option for XAI provider

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -116,6 +116,10 @@ await generateText({
 
 The following optional provider options are available for xAI chat models:
 
+- **parallel_function_calling** _boolean_
+
+  Whether to enable parallel function calling during tool use. When `true`, the model can call multiple functions in parallel. When `false`, the model will call functions sequentially. Defaults to `true`.
+
 - **reasoningEffort** _'low' | 'high'_
 
   Reasoning effort for reasoning models. Only supported by `grok-3-mini` and `grok-3-mini-fast` models.

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -301,6 +301,25 @@ describe('XaiChatLanguageModel', () => {
       });
     });
 
+    it('should pass parallel_function_calling provider option', async () => {
+      prepareJsonResponse({ content: '' });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          xai: {
+            parallel_function_calling: false,
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        model: 'grok-beta',
+        messages: [{ role: 'user', content: 'Hello' }],
+        parallel_function_calling: false,
+      });
+    });
+
     it('should pass headers', async () => {
       prepareJsonResponse({ content: '' });
 
@@ -370,6 +389,7 @@ describe('XaiChatLanguageModel', () => {
               },
             ],
             "model": "grok-beta",
+            "parallel_function_calling": undefined,
             "reasoning_effort": undefined,
             "response_format": undefined,
             "search_parameters": undefined,
@@ -1018,6 +1038,7 @@ describe('XaiChatLanguageModel', () => {
               },
             ],
             "model": "grok-beta",
+            "parallel_function_calling": undefined,
             "reasoning_effort": undefined,
             "response_format": undefined,
             "search_parameters": undefined,

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -144,6 +144,9 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
       seed,
       reasoning_effort: options.reasoningEffort,
 
+      // parallel function calling
+      parallel_function_calling: options.parallel_function_calling,
+
       // response format
       response_format:
         responseFormat?.type === 'json'

--- a/packages/xai/src/xai-chat-options.ts
+++ b/packages/xai/src/xai-chat-options.ts
@@ -73,6 +73,14 @@ const searchSourceSchema = z.discriminatedUnion('type', [
 export const xaiProviderOptions = z.object({
   reasoningEffort: z.enum(['low', 'high']).optional(),
 
+  /**
+   * Whether to enable parallel function calling during tool use.
+   * When true, the model can call multiple functions in parallel.
+   * When false, the model will call functions sequentially.
+   * Defaults to true.
+   */
+  parallel_function_calling: z.boolean().optional(),
+
   searchParameters: z
     .object({
       /**


### PR DESCRIPTION
This PR simply adds `parallel_function_calling` to the XAI provider, to match the similar provider options from OpenAI and Anthropic. XAI documentation for the option here: https://docs.x.ai/docs/guides/function-calling#parallel-function-calling