### PR TITLE
feat(ai): improve warnings with provider and model id

### DIFF
--- a/.changeset/new-news-destroy.md
+++ b/.changeset/new-news-destroy.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): improve warnings with provider and model id

--- a/.changeset/ninety-deers-drive.md
+++ b/.changeset/ninety-deers-drive.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+feat(provider): Add SharedV3Warning type

--- a/packages/ai/src/generate-image/generate-image.test.ts
+++ b/packages/ai/src/generate-image/generate-image.test.ts
@@ -166,7 +166,11 @@ describe('generateImage', () => {
     });
 
     expect(logWarningsSpy).toHaveBeenCalledOnce();
-    expect(logWarningsSpy).toHaveBeenCalledWith(expectedWarnings);
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: expectedWarnings,
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 
   it('should call logWarnings with aggregated warnings from multiple calls', async () => {
@@ -207,7 +211,11 @@ describe('generateImage', () => {
     });
 
     expect(logWarningsSpy).toHaveBeenCalledOnce();
-    expect(logWarningsSpy).toHaveBeenCalledWith(expectedAggregatedWarnings);
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: expectedAggregatedWarnings,
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 
   it('should call logWarnings with empty array when no warnings are present', async () => {
@@ -223,7 +231,11 @@ describe('generateImage', () => {
     });
 
     expect(logWarningsSpy).toHaveBeenCalledOnce();
-    expect(logWarningsSpy).toHaveBeenCalledWith([]);
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: [],
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 
   describe('base64 image data', () => {

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -202,7 +202,7 @@ Only applicable for HTTP-based providers.
     responses.push(result.response);
   }
 
-  logWarnings(warnings);
+  logWarnings({ warnings, provider: model.provider, model: model.modelId });
 
   if (!images.length) {
     throw new NoImageGeneratedError({ responses });

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -205,7 +205,11 @@ describe('generateObject', () => {
       });
 
       expect(logWarningsSpy).toHaveBeenCalledOnce();
-      expect(logWarningsSpy).toHaveBeenCalledWith(expectedWarnings);
+      expect(logWarningsSpy).toHaveBeenCalledWith({
+        warnings: expectedWarnings,
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
 
     it('should call logWarnings with empty array when no warnings are present', async () => {
@@ -222,7 +226,11 @@ describe('generateObject', () => {
       });
 
       expect(logWarningsSpy).toHaveBeenCalledOnce();
-      expect(logWarningsSpy).toHaveBeenCalledWith([]);
+      expect(logWarningsSpy).toHaveBeenCalledWith({
+        warnings: [],
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
 
     describe('result.request', () => {

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -433,7 +433,11 @@ Default and recommended: 'auto' (best mode for the model).
         response = generateResult.responseData;
         reasoning = generateResult.reasoning;
 
-        logWarnings(warnings);
+        logWarnings({
+          warnings,
+          provider: model.provider,
+          model: model.modelId,
+        });
 
         const object = await parseAndValidateObjectResultWithRepair(
           result,

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -1889,7 +1889,11 @@ describe('streamObject', () => {
       await convertAsyncIterableToArray(result.partialObjectStream);
 
       expect(logWarningsSpy).toHaveBeenCalledOnce();
-      expect(logWarningsSpy).toHaveBeenCalledWith(expectedWarnings);
+      expect(logWarningsSpy).toHaveBeenCalledWith({
+        warnings: expectedWarnings,
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
 
     it('should call logWarnings with empty array when no warnings are present', async () => {
@@ -1907,7 +1911,11 @@ describe('streamObject', () => {
       await convertAsyncIterableToArray(result.partialObjectStream);
 
       expect(logWarningsSpy).toHaveBeenCalledOnce();
-      expect(logWarningsSpy).toHaveBeenCalledWith([]);
+      expect(logWarningsSpy).toHaveBeenCalledWith({
+        warnings: [],
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
   });
 });

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -723,7 +723,11 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
                     });
 
                     // log warnings:
-                    logWarnings(warnings ?? []);
+                    logWarnings({
+                      warnings: warnings ?? [],
+                      provider: model.provider,
+                      model: model.modelId,
+                    });
 
                     // resolve promises that can be resolved now:
                     self._usage.resolve(usage);

--- a/packages/ai/src/generate-speech/generate-speech.test.ts
+++ b/packages/ai/src/generate-speech/generate-speech.test.ts
@@ -160,7 +160,11 @@ describe('generateSpeech', () => {
     });
 
     expect(logWarningsSpy).toHaveBeenCalledOnce();
-    expect(logWarningsSpy).toHaveBeenCalledWith(expectedWarnings);
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: expectedWarnings,
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 
   it('should call logWarnings with empty array when no warnings are present', async () => {
@@ -176,7 +180,11 @@ describe('generateSpeech', () => {
     });
 
     expect(logWarningsSpy).toHaveBeenCalledOnce();
-    expect(logWarningsSpy).toHaveBeenCalledWith([]);
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: [],
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 
   it('should return the audio data', async () => {

--- a/packages/ai/src/generate-speech/generate-speech.ts
+++ b/packages/ai/src/generate-speech/generate-speech.ts
@@ -147,7 +147,11 @@ Only applicable for HTTP-based providers.
     throw new NoSpeechGeneratedError({ responses: [result.response] });
   }
 
-  logWarnings(result.warnings);
+  logWarnings({
+    warnings: result.warnings,
+    provider: resolvedModel.provider,
+    model: resolvedModel.modelId,
+  });
 
   return new DefaultSpeechResult({
     audio: new DefaultGeneratedAudioFile({

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -3776,7 +3776,11 @@ describe('generateText', () => {
       });
 
       expect(logWarningsSpy).toHaveBeenCalledOnce();
-      expect(logWarningsSpy).toHaveBeenCalledWith(expectedWarnings);
+      expect(logWarningsSpy).toHaveBeenCalledWith({
+        warnings: expectedWarnings,
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
 
     it('should call logWarnings once for each step with warnings from that step', async () => {
@@ -3832,8 +3836,16 @@ describe('generateText', () => {
       });
 
       expect(logWarningsSpy).toHaveBeenCalledTimes(2);
-      expect(logWarningsSpy).toHaveBeenNthCalledWith(1, [warning1]);
-      expect(logWarningsSpy).toHaveBeenNthCalledWith(2, [warning2]);
+      expect(logWarningsSpy).toHaveBeenNthCalledWith(1, {
+        warnings: [warning1],
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
+      expect(logWarningsSpy).toHaveBeenNthCalledWith(2, {
+        warnings: [warning2],
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
 
     it('should call logWarnings with empty array when no warnings are present', async () => {
@@ -3849,7 +3861,11 @@ describe('generateText', () => {
       });
 
       expect(logWarningsSpy).toHaveBeenCalledOnce();
-      expect(logWarningsSpy).toHaveBeenCalledWith([]);
+      expect(logWarningsSpy).toHaveBeenCalledWith({
+        warnings: [],
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
   });
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -672,7 +672,11 @@ A function that attempts to repair a tool call that failed to parse.
             },
           });
 
-          logWarnings(currentModelResponse.warnings ?? []);
+          logWarnings({
+            warnings: currentModelResponse.warnings ?? [],
+            provider: stepModel.provider,
+            model: stepModel.modelId,
+          });
 
           steps.push(currentStepResult);
           await onStepFinish?.(currentStepResult);

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -14230,7 +14230,11 @@ describe('streamText', () => {
       await result.finishReason;
 
       expect(logWarningsSpy).toHaveBeenCalledOnce();
-      expect(logWarningsSpy).toHaveBeenCalledWith(expectedWarnings);
+      expect(logWarningsSpy).toHaveBeenCalledWith({
+        warnings: expectedWarnings,
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
 
     it('should call logWarnings once for each step with warnings from that step', async () => {
@@ -14321,8 +14325,16 @@ describe('streamText', () => {
       await result.finishReason;
 
       expect(logWarningsSpy).toHaveBeenCalledTimes(2);
-      expect(logWarningsSpy).toHaveBeenNthCalledWith(1, [warning1]);
-      expect(logWarningsSpy).toHaveBeenNthCalledWith(2, [warning2]);
+      expect(logWarningsSpy).toHaveBeenNthCalledWith(1, {
+        warnings: [warning1],
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
+      expect(logWarningsSpy).toHaveBeenNthCalledWith(2, {
+        warnings: [warning2],
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
 
     it('should call logWarnings with empty array when no warnings are present', async () => {
@@ -14337,7 +14349,11 @@ describe('streamText', () => {
       await result.finishReason;
 
       expect(logWarningsSpy).toHaveBeenCalledOnce();
-      expect(logWarningsSpy).toHaveBeenCalledWith([]);
+      expect(logWarningsSpy).toHaveBeenCalledWith({
+        warnings: [],
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+      });
     });
   });
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -863,7 +863,11 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
 
           await onStepFinish?.(currentStepResult);
 
-          logWarnings(recordedWarnings);
+          logWarnings({
+            warnings: recordedWarnings,
+            provider: model.provider,
+            model: model.modelId,
+          });
 
           recordedSteps.push(currentStepResult);
 

--- a/packages/ai/src/logger/log-warnings.ts
+++ b/packages/ai/src/logger/log-warnings.ts
@@ -1,6 +1,7 @@
 import {
   ImageModelV3CallWarning,
   LanguageModelV3CallWarning,
+  SharedV3Warning,
   SpeechModelV3CallWarning,
   TranscriptionModelV3CallWarning,
 } from '@ai-sdk/provider';
@@ -9,21 +10,42 @@ export type Warning =
   | LanguageModelV3CallWarning
   | ImageModelV3CallWarning
   | SpeechModelV3CallWarning
-  | TranscriptionModelV3CallWarning;
+  | TranscriptionModelV3CallWarning
+  | SharedV3Warning;
 
-export type LogWarningsFunction = (warnings: Warning[]) => void;
+export type LogWarningsFunction = (options: {
+  warnings: Warning[];
+  provider: string;
+  model: string;
+}) => void;
 
 /**
  * Formats a warning object into a human-readable string with clear AI SDK branding
  */
-function formatWarning(warning: Warning): string {
-  const prefix = 'AI SDK Warning:';
+function formatWarning({
+  warning,
+  provider,
+  model,
+}: {
+  warning: Warning;
+  provider: string;
+  model: string;
+}): string {
+  const prefix = `AI SDK Warning (${provider} / ${model}):`;
 
   switch (warning.type) {
     case 'unsupported-setting': {
-      let message = `${prefix} The "${warning.setting}" setting is not supported by this model`;
+      let message = `${prefix} The "${warning.setting}" setting is not supported.`;
       if (warning.details) {
-        message += ` - ${warning.details}`;
+        message += ` ${warning.details}`;
+      }
+      return message;
+    }
+
+    case 'compatibility': {
+      let message = `${prefix} The "${warning.feature}" feature is not fully supported.`;
+      if (warning.details) {
+        message += ` ${warning.details}`;
       }
       return message;
     }
@@ -31,9 +53,9 @@ function formatWarning(warning: Warning): string {
     case 'unsupported-tool': {
       const toolName =
         'name' in warning.tool ? warning.tool.name : 'unknown tool';
-      let message = `${prefix} The tool "${toolName}" is not supported by this model`;
+      let message = `${prefix} The tool "${toolName}" is not supported.`;
       if (warning.details) {
-        message += ` - ${warning.details}`;
+        message += ` ${warning.details}`;
       }
       return message;
     }
@@ -54,9 +76,9 @@ export const FIRST_WARNING_INFO_MESSAGE =
 
 let hasLoggedBefore = false;
 
-export const logWarnings: LogWarningsFunction = warnings => {
+export const logWarnings: LogWarningsFunction = options => {
   // if the warnings array is empty, do nothing
-  if (warnings.length === 0) {
+  if (options.warnings.length === 0) {
     return;
   }
 
@@ -69,7 +91,7 @@ export const logWarnings: LogWarningsFunction = warnings => {
 
   // use the provided logger if it is a function
   if (typeof logger === 'function') {
-    logger(warnings);
+    logger(options);
     return;
   }
 
@@ -80,8 +102,14 @@ export const logWarnings: LogWarningsFunction = warnings => {
   }
 
   // default behavior: log warnings to the console
-  for (const warning of warnings) {
-    console.warn(formatWarning(warning));
+  for (const warning of options.warnings) {
+    console.warn(
+      formatWarning({
+        warning,
+        provider: options.provider,
+        model: options.model,
+      }),
+    );
   }
 };
 

--- a/packages/ai/src/transcribe/transcribe.test.ts
+++ b/packages/ai/src/transcribe/transcribe.test.ts
@@ -173,7 +173,11 @@ describe('transcribe', () => {
     });
 
     expect(logWarningsSpy).toHaveBeenCalledOnce();
-    expect(logWarningsSpy).toHaveBeenCalledWith(expectedWarnings);
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: expectedWarnings,
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 
   it('should call logWarnings with empty array when no warnings are present', async () => {
@@ -189,7 +193,11 @@ describe('transcribe', () => {
     });
 
     expect(logWarningsSpy).toHaveBeenCalledOnce();
-    expect(logWarningsSpy).toHaveBeenCalledWith([]);
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: [],
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 
   it('should return the transcript', async () => {

--- a/packages/ai/src/transcribe/transcribe.ts
+++ b/packages/ai/src/transcribe/transcribe.ts
@@ -117,7 +117,11 @@ Only applicable for HTTP-based providers.
     }),
   );
 
-  logWarnings(result.warnings);
+  logWarnings({
+    warnings: result.warnings,
+    provider: resolvedModel.provider,
+    model: resolvedModel.modelId,
+  });
 
   if (!result.text) {
     throw new NoTranscriptGeneratedError({ responses: [result.response] });

--- a/packages/provider/src/shared/v3/index.ts
+++ b/packages/provider/src/shared/v3/index.ts
@@ -1,3 +1,4 @@
 export * from './shared-v3-headers';
 export * from './shared-v3-provider-metadata';
 export * from './shared-v3-provider-options';
+export * from './shared-v3-warning';

--- a/packages/provider/src/shared/v3/shared-v3-warning.ts
+++ b/packages/provider/src/shared/v3/shared-v3-warning.ts
@@ -1,0 +1,28 @@
+/**
+ * Warning from the model that certain features are e.g. unsupported or that compatibility
+ * functionality is used (which might lead to suboptimal results).
+ */
+export type SharedV3Warning =
+  | {
+      /**
+       * A configuration setting is not supported by the model.
+       */
+      type: 'unsupported-setting';
+      setting: string;
+      details?: string;
+    }
+  | {
+      /**
+       * A compatibility feature is used that might lead to suboptimal results.
+       */
+      type: 'compatibility';
+      feature: string;
+      details?: string;
+    }
+  | {
+      /**
+       * Other warning.
+       */
+      type: 'other';
+      message: string;
+    };


### PR DESCRIPTION
## Background

Warning logging currently does not show model or provider id, making it harder to pinpoint issues (e.g. from server logs).

Also, in the reranking feature ( #3764 ), a new `SharedV3Warning` type will be used, which is currently not supported in the warning logger.

## Summary

* **breaking change**: different warning logger signature (affects user developed loggers)
* display provider and model id in warnings
* add `SharedV3Warning` type
* support `SharedV3Warning` in warning logger

## Future Work
* Use `SharedV3Warning` in models unless specific warning types are needed.
* Add note to migration guide regarding this breaking change

## Related Issues
Extracted from #3764
