### PR TITLE
Add Perplexity Search API tool

### DIFF
--- a/.changeset/serious-icons-explode.md
+++ b/.changeset/serious-icons-explode.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/perplexity': patch
+---
+
+Add Perplexity Search API tool for web search capabilities

--- a/content/cookbook/05-node/56-web-search-agent.mdx
+++ b/content/cookbook/05-node/56-web-search-agent.mdx
@@ -131,7 +131,45 @@ Unlike the native web search examples where searching is built into the model, u
 
 ### Use ready-made tools
 
-If you prefer a ready-to-use web search tool without building one from scratch, [Exa](https://exa.ai/)(a web search API designed for AI applications) provides a tool that integrates directly with the AI SDK.
+If you prefer a ready-to-use web search tool without building one from scratch, several providers offer tools that integrate directly with the AI SDK.
+
+#### Perplexity
+
+Perplexity's Search API allows you to search the web and return ranked results, it can be used with any model that supports tool calling.
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { perplexity } from '@ai-sdk/perplexity';
+import { generateText, stepCountIs } from 'ai';
+
+const { text } = await generateText({
+  model: openai('gpt-5-mini'),
+  prompt: 'What are the latest AI developments? Use search.',
+  tools: {
+    search: perplexity.tools.search({
+      max_results: 10,
+    }),
+  },
+  stopWhen: stepCountIs(3),
+});
+
+console.log(text);
+```
+
+You can use advanced filters for more precise results:
+
+```ts
+search: perplexity.tools.search({
+  max_results: 10,
+  search_domain_filter: ['nature.com', 'science.org'],
+  search_language_filter: ['en'],
+  search_recency_filter: 'month',
+});
+```
+
+The tool also supports multi-query searches where the LLM can generate multiple search queries that are all processed together.
+
+For more configuration options, see the [Perplexity Search API documentation](https://ai-sdk.dev/providers/ai-sdk-providers/perplexity#search-api).
 
 #### Exa
 

--- a/content/providers/01-ai-sdk-providers/70-perplexity.mdx
+++ b/content/providers/01-ai-sdk-providers/70-perplexity.mdx
@@ -5,7 +5,7 @@ description: Learn how to use Perplexity's Sonar API with the AI SDK.
 
 # Perplexity Provider
 
-The [Perplexity](https://sonar.perplexity.ai) provider offers access to Sonar API - a language model that uniquely combines real-time web search with natural language processing. Each response is grounded in current web data and includes detailed citations, making it ideal for research, fact-checking, and obtaining up-to-date information.
+The [Perplexity](https://sonar.perplexity.ai) provider gives you access to both the Sonar and Search APIs. The Sonar API provides grounded language models that deliver responses enhanced by real-time web search with comprehensive citations, making them ideal for research, fact-checking, and staying current with the latest information. The Search API provides direct access to ranked search results, allowing you to augment any model that supports tool calling with real-time web data.
 
 API keys can be obtained from the [Perplexity Platform](https://docs.perplexity.ai).
 
@@ -179,6 +179,134 @@ respond to questions about it.
   For more details about Perplexity's capabilities, see the [Perplexity chat
   completion docs](https://docs.perplexity.ai/api-reference/chat-completions).
 </Note>
+
+### Search API
+
+The Perplexity provider includes a search tool that gives you access to Perplexity's Search API. This tool is designed to be used with **other models** (OpenAI, Anthropic, Gemini, etc.) to give them web search capabilities powered by Perplexity.
+
+<Note>
+  Perplexity's Sonar models already have native search built-in, so you don't
+  need to use this tool with them. Use this tool to add Perplexity search to
+  other models.
+</Note>
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { perplexity } from '@ai-sdk/perplexity';
+import { generateText, stepCountIs } from 'ai';
+
+const { text, toolResults } = await generateText({
+  model: openai('gpt-5-mini'),
+  prompt: 'What are the latest AI developments? Use search, then summarize the results.',
+  tools: {
+    search: perplexity.tools.search({
+      max_results: 10,
+    }),
+  },
+  stopWhen: stepCountIs(3),
+});
+
+console.log(text);
+
+// Access search results
+for (const toolResult of toolResults) {
+  if (toolResult.toolName === 'search') {
+    console.log('Search results:', toolResult.output.results);
+  }
+}
+```
+
+#### Search Configuration Options
+
+The search tool supports extensive filtering and configuration:
+
+**Basic Options:**
+
+- `max_results` (1-20, default: 10): Number of search results to return
+- `max_tokens_per_page` (default: 1024): Amount of text extracted per result page
+- `country` (ISO 3166-1 alpha-2): Two-letter country code for regional results (e.g., "US", "GB")
+
+**Domain Filtering:**
+
+```ts
+search: perplexity.tools.search({
+  search_domain_filter: [
+    'nature.com', // Include nature.com
+    'science.org', // Include science.org
+    'arxiv.org', // Include arxiv.org
+  ],
+});
+```
+
+**Language Filtering:**
+
+```ts
+search: perplexity.tools.search({
+  search_language_filter: ['en', 'fr', 'de'], // ISO 639-1 codes (max 10)
+});
+```
+
+**Date Range Filtering:**
+
+```ts
+search: perplexity.tools.search({
+  search_after_date: '3/1/2025', // Format: MM/DD/YYYY
+  search_before_date: '3/15/2025',
+});
+```
+
+**Recency Filtering:**
+
+```ts
+search: perplexity.tools.search({
+  search_recency_filter: 'week', // Options: 'day' | 'week' | 'month' | 'year'
+});
+```
+
+<Note>
+  `search_recency_filter` cannot be combined with `search_after_date` or
+  `search_before_date`.
+</Note>
+
+#### Multi-Query Search
+
+The search tool supports multi-query searches where the LLM can generate multiple search queries:
+
+```ts
+const { text } = await generateText({
+  model: openai('gpt-5-mini'),
+  prompt:
+    'Search for information on AI safety, AGI development, and AI regulation as a json array. Then summarize the results.',
+  tools: {
+    search: perplexity.tools.search({ max_results: 10 }),
+  },
+  stopWhen: stepCountIs(3),
+});
+```
+
+The LLM can generate a query array like `["AI safety research", "AGI development timeline", "AI regulation 2025"]`, and results from all queries are returned in a flat array.
+
+#### Usage with ToolLoopAgent
+
+You can also use the search tool with `ToolLoopAgent` for more complex search workflows:
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent } from 'ai';
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-5-mini'),
+  tools: {
+    search: perplexity.tools.search({
+      max_results: 10,
+    }),
+  },
+});
+
+const { text, toolResults } = await agent.generate({
+  prompt: 'Research the latest developments in quantum computing. Then summarize the results.',
+});
+```
 
 ## Model Capabilities
 

--- a/content/providers/01-ai-sdk-providers/70-perplexity.mdx
+++ b/content/providers/01-ai-sdk-providers/70-perplexity.mdx
@@ -197,7 +197,8 @@ import { generateText, stepCountIs } from 'ai';
 
 const { text, toolResults } = await generateText({
   model: openai('gpt-5-mini'),
-  prompt: 'What are the latest AI developments? Use search, then summarize the results.',
+  prompt:
+    'What are the latest AI developments? Use search, then summarize the results.',
   tools: {
     search: perplexity.tools.search({
       max_results: 10,
@@ -304,7 +305,8 @@ const agent = new ToolLoopAgent({
 });
 
 const { text, toolResults } = await agent.generate({
-  prompt: 'Research the latest developments in quantum computing. Then summarize the results.',
+  prompt:
+    'Research the latest developments in quantum computing. Then summarize the results.',
 });
 ```
 

