### PR TITLE
feat(provider/openai): support openai chat model's reasoning_content

### DIFF
--- a/.changeset/eight-hounds-divide.md
+++ b/.changeset/eight-hounds-divide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+support openai-chat-language-model's reasoning_content

--- a/packages/openai/src/chat/openai-chat-api.ts
+++ b/packages/openai/src/chat/openai-chat-api.ts
@@ -32,6 +32,7 @@ export const openaiChatResponseSchema = lazySchema(() =>
           message: z.object({
             role: z.literal('assistant').nullish(),
             content: z.string().nullish(),
+            reasoning_content: z.string().nullish(),
             tool_calls: z
               .array(
                 z.object({
@@ -116,6 +117,7 @@ export const openaiChatChunkSchema = lazySchema(() =>
               .object({
                 role: z.enum(['assistant']).nullish(),
                 content: z.string().nullish(),
+                reasoning_content: z.string().nullish(),
                 tool_calls: z
                   .array(
                     z.object({

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -344,6 +344,7 @@ describe('doGenerate', () => {
               "index": 0,
               "message": {
                 "content": "",
+                "reasoning_content": "",
                 "role": "assistant",
               },
             },
@@ -360,7 +361,7 @@ describe('doGenerate', () => {
           },
         },
         "headers": {
-          "content-length": "275",
+          "content-length": "298",
           "content-type": "application/json",
         },
         "id": "test-id",
@@ -443,7 +444,7 @@ describe('doGenerate', () => {
 
     expect(response?.headers).toMatchInlineSnapshot(`
       {
-        "content-length": "321",
+        "content-length": "344",
         "content-type": "application/json",
         "test-header": "test-value",
       }
@@ -1818,11 +1819,6 @@ describe('doStream', () => {
           "type": "text-start",
         },
         {
-          "delta": "",
-          "id": "0",
-          "type": "text-delta",
-        },
-        {
           "delta": "Hello",
           "id": "0",
           "type": "text-delta",
@@ -2003,17 +1999,17 @@ describe('doStream', () => {
           "type": "reasoning-delta",
         },
         {
-          "id": "txt-0",
+          "id": "0",
           "type": "text-start",
         },
         {
           "delta": "Here's",
-          "id": "txt-0",
+          "id": "0",
           "type": "text-delta",
         },
         {
           "delta": " my response",
-          "id": "txt-0",
+          "id": "0",
           "type": "text-delta",
         },
         {
@@ -2021,13 +2017,13 @@ describe('doStream', () => {
           "type": "reasoning-end",
         },
         {
-          "id": "txt-0",
+          "id": "0",
           "type": "text-end",
         },
         {
           "finishReason": "stop",
           "providerMetadata": {
-            "test-provider": {},
+            "openai": {},
           },
           "type": "finish",
           "usage": {
@@ -2075,7 +2071,6 @@ describe('doStream', () => {
           id: 'chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP',
         }),
         { type: 'text-start', id: '0' },
-        { type: 'text-delta', id: '0', delta: '' },
         { type: 'text-delta', id: '0', delta: 'Based on search results' },
         {
           type: 'source',
@@ -2442,15 +2437,6 @@ describe('doStream', () => {
           "type": "response-metadata",
         },
         {
-          "id": "0",
-          "type": "text-start",
-        },
-        {
-          "delta": "",
-          "id": "0",
-          "type": "text-delta",
-        },
-        {
           "id": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "toolName": "searchGoogle",
           "type": "tool-input-start",
@@ -2489,10 +2475,6 @@ describe('doStream', () => {
           "toolCallId": "chatcmpl-tool-b3b307239370432d9910d4b79b4dbbaa",
           "toolName": "searchGoogle",
           "type": "tool-call",
-        },
-        {
-          "id": "0",
-          "type": "text-end",
         },
         {
           "finishReason": "tool-calls",
@@ -3038,11 +3020,6 @@ describe('doStream', () => {
             "type": "text-start",
           },
           {
-            "delta": "",
-            "id": "0",
-            "type": "text-delta",
-          },
-          {
             "delta": "Hello, World!",
             "id": "0",
             "type": "text-delta",
@@ -3105,11 +3082,6 @@ describe('doStream', () => {
           {
             "id": "0",
             "type": "text-start",
-          },
-          {
-            "delta": "",
-            "id": "0",
-            "type": "text-delta",
           },
           {
             "delta": "Hello, World!",

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -343,8 +343,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
     }
 
     // reasoning content:
-    const reasoning =
-      choice.message.reasoning_content;
+    const reasoning = choice.message.reasoning_content;
     if (reasoning != null && reasoning.length > 0) {
       content.push({
         type: 'reasoning',
@@ -711,7 +710,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
             if (isActiveReasoning) {
               controller.enqueue({ type: 'reasoning-end', id: 'reasoning-0' });
             }
-            
+
             if (isActiveText) {
               controller.enqueue({ type: 'text-end', id: '0' });
             }

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -560,7 +560,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
               });
             }
 
-            if (delta.content != null) {
+            if (delta.content) {
               if (!isActiveText) {
                 controller.enqueue({ type: 'text-start', id: '0' });
                 isActiveText = true;


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

For non-official OpenAI models deployed in Azure OpenAI (such as DeepSeek R1), the `packages/openai` is used, so the `reasoning_content` field needs to be introduced in the responseSchema.

## Summary

<!-- What did you change? -->

Added the `reasoning_content` field, updated relevant tests, and aligned with the `openai-compatible` logic.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
