### PR TITLE
docs: add linkup websearch tool documentation

### DIFF
--- a/content/cookbook/05-node/56-web-search-agent.mdx
+++ b/content/cookbook/05-node/56-web-search-agent.mdx
@@ -131,7 +131,44 @@ Unlike the native web search examples where searching is built into the model, u
 
 ### Use ready-made tools
 
-If you prefer a ready-to-use web search tool without building one from scratch, [Exa](https://exa.ai/)(a web search API designed for AI applications) provides a tool that integrates directly with the AI SDK.
+If you prefer a ready-to-use web search tool without building one from scratch, several providers offer tools that integrate directly with the AI SDK.
+
+#### Linkup
+
+Linkup's Search API allows you to search the web in real time to retrieve current information, facts, and news from trusted sources.
+
+<Note>
+  Get your API key from the [Linkup App](https://app.linkup.so). Account
+  creation is totally free.
+</Note>
+
+Start by installing the Linkup `webSearch` tool:
+
+```bash
+pnpm install linkup-ai-sdk
+```
+
+And then use it in your code:
+
+```ts
+import { generateText, stepCountIs } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { webSearch } from 'linkup-ai-sdk';
+
+const { text } = await generateText({
+  model: openai('gpt-4o-mini'),
+  prompt:
+    'What was Microsoft’s revenue last quarter and was it well perceived by the market?',
+  tools: {
+    webSearch: webSearch({ depth: 'standard' }),
+  },
+  stopWhen: stepCountIs(3),
+});
+
+console.log(text);
+```
+
+Find all the configuration options and more in the [Linkup AI SDK documentation](https://docs.linkup.so/pages/integrations/vercel-ai-sdk).
 
 #### Exa
 

--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -150,6 +150,7 @@ These packages provide pre-built tools you can install and use immediately:
 
 - **[@exalabs/ai-sdk](https://www.npmjs.com/package/@exalabs/ai-sdk)** - Web search tool that lets AI search the web and get real-time information.
 - **[@parallel-web/ai-sdk-tools](https://www.npmjs.com/package/@parallel-web/ai-sdk-tools)** - Web search and extract tools powered by Parallel Web API for real-time information and content extraction.
+- **[linkup-ai-sdk](https://www.npmjs.com/package/linkup-ai-sdk)** - Web search tool provided by Linkup Search API, proving real-time information and news from trusted sources.
 - **[Stripe agent tools](https://docs.stripe.com/agents?framework=vercel)** - Tools for interacting with Stripe.
 - **[StackOne ToolSet](https://docs.stackone.com/agents/typescript/frameworks/vercel-ai-sdk)** - Agentic integrations for hundreds of [enterprise SaaS](https://www.stackone.com/integrations) platforms.
 - **[agentic](https://docs.agentic.so/marketplace/ts-sdks/ai-sdk)** - A collection of 20+ tools that connect to external APIs such as [Exa](https://exa.ai/) or [E2B](https://e2b.dev/).
@@ -162,7 +163,7 @@ These packages provide pre-built tools you can install and use immediately:
 
 These are pre-built tools available as MCP servers:
 
-- **[Smithery](https://smithery.ai/docs/integrations/vercel_ai_sdk)** - An open marketplace of 6,000+ MCPs, including [Browserbase](https://browserbase.com/) and [Exa](https://exa.ai/).
+- **[Smithery](https://smithery.ai/docs/integrations/vercel_ai_sdk)** - An open marketplace of 6,000+ MCPs, including [Browserbase](https://browserbase.com/), [Exa](https://exa.ai/) or [Linkup](https://www.linkup.so).
 - **[Pipedream](https://pipedream.com/docs/connect/mcp/ai-frameworks/vercel-ai-sdk)** - Developer toolkit that lets you easily add 3,000+ integrations to your app or AI agent.
 
 ### Tool Building Tutorials


### PR DESCRIPTION
## Background

Linkup web search tool integration for the AI SDK.

## Summary

- Added Linkup to the `Ready-to-Use Tool Packages` section in the Tools documentation page `content/docs/02-foundations/04-tools.mdx`
- Added Linkup to the list of examples of available MCP on Smithery in the Tools documentation page `content/docs/02-foundations/04-tools.mdx`
- Added an example on how to use Linkup tool to enable web search with the AI SDK in the section `Use ready-made tools
` from `content/cookbook/05-node/56-web-search-agent.mdx`

## Checklist

- [x] I have reviewed this pull request (self-review)
