### PR TITLE
fix(provider/anthropic): do not limit maxTokens when model id is unknown

### DIFF
--- a/.changeset/thirty-falcons-melt.md
+++ b/.changeset/thirty-falcons-melt.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(provider/anthropic): do not limit maxTokens when model id is unknown

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -534,7 +534,6 @@ describe('AnthropicMessagesLanguageModel', () => {
 
       const { warnings } = await provider('claude-haiku-4-5').doGenerate({
         prompt: TEST_PROMPT,
-        temperature: 0.5,
         maxOutputTokens: 999999,
       });
 
@@ -553,7 +552,6 @@ describe('AnthropicMessagesLanguageModel', () => {
             },
           ],
           "model": "claude-haiku-4-5",
-          "temperature": 0.5,
         }
       `);
 
@@ -566,6 +564,35 @@ describe('AnthropicMessagesLanguageModel', () => {
           },
         ]
       `);
+    });
+
+    it('should not limit max output tokens for unknown models', async () => {
+      prepareJsonResponse({});
+
+      const { warnings } = await provider('future-model').doGenerate({
+        prompt: TEST_PROMPT,
+        maxOutputTokens: 123456,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "max_tokens": 123456,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "future-model",
+        }
+      `);
+
+      expect(warnings).toMatchInlineSnapshot(`[]`);
     });
 
     it('should pass tools and toolChoice', async () => {


### PR DESCRIPTION
## Background

Limiting the max tokens for anthropic models in #9546 did not account for unknown model ids, leading to errors (see #9736 ).

## Summary

Do not limit max tokens in Anthropic provider for unknown model ids.

## Manual Verification

Ran modified console example and checked the provider request.

## Related Issues

Caused by #9546 
Fixes #9736