### PR TITLE
fix(ai): improve validation error messages with better context

### DIFF
--- a/.changeset/sharp-birds-hope.md
+++ b/.changeset/sharp-birds-hope.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Improve validation error messages in safeValidateUIMessages to provide better context about what's being validated (metadata, data part, tool, etc.). This makes debugging validation issues much easier by clearly indicating which part of the message structure failed validation.


### PR DESCRIPTION
## Background

When calling `safeValidateUIMessages`, the errors were difficult to decipher since they didn't mention what was being validated (metadata, tool, etc.). This made debugging validation issues challenging for developers using the AI SDK.

## Summary

Enhanced the error messages in `safeValidateUIMessages` to provide better context about what's being validated:
- Added specific context for metadata validation errors
- Added specific context for data part validation errors
- Added specific context for tool input/output validation errors
- Added specific context for message structure validation errors

Each error now clearly indicates which part of the message structure failed validation and includes the message ID when applicable.

## Manual Verification

I manually verified that the validation errors now include helpful context by running the tests and examining the error messages. For example, metadata validation errors now include "Metadata validation failed for message with ID [id]" in the error message.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #10137 - Validation errors are difficult to read