### PR TITLE
fix(anthropic): set providerExecuted on Anthropic web_fetch tool results

### DIFF
--- a/.changeset/wet-turkeys-rescue.md
+++ b/.changeset/wet-turkeys-rescue.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix: set providerExecuted on Anthropic web_fetch tool results

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -11262,6 +11262,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > raw chunks > web fetch tool
     "type": "tool-call",
   },
   {
+    "providerExecuted": true,
     "result": {
       "content": {
         "citations": undefined,

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -943,6 +943,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV2 {
                             },
                           },
                         },
+                        providerExecuted: true,
                       });
                     } else if (
                       part.content.type === 'web_fetch_tool_result_error'


### PR DESCRIPTION
## Background

This tool is providerExecuted and the tool call has that property set correctly, but the tool result does not. This fixed in main (and thus will be fixed in v6.x) by this change: https://github.com/vercel/ai/pull/9936 . But it is still broken in v5.x, so this fixes it there.

## Summary

Added `"providerExecuted": true` to the `tool-result` object for the Anthropic web fetch tool.

## Manual Verification

I didn't have a good way to verify manually.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

N/A