### PR TITLE
feat (provider/gateway): add models provider option for fallbacks

### DIFF
--- a/.changeset/four-papayas-divide.md
+++ b/.changeset/four-papayas-divide.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add models provider option for model routing

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -382,6 +382,12 @@ The following gateway provider options are available:
 
   Example: `only: ['anthropic', 'vertex']` will only allow routing to Anthropic or Vertex AI.
 
+- **models** _string[]_
+
+  Specifies fallback models to use when the primary model fails or is unavailable. The gateway will try the primary model first (specified in the `model` parameter), then try each model in this array in order until one succeeds.
+
+  Example: `models: ['openai/gpt-5-nano', 'gemini-2.0-flash']` will try the fallback models in order if the primary model fails.
+
 - **user** _string_
 
   Optional identifier for the end user on whose behalf the request is being made. This is used for spend tracking and attribution purposes, allowing you to track usage per end-user in your application.
@@ -410,6 +416,31 @@ const { text } = await generateText({
     } satisfies GatewayProviderOptions,
   },
 });
+```
+
+#### Model Fallbacks Example
+
+The `models` option enables automatic fallback to alternative models when the primary model fails:
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'openai/gpt-4o', // Primary model
+  prompt: 'Write a TypeScript haiku',
+  providerOptions: {
+    gateway: {
+      models: ['openai/gpt-5-nano', 'gemini-2.0-flash'], // Fallback models
+    } satisfies GatewayProviderOptions,
+  },
+});
+
+// This will:
+// 1. Try openai/gpt-4o first
+// 2. If it fails, try openai/gpt-5-nano
+// 3. If that fails, try gemini-2.0-flash
+// 4. Return the result from the first model that succeeds
 ```
 
 ### Provider-Specific Options

--- a/examples/ai-core/src/stream-text/gateway-provider-options-models.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-models.ts
@@ -1,0 +1,32 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    headers: {
+      'X-Simulate-Model-Failures': 'anthropic/claude-4-sonnet',
+    },
+    model: 'anthropic/claude-4-sonnet',
+    prompt: 'Tell me a short tale of the krakens of the deep.',
+    providerOptions: {
+      gateway: {
+        models: ['openai/gpt-5-nano', 'zai/glm-4.6'],
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -31,6 +31,12 @@ const gatewayProviderOptions = lazySchema(() =>
        * Example: `['chat', 'v2']`
        */
       tags: z.array(z.string()).optional(),
+      /**
+       * Array of model slugs specifying fallback models to use in order.
+       *
+       * Example: `['openai/gpt-5-nano', 'zai/glm-4.6']` will try `openai/gpt-5-nano` first, then `zai/glm-4.6` as fallback.
+       */
+      models: z.array(z.string()).optional(),
     }),
   ),
 );


### PR DESCRIPTION
## Background

Added support for model fallbacks in the AI Gateway provider, allowing users to specify alternative models to try when the primary model fails or is unavailable.

## Summary

This PR adds a new `models` option to the Gateway provider options, which accepts an array of model slugs to use as fallbacks. When the primary model specified in the `model` parameter fails, the gateway will automatically try each fallback model in the specified order until one succeeds.

The implementation includes:

- Added the `models` option to the Gateway provider options schema
- Updated documentation with examples of how to use model fallbacks
- Added a new example demonstrating the feature with simulated model failures

## Future Work

- there is no way to vary the headers or provider options on potential fallback to different models
- type-wise it could be desirable for models to be passed as `LanguageModel`​ instances rather than strings

## Manual Verification

Tested the implementation by creating an example that simulates a failure of the primary model and verifies that the gateway correctly falls back to alternative models in the specified order.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)