### PR TITLE
fix(ai): correct type field in arrayOutputStrategy from 'enum' to 'array'

### DIFF
--- a/.changeset/fix-array-output-type.md
+++ b/.changeset/fix-array-output-type.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): correct type field in arrayOutputStrategy from 'enum' to 'array'

--- a/packages/ai/src/generate-object/output-strategy.ts
+++ b/packages/ai/src/generate-object/output-strategy.ts
@@ -134,7 +134,7 @@ const arrayOutputStrategy = <ELEMENT>(
   schema: Schema<ELEMENT>,
 ): OutputStrategy<ELEMENT[], ELEMENT[], AsyncIterableStream<ELEMENT>> => {
   return {
-    type: 'enum',
+    type: 'array',
 
     // wrap in object that contains array of elements, since most LLMs will not
     // be able to generate an array directly:


### PR DESCRIPTION
## Background

  `arrayOutputStrategy` has incorrect `type: 'enum'` instead of `'array'`, causing
   wrong telemetry data and broken runtime type checks.

  ## Summary

  Changed `type: 'enum'` to `type: 'array'` in `arrayOutputStrategy` 

  ## Manual Verification

  Verified that `getOutputStrategy({ output: 'array', schema: z.array(z.string())
  })` now returns strategy with `type === 'array'` instead of `type === 'enum'`.

  ## Checklist

  - [x] A _patch_ changeset for relevant packages has been added (for bug fixes /
  features - run `pnpm changeset` in the project root)
  - [x] I have reviewed this pull request (self-review)