### PR TITLE
fix(@ai-sdk/google): Make title field optional in grounding metadata schema

### DIFF
--- a/.changeset/warm-oranges-smash.md
+++ b/.changeset/warm-oranges-smash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(@ai-sdk/google): Make title field optional in grounding metadata schema

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -88,6 +88,22 @@ describe('groundingMetadataSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('validates groundingChunks[].web with missing title', () => {
+    const metadata = {
+      groundingChunks: [
+        {
+          web: {
+            // Missing `title`
+            uri: 'https://example.com/weather',
+          },
+        },
+      ],
+    };
+
+    const result = groundingMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(true);
+  });
+
   it('validates complete grounding metadata with Vertex AI Search results', () => {
     const metadata = {
       retrievalQueries: ['How to make appointment to renew driving license?'],
@@ -108,6 +124,22 @@ describe('groundingMetadataSchema', () => {
           segment_text: 'ipsum lorem ...',
           supportChunkIndices: [1, 2],
           confidenceScore: [0.9541752, 0.97726375],
+        },
+      ],
+    };
+
+    const result = groundingMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(true);
+  });
+
+  it('validates groundingChunks[].retrievedContext with missing title', () => {
+    const metadata = {
+      groundingChunks: [
+        {
+          retrievedContext: {
+            // Missing `title`
+            uri: 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/AXiHM.....QTN92V5ePQ==',
+          },
         },
       ],
     };

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -708,9 +708,11 @@ export const getGroundingMetadataSchema = () =>
     groundingChunks: z
       .array(
         z.object({
-          web: z.object({ uri: z.string(), title: z.string() }).nullish(),
+          web: z
+            .object({ uri: z.string(), title: z.string().nullish() })
+            .nullish(),
           retrievedContext: z
-            .object({ uri: z.string(), title: z.string() })
+            .object({ uri: z.string(), title: z.string().nullish() })
             .nullish(),
         }),
       )


### PR DESCRIPTION
## Background

A small percentage of the time when using the Gemini "URL Context" feature we get a Zod validation error on the response due to a missing title property.

## Summary

Added `.nullish()` to `groundingChunks[].web.title` and `groundingChunks[].retrievedContext.title`. 

Notes:

* I've personally observed the missing `title` property only on `groundingChunks[].web.title`. I'm guessing that the same situation could occur on `groundingChunks[].retrievedContext.title` and they should have the same schema. 
* I used `.nullish()` instead of `.optional()` to maintain consistency with the rest of `packages/google/src/google-generative-ai-language-model.ts`, though I have only observed a missing (`undefined`) `title` property, not a `title: null`. 

Open to feedback on either of those choices. 

No documentation updates made. Let me know if needed. 

## Manual Verification

Added tests. 

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

Fixes #9842
