### PR TITLE
fix(test-server): make `msw` a production dependency

### DIFF
--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -37,11 +37,13 @@
       "require": "./dist/with-vitest.js"
     }
   },
+  "dependencies": {
+    "msw": "^2.7.0"
+  },
   "devDependencies": {
     "@types/node": "20.17.24",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",
-    "msw": "^2.7.0",
     "typescript": "5.8.3"
   },
   "engines": {

--- a/packages/test-server/tsconfig.json
+++ b/packages/test-server/tsconfig.json
@@ -13,11 +13,6 @@
       "build",
       "node_modules",
       "tsup.config.ts"
-    ],
-    "references": [
-        {
-        "path": "../provider"
-        }
     ]
   }
   

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2709,6 +2709,10 @@ importers:
         version: 3.25.76
 
   packages/test-server:
+    dependencies:
+      msw:
+        specifier: ^2.7.0
+        version: 2.7.0(@types/node@20.17.24)(typescript@5.8.3)
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -2716,9 +2720,6 @@ importers:
       '@vercel/ai-tsconfig':
         specifier: workspace:*
         version: link:../../tools/tsconfig
-      msw:
-        specifier: ^2.7.0
-        version: 2.7.0(@types/node@20.17.24)(typescript@5.8.3)
       tsup:
         specifier: ^8
         version: 8.3.0(jiti@2.4.0)(postcss@8.5.6)(tsx@4.19.2)(typescript@5.8.3)(yaml@2.7.0)


### PR DESCRIPTION
## Background

We introduced a new package for the test server in #8588. The test server always depended on `msw`, but we didn't add it as production dependency because before we created a dedicated package for it, it was part of provider-utils. Making `msw` a production dependency would have meant that installing `ai` would install `msw` without ever needing it.

## Summary

`msw` will now automatically installed when installing `@ai-sdk/test-server`. It's already fixed it in the `main` branch via #9988

## Manual Verification

I'll try after the release but I'm sure enough this works as designed.

## Related Issues

#8588, #9988