--- a/examples/ai-core/src/generate-text/perplexity-search-filters.ts
+++ b/examples/ai-core/src/generate-text/perplexity-search-filters.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { perplexity } from '@ai-sdk/perplexity';
-import { generateText } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -14,6 +14,7 @@ async function main() {
         max_results: 5,
       }),
     },
+    stopWhen: stepCountIs(3),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/perplexity-search-filters.ts
+++ b/examples/ai-core/src/generate-text/perplexity-search-filters.ts
@@ -1,0 +1,23 @@
+import { openai } from '@ai-sdk/openai';
+import { perplexity } from '@ai-sdk/perplexity';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: openai.responses('gpt-4o-mini'),
+    prompt: 'What are the latest developments in quantum computing?',
+    tools: {
+      search: perplexity.tools.search({
+        search_domain_filter: ['nature.com', 'science.org', 'arxiv.org'],
+        search_recency_filter: 'month',
+        max_results: 5,
+      }),
+    },
+  });
+
+  console.log(result.text);
+  console.log('\nUsage:', result.usage);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/perplexity-search.ts
+++ b/examples/ai-core/src/generate-text/perplexity-search.ts
@@ -1,6 +1,6 @@
 import { openai } from '@ai-sdk/openai';
 import { perplexity } from '@ai-sdk/perplexity';
