### PR TITLE
Fix mistral empty choices mistral on azure

### DIFF
--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -334,11 +334,11 @@ export class MistralChatLanguageModel implements LanguageModelV3 {
             }
 
             const choice = value.choices[0];
-            const delta = choice.delta;
+            const delta = choice?.delta;
 
-            const textContent = extractTextContent(delta.content);
+            const textContent = extractTextContent(delta?.content);
 
-            if (delta.content != null && Array.isArray(delta.content)) {
+            if (delta?.content != null && Array.isArray(delta?.content)) {
               for (const part of delta.content) {
                 if (part.type === 'thinking') {
                   const reasoningDelta = extractReasoningContent(part.thinking);
@@ -419,7 +419,7 @@ export class MistralChatLanguageModel implements LanguageModelV3 {
               }
             }
 
-            if (choice.finish_reason != null) {
+            if (choice?.finish_reason != null) {
               finishReason = mapMistralFinishReason(choice.finish_reason);
             }
           },

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -338,7 +338,7 @@ export class MistralChatLanguageModel implements LanguageModelV3 {
 
             const textContent = extractTextContent(delta?.content);
 
-            if (delta?.content != null && Array.isArray(delta?.content)) {
+            if (delta?.content != null && Array.isArray(delta?.content ?? '')) {
               for (const part of delta.content) {
                 if (part.type === 'thinking') {
                   const reasoningDelta = extractReasoningContent(part.thinking);


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Mistral model hosted on Azure Foundry send in their first chunk of a chat completion request an empty choices array.
For example :
```json
{
  "choices": [],
  "created": 0,
  "id": "",
  "model": "",
  "object": "",
  "prompt_filter_results": [
    {
      "prompt_index": 0,
      "content_filter_results": {
        "hate": {
          "filtered": false,
          "severity": "safe"
        },
        "jailbreak": {
          "filtered": false,
          "detected": false
        },
        "self_harm": {
          "filtered": false,
          "severity": "safe"
        },
        "sexual": {
          "filtered": false,
          "severity": "safe"
        },
        "violence": {
          "filtered": false,
          "severity": "safe"
        }
      }
    }
  ]
}
```

<!-- Why was this change necessary? -->

## Summary

<!-- What did you change? -->
I added the necessary handling for this case.

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
