### PR TITLE
fix(ai): check for non-empty providerMetadata

### DIFF
--- a/.changeset/young-pumpkins-provide.md
+++ b/.changeset/young-pumpkins-provide.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): check for non-empty providerMetadata

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -2687,4 +2687,75 @@ describe('convertToModelMessages', () => {
       });
     });
   });
+
+  describe('issue #9731: empty providerMetadata should not create providerOptions', () => {
+    it('should not add providerOptions for empty providerMetadata', () => {
+      const cases = [
+        {
+          role: 'user' as const,
+          parts: [{ type: 'text' as const, text: 'Hi', providerMetadata: {} }],
+        },
+        {
+          role: 'user' as const,
+          parts: [
+            {
+              type: 'file' as const,
+              mediaType: 'image/jpeg',
+              url: 'test.jpg',
+              providerMetadata: {},
+            },
+          ],
+        },
+        {
+          role: 'assistant' as const,
+          parts: [{ type: 'text' as const, text: 'Hi', providerMetadata: {} }],
+        },
+      ];
+
+      cases.forEach(msg => {
+        const result = convertToModelMessages([msg]);
+        const content = result[0].content as any[];
+        content.forEach(part => {
+          expect(part).not.toHaveProperty('providerOptions');
+        });
+      });
+    });
+
+    it('should add providerOptions for non-empty providerMetadata', () => {
+      const metadata = { test: { key: 'val' } };
+      const cases = [
+        {
+          role: 'user' as const,
+          parts: [
+            { type: 'text' as const, text: 'Hi', providerMetadata: metadata },
+          ],
+        },
+        {
+          role: 'user' as const,
+          parts: [
+            {
+              type: 'file' as const,
+              mediaType: 'image/jpeg',
+              url: 'test.jpg',
+              providerMetadata: metadata,
+            },
+          ],
+        },
+        {
+          role: 'assistant' as const,
+          parts: [
+            { type: 'text' as const, text: 'Hi', providerMetadata: metadata },
+          ],
+        },
+      ];
+
+      cases.forEach(msg => {
+        const result = convertToModelMessages([msg]);
+        const content = result[0].content as any[];
+        content.forEach(part => {
+          expect(part.providerOptions).toEqual(metadata);
+        });
+      });
+    });
+  });
 });

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -97,7 +97,8 @@ export function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                 return {
                   type: 'text' as const,
                   text: part.text,
-                  ...(part.providerMetadata != null
+                  ...(part.providerMetadata != null &&
+                  Object.keys(part.providerMetadata).length > 0
                     ? { providerOptions: part.providerMetadata }
                     : {}),
                 };
@@ -110,7 +111,8 @@ export function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                   mediaType: part.mediaType,
                   filename: part.filename,
                   data: part.url,
-                  ...(part.providerMetadata != null
+                  ...(part.providerMetadata != null &&
+                  Object.keys(part.providerMetadata).length > 0
                     ? { providerOptions: part.providerMetadata }
                     : {}),
                 };
@@ -152,7 +154,8 @@ export function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                 content.push({
                   type: 'text' as const,
                   text: part.text,
-                  ...(part.providerMetadata != null
+                  ...(part.providerMetadata != null &&
+                  Object.keys(part.providerMetadata).length > 0
                     ? { providerOptions: part.providerMetadata }
                     : {}),
                 });
@@ -167,7 +170,10 @@ export function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                 content.push({
                   type: 'reasoning' as const,
                   text: part.text,
-                  providerOptions: part.providerMetadata,
+                  ...(part.providerMetadata != null &&
+                  Object.keys(part.providerMetadata).length > 0
+                    ? { providerOptions: part.providerMetadata }
+                    : {}),
                 });
               } else if (isToolOrDynamicToolUIPart(part)) {
                 const toolName = getToolOrDynamicToolName(part);
@@ -183,7 +189,8 @@ export function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                           ('rawInput' in part ? part.rawInput : undefined))
                         : part.input,
                     providerExecuted: part.providerExecuted,
-                    ...(part.callProviderMetadata != null
+                    ...(part.callProviderMetadata != null &&
+                    Object.keys(part.callProviderMetadata).length > 0
                       ? { providerOptions: part.callProviderMetadata }
                       : {}),
                   });


### PR DESCRIPTION
## Background

`convertToModelMessages` was spreading empty `providerMetadata` objects as `providerOptions: {}`, causing `generateText()` and `streamText()` to reject the output with `AI_InvalidPromptError` even though the conversion was supposed to produce valid messages.

## Summary

Added checks to ensure `providerOptions` is only added when `providerMetadata` contains actual keys, not just an empty object. Applied this fix to all message part types: user text/file, assistant text, reasoning, and tool calls. This matches the existing pattern used for system messages.

Added regression tests covering both empty and non-empty `providerMetadata` cases.

## Manual Verification

Tested with the reproduction case from the issue:

```typescript
const uiMessages = [{
  role: 'assistant',
  parts: [{ type: 'text', text: 'Hello!', providerMetadata: {} }]
}];

const modelMessages = convertToModelMessages(uiMessages);
await generateText({ model, messages: modelMessages });
// No longer throws AI_InvalidPromptError
```

Verified that non-empty metadata still works correctly and can be used with both `generateText()` and `streamText()`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Similar pattern exists in `stream-text.ts` where `providerMetadata` is spread without empty object checks. Let me know if you'd like me to address this as part of this PR?

https://github.com/vercel/ai/blob/068a560afe7d9ec733ec63dd957fc6047a8d0156/packages/ai/src/generate-text/stream-text.ts#L1958-L1961

## Related Issues

Fixes #9731