### PR TITLE
fix(google): properly extract JSON schema from tool.inputSchema for Vertex AI

### DIFF
--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -122,7 +122,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
       tools: googleTools,
       toolConfig: googleToolConfig,
       toolWarnings,
-    } = prepareTools({
+    } = await prepareTools({
       tools,
       toolChoice,
       modelId: this.modelId,

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -3,6 +3,7 @@ import {
   LanguageModelV3CallWarning,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
+import { asSchema } from '@ai-sdk/provider-utils';
 import { convertJSONSchemaToOpenAPISchema } from './convert-json-schema-to-openapi-schema';
 import { GoogleGenerativeAIModelId } from './google-generative-ai-options';
 
@@ -14,7 +15,7 @@ export function prepareTools({
   tools: LanguageModelV3CallOptions['tools'];
   toolChoice?: LanguageModelV3CallOptions['toolChoice'];
   modelId: GoogleGenerativeAIModelId;
-}): {
+}): Promise<{
   tools:
     | {
         functionDeclarations: Array<{
@@ -34,7 +35,7 @@ export function prepareTools({
         };
       };
   toolWarnings: LanguageModelV3CallWarning[];
-} {
+}> {
   // when the tools array is empty, change it to undefined to prevent errors:
   tools = tools?.length ? tools : undefined;
 
@@ -144,7 +145,9 @@ export function prepareTools({
         functionDeclarations.push({
           name: tool.name,
           description: tool.description ?? '',
-          parameters: convertJSONSchemaToOpenAPISchema(tool.inputSchema),
+          parameters: convertJSONSchemaToOpenAPISchema(
+            await asSchema(tool.inputSchema).jsonSchema,
+          ),
         });
         break;
       default:


### PR DESCRIPTION
## Overview

This PR fixes a bug where custom tools with parameters fail when using the Google/Vertex AI provider. The issue was that `tool.inputSchema` was not properly converted to a plain JSON Schema before being passed to the schema converter.

## Root Cause

The `prepareTools` function in the Google provider was directly using `tool.inputSchema` without calling `asSchema().jsonSchema` to extract the actual JSON Schema. Since `tool.inputSchema` is a `FlexibleSchema` type (which includes Schema objects with a `.jsonSchema` getter), this caused a `Schema` object to be passed instead of a plain `JSONSchema7` object.  

During serialization for the Vertex AI API, only an empty `properties` object was preserved, while all actual property definitions, types, and required fields were lost. This made custom tools with parameters fail.

## Changes

- Added `import { asSchema } from '@ai-sdk/provider-utils'`.
- Updated line 147 in `prepare-tools.ts` from:
  ```ts
  parameters: convertJSONSchemaToOpenAPISchema(tool.inputSchema),
  
  to 
  
  parameters: convertJSONSchemaToOpenAPISchema(
    await asSchema(tool.inputSchema).jsonSchema,
  ),


- Made prepareTools async and updated its return type to Promise<...>.

- Added await to prepareTools calls in google-generative-ai-language-model.ts.

This now matches the pattern used in packages/ai/src/prompt/prepare-tools-and-tool-choice.ts.

# Testing

## Tested with custom tools that have:

- Simple string/number parameters

- Nested object parameters

- Required fields

- Tools created via both jsonSchema() and Zod schemas

All scenarios now work correctly with the Vertex AI provider.

## Related Issues

Fixes #9761