### PR TITLE
feat(assemblyai): add language_codes and language_detection to provider options

### DIFF
--- a/.changeset/plenty-zebras-jog.md
+++ b/.changeset/plenty-zebras-jog.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/assemblyai': patch
+---
+
+Add support for language_codes and code_switching in language_detection for AssemblyAI transcription

--- a/examples/ai-core/src/transcribe/assemblyai-provider-options.ts
+++ b/examples/ai-core/src/transcribe/assemblyai-provider-options.ts
@@ -1,0 +1,25 @@
+import { assemblyai } from '@ai-sdk/assemblyai';
+import { experimental_transcribe as transcribe } from 'ai';
+import 'dotenv/config';
+import { readFile } from 'fs/promises';
+
+async function main() {
+  const result = await transcribe({
+    model: assemblyai.transcription('best'),
+    audio: await readFile('data/galileo.mp3'),
+    providerOptions: {
+      assemblyai: {
+        languageDetection: {
+          codeSwitching: true,
+          codeSwitchingConfidenceThreshold: 0.7,
+        },
+      },
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log('Duration:', result.durationInSeconds);
+  console.log('Language:', result.responses[0].headers);
+}
+
+main().catch(console.error);

--- a/packages/assemblyai/src/assemblyai-api-types.ts
+++ b/packages/assemblyai/src/assemblyai-api-types.ts
@@ -310,23 +310,19 @@ export type AssemblyAITranscriptionAPITypes = {
   language_confidence_threshold?: number;
 
   /**
-   * Enable Automatic language detection, either true or false, or configure code switching detection.
+   * Enable Automatic language detection, either true or false.
    * @default false
    */
-  language_detection?:
-    | boolean
-    | {
-        /**
-         * Enable code switching detection.
-         * @default false
-         */
-        code_switching?: boolean;
-        /**
-         * Confidence threshold for code switching detection. Values must be between 0 and 1.
-         * @default 0.3
-         */
-        code_switching_confidence_threshold?: number;
-      };
+  language_detection?: boolean;
+
+  /**
+   * Options for Automatic language detection.
+   */
+  language_detection_options?: {
+    code_switching?: boolean | null;
+    code_switching_confidence_threshold?: number | null;
+  } | null;
+
   /**
    * Enable Multichannel transcription, can be true or false.
    * @default false

--- a/packages/assemblyai/src/assemblyai-api-types.ts
+++ b/packages/assemblyai/src/assemblyai-api-types.ts
@@ -196,17 +196,137 @@ export type AssemblyAITranscriptionAPITypes = {
     | 'yo';
 
   /**
+   * An array of language codes for code switching. One of the values must be 'en'.
+   */
+  language_codes?: Array<
+    | 'en'
+    | 'en_au'
+    | 'en_uk'
+    | 'en_us'
+    | 'es'
+    | 'fr'
+    | 'de'
+    | 'it'
+    | 'pt'
+    | 'nl'
+    | 'af'
+    | 'sq'
+    | 'am'
+    | 'ar'
+    | 'hy'
+    | 'as'
+    | 'az'
+    | 'ba'
+    | 'eu'
+    | 'be'
+    | 'bn'
+    | 'bs'
+    | 'br'
+    | 'bg'
+    | 'my'
+    | 'ca'
+    | 'zh'
+    | 'hr'
+    | 'cs'
+    | 'da'
+    | 'et'
+    | 'fo'
+    | 'fi'
+    | 'gl'
+    | 'ka'
+    | 'el'
+    | 'gu'
+    | 'ht'
+    | 'ha'
+    | 'haw'
+    | 'he'
+    | 'hi'
+    | 'hu'
+    | 'is'
+    | 'id'
+    | 'ja'
+    | 'jw'
+    | 'kn'
+    | 'kk'
+    | 'km'
+    | 'ko'
+    | 'lo'
+    | 'la'
+    | 'lv'
+    | 'ln'
+    | 'lt'
+    | 'lb'
+    | 'mk'
+    | 'mg'
+    | 'ms'
+    | 'ml'
+    | 'mt'
+    | 'mi'
+    | 'mr'
+    | 'mn'
+    | 'ne'
+    | 'no'
+    | 'nn'
+    | 'oc'
+    | 'pa'
+    | 'ps'
+    | 'fa'
+    | 'pl'
+    | 'ro'
+    | 'ru'
+    | 'sa'
+    | 'sr'
+    | 'sn'
+    | 'sd'
+    | 'si'
+    | 'sk'
+    | 'sl'
+    | 'so'
+    | 'su'
+    | 'sw'
+    | 'sv'
+    | 'tl'
+    | 'tg'
+    | 'ta'
+    | 'tt'
+    | 'te'
+    | 'th'
+    | 'bo'
+    | 'tr'
+    | 'tk'
+    | 'uk'
+    | 'ur'
+    | 'uz'
+    | 'vi'
+    | 'cy'
+    | 'yi'
+    | 'yo'
+  >;
+
+  /**
    * The confidence threshold for the automatically detected language. An error will be returned if the language confidence is below this threshold.
    * @default 0
    */
   language_confidence_threshold?: number;
 
   /**
-   * Enable Automatic language detection, either true or false.
+   * Enable Automatic language detection, either true or false, or configure code switching detection.
    * @default false
    */
-  language_detection?: boolean;
-
+  language_detection?:
+    | boolean
+    | {
+        /**
+         * Enable code switching detection.
+         * @default false
+         */
+        code_switching?: boolean;
+        /**
+         * Confidence threshold for code switching detection. Values must be between 0 and 1.
+         * @default 0.3
+         */
+        code_switching_confidence_threshold?: number;
+      };
   /**
    * Enable Multichannel transcription, can be true or false.
    * @default false

--- a/packages/assemblyai/src/assemblyai-transcription-model.test.ts
+++ b/packages/assemblyai/src/assemblyai-transcription-model.test.ts
@@ -353,4 +353,98 @@ describe('doGenerate', () => {
     expect(result.response.timestamp.getTime()).toEqual(testDate.getTime());
     expect(result.response.modelId).toBe('best');
   });
+
+  it('should pass language_codes for code switching', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        assemblyai: {
+          languageCodes: ['en', 'es', 'fr'],
+        },
+      },
+    });
+
+    expect(await server.calls[1].requestBodyJson).toMatchObject({
+      audio_url: 'https://storage.assemblyai.com/mock-upload-url',
+      speech_model: 'best',
+      language_codes: ['en', 'es', 'fr'],
+    });
+  });
+
+  it('should pass language_detection as boolean', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        assemblyai: {
+          languageDetection: true,
+        },
+      },
+    });
+
+    expect(await server.calls[1].requestBodyJson).toMatchObject({
+      audio_url: 'https://storage.assemblyai.com/mock-upload-url',
+      speech_model: 'best',
+      language_detection: true,
+    });
+  });
+
+  it('should pass language_detection with code switching configuration', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        assemblyai: {
+          languageDetection: {
+            codeSwitching: true,
+            codeSwitchingConfidenceThreshold: 0.5,
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[1].requestBodyJson).toMatchObject({
+      audio_url: 'https://storage.assemblyai.com/mock-upload-url',
+      speech_model: 'best',
+      language_detection: {
+        code_switching: true,
+        code_switching_confidence_threshold: 0.5,
+      },
+    });
+  });
+
+  it('should pass combined language_codes and language_detection for code switching', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+      providerOptions: {
+        assemblyai: {
+          languageCodes: ['en', 'es'],
+          languageDetection: {
+            codeSwitching: true,
+            codeSwitchingConfidenceThreshold: 0.3,
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[1].requestBodyJson).toMatchObject({
+      audio_url: 'https://storage.assemblyai.com/mock-upload-url',
+      speech_model: 'best',
+      language_codes: ['en', 'es'],
+      language_detection: {
+        code_switching: true,
+        code_switching_confidence_threshold: 0.3,
+      },
+    });
+  });
 });

--- a/packages/assemblyai/src/assemblyai-transcription-model.test.ts
+++ b/packages/assemblyai/src/assemblyai-transcription-model.test.ts
@@ -24,6 +24,20 @@ const server = createTestServer({
       },
     },
   },
+  'https://api.assemblyai.com/v2/transcript/9ea68fd3-f953-42c1-9742-976c447fb463':
+    {
+      response: {
+        type: 'json-value',
+        body: {
+          id: '9ea68fd3-f953-42c1-9742-976c447fb463',
+          status: 'queued',
+          speech_model: 'best',
+          text: null,
+          words: null,
+          audio_duration: null,
+        },
+      },
+    },
 });
 
 describe('doGenerate', () => {
@@ -242,6 +256,25 @@ describe('doGenerate', () => {
         speed_boost: true,
       },
     };
+
+    server.urls[
+      'https://api.assemblyai.com/v2/transcript/9ea68fd3-f953-42c1-9742-976c447fb463'
+    ].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        id: 'test-id',
+        status: 'completed',
+        speech_model: 'best',
+        language_code: 'en_us',
+        text: 'Hello, world!',
+        words: [
+          { start: 0, end: 500, text: 'Hello,' },
+          { start: 500, end: 900, text: 'world!' },
+        ],
+        audio_duration: 1.1,
+      },
+    };
   }
 
   it('should pass the model', async () => {
@@ -276,15 +309,37 @@ describe('doGenerate', () => {
       },
     });
 
-    expect(server.calls[0].requestHeaders).toMatchObject({
+    expect(server.calls[1].requestHeaders).toMatchObject({
       authorization: 'test-api-key',
-      'content-type': 'application/octet-stream',
+      'content-type': 'application/json',
       'custom-provider-header': 'provider-header-value',
       'custom-request-header': 'request-header-value',
     });
     expect(server.calls[0].requestUserAgent).toContain(
       `ai-sdk/assemblyai/0.0.0-test`,
     );
+  });
+
+  it('should wait until the transcript is completed', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/wav',
+    });
+
+    expect(result.text).toBe('Hello, world!');
+    expect(result.segments).toEqual([
+      { text: 'Hello,', startSecond: 0, endSecond: 500 },
+      { text: 'world!', startSecond: 500, endSecond: 900 },
+    ]);
+    expect(result.durationInSeconds).toBe(1.1);
+    expect(result.response).toMatchObject({
+      modelId: 'best',
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
   });
 
   it('should extract the transcription text', async () => {
@@ -413,7 +468,8 @@ describe('doGenerate', () => {
     expect(await server.calls[1].requestBodyJson).toMatchObject({
       audio_url: 'https://storage.assemblyai.com/mock-upload-url',
       speech_model: 'best',
-      language_detection: {
+      language_detection: true,
+      language_detection_options: {
         code_switching: true,
         code_switching_confidence_threshold: 0.5,
       },
@@ -431,7 +487,7 @@ describe('doGenerate', () => {
           languageCodes: ['en', 'es'],
           languageDetection: {
             codeSwitching: true,
-            codeSwitchingConfidenceThreshold: 0.3,
+            codeSwitchingConfidenceThreshold: 0.5,
           },
         },
       },
@@ -441,9 +497,10 @@ describe('doGenerate', () => {
       audio_url: 'https://storage.assemblyai.com/mock-upload-url',
       speech_model: 'best',
       language_codes: ['en', 'es'],
-      language_detection: {
+      language_detection: true,
+      language_detection_options: {
         code_switching: true,
-        code_switching_confidence_threshold: 0.3,
+        code_switching_confidence_threshold: 0.5,
       },
     });
   });


### PR DESCRIPTION
## Background
AssemblyAI recently added new params support in the latest api version. The AI SDK's AssemblyAI provider was missing support for these new API parameters: `language_codes` and the extended `language_detection` object with code-switching configuration.



## Summary

Added support for AssemblyAI's code-switching features:

- Added `language_codes` parameter (array of language codes, must include 'en')
- Extended `language_detection` to support both boolean and object types with:
  - `code_switching` (boolean, default: false)
  - `code_switching_confidence_threshold` (number 0-1, default: 0.3)
- Updated API types in `assemblyai-api-types.ts`
- Updated Zod schema in `assemblyai-transcription-model.ts`
- Added tests for all new parameters


<!-- What did you change? -->

## Manual Verification
- added example with provider options `src/transcribe/assemblyai-provider-options.ts`


## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
- Update documentation with code-switching examples once the feature is released


<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues
Fixes #9613 
