### PR TITLE
test: add type tests for generateText and streamText parsed outputs

### DIFF
--- a/packages/ai/src/generate-text/generate-text.test-d.ts
+++ b/packages/ai/src/generate-text/generate-text.test-d.ts
@@ -1,0 +1,59 @@
+import { JSONValue } from '@ai-sdk/provider';
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod';
+import { generateText, Output } from '../generate-text';
+import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
+
+describe('generateText types', () => {
+  describe('output', () => {
+    it('should infer text output type', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.text(),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<string>();
+    });
+
+    it('should infer object output type', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<{ value: string }>();
+    });
+
+    it('should infer array output type', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.array({ element: z.string() }),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<string[]>();
+    });
+
+    it('should infer choice output type', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.choice({ options: ['a', 'b', 'c'] as const }),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<'a' | 'b' | 'c'>();
+    });
+
+    it('should infer json output type', async () => {
+      const result = await generateText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.json(),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<JSONValue>();
+    });
+  });
+});

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -1,0 +1,63 @@
+import { JSONValue } from '@ai-sdk/provider';
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod';
+import { Output, streamText } from '../generate-text';
+import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
+
+describe('streamText types', () => {
+  describe('output', () => {
+    it('should infer text output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.text(),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<Promise<string>>();
+    });
+
+    it('should infer object output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<
+        Promise<{ value: string }>
+      >();
+    });
+
+    it('should infer array output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.array({ element: z.string() }),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<Promise<string[]>>();
+    });
+
+    it('should infer choice output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.choice({ options: ['a', 'b', 'c'] as const }),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<
+        Promise<'a' | 'b' | 'c'>
+      >();
+    });
+
+    it('should infer json output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.json(),
+      });
+
+      expectTypeOf<typeof result.output>().toEqualTypeOf<Promise<JSONValue>>();
+    });
+  });
+});

--- a/packages/ai/src/generate-text/stream-text.test-d.ts
+++ b/packages/ai/src/generate-text/stream-text.test-d.ts
@@ -3,6 +3,8 @@ import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 import { Output, streamText } from '../generate-text';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
+import { AsyncIterableStream } from '../util';
+import { DeepPartial } from '../util/deep-partial';
 
 describe('streamText types', () => {
   describe('output', () => {
@@ -58,6 +60,68 @@ describe('streamText types', () => {
       });
 
       expectTypeOf<typeof result.output>().toEqualTypeOf<Promise<JSONValue>>();
+    });
+  });
+
+  describe('partialOutputStream', () => {
+    it('should infer text partial output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.text(),
+      });
+
+      expectTypeOf<typeof result.partialOutputStream>().toEqualTypeOf<
+        AsyncIterableStream<string>
+      >();
+    });
+
+    it('should infer object partial output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.object({ schema: z.object({ value: z.string() }) }),
+      });
+
+      expectTypeOf<typeof result.partialOutputStream>().toEqualTypeOf<
+        AsyncIterableStream<DeepPartial<{ value: string }>>
+      >();
+    });
+
+    it('should infer array partial output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.array({ element: z.string() }),
+      });
+
+      expectTypeOf<typeof result.partialOutputStream>().toEqualTypeOf<
+        AsyncIterableStream<string[]>
+      >();
+    });
+
+    it('should infer choice partial output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.choice({ options: ['a', 'b', 'c'] as const }),
+      });
+
+      expectTypeOf<typeof result.partialOutputStream>().toEqualTypeOf<
+        AsyncIterableStream<'a' | 'b' | 'c'>
+      >();
+    });
+
+    it('should infer json partial output type', async () => {
+      const result = streamText({
+        model: new MockLanguageModelV3(),
+        prompt: 'Hello, world!',
+        output: Output.json(),
+      });
+
+      expectTypeOf<typeof result.partialOutputStream>().toEqualTypeOf<
+        AsyncIterableStream<JSONValue>
+      >();
     });
   });
 });


### PR DESCRIPTION
## Background

The type inference of the partial and complete outputs for `generateText` and `streamText` is complex and breakages might go undetected.

## Summary

Add type tests for `output` and `partialOutputStream` result property types on `generateText` and `streamText`.