### PR TITLE
feat(provider/google & provider/anthropic): support for custom provider name for anthropic and google

### DIFF
--- a/.changeset/hot-onions-reply.md
+++ b/.changeset/hot-onions-reply.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/google': patch
+---
+
+Support for custom provider name in google and anthropic providers

--- a/examples/ai-core/src/generate-text/anthropic-custom-provider-with-telemetry.ts
+++ b/examples/ai-core/src/generate-text/anthropic-custom-provider-with-telemetry.ts
@@ -1,0 +1,38 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
+const sdk = new NodeSDK({
+  traceExporter: new ConsoleSpanExporter(),
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+sdk.start();
+
+async function main() {
+  const myCustomProvider = createAnthropic({
+    name: 'my-anthropic-proxy',
+  });
+
+  await generateText({
+    model: myCustomProvider('claude-sonnet-4-20250514'),
+    prompt: 'Say hello in 5 words',
+    experimental_telemetry: {
+      isEnabled: true,
+      functionId: 'anthropic-custom-provider-demo',
+      metadata: {
+        environment: 'demo',
+        endpoint_type: 'my-anthropic-proxy',
+        cost_tracking: 'enabled',
+      },
+    },
+  });
+
+  await sdk.shutdown();
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/google-custom-provider-with-telemetry.ts
+++ b/examples/ai-core/src/generate-text/google-custom-provider-with-telemetry.ts
@@ -1,0 +1,38 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
+const sdk = new NodeSDK({
+  traceExporter: new ConsoleSpanExporter(),
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+sdk.start();
+
+async function main() {
+  const myCustomProvider = createGoogleGenerativeAI({
+    name: 'my-custom-provider',
+  });
+
+  await generateText({
+    model: myCustomProvider('gemini-2.5-flash'),
+    prompt: 'Say hello in 5 words',
+    experimental_telemetry: {
+      isEnabled: true,
+      functionId: 'custom-provider-demo',
+      metadata: {
+        environment: 'demo',
+        customer_id: 'demo-user',
+        request_source: 'example',
+      },
+    },
+  });
+
+  await sdk.shutdown();
+}
+
+main().catch(console.error);

--- a/packages/anthropic/src/anthropic-provider.test.ts
+++ b/packages/anthropic/src/anthropic-provider.test.ts
@@ -103,3 +103,28 @@ describe('createAnthropic', () => {
     });
   });
 });
+
+describe('anthropic provider - custom provider name', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should use custom provider name when specified', () => {
+    const provider = createAnthropic({
+      name: 'my-claude-proxy',
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-3-haiku-20240307');
+    expect(model.provider).toBe('my-claude-proxy');
+  });
+
+  it('should default to anthropic.messages when name not specified', () => {
+    const provider = createAnthropic({
+      apiKey: 'test-api-key',
+    });
+
+    const model = provider('claude-3-haiku-20240307');
+    expect(model.provider).toBe('anthropic.messages');
+  });
+});

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -62,6 +62,12 @@ or to provide a custom fetch implementation for e.g. testing.
   fetch?: FetchFunction;
 
   generateId?: () => string;
+
+  /**
+   * Custom provider name
+   * Defaults to 'anthropic.messages'.
+   */
+  name?: string;
 }
 
 /**
@@ -77,6 +83,8 @@ export function createAnthropic(
         environmentVariableName: 'ANTHROPIC_BASE_URL',
       }),
     ) ?? 'https://api.anthropic.com/v1';
+
+  const providerName = options.name ?? 'anthropic.messages';
 
   const getHeaders = () =>
     withUserAgentSuffix(
@@ -94,7 +102,7 @@ export function createAnthropic(
 
   const createChatModel = (modelId: AnthropicMessagesModelId) =>
     new AnthropicMessagesLanguageModel(modelId, {
-      provider: 'anthropic.messages',
+      provider: providerName,
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,

--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -268,3 +268,40 @@ describe('google-provider', () => {
     `);
   });
 });
+
+describe('google provider - custom provider name', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should use custom provider name when specified', () => {
+    const provider = createGoogleGenerativeAI({
+      name: 'my-gemini-proxy',
+      apiKey: 'test-api-key',
+    });
+
+    provider('gemini-pro');
+
+    expect(GoogleGenerativeAILanguageModel).toHaveBeenCalledWith(
+      'gemini-pro',
+      expect.objectContaining({
+        provider: 'my-gemini-proxy',
+      }),
+    );
+  });
+
+  it('should default to google.generative-ai when name not specified', () => {
+    const provider = createGoogleGenerativeAI({
+      apiKey: 'test-api-key',
+    });
+
+    provider('gemini-pro');
+
+    expect(GoogleGenerativeAILanguageModel).toHaveBeenCalledWith(
+      'gemini-pro',
+      expect.objectContaining({
+        provider: 'google.generative-ai',
+      }),
+    );
+  });
+});

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -90,6 +90,12 @@ or to provide a custom fetch implementation for e.g. testing.
 Optional function to generate a unique ID for each request.
      */
   generateId?: () => string;
+
+  /**
+   * Custom provider name
+   * Defaults to 'google.generative-ai'.
+   */
+  name?: string;
 }
 
 /**
@@ -101,6 +107,8 @@ export function createGoogleGenerativeAI(
   const baseURL =
     withoutTrailingSlash(options.baseURL) ??
     'https://generativelanguage.googleapis.com/v1beta';
+
+  const providerName = options.name ?? 'google.generative-ai';
 
   const getHeaders = () =>
     withUserAgentSuffix(
@@ -117,7 +125,7 @@ export function createGoogleGenerativeAI(
 
   const createChatModel = (modelId: GoogleGenerativeAIModelId) =>
     new GoogleGenerativeAILanguageModel(modelId, {
-      provider: 'google.generative-ai',
+      provider: providerName,
       baseURL,
       headers: getHeaders,
       generateId: options.generateId ?? generateId,
@@ -138,7 +146,7 @@ export function createGoogleGenerativeAI(
 
   const createEmbeddingModel = (modelId: GoogleGenerativeAIEmbeddingModelId) =>
     new GoogleGenerativeAIEmbeddingModel(modelId, {
-      provider: 'google.generative-ai',
+      provider: providerName,
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,
@@ -149,7 +157,7 @@ export function createGoogleGenerativeAI(
     settings: GoogleGenerativeAIImageSettings = {},
   ) =>
     new GoogleGenerativeAIImageModel(modelId, settings, {
-      provider: 'google.generative-ai',
+      provider: providerName,
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,


### PR DESCRIPTION


## Background
With the baseURL of createAnthropic and createGoogleGenerativeAI, we can use some providers that offer Anthropic or Gemini-compatible APIs. Therefore, we hope to pass in a custom provider name to make it easier to identify specific providers in logging and error tracking.

## Summary

Added support for custom provider name in google and anthropic

## Manual Verification
Wrote eg with telemetery for both google and anthropic to test the custom provider names
## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #9911 
