### PR TITLE
fix(ai): Preventing multiple concurrent chat resume calls

### DIFF
--- a/.changeset/fluffy-bobcats-film.md
+++ b/.changeset/fluffy-bobcats-film.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Prevented multiple stream resumption calls in useChat

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -193,6 +193,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
   protected state: ChatState<UI_MESSAGE>;
 
+  private isResuming: boolean = false;
   private messageMetadataSchema:
     | FlexibleSchema<InferUIMessageMetadata<UI_MESSAGE>>
     | undefined;
@@ -414,7 +415,17 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
    * Attempt to resume an ongoing streaming response.
    */
   resumeStream = async (options: ChatRequestOptions = {}): Promise<void> => {
-    await this.makeRequest({ trigger: 'resume-stream', ...options });
+    if (this.isResuming) {
+      return;
+    }
+
+    this.isResuming = true;
+
+    try {
+      await this.makeRequest({ trigger: 'resume-stream', ...options });
+    } finally {
+      this.isResuming = false;
+    }
   };
 
   /**


### PR DESCRIPTION
## Background

When using `React.StrictMode` and `useChat.resume=true`, calls to the stream resumption endpoint are made twice, which causes multiple duplicate messages to appear.

## Summary

This fixes the issue by preventing multiple calls to the resume endpoint, if one is already in progress.

## Manual Verification

I built the package locally with my changes, included in my React project, and verified that calls to the stream resumption endpoint are only made once - with no duplicate messages shown on screen either.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