-import { generateText } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import 'dotenv/config';
 
 async function main() {
@@ -10,6 +10,7 @@ async function main() {
     tools: {
       search: perplexity.tools.search(),
     },
+    stopWhen: stepCountIs(3),
   });
 
   console.log(result.text);

--- a/examples/ai-core/src/generate-text/perplexity-search.ts
+++ b/examples/ai-core/src/generate-text/perplexity-search.ts
@@ -1,0 +1,19 @@
+import { openai } from '@ai-sdk/openai';
+import { perplexity } from '@ai-sdk/perplexity';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: openai.responses('gpt-4o-mini'),
+    prompt: 'What are the latest developments in AI today?',
+    tools: {
+      search: perplexity.tools.search(),
+    },
+  });
+
+  console.log(result.text);
+  console.log('\nUsage:', result.usage);
+}
+
+main().catch(console.error);

--- a/packages/perplexity/README.md
+++ b/packages/perplexity/README.md
@@ -42,6 +42,37 @@ const { text } = await generateText({
 });
 ```
 
+## Search API
+
+The Perplexity provider includes a search tool that gives you access to Perplexity's Search API. This tool can be used with **any model that supports tool calling** (OpenAI, Anthropic, etc.) to give them web search capabilities powered by Perplexity.
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { perplexity } from '@ai-sdk/perplexity';
+import { generateText, stepCountIs } from 'ai';
+
+const { text } = await generateText({
+  model: openai('gpt-5-mini'),
+  prompt: 'What are the latest AI developments? Use search.',
+  tools: {
+    search: perplexity.tools.search({
+      max_results: 5,
+      search_recency_filter: 'week',
+    }),
+  },
+  stopWhen: stepCountIs(3),
+});
+```
+
+The search tool supports:
+
+- Single or multi-query searches
+- Domain filtering (include/exclude specific domains)
+- Language filtering
+- Date range filtering
+- Recency filtering (day, week, month, year)
+- Custom result limits and token limits per page
+
 ## Documentation
 
 Please check out the **[Perplexity provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/perplexity)** for more information.

--- a/packages/perplexity/src/index.ts
+++ b/packages/perplexity/src/index.ts
@@ -3,4 +3,9 @@ export type {
   PerplexityProvider,
   PerplexityProviderSettings,
 } from './perplexity-provider';
+export type {
+  PerplexitySearchConfig,
+  PerplexitySearchResult,
+  PerplexitySearchResponse,
+} from './tool/search';
 export { VERSION } from './version';

--- a/packages/perplexity/src/perplexity-provider.ts
+++ b/packages/perplexity/src/perplexity-provider.ts
@@ -12,6 +12,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { PerplexityLanguageModel } from './perplexity-language-model';
 import { PerplexityLanguageModelId } from './perplexity-language-model-options';
+import { perplexityTools } from './perplexity-tools';
 import { VERSION } from './version';
 
 export interface PerplexityProvider extends ProviderV3 {
@@ -24,6 +25,11 @@ Creates an Perplexity chat model for text generation.
 Creates an Perplexity language model for text generation.
    */
   languageModel(modelId: PerplexityLanguageModelId): LanguageModelV3;
+
+  /**
+   * Perplexity-specific tools.
+   */
+  tools: typeof perplexityTools;
 }
 
 export interface PerplexityProviderSettings {
@@ -88,6 +94,8 @@ export function createPerplexity(
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };
+
+  provider.tools = perplexityTools;
 
   return provider;
 }

