### PR TITLE
Allow multiple events per JSON stream chunk when streaming response

### DIFF
--- a/.changeset/thick-glasses-develop.md
+++ b/.changeset/thick-glasses-develop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Fix processing of a Json stream with multiple events per chunk


### PR DESCRIPTION
Previously, `createJsonStreamResponseHandler` assumed each steam chunk will contain at most one JSON event. Some streaming backends can buffer events if they are generated faster than they are consumed, resulting in multiple lines per chunk. This adds support for such streams

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Previously, `createJsonStreamResponseHandler` assumed each steam chunk will contain at most one JSON event. Some streaming backends can buffer events if they are generated faster than they are consumed, resulting in multiple lines per chunk. Currently, such stream will cause a JSONParseError to be thrown

## Summary

The PR changes the processing of the stream to look for newlines within the chunks as well as at the ends, and should process any stream, regardless of how it's chunked up.

## Manual Verification

I've added a test which generates a stream with the failing format, the test failed at first, with the fix it passed, alongside all other tests.

Happy to do further verification, we're likely to use a local patch before this is released.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)