### PR TITLE
fix(ai): do not mutate middleware array argument when wrapping

### DIFF
--- a/.changeset/olive-lamps-exist.md
+++ b/.changeset/olive-lamps-exist.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): do not mutate middleware array argument when wrapping

--- a/packages/ai/src/middleware/wrap-embedding-model.test.ts
+++ b/packages/ai/src/middleware/wrap-embedding-model.test.ts
@@ -1,4 +1,7 @@
-import { EmbeddingModelCallOptions } from '@ai-sdk/provider';
+import {
+  EmbeddingModelCallOptions,
+  EmbeddingModelV3Middleware,
+} from '@ai-sdk/provider';
 import { wrapEmbeddingModel } from '../middleware/wrap-embedding-model';
 import { describe, it, expect, vi } from 'vitest';
 import { MockEmbeddingModelV3 } from '../test/mock-embedding-model-v3';
@@ -324,6 +327,32 @@ describe('wrapEmbeddingModel', () => {
       expect(result).toBe('wrapEmbed1(wrapEmbed2(final generate result))');
       expect(wrapEmbed1).toHaveBeenCalled();
       expect(wrapEmbed2).toHaveBeenCalled();
+    });
+
+    it('should not mutate the middleware array argument', async () => {
+      const middleware1 = {
+        specificationVersion: 'v3',
+        wrapStream: vi.fn(),
+      };
+
+      const middleware2 = {
+        specificationVersion: 'v3',
+        wrapStream: vi.fn(),
+      };
+
+      const middlewares = [
+        middleware1,
+        middleware2,
+      ] as EmbeddingModelV3Middleware[];
+
+      wrapEmbeddingModel({
+        model: new MockEmbeddingModelV3(),
+        middleware: middlewares,
+      });
+
+      expect(middlewares.length).toBe(2);
+      expect(middlewares[0]).toBe(middleware1);
+      expect(middlewares[1]).toBe(middleware2);
     });
   });
 });

--- a/packages/ai/src/middleware/wrap-embedding-model.ts
+++ b/packages/ai/src/middleware/wrap-embedding-model.ts
@@ -25,7 +25,7 @@ export const wrapEmbeddingModel = ({
   modelId?: string;
   providerId?: string;
 }): EmbeddingModelV3<string> => {
-  return asArray(middlewareArg)
+  return [...asArray(middlewareArg)]
     .reverse()
     .reduce((wrappedModel, middleware) => {
       return doWrap({ model: wrappedModel, middleware, modelId, providerId });

--- a/packages/ai/src/middleware/wrap-language-model.test.ts
+++ b/packages/ai/src/middleware/wrap-language-model.test.ts
@@ -1,4 +1,8 @@
-import { LanguageModelV3, LanguageModelV3CallOptions } from '@ai-sdk/provider';
+import {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Middleware,
+} from '@ai-sdk/provider';
 import { wrapLanguageModel } from '../middleware/wrap-language-model';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
 import { describe, it, expect, vi } from 'vitest';
@@ -483,6 +487,32 @@ describe('wrapLanguageModel', () => {
       expect(result).toBe('wrapStream1(wrapStream2(final stream result))');
       expect(wrapStream1).toHaveBeenCalled();
       expect(wrapStream2).toHaveBeenCalled();
+    });
+
+    it('should not mutate the middleware array argument', async () => {
+      const middleware1 = {
+        specificationVersion: 'v3',
+        wrapStream: vi.fn(),
+      };
+
+      const middleware2 = {
+        specificationVersion: 'v3',
+        wrapStream: vi.fn(),
+      };
+
+      const middlewares = [
+        middleware1,
+        middleware2,
+      ] as LanguageModelV3Middleware[];
+
+      wrapLanguageModel({
+        model: new MockLanguageModelV3(),
+        middleware: middlewares,
+      });
+
+      expect(middlewares.length).toBe(2);
+      expect(middlewares[0]).toBe(middleware1);
+      expect(middlewares[1]).toBe(middleware2);
     });
   });
 });

--- a/packages/ai/src/middleware/wrap-language-model.ts
+++ b/packages/ai/src/middleware/wrap-language-model.ts
@@ -25,7 +25,7 @@ export const wrapLanguageModel = ({
   modelId?: string;
   providerId?: string;
 }): LanguageModelV3 => {
-  return asArray(middlewareArg)
+  return [...asArray(middlewareArg)]
     .reverse()
     .reduce((wrappedModel, middleware) => {
       return doWrap({ model: wrappedModel, middleware, modelId, providerId });


### PR DESCRIPTION
## Background

The `middleware` array arguments were reversed (side-effect) in `wrapLanguageModel` and `wrapEmbeddingModel`.

## Summary

Prevent mutation of `middleware` array parameters in `wrapLanguageModel` and `wrapEmbeddingModel`.