### PR TITLE
feat(ai): stable structured output on generateText, streamText, and ToolLoopAgent

### DIFF
--- a/.changeset/green-onions-pay.md
+++ b/.changeset/green-onions-pay.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): stable structured output on generateText, streamText, and ToolLoopAgent

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -158,7 +158,7 @@ import { z } from 'zod';
 
 const analysisAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  experimental_output: Output.object({
+  output: Output.object({
     schema: z.object({
       sentiment: z.enum(['positive', 'neutral', 'negative']),
       summary: z.string(),
@@ -168,7 +168,7 @@ const analysisAgent = new ToolLoopAgent({
   stopWhen: stepCountIs(10),
 });
 
-const { experimental_output: output } = await analysisAgent.generate({
+const { output: output } = await analysisAgent.generate({
   prompt: 'Analyze customer feedback from the last quarter',
 });
 ```

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -168,7 +168,7 @@ const analysisAgent = new ToolLoopAgent({
   stopWhen: stepCountIs(10),
 });
 
-const { output: output } = await analysisAgent.generate({
+const { output } = await analysisAgent.generate({
   prompt: 'Analyze customer feedback from the last quarter',
 });
 ```

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -60,7 +60,7 @@ The result object of `generateText` contains several promises that resolve when 
 - `result.response`: Additional response information, including response messages and body.
 - `result.providerMetadata`: Additional provider-specific metadata.
 - `result.steps`: Details for all steps, useful for getting information about intermediate steps.
-- `result.experimental_output`: The generated structured output using the `experimental_output` specification.
+- `result.output`: The generated structured output using the `output` specification.
 
 ### Accessing response headers & body
 

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -343,8 +343,8 @@ const { output } = await generateText({
 ### `streamText`
 
 ```ts highlight="2,4-18"
-// experimental_partialOutputStream contains generated partial objects:
-const { experimental_partialOutputStream } = await streamText({
+// partialOutputStream contains generated partial objects:
+const { partialOutputStream } = await streamText({
   // ...
   output: Output.object({
     schema: z.object({

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -310,11 +310,6 @@ You can generate structured data with `generateText` and `streamText` by using t
   at the same time. This is only possible with `generateText` and `streamText`.
 </Note>
 
-<Note type="warning">
-  Structured output generation with `generateText` and `streamText` is
-  experimental and may change in the future.
-</Note>
-
 ### `generateText`
 
 ```ts highlight="2,4-18"

--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -303,7 +303,7 @@ const { object } = await generateObject({
 
 ## Structured outputs with `generateText` and `streamText`
 
-You can generate structured data with `generateText` and `streamText` by using the `experimental_output` setting.
+You can generate structured data with `generateText` and `streamText` by using the `output` setting.
 
 <Note>
   Some models, e.g. those by OpenAI, support structured outputs and tool calling
@@ -318,10 +318,10 @@ You can generate structured data with `generateText` and `streamText` by using t
 ### `generateText`
 
 ```ts highlight="2,4-18"
-// experimental_output is a structured object that matches the schema:
-const { experimental_output } = await generateText({
+// output is a structured object that matches the schema:
+const { output } = await generateText({
   // ...
-  experimental_output: Output.object({
+  output: Output.object({
     schema: z.object({
       name: z.string(),
       age: z.number().nullable().describe('Age of the person.'),
@@ -346,7 +346,7 @@ const { experimental_output } = await generateText({
 // experimental_partialOutputStream contains generated partial objects:
 const { experimental_partialOutputStream } = await streamText({
   // ...
-  experimental_output: Output.object({
+  output: Output.object({
     schema: z.object({
       name: z.string(),
       age: z.number().nullable().describe('Age of the person.'),
@@ -374,12 +374,12 @@ The AI SDK supports multiple ways of specifying the expected structure of genera
 Use `Output.text()` to generate plain text from a model. This option doesn't enforce any schema on the result: you simply receive the model's text as a string.
 
 ```ts
-const { experimental_output } = await generateText({
+const { output } = await generateText({
   // ...
-  experimental_output: Output.text(),
+  output: Output.text(),
   prompt: 'Tell me a joke.',
 });
-// experimental_output will be a string (the joke)
+// output will be a string (the joke)
 ```
 
 #### `Output.object()`
@@ -387,9 +387,9 @@ const { experimental_output } = await generateText({
 Use `Output.object({ schema })` to generate a structured object based on a schema (for example, a Zod schema). The output is type-validated to ensure the returned result matches the schema.
 
 ```ts
-const { experimental_output } = await generateText({
+const { output } = await generateText({
   // ...
-  experimental_output: Output.object({
+  output: Output.object({
     schema: z.object({
       name: z.string(),
       age: z.number().nullable(),
@@ -398,7 +398,7 @@ const { experimental_output } = await generateText({
   }),
   prompt: 'Generate information for a test user.',
 });
-// experimental_output will be an object matching the schema above
+// output will be an object matching the schema above
 ```
 
 Partial outputs (e.g. with `streamText`) are also validated against your provided schema, as much as possible.
@@ -408,9 +408,9 @@ Partial outputs (e.g. with `streamText`) are also validated against your provide
 Use `Output.array({ element })` to specify that you expect an array of typed objects from the model, where each element should conform to a schema.
 
 ```ts
-const { experimental_output } = await generateText({
+const { output } = await generateText({
   // ...
-  experimental_output: Output.array({
+  output: Output.array({
     element: z.object({
       location: z.string(),
       temperature: z.number(),
@@ -419,7 +419,7 @@ const { experimental_output } = await generateText({
   }),
   prompt: 'List the weather for San Francisco and Paris.',
 });
-// experimental_output will be an array of objects like:
+// output will be an array of objects like:
 // [
 //   { location: 'San Francisco', temperature: 70, condition: 'Sunny' },
 //   { location: 'Paris', temperature: 65, condition: 'Cloudy' },
@@ -435,14 +435,14 @@ For more advanced validation or different structures, see [the Output API refere
 Use `Output.choice({ options })` when you expect the model to choose from a specific set of string options, such as for classification or fixed-enum answers.
 
 ```ts
-const { experimental_output } = await generateText({
+const { output } = await generateText({
   // ...
-  experimental_output: Output.choice({
+  output: Output.choice({
     options: ['sunny', 'rainy', 'snowy'],
   }),
   prompt: 'Is the weather sunny, rainy, or snowy today?',
 });
-// experimental_output will be one of: 'sunny', 'rainy', or 'snowy'
+// output will be one of: 'sunny', 'rainy', or 'snowy'
 ```
 
 You can provide any set of string options, and the output will always be a single string value that matches one of the specified options. The SDK validates that the result matches one of your options, and will throw if the model returns something invalid.

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -657,7 +657,7 @@ To see `generateText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_output',
+      name: 'output',
       type: 'Output',
       isOptional: true,
       description: 'Experimental setting for generating structured outputs.',
@@ -1422,7 +1422,7 @@ To see `generateText` in action, check out [these examples](#examples).
         'Optional metadata from the provider. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
     },
     {
-      name: 'experimental_output',
+      name: 'output',
       type: 'Output',
       isOptional: true,
       description: 'Experimental setting for generating structured outputs.',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2473,7 +2473,7 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_partialOutputStream',
+      name: 'partialOutputStream',
       type: 'AsyncIterableStream<PARTIAL_OUTPUT>',
       description:
         'A stream of partial outputs. It uses the `output` specification. AsyncIterableStream is defined as AsyncIterable<T> & ReadableStream<T>.',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -907,7 +907,7 @@ To see `streamText` in action, check out [these examples](#examples).
       ],
     },
     {
-      name: 'experimental_output',
+      name: 'output',
       type: 'Output',
       isOptional: true,
       description: 'Experimental setting for generating structured outputs.',
@@ -2476,7 +2476,7 @@ To see `streamText` in action, check out [these examples](#examples).
       name: 'experimental_partialOutputStream',
       type: 'AsyncIterableStream<PARTIAL_OUTPUT>',
       description:
-        'A stream of partial outputs. It uses the `experimental_output` specification. AsyncIterableStream is defined as AsyncIterable<T> & ReadableStream<T>.',
+        'A stream of partial outputs. It uses the `output` specification. AsyncIterableStream is defined as AsyncIterable<T> & ReadableStream<T>.',
     },
     {
       name: 'consumeStream',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -83,7 +83,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         'Limits the subset of tools that are available in a specific call.',
     },
     {
-      name: 'experimental_output',
+      name: 'output',
       type: 'Output',
       isOptional: true,
       description:
@@ -332,7 +332,7 @@ import { z } from 'zod';
 
 const analysisAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  experimental_output: {
+  output: {
     schema: z.object({
       sentiment: z.enum(['positive', 'negative', 'neutral']),
       score: z.number(),
@@ -345,7 +345,7 @@ const result = await analysisAgent.generate({
   prompt: 'Analyze this review: "The product exceeded my expectations!"',
 });
 
-console.log(result.experimental_output);
+console.log(result.output);
 // Typed as { sentiment: 'positive' | 'negative' | 'neutral', score: number, summary: string }
 ```
 

--- a/content/docs/09-troubleshooting/14-tool-calling-with-structured-outputs.mdx
+++ b/content/docs/09-troubleshooting/14-tool-calling-with-structured-outputs.mdx
@@ -11,18 +11,18 @@ You may want to combine tool calling with structured output generation. While `g
 
 ## Background
 
-To use tool calling with structured outputs, use `generateText` or `streamText` with the `experimental_output` option.
+To use tool calling with structured outputs, use `generateText` or `streamText` with the `output` option.
 
-**Important**: When using `experimental_output` with tool calling, the structured output generation counts as an additional step in the execution flow.
+**Important**: When using `output` with tool calling, the structured output generation counts as an additional step in the execution flow.
 
 ## Solution
 
-When using `experimental_output` with tool calling, adjust your `stopWhen` condition to account for the additional step required for structured output generation:
+When using `output` with tool calling, adjust your `stopWhen` condition to account for the additional step required for structured output generation:
 
 ```tsx
 const result = await generateText({
   model: openai('gpt-4o'),
-  experimental_output: Output.object({
+  output: Output.object({
     schema: z.object({
       summary: z.string(),
       sentiment: z.enum(['positive', 'neutral', 'negative']),

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -609,7 +609,7 @@ and the `mediaType` should be set to `'application/pdf'`.
 
 #### Structured Outputs
 
-The OpenAI Responses API supports structured outputs. You can enforce structured outputs using `generateObject` or `streamObject`, which expose a `schema` option. Additionally, you can pass a Zod or JSON Schema object to the `experimental_output` option when using `generateText` or `streamText`.
+The OpenAI Responses API supports structured outputs. You can enforce structured outputs using `generateObject` or `streamObject`, which expose a `schema` option. Additionally, you can pass a Zod or JSON Schema object to the `output` option when using `generateText` or `streamText`.
 
 ```ts
 // Using generateObject
@@ -634,7 +634,7 @@ const result = await generateObject({
 const result = await generateText({
   model: openai('gpt-4.1'),
   prompt: 'How do I make a pizza?',
-  experimental_output: Output.object({
+  output: Output.object({
     schema: z.object({
       ingredients: z.array(z.string()),
       steps: z.array(z.string()),

--- a/examples/ai-core/src/agent/openai-generate-json-array.ts
+++ b/examples/ai-core/src/agent/openai-generate-json-array.ts
@@ -14,7 +14,7 @@ const agent = new ToolLoopAgent({
     } satisfies OpenAIResponsesProviderOptions,
   },
   tools: { weather: weatherTool },
-  experimental_output: Output.array({
+  output: Output.array({
     element: z.object({
       location: z.string(),
       temperature: z.number(),
@@ -24,7 +24,7 @@ const agent = new ToolLoopAgent({
 });
 
 run(async () => {
-  const { experimental_output: output } = await agent.generate({
+  const { output: output } = await agent.generate({
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 

--- a/examples/ai-core/src/agent/openai-generate-json-array.ts
+++ b/examples/ai-core/src/agent/openai-generate-json-array.ts
@@ -24,7 +24,7 @@ const agent = new ToolLoopAgent({
 });
 
 run(async () => {
-  const { output: output } = await agent.generate({
+  const { output } = await agent.generate({
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 

--- a/examples/ai-core/src/agent/openai-generate-json.ts
+++ b/examples/ai-core/src/agent/openai-generate-json.ts
@@ -8,7 +8,7 @@ const agent = new ToolLoopAgent({
   callOptionsSchema: z.object({
     strict: z.boolean(),
   }),
-  experimental_output: Output.object({
+  output: Output.object({
     schema: z.object({
       recipe: z.object({
         name: z.string(),
@@ -33,7 +33,7 @@ const agent = new ToolLoopAgent({
 });
 
 run(async () => {
-  const { experimental_output: output } = await agent.generate({
+  const { output: output } = await agent.generate({
     prompt: 'Generate a lasagna recipe.',
     options: {
       strict: true,

--- a/examples/ai-core/src/agent/openai-generate-json.ts
+++ b/examples/ai-core/src/agent/openai-generate-json.ts
@@ -33,7 +33,7 @@ const agent = new ToolLoopAgent({
 });
 
 run(async () => {
-  const { output: output } = await agent.generate({
+  const { output } = await agent.generate({
     prompt: 'Generate a lasagna recipe.',
     options: {
       strict: true,

--- a/examples/ai-core/src/agent/openai-stream-json-news.ts
+++ b/examples/ai-core/src/agent/openai-stream-json-news.ts
@@ -8,7 +8,7 @@ import { run } from '../lib/run';
 const agent = new ToolLoopAgent({
   model: openai('gpt-5-mini'),
   callOptionsSchema: z.object({ topic: z.string() }),
-  experimental_output: Output.array({
+  output: Output.array({
     element: z.object({
       title: z.string(),
       tldr: z.string(),

--- a/examples/ai-core/src/agent/openai-stream-json.ts
+++ b/examples/ai-core/src/agent/openai-stream-json.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 
 const agent = new ToolLoopAgent({
   model: openai('gpt-4o'),
-  experimental_output: Output.object({
+  output: Output.object({
     schema: z.object({
       recipe: z.object({
         name: z.string(),

--- a/examples/ai-core/src/agent/openai-stream-json.ts
+++ b/examples/ai-core/src/agent/openai-stream-json.ts
@@ -31,7 +31,7 @@ run(async () => {
     prompt: 'Generate a lasagna recipe.',
   });
 
-  for await (const partialObject of result.experimental_partialOutputStream) {
+  for await (const partialObject of result.partialOutputStream) {
     console.clear();
     console.dir(partialObject, { depth: Infinity });
   }

--- a/examples/ai-core/src/generate-text/google-output-object.ts
+++ b/examples/ai-core/src/generate-text/google-output-object.ts
@@ -4,9 +4,9 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const { experimental_output } = await generateText({
+  const { output } = await generateText({
     model: google('gemini-2.5-flash'),
-    experimental_output: Output.object({
+    output: Output.object({
       schema: z.object({
         name: z.string(),
         age: z.number().nullable().describe('Age of the person.'),
@@ -24,7 +24,7 @@ async function main() {
     prompt: 'Generate an example person for testing.',
   });
 
-  console.log(experimental_output);
+  console.log(output);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-text/google-vertex-output-object.ts
+++ b/examples/ai-core/src/generate-text/google-vertex-output-object.ts
@@ -4,9 +4,9 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const { experimental_output } = await generateText({
+  const { output } = await generateText({
     model: vertex('gemini-1.5-flash'),
-    experimental_output: Output.object({
+    output: Output.object({
       schema: z.object({
         name: z.string(),
         age: z.number().nullable().describe('Age of the person.'),
@@ -24,7 +24,7 @@ async function main() {
     prompt: 'Generate an example person for testing.',
   });
 
-  console.log(experimental_output);
+  console.log(output);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-text/openai-output-array.ts
+++ b/examples/ai-core/src/generate-text/openai-output-array.ts
@@ -17,7 +17,7 @@ run(async () => {
       weather: weatherTool,
     },
     stopWhen: stepCountIs(5),
-    experimental_output: Output.array({
+    output: Output.array({
       element: z.object({
         location: z.string(),
         temperature: z.number(),
@@ -27,6 +27,6 @@ run(async () => {
     prompt: 'What is the weather in San Francisco, London, Paris, and Berlin?',
   });
 
-  print('Output:', result.experimental_output);
+  print('Output:', result.output);
   print('Request:', result.request.body);
 });

--- a/examples/ai-core/src/generate-text/openai-output-choice.ts
+++ b/examples/ai-core/src/generate-text/openai-output-choice.ts
@@ -16,7 +16,7 @@ run(async () => {
       weather: weatherTool,
     },
     stopWhen: stepCountIs(5),
-    experimental_output: Output.choice({
+    output: Output.choice({
       options: [
         'winter jacket',
         'shorts and tshirt',
@@ -27,6 +27,6 @@ run(async () => {
     prompt: 'Get the weather for San Francisco. What should I wear?',
   });
 
-  print('Output:', result.experimental_output);
+  print('Output:', result.output);
   print('Request:', result.request.body);
 });

--- a/examples/ai-core/src/generate-text/openai-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-output-object.ts
@@ -17,7 +17,7 @@ run(async () => {
       weather: weatherTool,
     },
     stopWhen: stepCountIs(5),
-    experimental_output: Output.object({
+    output: Output.object({
       schema: z.object({
         elements: z.array(
           z.object({
@@ -32,6 +32,6 @@ run(async () => {
   });
 
   // { location: 'San Francisco', temperature: 81 }
-  print('Output:', result.experimental_output);
+  print('Output:', result.output);
   print('Request:', result.request.body);
 });

--- a/examples/ai-core/src/generate-text/openai-responses-output-object.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-output-object.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { z } from 'zod';
 
 async function main() {
-  const { experimental_output } = await generateText({
+  const { output } = await generateText({
     model: openai.responses('gpt-4o-mini'),
     tools: {
       weather: tool({
@@ -19,7 +19,7 @@ async function main() {
         }),
       }),
     },
-    experimental_output: Output.object({
+    output: Output.object({
       schema: z.object({
         location: z.string(),
         temperature: z.number(),
@@ -30,7 +30,7 @@ async function main() {
   });
 
   // { location: 'San Francisco', temperature: 81 }
-  console.log(experimental_output);
+  console.log(output);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/generate-text/xai-structured-output.ts
+++ b/examples/ai-core/src/generate-text/xai-structured-output.ts
@@ -4,9 +4,9 @@ import { xai } from '@ai-sdk/xai';
 import { z } from 'zod';
 
 async function main() {
-  const { experimental_output } = await generateText({
+  const { output } = await generateText({
     model: xai('grok-3-beta'),
-    experimental_output: Output.object({
+    output: Output.object({
       schema: z.object({
         name: z.string(),
         age: z.number().nullable().describe('Age of the person.'),

--- a/examples/ai-core/src/stream-text/openai-output-array.ts
+++ b/examples/ai-core/src/stream-text/openai-output-array.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 import { weatherTool } from '../tools/weather-tool';
 
 run(async () => {
-  const { experimental_partialOutputStream: partialOutputStream } = streamText({
+  const { partialOutputStream: partialOutputStream } = streamText({
     model: openai('gpt-4o-mini'),
     providerOptions: {
       openai: {

--- a/examples/ai-core/src/stream-text/openai-output-array.ts
+++ b/examples/ai-core/src/stream-text/openai-output-array.ts
@@ -16,7 +16,7 @@ run(async () => {
       weather: weatherTool,
     },
     stopWhen: stepCountIs(5),
-    experimental_output: Output.array({
+    output: Output.array({
       element: z.object({
         location: z.string(),
         temperature: z.number(),

--- a/examples/ai-core/src/stream-text/openai-output-choice.ts
+++ b/examples/ai-core/src/stream-text/openai-output-choice.ts
@@ -15,7 +15,7 @@ run(async () => {
       weather: weatherTool,
     },
     stopWhen: stepCountIs(5),
-    experimental_output: Output.choice({
+    output: Output.choice({
       options: [
         'winter jacket',
         'shorts and tshirt',

--- a/examples/ai-core/src/stream-text/openai-output-choice.ts
+++ b/examples/ai-core/src/stream-text/openai-output-choice.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 import { weatherTool } from '../tools/weather-tool';
 
 run(async () => {
-  const { experimental_partialOutputStream: partialOutputStream } = streamText({
+  const { partialOutputStream: partialOutputStream } = streamText({
     model: openai('gpt-4o-mini'),
     providerOptions: {
       openai: {

--- a/examples/ai-core/src/stream-text/openai-output-object.ts
+++ b/examples/ai-core/src/stream-text/openai-output-object.ts
@@ -5,7 +5,7 @@ import { run } from '../lib/run';
 import { weatherTool } from '../tools/weather-tool';
 
 run(async () => {
-  const { experimental_partialOutputStream: partialOutputStream } = streamText({
+  const { partialOutputStream: partialOutputStream } = streamText({
     model: openai('gpt-4o-mini'),
     providerOptions: {
       openai: {

--- a/examples/ai-core/src/stream-text/openai-output-object.ts
+++ b/examples/ai-core/src/stream-text/openai-output-object.ts
@@ -16,7 +16,7 @@ run(async () => {
       weather: weatherTool,
     },
     stopWhen: stepCountIs(5),
-    experimental_output: Output.object({
+    output: Output.object({
       schema: z.object({
         elements: z.array(
           z.object({

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -71,9 +71,9 @@ changing the tool call and result types in the result.
   activeTools?: Array<keyof NoInfer<TOOLS>>;
 
   /**
-Optional specification for parsing structured outputs from the LLM response.
+Optional specification for generating structured outputs.
    */
-  experimental_output?: OUTPUT;
+  output?: OUTPUT;
 
   /**
 Optional function that you can use to provide different settings for a step.

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -50,7 +50,7 @@ describe('ToolLoopAgent', () => {
     it('should infer output type', async () => {
       const agent = new ToolLoopAgent({
         model: new MockLanguageModelV3(),
-        experimental_output: Output.object({
+        output: Output.object({
           schema: z.object({ value: z.string() }),
         }),
       });
@@ -59,7 +59,7 @@ describe('ToolLoopAgent', () => {
         prompt: 'Hello, world!',
       });
 
-      const output = generateResult.experimental_output;
+      const output = generateResult.output;
 
       expectTypeOf<typeof output>().toEqualTypeOf<{ value: string }>();
     });
@@ -107,7 +107,7 @@ describe('ToolLoopAgent', () => {
     it('should infer output type', async () => {
       const agent = new ToolLoopAgent({
         model: new MockLanguageModelV3(),
-        experimental_output: Output.object({
+        output: Output.object({
           schema: z.object({ value: z.string() }),
         }),
       });

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -116,7 +116,7 @@ describe('ToolLoopAgent', () => {
         prompt: 'Hello, world!',
       });
 
-      const partialOutputStream = streamResult.experimental_partialOutputStream;
+      const partialOutputStream = streamResult.partialOutputStream;
 
       expectTypeOf<typeof partialOutputStream>().toEqualTypeOf<
         AsyncIterableStream<DeepPartial<{ value: string }>>

--- a/packages/ai/src/generate-text/generate-text-result.ts
+++ b/packages/ai/src/generate-text/generate-text-result.ts
@@ -145,7 +145,15 @@ such as the tool calls or the response headers.
   readonly steps: Array<StepResult<TOOLS>>;
 
   /**
-The generated structured output. It uses the `experimental_output` specification.
+The generated structured output. It uses the `output` specification.
+
+@deprecated Use `output` instead.
    */
   readonly experimental_output: OUTPUT;
+
+  /**
+The generated structured output. It uses the `output` specification.
+
+   */
+  readonly output: OUTPUT;
 }

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -2775,7 +2775,7 @@ describe('generateText', () => {
         });
 
         expect(() => {
-          result.experimental_output;
+          result.output;
         }).toThrow('No output specified');
       });
     });
@@ -2790,10 +2790,10 @@ describe('generateText', () => {
             }),
           }),
           prompt: 'prompt',
-          experimental_output: Output.text(),
+          output: Output.text(),
         });
 
-        expect(result.experimental_output).toStrictEqual('Hello, world!');
+        expect(result.output).toStrictEqual('Hello, world!');
       });
 
       it('should set responseFormat to text and not change the prompt', async () => {
@@ -2810,7 +2810,7 @@ describe('generateText', () => {
             },
           }),
           prompt: 'prompt',
-          experimental_output: Output.text(),
+          output: Output.text(),
         });
 
         expect(callOptions!).toMatchInlineSnapshot(`
@@ -2860,12 +2860,12 @@ describe('generateText', () => {
             }),
           }),
           prompt: 'prompt',
-          experimental_output: Output.object({
+          output: Output.object({
             schema: z.object({ value: z.string() }),
           }),
         });
 
-        expect(result.experimental_output).toEqual({ value: 'test-value' });
+        expect(result.output).toEqual({ value: 'test-value' });
       });
 
       it('should set responseFormat to json and send schema as part of the responseFormat', async () => {
@@ -2882,7 +2882,7 @@ describe('generateText', () => {
             },
           }),
           prompt: 'prompt',
-          experimental_output: Output.object({
+          output: Output.object({
             schema: z.object({ value: z.string() }),
           }),
         });
@@ -2959,13 +2959,13 @@ describe('generateText', () => {
 
         const result = await generateText({
           model,
-          experimental_output: Output.array({
+          output: Output.array({
             element: z.object({ content: z.string() }),
           }),
           prompt: 'prompt',
         });
 
-        expect(result.experimental_output).toMatchInlineSnapshot(`
+        expect(result.output).toMatchInlineSnapshot(`
         [
           {
             "content": "element 1",
@@ -3043,13 +3043,13 @@ describe('generateText', () => {
 
         const result = await generateText({
           model,
-          experimental_output: Output.choice({
+          output: Output.choice({
             options: ['sunny', 'rainy', 'snowy'],
           }),
           prompt: 'prompt',
         });
 
-        expect(result.experimental_output).toEqual('sunny');
+        expect(result.output).toEqual('sunny');
         expect(model.doGenerateCalls[0].prompt).toMatchInlineSnapshot(`
         [
           {
@@ -3108,7 +3108,7 @@ describe('generateText', () => {
           }),
         }),
         prompt: 'prompt',
-        experimental_output: Output.object({
+        output: Output.object({
           schema: z.object({ summary: z.string() }),
         }),
         tools: {
@@ -3119,9 +3119,9 @@ describe('generateText', () => {
         },
       });
 
-      // experimental_output should be undefined when finish reason is tool-calls
+      // output should be undefined when finish reason is tool-calls
       expect(() => {
-        result.experimental_output;
+        result.output;
       }).toThrow('No output specified');
 
       // But tool calls should work normally

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -157,7 +157,8 @@ export async function generateText<
   abortSignal,
   headers,
   stopWhen = stepCountIs(1),
-  experimental_output: output,
+  experimental_output,
+  output = experimental_output,
   experimental_telemetry: telemetry,
   providerOptions,
   experimental_activeTools,
@@ -226,6 +227,13 @@ changing the tool call and result types in the result.
 
     /**
 Optional specification for parsing structured outputs from the LLM response.
+     */
+    output?: Output<OUTPUT, OUTPUT_PARTIAL>;
+
+    /**
+Optional specification for parsing structured outputs from the LLM response.
+
+@deprecated Use `output` instead.
      */
     experimental_output?: Output<OUTPUT, OUTPUT_PARTIAL>;
 
@@ -900,6 +908,10 @@ class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
   }
 
   get experimental_output() {
+    return this.output;
+  }
+
+  get output() {
     if (this.resolvedOutput == null) {
       throw new NoOutputSpecifiedError();
     }

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -145,7 +145,7 @@ A result object that contains the generated text, the results of the tool calls,
 export async function generateText<
   TOOLS extends ToolSet,
   OUTPUT = never,
-  OUTPUT_PARTIAL = never,
+  PARTIAL_OUTPUT = never,
 >({
   model: modelArg,
   tools,
@@ -228,14 +228,14 @@ changing the tool call and result types in the result.
     /**
 Optional specification for parsing structured outputs from the LLM response.
      */
-    output?: Output<OUTPUT, OUTPUT_PARTIAL>;
+    output?: Output<OUTPUT, PARTIAL_OUTPUT>;
 
     /**
 Optional specification for parsing structured outputs from the LLM response.
 
 @deprecated Use `output` instead.
      */
-    experimental_output?: Output<OUTPUT, OUTPUT_PARTIAL>;
+    experimental_output?: Output<OUTPUT, PARTIAL_OUTPUT>;
 
     /**
 Custom download function to use for URLs.

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -272,9 +272,16 @@ enables provider-specific results that can be fully encapsulated in the provider
   readonly fullStream: AsyncIterableStream<TextStreamPart<TOOLS>>;
 
   /**
-A stream of partial outputs. It uses the `experimental_output` specification.
+   * A stream of partial outputs. It uses the `output` specification.
+   *
+   * @deprecated Use `partialOutputStream` instead.
    */
   readonly experimental_partialOutputStream: AsyncIterableStream<PARTIAL_OUTPUT>;
+
+  /**
+   * A stream of partial outputs. It uses the `output` specification.
+   */
+  readonly partialOutputStream: AsyncIterableStream<PARTIAL_OUTPUT>;
 
   /**
 Consumes the stream without processing the parts.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -11424,7 +11424,7 @@ describe('streamText', () => {
               },
             ]),
           }),
-          experimental_output: text(),
+          output: text(),
           prompt: 'prompt',
         });
 
@@ -11463,7 +11463,7 @@ describe('streamText', () => {
               };
             },
           }),
-          experimental_output: object({
+          output: object({
             schema: z.object({ value: z.string() }),
           }),
           prompt: 'prompt',
@@ -11538,7 +11538,7 @@ describe('streamText', () => {
               },
             ]),
           }),
-          experimental_output: object({
+          output: object({
             schema: z.object({ value: z.string() }),
           }),
           prompt: 'prompt',
@@ -11575,7 +11575,7 @@ describe('streamText', () => {
               },
             ]),
           }),
-          experimental_output: object({
+          output: object({
             schema: z.object({ value: z.string() }),
           }),
           prompt: 'prompt',
@@ -11610,7 +11610,7 @@ describe('streamText', () => {
               },
             ]),
           }),
-          experimental_output: object({
+          output: object({
             schema: z.object({ value: z.string() }),
           }),
           prompt: 'prompt',
@@ -11641,7 +11641,7 @@ describe('streamText', () => {
               },
             ]),
           }),
-          experimental_output: object({
+          output: object({
             schema: z.object({ value: z.string() }),
           }),
           prompt: 'prompt',
@@ -11672,7 +11672,7 @@ describe('streamText', () => {
               },
             ]),
           }),
-          experimental_output: object({
+          output: object({
             schema: z.object({ value: z.string() }),
           }),
           prompt: 'prompt',
@@ -11838,7 +11838,7 @@ describe('streamText', () => {
                 },
               ]),
             }),
-            experimental_output: Output.array({
+            output: Output.array({
               element: z.object({ content: z.string() }),
             }),
             prompt: 'prompt',
@@ -11911,7 +11911,7 @@ describe('streamText', () => {
                 },
               ]),
             }),
-            experimental_output: Output.array({
+            output: Output.array({
               element: z.object({ content: z.string() }),
             }),
             prompt: 'prompt',
@@ -11960,7 +11960,7 @@ describe('streamText', () => {
 
         const result = streamText({
           model: mockModel,
-          experimental_output: Output.choice({
+          output: Output.choice({
             options: ['sunny', 'rainy', 'snowy'],
           }),
           prompt: 'prompt',
@@ -12000,7 +12000,7 @@ describe('streamText', () => {
 
         const result = streamText({
           model: mockModel,
-          experimental_output: Output.choice({
+          output: Output.choice({
             options: ['sunny', 'rainy', 'snowy'],
           }),
           prompt: 'prompt',
@@ -12033,7 +12033,7 @@ describe('streamText', () => {
 
         const result = streamText({
           model: mockModel,
-          experimental_output: Output.choice({
+          output: Output.choice({
             options: ['foobar', 'foobar2'],
           }),
           prompt: 'prompt',
@@ -12071,7 +12071,7 @@ describe('streamText', () => {
 
         const result = streamText({
           model: mockModel,
-          experimental_output: Output.choice({
+          output: Output.choice({
             options: ['foobar', 'barfoo'],
           }),
           prompt: 'prompt',

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -11400,9 +11400,7 @@ describe('streamText', () => {
         });
 
         await expect(async () => {
-          await convertAsyncIterableToArray(
-            result.experimental_partialOutputStream,
-          );
+          await convertAsyncIterableToArray(result.partialOutputStream);
         }).rejects.toThrow('No output specified');
       });
     });
@@ -11429,9 +11427,7 @@ describe('streamText', () => {
         });
 
         expect(
-          await convertAsyncIterableToArray(
-            result.experimental_partialOutputStream,
-          ),
+          await convertAsyncIterableToArray(result.partialOutputStream),
         ).toStrictEqual(['Hello, ', 'Hello, ,', 'Hello, , world!']);
       });
     });
@@ -11582,9 +11578,7 @@ describe('streamText', () => {
         });
 
         expect(
-          await convertAsyncIterableToArray(
-            result.experimental_partialOutputStream,
-          ),
+          await convertAsyncIterableToArray(result.partialOutputStream),
         ).toStrictEqual([
           {},
           { value: 'Hello, ' },
@@ -11617,9 +11611,7 @@ describe('streamText', () => {
         });
 
         expect(
-          await convertAsyncIterableToArray(
-            result.experimental_partialOutputStream,
-          ),
+          await convertAsyncIterableToArray(result.partialOutputStream),
         ).toStrictEqual([{}, { value: 'Hello, ' }, { value: 'Hello, world!' }]);
       });
 
@@ -11849,11 +11841,8 @@ describe('streamText', () => {
         });
 
         it('should stream only complete objects in partialObjectStream', async () => {
-          expect(
-            await convertAsyncIterableToArray(
-              result!.experimental_partialOutputStream,
-            ),
-          ).toMatchInlineSnapshot(`
+          expect(await convertAsyncIterableToArray(result!.partialOutputStream))
+            .toMatchInlineSnapshot(`
             [
               [],
               [
@@ -11922,11 +11911,8 @@ describe('streamText', () => {
         });
 
         it('should stream only complete objects in partialObjectStream', async () => {
-          expect(
-            await convertAsyncIterableToArray(
-              result!.experimental_partialOutputStream,
-            ),
-          ).toMatchInlineSnapshot(`
+          expect(await convertAsyncIterableToArray(result!.partialOutputStream))
+            .toMatchInlineSnapshot(`
             [
               [
                 {
@@ -11966,11 +11952,8 @@ describe('streamText', () => {
           prompt: 'prompt',
         });
 
-        expect(
-          await convertAsyncIterableToArray(
-            result.experimental_partialOutputStream,
-          ),
-        ).toMatchInlineSnapshot(`
+        expect(await convertAsyncIterableToArray(result.partialOutputStream))
+          .toMatchInlineSnapshot(`
             [
               "sunny",
             ]
@@ -12007,9 +11990,7 @@ describe('streamText', () => {
         });
 
         expect(
-          await convertAsyncIterableToArray(
-            result.experimental_partialOutputStream,
-          ),
+          await convertAsyncIterableToArray(result.partialOutputStream),
         ).toMatchInlineSnapshot(`[]`);
       });
 
@@ -12039,11 +12020,8 @@ describe('streamText', () => {
           prompt: 'prompt',
         });
 
-        expect(
-          await convertAsyncIterableToArray(
-            result.experimental_partialOutputStream,
-          ),
-        ).toMatchInlineSnapshot(`
+        expect(await convertAsyncIterableToArray(result.partialOutputStream))
+          .toMatchInlineSnapshot(`
           [
             "foobar",
           ]
@@ -12077,11 +12055,8 @@ describe('streamText', () => {
           prompt: 'prompt',
         });
 
-        expect(
-          await convertAsyncIterableToArray(
-            result.experimental_partialOutputStream,
-          ),
-        ).toMatchInlineSnapshot(`
+        expect(await convertAsyncIterableToArray(result.partialOutputStream))
+          .toMatchInlineSnapshot(`
           [
             "foobar",
           ]

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1811,6 +1811,10 @@ However, the LLM results are expected to be small enough to not cause issues.
   }
 
   get experimental_partialOutputStream(): AsyncIterableStream<PARTIAL_OUTPUT> {
+    return this.partialOutputStream;
+  }
+
+  get partialOutputStream(): AsyncIterableStream<PARTIAL_OUTPUT> {
     if (this.output == null) {
       throw new NoOutputSpecifiedError();
     }

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -239,7 +239,8 @@ export function streamText<
   abortSignal,
   headers,
   stopWhen = stepCountIs(1),
-  experimental_output: output,
+  experimental_output,
+  output = experimental_output,
   experimental_telemetry: telemetry,
   prepareStep,
   providerOptions,
@@ -316,6 +317,13 @@ functionality that can be fully encapsulated in the provider.
     /**
 Optional specification for parsing structured outputs from the LLM response.
      */
+    output?: Output<OUTPUT, PARTIAL_OUTPUT>;
+
+    /**
+Optional specification for parsing structured outputs from the LLM response.
+
+@deprecated Use `output` instead.
+ */
     experimental_output?: Output<OUTPUT, PARTIAL_OUTPUT>;
 
     /**


### PR DESCRIPTION
## Background

The experimental structured outputs API for streamText and generateText has been around for quite some time. In AI SDK 6, we are moving it to stable and adding features to achieve parity with generateObject and streamObject to support the Agent abstraction.

## Summary

Move structured outputs for streamText and generateText to stable.

## Tasks

- [x] streamText
- [x] generateText
- [x] agent
- [x] docs reference agent
- [x] docs reference generateText
- [x] docs reference streamText
- [x] docs guide
- [x] changeset

## Future Work

* add json mode
* add array element stream
