### PR TITLE
fix(groq): restrict reasoningEffort to allowed enum values

### DIFF
--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -28,7 +28,16 @@ export type GroqChatModelId =
 
 export const groqProviderOptions = z.object({
   reasoningFormat: z.enum(['parsed', 'raw', 'hidden']).optional(),
-  reasoningEffort: z.string().optional(),
+  
+  /**
+   * Specifies the reasoning effort level for model inference.
+   * - 'none': No reasoning
+   * - 'default': Default reasoning level
+   * - 'low': Low reasoning effort
+   * - 'medium': Medium reasoning effort
+   * - 'high': High reasoning effort
+   */
+  reasoningEffort: z.enum(['none', 'default', 'low', 'medium', 'high']).optional(),
 
   /**
    * Whether to enable parallel function calling during tool use. Default to true.


### PR DESCRIPTION
Change reasoningEffort from loose z.string() to strict z.enum(['none', 'default', 'low', 'medium', 'high']) to match Groq API specification. Added JSDoc comment documenting each reasoning effort level.

Fixes issue with overly permissive type definition for reasoningEffort parameter.

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

## Summary

<!-- What did you change? -->

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
