### PR TITLE
fix: handle mode='tool', issue #10023

### DIFF
--- a/.changeset/gentle-ghosts-drum.md
+++ b/.changeset/gentle-ghosts-drum.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix generateObject() and streamObject() to properly handle mode='tool' parameter by using tool calling instead of JSON response format

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -111,9 +111,10 @@ const { object } = await generateObject({
 ```
 
 <Note>
-  Not all models support all modes. When using `mode: 'tool'`, the model will use function calling
-  to generate the structured output. When using `mode: 'json'`, the model will use JSON mode.
-  The default `mode: 'auto'` lets the provider choose the best mode.
+  Not all models support all modes. When using `mode: 'tool'`, the model will
+  use function calling to generate the structured output. When using `mode:
+  'json'`, the model will use JSON mode. The default `mode: 'auto'` lets the
+  provider choose the best mode.
 </Note>
 
 To see `generateObject` in action, check out the [additional examples](#more-examples).

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -86,6 +86,36 @@ const { object } = await generateObject({
 });
 ```
 
+#### Example: using tool mode for structured output
+
+Some providers (like Groq, Google, and OpenRouter) work better with tool calling for structured output
+instead of JSON mode. You can use `mode: 'tool'` to generate objects using function calling:
+
+```ts highlight="8"
+import { groq } from '@ai-sdk/groq';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const { object } = await generateObject({
+  model: groq('llama-3.3-70b-versatile'),
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(z.string()),
+      steps: z.array(z.string()),
+    }),
+  }),
+  mode: 'tool',
+  prompt: 'Generate a lasagna recipe.',
+});
+```
+
+<Note>
+  Not all models support all modes. When using `mode: 'tool'`, the model will use function calling
+  to generate the structured output. When using `mode: 'json'`, the model will use JSON mode.
+  The default `mode: 'auto'` lets the provider choose the best mode.
+</Note>
+
 To see `generateObject` in action, check out the [additional examples](#more-examples).
 
 ## Import

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -129,9 +129,10 @@ for await (const partialObject of partialObjectStream) {
 ```
 
 <Note>
-  Not all models support all modes. When using `mode: 'tool'`, the model will use function calling
-  to stream the structured output. When using `mode: 'json'`, the model will use JSON mode.
-  The default `mode: 'auto'` lets the provider choose the best mode.
+  Not all models support all modes. When using `mode: 'tool'`, the model will
+  use function calling to stream the structured output. When using `mode:
+  'json'`, the model will use JSON mode. The default `mode: 'auto'` lets the
+  provider choose the best mode.
 </Note>
 
 To see `streamObject` in action, check out the [additional examples](#more-examples).

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -99,6 +99,41 @@ const { partialObjectStream } = streamObject({
 });
 ```
 
+#### Example: using tool mode for streaming structured output
+
+Some providers (like Groq, Google, and OpenRouter) work better with tool calling for structured output
+instead of JSON mode. You can use `mode: 'tool'` to stream objects using function calling:
+
+```ts highlight="8"
+import { groq } from '@ai-sdk/groq';
+import { streamObject } from 'ai';
+import { z } from 'zod';
+
+const { partialObjectStream } = streamObject({
+  model: groq('llama-3.3-70b-versatile'),
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(z.string()),
+      steps: z.array(z.string()),
+    }),
+  }),
+  mode: 'tool',
+  prompt: 'Generate a lasagna recipe.',
+});
+
+for await (const partialObject of partialObjectStream) {
+  console.clear();
+  console.log(partialObject);
+}
+```
+
+<Note>
+  Not all models support all modes. When using `mode: 'tool'`, the model will use function calling
+  to stream the structured output. When using `mode: 'json'`, the model will use JSON mode.
+  The default `mode: 'auto'` lets the provider choose the best mode.
+</Note>
+
 To see `streamObject` in action, check out the [additional examples](#more-examples).
 
 ## Import

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -994,12 +994,7 @@ describe('generateObject', () => {
       ]
     `);
       expect(model.doGenerateCalls[0].responseFormat).toMatchInlineSnapshot(`
-      {
-        "description": undefined,
-        "name": undefined,
-        "schema": undefined,
-        "type": "json",
-      }
+      undefined
     `);
     });
   });

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -1367,12 +1367,7 @@ describe('streamObject', () => {
       `);
 
       expect(mockModel.doStreamCalls[0].responseFormat).toMatchInlineSnapshot(`
-        {
-          "description": undefined,
-          "name": undefined,
-          "schema": undefined,
-          "type": "json",
-        }
+        undefined
       `);
     });
   });


### PR DESCRIPTION
## Background

The `mode` parameter in `generateObject()` and `streamObject()` was defined in the function signature but never actually used in the implementation. This caused the functions to always use JSON response format (`responseFormat`), even when `mode='tool'` was specified. 

Providers like Groq, Google, and OpenRouter reject requests that combine JSON response format with tool calling, causing errors such as "json mode cannot be combined with tool/function calling" (Groq) or "Forced function calling with response mime type: 'application/json' unsupported" (Google).

## Summary

- Extracted and used the `mode` parameter in both `generateObject()` and `streamObject()` (defaults to `'auto'`)
- Implemented conditional logic:
  - When `mode='tool'`: Uses `tools` + `toolChoice` instead of `responseFormat`
  - When `mode='json'` or `mode='auto'`: Uses `responseFormat` (existing behavior)
- Tool mode creates a function tool with schema as `inputSchema` and extracts result from tool call's `input` property
- Added `tool-input-delta` handling for streaming tool responses

## Manual Verification

Manually tested with:
- ✅ Groq provider (`llama-3.3-70b-versatile`) with `mode='tool'` - successfully generates structured objects using tool calling
- ✅ Google provider (`gemini-2.0-flash`) with `mode='tool'` - successfully generates structured objects using tool calling
- Both providers now return `finish reason: tool-calls` instead of throwing errors

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #10023