### PR TITLE
chore(ai): change output generics

### DIFF
--- a/.changeset/slow-ducks-invent.md
+++ b/.changeset/slow-ducks-invent.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(ai): change output generics

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -1,10 +1,6 @@
 import { ModelMessage } from '@ai-sdk/provider-utils';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
-import {
-  InferGenerateOutput,
-  InferStreamOutput,
-} from '../generate-text/output-utils';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 import { ToolSet } from '../generate-text/tool-set';
 
@@ -77,12 +73,12 @@ export interface Agent<
    */
   generate(
     options: AgentCallParameters<CALL_OPTIONS>,
-  ): PromiseLike<GenerateTextResult<TOOLS, InferGenerateOutput<OUTPUT>>>;
+  ): PromiseLike<GenerateTextResult<TOOLS, OUTPUT>>;
 
   /**
    * Streams an output from the agent (streaming).
    */
   stream(
     options: AgentCallParameters<CALL_OPTIONS>,
-  ): PromiseLike<StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>>>;
+  ): PromiseLike<StreamTextResult<TOOLS, OUTPUT>>;
 }

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -1,10 +1,6 @@
 import { generateText } from '../generate-text/generate-text';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { Output } from '../generate-text/output';
-import {
-  InferGenerateOutput,
-  InferStreamOutput,
-} from '../generate-text/output-utils';
 import { stepCountIs } from '../generate-text/stop-condition';
 import { streamText } from '../generate-text/stream-text';
 import { StreamTextResult } from '../generate-text/stream-text-result';
@@ -85,7 +81,7 @@ export class ToolLoopAgent<
    */
   async generate(
     options: AgentCallParameters<CALL_OPTIONS>,
-  ): Promise<GenerateTextResult<TOOLS, InferGenerateOutput<OUTPUT>>> {
+  ): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
     return generateText(await this.prepareCall(options));
   }
 
@@ -94,7 +90,7 @@ export class ToolLoopAgent<
    */
   async stream(
     options: AgentCallParameters<CALL_OPTIONS>,
-  ): Promise<StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>>> {
+  ): Promise<StreamTextResult<TOOLS, OUTPUT>> {
     return streamText(await this.prepareCall(options));
   }
 }

--- a/packages/ai/src/generate-text/generate-text-result.ts
+++ b/packages/ai/src/generate-text/generate-text-result.ts
@@ -5,6 +5,8 @@ import { LanguageModelResponseMetadata } from '../types/language-model-response-
 import { LanguageModelUsage } from '../types/usage';
 import { ContentPart } from './content-part';
 import { GeneratedFile } from './generated-file';
+import { Output } from './output';
+import { InferCompleteOutput } from './output-utils';
 import { ReasoningOutput } from './reasoning-output';
 import { ResponseMessage } from './response-message';
 import { StepResult } from './step-result';
@@ -20,7 +22,10 @@ import { ToolSet } from './tool-set';
 The result of a `generateText` call.
 It contains the generated text, the tool calls that were made during the generation, and the results of the tool calls.
  */
