### PR TITLE
fix(google): properly extract jsonSchema from tool.inputSchema

### DIFF
--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -122,7 +122,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
       tools: googleTools,
       toolConfig: googleToolConfig,
       toolWarnings,
-    } = prepareTools({
+    } = await prepareTools({
       tools,
       toolChoice,
       modelId: this.modelId,

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -3,10 +3,11 @@ import {
   LanguageModelV3CallWarning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
+import { asSchema } from '@ai-sdk/provider-utils';
 import { convertJSONSchemaToOpenAPISchema } from './convert-json-schema-to-openapi-schema';
 import { GoogleGenerativeAIModelId } from './google-generative-ai-options';
 
-export function prepareTools({
+export async function prepareTools({
   tools,
   toolChoice,
   modelId,
@@ -14,7 +15,7 @@ export function prepareTools({
   tools: LanguageModelV3CallOptions['tools'];
   toolChoice?: LanguageModelV3CallOptions['toolChoice'];
   modelId: GoogleGenerativeAIModelId;
-}): {
+}): Promise<{
   tools:
     | {
         functionDeclarations: Array<{
@@ -34,7 +35,7 @@ export function prepareTools({
         };
       };
   toolWarnings: LanguageModelV3CallWarning[];
-} {
+}> {
   // when the tools array is empty, change it to undefined to prevent errors:
   tools = tools?.length ? tools : undefined;
 
@@ -144,7 +145,9 @@ export function prepareTools({
         functionDeclarations.push({
           name: tool.name,
           description: tool.description ?? '',
-          parameters: convertJSONSchemaToOpenAPISchema(tool.inputSchema),
+          parameters: convertJSONSchemaToOpenAPISchema(
+            await asSchema(tool.inputSchema).jsonSchema,
+          ),
         });
         break;
       default:


### PR DESCRIPTION
## Description

This PR fixes a bug where custom tools with parameters fail when using the Google/Vertex AI provider. The issue was that `tool.inputSchema` was not being properly converted to a JSON Schema before being passed to the schema converter.

## Root Cause

The Google provider's `prepareTools` function was directly using `tool.inputSchema` without calling `asSchema().jsonSchema` to extract the actual JSON Schema. Since `tool.inputSchema` is a `FlexibleSchema` type (which includes Schema objects with a `jsonSchema` getter), this resulted in passing a Schema object instead of a plain JSONSchema7 object to `convertJSONSchemaToOpenAPISchema`.

When the object was serialized for the Vertex AI API, only the `properties` field was preserved (as an empty object), while all the actual property definitions, types, and required fields were lost.

## Changes

1. Added `import { asSchema } from '@ai-sdk/provider-utils'`
2. Changed line 147 from:
   ```typescript
   parameters: convertJSONSchemaToOpenAPISchema(tool.inputSchema),
   ```
   to:
   ```typescript
   parameters: convertJSONSchemaToOpenAPISchema(
     await asSchema(tool.inputSchema).jsonSchema,
   ),
   ```
3. Made `prepareTools` function async and updated its return type to `Promise<...>`
4. Added `await` to the `prepareTools` call in `google-generative-ai-language-model.ts`

This matches the pattern used in `packages/ai/src/prompt/prepare-tools-and-tool-choice.ts` (line 53).

## Testing

Tested with custom tools that have parameters:
- Tools with simple string/number parameters
- Tools with nested object parameters
- Tools with required fields
- Tools created via both `jsonSchema()` and Zod schemas

All now work correctly with the Vertex AI provider.

## Related Issues

Fixes #9761