### PR TITLE
feat(ai): add Output.array()

### DIFF
--- a/.changeset/nasty-buttons-grab.md
+++ b/.changeset/nasty-buttons-grab.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add Output.array()

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -365,6 +365,71 @@ const { experimental_partialOutputStream } = await streamText({
 });
 ```
 
+### Output Types
+
+The AI SDK supports multiple ways of specifying the expected structure of generated data via the `Output` object. You can select from various strategies for structured/text generation and validation.
+
+#### `Output.text()`
+
+Use `Output.text()` to generate plain text from a model. This option doesn't enforce any schema on the result: you simply receive the model's text as a string.
+
+```ts
+const { experimental_output } = await generateText({
+  // ...
+  experimental_output: Output.text(),
+  prompt: 'Tell me a joke.',
+});
+// experimental_output will be a string (the joke)
+```
+
+#### `Output.object()`
+
+Use `Output.object({ schema })` to generate a structured object based on a schema (for example, a Zod schema). The output is type-validated to ensure the returned result matches the schema.
+
+```ts
+const { experimental_output } = await generateText({
+  // ...
+  experimental_output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      age: z.number().nullable(),
+      labels: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate information for a test user.',
+});
+// experimental_output will be an object matching the schema above
+```
+
+Partial outputs (e.g. with `streamText`) are also validated against your provided schema, as much as possible.
+
+#### `Output.array()`
+
+Use `Output.array({ element })` to specify that you expect an array of typed objects from the model, where each element should conform to a schema.
+
+```ts
+const { experimental_output } = await generateText({
+  // ...
+  experimental_output: Output.array({
+    element: z.object({
+      location: z.string(),
+      temperature: z.number(),
+      condition: z.string(),
+    }),
+  }),
+  prompt: 'List the weather for San Francisco and Paris.',
+});
+// experimental_output will be an array of objects like:
+// [
+//   { location: 'San Francisco', temperature: 70, condition: 'Sunny' },
+//   { location: 'Paris', temperature: 65, condition: 'Cloudy' },
+// ]
+```
+
+With `Output.array`, the model is guided to return an object with an `elements` property that is an array; the SDK then extracts and validates this array for you.
+
+For more advanced validation or different structures, see [the Output API reference](/docs/reference/ai-sdk-core/output).
+
 ## More Examples
 
 You can see `generateObject` and `streamObject` in action using various frameworks in the following examples:

--- a/examples/ai-core/src/agent/openai-generate-json-array.ts
+++ b/examples/ai-core/src/agent/openai-generate-json-array.ts
@@ -28,12 +28,5 @@ run(async () => {
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 
-  // [
-  //   { location: 'San Francisco', temperature: 12, condition: 'cloudy' },
-  //   { location: 'London', temperature: 8, condition: 'cloudy' },
-  //   { location: 'Paris', temperature: -6, condition: 'snowy' },
-  //   { location: 'Berlin', temperature: 34, condition: 'sunny' }
-  // ]
-
   print('Output:', output);
 });

--- a/examples/ai-core/src/agent/openai-generate-json-array.ts
+++ b/examples/ai-core/src/agent/openai-generate-json-array.ts
@@ -6,15 +6,14 @@ import { weatherTool } from '../tools/weather-tool';
 import { print } from '../lib/print';
 
 const agent = new ToolLoopAgent({
-  model: openai('gpt-4o-mini'),
+  model: openai('gpt-5-mini'),
   providerOptions: {
     openai: {
+      reasoningEffort: 'medium',
       strictJsonSchema: true,
     } satisfies OpenAIResponsesProviderOptions,
   },
-  tools: {
-    weather: weatherTool,
-  },
+  tools: { weather: weatherTool },
   experimental_output: Output.array({
     element: z.object({
       location: z.string(),
@@ -28,6 +27,13 @@ run(async () => {
   const { experimental_output: output } = await agent.generate({
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
+
+  // [
+  //   { location: 'San Francisco', temperature: 12, condition: 'cloudy' },
+  //   { location: 'London', temperature: 8, condition: 'cloudy' },
+  //   { location: 'Paris', temperature: -6, condition: 'snowy' },
+  //   { location: 'Berlin', temperature: 34, condition: 'sunny' }
+  // ]
 
   print('Output:', output);
 });

--- a/examples/ai-core/src/agent/openai-generate-json-array.ts
+++ b/examples/ai-core/src/agent/openai-generate-json-array.ts
@@ -1,0 +1,33 @@
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { Output, ToolLoopAgent } from 'ai';
+import { run } from '../lib/run';
+import { z } from 'zod';
+import { weatherTool } from '../tools/weather-tool';
+import { print } from '../lib/print';
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-4o-mini'),
+  providerOptions: {
+    openai: {
+      strictJsonSchema: true,
+    } satisfies OpenAIResponsesProviderOptions,
+  },
+  tools: {
+    weather: weatherTool,
+  },
+  experimental_output: Output.array({
+    element: z.object({
+      location: z.string(),
+      temperature: z.number(),
+      condition: z.string(),
+    }),
+  }),
+});
+
+run(async () => {
+  const { experimental_output: output } = await agent.generate({
+    prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
+  });
+
+  print('Output:', output);
+});

--- a/examples/ai-core/src/agent/openai-stream-json-news.ts
+++ b/examples/ai-core/src/agent/openai-stream-json-news.ts
@@ -8,14 +8,10 @@ import { run } from '../lib/run';
 const agent = new ToolLoopAgent({
   model: openai('gpt-5-mini'),
   callOptionsSchema: z.object({ topic: z.string() }),
-  experimental_output: Output.object({
-    schema: z.object({
-      news: z.array(
-        z.object({
-          title: z.string(),
-          tldr: z.string(),
-        }),
-      ),
+  experimental_output: Output.array({
+    element: z.object({
+      title: z.string(),
+      tldr: z.string(),
     }),
   }),
   tools: {

--- a/examples/ai-core/src/generate-text/openai-output-array.ts
+++ b/examples/ai-core/src/generate-text/openai-output-array.ts
@@ -1,0 +1,34 @@
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { generateText, Output } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+import { print } from '../lib/print';
+
+async function main() {
+  const result = await generateText({
+    model: openai('gpt-4o-mini'),
+    providerOptions: {
+      openai: {
+        strictJsonSchema: true,
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+    experimental_output: Output.array({
+      element: z.object({
+        name: z.string(),
+        class: z
+          .string()
+          .describe('Character class, e.g. warrior, mage, or thief.'),
+        description: z.string(),
+      }),
+    }),
+    prompt:
+      'Generate 3 character descriptions for a fantasy role playing game.',
+  });
+
+  // { location: 'San Francisco', temperature: 81 }
+  console.log(result.experimental_output);
+
+  print('Request:', result.request.body);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-output-array.ts
+++ b/examples/ai-core/src/generate-text/openai-output-array.ts
@@ -1,10 +1,10 @@
 import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
 import { generateText, Output } from 'ai';
-import 'dotenv/config';
 import { z } from 'zod';
 import { print } from '../lib/print';
+import { run } from '../lib/run';
 
-async function main() {
+run(async () => {
   const result = await generateText({
     model: openai('gpt-4o-mini'),
     providerOptions: {
@@ -25,10 +25,6 @@ async function main() {
       'Generate 3 character descriptions for a fantasy role playing game.',
   });
 
-  // { location: 'San Francisco', temperature: 81 }
-  console.log(result.experimental_output);
-
+  print('Output:', result.experimental_output);
   print('Request:', result.request.body);
-}
-
-main().catch(console.error);
+});

--- a/examples/ai-core/src/generate-text/openai-output-array.ts
+++ b/examples/ai-core/src/generate-text/openai-output-array.ts
@@ -1,8 +1,9 @@
 import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
-import { generateText, Output } from 'ai';
+import { generateText, Output, stepCountIs } from 'ai';
 import { z } from 'zod';
 import { print } from '../lib/print';
 import { run } from '../lib/run';
+import { weatherTool } from '../tools/weather-tool';
 
 run(async () => {
   const result = await generateText({
@@ -12,17 +13,18 @@ run(async () => {
         strictJsonSchema: true,
       } satisfies OpenAIResponsesProviderOptions,
     },
+    tools: {
+      weather: weatherTool,
+    },
+    stopWhen: stepCountIs(5),
     experimental_output: Output.array({
       element: z.object({
-        name: z.string(),
-        class: z
-          .string()
-          .describe('Character class, e.g. warrior, mage, or thief.'),
-        description: z.string(),
+        location: z.string(),
+        temperature: z.number(),
+        condition: z.string(),
       }),
     }),
-    prompt:
-      'Generate 3 character descriptions for a fantasy role playing game.',
+    prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 
   print('Output:', result.experimental_output);

--- a/examples/ai-core/src/generate-text/openai-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-output-object.ts
@@ -19,12 +19,16 @@ run(async () => {
     stopWhen: stepCountIs(5),
     experimental_output: Output.object({
       schema: z.object({
-        location: z.string(),
-        temperature: z.number(),
-        condition: z.string(),
+        elements: z.array(
+          z.object({
+            location: z.string(),
+            temperature: z.number(),
+            condition: z.string(),
+          }),
+        ),
       }),
     }),
-    prompt: 'What is the weather in San Francisco?',
+    prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 
   // { location: 'San Francisco', temperature: 81 }

--- a/examples/ai-core/src/generate-text/openai-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-output-object.ts
@@ -1,32 +1,29 @@
-import { openai } from '@ai-sdk/openai';
-import { generateText, Output, stepCountIs, tool } from 'ai';
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { generateText, Output, stepCountIs } from 'ai';
 import { z } from 'zod';
 import { print } from '../lib/print';
 import { run } from '../lib/run';
+import { weatherTool } from '../tools/weather-tool';
 
 run(async () => {
   const result = await generateText({
     model: openai('gpt-4o-mini'),
-    tools: {
-      weather: tool({
-        description: 'Get the weather in a location',
-        inputSchema: z.object({
-          location: z.string().describe('The location to get the weather for'),
-        }),
-        // location below is inferred to be a string:
-        execute: async ({ location }) => ({
-          location,
-          temperature: 72 + Math.floor(Math.random() * 21) - 10,
-        }),
-      }),
+    providerOptions: {
+      openai: {
+        strictJsonSchema: true,
+      } satisfies OpenAIResponsesProviderOptions,
     },
+    tools: {
+      weather: weatherTool,
+    },
+    stopWhen: stepCountIs(5),
     experimental_output: Output.object({
       schema: z.object({
         location: z.string(),
         temperature: z.number(),
+        condition: z.string(),
       }),
     }),
-    stopWhen: stepCountIs(2),
     prompt: 'What is the weather in San Francisco?',
   });
 

--- a/examples/ai-core/src/generate-text/openai-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-output-object.ts
@@ -1,10 +1,11 @@
 import { openai } from '@ai-sdk/openai';
-import { generateText, stepCountIs, Output, tool } from 'ai';
-import 'dotenv/config';
+import { generateText, Output, stepCountIs, tool } from 'ai';
 import { z } from 'zod';
+import { print } from '../lib/print';
+import { run } from '../lib/run';
 
-async function main() {
-  const { experimental_output } = await generateText({
+run(async () => {
+  const result = await generateText({
     model: openai('gpt-4o-mini'),
     tools: {
       weather: tool({
@@ -30,7 +31,6 @@ async function main() {
   });
 
   // { location: 'San Francisco', temperature: 81 }
-  console.log(experimental_output);
-}
-
-main().catch(console.error);
+  print('Output:', result.experimental_output);
+  print('Request:', result.request.body);
+});

--- a/examples/ai-core/src/stream-text/openai-output-array.ts
+++ b/examples/ai-core/src/stream-text/openai-output-array.ts
@@ -1,0 +1,33 @@
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { Output, stepCountIs, streamText } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+import { weatherTool } from '../tools/weather-tool';
+
+run(async () => {
+  const { experimental_partialOutputStream: partialOutputStream } = streamText({
+    model: openai('gpt-4o-mini'),
+    providerOptions: {
+      openai: {
+        strictJsonSchema: true,
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+    tools: {
+      weather: weatherTool,
+    },
+    stopWhen: stepCountIs(5),
+    experimental_output: Output.array({
+      element: z.object({
+        location: z.string(),
+        temperature: z.number(),
+        condition: z.string(),
+      }),
+    }),
+    prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
+  });
+
+  for await (const partialOutput of partialOutputStream) {
+    console.clear();
+    console.log(partialOutput);
+  }
+});

--- a/examples/ai-core/src/stream-text/openai-output-object.ts
+++ b/examples/ai-core/src/stream-text/openai-output-object.ts
@@ -1,45 +1,37 @@
-import { openai } from '@ai-sdk/openai';
-import { stepCountIs, Output, streamText, tool } from 'ai';
-import 'dotenv/config';
+import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { Output, stepCountIs, streamText } from 'ai';
 import { z } from 'zod';
+import { run } from '../lib/run';
+import { weatherTool } from '../tools/weather-tool';
 
-async function main() {
+run(async () => {
   const { experimental_partialOutputStream: partialOutputStream } = streamText({
     model: openai('gpt-4o-mini'),
-    tools: {
-      weather: tool({
-        description: 'Get the weather in a location',
-        inputSchema: z.object({
-          location: z.string().describe('The location to get the weather for'),
-        }),
-        // location below is inferred to be a string:
-        execute: async ({ location }) => ({
-          location,
-          temperature: 72 + Math.floor(Math.random() * 21) - 10,
-        }),
-      }),
+    providerOptions: {
+      openai: {
+        strictJsonSchema: true,
+      } satisfies OpenAIResponsesProviderOptions,
     },
+    tools: {
+      weather: weatherTool,
+    },
+    stopWhen: stepCountIs(5),
     experimental_output: Output.object({
       schema: z.object({
         elements: z.array(
           z.object({
             location: z.string(),
             temperature: z.number(),
-            touristAttraction: z.string(),
+            condition: z.string(),
           }),
         ),
       }),
     }),
-    stopWhen: stepCountIs(2),
-    prompt:
-      'What is the weather and the main tourist attraction in San Francisco, London Paris, and Berlin?',
+    prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 
-  // [{ location: 'San Francisco', temperature: 81 }, ...]
   for await (const partialOutput of partialOutputStream) {
     console.clear();
     console.log(partialOutput);
   }
-}
-
-main().catch(console.error);
+});

--- a/examples/ai-core/src/tools/weather-tool.ts
+++ b/examples/ai-core/src/tools/weather-tool.ts
@@ -1,14 +1,33 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
+const conditions = [
+  { name: 'sunny', minTemperature: -5, maxTemperature: 35 },
+  { name: 'snowy', minTemperature: -10, maxTemperature: 0 },
+  { name: 'rainy', minTemperature: 0, maxTemperature: 15 },
+  { name: 'cloudy', minTemperature: 5, maxTemperature: 25 },
+];
+
 export const weatherTool = tool({
   description: 'Get the weather in a location',
   inputSchema: z.object({
     location: z.string().describe('The location to get the weather for'),
   }),
-  // location below is inferred to be a string:
-  execute: async ({ location }) => ({
-    location,
-    temperature: 72 + Math.floor(Math.random() * 21) - 10,
+  outputSchema: z.object({
+    location: z.string(),
+    condition: z.string(),
+    temperature: z.number(),
   }),
+  execute: async ({ location }) => {
+    const condition = conditions[Math.floor(Math.random() * conditions.length)];
+    return {
+      location,
+      condition: condition.name,
+      temperature:
+        Math.floor(
+          Math.random() *
+            (condition.maxTemperature - condition.minTemperature + 1),
+        ) + condition.minTemperature,
+    };
+  },
 });

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,10 +1,10 @@
 import { ModelMessage } from '@ai-sdk/provider-utils';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
+import { Output } from '../generate-text/output';
 import {
   InferGenerateOutput,
   InferStreamOutput,
-  Output,
-} from '../generate-text/output';
+} from '../generate-text/output-utils';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,10 +1,10 @@
 import { generateText } from '../generate-text/generate-text';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
+import { Output } from '../generate-text/output';
 import {
   InferGenerateOutput,
   InferStreamOutput,
-  Output,
-} from '../generate-text/output';
+} from '../generate-text/output-utils';
 import { stepCountIs } from '../generate-text/stop-condition';
 import { streamText } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2937,6 +2937,96 @@ describe('generateText', () => {
       });
     });
 
+    describe('array output', () => {
+      it('should generate an array with 3 elements', async () => {
+        const model = new MockLanguageModelV3({
+          doGenerate: {
+            ...dummyResponseValues,
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  elements: [
+                    { content: 'element 1' },
+                    { content: 'element 2' },
+                    { content: 'element 3' },
+                  ],
+                }),
+              },
+            ],
+          },
+        });
+
+        const result = await generateText({
+          model,
+          experimental_output: Output.array({
+            element: z.object({ content: z.string() }),
+          }),
+          prompt: 'prompt',
+        });
+
+        expect(result.experimental_output).toMatchInlineSnapshot(`
+        [
+          {
+            "content": "element 1",
+          },
+          {
+            "content": "element 2",
+          },
+          {
+            "content": "element 3",
+          },
+        ]
+      `);
+
+        expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
+        [
+          {
+            "content": [
+              {
+                "text": "prompt",
+                "type": "text",
+              },
+            ],
+            "providerOptions": undefined,
+            "role": "user",
+          },
+        ]
+      `);
+
+        expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
+        {
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "elements": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "content": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "content",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+            },
+            "required": [
+              "elements",
+            ],
+            "type": "object",
+          },
+          "type": "json",
+        }
+      `);
+      });
+    });
+
     it('should not parse output when finish reason is tool-calls', async () => {
       const result = await generateText({
         model: new MockLanguageModelV3({

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -8,7 +8,8 @@ export type {
   GeneratedFile as Experimental_GeneratedImage, // Image for backwards compatibility, TODO remove in v5
   GeneratedFile,
 } from './generated-file';
-export * as Output from './output';
+export { array, object, text } from './output';
+export type { InferGenerateOutput, InferStreamOutput, Output } from './output';
 export type { PrepareStepFunction, PrepareStepResult } from './prepare-step';
 export { pruneMessages } from './prune-messages';
 export type { ReasoningOutput } from './reasoning-output';

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -8,8 +8,8 @@ export type {
   GeneratedFile as Experimental_GeneratedImage, // Image for backwards compatibility, TODO remove in v5
   GeneratedFile,
 } from './generated-file';
-export { array, object, text } from './output';
-export type { InferGenerateOutput, InferStreamOutput, Output } from './output';
+export * as Output from './output';
+export type { InferGenerateOutput, InferStreamOutput } from './output-utils';
 export type { PrepareStepFunction, PrepareStepResult } from './prepare-step';
 export { pruneMessages } from './prune-messages';
 export type { ReasoningOutput } from './reasoning-output';

--- a/packages/ai/src/generate-text/output-utils.ts
+++ b/packages/ai/src/generate-text/output-utils.ts
@@ -1,0 +1,7 @@
+import { Output } from './output';
+
+export type InferGenerateOutput<OUTPUT extends Output> =
+  OUTPUT extends Output<infer T, any> ? T : never;
+
+export type InferStreamOutput<OUTPUT extends Output> =
+  OUTPUT extends Output<any, infer P> ? P : never;

--- a/packages/ai/src/generate-text/output.test.ts
+++ b/packages/ai/src/generate-text/output.test.ts
@@ -266,4 +266,63 @@ describe('Output.array', () => {
       }
     });
   });
+
+  describe('array.parsePartial', () => {
+    it('should parse partial output successfully for successful-parse', async () => {
+      const partial = await array1.parsePartial({
+        text: `{ "elements": [{ "content": "a" }, { "content": "b" }] }`,
+      });
+      expect(partial).toEqual({
+        partial: [{ content: 'a' }, { content: 'b' }],
+      });
+    });
+
+    it('should parse partial output successfully for repaired-parse (returns all but last element)', async () => {
+      // Simulate an incomplete last element (at the end, missing " }")
+      const partial = await array1.parsePartial({
+        text: `{ "elements": [{ "content": "a" }, { "content": "b" }`,
+      });
+      // Should only return [{ content: "a" }]
+      expect(partial).toEqual({
+        partial: [{ content: 'a' }],
+      });
+    });
+
+    it('should return undefined for failed-parse', async () => {
+      const partial = await array1.parsePartial({
+        text: '{ not valid json',
+      });
+      expect(partial).toBeUndefined();
+    });
+
+    it('should return undefined when input is undefined', async () => {
+      const partial = await array1.parsePartial({
+        text: undefined as any,
+      });
+      expect(partial).toBeUndefined();
+    });
+
+    it('should return undefined if elements is missing', async () => {
+      // "elements" property is missing
+      const partial = await array1.parsePartial({
+        text: `{ "foo": [1,2,3] }`,
+      });
+      expect(partial).toBeUndefined();
+    });
+
+    it('should return undefined if elements is not an array', async () => {
+      // "elements" property exists but is not an array
+      const partial = await array1.parsePartial({
+        text: `{ "elements": "not-an-array" }`,
+      });
+      expect(partial).toBeUndefined();
+    });
+
+    it('should handle an empty array of elements', async () => {
+      const partial = await array1.parsePartial({
+        text: `{ "elements": [] }`,
+      });
+      expect(partial).toEqual({ partial: [] });
+    });
+  });
 });

--- a/packages/ai/src/generate-text/output.test.ts
+++ b/packages/ai/src/generate-text/output.test.ts
@@ -2,7 +2,7 @@ import { fail } from 'assert';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { verifyNoObjectGeneratedError } from '../error/verify-no-object-generated-error';
-import { object, text } from './output';
+import { array, object, text } from './output';
 
 const context = {
   response: {
@@ -21,26 +21,34 @@ const context = {
 } as const;
 
 describe('Output.text', () => {
-  const outputText = text();
+  const text1 = text();
+
+  describe('responseFormat', () => {
+    it('should return the text as is', async () => {
+      const result = await text1.responseFormat;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "type": "text",
+        }
+      `);
+    });
+  });
 
   describe('parseOutput', () => {
     it('should return the text as is', async () => {
-      const result = await outputText.parseOutput(
-        { text: 'some output' },
-        context,
-      );
+      const result = await text1.parseOutput({ text: 'some output' }, context);
       expect(result).toBe('some output');
     });
 
     it('should handle empty string', async () => {
-      const result = await outputText.parseOutput({ text: '' }, context);
+      const result = await text1.parseOutput({ text: '' }, context);
       expect(result).toBe('');
     });
 
     it('should handle undefined as string "undefined"', async () => {
       // Output.text() expects a string, so passing undefined would be a type error,
       // but we cast for test purposes to ensure what happens
-      const result = await outputText.parseOutput(
+      const result = await text1.parseOutput(
         { text: undefined as any },
         context,
       );
@@ -50,23 +58,47 @@ describe('Output.text', () => {
 
   describe('parsePartial', () => {
     it('should return the string as partial', async () => {
-      const result = await outputText.parsePartial({ text: 'partial text' });
+      const result = await text1.parsePartial({ text: 'partial text' });
       expect(result).toEqual({ partial: 'partial text' });
     });
 
     it('should handle empty string partial', async () => {
-      const result = await outputText.parsePartial({ text: '' });
+      const result = await text1.parsePartial({ text: '' });
       expect(result).toEqual({ partial: '' });
     });
   });
 });
 
 describe('Output.object', () => {
-  const output1 = object({ schema: z.object({ content: z.string() }) });
+  const object1 = object({ schema: z.object({ content: z.string() }) });
+
+  describe('responseFormat', () => {
+    it('should return the text as is', async () => {
+      const result = await object1.responseFormat;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "content": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "content",
+            ],
+            "type": "object",
+          },
+          "type": "json",
+        }
+      `);
+    });
+  });
 
   describe('parseOutput', () => {
     it('should parse the output of the model', async () => {
-      const result = await output1.parseOutput(
+      const result = await object1.parseOutput(
         { text: `{ "content": "test" }` },
         context,
       );
@@ -76,7 +108,7 @@ describe('Output.object', () => {
 
     it('should throw NoObjectGeneratedError when parsing fails', async () => {
       try {
-        await output1.parseOutput({ text: '{ broken json' }, context);
+        await object1.parseOutput({ text: '{ broken json' }, context);
         fail('must throw error');
       } catch (error) {
         verifyNoObjectGeneratedError(error, {
@@ -90,7 +122,7 @@ describe('Output.object', () => {
 
     it('should throw NoObjectGeneratedError when schema validation fails', async () => {
       try {
-        await output1.parseOutput({ text: `{ "content": 123 }` }, context);
+        await object1.parseOutput({ text: `{ "content": 123 }` }, context);
         fail('must throw error');
       } catch (error) {
         verifyNoObjectGeneratedError(error, {
@@ -105,26 +137,26 @@ describe('Output.object', () => {
 
   describe('parsePartial', () => {
     it('should return undefined for undefined input', async () => {
-      const result = await output1.parsePartial({ text: undefined as any });
+      const result = await object1.parsePartial({ text: undefined as any });
       expect(result).toBeUndefined();
     });
 
     it('should return partial object for valid JSON', async () => {
-      const result = await output1.parsePartial({
+      const result = await object1.parsePartial({
         text: '{ "content": "test" }',
       });
       expect(result).toEqual({ partial: { content: 'test' } });
     });
 
     it('should return partial object for repairable JSON', async () => {
-      const result = await output1.parsePartial({
+      const result = await object1.parsePartial({
         text: '{ "content": "test"',
       });
       expect(result).toEqual({ partial: { content: 'test' } });
     });
 
     it('should handle partial object with missing closing brace', async () => {
-      const result = await output1.parsePartial({
+      const result = await object1.parsePartial({
         text: '{ "content": "partial", "count": 42',
       });
       expect(result).toEqual({ partial: { content: 'partial', count: 42 } });
@@ -141,15 +173,55 @@ describe('Output.object', () => {
     });
 
     it('should handle empty string input', async () => {
-      const result = await output1.parsePartial({ text: '' });
+      const result = await object1.parsePartial({ text: '' });
       expect(result).toBeUndefined();
     });
 
     it('should handle partial string value', async () => {
-      const result = await output1.parsePartial({
+      const result = await object1.parsePartial({
         text: '{ "content": "partial str',
       });
       expect(result).toEqual({ partial: { content: 'partial str' } });
+    });
+  });
+});
+
+describe('Output.array', () => {
+  const array1 = array({ element: z.object({ content: z.string() }) });
+
+  describe('responseFormat', () => {
+    it('should return the text as is', async () => {
+      const result = await array1.responseFormat;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "elements": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "content": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "content",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+            },
+            "required": [
+              "elements",
+            ],
+            "type": "object",
+          },
+          "type": "json",
+        }
+      `);
     });
   });
 });

--- a/packages/ai/src/generate-text/output.test.ts
+++ b/packages/ai/src/generate-text/output.test.ts
@@ -224,4 +224,46 @@ describe('Output.array', () => {
       `);
     });
   });
+
+  describe('parseOutput', () => {
+    it('should parse the output of the model', async () => {
+      const result = await array1.parseOutput(
+        { text: `{ "elements": [{ "content": "test" }] }` },
+        context,
+      );
+
+      expect(result).toStrictEqual([{ content: 'test' }]);
+    });
+
+    it('should throw NoObjectGeneratedError when parsing fails', async () => {
+      try {
+        await array1.parseOutput({ text: '{ broken json' }, context);
+        fail('must throw error');
+      } catch (error) {
+        verifyNoObjectGeneratedError(error, {
+          message: 'No object generated: could not parse the response.',
+          response: context.response,
+          usage: context.usage,
+          finishReason: context.finishReason,
+        });
+      }
+    });
+
+    it('should throw NoObjectGeneratedError when schema validation fails', async () => {
+      try {
+        await array1.parseOutput(
+          { text: `{ "elements": [{ "content": 123 }] }` },
+          context,
+        );
+        fail('must throw error');
+      } catch (error) {
+        verifyNoObjectGeneratedError(error, {
+          message: 'No object generated: response did not match schema.',
+          response: context.response,
+          usage: context.usage,
+          finishReason: context.finishReason,
+        });
+      }
+    });
+  });
 });

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -138,9 +138,10 @@ export const object = <OUTPUT>({
 };
 
 export const array = <ELEMENT>({
-  elementSchema: inputElementSchema,
+  element: inputElementSchema,
+  // TODO: add optional name
 }: {
-  elementSchema: FlexibleSchema<ELEMENT>;
+  element: FlexibleSchema<ELEMENT>;
 }): Output<string, string> => {
   const elementSchema = asSchema(inputElementSchema);
 

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -137,6 +137,45 @@ export const object = <OUTPUT>({
   };
 };
 
+export const array = <ELEMENT>({
+  elementSchema: inputElementSchema,
+}: {
+  elementSchema: FlexibleSchema<ELEMENT>;
+}): Output<string, string> => {
+  const elementSchema = asSchema(inputElementSchema);
+
+  return {
+    type: 'object',
+
+    // returns a JSON schema that describes an array of elements:
+    responseFormat: resolve(elementSchema.jsonSchema).then(jsonSchema => {
+      // remove $schema from schema.jsonSchema:
+      const { $schema, ...itemSchema } = jsonSchema;
+
+      return {
+        type: 'json' as const,
+        schema: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            elements: { type: 'array', items: itemSchema },
+          },
+          required: ['elements'],
+          additionalProperties: false,
+        },
+      };
+    }),
+
+    async parsePartial({ text }: { text: string }) {
+      return { partial: text }; // TODO
+    },
+
+    async parseOutput({ text }: { text: string }) {
+      return text; // TODO
+    },
+  };
+};
+
 export type InferGenerateOutput<OUTPUT extends Output> =
   OUTPUT extends Output<infer T, any> ? T : never;
 

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -175,9 +175,3 @@ export const array = <ELEMENT>({
     },
   };
 };
-
-export type InferGenerateOutput<OUTPUT extends Output> =
-  OUTPUT extends Output<infer T, any> ? T : never;
-
-export type InferStreamOutput<OUTPUT extends Output> =
-  OUTPUT extends Output<any, infer P> ? P : never;

--- a/packages/ai/src/generate-text/output.ts
+++ b/packages/ai/src/generate-text/output.ts
@@ -257,7 +257,6 @@ export const array = <ELEMENT>({
             return undefined;
           }
 
-          // Note: currently no validation of partial results:
           const rawElements =
             result.state === 'repaired-parse' && outerValue.elements.length > 0
               ? outerValue.elements.slice(0, -1)


### PR DESCRIPTION
## Background

`experimental_output` on `generateText` and `streamText` should support the same options as `generateObject` and eventually replace it.

## Summary

* Add `Output.array` option
* Add output response format tests

## Manual Verification

- [x] run `examples/ai-core/src/generate-text/openai-output-array.ts`
- [x] run `examples/ai-core/src/stream-text/openai-output-array.ts`

## Tasks

- [x] add responseFormat tests
- [x] separate type inference helpers
- [x] implement json parsing
- [x] implement response format
- [x] add generate example
- [x] add stream example
- [x] implement partial parsing
- [x] stream text test updates (copy from stream object)
- [x] generate text test updates (copy from generate object)
- [x] change to full parsing, add type test
- [x] documentation
- [x] changeset

## Future Work

* custom array name
* array element stream
* enum type
* json type