-export interface GenerateTextResult<TOOLS extends ToolSet, OUTPUT> {
+export interface GenerateTextResult<
+  TOOLS extends ToolSet,
+  OUTPUT extends Output,
+> {
   /**
 The content that was generated in the last step.
    */
@@ -149,11 +154,11 @@ The generated structured output. It uses the `output` specification.
 
 @deprecated Use `output` instead.
    */
-  readonly experimental_output: OUTPUT;
+  readonly experimental_output: InferCompleteOutput<OUTPUT>;
 
   /**
 The generated structured output. It uses the `output` specification.
 
    */
-  readonly output: OUTPUT;
+  readonly output: InferCompleteOutput<OUTPUT>;
 }

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -44,6 +44,7 @@ import { GenerateTextResult } from './generate-text-result';
 import { DefaultGeneratedFile } from './generated-file';
 import { isApprovalNeeded } from './is-approval-needed';
 import { Output } from './output';
+import { InferCompleteOutput } from './output-utils';
 import { parseToolCall } from './parse-tool-call';
 import { PrepareStepFunction } from './prepare-step';
 import { ResponseMessage } from './response-message';
@@ -144,8 +145,7 @@ A result object that contains the generated text, the results of the tool calls,
  */
 export async function generateText<
   TOOLS extends ToolSet,
-  OUTPUT = never,
-  PARTIAL_OUTPUT = never,
+  OUTPUT extends Output = never,
 >({
   model: modelArg,
   tools,
@@ -228,14 +228,14 @@ changing the tool call and result types in the result.
     /**
 Optional specification for parsing structured outputs from the LLM response.
      */
-    output?: Output<OUTPUT, PARTIAL_OUTPUT>;
+    output?: OUTPUT;
 
     /**
 Optional specification for parsing structured outputs from the LLM response.
 
 @deprecated Use `output` instead.
      */
-    experimental_output?: Output<OUTPUT, PARTIAL_OUTPUT>;
+    experimental_output?: OUTPUT;
 
     /**
 Custom download function to use for URLs.
@@ -817,17 +817,17 @@ async function executeTools<TOOLS extends ToolSet>({
   );
 }
 
-class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT>
+class DefaultGenerateTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
   implements GenerateTextResult<TOOLS, OUTPUT>
 {
   readonly steps: GenerateTextResult<TOOLS, OUTPUT>['steps'];
   readonly totalUsage: LanguageModelUsage;
 
-  private readonly resolvedOutput: OUTPUT;
+  private readonly resolvedOutput: InferCompleteOutput<OUTPUT>;
 
   constructor(options: {
     steps: GenerateTextResult<TOOLS, OUTPUT>['steps'];
-    resolvedOutput: OUTPUT;
+    resolvedOutput: InferCompleteOutput<OUTPUT>;
     totalUsage: LanguageModelUsage;
   }) {
     this.steps = options.steps;

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -9,7 +9,10 @@ export type {
   GeneratedFile,
 } from './generated-file';
 export * as Output from './output';
-export type { InferGenerateOutput, InferStreamOutput } from './output-utils';
+export type {
+  InferCompleteOutput as InferGenerateOutput,
+  InferPartialOutput as InferStreamOutput,
+} from './output-utils';
 export type { PrepareStepFunction, PrepareStepResult } from './prepare-step';
 export { pruneMessages } from './prune-messages';
 export type { ReasoningOutput } from './reasoning-output';

--- a/packages/ai/src/generate-text/output-utils.ts
+++ b/packages/ai/src/generate-text/output-utils.ts
@@ -1,7 +1,13 @@
 import { Output } from './output';
 
-export type InferGenerateOutput<OUTPUT extends Output> =
-  OUTPUT extends Output<infer T, any> ? T : never;
+/**
+ * Infers the complete output type from the output specification.
+ */
+export type InferCompleteOutput<OUTPUT extends Output> =
+  OUTPUT extends Output<infer COMPLETE_OUTPUT, any> ? COMPLETE_OUTPUT : never;
 
-export type InferStreamOutput<OUTPUT extends Output> =
-  OUTPUT extends Output<any, infer P> ? P : never;
+/**
+ * Infers the partial output type from the output specification.
+ */
+export type InferPartialOutput<OUTPUT extends Output> =
+  OUTPUT extends Output<any, infer PARTIAL_OUTPUT> ? PARTIAL_OUTPUT : never;

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -17,6 +17,8 @@ import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { ErrorHandler } from '../util/error-handler';
 import { ContentPart } from './content-part';
 import { GeneratedFile } from './generated-file';
+import { Output } from './output';
+import { InferPartialOutput } from './output-utils';
 import { ReasoningOutput } from './reasoning-output';
 import { ResponseMessage } from './response-message';
 import { StepResult } from './step-result';
@@ -100,7 +102,10 @@ export type ConsumeStreamOptions = {
 /**
 A result object for accessing different stream types and additional information.
  */
-export interface StreamTextResult<TOOLS extends ToolSet, PARTIAL_OUTPUT> {
+export interface StreamTextResult<
+  TOOLS extends ToolSet,
+  OUTPUT extends Output,
+> {
   /**
 The content that was generated in the last step.
 
@@ -276,12 +281,14 @@ enables provider-specific results that can be fully encapsulated in the provider
    *
    * @deprecated Use `partialOutputStream` instead.
    */
-  readonly experimental_partialOutputStream: AsyncIterableStream<PARTIAL_OUTPUT>;
+  readonly experimental_partialOutputStream: AsyncIterableStream<
+    InferPartialOutput<OUTPUT>
+  >;
 
   /**
    * A stream of partial outputs. It uses the `output` specification.
    */
-  readonly partialOutputStream: AsyncIterableStream<PARTIAL_OUTPUT>;
+  readonly partialOutputStream: AsyncIterableStream<InferPartialOutput<OUTPUT>>;
 
   /**
 Consumes the stream without processing the parts.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -11827,9 +11827,7 @@ describe('streamText', () => {
     });
 
     describe('array output', () => {
-      let result:
-        | StreamTextResult<any, Array<DeepPartial<{ content: string }>>>
-        | undefined;
+      let result: StreamTextResult<any, any> | undefined;
 
       let onFinishResult:
         | Parameters<Required<Parameters<typeof streamText>[0]>['onFinish']>[0]
@@ -12737,7 +12735,7 @@ describe('streamText', () => {
 
   describe('abort signal', () => {
     describe('basic abort', () => {
-      let result: StreamTextResult<ToolSet, TextStreamPart<ToolSet>>;
+      let result: StreamTextResult<ToolSet, never>;
       let onErrorCalls: Array<{ error: unknown }> = [];
       let onAbortCalls: Array<{ steps: StepResult<ToolSet>[] }> = [];
 
@@ -12852,7 +12850,7 @@ describe('streamText', () => {
     });
 
     describe('abort in 2nd step', () => {
-      let result: StreamTextResult<any, TextStreamPart<any>>;
+      let result: StreamTextResult<any, never>;
       let onErrorCalls: Array<{ error: unknown }> = [];
       let onAbortCalls: Array<{ steps: StepResult<any>[] }> = [];
 
@@ -13142,7 +13140,7 @@ describe('streamText', () => {
     });
 
     describe('abort during tool call', () => {
-      let result: StreamTextResult<any, TextStreamPart<any>>;
+      let result: StreamTextResult<any, never>;
       let onErrorCalls: Array<{ error: unknown }> = [];
       let onAbortCalls: Array<{ steps: StepResult<any>[] }> = [];
 


### PR DESCRIPTION
## Background

The Output type combines two generic types: complete and partial outputs. In the future there might be more.
The agent code already uses `OUTPUT extends Output` as generic type. To simplify the code, the same generic type should be used in `generateText` and `streamText`.

## Summary

* change output generics for `streamText` and `generateText` to `OUTPUT extends Output`
* rename output inference methods and add jsdoc