### PR TITLE
fix(provider/xai): remove json schema unsupported warning

### DIFF
--- a/.changeset/many-tips-clap.md
+++ b/.changeset/many-tips-clap.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(provider/xai): remove json schema unsupported warning

--- a/examples/ai-core/src/generate-object/xai-grok-3-mini-reasoning-effort.ts
+++ b/examples/ai-core/src/generate-object/xai-grok-3-mini-reasoning-effort.ts
@@ -1,0 +1,35 @@
+import { xai } from '@ai-sdk/xai';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await generateObject({
+    model: xai('grok-3-mini'),
+    schema: z.object({
+      name: z.string(),
+      age: z.number().optional(),
+      occupation: z.string().optional(),
+    }),
+    system: 'identify the person information from the following text',
+    messages: [
+      {
+        role: 'user',
+        content:
+          'my name is john doe, i am 35 years old and work as a software engineer',
+      },
+    ],
+    providerOptions: {
+      xai: {
+        reasoningEffort: 'high',
+      },
+    },
+  });
+
+  console.log('extracted person:', result.object);
+  console.log();
+  console.log('token usage:', result.usage);
+  console.log('finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-object/xai-grok-4-fast-reasoning.ts
+++ b/examples/ai-core/src/generate-object/xai-grok-4-fast-reasoning.ts
@@ -1,0 +1,30 @@
+import { xai } from '@ai-sdk/xai';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await generateObject({
+    model: xai('grok-4-fast-reasoning'),
+    schema: z.object({
+      name: z.string(),
+      age: z.number().optional(),
+      occupation: z.string().optional(),
+    }),
+    system: 'identify the person information from the following text',
+    messages: [
+      {
+        role: 'user',
+        content:
+          'my name is john doe, i am 35 years old and work as a software engineer',
+      },
+    ],
+  });
+
+  console.log('extracted person:', result.object);
+  console.log();
+  console.log('token usage:', result.usage);
+  console.log('finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -719,6 +719,64 @@ describe('XaiChatLanguageModel', () => {
         ]
       `);
     });
+
+    it('should support json schema response format without warnings', async () => {
+      prepareJsonResponse({ content: '{"name":"john doe"}' });
+
+      const { warnings } = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            required: ['name'],
+            additionalProperties: false,
+          },
+        },
+      });
+
+      expect(warnings).toEqual([]);
+    });
+
+    it('should send json schema in response format', async () => {
+      prepareJsonResponse({ content: '{"name":"john"}' });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          name: 'person',
+          schema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            required: ['name'],
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        model: 'grok-beta',
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'person',
+            schema: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+              },
+              required: ['name'],
+            },
+            strict: true,
+          },
+        },
+      });
+    });
   });
 
   describe('doStream', () => {

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -105,18 +105,6 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
       });
     }
 
-    if (
-      responseFormat != null &&
-      responseFormat.type === 'json' &&
-      responseFormat.schema != null
-    ) {
-      warnings.push({
-        type: 'unsupported-setting',
-        setting: 'responseFormat',
-        details: 'JSON response format schema is not supported',
-      });
-    }
-
     // convert ai sdk messages to xai format
     const { messages, warnings: messageWarnings } =
       convertToXaiChatMessages(prompt);


### PR DESCRIPTION
## Background

xai responses api sometimes returns structured outputs with json_schema support, but the ai sdk was showing a warning that json response format schema is not supported. this warning was outdated - the code was actually already sending response_format with json_schema to the api and it works correctly. this caused confusing error messages for users trying to use generateobject with xai models like grok-4-fast-reasoning

## Summary

- removed outdated warning that claimed json schema response format is not supported
- added tests to verify json schema response format works without warnings
- added example for grok-4-fast-reasoning with generateobject
- added example for grok-3-mini with reasoningeffort parameter

## Manual Verification

tested generateobject with both grok-4-fast-reasoning and grok-3-mini models. both now work without warnings:

- grok-4-fast-reasoning successfully generates structured objects (176 reasoning tokens)
- grok-3-mini with reasoningeffort high successfully generates structured objects (770 reasoning tokens)

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- update xai provider documentation to clarify which models support reasoningeffort parameter
- add note that grok-4-fast-reasoning automatically uses reasoning without needing the parameter

## Related Issues

Fixes #9315