### PR TITLE
feat(agent): add abortSignal parameter to generate and stream

### DIFF
--- a/.changeset/slimy-laws-hunt.md
+++ b/.changeset/slimy-laws-hunt.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(agent): add abortSignal parameter to generate and stream

--- a/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/15-agent.mdx
@@ -12,84 +12,123 @@ Implementations of the `Agent` interface—such as `ToolLoopAgent`—fulfill the
 ## Interface Definition
 
 ```ts
+import { ModelMessage } from '@ai-sdk/provider-utils';
 import { ToolSet } from '../generate-text/tool-set';
-import {
-  Output,
-  InferGenerateOutput,
-  InferStreamOutput,
-} from '../generate-text/output';
+import { Output } from '../generate-text/output';
 import { GenerateTextResult } from '../generate-text/generate-text-result';
 import { StreamTextResult } from '../generate-text/stream-text-result';
 
+export type AgentCallParameters<CALL_OPTIONS> = ([CALL_OPTIONS] extends [never]
+  ? { options?: never }
+  : { options: CALL_OPTIONS }) &
+  (
+    | {
+        /**
+         * A prompt. It can be either a text prompt or a list of messages.
+         *
+         * You can either use `prompt` or `messages` but not both.
+         */
+        prompt: string | Array<ModelMessage>;
+
+        /**
+         * A list of messages.
+         *
+         * You can either use `prompt` or `messages` but not both.
+         */
+        messages?: never;
+      }
+    | {
+        /**
+         * A list of messages.
+         *
+         * You can either use `prompt` or `messages` but not both.
+         */
+        messages: Array<ModelMessage>;
+
+        /**
+         * A prompt. It can be either a text prompt or a list of messages.
+         *
+         * You can either use `prompt` or `messages` but not both.
+         */
+        prompt?: never;
+      }
+  ) & {
+    /**
+     * Abort signal.
+     */
+    abortSignal?: AbortSignal;
+  };
+
 /**
- * Agents process prompts (text or list of messages) and generate/stream results
- * including steps, tool calls, and/or other data.
+ * An Agent receives a prompt (text or messages) and generates or streams an output
+ * that consists of steps, tool calls, data parts, etc.
+ *
+ * You can implement your own Agent by implementing the `Agent` interface,
+ * or use the `ToolLoopAgent` class.
  */
 export interface Agent<
+  CALL_OPTIONS = never,
   TOOLS extends ToolSet = {},
   OUTPUT extends Output = never,
 > {
   /**
-   * The specification version of the agent interface,
-   * enabling versioned compatibility with SDK utilities.
+   * The specification version of the agent interface. This will enable
+   * us to evolve the agent interface and retain backwards compatibility.
    */
   readonly version: 'agent-v1';
 
   /**
-   * The id of the agent, if present.
+   * The id of the agent.
    */
   readonly id: string | undefined;
 
   /**
-   * The set of tools that the agent can use.
+   * The tools that the agent can use.
    */
   readonly tools: TOOLS;
 
   /**
-   * Generates a response (non-streaming) for the provided prompt or messages.
-   * @param options The input prompt or messages.
-   * @returns A Promise resolving to the generated result.
+   * Generates an output from the agent (non-streaming).
    */
   generate(
-    options:
-      | {
-          prompt: string | Array<any>;
-          messages?: never;
-        }
-      | {
-          messages: Array<any>;
-          prompt?: never;
-        },
-  ): PromiseLike<GenerateTextResult<TOOLS, InferGenerateOutput<OUTPUT>>>;
+    options: AgentCallParameters<CALL_OPTIONS>,
+  ): PromiseLike<GenerateTextResult<TOOLS, OUTPUT>>;
 
   /**
-   * Streams a response incrementally for the provided prompt or messages.
-   * @param options The input prompt or messages.
-   * @returns An object representing the text or tool call stream.
+   * Streams an output from the agent (streaming).
    */
   stream(
-    options:
-      | {
-          prompt: string | Array<any>;
-          messages?: never;
-        }
-      | {
-          messages: Array<any>;
-          prompt?: never;
-        },
-  ): StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>>;
+    options: AgentCallParameters<CALL_OPTIONS>,
+  ): PromiseLike<StreamTextResult<TOOLS, OUTPUT>>;
 }
 ```
 
 ## Core Properties & Methods
 
