### PR TITLE
fix (provider/amazon-bedrock): deal gracefully with empty tool descriptions

### DIFF
--- a/.changeset/flat-geese-hammer.md
+++ b/.changeset/flat-geese-hammer.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix (provider/amazon-bedrock): deal gracefully with empty tool descriptions

--- a/examples/ai-core/src/stream-text/amazon-bedrock-tool-call-empty-description.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-tool-call-empty-description.ts
@@ -1,0 +1,44 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { streamText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+const toolWithEmptyDescription = tool({
+  description: '',
+  inputSchema: z.object({
+    location: z.string().describe('The location to get the weather for'),
+  }),
+  execute: async ({ location }) => ({
+    location,
+    temperature: 72,
+  }),
+});
+
+async function main() {
+  const result = streamText({
+    model: bedrock('global.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+    tools: {
+      emptyDescTool: toolWithEmptyDescription,
+    },
+    toolChoice: 'required',
+    prompt: 'Use the tool to get weather for San Francisco',
+  });
+
+  for await (const delta of result.fullStream) {
+    switch (delta.type) {
+      case 'text-delta': {
+        process.stdout.write(delta.text);
+        break;
+      }
+      case 'tool-call': {
+        process.stdout.write(
+          `\nTool call: '${delta.toolName}' ${JSON.stringify(delta.input)}`,
+        );
+        break;
+      }
+    }
+  }
+  process.stdout.write('\n\n');
+}
+
+main().catch(console.error);

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -140,7 +140,11 @@ export async function prepareTools({
     bedrockTools.push({
       toolSpec: {
         name: tool.name,
-        description: tool.description,
+        // Only include description if it's a non-empty string
+        // Bedrock API requires description to have length >= 1 if present
+        ...(tool.description && tool.description.trim() !== ''
+          ? { description: tool.description }
+          : {}),
         inputSchema: {
           json: tool.inputSchema as JSONObject,
         },

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -140,9 +140,7 @@ export async function prepareTools({
     bedrockTools.push({
       toolSpec: {
         name: tool.name,
-        ...(tool.description && tool.description.trim() !== ''
-          ? { description: tool.description }
-          : {}),
+        description: tool.description,
         inputSchema: {
           json: tool.inputSchema as JSONObject,
         },

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -140,8 +140,6 @@ export async function prepareTools({
     bedrockTools.push({
       toolSpec: {
         name: tool.name,
-        // Only include description if it's a non-empty string
-        // Bedrock API requires description to have length >= 1 if present
         ...(tool.description && tool.description.trim() !== ''
           ? { description: tool.description }
           : {}),

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -140,7 +140,9 @@ export async function prepareTools({
     bedrockTools.push({
       toolSpec: {
         name: tool.name,
-        description: tool.description,
+        ...(tool.description?.trim() !== ''
+          ? { description: tool.description }
+          : {}),
         inputSchema: {
           json: tool.inputSchema as JSONObject,
         },


### PR DESCRIPTION
## Background

Bedrock Converse API reports an error on tool definitions with a description having an empty string. Sample error, status code 400:

```
Value '' at 'toolConfig.tools.15.member.toolSpec.description' failed to satisfy constraint: Member must have length greater than or equal to 1
```

## Summary

Only include tool description parameter when the value is a non-empty string.

## Manual Verification

Added example script demonstrating the issue. Breaks before patch, passes after.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
