### PR TITLE
docs: update system prompt to instructions for agent

### DIFF
--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -27,7 +27,7 @@ import { ToolLoopAgent } from 'ai';
 
 const myAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system: 'You are a helpful assistant.',
+  instructions: 'You are a helpful assistant.',
   tools: {
     // Your tools here
   },
@@ -38,14 +38,14 @@ const myAgent = new ToolLoopAgent({
 
 The Agent class accepts all the same settings as `generateText` and `streamText`. Configure:
 
-### Model and System Prompt
+### Model and System Instructions
 
 ```ts
 import { ToolLoopAgent } from 'ai';
 
 const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system: 'You are an expert software engineer.',
+  instructions: 'You are an expert software engineer.',
 });
 ```
 
@@ -173,18 +173,18 @@ const { output } = await analysisAgent.generate({
 });
 ```
 
-## Define Agent Behavior with System Prompts
+## Define Agent Behavior with System Instructions
 
-System prompts define your agent's behavior, personality, and constraints. They set the context for all interactions and guide how the agent responds to user queries and uses tools.
+System instructions define your agent's behavior, personality, and constraints. They set the context for all interactions and guide how the agent responds to user queries and uses tools.
 
-### Basic System Prompts
+### Basic System Instructions
 
 Set the agent's role and expertise:
 
 ```ts
 const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system:
+  instructions:
     'You are an expert data analyst. You provide clear insights from complex data.',
 });
 ```
@@ -196,7 +196,7 @@ Provide specific guidelines for agent behavior:
 ```ts
 const codeReviewAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system: `You are a senior software engineer conducting code reviews.
+  instructions: `You are a senior software engineer conducting code reviews.
 
   Your approach:
   - Focus on security vulnerabilities first
@@ -214,7 +214,7 @@ Set boundaries and ensure consistent behavior:
 ```ts
 const customerSupportAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system: `You are a customer support specialist for an e-commerce platform.
+  instructions: `You are a customer support specialist for an e-commerce platform.
 
   Rules:
   - Never make promises about refunds without checking the policy
@@ -237,7 +237,7 @@ Guide how the agent should use available tools:
 ```ts
 const researchAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system: `You are a research assistant with access to search and document tools.
+  instructions: `You are a research assistant with access to search and document tools.
 
   When researching:
   1. Always start with a broad search to understand the topic
@@ -260,7 +260,7 @@ Control the output format and communication style:
 ```ts
 const technicalWriterAgent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system: `You are a technical documentation writer.
+  instructions: `You are a technical documentation writer.
 
   Writing style:
   - Use clear, simple language

--- a/content/docs/03-agents/04-loop-control.mdx
+++ b/content/docs/03-agents/04-loop-control.mdx
@@ -158,7 +158,7 @@ const agent = new ToolLoopAgent({
     if (messages.length > 20) {
       return {
         messages: [
-          messages[0], // Keep system message
+          messages[0], // Keep system instructions
           ...messages.slice(-10), // Keep last 10 messages
         ],
       };

--- a/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/17-create-agent-ui-stream.mdx
@@ -18,7 +18,7 @@ import { ToolLoopAgent, createAgentUIStream } from 'ai';
 
 const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system: 'You are a helpful assistant.',
+  instructions: 'You are a helpful assistant.',
   tools: { weather: weatherTool, calculator: calculatorTool },
 });
 

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -21,7 +21,7 @@ import { ToolLoopAgent, createAgentUIStreamResponse } from 'ai';
 
 const agent = new ToolLoopAgent({
   model: 'openai/gpt-4o',
-  system: 'You are a helpful assistant.',
+  instructions: 'You are a helpful assistant.',
   tools: { weather: weatherTool, calculator: calculatorTool },
 });
 


### PR DESCRIPTION
## Background

In v6, `system` has been renamed to `instructions` (#9673). Lingering docs changes.
