### PR TITLE
feat(ai): `chat.addToolResult()` is now `chat.addToolOutput()`

### DIFF
--- a/.changeset/early-maps-grin.md
+++ b/.changeset/early-maps-grin.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/react': patch
+'ai': patch
+---
+
+rename chat.addToolResult() to addToolOutput();
+mark addToolResult() as deprecated.

--- a/.changeset/early-maps-grin.md
+++ b/.changeset/early-maps-grin.md
@@ -3,5 +3,4 @@
 'ai': patch
 ---
 
-rename chat.addToolResult() to addToolOutput();
-mark addToolResult() as deprecated.
+feat(ai): `chat.addToolResult()` is now `chat.addToolOutput()`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "vsicons.presets.nestjs": true
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "vsicons.presets.nestjs": true
 }

--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -195,7 +195,7 @@ import { DefaultChatTransport, isToolUIPart, getToolName } from 'ai';
 import { useState } from 'react';
 
 export default function Chat() {
-  const { messages, addToolResult, sendMessage } = useChat({
+  const { messages, addToolOutput, sendMessage } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/chat',
     }),
@@ -227,7 +227,7 @@ export default function Chat() {
                       <div>
                         <button
                           onClick={async () => {
-                            await addToolResult({
+                            await addToolOutput({
                               toolCallId,
                               tool: toolName,
                               output: 'Yes, confirmed.',
@@ -239,7 +239,7 @@ export default function Chat() {
                         </button>
                         <button
                           onClick={async () => {
-                            await addToolResult({
+                            await addToolOutput({
                               toolCallId,
                               tool: toolName,
                               output: 'No, denied.',
@@ -281,13 +281,13 @@ export default function Chat() {
 ```
 
 <Note>
-  The `sendMessage()` function after `addToolResult` will trigger a call to your
+  The `sendMessage()` function after `addToolOutput` will trigger a call to your
   route handler.
 </Note>
 
 ### Handle Confirmation Response
 
-Adding a tool result and sending the message will trigger another call to your route handler. Before sending the new messages to the language model, you pull out the last message and map through the message parts to see if the tool requiring confirmation was called and whether it's in a "result" state. If those conditions are met, you check the confirmation state (the tool result state that you set on the frontend with the `addToolResult` function).
+Adding a tool result and sending the message will trigger another call to your route handler. Before sending the new messages to the language model, you pull out the last message and map through the message parts to see if the tool requiring confirmation was called and whether it's in a "result" state. If those conditions are met, you check the confirmation state (the tool result state that you set on the frontend with the `addToolOutput` function).
 
 ```ts filename="api/chat/route.ts"
 import { openai } from '@ai-sdk/openai';
@@ -388,7 +388,7 @@ async function executeWeatherTool({ city }: { city: string }) {
 }
 ```
 
-In this implementation, you use simple strings like "Yes, the user confirmed" or "No, the user declined" as states. If confirmed, you execute the tool. If declined, you do not execute the tool. In both cases, you update the tool result from the arbitrary data you sent with the `addToolResult` function to either the result of the execute function or an "Execution declined" statement. You send the updated tool result back to the frontend to maintain state synchronization.
+In this implementation, you use simple strings like "Yes, the user confirmed" or "No, the user declined" as states. If confirmed, you execute the tool. If declined, you do not execute the tool. In both cases, you update the tool result from the arbitrary data you sent with the `addToolOutput` function to either the result of the execute function or an "Execution declined" statement. You send the updated tool result back to the frontend to maintain state synchronization.
 
 After handling the tool result, your API route continues. This triggers another generation with the updated tool result, allowing the LLM to continue attempting to solve the query.
 
@@ -666,7 +666,7 @@ import { useState } from 'react';
 import { HumanInTheLoopUIMessage, MyTools } from '../api/chat/types';
 
 export default function Chat() {
-  const { messages, addToolResult, sendMessage } =
+  const { messages, addToolOutput, sendMessage } =
     useChat<HumanInTheLoopUIMessage>({
       transport: new DefaultChatTransport({
         api: '/api/chat',
@@ -716,7 +716,7 @@ export default function Chat() {
                       <button
                         className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700"
                         onClick={async () => {
-                          await addToolResult({
+                          await addToolOutput({
                             toolCallId,
                             tool: toolName,
                             output: APPROVAL.YES,
@@ -729,7 +729,7 @@ export default function Chat() {
                       <button
                         className="px-4 py-2 font-bold text-white bg-red-500 rounded hover:bg-red-700"
                         onClick={async () => {
-                          await addToolResult({
+                          await addToolOutput({
                             toolCallId,
                             tool: toolName,
                             output: APPROVAL.NO,

--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -185,7 +185,7 @@ export async function POST(req: Request) {
 
 On the frontend, you map through the messages, either rendering the message content or checking for tool invocations and rendering custom UI.
 
-You can check if the tool requiring confirmation has been called and, if so, present options to either confirm or deny the proposed tool call. This confirmation is done using the `addToolResult` function to create a tool result and append it to the associated tool call.
+You can check if the tool requiring confirmation has been called and, if so, present options to either confirm or deny the proposed tool call. This confirmation is done using the `addToolOutput` function to create a tool result and append it to the associated tool call.
 
 ```tsx filename="app/page.tsx"
 'use client';

--- a/content/cookbook/01-next/90-render-visual-interface-in-chat.mdx
+++ b/content/cookbook/01-next/90-render-visual-interface-in-chat.mdx
@@ -54,7 +54,7 @@ import { ChatMessage } from './api/chat/route';
 
 export default function Chat() {
   const [input, setInput] = useState('');
-  const { messages, sendMessage, addToolResult } = useChat<ChatMessage>({
+  const { messages, sendMessage, addToolOutput } = useChat<ChatMessage>({
     transport: new DefaultChatTransport({
       api: '/api/chat',
     }),
@@ -67,7 +67,7 @@ export default function Chat() {
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
 
         // No await - avoids potential deadlocks
-        addToolResult({
+        addToolOutput({
           tool: 'getLocation',
           toolCallId: toolCall.toolCallId,
           output: cities[Math.floor(Math.random() * cities.length)],
@@ -100,7 +100,7 @@ export default function Chat() {
                           <button
                             className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700"
                             onClick={() =>
-                              addToolResult({
+                              addToolOutput({
                                 tool: 'askForConfirmation',
                                 toolCallId: part.toolCallId,
                                 output: 'Yes, confirmed.',
@@ -112,7 +112,7 @@ export default function Chat() {
                           <button
                             className="px-4 py-2 font-bold text-white bg-red-500 rounded hover:bg-red-700"
                             onClick={() =>
-                              addToolResult({
+                              addToolOutput({
                                 tool: 'askForConfirmation',
                                 toolCallId: part.toolCallId,
                                 output: 'No, denied',

--- a/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-tool-usage.mdx
@@ -20,10 +20,10 @@ The flow is as follows:
 1. All tool calls are forwarded to the client.
 1. Server-side tools are executed using their `execute` method and their results are forwarded to the client.
 1. Client-side tools that should be automatically executed are handled with the `onToolCall` callback.
-   You must call `addToolResult` to provide the tool result.
+   You must call `addToolOutput` to provide the tool result.
 1. Client-side tool that require user interactions can be displayed in the UI.
    The tool calls and results are available as tool invocation parts in the `parts` property of the last assistant message.
-1. When the user interaction is done, `addToolResult` can be used to add the tool result to the chat.
+1. When the user interaction is done, `addToolOutput` can be used to add the tool result to the chat.
 1. The chat can be configured to automatically submit when all tool results are available using `sendAutomaticallyWhen`.
    This triggers another iteration of this flow.
 
@@ -104,13 +104,13 @@ There are three things worth mentioning:
 
 1. The [`onToolCall`](/docs/reference/ai-sdk-ui/use-chat#on-tool-call) callback is used to handle client-side tools that should be automatically executed.
    In this example, the `getLocation` tool is a client-side tool that returns a random city.
-   You call `addToolResult` to provide the result (without `await` to avoid potential deadlocks).
+   You call `addToolOutput` to provide the result (without `await` to avoid potential deadlocks).
 
    <Note>
      Always check `if (toolCall.dynamic)` first in your `onToolCall` handler.
      Without this check, TypeScript will throw an error like: `Type 'string' is
      not assignable to type '"toolName1" | "toolName2"'` when you try to use
-     `toolCall.toolName` in `addToolResult`.
+     `toolCall.toolName` in `addToolOutput`.
    </Note>
 
 2. The [`sendAutomaticallyWhen`](/docs/reference/ai-sdk-ui/use-chat#send-automatically-when) option with `lastAssistantMessageIsCompleteWithToolCalls` helper automatically submits when all tool results are available.
@@ -118,7 +118,7 @@ There are three things worth mentioning:
 3. The `parts` array of assistant messages contains tool parts with typed names like `tool-askForConfirmation`.
    The client-side tool `askForConfirmation` is displayed in the UI.
    It asks the user for confirmation and displays the result once the user confirms or denies the execution.
-   The result is added to the chat using `addToolResult` with the `tool` parameter for type safety.
+   The result is added to the chat using `addToolOutput` with the `tool` parameter for type safety.
 
 ```tsx filename='app/page.tsx' highlight="2,6,10,14-20"
 'use client';
@@ -131,7 +131,7 @@ import {
 import { useState } from 'react';
 
 export default function Chat() {
-  const { messages, sendMessage, addToolResult } = useChat({
+  const { messages, sendMessage, addToolOutput } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/chat',
     }),
@@ -149,7 +149,7 @@ export default function Chat() {
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
 
         // No await - avoids potential deadlocks
-        addToolResult({
+        addToolOutput({
           tool: 'getLocation',
           toolCallId: toolCall.toolCallId,
           output: cities[Math.floor(Math.random() * cities.length)],
@@ -186,7 +186,7 @@ export default function Chat() {
                         <div>
                           <button
                             onClick={() =>
-                              addToolResult({
+                              addToolOutput({
                                 tool: 'askForConfirmation',
                                 toolCallId: callId,
                                 output: 'Yes, confirmed.',
@@ -197,7 +197,7 @@ export default function Chat() {
                           </button>
                           <button
                             onClick={() =>
-                              addToolResult({
+                              addToolOutput({
                                 tool: 'askForConfirmation',
                                 toolCallId: callId,
                                 output: 'No, denied',
@@ -298,7 +298,7 @@ export default function Chat() {
 
 ### Error handling
 
-Sometimes an error may occur during client-side tool execution. Use the `addToolResult` method with a `state` of `output-error` and `errorText` value instead of `output` record the error.
+Sometimes an error may occur during client-side tool execution. Use the `addToolOutput` method with a `state` of `output-error` and `errorText` value instead of `output` record the error.
 
 ```tsx filename='app/page.tsx' highlight="19,36-41"
 'use client';
@@ -311,7 +311,7 @@ import {
 import { useState } from 'react';
 
 export default function Chat() {
-  const { messages, sendMessage, addToolResult } = useChat({
+  const { messages, sendMessage, addToolOutput } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/chat',
     }),
@@ -330,13 +330,13 @@ export default function Chat() {
           const weather = await getWeatherInformation(toolCall.input);
 
           // No await - avoids potential deadlocks
-          addToolResult({
+          addToolOutput({
             tool: 'getWeatherInformation',
             toolCallId: toolCall.toolCallId,
             output: weather,
           });
         } catch (err) {
-          addToolResult({
+          addToolOutput({
             tool: 'getWeatherInformation',
             toolCallId: toolCall.toolCallId,
             state: 'output-error',

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -230,7 +230,7 @@ Allows you to easily create a conversational user interface for your chatbot app
       type: '({toolCall: ToolCall}) => void | Promise<void>',
       isOptional: true,
       description:
-        'Optional callback function that is invoked when a tool call is received. You must call addToolResult to provide the tool result.',
+        'Optional callback function that is invoked when a tool call is received. You must call addToolOutput to provide the tool result.',
     },
     {
       name: 'sendAutomaticallyWhen',
@@ -418,7 +418,7 @@ Allows you to easily create a conversational user interface for your chatbot app
         'Function to resume an interrupted streaming response. Useful when a network error occurs during streaming.',
     },
     {
-      name: 'addToolResult',
+      name: 'addToolOutput',
       type: '(options: { tool: string; toolCallId: string; output: unknown } | { tool: string; toolCallId: string; state: "output-error", errorText: string }) => void',
       description:
         'Function to add a tool result to the chat. This will update the chat messages with the tool result. If sendAutomaticallyWhen is configured, it may trigger an automatic submission.',

--- a/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
+++ b/content/docs/08-migration-guides/26-migration-guide-5-0.mdx
@@ -1294,15 +1294,15 @@ import {
   lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
 
-const { messages, sendMessage, addToolResult } = useChat({
+const { messages, sendMessage, addToolOutput } = useChat({
   // Automatically submit when all tool results are available
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
   async onToolCall({ toolCall }) {
     const result = await executeToolCall(toolCall);
 
-    // Important: Don't await addToolResult inside onToolCall to avoid deadlocks
-    addToolResult({
+    // Important: Don't await addToolOutput inside onToolCall to avoid deadlocks
+    addToolOutput({
       tool: toolCall.toolName,
       toolCallId: toolCall.toolCallId,
       output: result,
@@ -1313,7 +1313,7 @@ const { messages, sendMessage, addToolResult } = useChat({
 
 <Note>
   Important: When using `sendAutomaticallyWhen`, don't use `await` with
-  `addToolResult` inside `onToolCall` as it can cause deadlocks. The `await` is
+  `addToolOutput` inside `onToolCall` as it can cause deadlocks. The `await` is
   useful when you're not using automatic submission and need to ensure the
   messages are updated before manually calling `sendMessage()`.
 </Note>
@@ -1613,9 +1613,9 @@ import type { RequestOptions } from 'ai';
 import type { CompletionRequestOptions } from 'ai';
 ```
 
-#### addToolResult Changes
+#### addToolResult Renamed to addToolOutput
 
-In the `addToolResult` function, the `result` parameter has been renamed to `output` for consistency with other tool-related APIs.
+The `addToolResult` method has been renamed to `addToolOutput`. Additionally, the `result` parameter has been renamed to `output` for consistency with other tool-related APIs.
 
 ```tsx filename="AI SDK 4.0"
 const { addToolResult } = useChat();
@@ -1628,24 +1628,29 @@ addToolResult({
 ```
 
 ```tsx filename="AI SDK 5.0"
-const { addToolResult } = useChat();
+const { addToolOutput } = useChat();
 
-// Add tool result with 'output' parameter and 'tool' name for type safety
-addToolResult({
+// Add tool output with 'output' parameter and 'tool' name for type safety
+addToolOutput({
   tool: 'getWeather',
   toolCallId: 'tool-call-123',
   output: 'Weather: 72°F, sunny',
 });
 ```
 
+<Note>
+  `addToolResult` is still available but deprecated. It will be removed in
+  version 6.
+</Note>
+
 #### Tool Result Submission Changes
 
 The automatic tool result submission behavior has been updated in `useChat` and the `Chat` component. You now have more control and flexibility over when tool results are submitted.
 
 - `onToolCall` no longer supports returning values to automatically submit tool results
-- You must explicitly call `addToolResult` to provide tool results
+- You must explicitly call `addToolOutput` to provide tool results
 - Use `sendAutomaticallyWhen` with `lastAssistantMessageIsCompleteWithToolCalls` helper for automatic submission
-- Important: Don't use `await` with `addToolResult` inside `onToolCall` to avoid deadlocks
+- Important: Don't use `await` with `addToolOutput` inside `onToolCall` to avoid deadlocks
 - The `maxSteps` parameter has been removed from the `Chat` component and `useChat` hook
 - For multi-step tool execution, use server-side `stopWhen` conditions instead (see [maxSteps Removal](#maxsteps-removal))
 
@@ -1670,7 +1675,7 @@ import {
   lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
 
-const { messages, sendMessage, addToolResult } = useChat({
+const { messages, sendMessage, addToolOutput } = useChat({
   // Automatic submission with helper
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
@@ -1679,7 +1684,7 @@ const { messages, sendMessage, addToolResult } = useChat({
       const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
 
       // Important: Don't await inside onToolCall to avoid deadlocks
-      addToolResult({
+      addToolOutput({
         tool: 'getLocation',
         toolCallId: toolCall.toolCallId,
         output: cities[Math.floor(Math.random() * cities.length)],

--- a/content/docs/09-troubleshooting/05-tool-invocation-missing-result.mdx
+++ b/content/docs/09-troubleshooting/05-tool-invocation-missing-result.mdx
@@ -11,7 +11,7 @@ When using `generateText()` or `streamText()`, you may encounter the error "Tool
 
 ## Cause
 
-The error occurs when you define a tool without an `execute` function and don't provide the result through other means (like `useChat`'s `onToolCall` or `addToolResult` functions).
+The error occurs when you define a tool without an `execute` function and don't provide the result through other means (like `useChat`'s `onToolCall` or `addToolOutput` functions).
 
 Each time a tool is invoked, the model expects to receive a result before continuing the conversation. Without a result, the model cannot determine if the tool call succeeded or failed and the conversation state becomes invalid.
 
@@ -38,7 +38,7 @@ const tools = {
 };
 ```
 
-2. Client-side execution with `useChat` (omitting the `execute` function), you must provide results using `addToolResult`:
+2. Client-side execution with `useChat` (omitting the `execute` function), you must provide results using `addToolOutput`:
 
 ```tsx
 import { useChat } from '@ai-sdk/react';
@@ -47,7 +47,7 @@ import {
   lastAssistantMessageIsCompleteWithToolCalls,
 } from 'ai';
 
-const { messages, sendMessage, addToolResult } = useChat({
+const { messages, sendMessage, addToolOutput } = useChat({
   // Automatically submit when all tool results are available
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
@@ -58,14 +58,14 @@ const { messages, sendMessage, addToolResult } = useChat({
         const result = await getLocationData();
 
         // Important: Don't await inside onToolCall to avoid deadlocks
-        addToolResult({
+        addToolOutput({
           tool: 'getLocation',
           toolCallId: toolCall.toolCallId,
           output: result,
         });
       } catch (err) {
         // Important: Don't await inside onToolCall to avoid deadlocks
-        addToolResult({
+        addToolOutput({
           tool: 'getLocation',
           toolCallId: toolCall.toolCallId,
           state: 'output-error',
@@ -79,7 +79,7 @@ const { messages, sendMessage, addToolResult } = useChat({
 
 ```tsx
 // For interactive UI elements:
-const { messages, sendMessage, addToolResult } = useChat({
+const { messages, sendMessage, addToolOutput } = useChat({
   transport: new DefaultChatTransport({ api: '/api/chat' }),
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 });
@@ -87,7 +87,7 @@ const { messages, sendMessage, addToolResult } = useChat({
 // Inside your JSX, when rendering tool calls:
 <button
   onClick={() =>
-    addToolResult({
+    addToolOutput({
       tool: 'myTool',
       toolCallId, // must provide tool call ID
       output: {

--- a/content/docs/09-troubleshooting/18-ontoolcall-type-narrowing.mdx
+++ b/content/docs/09-troubleshooting/18-ontoolcall-type-narrowing.mdx
@@ -5,7 +5,7 @@ description: How to handle TypeScript type errors when using the onToolCall call
 
 # Type Error with onToolCall
 
-When using the `onToolCall` callback with TypeScript, you may encounter type errors when trying to pass tool properties directly to `addToolResult`.
+When using the `onToolCall` callback with TypeScript, you may encounter type errors when trying to pass tool properties directly to `addToolOutput`.
 
 ## Problem
 
@@ -13,9 +13,9 @@ TypeScript cannot automatically narrow the type of `toolCall.toolName` when you 
 
 ```tsx
 // ❌ This causes a TypeScript error
-const { messages, sendMessage, addToolResult } = useChat({
+const { messages, sendMessage, addToolOutput } = useChat({
   async onToolCall({ toolCall }) {
-    addToolResult({
+    addToolOutput({
       tool: toolCall.toolName, // Type 'string' is not assignable to type '"yourTool" | "yourOtherTool"'
       toolCallId: toolCall.toolCallId,
       output: someOutput,
@@ -36,7 +36,7 @@ Check if the tool is dynamic first to enable proper type narrowing:
 
 ```tsx
 // ✅ Correct approach with type narrowing
-const { messages, sendMessage, addToolResult } = useChat({
+const { messages, sendMessage, addToolOutput } = useChat({
   async onToolCall({ toolCall }) {
     // Check if it's a dynamic tool first
     if (toolCall.dynamic) {
@@ -44,7 +44,7 @@ const { messages, sendMessage, addToolResult } = useChat({
     }
 
     // Now TypeScript knows this is a static tool with the correct type
-    addToolResult({
+    addToolOutput({
       tool: toolCall.toolName, // No type error!
       toolCallId: toolCall.toolCallId,
       output: someOutput,
@@ -52,6 +52,12 @@ const { messages, sendMessage, addToolResult } = useChat({
   },
 });
 ```
+
+<Note>
+  If you're still using the deprecated `addToolResult` method, this solution
+  applies the same way. Consider migrating to `addToolOutput` for consistency
+  with the latest API.
+</Note>
 
 ## Related
 

--- a/examples/next-openai/app/use-chat-human-in-the-loop/page.tsx
+++ b/examples/next-openai/app/use-chat-human-in-the-loop/page.tsx
@@ -15,7 +15,7 @@ import {
 
 export default function Chat() {
   const [input, setInput] = useState('');
-  const { messages, sendMessage, addToolResult } =
+  const { messages, sendMessage, addToolOutput } =
     useChat<HumanInTheLoopUIMessage>({
       transport: new DefaultChatTransport({
         api: '/api/use-chat-human-in-the-loop',
@@ -64,7 +64,7 @@ export default function Chat() {
                       <button
                         className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700"
                         onClick={async () => {
-                          await addToolResult({
+                          await addToolOutput({
                             toolCallId,
                             tool: toolName,
                             output: APPROVAL.YES,
@@ -79,7 +79,7 @@ export default function Chat() {
                       <button
                         className="px-4 py-2 font-bold text-white bg-red-500 rounded hover:bg-red-700"
                         onClick={async () => {
-                          await addToolResult({
+                          await addToolOutput({
                             toolCallId,
                             tool: toolName,
                             output: APPROVAL.NO,

--- a/examples/next-openai/app/use-chat-reasoning-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-reasoning-tools/page.tsx
@@ -6,7 +6,7 @@ import { DefaultChatTransport } from 'ai';
 import { ReasoningToolsMessage } from '../api/use-chat-reasoning-tools/route';
 
 export default function Chat() {
-  const { messages, sendMessage, addToolResult, status } =
+  const { messages, sendMessage, addToolOutput, status } =
     useChat<ReasoningToolsMessage>({
       transport: new DefaultChatTransport({
         api: '/api/use-chat-reasoning-tools',

--- a/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
+++ b/examples/next-openai/app/use-chat-streaming-tool-calls/page.tsx
@@ -9,7 +9,7 @@ import {
 import { StreamingToolCallsMessage } from '../api/use-chat-streaming-tool-calls/route';
 
 export default function Chat() {
-  const { messages, status, sendMessage, addToolResult } =
+  const { messages, status, sendMessage, addToolOutput } =
     useChat<StreamingToolCallsMessage>({
       transport: new DefaultChatTransport({
         api: '/api/use-chat-streaming-tool-calls',
@@ -21,7 +21,7 @@ export default function Chat() {
       async onToolCall({ toolCall }) {
         if (toolCall.toolName === 'showWeatherInformation') {
           // display tool. add tool result that informs the llm that the tool was executed.
-          addToolResult({
+          addToolOutput({
             tool: 'showWeatherInformation',
             toolCallId: toolCall.toolCallId,
             output: 'Weather information was shown to the user.',

--- a/examples/next-openai/app/use-chat-tools/page.tsx
+++ b/examples/next-openai/app/use-chat-tools/page.tsx
@@ -9,7 +9,7 @@ import {
 import { UseChatToolsMessage } from '../api/use-chat-tools/route';
 
 export default function Chat() {
-  const { messages, sendMessage, addToolResult, status } =
+  const { messages, sendMessage, addToolOutput, status } =
     useChat<UseChatToolsMessage>({
       transport: new DefaultChatTransport({ api: '/api/use-chat-tools' }),
       sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
@@ -27,7 +27,7 @@ export default function Chat() {
             'San Francisco',
           ];
 
-          addToolResult({
+          addToolOutput({
             tool: 'getLocation',
             toolCallId: toolCall.toolCallId,
             output: cities[Math.floor(Math.random() * cities.length)],
@@ -63,7 +63,7 @@ export default function Chat() {
                           <button
                             className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700"
                             onClick={async () => {
-                              addToolResult({
+                              addToolOutput({
                                 tool: 'askForConfirmation',
                                 toolCallId: part.toolCallId,
                                 output: 'Yes, confirmed.',
@@ -75,7 +75,7 @@ export default function Chat() {
                           <button
                             className="px-4 py-2 font-bold text-white bg-red-500 rounded hover:bg-red-700"
                             onClick={async () => {
-                              addToolResult({
+                              addToolOutput({
                                 tool: 'askForConfirmation',
                                 toolCallId: part.toolCallId,
                                 output: 'No, denied',

--- a/examples/nuxt-openai/pages/use-chat-tools/index.vue
+++ b/examples/nuxt-openai/pages/use-chat-tools/index.vue
@@ -12,7 +12,7 @@ const chat = new Chat({
     if (toolCall.toolName === 'getLocation') {
       const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
       const location = cities[Math.floor(Math.random() * cities.length)];
-
+      
       await chat.addToolOutput({
         toolCallId: toolCall.toolCallId,
         tool: 'getLocation',
@@ -49,7 +49,10 @@ const handleSubmit = (e: Event) => {
         </template>
         <template v-else-if="part.type === 'tool-askForConfirmation'">
           <template v-if="part.state === 'input-available'">
-            <div :key="part.toolCallId" className="text-gray-500">
+            <div
+              :key="part.toolCallId"
+              className="text-gray-500"
+            >
               {{ (part.input as { message: string }).message }}
               <div className="flex gap-2">
                 <button
@@ -80,19 +83,28 @@ const handleSubmit = (e: Event) => {
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div :key="part.toolCallId" className="text-gray-500">
+            <div
+              :key="part.toolCallId"
+              className="text-gray-500"
+            >
               Location access allowed: {{ part.output }}
             </div>
           </template>
         </template>
         <template v-else-if="part.type === 'tool-getLocation'">
           <template v-if="part.state === 'input-available'">
-            <div :key="part.toolCallId" className="text-gray-500">
+            <div
+              :key="part.toolCallId"
+              className="text-gray-500"
+            >
               Getting location...
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div :key="part.toolCallId" className="text-gray-500">
+            <div
+              :key="part.toolCallId"
+              className="text-gray-500"
+            >
               Location: {{ part.output }}
             </div>
           </template>
@@ -104,13 +116,19 @@ const handleSubmit = (e: Event) => {
             </pre>
           </template>
           <template v-if="part.state === 'input-available'">
-            <div :key="part.toolCallId" className="text-gray-500">
+            <div
+              :key="part.toolCallId"
+              className="text-gray-500"
+            >
               Getting weather information for
               {{ (part.input as { city: string }).city }}...
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div :key="part.toolCallId" className="text-gray-500">
+            <div
+              :key="part.toolCallId"
+              className="text-gray-500"
+            >
               Weather in {{ (part.input as { city: string }).city }}:
               {{ part.output }}
             </div>

--- a/examples/nuxt-openai/pages/use-chat-tools/index.vue
+++ b/examples/nuxt-openai/pages/use-chat-tools/index.vue
@@ -12,8 +12,8 @@ const chat = new Chat({
     if (toolCall.toolName === 'getLocation') {
       const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
       const location = cities[Math.floor(Math.random() * cities.length)];
-      
-      await chat.addToolResult({
+
+      await chat.addToolOutput({
         toolCallId: toolCall.toolCallId,
         tool: 'getLocation',
         output: location,
@@ -49,16 +49,13 @@ const handleSubmit = (e: Event) => {
         </template>
         <template v-else-if="part.type === 'tool-askForConfirmation'">
           <template v-if="part.state === 'input-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               {{ (part.input as { message: string }).message }}
               <div className="flex gap-2">
                 <button
                   class="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700"
                   @click="
-                    chat.addToolResult({
+                    chat.addToolOutput({
                       toolCallId: part.toolCallId,
                       tool: 'askForConfirmation',
                       output: 'Yes, confirmed.',
@@ -70,7 +67,7 @@ const handleSubmit = (e: Event) => {
                 <button
                   class="px-4 py-2 font-bold text-white bg-red-500 rounded hover:bg-red-700"
                   @click="
-                    chat.addToolResult({
+                    chat.addToolOutput({
                       toolCallId: part.toolCallId,
                       tool: 'askForConfirmation',
                       output: 'No, denied',
@@ -83,28 +80,19 @@ const handleSubmit = (e: Event) => {
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Location access allowed: {{ part.output }}
             </div>
           </template>
         </template>
         <template v-else-if="part.type === 'tool-getLocation'">
           <template v-if="part.state === 'input-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Getting location...
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Location: {{ part.output }}
             </div>
           </template>
@@ -116,19 +104,13 @@ const handleSubmit = (e: Event) => {
             </pre>
           </template>
           <template v-if="part.state === 'input-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Getting weather information for
               {{ (part.input as { city: string }).city }}...
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Weather in {{ (part.input as { city: string }).city }}:
               {{ part.output }}
             </div>

--- a/examples/nuxt-openai/pages/use-chat-tools/index.vue
+++ b/examples/nuxt-openai/pages/use-chat-tools/index.vue
@@ -12,7 +12,7 @@ const chat = new Chat({
     if (toolCall.toolName === 'getLocation') {
       const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
       const location = cities[Math.floor(Math.random() * cities.length)];
-      
+
       await chat.addToolOutput({
         toolCallId: toolCall.toolCallId,
         tool: 'getLocation',
@@ -49,10 +49,7 @@ const handleSubmit = (e: Event) => {
         </template>
         <template v-else-if="part.type === 'tool-askForConfirmation'">
           <template v-if="part.state === 'input-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               {{ (part.input as { message: string }).message }}
               <div className="flex gap-2">
                 <button
@@ -83,28 +80,19 @@ const handleSubmit = (e: Event) => {
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Location access allowed: {{ part.output }}
             </div>
           </template>
         </template>
         <template v-else-if="part.type === 'tool-getLocation'">
           <template v-if="part.state === 'input-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Getting location...
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Location: {{ part.output }}
             </div>
           </template>
@@ -116,19 +104,13 @@ const handleSubmit = (e: Event) => {
             </pre>
           </template>
           <template v-if="part.state === 'input-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Getting weather information for
               {{ (part.input as { city: string }).city }}...
             </div>
           </template>
           <template v-if="part.state === 'output-available'">
-            <div
-              :key="part.toolCallId"
-              className="text-gray-500"
-            >
+            <div :key="part.toolCallId" className="text-gray-500">
               Weather in {{ (part.input as { city: string }).city }}:
               {{ part.output }}
             </div>

--- a/examples/sveltekit-openai/src/routes/chat/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat/+page.svelte
@@ -14,7 +14,7 @@
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
         const location = cities[Math.floor(Math.random() * cities.length)];
 
-        await chat.addToolResult({
+        await chat.addToolOutput({
           toolCallId: toolCall.toolCallId,
           tool: 'getLocation',
           output: location,
@@ -66,7 +66,7 @@
                     <Button
                       variant="default"
                       onclick={() =>
-                        chat.addToolResult({
+                        chat.addToolOutput({
                           toolCallId,
                           tool: 'askForConfirmation',
                           output: 'Yes, confirmed',
@@ -75,7 +75,7 @@
                     <Button
                       variant="secondary"
                       onclick={() =>
-                        chat.addToolResult({
+                        chat.addToolOutput({
                           toolCallId,
                           tool: 'askForConfirmation',
                           output: 'No, denied',

--- a/examples/sveltekit-openai/src/routes/chat/[id]/+page.svelte
+++ b/examples/sveltekit-openai/src/routes/chat/[id]/+page.svelte
@@ -16,7 +16,7 @@
         const cities = ['New York', 'Los Angeles', 'Chicago', 'San Francisco'];
         const location = cities[Math.floor(Math.random() * cities.length)];
 
-        await chat.addToolResult({
+        await chat.addToolOutput({
           toolCallId: toolCall.toolCallId,
           tool: 'getLocation',
           output: location,
@@ -67,7 +67,7 @@
                     <Button
                       variant="default"
                       onclick={() =>
-                        chat.addToolResult({
+                        chat.addToolOutput({
                           toolCallId: part.toolCallId,
                           tool: 'askForConfirmation',
                           output: 'Yes, confirmed',
@@ -76,7 +76,7 @@
                     <Button
                       variant="secondary"
                       onclick={() =>
-                        chat.addToolResult({
+                        chat.addToolOutput({
                           toolCallId: part.toolCallId,
                           tool: 'askForConfirmation',
                           output: 'No, denied',

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1451,7 +1451,7 @@ describe('Chat', () => {
   });
 
   describe('sendAutomaticallyWhen', () => {
-    it('should delay tool result submission until the stream is finished', async () => {
+    it('should delay tool output submission until the stream is finished', async () => {
       const controller1 = new TestResponseController();
 
       server.urls['http://localhost:3000/api/chat'].response = [
@@ -1500,14 +1500,14 @@ describe('Chat', () => {
 
       await toolCallPromise.promise;
 
-      // user submits the tool result
-      await chat.addToolResult({
+      // user submits the tool output
+      await chat.addToolOutput({
         tool: 'test-tool',
         toolCallId: 'tool-call-0',
-        output: 'test-result',
+        output: 'test-output',
       });
 
-      // UI should show the tool result
+      // UI should show the tool output
       expect(chat.messages).toMatchInlineSnapshot(`
         [
           {
@@ -1533,7 +1533,7 @@ describe('Chat', () => {
                 "input": {
                   "testArg": "test-value",
                 },
-                "output": "test-result",
+                "output": "test-output",
                 "preliminary": undefined,
                 "providerExecuted": undefined,
                 "rawInput": undefined,
@@ -1588,7 +1588,7 @@ describe('Chat', () => {
                   "input": {
                     "testArg": "test-value",
                   },
-                  "output": "test-result",
+                  "output": "test-output",
                   "state": "output-available",
                   "toolCallId": "tool-call-0",
                   "type": "tool-test-tool",
@@ -1602,7 +1602,7 @@ describe('Chat', () => {
       `);
     });
 
-    it('should send message when a tool result is submitted', async () => {
+    it('should send message when a tool output is submitted', async () => {
       server.urls['http://localhost:3000/api/chat'].response = [
         {
           type: 'stream-chunks',
@@ -1652,14 +1652,14 @@ describe('Chat', () => {
         text: 'Hello, world!',
       });
 
-      // user submits the tool result
-      await chat.addToolResult({
+      // user submits the tool output
+      await chat.addToolOutput({
         tool: 'test-tool',
         toolCallId: 'tool-call-0',
-        output: 'test-result',
+        output: 'test-output',
       });
 
-      // UI should show the tool result
+      // UI should show the tool output
       expect(chat.messages).toMatchInlineSnapshot(`
         [
           {
@@ -1685,7 +1685,7 @@ describe('Chat', () => {
                 "input": {
                   "testArg": "test-value",
                 },
-                "output": "test-result",
+                "output": "test-output",
                 "preliminary": undefined,
                 "providerExecuted": undefined,
                 "rawInput": undefined,
@@ -1731,7 +1731,7 @@ describe('Chat', () => {
                   "input": {
                     "testArg": "test-value",
                   },
-                  "output": "test-result",
+                  "output": "test-output",
                   "state": "output-available",
                   "toolCallId": "tool-call-0",
                   "type": "tool-test-tool",
@@ -1795,15 +1795,15 @@ describe('Chat', () => {
         text: 'Hello, world!',
       });
 
-      // user submits the tool result
-      await chat.addToolResult({
+      // user submits the tool output
+      await chat.addToolOutput({
         state: 'output-error',
         tool: 'test-tool',
         toolCallId: 'tool-call-0',
         errorText: 'test-error',
       });
 
-      // UI should show the tool result
+      // UI should show the tool output
       expect(chat.messages).toMatchInlineSnapshot(`
         [
           {
@@ -1889,7 +1889,7 @@ describe('Chat', () => {
       `);
     });
 
-    it('should send message when a dynamic tool result is submitted', async () => {
+    it('should send message when a dynamic tool output is submitted', async () => {
       server.urls['http://localhost:3000/api/chat'].response = [
         {
           type: 'stream-chunks',
@@ -1947,15 +1947,15 @@ describe('Chat', () => {
         text: 'Hello, world!',
       });
 
-      // user submits the tool result
-      await chat.addToolResult({
+      // user submits the tool output
+      await chat.addToolOutput({
         state: 'output-available',
         tool: 'test-tool',
         toolCallId: 'tool-call-0',
-        output: 'test-result',
+        output: 'test-output',
       });
 
-      // UI should show the tool result
+      // UI should show the tool output
       expect(chat.messages).toMatchInlineSnapshot(`
         [
           {
@@ -1981,7 +1981,7 @@ describe('Chat', () => {
                 "input": {
                   "testArg": "test-value",
                 },
-                "output": "test-result",
+                "output": "test-output",
                 "preliminary": undefined,
                 "providerExecuted": undefined,
                 "state": "output-available",
@@ -2027,7 +2027,7 @@ describe('Chat', () => {
                   "input": {
                     "testArg": "test-value",
                   },
-                  "output": "test-result",
+                  "output": "test-output",
                   "state": "output-available",
                   "toolCallId": "tool-call-0",
                   "toolName": "test-tool",
@@ -2067,7 +2067,7 @@ describe('Chat', () => {
                 "input": {
                   "testArg": "test-value",
                 },
-                "output": "test-result",
+                "output": "test-output",
                 "preliminary": undefined,
                 "providerExecuted": undefined,
                 "state": "output-available",
@@ -2139,15 +2139,15 @@ describe('Chat', () => {
         text: 'Hello, world!',
       });
 
-      // user submits the tool result
-      await chat.addToolResult({
+      // user submits the tool output
+      await chat.addToolOutput({
         state: 'output-available',
         tool: 'test-tool',
         toolCallId: 'tool-call-0',
-        output: 'test-result',
+        output: 'test-output',
       });
 
-      // UI should show the tool result
+      // UI should show the tool output
       expect(chat.messages).toMatchInlineSnapshot(`
         [
           {
@@ -2173,7 +2173,7 @@ describe('Chat', () => {
                 "input": {
                   "testArg": "test-value",
                 },
-                "output": "test-result",
+                "output": "test-output",
                 "preliminary": undefined,
                 "providerExecuted": undefined,
                 "state": "output-available",
@@ -2219,7 +2219,7 @@ describe('Chat', () => {
                   "input": {
                     "testArg": "test-value",
                   },
-                  "output": "test-result",
+                  "output": "test-output",
                   "state": "output-available",
                   "toolCallId": "tool-call-0",
                   "toolName": "test-tool",
@@ -2259,7 +2259,7 @@ describe('Chat', () => {
                 "input": {
                   "testArg": "test-value",
                 },
-                "output": "test-result",
+                "output": "test-output",
                 "preliminary": undefined,
                 "providerExecuted": undefined,
                 "state": "output-available",
@@ -2525,6 +2525,151 @@ describe('Chat', () => {
           ]
         `);
       });
+    });
+  });
+
+  describe('addToolResult', () => {
+    it('should send message when a tool result is submitted', async () => {
+      server.urls['http://localhost:3000/api/chat'].response = [
+        {
+          type: 'stream-chunks',
+          chunks: [
+            formatChunk({ type: 'start' }),
+            formatChunk({ type: 'start-step' }),
+            formatChunk({
+              type: 'tool-input-available',
+              toolCallId: 'tool-call-0',
+              toolName: 'test-tool',
+              input: { testArg: 'test-value' },
+            }),
+            formatChunk({ type: 'finish-step' }),
+            formatChunk({ type: 'finish' }),
+          ],
+        },
+        {
+          type: 'stream-chunks',
+          chunks: [
+            formatChunk({ type: 'start' }),
+            formatChunk({ type: 'start-step' }),
+            formatChunk({ type: 'finish-step' }),
+            formatChunk({ type: 'finish' }),
+          ],
+        },
+      ];
+
+      let callCount = 0;
+      const onFinishPromise = createResolvablePromise<void>();
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: new DefaultChatTransport({
+          api: 'http://localhost:3000/api/chat',
+        }),
+        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+        onFinish: () => {
+          callCount++;
+          if (callCount === 2) {
+            onFinishPromise.resolve();
+          }
+        },
+      });
+
+      await chat.sendMessage({
+        text: 'Hello, world!',
+      });
+
+      // user submits the tool output
+      await chat.addToolOutput({
+        tool: 'test-tool',
+        toolCallId: 'tool-call-0',
+        output: 'test-output',
+      });
+
+      // UI should show the tool output
+      expect(chat.messages).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "id-0",
+            "metadata": undefined,
+            "parts": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+          {
+            "id": "id-1",
+            "metadata": undefined,
+            "parts": [
+              {
+                "type": "step-start",
+              },
+              {
+                "errorText": undefined,
+                "input": {
+                  "testArg": "test-value",
+                },
+                "output": "test-output",
+                "preliminary": undefined,
+                "providerExecuted": undefined,
+                "rawInput": undefined,
+                "state": "output-available",
+                "title": undefined,
+                "toolCallId": "tool-call-0",
+                "type": "tool-test-tool",
+              },
+            ],
+            "role": "assistant",
+          },
+        ]
+      `);
+
+      await onFinishPromise.promise;
+
+      // 2nd call should happen after the stream is finished
+      expect(server.calls.length).toBe(2);
+
+      // check details of the 2nd call
+      expect(await server.calls[1].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "id": "123",
+          "messageId": "id-1",
+          "messages": [
+            {
+              "id": "id-0",
+              "parts": [
+                {
+                  "text": "Hello, world!",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "id": "id-1",
+              "parts": [
+                {
+                  "type": "step-start",
+                },
+                {
+                  "input": {
+                    "testArg": "test-value",
+                  },
+                  "output": "test-output",
+                  "state": "output-available",
+                  "toolCallId": "tool-call-0",
+                  "type": "tool-test-tool",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          "trigger": "submit-message",
+        }
+      `);
     });
   });
 });

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -2580,7 +2580,7 @@ describe('Chat', () => {
       });
 
       // user submits the tool output
-      await chat.addToolOutput({
+      await chat.addToolResult({
         tool: 'test-tool',
         toolCallId: 'tool-call-0',
         output: 'test-output',

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -18,7 +18,6 @@ import {
 import {
   InferUIMessageToolCall,
   isToolOrDynamicToolUIPart,
-  isToolUIPart,
   UIMessagePart,
   UITools,
   type DataUIPart,
@@ -475,7 +474,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       }
     });
 
-  addToolResult = async <TOOL extends keyof InferUIMessageTools<UI_MESSAGE>>({
+  addToolOutput = async <TOOL extends keyof InferUIMessageTools<UI_MESSAGE>>({
     state = 'output-available',
     tool,
     toolCallId,
@@ -532,6 +531,9 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         });
       }
     });
+
+  /** @deprecated Use addToolOutput */
+  addToolResult = this.addToolOutput;
 
   /**
    * Abort the current request immediately, keep the generated tokens if any.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -163,7 +163,7 @@ await chat.regenerate(options?: {
 });
 
 // Add tool execution result
-chat.addToolResult({
+chat.addToolOutput({
   toolCallId: string;
   output: string;
 });

--- a/packages/angular/src/lib/chat.ng.test.ts
+++ b/packages/angular/src/lib/chat.ng.test.ts
@@ -419,7 +419,7 @@ describe('onToolCall', () => {
     chat = new Chat({
       async onToolCall({ toolCall }) {
         await toolCallPromise;
-        chat.addToolResult({
+        chat.addToolOutput({
           tool: 'test-tool',
           toolCallId: toolCall.toolCallId,
           output: `test-tool-response: ${toolCall.toolName} ${
@@ -697,7 +697,7 @@ describe('tool invocations', () => {
     ]);
   });
 
-  it('should update tool call to result when addToolResult is called', async () => {
+  it('should update tool call to result when addToolOutput is called', async () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
@@ -731,7 +731,7 @@ describe('tool invocations', () => {
       ]);
     });
 
-    chat.addToolResult({
+    chat.addToolOutput({
       tool: 'test-tool',
       toolCallId: 'tool-call-0',
       output: 'test-result',

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -98,6 +98,7 @@ npx @ai-sdk/codemod v5/rename-format-stream-part .
 | `v5/remove-openai-compatibility`                                      | Transforms v5/remove openai compatibility                                      |
 | `v5/remove-sendExtraMessageFields`                                    | Transforms v5/remove sendExtraMessageFields                                    |
 | `v5/rename-IDGenerator-to-IdGenerator`                                | Transforms v5/rename IDGenerator to IdGenerator                                |
+| `v5/rename-addtoolresult-to-addtooloutput`                            | Transforms v5/rename addtoolresult to addtooloutput                            |
 | `v5/rename-converttocoremessages-to-converttomodelmessages`           | Transforms v5/rename converttocoremessages to converttomodelmessages           |
 | `v5/rename-core-message-to-model-message`                             | Transforms v5/rename core message to model message                             |
 | `v5/rename-datastream-methods-to-uimessage`                           | Transforms v5/rename datastream methods to uimessage                           |

--- a/packages/codemod/src/codemods/v5/rename-addtoolresult-to-addtooloutput.ts
+++ b/packages/codemod/src/codemods/v5/rename-addtoolresult-to-addtooloutput.ts
@@ -1,0 +1,137 @@
+import { createTransformer } from '../lib/create-transformer';
+
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  // Track variable names that were renamed from addToolResult to addToolOutput
+  const renamedVariables = new Set<string>();
+
+  // Replace member expressions (e.g., chat.addToolResult, options.addToolResult)
+  root
+    .find(j.MemberExpression, {
+      property: { name: 'addToolOutput' },
+    })
+    .forEach(path => {
+      context.hasChanges = true;
+      path.node.property = j.identifier('addToolOutput');
+    });
+
+  // Replace destructured identifiers in object patterns
+  root.find(j.ObjectPattern).forEach(path => {
+    let hasPatternChanges = false;
+    path.node.properties.forEach(prop => {
+      // Handle both ObjectProperty and Property nodes in destructuring
+      if (
+        (prop.type === 'ObjectProperty' || prop.type === 'Property') &&
+        prop.key.type === 'Identifier' &&
+        prop.key.name === 'addToolOutput'
+      ) {
+        prop.key = j.identifier('addToolOutput');
+        // If it's shorthand, update the value as well
+        if (prop.shorthand && prop.value.type === 'Identifier') {
+          // Track the old name before renaming
+          renamedVariables.add(prop.value.name);
+          prop.value = j.identifier('addToolOutput');
+        } else if (prop.value.type === 'Identifier') {
+          // For non-shorthand like { addToolResult: localName }, track localName
+          renamedVariables.add(prop.value.name);
+        }
+        hasPatternChanges = true;
+      }
+    });
+    if (hasPatternChanges) {
+      context.hasChanges = true;
+    }
+  });
+
+  // Replace object property shorthand (e.g., { addToolResult })
+  root
+    .find(j.Property, {
+      key: { name: 'addToolOutput' },
+      shorthand: true,
+    })
+    .forEach(path => {
+      context.hasChanges = true;
+      if (path.node.value.type === 'Identifier') {
+        renamedVariables.add(path.node.value.name);
+      }
+      path.node.key = j.identifier('addToolOutput');
+      path.node.value = j.identifier('addToolOutput');
+    });
+
+  // Replace non-shorthand object properties (e.g., { addToolResult: func })
+  root
+    .find(j.ObjectProperty, {
+      key: { name: 'addToolOutput' },
+    })
+    .forEach(path => {
+      context.hasChanges = true;
+      path.node.key = j.identifier('addToolOutput');
+    });
+
+  // Replace non-shorthand Property nodes
+  root
+    .find(j.Property, {
+      key: { name: 'addToolOutput' },
+      shorthand: false,
+    })
+    .forEach(path => {
+      context.hasChanges = true;
+      path.node.key = j.identifier('addToolOutput');
+    });
+
+  // Replace all references to renamed variables
+  if (renamedVariables.size > 0) {
+    root
+      .find(j.Identifier)
+      .filter(path => {
+        return (
+          renamedVariables.has(path.node.name) &&
+          // Don't modify the variable declaration itself
+          !(
+            path.parent.node.type === 'Property' &&
+            path.parent.node.value === path.node
+          ) &&
+          !(
+            path.parent.node.type === 'ObjectProperty' &&
+            path.parent.node.value === path.node
+          )
+        );
+      })
+      .forEach(path => {
+        context.hasChanges = true;
+        if (path.node.name === 'addToolOutput') {
+          path.node.name = 'addToolOutput';
+        }
+      });
+  }
+
+  // Replace TypeScript interface/type properties
+  root
+    .find(j.TSPropertySignature)
+    .filter(path => {
+      const key = path.node.key;
+      return (
+        (key.type === 'Identifier' && key.name === 'addToolOutput') ||
+        (key.type === 'StringLiteral' && key.value === 'addToolOutput')
+      );
+    })
+    .forEach(path => {
+      const key = path.node.key;
+      if (key.type === 'Identifier') {
+        key.name = 'addToolOutput';
+        context.hasChanges = true;
+      } else if (key.type === 'StringLiteral') {
+        key.value = 'addToolOutput';
+        context.hasChanges = true;
+      }
+    });
+
+  // Replace string literals in type unions (e.g., Pick<any, 'addToolResult' | 'sendMessage'>)
+  root.find(j.StringLiteral).forEach(path => {
+    if (path.node.value === 'addToolOutput') {
+      path.node.value = 'addToolOutput';
+      context.hasChanges = true;
+    }
+  });
+});

--- a/packages/codemod/src/lib/upgrade.ts
+++ b/packages/codemod/src/lib/upgrade.ts
@@ -78,6 +78,7 @@ const bundle = [
   'v5/rsc-package',
   'v5/move-tool-invocations-to-parts',
   'v5/not-implemented/pattern',
+  'v5/rename-addtoolresult-to-addtooloutput',
 ];
 
 const log = debug('codemod:upgrade');

--- a/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput-not-ai.input.tsx
+++ b/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput-not-ai.input.tsx
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import { addToolResult } from 'not-ai-package';
+
+// Should NOT be transformed - imported from different package
+function ChatComponent() {
+  return (
+    <button
+      onClick={() => {
+        addToolResult({
+          tool: 'test-tool',
+          toolCallId: 'call-1',
+          output: 'result',
+        });
+      }}
+    >
+      Submit Result
+    </button>
+  );
+}
+

--- a/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput-not-ai.output.tsx
+++ b/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput-not-ai.output.tsx
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import { addToolResult } from 'not-ai-package';
+
+// Should NOT be transformed - imported from different package
+function ChatComponent() {
+  return (
+    <button
+      onClick={() => {
+        addToolResult({
+          tool: 'test-tool',
+          toolCallId: 'call-1',
+          output: 'result',
+        });
+      }}
+    >
+      Submit Result
+    </button>
+  );
+}
+

--- a/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput.input.tsx
+++ b/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput.input.tsx
@@ -1,0 +1,110 @@
+// @ts-nocheck
+import { useChat } from 'ai';
+import { useChat as useReactChat } from '@ai-sdk/react';
+
+// Test 1: Destructuring from useChat hook
+function ChatComponent1() {
+  const { messages, sendMessage, addToolOutput } = useChat();
+
+  return (
+    (<button
+      onClick={() => {
+        addToolOutput({
+          tool: 'test-tool',
+          toolCallId: 'call-1',
+          output: 'result',
+        });
+      }}
+    >Submit Result
+          </button>)
+  );
+}
+
+// Test 2: Destructuring with alias
+function ChatComponent2() {
+  const { addToolOutput: submitToolResult } = useReactChat();
+
+  return (
+    <button onClick={() => submitToolResult({ tool: 'tool', toolCallId: 'id', output: 'data' })}>
+      Submit
+    </button>
+  );
+}
+
+// Test 3: Using chat object directly
+function ChatComponent3() {
+  const chat = useChat();
+
+  return (
+    (<button onClick={() => chat.addToolOutput({ tool: 'test', toolCallId: 'id', output: 'out' })}>Submit
+          </button>)
+  );
+}
+
+// Test 4: Object property shorthand
+function ChatComponent4() {
+  const { addToolOutput, sendMessage } = useChat();
+
+  const handlers = {
+    addToolOutput,
+    sendMessage,
+  };
+
+  return <div>{JSON.stringify(handlers)}</div>;
+}
+
+// Test 5: Object property non-shorthand
+const config = {
+  addToolOutput: (data: any) => console.log(data),
+  other: 'value',
+};
+
+// Test 6: Member expression in various contexts
+class ChatManager {
+  chat: any;
+
+  constructor(chat: any) {
+    this.chat = chat;
+  }
+
+  submitResult() {
+    this.chat.addToolOutput({ tool: 'test', toolCallId: 'id', output: 'result' });
+  }
+
+  getHandler() {
+    return this.chat.addToolOutput;
+  }
+}
+
+// Test 7: Passed as callback
+function processChat(callback: any) {
+  callback();
+}
+
+function ChatComponent5() {
+  const chat = useChat();
+
+  processChat(() => {
+    chat.addToolOutput({ tool: 'tool', toolCallId: 'id', output: 'data' });
+  });
+
+  return null;
+}
+
+// Test 8: Type annotation (should be renamed in Pick type)
+type ChatHelpers = Pick<any, 'sendMessage' | 'addToolOutput' | 'stop'>;
+
+// Test 9: Interface property
+interface IChatHandlers {
+  addToolOutput: (args: any) => void;
+  sendMessage: (msg: string) => void;
+}
+
+// Test 10: Should NOT transform - different package
+import { addToolOutput as otherToolResult } from 'other-package';
+
+function OtherComponent() {
+  otherToolResult({ tool: 'other', toolCallId: 'id', output: 'data' });
+  return null;
+}
+

--- a/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput.output.tsx
+++ b/packages/codemod/src/test/__testfixtures__/rename-addtoolresult-to-addtooloutput.output.tsx
@@ -1,0 +1,110 @@
+// @ts-nocheck
+import { useChat } from 'ai';
+import { useChat as useReactChat } from '@ai-sdk/react';
+
+// Test 1: Destructuring from useChat hook
+function ChatComponent1() {
+  const { messages, sendMessage, addToolOutput } = useChat();
+
+  return (
+    (<button
+      onClick={() => {
+        addToolOutput({
+          tool: 'test-tool',
+          toolCallId: 'call-1',
+          output: 'result',
+        });
+      }}
+    >Submit Result
+          </button>)
+  );
+}
+
+// Test 2: Destructuring with alias
+function ChatComponent2() {
+  const { addToolOutput: submitToolResult } = useReactChat();
+
+  return (
+    <button onClick={() => submitToolResult({ tool: 'tool', toolCallId: 'id', output: 'data' })}>
+      Submit
+    </button>
+  );
+}
+
+// Test 3: Using chat object directly
+function ChatComponent3() {
+  const chat = useChat();
+
+  return (
+    (<button onClick={() => chat.addToolOutput({ tool: 'test', toolCallId: 'id', output: 'out' })}>Submit
+                </button>)
+  );
+}
+
+// Test 4: Object property shorthand
+function ChatComponent4() {
+  const { addToolOutput, sendMessage } = useChat();
+
+  const handlers = {
+    addToolOutput,
+    sendMessage,
+  };
+
+  return <div>{JSON.stringify(handlers)}</div>;
+}
+
+// Test 5: Object property non-shorthand
+const config = {
+  addToolOutput: (data: any) => console.log(data),
+  other: 'value',
+};
+
+// Test 6: Member expression in various contexts
+class ChatManager {
+  chat: any;
+
+  constructor(chat: any) {
+    this.chat = chat;
+  }
+
+  submitResult() {
+    this.chat.addToolOutput({ tool: 'test', toolCallId: 'id', output: 'result' });
+  }
+
+  getHandler() {
+    return this.chat.addToolOutput;
+  }
+}
+
+// Test 7: Passed as callback
+function processChat(callback: any) {
+  callback();
+}
+
+function ChatComponent5() {
+  const chat = useChat();
+
+  processChat(() => {
+    chat.addToolOutput({ tool: 'tool', toolCallId: 'id', output: 'data' });
+  });
+
+  return null;
+}
+
+// Test 8: Type annotation (should be renamed in Pick type)
+type ChatHelpers = Pick<any, 'sendMessage' | 'addToolOutput' | 'stop'>;
+
+// Test 9: Interface property
+interface IChatHandlers {
+  addToolOutput: (args: any) => void;
+  sendMessage: (msg: string) => void;
+}
+
+// Test 10: Should NOT transform - different package
+import { addToolOutput as otherToolResult } from 'other-package';
+
+function OtherComponent() {
+  otherToolResult({ tool: 'other', toolCallId: 'id', output: 'data' });
+  return null;
+}
+

--- a/packages/codemod/src/test/rename-addtoolresult-to-addtooloutput.test.ts
+++ b/packages/codemod/src/test/rename-addtoolresult-to-addtooloutput.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v5/rename-addtoolresult-to-addtooloutput';
+import { testTransform } from './test-utils';
+
+describe('rename-addtoolresult-to-addtooloutput', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'rename-addtoolresult-to-addtooloutput');
+  });
+
+  it('does not transform from other packages', () => {
+    testTransform(
+      transformer,
+      'rename-addtoolresult-to-addtooloutput-not-ai',
+    );
+  });
+});
+

--- a/packages/codemod/src/test/rename-addtoolresult-to-addtooloutput.test.ts
+++ b/packages/codemod/src/test/rename-addtoolresult-to-addtooloutput.test.ts
@@ -8,10 +8,6 @@ describe('rename-addtoolresult-to-addtooloutput', () => {
   });
 
   it('does not transform from other packages', () => {
-    testTransform(
-      transformer,
-      'rename-addtoolresult-to-addtooloutput-not-ai',
-    );
+    testTransform(transformer, 'rename-addtoolresult-to-addtooloutput-not-ai');
   });
 });
-

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -32,6 +32,7 @@ export type UseChatHelpers<UI_MESSAGE extends UIMessage> = {
   | 'stop'
   | 'resumeStream'
   | 'addToolResult'
+  | 'addToolOutput'
   | 'addToolApprovalResponse'
   | 'status'
   | 'messages'
@@ -128,7 +129,11 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     error,
     resumeStream: chatRef.current.resumeStream,
     status,
-    addToolResult: chatRef.current.addToolResult,
+    /**
+     * @deprecated Use `addToolOutput` instead.
+     */
+    addToolResult: chatRef.current.addToolOutput,
+    addToolOutput: chatRef.current.addToolOutput,
     addToolApprovalResponse: chatRef.current.addToolApprovalResponse,
   };
 }

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -721,10 +721,10 @@ describe('onToolCall', () => {
   let toolCallPromise: Promise<void>;
 
   setupTestComponent(() => {
-    const { messages, sendMessage, addToolResult } = useChat({
+    const { messages, sendMessage, addToolOutput } = useChat({
       async onToolCall({ toolCall }) {
         await toolCallPromise;
-        addToolResult({
+        addToolOutput({
           tool: 'test-tool',
           toolCallId: toolCall.toolCallId,
           output: `test-tool-response: ${toolCall.toolName} ${
@@ -808,7 +808,7 @@ describe('onToolCall', () => {
 
 describe('tool invocations', () => {
   setupTestComponent(() => {
-    const { messages, sendMessage, addToolResult } = useChat({
+    const { messages, sendMessage, addToolOutput } = useChat({
       generateId: mockId(),
     });
 
@@ -826,7 +826,7 @@ describe('tool invocations', () => {
                     <button
                       data-testid={`add-result-${toolIdx}`}
                       onClick={() => {
-                        addToolResult({
+                        addToolOutput({
                           tool: 'test-tool',
                           toolCallId: toolPart.toolCallId,
                           output: 'test-result',
@@ -1020,7 +1020,7 @@ describe('tool invocations', () => {
     });
   });
 
-  it('should update tool call to result when addToolResult is called', async () => {
+  it('should update tool call to result when addToolOutput is called', async () => {
     const controller = new TestResponseController();
     server.urls['/api/chat'].response = {
       type: 'controlled-stream',

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -422,7 +422,7 @@ describe('onToolCall', () => {
       async onToolCall({ toolCall }) {
         await toolCallPromise;
 
-        chat.addToolResult({
+        chat.addToolOutput({
           tool: 'test-tool',
           toolCallId: toolCall.toolCallId,
           output: `test-tool-response: ${toolCall.toolName} ${
@@ -700,7 +700,7 @@ describe('tool invocations', () => {
     ]);
   });
 
-  it('should update tool call to result when addToolResult is called', async () => {
+  it('should update tool call to result when addToolOutput is called', async () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
@@ -734,7 +734,7 @@ describe('tool invocations', () => {
       ]);
     });
 
-    chat.addToolResult({
+    chat.addToolOutput({
       tool: 'test-tool',
       toolCallId: 'tool-call-0',
       output: 'test-result',

--- a/packages/vue/src/TestChatToolInvocationsComponent.vue
+++ b/packages/vue/src/TestChatToolInvocationsComponent.vue
@@ -2,9 +2,7 @@
 import { isToolUIPart } from 'ai';
 import { Chat } from './chat.vue';
 
-const chat = new Chat({
-  maxSteps: 5,
-});
+const chat = new Chat({});
 </script>
 
 <template>
@@ -23,8 +21,9 @@ const chat = new Chat({
           v-if="toolPart.state === 'input-available'"
           :data-testid="`add-result-${toolIdx}`"
           @click="
-            chat.addToolResult({
+            chat.addToolOutput({
               toolCallId: toolPart.toolCallId,
+              tool: 'test-tool',
               output: 'test-result',
             })
           "

--- a/packages/vue/src/chat.vue.ui.test.tsx
+++ b/packages/vue/src/chat.vue.ui.test.tsx
@@ -557,7 +557,7 @@ describe('tool invocations', () => {
     });
   });
 
-  it('should update tool call to result when addToolResult is called', async () => {
+  it('should update tool call to result when addToolOutput is called', async () => {
     const controller = new TestResponseController();
     server.urls['/api/chat'].response = [
       {


### PR DESCRIPTION
## Summary

* Renamed `addToolResult()` into `addToolOutput()`
* `addToolResult` in `chat` and `useChat` is left with deprecation notice, pointing to `addToolOutput`
* Updated method call in tests; Copied one test with `addToolResult` to make sure it works the same
* Updated docs & v5 migration guide
* Added codemod

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #8575


## TBD

In the issue description, there is item (7) "Add before/after code examples to the .changeset/ file" — I glanced through other changesets and did not see it done anywhere else. However, I updated the v5 migration guide with a before/after example.