### PR TITLE
feat(google): add function calling config

### DIFF
--- a/.changeset/strong-pugs-crash.md
+++ b/.changeset/strong-pugs-crash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Adds support for Google's function calling configuration through provider options, enabling control over function calling modes (AUTO/NONE/ANY), parallel function calling, and restricting allowed functions. When toolChoice is 'auto' or unspecified, functionCallingConfig takes precedence to allow fine-grained control over function calling behavior.

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -191,6 +191,121 @@ The following optional provider options are available for Google Generative AI m
   - 16:9
   - 21:9
 
+- **functionCallingConfig** _object_
+
+  Optional. Configuration for function calling behavior.
+
+  This provides direct control over Google's function calling modes, including:
+
+  - Enabling parallel function calling (model can call multiple functions in one response)
+  - Restricting function calls to a specific subset of available functions
+  - Controlling when the model should or shouldn't call functions
+
+  **Note**: If `toolChoice` is specified in the main options, it takes precedence over this setting for backward compatibility.
+
+  - **mode** _'AUTO' | 'NONE' | 'ANY'_
+
+    Controls when the model should invoke functions:
+
+    - `AUTO`: Model autonomously decides whether to call functions or respond with text
+    - `ANY`: Model must call at least one function (enables parallel function calling)
+    - `NONE`: Model cannot call any functions, responds only with text
+
+  - **allowedFunctionNames** _string[]_
+
+    Optional. Array of function names that the model is allowed to call.
+    Only used when `mode` is `ANY`.
+    If not provided or empty, all available functions can be called.
+
+  **Example: Enable parallel function calling**
+
+  ```ts
+  import { google } from '@ai-sdk/google';
+  import { generateText } from 'ai';
+
+  const result = await generateText({
+    model: google('gemini-2.5-flash'),
+    prompt:
+      'What is the weather in London and schedule a meeting for tomorrow at 3pm?',
+    tools: {
+      getWeather: {
+        description: 'Get weather information for a city',
+        parameters: z.object({
+          city: z.string(),
+        }),
+      },
+      scheduleMeeting: {
+        description: 'Schedule a meeting',
+        parameters: z.object({
+          date: z.string(),
+          time: z.string(),
+        }),
+      },
+    },
+    providerOptions: {
+      google: {
+        functionCallingConfig: {
+          mode: 'ANY', // Model can call multiple functions in parallel
+        },
+      },
+    },
+  });
+  ```
+
+  **Example: Restrict to specific functions**
+
+  ```ts
+  const result = await generateText({
+    model: google('gemini-2.5-flash'),
+    prompt: 'Help me with my tasks',
+    tools: {
+      weather: {
+        /* ... */
+      },
+      calendar: {
+        /* ... */
+      },
+      email: {
+        /* ... */
+      },
+      database: {
+        /* ... */
+      },
+    },
+    providerOptions: {
+      google: {
+        functionCallingConfig: {
+          mode: 'ANY',
+          allowedFunctionNames: ['weather', 'calendar'], // Only these two can be called
+        },
+      },
+    },
+  });
+  ```
+
+  **Example: Disable function calling**
+
+  ```ts
+  const result = await generateText({
+    model: google('gemini-2.5-flash'),
+    prompt: 'Just give me a text response',
+    tools: {
+      someFunction: {
+        /* ... */
+      },
+    },
+    providerOptions: {
+      google: {
+        functionCallingConfig: {
+          mode: 'NONE', // Model cannot call any functions
+        },
+      },
+    },
+  });
+  ```
+
+  For more information, see [Google's Function Calling documentation](https://ai.google.dev/gemini-api/docs/function-calling#function_calling_modes).
+
 ### Thinking
 
 The Gemini 2.5 series models use an internal "thinking process" that significantly improves their reasoning and multi-step planning abilities, making them highly effective for complex tasks such as coding, advanced mathematics, and data analysis. For more information see [Google Generative AI thinking documentation](https://ai.google.dev/gemini-api/docs/thinking).

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -126,6 +126,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
       tools,
       toolChoice,
       modelId: this.modelId,
+      functionCallingConfig: googleOptions?.functionCallingConfig,
     });
 
     return {

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -159,6 +159,36 @@ export const googleGenerativeAIProviderOptions = lazySchema(() =>
             .optional(),
         })
         .optional(),
