### PR TITLE
feat(examples): add anthropic tools example

### DIFF
--- a/examples/next-openai/agent/anthropic-tools-agent.ts
+++ b/examples/next-openai/agent/anthropic-tools-agent.ts
@@ -1,0 +1,14 @@
+import { weatherTool } from '@/tool/weather-tool';
+import { anthropic } from '@ai-sdk/anthropic';
+import { InferAgentUIMessage, ToolLoopAgent } from 'ai';
+
+export const anthropicToolsAgent = new ToolLoopAgent({
+  model: anthropic('claude-haiku-4-5'),
+  tools: {
+    weather: weatherTool,
+  },
+});
+
+export type AnthropicToolsAgentMessage = InferAgentUIMessage<
+  typeof anthropicToolsAgent
+>;

--- a/examples/next-openai/app/api/chat-anthropic-tools/route.ts
+++ b/examples/next-openai/app/api/chat-anthropic-tools/route.ts
@@ -1,0 +1,11 @@
+import { anthropicToolsAgent } from '@/agent/anthropic-tools-agent';
+import { createAgentUIStreamResponse } from 'ai';
+
+export async function POST(request: Request) {
+  const { messages } = await request.json();
+
+  return createAgentUIStreamResponse({
+    agent: anthropicToolsAgent,
+    messages,
+  });
+}

--- a/examples/next-openai/app/chat-anthropic-tools/page.tsx
+++ b/examples/next-openai/app/chat-anthropic-tools/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { AnthropicToolsAgentMessage } from '@/agent/anthropic-tools-agent';
+import { Response } from '@/components/ai-elements/response';
+import ChatInput from '@/components/chat-input';
+import WeatherView from '@/components/tool/weather-view';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+
+export default function TestAnthropicCodeExecution() {
+  const { error, status, sendMessage, messages, regenerate } =
+    useChat<AnthropicToolsAgentMessage>({
+      transport: new DefaultChatTransport({
+        api: '/api/chat-anthropic-tools',
+      }),
+    });
+
+  return (
+    <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
+      <h1 className="mb-4 text-xl font-bold">Anthropic MCP Test</h1>
+
+      {messages.map(message => (
+        <div key={message.id} className="whitespace-pre-wrap">
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) => {
+            switch (part.type) {
+              case 'text': {
+                return <Response key={index}>{part.text}</Response>;
+              }
+              case 'tool-weather': {
+                return <WeatherView invocation={part} key={index} />;
+              }
+            }
+          })}
+        </div>
+      ))}
+
+      {error && (
+        <div className="mt-4">
+          <div className="text-red-500">An error occurred.</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-4 text-blue-500 rounded-md border border-blue-500"
+            onClick={() => regenerate()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/examples/next-openai/app/chat-anthropic-tools/page.tsx
+++ b/examples/next-openai/app/chat-anthropic-tools/page.tsx
@@ -17,7 +17,7 @@ export default function TestAnthropicCodeExecution() {
 
   return (
     <div className="flex flex-col py-24 mx-auto w-full max-w-md stretch">
-      <h1 className="mb-4 text-xl font-bold">Anthropic MCP Test</h1>
+      <h1 className="mb-4 text-xl font-bold">Anthropic Tools</h1>
 
       {messages.map(message => (
         <div key={message.id} className="whitespace-pre-wrap">

--- a/examples/next-openai/components/tool/weather-view.tsx
+++ b/examples/next-openai/components/tool/weather-view.tsx
@@ -1,0 +1,21 @@
+import { WeatherUIToolInvocation } from '@/tool/weather-tool';
+
+export default function WeatherView({
+  invocation,
+}: {
+  invocation: WeatherUIToolInvocation;
+}) {
+  switch (invocation.state) {
+    case 'output-available':
+      return (
+        <div className="text-gray-500">
+          {invocation.output.state === 'loading'
+            ? 'Fetching weather information...'
+            : `Weather in ${invocation.input.city}: ${invocation.output.weather}`}
+        </div>
+      );
+
+    case 'output-error':
+      return <div className="text-red-500">Error: {invocation.errorText}</div>;
+  }
+}

--- a/examples/next-openai/tool/weather-tool-with-approval.ts
+++ b/examples/next-openai/tool/weather-tool-with-approval.ts
@@ -13,8 +13,10 @@ export const weatherToolWithApproval = tool({
   async *execute() {
     yield { state: 'loading' as const };
 
-    // Add artificial delay of 2 seconds
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    // Add randomized delay of 1 and 5 seconds (to mix up tool result ordering)
+    await new Promise(resolve =>
+      setTimeout(resolve, 1000 + Math.floor(Math.random() * 4000)),
+    );
 
     yield {
       state: 'ready' as const,

--- a/examples/next-openai/tool/weather-tool.ts
+++ b/examples/next-openai/tool/weather-tool.ts
@@ -1,14 +1,14 @@
 import { UIToolInvocation, tool } from 'ai';
-import * as v from 'valibot';
+import { z } from 'zod';
 
 function randomWeather() {
   const weatherOptions = ['sunny', 'cloudy', 'rainy', 'windy'];
   return weatherOptions[Math.floor(Math.random() * weatherOptions.length)];
 }
 
-export const weatherToolValibot = tool({
+export const weatherTool = tool({
   description: 'Get the weather in a location',
-  inputSchema: v.object({ city: v.string() }),
+  inputSchema: z.object({ city: z.string() }),
   async *execute() {
     yield { state: 'loading' as const };
 
@@ -25,6 +25,4 @@ export const weatherToolValibot = tool({
   },
 });
 
-export type WeatherUIToolValibotInvocation = UIToolInvocation<
-  typeof weatherToolValibot
->;
+export type WeatherUIToolInvocation = UIToolInvocation<typeof weatherTool>;


### PR DESCRIPTION
## Background

Users keep reporting issues with Anthropic parallel tool calls with Claude Haiku 4.5 and UIs. This example is a failed attempt to reproduce the problem (but useful to have regardless).

## Summary

* adds an Anthropic tools UI example
* randomizes weather tool response times

## Steps

* `examples/next-openai`
* http://localhost:3000/chat-anthropic-tools
* first msg: `what is the weather in berlin, paris, london, new york?`
* follow-up msg: `give me more information about the cities`

## Related Issues

Investigates #8516