### PR TITLE
fix(mistral): convert messages with PDF file parts from Uint8Array to base64

### DIFF
--- a/.changeset/perfect-swans-look.md
+++ b/.changeset/perfect-swans-look.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+Add PDF base64 coverage and refactor file URL formatting

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -72,6 +72,40 @@ describe('user messages', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should convert messages with PDF file parts from Uint8Array', () => {
+    const result = convertToMistralChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Analyze this PDF' },
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'application/pdf',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "text": "Analyze this PDF",
+              "type": "text",
+            },
+            {
+              "document_url": "data:application/pdf;base64,AAECAw==",
+              "type": "document_url",
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
   it('should convert messages with reasoning content', () => {
     const result = convertToMistralChatMessages([
       {

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -1,9 +1,22 @@
 import {
+  LanguageModelV3DataContent,
   LanguageModelV3Prompt,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { MistralPrompt } from './mistral-chat-prompt';
 import { convertToBase64 } from '@ai-sdk/provider-utils';
+
+function formatFileUrl({
+  data,
+  mediaType,
+}: {
+  data: LanguageModelV3DataContent;
+  mediaType: string;
+}): string {
+  return data instanceof URL
+    ? data.toString()
+    : `data:${mediaType};base64,${convertToBase64(data as Uint8Array)}`;
+}
 
 export function convertToMistralChatMessages(
   prompt: LanguageModelV3Prompt,
@@ -38,15 +51,15 @@ export function convertToMistralChatMessages(
 
                   return {
                     type: 'image_url',
-                    image_url:
-                      part.data instanceof URL
-                        ? part.data.toString()
-                        : `data:${mediaType};base64,${convertToBase64(part.data)}`,
+                    image_url: formatFileUrl({ data: part.data, mediaType }),
                   };
                 } else if (part.mediaType === 'application/pdf') {
                   return {
                     type: 'document_url',
-                    document_url: part.data.toString(),
+                    document_url: formatFileUrl({
+                      data: part.data,
+                      mediaType: 'application/pdf',
+                    }),
                   };
                 } else {
                   throw new UnsupportedFunctionalityError({


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Mistral's API requires PDF documents to be formatted as either HTTPS URLs or data URIs with the format `data:application/pdf;base64,<encoded-data>`. When attempting to send PDF files as base64 directly from API endpoints (common use case: file upload → Mistral), the existing implementation handled this correctly but lacked test coverage to validate the format. This left uncertainty about whether PDFs could be sent directly without uploading to cloud storage first.

## Summary

- Added test coverage validating PDF base64 data is correctly formatted with `data:application/pdf;base64`, prefix
- Refactored duplicated URL/base64 formatting logic into shared formatFileUrl helper function
- Improved type safety with explicit LanguageModelV3DataContent typing

## Manual Verification

Simulated real-world API flow where PDF is received and sent directly to Mistral:
1. Received PDF as Uint8Array (mimicking file upload at API endpoint)
2. Passed to convertToMistralChatMessages with mediaType: 'application/pdf'
3. Verified output format matches Mistral's requirement: data:application/pdf;base64,AAECAw==
4. All 45 tests pass (Node + Edge environments)

This eliminates the need to upload PDFs to cloud storage before sending to Mistral.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
N/A

## Related Issues
N/A