### PR TITLE
fix: remove code for unsuported o1-mini and o1-preview models

### DIFF
--- a/.changeset/curvy-boats-repair.md
+++ b/.changeset/curvy-boats-repair.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix: remove code for unsuported o1-mini and o1-preview models

--- a/examples/ai-core/src/e2e/openai.test.ts
+++ b/examples/ai-core/src/e2e/openai.test.ts
@@ -25,7 +25,6 @@ createFeatureTestSuite({
       createChatModel('gpt-4.1-nano'),
       createChatModel('o3'),
       createChatModel('o4-mini'),
-      createChatModel('o1-mini'),
       createChatModel('gpt-4o-mini'),
       createChatModel('gpt-3.5-turbo'),
       createChatModel('gpt-4-turbo-preview'),

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -471,7 +471,7 @@ describe('doGenerate', () => {
   it('should pass reasoningEffort setting from provider metadata', async () => {
     prepareJsonResponse({ content: '' });
 
-    const model = provider.chat('o3-mini');
+    const model = provider.chat('o4-mini');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -481,7 +481,7 @@ describe('doGenerate', () => {
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'o3-mini',
+      model: 'o4-mini',
       messages: [{ role: 'user', content: 'Hello' }],
       reasoning_effort: 'low',
     });
@@ -490,7 +490,7 @@ describe('doGenerate', () => {
   it('should pass reasoningEffort setting from settings', async () => {
     prepareJsonResponse({ content: '' });
 
-    const model = provider.chat('o3-mini');
+    const model = provider.chat('o4-mini');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -500,7 +500,7 @@ describe('doGenerate', () => {
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'o3-mini',
+      model: 'o4-mini',
       messages: [{ role: 'user', content: 'Hello' }],
       reasoning_effort: 'high',
     });
@@ -1202,7 +1202,7 @@ describe('doGenerate', () => {
     it('should clear out temperature, top_p, frequency_penalty, presence_penalty and return warnings', async () => {
       prepareJsonResponse();
 
-      const model = provider.chat('o3-mini');
+      const model = provider.chat('o4-mini');
 
       const result = await model.doGenerate({
         prompt: TEST_PROMPT,
@@ -1213,7 +1213,7 @@ describe('doGenerate', () => {
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'o3-mini',
+        model: 'o4-mini',
         messages: [{ role: 'user', content: 'Hello' }],
       });
 
@@ -1244,7 +1244,7 @@ describe('doGenerate', () => {
     it('should convert maxOutputTokens to max_completion_tokens', async () => {
       prepareJsonResponse();
 
-      const model = provider.chat('o3-mini');
+      const model = provider.chat('o4-mini');
 
       await model.doGenerate({
         prompt: TEST_PROMPT,
@@ -1252,7 +1252,7 @@ describe('doGenerate', () => {
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'o3-mini',
+        model: 'o4-mini',
         messages: [{ role: 'user', content: 'Hello' }],
         max_completion_tokens: 1000,
       });
@@ -1294,7 +1294,7 @@ describe('doGenerate', () => {
       },
     });
 
-    const model = provider.chat('o3-mini');
+    const model = provider.chat('o4-mini');
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -1312,9 +1312,9 @@ describe('doGenerate', () => {
   });
 
   it('should send max_completion_tokens extension setting', async () => {
-    prepareJsonResponse({ model: 'o3-mini' });
+    prepareJsonResponse({ model: 'o4-mini' });
 
-    const model = provider.chat('o3-mini');
+    const model = provider.chat('o4-mini');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -1326,7 +1326,7 @@ describe('doGenerate', () => {
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'o3-mini',
+      model: 'o4-mini',
       messages: [{ role: 'user', content: 'Hello' }],
       max_completion_tokens: 255,
     });
@@ -1506,7 +1506,7 @@ describe('doGenerate', () => {
   it('should send serviceTier flex processing setting', async () => {
     prepareJsonResponse({ content: '' });
 
-    const model = provider.chat('o3-mini');
+    const model = provider.chat('o4-mini');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -1525,7 +1525,7 @@ describe('doGenerate', () => {
             "role": "user",
           },
         ],
-        "model": "o3-mini",
+        "model": "o4-mini",
         "service_tier": "flex",
       }
     `);
@@ -1650,7 +1650,7 @@ describe('doGenerate', () => {
   it('should allow priority processing with o3 model without warnings', async () => {
     prepareJsonResponse();
 
-    const model = provider.chat('o3-mini');
+    const model = provider.chat('o4-mini');
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -2802,7 +2802,7 @@ describe('doStream', () => {
   it('should send serviceTier flex processing setting in streaming', async () => {
     prepareStreamResponse({ content: [] });
 
-    const model = provider.chat('o3-mini');
+    const model = provider.chat('o4-mini');
 
     await model.doStream({
       prompt: TEST_PROMPT,
@@ -2822,7 +2822,7 @@ describe('doStream', () => {
             "role": "user",
           },
         ],
-        "model": "o3-mini",
+        "model": "o4-mini",
         "service_tier": "flex",
         "stream": true,
         "stream_options": {
@@ -2869,10 +2869,10 @@ describe('doStream', () => {
     it('should stream text delta', async () => {
       prepareStreamResponse({
         content: ['Hello, World!'],
-        model: 'o3-mini',
+        model: 'o4-mini',
       });
 
-      const model = provider.chat('o3-mini');
+      const model = provider.chat('o4-mini');
 
       const { stream } = await model.doStream({
         prompt: TEST_PROMPT,
@@ -2887,7 +2887,7 @@ describe('doStream', () => {
           },
           {
             "id": "chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP",
-            "modelId": "o3-mini",
+            "modelId": "o4-mini",
             "timestamp": 2023-12-15T16:17:00.000Z,
             "type": "response-metadata",
           },
@@ -2930,7 +2930,7 @@ describe('doStream', () => {
     it('should send reasoning tokens', async () => {
       prepareStreamResponse({
         content: ['Hello, World!'],
-        model: 'o3-mini',
+        model: 'o4-mini',
         usage: {
           prompt_tokens: 15,
           completion_tokens: 20,
@@ -2941,7 +2941,7 @@ describe('doStream', () => {
         },
       });
 
-      const model = provider.chat('o3-mini');
+      const model = provider.chat('o4-mini');
 
       const { stream } = await model.doStream({
         prompt: TEST_PROMPT,
@@ -2956,7 +2956,7 @@ describe('doStream', () => {
           },
           {
             "id": "chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP",
-            "modelId": "o3-mini",
+            "modelId": "o4-mini",
             "timestamp": 2023-12-15T16:17:00.000Z,
             "type": "response-metadata",
           },

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -471,7 +471,7 @@ describe('doGenerate', () => {
   it('should pass reasoningEffort setting from provider metadata', async () => {
     prepareJsonResponse({ content: '' });
 
-    const model = provider.chat('o1-mini');
+    const model = provider.chat('o3-mini');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -481,7 +481,7 @@ describe('doGenerate', () => {
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'o1-mini',
+      model: 'o3-mini',
       messages: [{ role: 'user', content: 'Hello' }],
       reasoning_effort: 'low',
     });
@@ -490,7 +490,7 @@ describe('doGenerate', () => {
   it('should pass reasoningEffort setting from settings', async () => {
     prepareJsonResponse({ content: '' });
 
-    const model = provider.chat('o1-mini');
+    const model = provider.chat('o3-mini');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -500,7 +500,7 @@ describe('doGenerate', () => {
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'o1-mini',
+      model: 'o3-mini',
       messages: [{ role: 'user', content: 'Hello' }],
       reasoning_effort: 'high',
     });
@@ -1202,7 +1202,7 @@ describe('doGenerate', () => {
     it('should clear out temperature, top_p, frequency_penalty, presence_penalty and return warnings', async () => {
       prepareJsonResponse();
 
-      const model = provider.chat('o1-preview');
+      const model = provider.chat('o3-mini');
 
       const result = await model.doGenerate({
         prompt: TEST_PROMPT,
@@ -1213,7 +1213,7 @@ describe('doGenerate', () => {
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'o1-preview',
+        model: 'o3-mini',
         messages: [{ role: 'user', content: 'Hello' }],
       });
 
@@ -1244,7 +1244,7 @@ describe('doGenerate', () => {
     it('should convert maxOutputTokens to max_completion_tokens', async () => {
       prepareJsonResponse();
 
-      const model = provider.chat('o1-preview');
+      const model = provider.chat('o3-mini');
 
       await model.doGenerate({
         prompt: TEST_PROMPT,
@@ -1252,36 +1252,11 @@ describe('doGenerate', () => {
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
-        model: 'o1-preview',
+        model: 'o3-mini',
         messages: [{ role: 'user', content: 'Hello' }],
         max_completion_tokens: 1000,
       });
     });
-  });
-
-  it('should remove system messages for o1-preview and add a warning', async () => {
-    prepareJsonResponse();
-
-    const model = provider.chat('o1-preview');
-
-    const result = await model.doGenerate({
-      prompt: [
-        { role: 'system', content: 'You are a helpful assistant.' },
-        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
-      ],
-    });
-
-    expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'o1-preview',
-      messages: [{ role: 'user', content: 'Hello' }],
-    });
-
-    expect(result.warnings).toStrictEqual([
-      {
-        type: 'other',
-        message: 'system messages are removed for this model',
-      },
-    ]);
   });
 
   it('should use developer messages for o1', async () => {
@@ -1319,7 +1294,7 @@ describe('doGenerate', () => {
       },
     });
 
-    const model = provider.chat('o1-preview');
+    const model = provider.chat('o3-mini');
 
     const result = await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -1337,9 +1312,9 @@ describe('doGenerate', () => {
   });
 
   it('should send max_completion_tokens extension setting', async () => {
-    prepareJsonResponse({ model: 'o1-preview' });
+    prepareJsonResponse({ model: 'o3-mini' });
 
-    const model = provider.chat('o1-preview');
+    const model = provider.chat('o3-mini');
 
     await model.doGenerate({
       prompt: TEST_PROMPT,
@@ -1351,7 +1326,7 @@ describe('doGenerate', () => {
     });
 
     expect(await server.calls[0].requestBodyJson).toStrictEqual({
-      model: 'o1-preview',
+      model: 'o3-mini',
       messages: [{ role: 'user', content: 'Hello' }],
       max_completion_tokens: 255,
     });
@@ -2894,10 +2869,10 @@ describe('doStream', () => {
     it('should stream text delta', async () => {
       prepareStreamResponse({
         content: ['Hello, World!'],
-        model: 'o1-preview',
+        model: 'o3-mini',
       });
 
-      const model = provider.chat('o1-preview');
+      const model = provider.chat('o3-mini');
 
       const { stream } = await model.doStream({
         prompt: TEST_PROMPT,
@@ -2912,7 +2887,7 @@ describe('doStream', () => {
           },
           {
             "id": "chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP",
-            "modelId": "o1-preview",
+            "modelId": "o3-mini",
             "timestamp": 2023-12-15T16:17:00.000Z,
             "type": "response-metadata",
           },
@@ -2955,7 +2930,7 @@ describe('doStream', () => {
     it('should send reasoning tokens', async () => {
       prepareStreamResponse({
         content: ['Hello, World!'],
-        model: 'o1-preview',
+        model: 'o3-mini',
         usage: {
           prompt_tokens: 15,
           completion_tokens: 20,
@@ -2966,7 +2941,7 @@ describe('doStream', () => {
         },
       });
 
-      const model = provider.chat('o1-preview');
+      const model = provider.chat('o3-mini');
 
       const { stream } = await model.doStream({
         prompt: TEST_PROMPT,
@@ -2981,7 +2956,7 @@ describe('doStream', () => {
           },
           {
             "id": "chatcmpl-96aZqmeDpA9IPD6tACY8djkMsJCMP",
-            "modelId": "o1-preview",
+            "modelId": "o3-mini",
             "timestamp": 2023-12-15T16:17:00.000Z,
             "type": "response-metadata",
           },

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -737,18 +737,6 @@ function getSystemMessageMode(modelId: string) {
 }
 
 const reasoningModels = {
-  'o1-mini': {
-    systemMessageMode: 'remove',
-  },
-  'o1-mini-2024-09-12': {
-    systemMessageMode: 'remove',
-  },
-  'o1-preview': {
-    systemMessageMode: 'remove',
-  },
-  'o1-preview-2024-09-12': {
-    systemMessageMode: 'remove',
-  },
   o3: {
     systemMessageMode: 'developer',
   },

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -264,9 +264,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             { role: 'developer', content: 'You are a helpful assistant.' },
             {
               role: 'user',
-              content: [
-                { type: 'input_text', text: 'Hello' },
-              ],
+              content: [{ type: 'input_text', text: 'Hello' }],
             },
           ],
         });
@@ -299,9 +297,9 @@ describe('OpenAIResponsesLanguageModel', () => {
 
           const expectedMessages = [
             {
-                    role: 'developer',
-                    content: 'You are a helpful assistant.',
-                  },
+              role: 'developer',
+              content: 'You are a helpful assistant.',
+            },
             { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
           ];
 

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -249,7 +249,7 @@ describe('OpenAIResponsesLanguageModel', () => {
       });
 
       it('should remove unsupported settings for o1', async () => {
-        const { warnings } = await createModel('o1-mini').doGenerate({
+        const { warnings } = await createModel('o1').doGenerate({
           prompt: [
             { role: 'system', content: 'You are a helpful assistant.' },
             { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -259,17 +259,19 @@ describe('OpenAIResponsesLanguageModel', () => {
         });
 
         expect(await server.calls[0].requestBodyJson).toStrictEqual({
-          model: 'o1-mini',
+          model: 'o1',
           input: [
-            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+            { role: 'developer', content: 'You are a helpful assistant.' },
+            {
+              role: 'user',
+              content: [
+                { type: 'input_text', text: 'Hello' },
+              ],
+            },
           ],
         });
 
         expect(warnings).toStrictEqual([
-          {
-            type: 'other',
-            message: 'system messages are removed for this model',
-          },
           {
             details: 'temperature is not supported for reasoning models',
             setting: 'temperature',
@@ -296,21 +298,10 @@ describe('OpenAIResponsesLanguageModel', () => {
           });
 
           const expectedMessages = [
-            // o1 models prior to o1-2024-12-17 should remove system messages, all other models should replace
-            // them with developer messages
-            ...(![
-              'o1-mini',
-              'o1-mini-2024-09-12',
-              'o1-preview',
-              'o1-preview-2024-09-12',
-            ].includes(modelId)
-              ? [
-                  {
+            {
                     role: 'developer',
                     content: 'You are a helpful assistant.',
                   },
-                ]
-              : []),
             { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
           ];
 
@@ -320,21 +311,6 @@ describe('OpenAIResponsesLanguageModel', () => {
           });
 
           expect(warnings).toStrictEqual([
-            // o1 models prior to o1-2024-12-17 should remove system messages, all other models should replace
-            // them with developer messages
-            ...([
-              'o1-mini',
-              'o1-mini-2024-09-12',
-              'o1-preview',
-              'o1-preview-2024-09-12',
-            ].includes(modelId)
-              ? [
-                  {
-                    message: 'system messages are removed for this model',
-                    type: 'other',
-                  },
-                ]
-              : []),
             {
               details: 'temperature is not supported for reasoning models',
               setting: 'temperature',

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1358,14 +1358,6 @@ function getResponsesModelConfig(modelId: string): ResponsesModelConfig {
     modelId.startsWith('codex-') ||
     modelId.startsWith('computer-use')
   ) {
-    if (modelId.startsWith('o1-mini') || modelId.startsWith('o1-preview')) {
-      return {
-        ...defaults,
-        isReasoningModel: true,
-        systemMessageMode: 'remove',
-      };
-    }
-
     return {
       ...defaults,
       isReasoningModel: true,


### PR DESCRIPTION
## Background

Follow up to

- #7963

## Summary

Removed artifactes related to unsupported `o1-mini` and `o1-preview` models

## Manual Verification

Made sure `examples/ai-core/src/stream-text/openai.ts` is working with `o1` and other still supported models.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] n/a ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

#7963