### PR TITLE
feat(assemblyai): add polling mechanism for async transcription

### DIFF
--- a/.changeset/gorgeous-students-wonder.md
+++ b/.changeset/gorgeous-students-wonder.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/assemblyai': patch
+---
+
+adding polling to assemblyai transcribe async

--- a/packages/assemblyai/src/assemblyai-transcription-model.test.ts
+++ b/packages/assemblyai/src/assemblyai-transcription-model.test.ts
@@ -15,6 +15,8 @@ const model = provider.transcription('best');
 
 const server = createTestServer({
   'https://api.assemblyai.com/v2/transcript': {},
+  'https://api.assemblyai.com/v2/transcript/9ea68fd3-f953-42c1-9742-976c447fb463':
+    {},
   'https://api.assemblyai.com/v2/upload': {
     response: {
       type: 'json-value',
@@ -33,6 +35,16 @@ describe('doGenerate', () => {
     headers?: Record<string, string>;
   } = {}) {
     server.urls['https://api.assemblyai.com/v2/transcript'].response = {
+      type: 'json-value',
+      body: {
+        id: '9ea68fd3-f953-42c1-9742-976c447fb463',
+        status: 'queued',
+      },
+    };
+
+    server.urls[
+      'https://api.assemblyai.com/v2/transcript/9ea68fd3-f953-42c1-9742-976c447fb463'
+    ].response = {
       type: 'json-value',
       headers,
       body: {

--- a/packages/assemblyai/src/assemblyai-transcription-model.ts
+++ b/packages/assemblyai/src/assemblyai-transcription-model.ts
@@ -5,6 +5,7 @@ import {
 import {
   combineHeaders,
   createJsonResponseHandler,
+  extractResponseHeaders,
   parseProviderOptions,
   postJsonToApi,
   postToApi,
@@ -171,10 +172,15 @@ interface AssemblyAITranscriptionModelConfig extends AssemblyAIConfig {
   _internal?: {
     currentDate?: () => Date;
   };
+  /**
+   * The polling interval for checking transcript status in milliseconds.
+   */
+  pollingInterval?: number;
 }
 
 export class AssemblyAITranscriptionModel implements TranscriptionModelV3 {
   readonly specificationVersion = 'v3';
+  private readonly POLLING_INTERVAL_MS = 3000;
 
   get provider(): string {
     return this.config.provider;
@@ -257,6 +263,72 @@ export class AssemblyAITranscriptionModel implements TranscriptionModelV3 {
     };
   }
 
+  /**
+   * Polls the given transcript until we have a status other than `processing` or `queued`.
+   */
+  private async waitForCompletion(
+    transcriptId: string,
+    headers: Record<string, string | undefined> | undefined,
+    abortSignal?: AbortSignal,
+  ): Promise<{
+    transcript: z.infer<typeof assemblyaiTranscriptionResponseSchema>;
+    responseHeaders: Record<string, string>;
+  }> {
+    const pollingInterval =
+      this.config.pollingInterval ?? this.POLLING_INTERVAL_MS;
+
+    while (true) {
+      if (abortSignal?.aborted) {
+        throw new Error('Transcription request was aborted');
+      }
+
+      const response = await fetch(
+        this.config.url({
+          path: `/v2/transcript/${transcriptId}`,
+          modelId: this.modelId,
+        }),
+        {
+          method: 'GET',
+          headers: combineHeaders(
+            this.config.headers(),
+            headers,
+          ) as HeadersInit,
+          signal: abortSignal,
+        },
+      );
+
+      if (!response.ok) {
+        throw await assemblyaiFailedResponseHandler({
+          response,
+          url: this.config.url({
+            path: `/v2/transcript/${transcriptId}`,
+            modelId: this.modelId,
+          }),
+          requestBodyValues: {},
+        });
+      }
+
+      const transcript = assemblyaiTranscriptionResponseSchema.parse(
+        await response.json(),
+      );
+
+      if (transcript.status === 'completed') {
+        return {
+          transcript,
+          responseHeaders: extractResponseHeaders(response),
+        };
+      }
+
+      if (transcript.status === 'error') {
+        throw new Error(
+          `Transcription failed: ${transcript.error ?? 'Unknown error'}`,
+        );
+      }
+
+      await new Promise(resolve => setTimeout(resolve, pollingInterval));
+    }
+  }
+
   async doGenerate(
     options: Parameters<TranscriptionModelV3['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<TranscriptionModelV3['doGenerate']>>> {
@@ -285,11 +357,7 @@ export class AssemblyAITranscriptionModel implements TranscriptionModelV3 {
 
     const { body, warnings } = await this.getArgs(options);
 
-    const {
-      value: response,
-      responseHeaders,
-      rawValue: rawResponse,
-    } = await postJsonToApi({
+    const { value: submitResponse } = await postJsonToApi({
       url: this.config.url({
         path: '/v2/transcript',
         modelId: this.modelId,
@@ -301,29 +369,35 @@ export class AssemblyAITranscriptionModel implements TranscriptionModelV3 {
       },
       failedResponseHandler: assemblyaiFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
-        assemblyaiTranscriptionResponseSchema,
+        assemblyaiSubmitResponseSchema,
       ),
       abortSignal: options.abortSignal,
       fetch: this.config.fetch,
     });
 
+    const { transcript, responseHeaders } = await this.waitForCompletion(
+      submitResponse.id,
+      options.headers,
+      options.abortSignal,
+    );
+
     return {
-      text: response.text ?? '',
+      text: transcript.text ?? '',
       segments:
-        response.words?.map(word => ({
+        transcript.words?.map(word => ({
           text: word.text,
           startSecond: word.start,
           endSecond: word.end,
         })) ?? [],
-      language: response.language_code ?? undefined,
+      language: transcript.language_code ?? undefined,
       durationInSeconds:
-        response.audio_duration ?? response.words?.at(-1)?.end ?? undefined,
+        transcript.audio_duration ?? transcript.words?.at(-1)?.end ?? undefined,
       warnings,
       response: {
         timestamp: currentDate,
         modelId: this.modelId,
-        headers: responseHeaders,
-        body: rawResponse,
+        headers: responseHeaders, // Headers from final GET request
+        body: transcript, // Raw response from final GET request
       },
     };
   }
@@ -333,7 +407,14 @@ const assemblyaiUploadResponseSchema = z.object({
   upload_url: z.string(),
 });
 
+const assemblyaiSubmitResponseSchema = z.object({
+  id: z.string(),
+  status: z.enum(['queued', 'processing', 'completed', 'error']),
+});
+
 const assemblyaiTranscriptionResponseSchema = z.object({
+  id: z.string(),
+  status: z.enum(['queued', 'processing', 'completed', 'error']),
   text: z.string().nullish(),
   language_code: z.string().nullish(),
   words: z
@@ -346,4 +427,5 @@ const assemblyaiTranscriptionResponseSchema = z.object({
     )
     .nullish(),
   audio_duration: z.number().nullish(),
+  error: z.string().nullish(),
 });

--- a/packages/assemblyai/src/assemblyai-transcription-model.ts
+++ b/packages/assemblyai/src/assemblyai-transcription-model.ts
@@ -265,6 +265,8 @@ export class AssemblyAITranscriptionModel implements TranscriptionModelV3 {
 
   /**
    * Polls the given transcript until we have a status other than `processing` or `queued`.
+   *
+   * @see https://www.assemblyai.com/docs/getting-started/transcribe-an-audio-file#step-33
    */
   private async waitForCompletion(
     transcriptId: string,


### PR DESCRIPTION
Implements proper async transcription flow matching AssemblyAI API behavior:
- Upload audio to storage
- Submit transcription job (returns queued status)
- Poll GET endpoint until transcription completes
- Add configurable polling interval (default 3000ms)
- Handle error status in polling responses

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The AssemblyAI transcription API is asynchronous - it immediately returns a job ID with queued status and requires polling to retrieve the completed transcription. The previous implementation expected the transcription to be completed immediately, which doesn't match the actual API behavior.

## Summary

Implements proper async transcription flow matching AssemblyAI API behavior:

- Upload audio to storage
- Submit transcription job (returns queued status)
- Poll GET endpoint until transcription completes
- Add configurable polling interval (default 3000ms)
- Handle error status in polling responses


## Manual Verification

Tested with real AssemblyAI API calls using various file sizes:

- Small audio file (40KB test file) - transcription completed successfully
- Medium audio file (34MB WAV) - transcription completed successfully
- Large audio file (220MB MP3, 4+ hours) - transcription completed successfully
- All transcriptions returned accurate text, duration, language, and segment information.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