-| Name         | Type                                                 | Description                                                         |
-| ------------ | ---------------------------------------------------- | ------------------------------------------------------------------- |
-| `version`    | `'agent-v1'`                                         | Interface version for compatibility.                                |
-| `id`         | `string \| undefined`                                | Optional agent identifier.                                          |
-| `tools`      | `ToolSet`                                            | The set of tools available to this agent.                           |
-| `generate()` | `PromiseLike<GenerateTextResult<TOOLS, OUTPUT>>`     | Generates full, non-streaming output for a text prompt or messages. |
-| `stream()`   | `StreamTextResult<TOOLS, InferStreamOutput<OUTPUT>>` | Streams output (chunks or steps) for a text prompt or messages.     |
+| Name         | Type                                             | Description                                                         |
+| ------------ | ------------------------------------------------ | ------------------------------------------------------------------- |
+| `version`    | `'agent-v1'`                                     | Interface version for compatibility.                                |
+| `id`         | `string \| undefined`                            | Optional agent identifier.                                          |
+| `tools`      | `ToolSet`                                        | The set of tools available to this agent.                           |
+| `generate()` | `PromiseLike<GenerateTextResult<TOOLS, OUTPUT>>` | Generates full, non-streaming output for a text prompt or messages. |
+| `stream()`   | `PromiseLike<StreamTextResult<TOOLS, OUTPUT>>`   | Streams output (chunks or steps) for a text prompt or messages.     |
+
+## Generic Parameters
+
+| Parameter      | Default | Description                                                                |
+| -------------- | ------- | -------------------------------------------------------------------------- |
+| `CALL_OPTIONS` | `never` | Optional type for additional call options that can be passed to the agent. |
+| `TOOLS`        | `{}`    | The type of the tool set available to this agent.                          |
+| `OUTPUT`       | `never` | The type of additional output data that the agent can produce.             |
+
+## Method Parameters
+
+Both `generate()` and `stream()` accept an `AgentCallParameters<CALL_OPTIONS>` object with:
+
+- `prompt` (optional): A string prompt or array of `ModelMessage` objects
+- `messages` (optional): An array of `ModelMessage` objects (mutually exclusive with `prompt`)
+- `options` (optional): Additional call options when `CALL_OPTIONS` is not `never`
+- `abortSignal` (optional): An `AbortSignal` to cancel the operation
 
 ## Example: Custom Agent Implementation
 
