### PR TITLE
feat(provider/gateway): Add Kimi K2 Thinking models to Gateway model string autocomplete

### DIFF
--- a/.changeset/small-avocados-deny.md
+++ b/.changeset/small-avocados-deny.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): Add Kimi K2 Thinking models to Gateway model string autocomplete

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -70,6 +70,8 @@ export type GatewayModelId =
   | 'mistral/pixtral-large'
   | 'moonshotai/kimi-k2'
   | 'moonshotai/kimi-k2-0905'
+  | 'moonshotai/kimi-k2-thinking'
+  | 'moonshotai/kimi-k2-thinking-turbo'
   | 'moonshotai/kimi-k2-turbo'
   | 'morph/morph-v3-fast'
   | 'morph/morph-v3-large'


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
New Kimi K2 Thinking models

## Summary
Added them to Gateway model string autocomplete

## Manual Verification
Autocomplete works

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)