### PR TITLE
Feat/tool write source

### DIFF
--- a/.changeset/proud-lions-write.md
+++ b/.changeset/proud-lions-write.md
@@ -1,0 +1,8 @@
+---
+'ai': patch
+'@ai-sdk/provider-utils': patch
+---
+
+feat(ai): add writeSource callback to tool execute options for RAG sources
+
+Tools can now write sources directly to the stream using the writeSource callback in the execute function's second argument, eliminating the need for manual stream creation and writer wrapping in RAG use-cases.

--- a/examples/ai-core/src/stream-text/google-rag-tool-sources.ts
+++ b/examples/ai-core/src/stream-text/google-rag-tool-sources.ts
@@ -38,7 +38,7 @@ async function main() {
       },
     ],
     tools: {
-      // RAG tool that searches knowledge base and writes sources
+      
       searchKnowledge: tool({
         description:
           'Search the knowledge base for relevant information. Always use this tool when answering questions to provide accurate, sourced information.',
@@ -51,43 +51,43 @@ async function main() {
             .describe('Maximum number of results to return'),
         }),
         execute: async ({ query, limit = 3 }, { writeSource }) => {
-          console.log(`\n[Tool] Searching knowledge base for: "${query}"`);
+          
 
-          // Simulate search (in a real app, this would use vector similarity search)
+          
           const results = knowledgeBase
             .filter(doc =>
               doc.content.toLowerCase().includes(query.toLowerCase()),
             )
             .slice(0, limit);
 
-          console.log(`[Tool] Found ${results.length} results`);
+          
 
-          // Write sources to the stream as we find them
+          
           results.forEach(doc => {
-            console.log(`[Tool] Writing source: ${doc.title}`);
+            
 
-            // This is the new feature! Tools can now write sources directly
+            
             writeSource?.({
               sourceType: 'url',
               url: doc.url,
               title: doc.title,
-              id: doc.id, // Optional: provide custom ID
+              id: doc.id, 
             });
           });
 
-          // Return the content to the LLM
+          
           return results.length > 0
             ? results.map(doc => `${doc.title}: ${doc.content}`).join('\n\n')
             : 'No relevant information found.';
         },
       }),
     },
-    maxSteps: 5, // Allow the model to use tools
+    maxSteps: 5, 
   });
 
-  console.log('\n=== Streaming Response ===\n');
+  
 
-  // Process the stream and display both text and sources
+  
   for await (const part of result.fullStream) {
     switch (part.type) {
       case 'text-delta': {
@@ -96,51 +96,50 @@ async function main() {
       }
 
       case 'tool-call': {
-        console.log(`\n\n[Tool Call] ${part.toolName}`);
-        console.log(`[Arguments] ${JSON.stringify(part.args)}`);
+        
+        
         break;
       }
 
       case 'source': {
-        // Sources written by tools appear here!
-        console.log('\n--- Source Referenced ---');
+        
+        
         if (part.sourceType === 'url') {
-          console.log(`Title: ${part.title}`);
-          console.log(`URL: ${part.url}`);
-          console.log(`ID: ${part.id}`);
+          
+          
+          
         }
-        console.log('------------------------\n');
+        
         break;
       }
 
       case 'tool-result': {
         const resultText = typeof part.output === 'string' ? part.output : JSON.stringify(part.output);
-        console.log(`\n[Tool Result] Returned ${resultText.length} characters`);
+        
         break;
       }
 
       case 'finish': {
-        console.log(`\n\n[Finished] Reason: ${part.finishReason}`);
+        
         break;
       }
 
       case 'error': {
-        console.error('\n[Error]', part.error);
         break;
       }
     }
   }
 
-  // Access sources from the final result
-  console.log('\n\n=== All Sources ===');
+  
+  
   const sources = result.experimental_providerMetadata?.sources || [];
   if (sources.length > 0) {
     sources.forEach((source: any, index: number) => {
-      console.log(`${index + 1}. ${source.title} - ${source.url}`);
+      
     });
   } else {
-    console.log('No sources available in metadata');
+    
   }
 }
 
-main().catch(console.error);
+main();

