### PR TITLE
fix(provider): add specificationVersion to ProviderV3

### DIFF
--- a/.changeset/angry-cobras-care.md
+++ b/.changeset/angry-cobras-care.md
@@ -1,0 +1,35 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/huggingface': patch
+'@ai-sdk/assemblyai': patch
+'@ai-sdk/elevenlabs': patch
+'@ai-sdk/perplexity': patch
+'@ai-sdk/togetherai': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/deepinfra': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/replicate': patch
+'@ai-sdk/cerebras': patch
+'@ai-sdk/deepgram': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/baseten': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/gladia': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/vercel': patch
+'@ai-sdk/azure': patch
+'@ai-sdk/revai': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/luma': patch
+'@ai-sdk/fal': patch
+'@ai-sdk/xai': patch
+'ai': patch
+---
+
+fix(provider): add specificationVersion to ProviderV3

--- a/packages/ai/src/middleware/wrap-provider.ts
+++ b/packages/ai/src/middleware/wrap-provider.ts
@@ -1,6 +1,7 @@
-import type { LanguageModelV3, ProviderV2, ProviderV3 } from '@ai-sdk/provider';
+import type { ProviderV2, ProviderV3 } from '@ai-sdk/provider';
 import { LanguageModelMiddleware } from '../types/language-model-middleware';
 import { wrapLanguageModel } from './wrap-language-model';
