### PR TITLE
ci(load-time): Increase max load time for 'ai' module to 100

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
       matrix:
         include:
           - module: 'ai'
-            max-load-time: 95
+            max-load-time: 100
           - module: '@ai-sdk/openai'
             max-load-time: 65
           - module: '@ai-sdk/openai-compatible'


### PR DESCRIPTION
addresses https://github.com/vercel/ai/commit/d6cd7a0fccb4217e5c6a065ffe0183a3b3b367af