+      /**
+       * Optional. Configuration for function calling behavior.
+       *
+       * Controls how the model handles function calls, including:
+       * - Enabling parallel function calling (calling multiple functions in one response)
+       * - Restricting which functions can be called
+       * - Setting the overall function calling mode
+       *
+       * Note: Explicit toolChoice ('none', 'required', 'tool') takes precedence. 
+       * When toolChoice is 'auto' or unspecified, functionCallingConfig is used
+       *
+       * @see https://ai.google.dev/gemini-api/docs/function-calling#function_calling_modes
+       */
+      functionCallingConfig: z
+        .object({
+          /**
+           * The mode of function calling.
+           * - AUTO: Model decides whether to call functions or respond with text
+           * - ANY: Model must call at least one function (enables parallel calling)
+           * - NONE: Model cannot call any functions
+           */
+          mode: z.enum(['AUTO', 'NONE', 'ANY']).optional(),
+          /**
+           * Optional list of function names the model is allowed to call.
+           * Only used when mode is 'ANY'.
+           * If empty or not provided, all functions are allowed.
+           */
+          allowedFunctionNames: z.array(z.string()).optional(),
+        })
+        .optional(),
     }),
   ),
 );

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -167,7 +167,7 @@ export const googleGenerativeAIProviderOptions = lazySchema(() =>
        * - Restricting which functions can be called
        * - Setting the overall function calling mode
        *
-       * Note: Explicit toolChoice ('none', 'required', 'tool') takes precedence. 
+       * Note: Explicit toolChoice ('none', 'required', 'tool') takes precedence.
        * When toolChoice is 'auto' or unspecified, functionCallingConfig is used
        *
        * @see https://ai.google.dev/gemini-api/docs/function-calling#function_calling_modes

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -410,3 +410,178 @@ it('should handle url context tool alone', () => {
   expect(result.toolConfig).toBeUndefined();
   expect(result.toolWarnings).toEqual([]);
 });
+
+it('should use functionCallingConfig from provider options when toolChoice is not provided', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'Test',
+        inputSchema: {},
+      },
+    ],
+    functionCallingConfig: { mode: 'AUTO' },
+    modelId: 'gemini-2.5-flash',
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'AUTO' },
+  });
+  expect(result.toolWarnings).toEqual([]);
+});
+
+it('should use functionCallingConfig with mode ANY for parallel calling', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'weather',
+        description: 'Get weather',
+        inputSchema: {},
+      },
+      {
+        type: 'function',
+        name: 'calendar',
+        description: 'Check calendar',
+        inputSchema: {},
+      },
+    ],
+    functionCallingConfig: { mode: 'ANY' },
+    modelId: 'gemini-2.5-flash',
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'ANY' },
+  });
+});
+
+it('should use functionCallingConfig with allowedFunctionNames to restrict function subset', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'weather',
+        description: 'Get weather',
+        inputSchema: {},
+      },
+      {
+        type: 'function',
+        name: 'calendar',
+        description: 'Check calendar',
+        inputSchema: {},
+      },
+      {
+        type: 'function',
+        name: 'email',
+        description: 'Send email',
+        inputSchema: {},
+      },
+    ],
+    functionCallingConfig: {
+      mode: 'ANY',
+      allowedFunctionNames: ['weather', 'calendar'],
+    },
+    modelId: 'gemini-2.5-flash',
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: {
+      mode: 'ANY',
+      allowedFunctionNames: ['weather', 'calendar'],
+    },
+  });
+});
+
+it('should use functionCallingConfig with mode NONE to disable function calling', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'Test',
+        inputSchema: {},
+      },
+    ],
+    functionCallingConfig: { mode: 'NONE' },
+    modelId: 'gemini-2.5-flash',
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'NONE' },
+  });
+});
+
+it('should prioritize functionCallingConfig over toolChoice when toolChoice is auto', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'Test',
+        inputSchema: {},
+      },
+    ],
+    toolChoice: { type: 'auto' },
+    functionCallingConfig: { mode: 'NONE' },
+    modelId: 'gemini-2.5-flash',
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'NONE' },
+  });
+});
+
+it('should prioritize explicit toolChoice over functionCallingConfig when toolChoice is not auto', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'Test',
+        inputSchema: {},
+      },
+    ],
+    toolChoice: { type: 'required' },
+    functionCallingConfig: { mode: 'NONE' },
+    modelId: 'gemini-2.5-flash',
+  });
+
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'ANY' },
+  });
+});
+
+it('should return undefined toolConfig when neither toolChoice nor functionCallingConfig is provided', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'testFunction',
+        description: 'Test',
+        inputSchema: {},
+      },
+    ],
+    modelId: 'gemini-2.5-flash',
+  });
+
+  expect(result.toolConfig).toBeUndefined();
+});
+
+it('should not apply functionCallingConfig to provider-defined tools', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'google.google_search',
+        name: 'google_search',
+        args: {},
+      },
+    ],
+    functionCallingConfig: { mode: 'ANY' },
+    modelId: 'gemini-2.5-flash',
+  });
+
+  expect(result.tools).toEqual([{ googleSearch: {} }]);
+  expect(result.toolConfig).toBeUndefined();
+});

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -585,3 +585,32 @@ it('should not apply functionCallingConfig to provider-defined tools', () => {
   expect(result.tools).toEqual([{ googleSearch: {} }]);
   expect(result.toolConfig).toBeUndefined();
 });