+import { asProviderV3 } from '../model/as-provider-v3';
 
 /**
  * Wraps a ProviderV3 instance with middleware functionality.
@@ -20,20 +21,17 @@ export function wrapProvider({
   provider: ProviderV3 | ProviderV2;
   languageModelMiddleware: LanguageModelMiddleware | LanguageModelMiddleware[];
 }): ProviderV3 {
-  const wrappedProvider = {
-    languageModel(modelId: string) {
-      let model = provider.languageModel(modelId);
-      model = wrapLanguageModel({
-        model: model as LanguageModelV3,
+  const providerV3 = asProviderV3(provider);
+  return {
+    specificationVersion: 'v3',
+    languageModel: (modelId: string) =>
+      wrapLanguageModel({
+        model: providerV3.languageModel(modelId),
         middleware: languageModelMiddleware,
-      });
-      return model;
-    },
-    textEmbeddingModel: provider.textEmbeddingModel,
-    imageModel: provider.imageModel,
-    transcriptionModel: provider.transcriptionModel,
-    speechModel: provider.speechModel,
+      }),
+    textEmbeddingModel: providerV3.textEmbeddingModel,
+    imageModel: providerV3.imageModel,
+    transcriptionModel: providerV3.transcriptionModel,
+    speechModel: providerV3.speechModel,
   };
-
-  return wrappedProvider as ProviderV3;
 }

--- a/packages/ai/src/model/as-embedding-model-v3.ts
+++ b/packages/ai/src/model/as-embedding-model-v3.ts
@@ -1,0 +1,18 @@
+import { EmbeddingModelV2, EmbeddingModelV3 } from '@ai-sdk/provider';
+
+export function asEmbeddingModelV3<VALUE>(
+  model: EmbeddingModelV2<VALUE> | EmbeddingModelV3<VALUE>,
+): EmbeddingModelV3<VALUE> {
+  if (model.specificationVersion === 'v3') {
+    return model;
+  }
+
+  // TODO this could break, we need to properly map v2 to v3
+  // and support all relevant v3 properties:
+  return new Proxy(model, {
+    get(target, prop: keyof EmbeddingModelV2<VALUE>) {
+      if (prop === 'specificationVersion') return 'v3';
+      return target[prop];
+    },
+  }) as unknown as EmbeddingModelV3<VALUE>;
+}

--- a/packages/ai/src/model/as-image-model-v3.ts
+++ b/packages/ai/src/model/as-image-model-v3.ts
@@ -1,0 +1,18 @@
+import { ImageModelV2, ImageModelV3 } from '@ai-sdk/provider';
+
+export function asImageModelV3(
+  model: ImageModelV2 | ImageModelV3,
+): ImageModelV3 {
+  if (model.specificationVersion === 'v3') {
+    return model;
+  }
+
+  // TODO this could break, we need to properly map v2 to v3
+  // and support all relevant v3 properties:
+  return new Proxy(model, {
+    get(target, prop: keyof ImageModelV2) {
+      if (prop === 'specificationVersion') return 'v3';
+      return target[prop];
+    },
+  }) as unknown as ImageModelV3;
+}

--- a/packages/ai/src/model/as-language-model-v3.ts
+++ b/packages/ai/src/model/as-language-model-v3.ts
@@ -1,0 +1,18 @@
+import { LanguageModelV2, LanguageModelV3 } from '@ai-sdk/provider';
+
+export function asLanguageModelV3(
+  model: LanguageModelV2 | LanguageModelV3,
+): LanguageModelV3 {
+  if (model.specificationVersion === 'v3') {
+    return model;
+  }
+
+  // TODO this could break, we need to properly map v2 to v3
+  // and support all relevant v3 properties:
+  return new Proxy(model, {
+    get(target, prop: keyof LanguageModelV2) {
+      if (prop === 'specificationVersion') return 'v3';
+      return target[prop];
+    },
+  }) as unknown as LanguageModelV3;
+}

--- a/packages/ai/src/model/as-provider-v3.ts
+++ b/packages/ai/src/model/as-provider-v3.ts
@@ -1,0 +1,32 @@
+import { ProviderV2, ProviderV3 } from '@ai-sdk/provider';
+import { asEmbeddingModelV3 } from './as-embedding-model-v3';
+import { asImageModelV3 } from './as-image-model-v3';
+import { asLanguageModelV3 } from './as-language-model-v3';
+import { asTranscriptionModelV3 } from './as-transcription-model-v3';
+import { asSpeechModelV3 } from './as-speech-model-v3';
+
+export function asProviderV3(provider: ProviderV2 | ProviderV3): ProviderV3 {
+  if (
+    'specificationVersion' in provider &&
+    provider.specificationVersion === 'v3'
+  ) {
+    return provider;
+  }
+
+  return {
+    specificationVersion: 'v3',
+    languageModel: (modelId: string) =>
+      asLanguageModelV3(provider.languageModel(modelId)),
+    textEmbeddingModel: (modelId: string) =>
+      asEmbeddingModelV3(provider.textEmbeddingModel(modelId)),
+    imageModel: (modelId: string) =>
+      asImageModelV3(provider.imageModel(modelId)),
+    transcriptionModel: provider.transcriptionModel
+      ? (modelId: string) =>
+          asTranscriptionModelV3(provider.transcriptionModel!(modelId))
+      : undefined,
+    speechModel: provider.speechModel
+      ? (modelId: string) => asSpeechModelV3(provider.speechModel!(modelId))
+      : undefined,
+  };
+}

--- a/packages/ai/src/model/as-speech-model-v3.ts
+++ b/packages/ai/src/model/as-speech-model-v3.ts
@@ -1,0 +1,18 @@
+import { SpeechModelV2, SpeechModelV3 } from '@ai-sdk/provider';
+
+export function asSpeechModelV3(
+  model: SpeechModelV3 | SpeechModelV2,
+): SpeechModelV3 {
+  if (model.specificationVersion === 'v3') {
+    return model;
+  }
+
+  // TODO this could break, we need to properly map v2 to v3
+  // and support all relevant v3 properties:
+  return new Proxy(model, {
+    get(target, prop: keyof SpeechModelV2) {
+      if (prop === 'specificationVersion') return 'v3';
+      return target[prop];
+    },
+  }) as unknown as SpeechModelV3;
+}

--- a/packages/ai/src/model/as-transcription-model-v3.ts
+++ b/packages/ai/src/model/as-transcription-model-v3.ts
@@ -1,0 +1,18 @@
+import { TranscriptionModelV2, TranscriptionModelV3 } from '@ai-sdk/provider';
+
+export function asTranscriptionModelV3(
+  model: TranscriptionModelV3 | TranscriptionModelV2,
+): TranscriptionModelV3 {
+  if (model.specificationVersion === 'v3') {
+    return model;
+  }
+
+  // TODO this could break, we need to properly map v2 to v3
+  // and support all relevant v3 properties:
+  return new Proxy(model, {
+    get(target, prop: keyof TranscriptionModelV2) {
+      if (prop === 'specificationVersion') return 'v3';
+      return target[prop];
+    },
+  }) as unknown as TranscriptionModelV3;
+}

--- a/packages/ai/src/model/resolve-model.ts
+++ b/packages/ai/src/model/resolve-model.ts
@@ -1,13 +1,9 @@
 import { gateway } from '@ai-sdk/gateway';
 import {
-  EmbeddingModelV2,
   EmbeddingModelV3,
-  LanguageModelV2,
   LanguageModelV3,
   ProviderV3,
-  SpeechModelV2,
   SpeechModelV3,
-  TranscriptionModelV2,
   TranscriptionModelV3,
 } from '@ai-sdk/provider';
 import { UnsupportedModelVersionError } from '../error';
@@ -15,46 +11,10 @@ import { EmbeddingModel } from '../types/embedding-model';
 import { LanguageModel } from '../types/language-model';
 import { SpeechModel } from '../types/speech-model';
 import { TranscriptionModel } from '../types/transcription-model';
-
-function transformToV3LanguageModel(model: LanguageModelV2): LanguageModelV3 {
-  return new Proxy(model, {
-    get(target, prop: keyof LanguageModelV2) {
-      if (prop === 'specificationVersion') return 'v3';
-      return target[prop];
-    },
-  }) as unknown as LanguageModelV3;
-}
-
-function transformToV3EmbeddingModel<VALUE>(
-  model: EmbeddingModelV2<VALUE>,
-): EmbeddingModelV3<VALUE> {
-  return new Proxy(model, {
-    get(target, prop: keyof EmbeddingModelV2<VALUE>) {
-      if (prop === 'specificationVersion') return 'v3';
-      return target[prop];
-    },
-  }) as unknown as EmbeddingModelV3<VALUE>;
-}
-
-function transformToV3TranscriptionModel(
-  model: TranscriptionModelV2,
-): TranscriptionModelV3 {
-  return new Proxy(model, {
-    get(target, prop: keyof TranscriptionModelV2) {
-      if (prop === 'specificationVersion') return 'v3';
-      return target[prop];
-    },
-  }) as unknown as TranscriptionModelV3;
-}
-
-function transformToV3SpeechModel(model: SpeechModelV2): SpeechModelV3 {
-  return new Proxy(model, {
-    get(target, prop: keyof SpeechModelV2) {
-      if (prop === 'specificationVersion') return 'v3';
-      return target[prop];
-    },
-  }) as unknown as SpeechModelV3;
-}
+import { asEmbeddingModelV3 } from './as-embedding-model-v3';
+import { asLanguageModelV3 } from './as-language-model-v3';
+import { asSpeechModelV3 } from './as-speech-model-v3';
+import { asTranscriptionModelV3 } from './as-transcription-model-v3';
 
 export function resolveLanguageModel(model: LanguageModel): LanguageModelV3 {
   if (typeof model !== 'string') {
@@ -69,10 +29,8 @@ export function resolveLanguageModel(model: LanguageModel): LanguageModelV3 {
         modelId: unsupportedModel.modelId,
       });
     }
-    if (model.specificationVersion === 'v2') {
-      return transformToV3LanguageModel(model);
-    }
-    return model;
+
+    return asLanguageModelV3(model);
   }
 
   return getGlobalProvider().languageModel(model);
@@ -93,11 +51,8 @@ export function resolveEmbeddingModel<VALUE = string>(
         modelId: unsupportedModel.modelId,
       });
     }
-    if (model.specificationVersion === 'v2') {
-      return transformToV3EmbeddingModel(model);
-    }
 
-    return model;
+    return asEmbeddingModelV3(model);
   }
 
   // TODO AI SDK 6: figure out how to cleanly support different generic types
@@ -121,10 +76,7 @@ export function resolveTranscriptionModel(
         modelId: unsupportedModel.modelId,
       });
     }
-    if (model.specificationVersion === 'v2') {
-      return transformToV3TranscriptionModel(model);
-    }
-    return model;
+    return asTranscriptionModelV3(model);
   }
 
   return getGlobalProvider().transcriptionModel?.(model);
@@ -145,10 +97,7 @@ export function resolveSpeechModel(
         modelId: unsupportedModel.modelId,
       });
     }
-    if (model.specificationVersion === 'v2') {
-      return transformToV3SpeechModel(model);
-    }
-    return model;
+    return asSpeechModelV3(model);
   }
 
   return getGlobalProvider().speechModel?.(model);

--- a/packages/ai/src/registry/custom-provider.ts
+++ b/packages/ai/src/registry/custom-provider.ts
@@ -55,6 +55,7 @@ export function customProvider<
   speechModel(modelId: ExtractModelId<SPEECH_MODELS>): SpeechModelV3;
 } {
   return {
+    specificationVersion: 'v3',
     languageModel(modelId: ExtractModelId<LANGUAGE_MODELS>): LanguageModelV3 {
       if (languageModels != null && modelId in languageModels) {
         return languageModels[modelId];

--- a/packages/ai/src/registry/provider-registry.test.ts
+++ b/packages/ai/src/registry/provider-registry.test.ts
@@ -15,6 +15,7 @@ describe('languageModel', () => {
 
     const modelRegistry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         languageModel: (id: string) => {
           expect(id).toEqual('model');
           return model;
@@ -36,6 +37,7 @@ describe('languageModel', () => {
 
     const modelRegistry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         languageModel: id => {
           expect(id).toEqual('model:part2');
           return model;
@@ -64,6 +66,7 @@ describe('languageModel', () => {
   it('should throw NoSuchModelError if provider does not return a model', () => {
     const registry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         languageModel: () => {
           return null as any;
         },
@@ -102,6 +105,7 @@ describe('languageModel', () => {
     const modelRegistry = createProviderRegistry(
       {
         provider: {
+          specificationVersion: 'v3',
           languageModel: id => {
             expect(id).toEqual('model');
             return model;
@@ -132,6 +136,7 @@ describe('languageModel', () => {
     const modelRegistry = createProviderRegistry(
       {
         provider: {
+          specificationVersion: 'v3',
           languageModel: id => {
             expect(id).toEqual('model');
             return model;
@@ -163,6 +168,7 @@ describe('textEmbeddingModel', () => {
 
     const modelRegistry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         textEmbeddingModel: id => {
           expect(id).toEqual('model');
           return model;
@@ -197,6 +203,7 @@ describe('textEmbeddingModel', () => {
   it('should throw NoSuchModelError if provider does not return a model', () => {
     const registry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         textEmbeddingModel: () => {
           return null as any;
         },
@@ -229,6 +236,7 @@ describe('textEmbeddingModel', () => {
     const modelRegistry = createProviderRegistry(
       {
         provider: {
+          specificationVersion: 'v3',
           textEmbeddingModel: id => {
             expect(id).toEqual('model');
             return model;
@@ -260,6 +268,7 @@ describe('imageModel', () => {
 
     const modelRegistry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         imageModel: id => {
           expect(id).toEqual('model');
           return model;
@@ -286,6 +295,7 @@ describe('imageModel', () => {
   it('should throw NoSuchModelError if provider does not return a model', () => {
     const registry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         imageModel: () => null as any,
         languageModel: () => null as any,
         textEmbeddingModel: () => null as any,
@@ -310,6 +320,7 @@ describe('imageModel', () => {
     const modelRegistry = createProviderRegistry(
       {
         provider: {
+          specificationVersion: 'v3',
           imageModel: id => {
             expect(id).toEqual('model');
             return model;
@@ -331,6 +342,7 @@ describe('transcriptionModel', () => {
 
     const modelRegistry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         transcriptionModel: id => {
           expect(id).toEqual('model');
           return model;
@@ -356,6 +368,7 @@ describe('transcriptionModel', () => {
   it('should throw NoSuchModelError if provider does not return a model', () => {
     const registry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         transcriptionModel: () => null as any,
         languageModel: () => null as any,
         textEmbeddingModel: () => null as any,
@@ -384,6 +397,7 @@ describe('speechModel', () => {
 
     const modelRegistry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         speechModel: id => {
           expect(id).toEqual('model');
           return model;
@@ -409,6 +423,7 @@ describe('speechModel', () => {
   it('should throw NoSuchModelError if provider does not return a model', () => {
     const registry = createProviderRegistry({
       provider: {
+        specificationVersion: 'v3',
         speechModel: () => null as any,
         languageModel: () => null as any,
         textEmbeddingModel: () => null as any,

--- a/packages/ai/src/test/mock-provider-v3.ts
+++ b/packages/ai/src/test/mock-provider-v3.ts
@@ -9,6 +9,8 @@ import {
 } from '@ai-sdk/provider';
 
 export class MockProviderV3 implements ProviderV3 {
+  readonly specificationVersion = 'v3' as const;
+
   languageModel: ProviderV3['languageModel'];
   textEmbeddingModel: ProviderV3['textEmbeddingModel'];
   imageModel: ProviderV3['imageModel'];

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -275,6 +275,7 @@ export function createAmazonBedrock(
       fetch: fetchFunction,
     });
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.embedding = createEmbeddingModel;
   provider.textEmbedding = createEmbeddingModel;

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -114,6 +114,7 @@ export function createAnthropic(
     return createChatModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
   provider.messages = createChatModel;

--- a/packages/assemblyai/src/assemblyai-provider.ts
+++ b/packages/assemblyai/src/assemblyai-provider.ts
@@ -77,6 +77,7 @@ export function createAssemblyAI(
     };
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
 

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -123,8 +123,8 @@ Custom api version to use. Defaults to `preview`.
   apiVersion?: string;
 
   /**
-Use deployment-based URLs for specific model types. Set to true to use legacy deployment format: 
-`{baseURL}/deployments/{deploymentId}{path}?api-version={apiVersion}` instead of 
+Use deployment-based URLs for specific model types. Set to true to use legacy deployment format:
+`{baseURL}/deployments/{deploymentId}{path}?api-version={apiVersion}` instead of
 `{baseURL}/v1{path}?api-version={apiVersion}`.
    */
   useDeploymentBasedUrls?: boolean;
