### PR TITLE
fix(google): improve error message for mixed tool types to clarify fallback behavior

### DIFF
--- a/.changeset/mighty-eagles-sip.md
+++ b/.changeset/mighty-eagles-sip.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Improve error message when mixing function tools with provider-defined tools to clarify fallback behavior and list ignored function tools

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -311,7 +311,7 @@ it('should warn when mixing function and provider-defined tools', () => {
         inputSchema: { type: 'object', properties: {} },
       },
       details:
-        'Cannot mix function tools with provider-defined tools in the same request. Please use either function tools or provider-defined tools, but not both.',
+        'Cannot mix function tools with provider-defined tools in the same request. Falling back to provider-defined tools only. The following function tools will be ignored: testFunction. Please use either function tools or provider-defined tools, but not both.',
     },
   ]);
 
@@ -355,7 +355,7 @@ it('should handle tool choice with mixed tools (provider-defined tools only)', (
         inputSchema: { type: 'object', properties: {} },
       },
       details:
-        'Cannot mix function tools with provider-defined tools in the same request. Please use either function tools or provider-defined tools, but not both.',
+        'Cannot mix function tools with provider-defined tools in the same request. Falling back to provider-defined tools only. The following function tools will be ignored: testFunction. Please use either function tools or provider-defined tools, but not both.',
     },
   ]);
 });

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -63,11 +63,11 @@ export function prepareTools({
   );
 
   if (hasFunctionTools && hasProviderDefinedTools) {
+    const functionTools = tools.filter(tool => tool.type === 'function');
     toolWarnings.push({
       type: 'unsupported-tool',
       tool: tools.find(tool => tool.type === 'function')!,
-      details:
-        'Cannot mix function tools with provider-defined tools in the same request. Please use either function tools or provider-defined tools, but not both.',
+      details: `Cannot mix function tools with provider-defined tools in the same request. Falling back to provider-defined tools only. The following function tools will be ignored: ${functionTools.map(t => t.name).join(', ')}. Please use either function tools or provider-defined tools, but not both.`,
     });
   }
 


### PR DESCRIPTION


<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Users reported confusion with the error message when mixing function tools with provider-defined tools in `@ai-sdk/google`. The message didn't clarify which tools were being used or that a fallback was occurring.

## Summary

Improved the error message in `google-prepare-tools.ts` to:
- Explicitly state that the SDK falls back to provider-defined tools
- List the specific function tools being ignored by name


## Manual Verification

Code change is minimal and only affects the warning message string. The fallback logic remains unchanged.

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #8401 

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