+
+it('should ignore allowedFunctionNames when mode is not ANY', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'function',
+        name: 'weather',
+        description: 'Get weather',
+        inputSchema: {},
+      },
+      {
+        type: 'function',
+        name: 'calendar',
+        description: 'Check calendar',
+        inputSchema: {},
+      },
+    ],
+    functionCallingConfig: {
+      mode: 'AUTO',
+      allowedFunctionNames: ['weather'],
+    },
+    modelId: 'gemini-2.5-flash',
+  });
+
+  // allowedFunctionNames should be ignored when mode is AUTO
+  expect(result.toolConfig).toEqual({
+    functionCallingConfig: { mode: 'AUTO' },
+  });
+});

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -176,14 +176,17 @@ export function prepareTools({
   if (toolChoice == null || toolChoice.type === 'auto') {
     // If functionCallingConfig is provided via provider options, use it
     if (functionCallingConfig != null) {
+      const mode = functionCallingConfig.mode ?? 'AUTO';
       const config: {
         mode: 'AUTO' | 'NONE' | 'ANY';
         allowedFunctionNames?: string[];
       } = {
-        mode: functionCallingConfig.mode ?? 'AUTO',
+        mode,
       };
 
+      // allowedFunctionNames is only valid when mode is 'ANY'
       if (
+        mode === 'ANY' &&
         functionCallingConfig.allowedFunctionNames != null &&
         functionCallingConfig.allowedFunctionNames.length > 0
       ) {


### PR DESCRIPTION
## Background

Google's Gemini API supports fine-grained control over function calling behavior through the `functionCallingConfig` parameter, including:
- Setting function calling modes (AUTO/NONE/ANY)
- Enabling parallel function calling
- Restricting which functions can be called via `allowedFunctionNames`

However, the AI SDK's Google provider didn't expose this configuration as a provider option, limiting users' ability to control function calling behavior beyond the standard `toolChoice` parameter.

## Summary

Added `functionCallingConfig` as a provider option for the Google provider with the following capabilities:

- **New provider option**: `providerOptions.google.functionCallingConfig` with `mode` and `allowedFunctionNames` fields
- **Precedence rules**: When `toolChoice` is 'auto' or unspecified, `functionCallingConfig` takes precedence to allow fine-grained control. Explicit `toolChoice` values ('none', 'required', 'tool') still override provider options.
- **Validation**: `allowedFunctionNames` is only included in API requests when `mode` is 'ANY', per Google's API specification

## Manual Verification

Created a debug script that intercepts and logs the actual API request being sent to Google's API. All functionality has been manually verified to work correctly.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #10006
