### PR TITLE
chore(examples): fix package versions

### DIFF
--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -41,7 +41,7 @@
     "@opentelemetry/sdk-node": "0.54.2",
     "@opentelemetry/sdk-trace-node": "1.28.0",
     "@valibot/to-json-schema": "^1.3.0",
-    "ai": "6.0.0-beta.65",
+    "ai": "workspace:*",
     "arktype": "2.1.22",
     "dotenv": "16.4.5",
     "effect": "3.18.4",

--- a/examples/next-google-vertex/package.json
+++ b/examples/next-google-vertex/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ai-sdk/google-vertex": "4.0.0-beta.40",
+    "@ai-sdk/google-vertex": "4.0.0-beta.41",
     "ai": "6.0.0-beta.65",
     "geist": "^1.3.1",
     "next": "^15.5.4",

--- a/examples/next-openai/package.json
+++ b/examples/next-openai/package.json
@@ -9,13 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ai-sdk/amazon-bedrock": "4.0.0-beta.36",
-    "@ai-sdk/anthropic": "3.0.0-beta.32",
+    "@ai-sdk/amazon-bedrock": "4.0.0-beta.37",
+    "@ai-sdk/anthropic": "3.0.0-beta.33",
     "@ai-sdk/cohere": "3.0.0-beta.19",
     "@ai-sdk/deepseek": "2.0.0-beta.20",
     "@ai-sdk/fireworks": "2.0.0-beta.20",
     "@ai-sdk/google": "3.0.0-beta.26",
-    "@ai-sdk/google-vertex": "4.0.0-beta.40",
+    "@ai-sdk/google-vertex": "4.0.0-beta.41",
     "@ai-sdk/groq": "3.0.0-beta.19",
     "@ai-sdk/mistral": "3.0.0-beta.20",
     "@ai-sdk/openai": "3.0.0-beta.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(valibot@1.1.0(typescript@5.8.3))
       ai:
-        specifier: 6.0.0-beta.65
+        specifier: workspace:*
         version: link:../../packages/ai
       arktype:
         specifier: 2.1.22
@@ -676,7 +676,7 @@ importers:
   examples/next-google-vertex:
     dependencies:
       '@ai-sdk/google-vertex':
-        specifier: 4.0.0-beta.40
+        specifier: 4.0.0-beta.41
         version: link:../../packages/google-vertex
       ai:
         specifier: 6.0.0-beta.65
@@ -777,10 +777,10 @@ importers:
   examples/next-openai:
     dependencies:
       '@ai-sdk/amazon-bedrock':
-        specifier: 4.0.0-beta.36
+        specifier: 4.0.0-beta.37
         version: link:../../packages/amazon-bedrock
       '@ai-sdk/anthropic':
-        specifier: 3.0.0-beta.32
+        specifier: 3.0.0-beta.33
         version: link:../../packages/anthropic
       '@ai-sdk/cohere':
         specifier: 3.0.0-beta.19
@@ -795,7 +795,7 @@ importers:
         specifier: 3.0.0-beta.26
         version: link:../../packages/google
       '@ai-sdk/google-vertex':
-        specifier: 4.0.0-beta.40
+        specifier: 4.0.0-beta.41
         version: link:../../packages/google-vertex
       '@ai-sdk/groq':
         specifier: 3.0.0-beta.19


### PR DESCRIPTION
## Background

#9689 updated example package versions. By the time it merged the versions were outdated. The versions need to be the latest version number or changesets won't update them.

## Summary

Update example version numbers to current versions.

## Related Issues

Caused by #9689