### PR TITLE
docs: use tool-name in reading ui message streams

### DIFF
--- a/content/docs/04-ai-sdk-ui/24-reading-ui-message-streams.mdx
+++ b/content/docs/04-ai-sdk-ui/24-reading-ui-message-streams.mdx
@@ -1,7 +1,6 @@
 ---
-title: Reading UIMessage Streams
-description: Learn how to read UIMessage streams.
----
+
+## title: Reading UIMessage Streams description: Learn how to read UIMessage streams.
 
 # Reading UI Message Streams
 
@@ -35,7 +34,7 @@ Handle streaming responses that include tool calls:
 
 ```tsx
 import { openai } from '@ai-sdk/openai';
-import { readUIMessageStream, streamText, tool } from 'ai';
+import { readUIMessageStream, streamText, tool, getToolName, stepCountIs } from 'ai';
 import { z } from 'zod';
 
 async function handleToolCalls() {
@@ -53,6 +52,7 @@ async function handleToolCalls() {
         }),
       }),
     },
+    stopWhen: stepCountIs(5),
     prompt: 'What is the weather in Tokyo?',
   });
 
@@ -65,12 +65,19 @@ async function handleToolCalls() {
         case 'text':
           console.log('Text:', part.text);
           break;
-        case 'tool-call':
-          console.log('Tool called:', part.toolName, 'with args:', part.args);
+        case 'tool-weather': {
+          const toolName = getToolName(part);
+
+          switch (part.state) {
+            case 'input-available':
+              console.log('Tool called:', toolName, 'with input:', part.input);
+              break;
+            case 'output-available':
+              console.log('Tool output:', part.output);
+              break;
+          }
           break;
-        case 'tool-result':
-          console.log('Tool result:', part.result);
-          break;
+        }
       }
     });
   }

--- a/content/docs/04-ai-sdk-ui/24-reading-ui-message-streams.mdx
+++ b/content/docs/04-ai-sdk-ui/24-reading-ui-message-streams.mdx
@@ -1,6 +1,7 @@
 ---
-
-## title: Reading UIMessage Streams description: Learn how to read UIMessage streams.
+title: Reading UIMessage Streams
+description: Learn how to read UIMessage streams.
+---
 
 # Reading UI Message Streams
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

The example was using the part type literals `tool-call` and `tool-result` instead of the correct `tool-weather` literal.

## Summary

<!-- What did you change? -->
Changed part type to `tool-weather` and added a `stepWhen` condition so when the example runs, it generates a text part after the tool call.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