@@ -97,18 +136,19 @@ Here's how you might implement your own Agent:
 
 ```ts
 import { Agent, GenerateTextResult, StreamTextResult } from 'ai';
+import type { ModelMessage } from '@ai-sdk/provider-utils';
 
 class MyEchoAgent implements Agent {
-  version = 'agent-v1';
+  version = 'agent-v1' as const;
   id = 'echo';
   tools = {};
 
-  async generate({ prompt, messages }) {
+  async generate({ prompt, messages, abortSignal }) {
     const text = prompt ?? JSON.stringify(messages);
     return { text, steps: [] };
   }
 
-  stream({ prompt, messages }) {
+  async stream({ prompt, messages, abortSignal }) {
     const text = prompt ?? JSON.stringify(messages);
     return {
       textStream: (async function* () {
@@ -151,4 +191,6 @@ for await (const chunk of stream) {
 
 - Agents should define their `tools` property, even if empty (`{}`), for compatibility with SDK utilities.
 - The interface accepts both plain prompts and message arrays as input, but only one at a time.
+- The `CALL_OPTIONS` generic parameter allows agents to accept additional call-specific options when needed.
+- The `abortSignal` parameter enables cancellation of agent operations.
 - This design is extensible for both complex autonomous agents and simple LLM wrappers.

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -225,6 +225,13 @@ const result = await agent.generate({
       type: 'Array<ModelMessage>',
       description: 'A full conversation history as a list of model messages.',
     },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal',
+      isOptional: true,
+      description:
+        'An optional abort signal that can be used to cancel the call.',
+    },
   ]}
 />
 
@@ -257,6 +264,13 @@ for await (const chunk of stream.textStream) {
       name: 'messages',
       type: 'Array<ModelMessage>',
       description: 'A full conversation history as a list of model messages.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal',
+      isOptional: true,
+      description:
+        'An optional abort signal that can be used to cancel the call.',
     },
   ]}
 />

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -79,6 +79,11 @@ export interface Agent<
    * Streams an output from the agent (streaming).
    */
   stream(
-    options: AgentCallParameters<CALL_OPTIONS>,
+    options: AgentCallParameters<CALL_OPTIONS> & {
+      /**
+Abort signal.
+   */
+      abortSignal?: AbortSignal;
+    },
   ): PromiseLike<StreamTextResult<TOOLS, OUTPUT>>;
 }

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -38,7 +38,12 @@ export type AgentCallParameters<CALL_OPTIONS> = ([CALL_OPTIONS] extends [never]
          */
         prompt?: never;
       }
-  );
+  ) & {
+    /**
+     * Abort signal.
+     */
+    abortSignal?: AbortSignal;
+  };
 
 /**
  * An Agent receives a prompt (text or messages) and generates or streams an output
@@ -79,11 +84,6 @@ export interface Agent<
    * Streams an output from the agent (streaming).
    */
   stream(
-    options: AgentCallParameters<CALL_OPTIONS> & {
-      /**
-Abort signal.
-   */
-      abortSignal?: AbortSignal;
-    },
+    options: AgentCallParameters<CALL_OPTIONS>,
   ): PromiseLike<StreamTextResult<TOOLS, OUTPUT>>;
 }

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -23,7 +23,7 @@ export type ToolLoopAgentSettings<
   CALL_OPTIONS = never,
   TOOLS extends ToolSet = {},
   OUTPUT extends Output = never,
-> = CallSettings & {
+> = Omit<CallSettings, 'abortSignal'> & {
   /**
    * The id of the agent.
    */

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -2,10 +2,10 @@ import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 import { Output } from '../generate-text';
 import { MockLanguageModelV3 } from '../test/mock-language-model-v3';
-import { ToolLoopAgent } from './tool-loop-agent';
 import { AsyncIterableStream } from '../util/async-iterable-stream';
 import { DeepPartial } from '../util/deep-partial';
-import { ModelMessage } from '../prompt';
+import { AgentCallParameters } from './agent';
+import { ToolLoopAgent } from './tool-loop-agent';
 
 describe('ToolLoopAgent', () => {
   describe('generate', () => {
@@ -27,10 +27,7 @@ describe('ToolLoopAgent', () => {
       });
 
       expectTypeOf<Parameters<typeof agent.generate>[0]>().toEqualTypeOf<
-        { options: { callOption: string } } & (
-          | { prompt: string | ModelMessage[]; messages?: never }
-          | { messages: ModelMessage[]; prompt?: never }
-        )
+        AgentCallParameters<{ callOption: string }>
       >();
     });
 
@@ -40,10 +37,7 @@ describe('ToolLoopAgent', () => {
       });
 
       expectTypeOf<Parameters<typeof agent.generate>[0]>().toEqualTypeOf<
-        { options?: never } & (
-          | { prompt: string | ModelMessage[]; messages?: never }
-          | { messages: ModelMessage[]; prompt?: never }
-        )
+        AgentCallParameters<never>
       >();
     });
 
@@ -84,10 +78,7 @@ describe('ToolLoopAgent', () => {
       });
 
       expectTypeOf<Parameters<typeof agent.stream>[0]>().toEqualTypeOf<
-        { options: { callOption: string } } & (
-          | { prompt: string | ModelMessage[]; messages?: never }
-          | { messages: ModelMessage[]; prompt?: never }
-        )
+        AgentCallParameters<{ callOption: string }>
       >();
     });
 
@@ -97,10 +88,7 @@ describe('ToolLoopAgent', () => {
       });
 
       expectTypeOf<Parameters<typeof agent.stream>[0]>().toEqualTypeOf<
-        { options?: never } & (
-          | { prompt: string | ModelMessage[]; messages?: never }
-          | { messages: ModelMessage[]; prompt?: never }
-        )
+        AgentCallParameters<never>
       >();
     });
 

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -79,10 +79,16 @@ export class ToolLoopAgent<
   /**
    * Generates an output from the agent (non-streaming).
    */
-  async generate(
-    options: AgentCallParameters<CALL_OPTIONS>,
-  ): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
-    return generateText(await this.prepareCall(options));
+  async generate({
+    abortSignal,
+    ...options
+  }: AgentCallParameters<CALL_OPTIONS>): Promise<
+    GenerateTextResult<TOOLS, OUTPUT>
+  > {
+    return generateText({
+      ...(await this.prepareCall(options)),
+      abortSignal,
+    });
   }
 
   /**
@@ -91,12 +97,9 @@ export class ToolLoopAgent<
   async stream({
     abortSignal,
     ...options
-  }: AgentCallParameters<CALL_OPTIONS> & {
-    /**
-Abort signal.
-   */
-    abortSignal?: AbortSignal;
-  }): Promise<StreamTextResult<TOOLS, OUTPUT>> {
+  }: AgentCallParameters<CALL_OPTIONS>): Promise<
+    StreamTextResult<TOOLS, OUTPUT>
+  > {
     return streamText({
       ...(await this.prepareCall(options)),
       abortSignal,

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -88,9 +88,18 @@ export class ToolLoopAgent<
   /**
    * Streams an output from the agent (streaming).
    */
-  async stream(
-    options: AgentCallParameters<CALL_OPTIONS>,
-  ): Promise<StreamTextResult<TOOLS, OUTPUT>> {
-    return streamText(await this.prepareCall(options));
+  async stream({
+    abortSignal,
+    ...options
+  }: AgentCallParameters<CALL_OPTIONS> & {
+    /**
+Abort signal.
+   */
+    abortSignal?: AbortSignal;
+  }): Promise<StreamTextResult<TOOLS, OUTPUT>> {
+    return streamText({
+      ...(await this.prepareCall(options)),
+      abortSignal,
+    });
   }
 }


### PR DESCRIPTION
## Background

Abort signals need to be support on a per-call basis in agents (see #9146 ).

## Summary

* Add `abortSignal` parameter to `Agent.generate()` and `Agent.stream()`
* Remove `abortSignal` from `ToolLoopAgentSettings`

## Related Issues

Fixes #9146