--- a/examples/ai-core/src/stream-text/google-rag-tool-sources.ts
+++ b/examples/ai-core/src/stream-text/google-rag-tool-sources.ts
@@ -1,0 +1,146 @@
+import { google } from '@ai-sdk/google';
+import { streamText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+// Simulated knowledge base - in a real application, this would be a vector database
+const knowledgeBase = [
+  {
+    id: 'doc-1',
+    title: 'Introduction to AI',
+    url: 'https://example.com/intro-to-ai',
+    content:
+      'Artificial Intelligence (AI) is the simulation of human intelligence processes by machines, especially computer systems.',
+  },
+  {
+    id: 'doc-2',
+    title: 'Machine Learning Basics',
+    url: 'https://example.com/ml-basics',
+    content:
+      'Machine Learning is a subset of AI that enables systems to learn and improve from experience without being explicitly programmed.',
+  },
+  {
+    id: 'doc-3',
+    title: 'Neural Networks Explained',
+    url: 'https://example.com/neural-networks',
+    content:
+      'Neural networks are computing systems inspired by biological neural networks that constitute animal brains.',
+  },
+];
+
+async function main() {
+  const result = streamText({
+    model: google('gemini-2.5-pro'),
+    messages: [
+      {
+        role: 'user',
+        content: 'What is machine learning? Please cite your sources.',
+      },
+    ],
+    tools: {
+      // RAG tool that searches knowledge base and writes sources
+      searchKnowledge: tool({
+        description:
+          'Search the knowledge base for relevant information. Always use this tool when answering questions to provide accurate, sourced information.',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+          limit: z
+            .number()
+            .optional()
+            .default(3)
+            .describe('Maximum number of results to return'),
+        }),
+        execute: async ({ query, limit = 3 }, { writeSource }) => {
+          console.log(`\n[Tool] Searching knowledge base for: "${query}"`);
+
+          // Simulate search (in a real app, this would use vector similarity search)
+          const results = knowledgeBase
+            .filter(doc =>
+              doc.content.toLowerCase().includes(query.toLowerCase()),
+            )
+            .slice(0, limit);
+
+          console.log(`[Tool] Found ${results.length} results`);
+
+          // Write sources to the stream as we find them
+          results.forEach(doc => {
+            console.log(`[Tool] Writing source: ${doc.title}`);
+
+            // This is the new feature! Tools can now write sources directly
+            writeSource?.({
+              sourceType: 'url',
+              url: doc.url,
+              title: doc.title,
+              id: doc.id, // Optional: provide custom ID
+            });
+          });
+
+          // Return the content to the LLM
+          return results.length > 0
+            ? results.map(doc => `${doc.title}: ${doc.content}`).join('\n\n')
+            : 'No relevant information found.';
+        },
+      }),
+    },
+    maxSteps: 5, // Allow the model to use tools
+  });
+
+  console.log('\n=== Streaming Response ===\n');
+
+  // Process the stream and display both text and sources
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-delta': {
+        process.stdout.write(part.textDelta);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(`\n\n[Tool Call] ${part.toolName}`);
+        console.log(`[Arguments] ${JSON.stringify(part.args)}`);
+        break;
+      }
+
+      case 'source': {
+        // Sources written by tools appear here!
+        console.log('\n--- Source Referenced ---');
+        if (part.sourceType === 'url') {
+          console.log(`Title: ${part.title}`);
+          console.log(`URL: ${part.url}`);
+          console.log(`ID: ${part.id}`);
+        }
+        console.log('------------------------\n');
+        break;
+      }
+
+      case 'tool-result': {
+        const resultText = typeof part.output === 'string' ? part.output : JSON.stringify(part.output);
+        console.log(`\n[Tool Result] Returned ${resultText.length} characters`);
+        break;
+      }
+
+      case 'finish': {
+        console.log(`\n\n[Finished] Reason: ${part.finishReason}`);
+        break;
+      }
+
+      case 'error': {
+        console.error('\n[Error]', part.error);
+        break;
+      }
+    }
+  }
+
+  // Access sources from the final result
+  console.log('\n\n=== All Sources ===');
+  const sources = result.experimental_providerMetadata?.sources || [];
+  if (sources.length > 0) {
+    sources.forEach((source: any, index: number) => {
+      console.log(`${index + 1}. ${source.title} - ${source.url}`);
+    });
+  } else {
+    console.log('No sources available in metadata');
+  }
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/google-rag-tool-sources.ts
+++ b/examples/ai-core/src/stream-text/google-rag-tool-sources.ts
@@ -38,7 +38,6 @@ async function main() {
       },
     ],
     tools: {
-      
       searchKnowledge: tool({
         description:
           'Search the knowledge base for relevant information. Always use this tool when answering questions to provide accurate, sourced information.',
@@ -51,22 +50,13 @@ async function main() {
             .describe('Maximum number of results to return'),
         }),
         execute: async ({ query, limit = 3 }, { writeSource }) => {
-          
-
-          
           const results = knowledgeBase
             .filter(doc =>
               doc.content.toLowerCase().includes(query.toLowerCase()),
             )
             .slice(0, limit);
 
-          
-
-          
           results.forEach(doc => {
-            
-
-            
             writeSource?.({
               sourceType: 'url',
               url: doc.url,
@@ -75,70 +65,19 @@ async function main() {
             });
           });
 
-          
           return results.length > 0
             ? results.map(doc => `${doc.title}: ${doc.content}`).join('\n\n')
             : 'No relevant information found.';
         },
       }),
     },
-    maxSteps: 5, 
+    maxSteps: 5,
   });
 
-  
-
-  
   for await (const part of result.fullStream) {
-    switch (part.type) {
-      case 'text-delta': {
-        process.stdout.write(part.textDelta);
-        break;
-      }
-
-      case 'tool-call': {
-        
-        
-        break;
-      }
-
-      case 'source': {
-        
-        
-        if (part.sourceType === 'url') {
-          
-          
-          
-        }
-        
-        break;
-      }
-
-      case 'tool-result': {
-        const resultText = typeof part.output === 'string' ? part.output : JSON.stringify(part.output);
-        
-        break;
-      }
-
-      case 'finish': {
-        
-        break;
-      }
-
-      case 'error': {
-        break;
-      }
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
     }
-  }
-
-  
-  
-  const sources = result.experimental_providerMetadata?.sources || [];
-  if (sources.length > 0) {
-    sources.forEach((source: any, index: number) => {
-      
-    });
-  } else {
-    
   }
 }
 

