### PR TITLE
fix(examples): add token usage logging to gemini image example

### DIFF
--- a/examples/ai-core/src/generate-image/google-gemini-image.ts
+++ b/examples/ai-core/src/generate-image/google-gemini-image.ts
@@ -21,6 +21,10 @@ async function main() {
       console.log(`Generated and saved image: output/${fileName}`);
     }
   }
+
+  console.log();
+  console.log('token usage:', result.usage);
+  console.log('finish reason:', result.finishReason);
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Background

users wanted to see token usage data when generating images with gemini-2.5-flash-image-preview to understand costs. the example was not logging usage information, making it unclear what the token consumption was

## Summary

- added token usage and finish reason logging to gemini image example

## Manual Verification

ran the gemini image example and verified usage data is now logged showing input tokens, output tokens, and total tokens.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Related to #8646
