### PR TITLE
fix(cerebras): update list of models

### DIFF
--- a/.changeset/moody-apes-destroy.md
+++ b/.changeset/moody-apes-destroy.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cerebras': patch
+---
+
+fix(cerebras): update model IDs based on https://inference-docs.cerebras.ai/models/overview

--- a/content/providers/01-ai-sdk-providers/40-cerebras.mdx
+++ b/content/providers/01-ai-sdk-providers/40-cerebras.mdx
@@ -104,10 +104,10 @@ const model = cerebras.chat('llama-3.3-70b');
 | `llama3.1-8b`                    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `llama-3.3-70b`                  | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gpt-oss-120b`                   | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `qwen-3-32b`                     | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `qwen-3-235b-a22b-instruct-2507` | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `qwen-3-235b-a22b-thinking-2507` | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `qwen-3-32b`                     | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `qwen-3-coder-480b`              | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `zai-glm-4.6`                    | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   Please see the [Cerebras

--- a/packages/cerebras/README.md
+++ b/packages/cerebras/README.md
@@ -21,57 +21,7 @@ import { cerebras } from '@ai-sdk/cerebras';
 ## Available Models
 
 Cerebras offers a variety of high-performance language models:
-
-### Llama 3.3 70B
-
-- Model ID: `llama-3.3-70b`
-- 70 billion parameters
-- Knowledge cutoff: December 2023
-- Context Length: 8192
-- Training Tokens: 15 trillion+
-
-### Llama 3.1 8B
-
-- Model ID: `llama3.1-8b`
-- 8 billion parameters
-- Knowledge cutoff: March 2023
-- Context Length: 8192
-- Training Tokens: 15 trillion+
-
-### GPT-OSS 120B
-
-- Model ID: `gpt-oss-120b`
-- 120 billion parameters
-- High-performance open-source model
-- Optimized for inference speed
-
-### Qwen 3 235B A22B Instruct 2507
-
-- Model ID: `qwen-3-235b-a22b-instruct-2507`
-- 235 billion parameters
-- Instruction-tuned model
-- Released July 2025
-
-### Qwen 3 235B A22B Thinking 2507
-
-- Model ID: `qwen-3-235b-a22b-thinking-2507`
-- 235 billion parameters
-- Enhanced reasoning capabilities
-- Released July 2025
-
-### Qwen 3 32B
-
-- Model ID: `qwen-3-32b`
-- 32 billion parameters
-- Balanced performance and efficiency
-- Multilingual capabilities
-
-### Qwen 3 Coder 480B
-
-- Model ID: `qwen-3-coder-480b`
-- 480 billion parameters
-- Specialized for code generation and understanding
-- Advanced programming capabilities
+https://inference-docs.cerebras.ai/models/overview
 
 ## Example
 

--- a/packages/cerebras/src/cerebras-chat-options.ts
+++ b/packages/cerebras/src/cerebras-chat-options.ts
@@ -1,10 +1,12 @@
-// https://inference-docs.cerebras.ai/introduction
+// https://inference-docs.cerebras.ai/models/overview
 export type CerebrasChatModelId =
-  | 'llama-3.3-70b'
+  // production
   | 'llama3.1-8b'
+  | 'llama-3.3-70b'
   | 'gpt-oss-120b'
+  | 'qwen-3-32b'
+  // preview
   | 'qwen-3-235b-a22b-instruct-2507'
   | 'qwen-3-235b-a22b-thinking-2507'
-  | 'qwen-3-32b'
-  | 'qwen-3-coder-480b'
+  | 'zai-glm-4.6'
   | (string & {});


### PR DESCRIPTION
Tested with 

```js
import 'dotenv/config';
import { cerebras as provider } from '@ai-sdk/cerebras';
import { generateText } from 'ai';

async function main() {
  const models = [
    'llama3.1-8b',
    'llama-3.3-70b',
    'qwen-3-32b',
    'qwen-3-235b-a22b-instruct-2507',
    'qwen-3-235b-a22b-thinking-2507',
    'gpt-oss-120b',
    'zai-glm-4.6',
  ];

  for (const model of models) {
    const result = await generateText({
      model: provider.chat(model),
      prompt: 'Explain the theory of relativity in simple terms.',
    });

    console.log(`Model: ${model}`);
    console.log(result.text);
    console.log();
    console.log('Token usage:', result.usage);
    console.log('Finish reason:', result.finishReason);
    console.log('-----------------------------------\n');
  }
}

main().catch(error => {
  console.log(JSON.stringify(error, null, 2));
});
```

Also tested with these deprecated models

```
llama-4-maverick-17b-128e-instruct
llama-4-scout-17b-16e-instruct
qwen-3-coder-480b
```

The Cerebras API responds with a 503 when using any of these.