--- a/examples/ai-core/src/stream-text/openai-rag-tool-sources.ts
+++ b/examples/ai-core/src/stream-text/openai-rag-tool-sources.ts
@@ -1,0 +1,146 @@
+import { openai } from '@ai-sdk/openai';
+import { streamText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+// Simulated knowledge base - in a real application, this would be a vector database
+const knowledgeBase = [
+  {
+    id: 'doc-1',
+    title: 'Introduction to AI',
+    url: 'https://example.com/intro-to-ai',
+    content:
+      'Artificial Intelligence (AI) is the simulation of human intelligence processes by machines, especially computer systems.',
+  },
+  {
+    id: 'doc-2',
+    title: 'Machine Learning Basics',
+    url: 'https://example.com/ml-basics',
+    content:
+      'Machine Learning is a subset of AI that enables systems to learn and improve from experience without being explicitly programmed.',
+  },
+  {
+    id: 'doc-3',
+    title: 'Neural Networks Explained',
+    url: 'https://example.com/neural-networks',
+    content:
+      'Neural networks are computing systems inspired by biological neural networks that constitute animal brains.',
+  },
+];
+
+async function main() {
+  const result = streamText({
+    model: openai('gpt-4o'),
+    messages: [
+      {
+        role: 'user',
+        content: 'What is machine learning? Please cite your sources.',
+      },
+    ],
+    tools: {
+      // RAG tool that searches knowledge base and writes sources
+      searchKnowledge: tool({
+        description:
+          'Search the knowledge base for relevant information. Always use this tool when answering questions to provide accurate, sourced information.',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+          limit: z
+            .number()
+            .optional()
+            .default(3)
+            .describe('Maximum number of results to return'),
+        }),
+        execute: async ({ query, limit = 3 }, { writeSource }) => {
+          console.log(`\n[Tool] Searching knowledge base for: "${query}"`);
+
+          // Simulate search (in a real app, this would use vector similarity search)
+          const results = knowledgeBase
+            .filter(doc =>
+              doc.content.toLowerCase().includes(query.toLowerCase()),
+            )
+            .slice(0, limit);
+
+          console.log(`[Tool] Found ${results.length} results`);
+
+          // Write sources to the stream as we find them
+          results.forEach(doc => {
+            console.log(`[Tool] Writing source: ${doc.title}`);
+
+            // This is the new feature! Tools can now write sources directly
+            writeSource?.({
+              sourceType: 'url',
+              url: doc.url,
+              title: doc.title,
+              id: doc.id, // Optional: provide custom ID
+            });
+          });
+
+          // Return the content to the LLM
+          return results.length > 0
+            ? results.map(doc => `${doc.title}: ${doc.content}`).join('\n\n')
+            : 'No relevant information found.';
+        },
+      }),
+    },
+    maxSteps: 5, // Allow the model to use tools
+  });
+
+  console.log('\n=== Streaming Response ===\n');
+
+  // Process the stream and display both text and sources
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-delta': {
+        process.stdout.write(part.textDelta);
+        break;
+      }
+
+      case 'tool-call': {
+        console.log(`\n\n[Tool Call] ${part.toolName}`);
+        console.log(`[Arguments] ${JSON.stringify(part.args)}`);
+        break;
+      }
+
+      case 'source': {
+        // Sources written by tools appear here!
+        console.log('\n--- Source Referenced ---');
+        if (part.sourceType === 'url') {
+          console.log(`Title: ${part.title}`);
+          console.log(`URL: ${part.url}`);
+          console.log(`ID: ${part.id}`);
+        }
+        console.log('------------------------\n');
+        break;
+      }
+
+      case 'tool-result': {
+        const resultText = typeof part.output === 'string' ? part.output : JSON.stringify(part.output);
+        console.log(`\n[Tool Result] Returned ${resultText.length} characters`);
+        break;
+      }
+
+      case 'finish': {
+        console.log(`\n\n[Finished] Reason: ${part.finishReason}`);
+        break;
+      }
+
+      case 'error': {
+        console.error('\n[Error]', part.error);
+        break;
+      }
+    }
+  }
+
+  // Access sources from the final result
+  console.log('\n\n=== All Sources ===');
+  const sources = result.experimental_providerMetadata?.sources || [];
+  if (sources.length > 0) {
+    sources.forEach((source: any, index: number) => {
+      console.log(`${index + 1}. ${source.title} - ${source.url}`);
+    });
+  } else {
+    console.log('No sources available in metadata');
+  }
+}
+
+main().catch(console.error);

--- a/examples/next-openai/app/api/chat-rag-tool-sources/route.ts
+++ b/examples/next-openai/app/api/chat-rag-tool-sources/route.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 export const maxDuration = 30;
 