@@ -242,6 +242,7 @@ export function createAzure(
     return createChatModel(deploymentId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
   provider.completion = createCompletionModel;

--- a/packages/baseten/src/baseten-provider.ts
+++ b/packages/baseten/src/baseten-provider.ts
@@ -228,6 +228,8 @@ export function createBaseten(
   };
 
   const provider = (modelId?: BasetenChatModelId) => createChatModel(modelId);
+
+  provider.specificationVersion = 'v3' as const;
   provider.chatModel = createChatModel;
   provider.languageModel = createChatModel;
   provider.imageModel = (modelId: string) => {

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -100,6 +100,7 @@ export function createCerebras(
   const provider = (modelId: CerebrasChatModelId) =>
     createLanguageModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createLanguageModel;
 

--- a/packages/cohere/src/cohere-provider.ts
+++ b/packages/cohere/src/cohere-provider.ts
@@ -109,6 +109,7 @@ export function createCohere(
     return createChatModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.embedding = createTextEmbeddingModel;
   provider.textEmbeddingModel = createTextEmbeddingModel;

--- a/packages/deepgram/src/deepgram-provider.ts
+++ b/packages/deepgram/src/deepgram-provider.ts
@@ -77,6 +77,7 @@ export function createDeepgram(
     };
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
 

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -143,6 +143,7 @@ export function createDeepInfra(
 
   const provider = (modelId: DeepInfraChatModelId) => createChatModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.completionModel = createCompletionModel;
   provider.chatModel = createChatModel;
   provider.image = createImageModel;

--- a/packages/deepseek/src/deepseek-provider.ts
+++ b/packages/deepseek/src/deepseek-provider.ts
@@ -83,6 +83,7 @@ export function createDeepSeek(
   const provider = (modelId: DeepSeekChatModelId) =>
     createLanguageModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createLanguageModel;
 

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -93,6 +93,7 @@ export function createElevenLabs(
     };
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
   provider.speech = createSpeechModel;

--- a/packages/fal/src/fal-provider.ts
+++ b/packages/fal/src/fal-provider.ts
@@ -149,6 +149,7 @@ export function createFal(options: FalProviderSettings = {}): FalProvider {
     });
 
   return {
+    specificationVersion: 'v3' as const,
     imageModel: createImageModel,
     image: createImageModel,
     languageModel: () => {

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -155,6 +155,7 @@ export function createFireworks(
 
   const provider = (modelId: FireworksChatModelId) => createChatModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.completionModel = createCompletionModel;
   provider.chatModel = createChatModel;
   provider.languageModel = createChatModel;

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -213,6 +213,7 @@ export function createGatewayProvider(
     return createLanguageModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.getAvailableModels = getAvailableModels;
   provider.getCredits = getCredits;
   provider.imageModel = (modelId: string) => {

--- a/packages/gladia/src/gladia-provider.ts
+++ b/packages/gladia/src/gladia-provider.ts
@@ -73,6 +73,7 @@ export function createGladia(
     };
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
 

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -112,6 +112,7 @@ export function createVertexAnthropic(
     return createChatModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
   provider.messages = createChatModel;

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -159,6 +159,7 @@ export function createVertex(
     return createChatModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -165,6 +165,7 @@ export function createGoogleGenerativeAI(
     return createChatModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
   provider.generativeAI = createChatModel;

--- a/packages/groq/src/groq-provider.ts
+++ b/packages/groq/src/groq-provider.ts
@@ -113,6 +113,7 @@ export function createGroq(options: GroqProviderSettings = {}): GroqProvider {
     return createLanguageModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createChatModel;
 

--- a/packages/huggingface/src/huggingface-provider.ts
+++ b/packages/huggingface/src/huggingface-provider.ts
@@ -82,6 +82,7 @@ export function createHuggingFace(
   const provider = (modelId: HuggingFaceResponsesModelId) =>
     createResponsesModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createResponsesModel;
   provider.responses = createResponsesModel;
 

--- a/packages/luma/src/luma-provider.ts
+++ b/packages/luma/src/luma-provider.ts
@@ -68,6 +68,7 @@ export function createLuma(options: LumaProviderSettings = {}): LumaProvider {
     });
 
   return {
+    specificationVersion: 'v3' as const,
     image: createImageModel,
     imageModel: createImageModel,
     languageModel: () => {

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -117,6 +117,7 @@ export function createMistral(
     return createChatModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
   provider.embedding = createEmbeddingModel;

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -160,6 +160,7 @@ export function createOpenAICompatible<
 
   const provider = (modelId: CHAT_MODEL_IDS) => createLanguageModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createLanguageModel;
   provider.chatModel = createChatModel;
   provider.completionModel = createCompletionModel;

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -235,6 +235,7 @@ export function createOpenAI(
     return createLanguageModel(modelId);
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createChatModel;
   provider.completion = createCompletionModel;

--- a/packages/perplexity/src/perplexity-provider.ts
+++ b/packages/perplexity/src/perplexity-provider.ts
@@ -79,6 +79,7 @@ export function createPerplexity(
   const provider = (modelId: PerplexityLanguageModelId) =>
     createLanguageModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createLanguageModel;
 
   provider.textEmbeddingModel = (modelId: string) => {

--- a/packages/provider/src/provider/v3/provider-v3.ts
+++ b/packages/provider/src/provider/v3/provider-v3.ts
@@ -8,6 +8,8 @@ import { TranscriptionModelV3 } from '../../transcription-model/v3/transcription
  * Provider for language, text embedding, and image generation models.
  */
 export interface ProviderV3 {
+  readonly specificationVersion: 'v3';
+
   /**
 Returns the language model with the given id.
 The model id is then passed to the provider function to get the model.

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -67,6 +67,7 @@ export function createReplicate(
     });
 
   return {
+    specificationVersion: 'v3' as const,
     image: createImageModel,
     imageModel: createImageModel,
     languageModel: () => {

--- a/packages/revai/src/revai-provider.ts
+++ b/packages/revai/src/revai-provider.ts
@@ -77,6 +77,7 @@ export function createRevai(
     };
   };
 
+  provider.specificationVersion = 'v3' as const;
   provider.transcription = createTranscriptionModel;
   provider.transcriptionModel = createTranscriptionModel;
 

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -141,6 +141,7 @@ export function createTogetherAI(
 
   const provider = (modelId: TogetherAIChatModelId) => createChatModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.completionModel = createCompletionModel;
   provider.languageModel = createChatModel;
   provider.chatModel = createChatModel;

--- a/packages/vercel/src/vercel-provider.ts
+++ b/packages/vercel/src/vercel-provider.ts
@@ -86,6 +86,7 @@ export function createVercel(
 
   const provider = (modelId: VercelChatModelId) => createChatModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.textEmbeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'textEmbeddingModel' });

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -115,6 +115,7 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
 
   const provider = (modelId: XaiChatModelId) => createLanguageModel(modelId);
 
+  provider.specificationVersion = 'v3' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createLanguageModel;
   provider.textEmbeddingModel = (modelId: string) => {


### PR DESCRIPTION
## Background

`ProviderV3` was missing specification version.
We had no `ProviderV2` to `ProviderV3` adapter.

## Summary

* introduce `specificationVersion` on `ProviderV3`
* add `asProviderV3` adapter
* extract adapter functions for the models

## Future Work

* ensure that we have correct model v2 to v3 adapters

## Related Issues

Extracted from #3764