### PR TITLE
chore(documentation): correct imports in caching documentation

### DIFF
--- a/content/docs/06-advanced/04-caching.mdx
+++ b/content/docs/06-advanced/04-caching.mdx
@@ -15,12 +15,33 @@ and the [`simulateReadableStream`](/docs/reference/ai-sdk-core/simulate-readable
 Language model middleware is a way to enhance the behavior of language models by intercepting and modifying the calls to the language model.
 Let's see how you can use language model middleware to cache responses.
 
+<Note>  
+To use the middleware API, you’ll need to install the `@ai-sdk/provider` package:
+</Note>
+<div className="my-4">
+  <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+    <Tab>
+      <Snippet text="pnpm add @ai-sdk/provider" dark />
+    </Tab>
+    <Tab>
+      <Snippet text="npm install @ai-sdk/provider" dark />
+    </Tab>
+    <Tab>
+      <Snippet text="yarn add @ai-sdk/provider" dark />
+    </Tab>
+    <Tab>
+      <Snippet text="bun add @ai-sdk/provider" dark />
+    </Tab>
+  </Tabs>
+</div>
 ```ts filename="ai/middleware.ts"
 import { Redis } from '@upstash/redis';
 import {
   type LanguageModelV2,
   type LanguageModelV2Middleware,
   type LanguageModelV2StreamPart,
+} from '@ai-sdk/provider';
+import {
   simulateReadableStream,
 } from 'ai';
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
The current caching documentation example in [content/docs/06-advanced/04-caching.mdx](https://github.com/vercel/ai/blob/0bdada69f14d7c601d2b273d6abf99d9703de790/content/docs/06-advanced/04-caching.mdx) imports the types `LanguageModelV2`, `LanguageModelV2Middleware`, and `LanguageModelV2StreamPart` from the ai package. However, these types are provided by the @ai-sdk/provider package.

## Summary

This change updates the imports to use @ai-sdk/provider and adds a short note explaining that this package needs to be installed to use the middleware API.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

There seems to be a [separate issue](https://github.com/vercel/ai/issues/8059) with the return type of doGenerate and how it’s used in this example, which is outside the scope of this PR.

Also, these changes only apply to version 5 — other versions may need the same fix, I didn't check.

## Related Issues
#8059