-// Simulated knowledge base - in a real application, this would be a vector database
+
 const knowledgeBase = [
   {
     id: 'doc-1',
@@ -47,16 +47,13 @@ const searchKnowledge = tool({
       .default(3)
       .describe('Maximum number of results'),
   }),
-  execute: async ({ query, limit = 3 }, { writeSource }) => {
-    // Extract keywords from query (remove common stop words)
+  execute: async ({ query, limit = 3 }, { writeSource }) => {   
     const stopWords = ['what', 'is', 'are', 'the', 'a', 'an', 'how', 'why', 'when', 'where', 'who', 'tell', 'me', 'about', 'explain'];
     const keywords = query
       .toLowerCase()
       .split(/\s+/)
       .filter(word => word.length > 2 && !stopWords.includes(word));
 
-    // Simulate vector search (in production, use a real vector database)
-    // Search for documents that contain any of the keywords
     const results = knowledgeBase
       .filter(doc => {
         const contentLower = doc.content.toLowerCase();
@@ -67,7 +64,6 @@ const searchKnowledge = tool({
       })
       .slice(0, limit);
 
-    // Write sources to the stream - they will appear in message.parts
     results.forEach(doc => {
       writeSource?.({
         sourceType: 'url',
@@ -77,7 +73,6 @@ const searchKnowledge = tool({
       });
     });
 
-    // Return content for the LLM to use
     return results.length > 0
       ? results.map(doc => `${doc.title}: ${doc.content}`).join('\n\n')
       : 'No relevant information found.';
@@ -91,7 +86,6 @@ const tools = {
 export async function POST(req: Request) {
   const body = await req.json();
 
-  // Convert simple messages to ModelMessages format
   const modelMessages = body.messages.map((msg: any) => ({
     role: msg.role,
     content: msg.content || msg.parts?.map((p: any) => p.text || p).join('') || '',

--- a/examples/next-openai/app/api/chat-rag-tool-sources/route.ts
+++ b/examples/next-openai/app/api/chat-rag-tool-sources/route.ts
@@ -48,17 +48,12 @@ const searchKnowledge = tool({
       .describe('Maximum number of results'),
   }),
   execute: async ({ query, limit = 3 }, { writeSource }) => {
-    
-    
-
     // Extract keywords from query (remove common stop words)
     const stopWords = ['what', 'is', 'are', 'the', 'a', 'an', 'how', 'why', 'when', 'where', 'who', 'tell', 'me', 'about', 'explain'];
     const keywords = query
       .toLowerCase()
       .split(/\s+/)
       .filter(word => word.length > 2 && !stopWords.includes(word));
-
-    
 
     // Simulate vector search (in production, use a real vector database)
     // Search for documents that contain any of the keywords
@@ -72,11 +67,8 @@ const searchKnowledge = tool({
       })
       .slice(0, limit);
 
-    
-
     // Write sources to the stream - they will appear in message.parts
     results.forEach(doc => {
-      
       writeSource?.({
         sourceType: 'url',
         url: doc.url,
@@ -98,8 +90,6 @@ const tools = {
 
 export async function POST(req: Request) {
   const body = await req.json();
-
-  
 
   // Convert simple messages to ModelMessages format
   const modelMessages = body.messages.map((msg: any) => ({

--- a/examples/next-openai/app/api/chat-rag-tool-sources/route.ts
+++ b/examples/next-openai/app/api/chat-rag-tool-sources/route.ts
@@ -114,5 +114,5 @@ export async function POST(req: Request) {
     stopWhen: stepCountIs(5),
   });
 
-  return result.toUIMessageStreamResponse();
+  return result.toUIMessageStreamResponse({ sendSources: true });
 }

--- a/examples/next-openai/app/api/chat-rag-tool-sources/route.ts
+++ b/examples/next-openai/app/api/chat-rag-tool-sources/route.ts
@@ -1,0 +1,118 @@
+import { google } from '@ai-sdk/google';
+import { convertToModelMessages, stepCountIs, streamText, tool, validateUIMessages } from 'ai';
+import { z } from 'zod';
+
+export const maxDuration = 30;
+
+// Simulated knowledge base - in a real application, this would be a vector database
+const knowledgeBase = [
+  {
+    id: 'doc-1',
+    title: 'Introduction to AI',
+    url: 'https://example.com/intro-to-ai',
+    content:
+      'Artificial Intelligence (AI) is the simulation of human intelligence processes by machines.',
+  },
+  {
+    id: 'doc-2',
+    title: 'Machine Learning Guide',
+    url: 'https://example.com/ml-guide',
+    content:
+      'Machine Learning is a subset of AI that enables systems to learn from data without explicit programming.',
+  },
+  {
+    id: 'doc-3',
+    title: 'Neural Networks Overview',
+    url: 'https://example.com/neural-networks',
+    content:
+      'Neural networks are computing systems inspired by biological neural networks.',
+  },
+  {
+    id: 'doc-4',
+    title: 'Deep Learning Fundamentals',
+    url: 'https://example.com/deep-learning',
+    content:
+      'Deep Learning uses multi-layered neural networks to progressively extract higher-level features.',
+  },
+];
+
+const searchKnowledge = tool({
+  description:
+    'Search the knowledge base for relevant information. Use this tool to find accurate, sourced information to answer user questions.',
+  inputSchema: z.object({
+    query: z.string().describe('The search query'),
+    limit: z
+      .number()
+      .optional()
+      .default(3)
+      .describe('Maximum number of results'),
+  }),
+  execute: async ({ query, limit = 3 }, { writeSource }) => {
+    
+    
+
+    // Extract keywords from query (remove common stop words)
+    const stopWords = ['what', 'is', 'are', 'the', 'a', 'an', 'how', 'why', 'when', 'where', 'who', 'tell', 'me', 'about', 'explain'];
+    const keywords = query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(word => word.length > 2 && !stopWords.includes(word));
+
+    
+
+    // Simulate vector search (in production, use a real vector database)
+    // Search for documents that contain any of the keywords
+    const results = knowledgeBase
+      .filter(doc => {
+        const contentLower = doc.content.toLowerCase();
+        const titleLower = doc.title.toLowerCase();
+        return keywords.some(keyword =>
+          contentLower.includes(keyword) || titleLower.includes(keyword)
+        );
+      })
+      .slice(0, limit);
+
+    
+
+    // Write sources to the stream - they will appear in message.parts
+    results.forEach(doc => {
+      
+      writeSource?.({
+        sourceType: 'url',
+        url: doc.url,
+        title: doc.title,
+        id: doc.id,
+      });
+    });
+
+    // Return content for the LLM to use
+    return results.length > 0
+      ? results.map(doc => `${doc.title}: ${doc.content}`).join('\n\n')
+      : 'No relevant information found.';
+  },
+});
+
+const tools = {
+  searchKnowledge,
+} as const;
+
+export async function POST(req: Request) {
+  const body = await req.json();
+
+  
+
+  // Convert simple messages to ModelMessages format
+  const modelMessages = body.messages.map((msg: any) => ({
+    role: msg.role,
+    content: msg.content || msg.parts?.map((p: any) => p.text || p).join('') || '',
+  }));
+
+  const result = streamText({
+    model: google('gemini-2.5-pro'),
+    messages: modelMessages,
+    tools,
+    stopWhen: stepCountIs(5),
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/examples/next-openai/app/chat-rag-tool-sources/page.tsx
+++ b/examples/next-openai/app/chat-rag-tool-sources/page.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { useState } from 'react';
+
+export default function Page() {
+  const [input, setInput] = useState('');
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({
+      api: '/api/chat-rag-tool-sources',
+    }),
+  });
+
+  console.log('[PAGE] Messages count:', messages.length);
+  messages.forEach((msg: any, i: number) => {
+    console.log(`[PAGE] Message ${i}:`, {
+      role: msg.role,
+      parts: msg.parts?.length || 0,
+    });
+    if (msg.parts) {
+      msg.parts.forEach((part: any, j: number) => {
+        console.log(`[PAGE]   Part ${j}:`, part.type, part);
+      });
+    }
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+
+    console.log('[PAGE] Sending message:', input);
+    await sendMessage({ role: 'user', content: input });
+    setInput('');
+  };
+
+  const isLoading = status === 'streaming' || status === 'submitted';
+
+  return (
+    <div className="flex flex-col gap-4 w-full max-w-3xl mx-auto py-8 px-4">
+      <div className="flex flex-col gap-4">
+        <h1 className="text-2xl font-bold">RAG with Tool Sources</h1>
+        <p className="text-gray-600">
+          This example demonstrates how tools can write sources directly to the
+          stream. Ask questions about AI, ML, or neural networks to see sources
+          appear as citations.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {messages.map((message: any) => {
+          // Extract sources for this message
+          const sources = message.parts?.filter((p: any) => p.type === 'source-url') || [];
+
+          return (
+            <div
+              key={message.id}
+              className={`flex flex-col gap-2 p-4 rounded-lg ${
+                message.role === 'user'
+                  ? 'bg-blue-50 ml-auto max-w-[80%]'
+                  : 'bg-gray-50 mr-auto max-w-[80%]'
+              }`}
+            >
+              <div className="font-semibold text-sm text-gray-600">
+                {message.role === 'user' ? 'You' : 'Assistant'}
+              </div>
+
+              {/* Display message parts */}
+              {message.parts && message.parts.length > 0 ? (
+                message.parts.map((part: any, index: number) => {
+                  if (part.type === 'text') {
+                    return (
+                      <div key={index} className="whitespace-pre-wrap">
+                        {part.text}
+                      </div>
+                    );
+                  }
+                  if (part.type === 'tool-call') {
+                    return (
+                      <div
+                        key={index}
+                        className="mt-2 p-3 bg-white rounded border border-gray-200"
+                      >
+                        <div className="text-xs font-semibold text-gray-500 mb-1">
+                          🔧 Tool: {part.toolName}
+                        </div>
+                        <div className="text-xs text-gray-600">
+                          Query: {part.args?.query || 'N/A'}
+                        </div>
+                      </div>
+                    );
+                  }
+                  // Skip rendering source-url here, we'll show them separately below
+                  if (part.type === 'source-url') {
+                    return null;
+                  }
+                  return null;
+                })
+              ) : (
+                // Fallback for user messages without parts
+                <div className="whitespace-pre-wrap">{message.content}</div>
+              )}
+
+              {/* Display sources section - only if sources exist */}
+              {sources.length > 0 && (
+                <div className="mt-3 flex flex-col gap-2">
+                  <div className="text-sm font-semibold text-gray-700">
+                    📚 Sources:
+                  </div>
+                  {sources.map((source: any, index: number) => (
+                    <a
+                      key={source.id || index}
+                      href={source.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-start gap-2 p-2 bg-white rounded border border-blue-200 hover:border-blue-400 transition-colors text-sm"
+                    >
+                      <span className="text-blue-600 font-medium">
+                        [{index + 1}]
+                      </span>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-gray-800 font-medium">
+                          {source.title || 'Untitled'}
+                        </span>
+                        <span className="text-gray-500 text-xs truncate max-w-md">
+                          {source.url}
+                        </span>
+                      </div>
+                      <span className="ml-auto text-blue-500">↗</span>
+                    </a>
+                  ))}
+                </div>
+              )}
+
+              {/* Show when tool found no sources */}
+              {message.role === 'assistant' &&
+               message.parts?.some((p: any) => p.type === 'tool-result') &&
+               sources.length === 0 && (
+                <div className="mt-2 text-sm text-gray-500 italic">
+                  No relevant sources found in knowledge base.
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {isLoading && (
+          <div className="flex items-center gap-2 text-gray-500 text-sm">
+            <div className="animate-spin h-4 w-4 border-2 border-gray-300 border-t-blue-600 rounded-full" />
+            Thinking...
+          </div>
+        )}
+      </div>
+
+      <form onSubmit={handleSubmit} className="mt-4">
+        <div className="flex gap-2">
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Ask about AI, ML, or neural networks..."
+            className="flex-1 p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            disabled={isLoading}
+          />
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+          >
+            Send
+          </button>
+        </div>
+        <div className="mt-2 text-sm text-gray-500">
+          Try asking: "What is machine learning?" or "Explain neural networks"
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/examples/next-openai/app/chat-rag-tool-sources/page.tsx
+++ b/examples/next-openai/app/chat-rag-tool-sources/page.tsx
@@ -12,24 +12,10 @@ export default function Page() {
     }),
   });
 
-  console.log('[PAGE] Messages count:', messages.length);
-  messages.forEach((msg: any, i: number) => {
-    console.log(`[PAGE] Message ${i}:`, {
-      role: msg.role,
-      parts: msg.parts?.length || 0,
-    });
-    if (msg.parts) {
-      msg.parts.forEach((part: any, j: number) => {
-        console.log(`[PAGE]   Part ${j}:`, part.type, part);
-      });
-    }
-  });
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!input.trim()) return;
 
-    console.log('[PAGE] Sending message:', input);
     await sendMessage({ role: 'user', content: input });
     setInput('');
   };

--- a/examples/next-openai/app/chat-rag-tool-sources/page.tsx
+++ b/examples/next-openai/app/chat-rag-tool-sources/page.tsx
@@ -35,7 +35,6 @@ export default function Page() {
 
       <div className="flex flex-col gap-4">
         {messages.map((message: any) => {
-          // Extract sources for this message
           const sources = message.parts?.filter((p: any) => p.type === 'source-url') || [];
 
           return (
@@ -51,7 +50,6 @@ export default function Page() {
                 {message.role === 'user' ? 'You' : 'Assistant'}
               </div>
 
-              {/* Display message parts */}
               {message.parts && message.parts.length > 0 ? (
                 message.parts.map((part: any, index: number) => {
                   if (part.type === 'text') {
@@ -76,18 +74,15 @@ export default function Page() {
                       </div>
                     );
                   }
-                  // Skip rendering source-url here, we'll show them separately below
                   if (part.type === 'source-url') {
                     return null;
                   }
                   return null;
                 })
               ) : (
-                // Fallback for user messages without parts
                 <div className="whitespace-pre-wrap">{message.content}</div>
               )}
 
-              {/* Display sources section - only if sources exist */}
               {sources.length > 0 && (
                 <div className="mt-3 flex flex-col gap-2">
                   <div className="text-sm font-semibold text-gray-700">
@@ -118,7 +113,6 @@ export default function Page() {
                 </div>
               )}
 
-              {/* Show when tool found no sources */}
               {message.role === 'assistant' &&
                message.parts?.some((p: any) => p.type === 'tool-result') &&
                sources.length === 0 && (

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -19,6 +19,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   abortSignal,
   experimental_context,
   onPreliminaryToolResult,
+  writeSource,
 }: {
   toolCall: TypedToolCall<TOOLS>;
   tools: TOOLS | undefined;
@@ -28,6 +29,22 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   abortSignal: AbortSignal | undefined;
   experimental_context: unknown;
   onPreliminaryToolResult?: (result: TypedToolResult<TOOLS>) => void;
+  writeSource?: (
+    source:
+      | {
+          sourceType: 'url';
+          url: string;
+          title?: string;
+          id?: string;
+        }
+      | {
+          sourceType: 'document';
+          mediaType: string;
+          title: string;
+          filename?: string;
+          id?: string;
+        },
+  ) => void;
 }): Promise<ToolOutput<TOOLS> | undefined> {
   const { toolName, toolCallId, input } = toolCall;
   const tool = tools?.[toolName];
@@ -65,6 +82,7 @@ export async function executeToolCall<TOOLS extends ToolSet>({
             messages,
             abortSignal,
             experimental_context,
+            writeSource,
           },
         });
 

--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -251,7 +251,7 @@ describe('runToolsTransformation', () => {
           title: 'Delayed Tool',
           inputSchema: z.object({ value: z.string() }),
           execute: async ({ value }) => {
-            await delay(0); // Simulate delayed execution
+            await delay(0); 
             return `${value}-delayed-result`;
           },
         },
@@ -481,7 +481,7 @@ describe('runToolsTransformation', () => {
         experimental_context: undefined,
       });
 
-      // consume each chunk to maintain order
+      
       const reader = transformedStream.getReader();
       while (true) {
         const { done, value } = await reader.read();
@@ -562,7 +562,7 @@ describe('runToolsTransformation', () => {
         experimental_context: undefined,
       });
 
-      // consume each chunk to maintain order
+      
       const reader = transformedStream.getReader();
       while (true) {
         const { done, value } = await reader.read();
@@ -644,10 +644,10 @@ describe('runToolsTransformation', () => {
           searchTool: tool({
             inputSchema: z.object({ query: z.string() }),
             execute: async ({ query }, { writeSource }) => {
-              // Write a URL source
+              
               writeSource?.({
                 sourceType: 'url',
-                url: 'https://example.com/doc',
+                url: 'https://example.com/doc1',
                 title: 'Example Document',
               });
 
@@ -667,7 +667,7 @@ describe('runToolsTransformation', () => {
 
       const result = await convertReadableStreamToArray(transformedStream);
 
-      // Should contain tool-call, source, tool-result, and finish
+      
       expect(result).toHaveLength(4);
       expect(result[0]).toMatchObject({
         type: 'tool-call',
@@ -677,9 +677,9 @@ describe('runToolsTransformation', () => {
       expect(result[1]).toMatchObject({
         type: 'source',
         sourceType: 'url',
-        url: 'https://example.com/doc',
+        url: 'https://example.com/doc1',
         title: 'Example Document',
-        id: 'id-1', // auto-generated (id-0 is used for toolExecutionId)
+        id: 'id-1', 
       });
       expect(result[2]).toMatchObject({
         type: 'tool-result',
@@ -714,7 +714,7 @@ describe('runToolsTransformation', () => {
           searchTool: tool({
             inputSchema: z.object({ query: z.string() }),
             execute: async ({ query }, { writeSource }) => {
-              // Write a document source
+              
               writeSource?.({
                 sourceType: 'document',
                 mediaType: 'application/pdf',
@@ -738,7 +738,7 @@ describe('runToolsTransformation', () => {
 
       const result = await convertReadableStreamToArray(transformedStream);
 
-      // Should contain tool-call, source, tool-result, and finish
+      
       expect(result).toHaveLength(4);
       expect(result[1]).toMatchObject({
         type: 'source',
@@ -746,7 +746,7 @@ describe('runToolsTransformation', () => {
         mediaType: 'application/pdf',
         title: 'Research Paper',
         filename: 'paper.pdf',
-        id: 'id-1', // auto-generated (id-0 is used for toolExecutionId)
+        id: 'id-1', 
       });
     });
 
@@ -772,7 +772,7 @@ describe('runToolsTransformation', () => {
           searchTool: tool({
             inputSchema: z.object({ query: z.string() }),
             execute: async ({ query }, { writeSource }) => {
-              // Write multiple sources
+              
               writeSource?.({
                 sourceType: 'url',
                 url: 'https://example.com/doc1',
@@ -801,19 +801,19 @@ describe('runToolsTransformation', () => {
 
       const result = await convertReadableStreamToArray(transformedStream);
 
-      // Should contain tool-call, source1, source2, tool-result, and finish
+      
       expect(result).toHaveLength(5);
       expect(result[1]).toMatchObject({
         type: 'source',
         sourceType: 'url',
         url: 'https://example.com/doc1',
         title: 'Document 1',
-        id: 'id-1', // id-0 is used for toolExecutionId
+        id: 'id-1', 
       });
       expect(result[2]).toMatchObject({
         type: 'source',
         sourceType: 'url',
-        url: 'https://example.com/doc2',
+        url: 'https://example.com/doc2',  
         title: 'Document 2',
         id: 'id-2',
       });
@@ -841,7 +841,7 @@ describe('runToolsTransformation', () => {
           searchTool: tool({
             inputSchema: z.object({ query: z.string() }),
             execute: async ({ query }, { writeSource }) => {
-              // Write source with custom ID
+              
               writeSource?.({
                 sourceType: 'url',
                 url: 'https://example.com/doc',
@@ -867,7 +867,7 @@ describe('runToolsTransformation', () => {
 
       expect(result[1]).toMatchObject({
         type: 'source',
-        id: 'custom-source-id', // should use provided ID
+        id: 'custom-source-id', 
       });
     });
 
@@ -893,7 +893,7 @@ describe('runToolsTransformation', () => {
           simpleTool: tool({
             inputSchema: z.object({ value: z.string() }),
             execute: async ({ value }) => {
-              // Don't use writeSource at all
+              
               return `Result: ${value}`;
             },
           }),
@@ -909,8 +909,7 @@ describe('runToolsTransformation', () => {
       });
 
       const result = await convertReadableStreamToArray(transformedStream);
-
-      // Should work normally without sources
+      
       expect(result).toHaveLength(3);
       expect(result[0]).toMatchObject({
         type: 'tool-call',

--- a/packages/ai/src/generate-text/run-tools-transformation.test.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.test.ts
@@ -620,4 +620,308 @@ describe('runToolsTransformation', () => {
       `);
     });
   });
+
+  describe('writeSource', () => {
+    it('should allow tools to write URL sources to the stream', async () => {
+      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+        convertArrayToReadableStream([
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'searchTool',
+            input: `{ "query": "test" }`,
+          },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: testUsage,
+          },
+        ]);
+
+      const transformedStream = runToolsTransformation({
+        generateId: mockId({ prefix: 'id' }),
+        tools: {
+          searchTool: tool({
+            inputSchema: z.object({ query: z.string() }),
+            execute: async ({ query }, { writeSource }) => {
+              // Write a URL source
+              writeSource?.({
+                sourceType: 'url',
+                url: 'https://example.com/doc',
+                title: 'Example Document',
+              });
+
+              return `Results for: ${query}`;
+            },
+          }),
+        },
+        generatorStream: inputStream,
+        tracer: new MockTracer(),
+        telemetry: undefined,
+        messages: [],
+        system: undefined,
+        abortSignal: undefined,
+        repairToolCall: undefined,
+        experimental_context: undefined,
+      });
+
+      const result = await convertReadableStreamToArray(transformedStream);
+
+      // Should contain tool-call, source, tool-result, and finish
+      expect(result).toHaveLength(4);
+      expect(result[0]).toMatchObject({
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'searchTool',
+      });
+      expect(result[1]).toMatchObject({
+        type: 'source',
+        sourceType: 'url',
+        url: 'https://example.com/doc',
+        title: 'Example Document',
+        id: 'id-1', // auto-generated (id-0 is used for toolExecutionId)
+      });
+      expect(result[2]).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        output: 'Results for: test',
+      });
+      expect(result[3]).toMatchObject({
+        type: 'finish',
+        finishReason: 'stop',
+      });
+    });
+
+    it('should allow tools to write document sources to the stream', async () => {
+      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+        convertArrayToReadableStream([
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'searchTool',
+            input: `{ "query": "test" }`,
+          },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: testUsage,
+          },
+        ]);
+
+      const transformedStream = runToolsTransformation({
+        generateId: mockId({ prefix: 'id' }),
+        tools: {
+          searchTool: tool({
+            inputSchema: z.object({ query: z.string() }),
+            execute: async ({ query }, { writeSource }) => {
+              // Write a document source
+              writeSource?.({
+                sourceType: 'document',
+                mediaType: 'application/pdf',
+                title: 'Research Paper',
+                filename: 'paper.pdf',
+              });
+
+              return `Results for: ${query}`;
+            },
+          }),
+        },
+        generatorStream: inputStream,
+        tracer: new MockTracer(),
+        telemetry: undefined,
+        messages: [],
+        system: undefined,
+        abortSignal: undefined,
+        repairToolCall: undefined,
+        experimental_context: undefined,
+      });
+
+      const result = await convertReadableStreamToArray(transformedStream);
+
+      // Should contain tool-call, source, tool-result, and finish
+      expect(result).toHaveLength(4);
+      expect(result[1]).toMatchObject({
+        type: 'source',
+        sourceType: 'document',
+        mediaType: 'application/pdf',
+        title: 'Research Paper',
+        filename: 'paper.pdf',
+        id: 'id-1', // auto-generated (id-0 is used for toolExecutionId)
+      });
+    });
+
+    it('should allow tools to write multiple sources to the stream', async () => {
+      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+        convertArrayToReadableStream([
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'searchTool',
+            input: `{ "query": "test" }`,
+          },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: testUsage,
+          },
+        ]);
+
+      const transformedStream = runToolsTransformation({
+        generateId: mockId({ prefix: 'id' }),
+        tools: {
+          searchTool: tool({
+            inputSchema: z.object({ query: z.string() }),
+            execute: async ({ query }, { writeSource }) => {
+              // Write multiple sources
+              writeSource?.({
+                sourceType: 'url',
+                url: 'https://example.com/doc1',
+                title: 'Document 1',
+              });
+
+              writeSource?.({
+                sourceType: 'url',
+                url: 'https://example.com/doc2',
+                title: 'Document 2',
+              });
+
+              return `Results for: ${query}`;
+            },
+          }),
+        },
+        generatorStream: inputStream,
+        tracer: new MockTracer(),
+        telemetry: undefined,
+        messages: [],
+        system: undefined,
+        abortSignal: undefined,
+        repairToolCall: undefined,
+        experimental_context: undefined,
+      });
+
+      const result = await convertReadableStreamToArray(transformedStream);
+
+      // Should contain tool-call, source1, source2, tool-result, and finish
+      expect(result).toHaveLength(5);
+      expect(result[1]).toMatchObject({
+        type: 'source',
+        sourceType: 'url',
+        url: 'https://example.com/doc1',
+        title: 'Document 1',
+        id: 'id-1', // id-0 is used for toolExecutionId
+      });
+      expect(result[2]).toMatchObject({
+        type: 'source',
+        sourceType: 'url',
+        url: 'https://example.com/doc2',
+        title: 'Document 2',
+        id: 'id-2',
+      });
+    });
+
+    it('should use provided ID when specified', async () => {
+      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+        convertArrayToReadableStream([
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'searchTool',
+            input: `{ "query": "test" }`,
+          },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: testUsage,
+          },
+        ]);
+
+      const transformedStream = runToolsTransformation({
+        generateId: mockId({ prefix: 'id' }),
+        tools: {
+          searchTool: tool({
+            inputSchema: z.object({ query: z.string() }),
+            execute: async ({ query }, { writeSource }) => {
+              // Write source with custom ID
+              writeSource?.({
+                sourceType: 'url',
+                url: 'https://example.com/doc',
+                title: 'Example Document',
+                id: 'custom-source-id',
+              });
+
+              return `Results for: ${query}`;
+            },
+          }),
+        },
+        generatorStream: inputStream,
+        tracer: new MockTracer(),
+        telemetry: undefined,
+        messages: [],
+        system: undefined,
+        abortSignal: undefined,
+        repairToolCall: undefined,
+        experimental_context: undefined,
+      });
+
+      const result = await convertReadableStreamToArray(transformedStream);
+
+      expect(result[1]).toMatchObject({
+        type: 'source',
+        id: 'custom-source-id', // should use provided ID
+      });
+    });
+
+    it('should work when writeSource is not called', async () => {
+      const inputStream: ReadableStream<LanguageModelV3StreamPart> =
+        convertArrayToReadableStream([
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'simpleTool',
+            input: `{ "value": "test" }`,
+          },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: testUsage,
+          },
+        ]);
+
+      const transformedStream = runToolsTransformation({
+        generateId: mockId({ prefix: 'id' }),
+        tools: {
+          simpleTool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            execute: async ({ value }) => {
+              // Don't use writeSource at all
+              return `Result: ${value}`;
+            },
+          }),
+        },
+        generatorStream: inputStream,
+        tracer: new MockTracer(),
+        telemetry: undefined,
+        messages: [],
+        system: undefined,
+        abortSignal: undefined,
+        repairToolCall: undefined,
+        experimental_context: undefined,
+      });
+
+      const result = await convertReadableStreamToArray(transformedStream);
+
+      // Should work normally without sources
+      expect(result).toHaveLength(3);
+      expect(result[0]).toMatchObject({
+        type: 'tool-call',
+      });
+      expect(result[1]).toMatchObject({
+        type: 'tool-result',
+        output: 'Result: test',
+      });
+      expect(result[2]).toMatchObject({
+        type: 'finish',
+      });
+    });
+  });
 });

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -300,10 +300,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                   toolResultsStreamController!.enqueue(result);
                 },
                 writeSource: source => {
-                  // Auto-generate ID if not provided
                   const sourceId = source.id ?? generateId();
-
-                  // Enqueue source part to stream
                   toolResultsStreamController!.enqueue({
                     type: 'source',
                     ...source,

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -299,6 +299,17 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
                 onPreliminaryToolResult: result => {
                   toolResultsStreamController!.enqueue(result);
                 },
+                writeSource: source => {
+                  // Auto-generate ID if not provided
+                  const sourceId = source.id ?? generateId();
+
+                  // Enqueue source part to stream
+                  toolResultsStreamController!.enqueue({
+                    type: 'source',
+                    ...source,
+                    id: sourceId,
+                  } as SingleRequestTextStreamPart<TOOLS>);
+                },
               }).then(result => {
                 toolResultsStreamController!.enqueue(result);
                 outstandingToolResults.delete(toolExecutionId);

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -9264,6 +9264,8 @@ describe('streamText', () => {
           abortSignal: abortController.signal,
           toolCallId: 'call-1',
           messages: expect.any(Array),
+          experimental_context: undefined,
+          writeSource: expect.any(Function),
         },
       );
     });

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -31,6 +31,80 @@ export interface ToolCallOptions {
    * Experimental (can break in patch releases).
    */
   experimental_context?: unknown;
+
+  /**
+   * Optional callback to write a source reference to the stream.
+   * Sources appear alongside tool output in the UI and can be used to show citations or references.
+   *
+   * The source ID will be auto-generated if not provided.
+   *
+   * @example
+   * ```typescript
+   * execute: async (input, { writeSource }) => {
+   *   const results = await search(input.query);
+   *
+   *   results.forEach(result => {
+   *     writeSource?.({
+   *       sourceType: 'url',
+   *       url: result.url,
+   *       title: result.title,
+   *     });
+   *   });
+   *
+   *   return results.map(r => r.content).join('\n');
+   * }
+   * ```
+   */
+  writeSource?: (
+    source:
+      | {
+          /**
+           * The type of source - URL sources reference web content.
+           */
+          sourceType: 'url';
+
+          /**
+           * The URL of the source.
+           */
+          url: string;
+
+          /**
+           * The title of the source.
+           */
+          title?: string;
+
+          /**
+           * Optional ID for the source. Will be auto-generated if not provided.
+           */
+          id?: string;
+        }
+      | {
+          /**
+           * The type of source - document sources reference files/documents.
+           */
+          sourceType: 'document';
+
+          /**
+           * IANA media type of the document (e.g., 'application/pdf').
+           */
+          mediaType: string;
+
+          /**
+           * The title of the document.
+           */
+          title: string;
+
+          /**
+           * Optional filename of the document.
+           */
+          filename?: string;
+
+          /**
+           * Optional ID for the source. Will be auto-generated if not provided.
+           */
+          id?: string;
+        },
+  ) => void;
 }
 
 /**


### PR DESCRIPTION
## Background

For RAG use-cases, the only way to send sources was manually creating a `UIMessageStream` and calling `writer.write()` with source parts, requiring wrapper functions around tools.

## Summary

Added `writeSource` callback to tool's execute function options (second argument), allowing RAG tools to write sources directly to the stream.

**Example:**
```typescript
execute: async ({ query }, { writeSource }) => {
  const results = await searchDatabase(query);
  
  results.forEach(doc => {
    writeSource?.({
      sourceType: 'url',
      url: doc.url,
      title: doc.title,
    });
  });
  
  return results.map(r => r.content).join('\n');
}
```

- Added `writeSource` to `ToolCallOptions` interface
- Sources auto-generate IDs if not provided
- Sources flow through existing stream infrastructure

## Manual Verification

Tested with CLI examples (OpenAI + Google Gemini) - sources appear in stream output.
Tested with Next.js frontend - sources render as clickable links in UI.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #10219