--- a/packages/perplexity/src/perplexity-tools.ts
+++ b/packages/perplexity/src/perplexity-tools.ts
@@ -1,0 +1,28 @@
+import { search } from './tool/search';
+
+export const perplexityTools = {
+  /**
+   * Search the web using Perplexity's Search API for real-time information,
+   * news, research papers, and articles.
+   *
+   * @param config - Configuration options for search including API key,
+   * result limits, domain filters, language filters, and date ranges.
+   *
+   * @example
+   * ```ts
+   * import { perplexity } from '@ai-sdk/perplexity';
+   * import { openai } from '@ai-sdk/openai';
+   * import { generateText, stepCountIs } from 'ai';
+   *
+   * const { text } = await generateText({
+   *   model: openai('gpt-5-mini'),
+   *   prompt: 'What are the latest AI developments?',
+   *   tools: {
+   *     search: perplexity.tools.search({ max_results: 10 }),
+   *   },
+   *   stopWhen: stepCountIs(3),
+   * });
+   * ```
+   */
+  search,
+};

--- a/packages/perplexity/src/tool/search.test.ts
+++ b/packages/perplexity/src/tool/search.test.ts
@@ -8,22 +8,19 @@ describe('Perplexity Search Tool', () => {
       const searchTool = search({ apiKey: 'test-key' });
 
       expectTypeOf(searchTool).toEqualTypeOf<
-        Tool<
-          { query: string | string[] },
-          PerplexitySearchResponse
-        >
+        Tool<{ query: string | string[] }, PerplexitySearchResponse>
       >();
     });
 
     it('should accept single query string', () => {
       const searchTool = search({ apiKey: 'test-key' });
-      
+
       expectTypeOf(searchTool.inputSchema).toMatchTypeOf<any>();
     });
 
     it('should accept query array for multi-query', () => {
       const searchTool = search({ apiKey: 'test-key' });
-      
+
       expectTypeOf(searchTool.inputSchema).toMatchTypeOf<any>();
     });
   });
@@ -31,7 +28,7 @@ describe('Perplexity Search Tool', () => {
   describe('Configuration', () => {
     it('should create tool with API key from config', () => {
       const searchTool = search({ apiKey: 'test-key' });
-      
+
       expect(searchTool.description).toContain('Perplexity Search API');
       expect(searchTool.execute).toBeDefined();
     });
@@ -41,7 +38,7 @@ describe('Perplexity Search Tool', () => {
       process.env.PERPLEXITY_API_KEY = 'env-key';
 
       const searchTool = search();
-      
+
       expect(searchTool.execute).toBeDefined();
 
       process.env.PERPLEXITY_API_KEY = originalKey;
@@ -54,7 +51,10 @@ describe('Perplexity Search Tool', () => {
       const searchTool = search();
 
       await expect(
-        searchTool.execute!({ query: 'test' }, { toolCallId: 'test', messages: [] }),
+        searchTool.execute!(
+          { query: 'test' },
+          { toolCallId: 'test', messages: [] },
+        ),
       ).rejects.toThrow('Please provide an API key');
 
       process.env.PERPLEXITY_API_KEY = originalKey;

--- a/packages/perplexity/src/tool/search.test.ts
+++ b/packages/perplexity/src/tool/search.test.ts
@@ -1,0 +1,82 @@
+import { InferSchema, Tool } from '@ai-sdk/provider-utils';
+import { describe, expectTypeOf, it, expect } from 'vitest';
+import { search, PerplexitySearchResponse } from './search';
+
+describe('Perplexity Search Tool', () => {
+  describe('Type Safety', () => {
+    it('should have correct Tool type', () => {
+      const searchTool = search({ apiKey: 'test-key' });
+
+      expectTypeOf(searchTool).toEqualTypeOf<
+        Tool<
+          { query: string | string[] },
+          PerplexitySearchResponse
+        >
+      >();
+    });
+
+    it('should accept single query string', () => {
+      const searchTool = search({ apiKey: 'test-key' });
+      
+      expectTypeOf(searchTool.inputSchema).toMatchTypeOf<any>();
+    });
+
+    it('should accept query array for multi-query', () => {
+      const searchTool = search({ apiKey: 'test-key' });
+      
+      expectTypeOf(searchTool.inputSchema).toMatchTypeOf<any>();
+    });
+  });
+
+  describe('Configuration', () => {
+    it('should create tool with API key from config', () => {
+      const searchTool = search({ apiKey: 'test-key' });
+      
+      expect(searchTool.description).toContain('Perplexity Search API');
+      expect(searchTool.execute).toBeDefined();
+    });
+
+    it('should create tool with API key from environment', () => {
+      const originalKey = process.env.PERPLEXITY_API_KEY;
+      process.env.PERPLEXITY_API_KEY = 'env-key';
+
+      const searchTool = search();
+      
+      expect(searchTool.execute).toBeDefined();
+
+      process.env.PERPLEXITY_API_KEY = originalKey;
+    });
+
+    it('should throw error when API key is missing', async () => {
+      const originalKey = process.env.PERPLEXITY_API_KEY;
+      delete process.env.PERPLEXITY_API_KEY;
+
+      const searchTool = search();
+
+      await expect(
+        searchTool.execute!({ query: 'test' }, { toolCallId: 'test', messages: [] }),
+      ).rejects.toThrow('Please provide an API key');
+
+      process.env.PERPLEXITY_API_KEY = originalKey;
+    });
+  });
+
+  describe('Search Options', () => {
+    it('should accept all filter options', () => {
+      const searchTool = search({
+        apiKey: 'test-key',
+        max_results: 5,
+        max_tokens_per_page: 2000,
+        country: 'US',
+        search_domain_filter: ['example.com'],
+        search_language_filter: ['en'],
+        search_after_date: '1/1/2025',
+        search_before_date: '12/31/2025',
+        search_recency_filter: 'week',
+      });
+
+      expect(searchTool.description).toContain('search results');
+      expect(searchTool.description).toContain('metadata');
+    });
+  });
+});

--- a/packages/perplexity/src/tool/search.ts
+++ b/packages/perplexity/src/tool/search.ts
@@ -1,0 +1,192 @@
+import { tool } from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+
+export interface PerplexitySearchConfig {
+  /**
+   * API key for authenticating requests to Perplexity Search API.
+   * If not provided, will use PERPLEXITY_API_KEY environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * Maximum number of search results to return (1-20).
+   * @default 10
+   */
+  max_results?: number;
+
+  /**
+   * Maximum number of tokens to extract per search result page.
+   * @default 1024
+   */
+  max_tokens_per_page?: number;
+
+  /**
+   * Two-letter ISO 3166-1 alpha-2 country code for regional search results.
+   * Examples: "US", "GB", "FR"
+   */
+  country?: string;
+
+  /**
+   * List of domains to include or exclude from search results (max 20).
+   * To include: ["nature.com", "science.org"]
+   * To exclude: ["-example.com", "-spam.net"]
+   */
+  search_domain_filter?: string[];
+
+  /**
+   * List of ISO 639-1 language codes to filter results (max 10, lowercase).
+   * Examples: ["en", "fr", "de"]
+   */
+  search_language_filter?: string[];
+
+  /**
+   * Include only results published after this date.
+   * Format: "MM/DD/YYYY" (e.g., "3/1/2025")
+   * Cannot be used with search_recency_filter.
+   */
+  search_after_date?: string;
+
+  /**
+   * Include only results published before this date.
+   * Format: "MM/DD/YYYY" (e.g., "3/5/2025")
+   * Cannot be used with search_recency_filter.
+   */
+  search_before_date?: string;
+
+  /**
+   * Filter results by relative time period.
+   * Cannot be used with search_after_date or search_before_date.
+   * Allowed values: "day" | "week" | "month" | "year"
+   */
+  search_recency_filter?: 'day' | 'week' | 'month' | 'year';
+}
+
+/**
+ * Individual search result from Perplexity Search API
+ */
+export interface PerplexitySearchResult {
+  /**
+   * Title of the search result
+   */
+  title: string;
+
+  /**
+   * URL of the search result
+   */
+  url: string;
+
+  /**
+   * Text snippet/preview of the content
+   */
+  snippet: string;
+
+  /**
+   * Publication date of the content
+   */
+  date?: string;
+
+  /**
+   * Last updated date of the content
+   */
+  last_updated?: string;
+}
+
+/**
+ * Response from Perplexity Search API
+ */
+export interface PerplexitySearchResponse {
+  /**
+   * Array of search results
+   */
+  results: PerplexitySearchResult[];
+
+  /**
+   * Unique identifier for this search request
+   */
+  id: string;
+}
+
+export function search(config: PerplexitySearchConfig = {}) {
+  const { apiKey = process.env.PERPLEXITY_API_KEY, ...searchOptions } = config;
+
+  return tool({
+    description:
+      'Performs web search using the Perplexity Search API. Returns ranked search results with titles, URLs, snippets, and metadata.',
+    inputSchema: z.object({
+      query: z
+        .union([z.string(), z.array(z.string())])
+        .describe(
+          'Search query (string) or multiple queries (array). Multi-query searches return combined results from all queries.',
+        ),
+    }),
+    execute: async ({ query }): Promise<PerplexitySearchResponse> => {
+      if (!apiKey) {
+        throw new Error(
+          'Please provide an API key for the Perplexity Search API.',
+        );
+      }
+
+      const requestBody: Record<string, unknown> = {
+        query,
+      };
+
+      if (searchOptions.max_results !== undefined) {
+        requestBody.max_results = searchOptions.max_results;
+      }
+      if (searchOptions.max_tokens_per_page !== undefined) {
+        requestBody.max_tokens_per_page = searchOptions.max_tokens_per_page;
+      }
+      if (searchOptions.country !== undefined) {
+        requestBody.country = searchOptions.country;
+      }
+      if (
+        searchOptions.search_domain_filter &&
+        searchOptions.search_domain_filter.length > 0
+      ) {
+        requestBody.search_domain_filter = searchOptions.search_domain_filter;
+      }
+      if (
+        searchOptions.search_language_filter &&
+        searchOptions.search_language_filter.length > 0
+      ) {
+        requestBody.search_language_filter =
+          searchOptions.search_language_filter;
+      }
+      if (searchOptions.search_after_date !== undefined) {
+        requestBody.search_after_date = searchOptions.search_after_date;
+      }
+      if (searchOptions.search_before_date !== undefined) {
+        requestBody.search_before_date = searchOptions.search_before_date;
+      }
+      if (searchOptions.search_recency_filter !== undefined) {
+        requestBody.search_recency_filter = searchOptions.search_recency_filter;
+      }
+
+      try {
+        const response = await fetch('https://api.perplexity.ai/search', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify(requestBody),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(
+            `Perplexity Search API error: ${response.status} - ${errorText}`,
+          );
+        }
+
+        const data: PerplexitySearchResponse = await response.json();
+        return data;
+      } catch (error) {
+        if (error instanceof Error) {
+          throw new Error(`Failed to search with Perplexity Search API: ${error.message}`);
+        }
+        throw error;
+      }
+    },
+  });
+}

--- a/packages/perplexity/src/tool/search.ts
+++ b/packages/perplexity/src/tool/search.ts
@@ -183,7 +183,9 @@ export function search(config: PerplexitySearchConfig = {}) {
         return data;
       } catch (error) {
         if (error instanceof Error) {
-          throw new Error(`Failed to search with Perplexity Search API: ${error.message}`);
+          throw new Error(
+            `Failed to search with Perplexity Search API: ${error.message}`,
+          );
         }
         throw error;
       }


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The Perplexity provider currently only supports the Sonar API (language models with native search). However, Perplexity also offers a standalone Search API that provides direct access to ranked search results. This PR adds a search tool that enables developers to use Perplexity's Search API with any model that supports tool calling (OpenAI, Anthropic, Google, etc.)

This fills a gap where developers want to use the same global-scale infrastructure that powers Perplexity’s public answer engine while still leveraging their models of choice. 

## Summary

Added `perplexity.tools.search()` tool with the following:
- `packages/perplexity/src/tool/search.ts` - Search API wrapper with types
- `packages/perplexity/src/perplexity-tools.ts` - Tool export
- `packages/perplexity/src/perplexity-provider.ts` - Added `tools` property to provider
- `packages/perplexity/src/index.ts` - Exported types
- `examples/ai-core/src/generate-text/perplexity-search.ts` - An example of basic usage with the API. 
- `examples/ai-core/src/generate-text/perplexity-search-filters.ts` - An example of advanced usage via filters with the API. 
- `packages/perplexity/README.md` - Added Search API section
- `content/providers/01-ai-sdk-providers/70-perplexity.mdx` - Documented all filter options
- `content/cookbook/05-node/56-web-search-agent.mdx` - Added the perplexity search tool

## Manual Verification

- Set `OPENAI_API_KEY` and `PERPLEXITY_API_KEY` in `examples/ai-core/.env`
- Test examples

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)