### PR TITLE
feat(groq,google,openrouter,gateway): fix structured output with tools (#10023)

### DIFF
--- a/.changeset/tough-tools-march.md
+++ b/.changeset/tough-tools-march.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google': patch
+'@ai-sdk/groq': patch
+---
+
+Add synthetic JSON tool fallback for structured output when used together with tool calling. When a model does not support native structured output combined with tools, a synthetic `json` function tool is injected and its response is extracted as text content. A `structuredOutputMode` provider option (`auto` | `outputFormat` | `jsonTool`) controls the strategy per request.

--- a/packages/google/src/__snapshots__/google-generative-ai-language-model.test.ts.snap
+++ b/packages/google/src/__snapshots__/google-generative-ai-language-model.test.ts.snap
@@ -25,10 +25,17 @@ Here is the breakdown: st**r**awbe**rr**y.",
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
+      "serviceTier": null,
       "urlContextMetadata": null,
       "usageMetadata": {
         "candidatesTokenCount": 29,
         "promptTokenCount": 9,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 9,
+          },
+        ],
         "thoughtsTokenCount": 258,
         "totalTokenCount": 296,
       },
@@ -63,6 +70,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
       },
       "labels": undefined,
       "safetySettings": undefined,
+      "serviceTier": undefined,
       "systemInstruction": undefined,
       "toolConfig": undefined,
       "tools": undefined,
@@ -122,6 +130,12 @@ Here is the breakdown: st**r**awbe**rr**y.",
     "raw": {
       "candidatesTokenCount": 29,
       "promptTokenCount": 9,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 9,
+        },
+      ],
       "thoughtsTokenCount": 258,
       "totalTokenCount": 296,
     },
@@ -155,10 +169,17 @@ Here is the breakdown: st**r**awbe**rr**y.",
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
+      "serviceTier": null,
       "urlContextMetadata": null,
       "usageMetadata": {
         "candidatesTokenCount": 28,
         "promptTokenCount": 9,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 9,
+          },
+        ],
         "thoughtsTokenCount": 244,
         "totalTokenCount": 281,
       },
@@ -193,6 +214,7 @@ Here is the breakdown: st**r**awbe**rr**y.",
       },
       "labels": undefined,
       "safetySettings": undefined,
+      "serviceTier": undefined,
       "systemInstruction": undefined,
       "toolConfig": undefined,
       "tools": undefined,
@@ -252,6 +274,12 @@ Here is the breakdown: st**r**awbe**rr**y.",
     "raw": {
       "candidatesTokenCount": 28,
       "promptTokenCount": 9,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 9,
+        },
+      ],
       "thoughtsTokenCount": 244,
       "totalTokenCount": 281,
     },
@@ -276,6 +304,12 @@ exports[`doGenerate > text > should extract usage 1`] = `
   "raw": {
     "candidatesTokenCount": 28,
     "promptTokenCount": 9,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 9,
+      },
+    ],
     "thoughtsTokenCount": 244,
     "totalTokenCount": 281,
   },
@@ -307,10 +341,17 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
+      "serviceTier": null,
       "urlContextMetadata": null,
       "usageMetadata": {
         "candidatesTokenCount": 15,
         "promptTokenCount": 29,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 29,
+          },
+        ],
         "thoughtsTokenCount": 893,
         "totalTokenCount": 937,
       },
@@ -345,6 +386,7 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
       },
       "labels": undefined,
       "safetySettings": undefined,
+      "serviceTier": undefined,
       "systemInstruction": undefined,
       "toolConfig": undefined,
       "tools": [
@@ -428,6 +470,12 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
     "raw": {
       "candidatesTokenCount": 15,
       "promptTokenCount": 29,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 29,
+        },
+      ],
       "thoughtsTokenCount": 893,
       "totalTokenCount": 937,
     },
@@ -461,10 +509,17 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
+      "serviceTier": null,
       "urlContextMetadata": null,
       "usageMetadata": {
         "candidatesTokenCount": 15,
         "promptTokenCount": 29,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 29,
+          },
+        ],
         "thoughtsTokenCount": 1801,
         "totalTokenCount": 1845,
       },
@@ -499,6 +554,7 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
       },
       "labels": undefined,
       "safetySettings": undefined,
+      "serviceTier": undefined,
       "systemInstruction": undefined,
       "toolConfig": undefined,
       "tools": undefined,
@@ -562,6 +618,12 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
     "raw": {
       "candidatesTokenCount": 15,
       "promptTokenCount": 29,
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 29,
+        },
+      ],
       "thoughtsTokenCount": 1801,
       "totalTokenCount": 1845,
     },
@@ -620,10 +682,17 @@ Here is the breakdown: st**r**awbe**rr**y.",
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
+        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 29,
           "promptTokenCount": 9,
+          "promptTokensDetails": [
+            {
+              "modality": "TEXT",
+              "tokenCount": 9,
+            },
+          ],
           "thoughtsTokenCount": 256,
           "totalTokenCount": 294,
         },
@@ -645,6 +714,12 @@ Here is the breakdown: st**r**awbe**rr**y.",
       "raw": {
         "candidatesTokenCount": 29,
         "promptTokenCount": 9,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 9,
+          },
+        ],
         "thoughtsTokenCount": 256,
         "totalTokenCount": 294,
       },
@@ -703,10 +778,17 @@ exports[`doStream > reasoning-gemini3 > should stream reasoning with thoughtSign
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
+        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 23,
           "promptTokenCount": 9,
+          "promptTokensDetails": [
+            {
+              "modality": "TEXT",
+              "tokenCount": 9,
+            },
+          ],
           "thoughtsTokenCount": 302,
           "totalTokenCount": 334,
         },
@@ -728,6 +810,12 @@ exports[`doStream > reasoning-gemini3 > should stream reasoning with thoughtSign
       "raw": {
         "candidatesTokenCount": 23,
         "promptTokenCount": 9,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 9,
+          },
+        ],
         "thoughtsTokenCount": 302,
         "totalTokenCount": 334,
       },
@@ -891,10 +979,17 @@ st**r**awbe**rr**y",
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
+        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 23,
           "promptTokenCount": 9,
+          "promptTokensDetails": [
+            {
+              "modality": "TEXT",
+              "tokenCount": 9,
+            },
+          ],
           "thoughtsTokenCount": 185,
           "totalTokenCount": 217,
         },
@@ -916,6 +1011,12 @@ st**r**awbe**rr**y",
       "raw": {
         "candidatesTokenCount": 23,
         "promptTokenCount": 9,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 9,
+          },
+        ],
         "thoughtsTokenCount": 185,
         "totalTokenCount": 217,
       },
@@ -981,10 +1082,17 @@ exports[`doStream > tool-call > should stream tool call 1`] = `
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
+        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 15,
           "promptTokenCount": 29,
+          "promptTokensDetails": [
+            {
+              "modality": "TEXT",
+              "tokenCount": 29,
+            },
+          ],
           "thoughtsTokenCount": 45,
           "totalTokenCount": 89,
         },
@@ -1006,6 +1114,12 @@ exports[`doStream > tool-call > should stream tool call 1`] = `
       "raw": {
         "candidatesTokenCount": 15,
         "promptTokenCount": 29,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 29,
+          },
+        ],
         "thoughtsTokenCount": 45,
         "totalTokenCount": 89,
       },
@@ -1071,10 +1185,17 @@ exports[`doStream > tool-call-gemini3 > should stream tool call with thoughtSign
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
+        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 15,
           "promptTokenCount": 29,
+          "promptTokensDetails": [
+            {
+              "modality": "TEXT",
+              "tokenCount": 29,
+            },
+          ],
           "thoughtsTokenCount": 804,
           "totalTokenCount": 848,
         },
@@ -1096,6 +1217,12 @@ exports[`doStream > tool-call-gemini3 > should stream tool call with thoughtSign
       "raw": {
         "candidatesTokenCount": 15,
         "promptTokenCount": 29,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 29,
+          },
+        ],
         "thoughtsTokenCount": 804,
         "totalTokenCount": 848,
       },

--- a/packages/google/src/__snapshots__/google-generative-ai-language-model.test.ts.snap
+++ b/packages/google/src/__snapshots__/google-generative-ai-language-model.test.ts.snap
@@ -25,17 +25,10 @@ Here is the breakdown: st**r**awbe**rr**y.",
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
-      "serviceTier": null,
       "urlContextMetadata": null,
       "usageMetadata": {
         "candidatesTokenCount": 29,
         "promptTokenCount": 9,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 9,
-          },
-        ],
         "thoughtsTokenCount": 258,
         "totalTokenCount": 296,
       },
@@ -70,7 +63,6 @@ Here is the breakdown: st**r**awbe**rr**y.",
       },
       "labels": undefined,
       "safetySettings": undefined,
-      "serviceTier": undefined,
       "systemInstruction": undefined,
       "toolConfig": undefined,
       "tools": undefined,
@@ -130,12 +122,6 @@ Here is the breakdown: st**r**awbe**rr**y.",
     "raw": {
       "candidatesTokenCount": 29,
       "promptTokenCount": 9,
-      "promptTokensDetails": [
-        {
-          "modality": "TEXT",
-          "tokenCount": 9,
-        },
-      ],
       "thoughtsTokenCount": 258,
       "totalTokenCount": 296,
     },
@@ -169,17 +155,10 @@ Here is the breakdown: st**r**awbe**rr**y.",
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
-      "serviceTier": null,
       "urlContextMetadata": null,
       "usageMetadata": {
         "candidatesTokenCount": 28,
         "promptTokenCount": 9,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 9,
-          },
-        ],
         "thoughtsTokenCount": 244,
         "totalTokenCount": 281,
       },
@@ -214,7 +193,6 @@ Here is the breakdown: st**r**awbe**rr**y.",
       },
       "labels": undefined,
       "safetySettings": undefined,
-      "serviceTier": undefined,
       "systemInstruction": undefined,
       "toolConfig": undefined,
       "tools": undefined,
@@ -274,12 +252,6 @@ Here is the breakdown: st**r**awbe**rr**y.",
     "raw": {
       "candidatesTokenCount": 28,
       "promptTokenCount": 9,
-      "promptTokensDetails": [
-        {
-          "modality": "TEXT",
-          "tokenCount": 9,
-        },
-      ],
       "thoughtsTokenCount": 244,
       "totalTokenCount": 281,
     },
@@ -304,12 +276,6 @@ exports[`doGenerate > text > should extract usage 1`] = `
   "raw": {
     "candidatesTokenCount": 28,
     "promptTokenCount": 9,
-    "promptTokensDetails": [
-      {
-        "modality": "TEXT",
-        "tokenCount": 9,
-      },
-    ],
     "thoughtsTokenCount": 244,
     "totalTokenCount": 281,
   },
@@ -341,17 +307,10 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
-      "serviceTier": null,
       "urlContextMetadata": null,
       "usageMetadata": {
         "candidatesTokenCount": 15,
         "promptTokenCount": 29,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 29,
-          },
-        ],
         "thoughtsTokenCount": 893,
         "totalTokenCount": 937,
       },
@@ -386,7 +345,6 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
       },
       "labels": undefined,
       "safetySettings": undefined,
-      "serviceTier": undefined,
       "systemInstruction": undefined,
       "toolConfig": undefined,
       "tools": [
@@ -470,12 +428,6 @@ exports[`doGenerate > tool-call > should extract tool calls 1`] = `
     "raw": {
       "candidatesTokenCount": 15,
       "promptTokenCount": 29,
-      "promptTokensDetails": [
-        {
-          "modality": "TEXT",
-          "tokenCount": 29,
-        },
-      ],
       "thoughtsTokenCount": 893,
       "totalTokenCount": 937,
     },
@@ -509,17 +461,10 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
       "groundingMetadata": null,
       "promptFeedback": null,
       "safetyRatings": null,
-      "serviceTier": null,
       "urlContextMetadata": null,
       "usageMetadata": {
         "candidatesTokenCount": 15,
         "promptTokenCount": 29,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 29,
-          },
-        ],
         "thoughtsTokenCount": 1801,
         "totalTokenCount": 1845,
       },
@@ -554,7 +499,6 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
       },
       "labels": undefined,
       "safetySettings": undefined,
-      "serviceTier": undefined,
       "systemInstruction": undefined,
       "toolConfig": undefined,
       "tools": undefined,
@@ -618,12 +562,6 @@ exports[`doGenerate > tool-call-gemini3 > should extract tool call with thoughtS
     "raw": {
       "candidatesTokenCount": 15,
       "promptTokenCount": 29,
-      "promptTokensDetails": [
-        {
-          "modality": "TEXT",
-          "tokenCount": 29,
-        },
-      ],
       "thoughtsTokenCount": 1801,
       "totalTokenCount": 1845,
     },
@@ -682,17 +620,10 @@ Here is the breakdown: st**r**awbe**rr**y.",
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
-        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 29,
           "promptTokenCount": 9,
-          "promptTokensDetails": [
-            {
-              "modality": "TEXT",
-              "tokenCount": 9,
-            },
-          ],
           "thoughtsTokenCount": 256,
           "totalTokenCount": 294,
         },
@@ -714,12 +645,6 @@ Here is the breakdown: st**r**awbe**rr**y.",
       "raw": {
         "candidatesTokenCount": 29,
         "promptTokenCount": 9,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 9,
-          },
-        ],
         "thoughtsTokenCount": 256,
         "totalTokenCount": 294,
       },
@@ -778,17 +703,10 @@ exports[`doStream > reasoning-gemini3 > should stream reasoning with thoughtSign
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
-        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 23,
           "promptTokenCount": 9,
-          "promptTokensDetails": [
-            {
-              "modality": "TEXT",
-              "tokenCount": 9,
-            },
-          ],
           "thoughtsTokenCount": 302,
           "totalTokenCount": 334,
         },
@@ -810,12 +728,6 @@ exports[`doStream > reasoning-gemini3 > should stream reasoning with thoughtSign
       "raw": {
         "candidatesTokenCount": 23,
         "promptTokenCount": 9,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 9,
-          },
-        ],
         "thoughtsTokenCount": 302,
         "totalTokenCount": 334,
       },
@@ -979,17 +891,10 @@ st**r**awbe**rr**y",
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
-        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 23,
           "promptTokenCount": 9,
-          "promptTokensDetails": [
-            {
-              "modality": "TEXT",
-              "tokenCount": 9,
-            },
-          ],
           "thoughtsTokenCount": 185,
           "totalTokenCount": 217,
         },
@@ -1011,12 +916,6 @@ st**r**awbe**rr**y",
       "raw": {
         "candidatesTokenCount": 23,
         "promptTokenCount": 9,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 9,
-          },
-        ],
         "thoughtsTokenCount": 185,
         "totalTokenCount": 217,
       },
@@ -1082,17 +981,10 @@ exports[`doStream > tool-call > should stream tool call 1`] = `
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
-        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 15,
           "promptTokenCount": 29,
-          "promptTokensDetails": [
-            {
-              "modality": "TEXT",
-              "tokenCount": 29,
-            },
-          ],
           "thoughtsTokenCount": 45,
           "totalTokenCount": 89,
         },
@@ -1114,12 +1006,6 @@ exports[`doStream > tool-call > should stream tool call 1`] = `
       "raw": {
         "candidatesTokenCount": 15,
         "promptTokenCount": 29,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 29,
-          },
-        ],
         "thoughtsTokenCount": 45,
         "totalTokenCount": 89,
       },
@@ -1185,17 +1071,10 @@ exports[`doStream > tool-call-gemini3 > should stream tool call with thoughtSign
         "groundingMetadata": null,
         "promptFeedback": null,
         "safetyRatings": null,
-        "serviceTier": null,
         "urlContextMetadata": null,
         "usageMetadata": {
           "candidatesTokenCount": 15,
           "promptTokenCount": 29,
-          "promptTokensDetails": [
-            {
-              "modality": "TEXT",
-              "tokenCount": 29,
-            },
-          ],
           "thoughtsTokenCount": 804,
           "totalTokenCount": 848,
         },
@@ -1217,12 +1096,6 @@ exports[`doStream > tool-call-gemini3 > should stream tool call with thoughtSign
       "raw": {
         "candidatesTokenCount": 15,
         "promptTokenCount": 29,
-        "promptTokensDetails": [
-          {
-            "modality": "TEXT",
-            "tokenCount": 29,
-          },
-        ],
         "thoughtsTokenCount": 804,
         "totalTokenCount": 848,
       },

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -355,32 +355,12 @@ describe('doGenerate', () => {
   const TEST_URL_GEMINI_1_5_FLASH =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
 
-  const TEST_URL_GEMINI_3_PRO =
-    'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent';
-
-  const TEST_URL_GEMINI_3_1_PRO =
-    'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent';
-
-  const TEST_URL_GEMINI_2_5_PRO =
-    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent';
-
-  const TEST_URL_GEMINI_2_5_FLASH =
-    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
-
-  const TEST_URL_GEMINI_2_5_FLASH_LITE =
-    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent';
-
   const server = createTestServer({
     [TEST_URL_GEMINI_PRO]: {},
     [TEST_URL_GEMINI_2_0_PRO]: {},
     [TEST_URL_GEMINI_2_0_FLASH_EXP]: {},
     [TEST_URL_GEMINI_1_0_PRO]: {},
     [TEST_URL_GEMINI_1_5_FLASH]: {},
-    [TEST_URL_GEMINI_3_PRO]: {},
-    [TEST_URL_GEMINI_3_1_PRO]: {},
-    [TEST_URL_GEMINI_2_5_PRO]: {},
-    [TEST_URL_GEMINI_2_5_FLASH_LITE]: {},
-    [TEST_URL_GEMINI_2_5_FLASH]: {},
   });
 
   function prepareJsonFixtureResponse(
@@ -573,74 +553,6 @@ describe('doGenerate', () => {
     });
 
     expect(providerMetadata?.google.finishMessage).toBeNull();
-  });
-
-  it('should send serviceTier in request body when specified', async () => {
-    prepareJsonResponse({ content: 'test response' });
-
-    await model.doGenerate({
-      prompt: TEST_PROMPT,
-      providerOptions: {
-        google: {
-          serviceTier: 'flex',
-        },
-      },
-    });
-
-    expect(await server.calls[0].requestBodyJson).toMatchObject({
-      serviceTier: 'flex',
-    });
-  });
-
-  it('should not send serviceTier in request body when not specified', async () => {
-    prepareJsonResponse({ content: 'test response' });
-
-    await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    const body = await server.calls[0].requestBodyJson;
-    expect(body).not.toHaveProperty('serviceTier');
-  });
-
-  it('should expose serviceTier in provider metadata', async () => {
-    server.urls[TEST_URL_GEMINI_PRO].response = {
-      type: 'json-value',
-      body: {
-        candidates: [
-          {
-            content: {
-              parts: [{ text: 'test response' }],
-              role: 'model',
-            },
-            finishReason: 'STOP',
-            safetyRatings: SAFETY_RATINGS,
-          },
-        ],
-        usageMetadata: {
-          promptTokenCount: 1,
-          candidatesTokenCount: 2,
-          totalTokenCount: 3,
-        },
-        serviceTier: 'flex',
-      },
-    };
-
-    const { providerMetadata } = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(providerMetadata?.google.serviceTier).toBe('flex');
-  });
-
-  it('should expose null serviceTier in provider metadata when not present', async () => {
-    prepareJsonResponse({ content: 'test response' });
-
-    const { providerMetadata } = await model.doGenerate({
-      prompt: TEST_PROMPT,
-    });
-
-    expect(providerMetadata?.google.serviceTier).toBeNull();
   });
 
   describe('tool-call', () => {
@@ -1006,6 +918,194 @@ describe('doGenerate', () => {
         },
       }
     `);
+  });
+
+  it('should use json tool fallback when responseFormat schema and tools are both present (auto)', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await provider.languageModel('gemini-pro').doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body.generationConfig.responseMimeType).toBeUndefined();
+    expect(body.generationConfig.responseSchema).toBeUndefined();
+    const decls = body.tools[0].functionDeclarations;
+    expect(decls).toHaveLength(2);
+    expect(decls.map((d: { name: string }) => d.name).sort()).toEqual([
+      'json',
+      'test-tool',
+    ]);
+    expect(body.toolConfig.functionCallingConfig.mode).toBe('ANY');
+  });
+
+  it('should use reserved synthetic tool name when user already defines a json tool', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await provider.languageModel('gemini-pro').doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'json',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { legacy: { type: 'string' } },
+            required: ['legacy'],
+            additionalProperties: false,
+          },
+        },
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    const decls = body.tools[0].functionDeclarations;
+    expect(decls.map((d: { name: string }) => d.name).sort()).toEqual([
+      '__ai_sdk_json_response',
+      'json',
+      'test-tool',
+    ]);
+  });
+
+  it('should map finish reason to stop when response is only synthetic json function call', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'json',
+                    args: { out: 'ok' },
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        promptFeedback: { safetyRatings: SAFETY_RATINGS },
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: 2,
+          totalTokenCount: 3,
+        },
+      },
+    };
+
+    const result = await provider.languageModel('gemini-pro').doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.finishReason.unified).toBe('stop');
+    expect(result.content).toEqual([
+      { type: 'text', text: '{"out":"ok"}' },
+    ]);
+  });
+
+  it('should use native responseSchema when structuredOutputMode is outputFormat with schema and tools', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await provider.languageModel('gemini-pro').doGenerate({
+      providerOptions: {
+        google: { structuredOutputMode: 'outputFormat' },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body.generationConfig.responseMimeType).toBe('application/json');
+    expect(body.generationConfig.responseSchema).toBeDefined();
+    const decls = body.tools[0].functionDeclarations;
+    expect(decls).toHaveLength(1);
+    expect(decls[0].name).toBe('test-tool');
   });
 
   it('should pass tools and toolChoice', async () => {
@@ -2158,179 +2258,6 @@ describe('doGenerate', () => {
     `);
   });
 
-  it('should handle server-side toolCall and toolResponse parts (tool combination)', async () => {
-    server.urls[TEST_URL_GEMINI_3_PRO].response = {
-      type: 'json-value',
-      body: {
-        candidates: [
-          {
-            content: {
-              parts: [
-                {
-                  toolCall: {
-                    toolType: 'GOOGLE_SEARCH_WEB',
-                    args: { query: 'San Francisco weather' },
-                    id: 'server-call-1',
-                  },
-                  thoughtSignature: 'sig-abc',
-                },
-                {
-                  toolResponse: {
-                    toolType: 'GOOGLE_SEARCH_WEB',
-                    response: {
-                      results: [{ title: 'Weather in SF' }],
-                    },
-                    id: 'server-call-1',
-                  },
-                  thoughtSignature: 'sig-def',
-                },
-                {
-                  text: 'The weather in San Francisco is sunny.',
-                },
-              ],
-              role: 'model',
-            },
-            finishReason: 'STOP',
-          },
-        ],
-        usageMetadata: {
-          promptTokenCount: 10,
-          candidatesTokenCount: 20,
-          totalTokenCount: 30,
-        },
-      },
-    };
-
-    const model = provider.languageModel('gemini-3-pro-preview');
-    const { content, finishReason } = await model.doGenerate({
-      tools: [
-        {
-          type: 'provider',
-          id: 'google.google_search',
-          name: 'google_search',
-          args: {},
-        },
-        {
-          type: 'function',
-          name: 'weather',
-          inputSchema: {
-            type: 'object',
-            properties: { location: { type: 'string' } },
-          },
-        },
-      ],
-      prompt: TEST_PROMPT,
-    });
-
-    expect(content).toMatchInlineSnapshot(`
-      [
-        {
-          "dynamic": true,
-          "input": "{"query":"San Francisco weather"}",
-          "providerExecuted": true,
-          "providerMetadata": {
-            "google": {
-              "serverToolCallId": "server-call-1",
-              "serverToolType": "GOOGLE_SEARCH_WEB",
-              "thoughtSignature": "sig-abc",
-            },
-          },
-          "toolCallId": "server-call-1",
-          "toolName": "server:GOOGLE_SEARCH_WEB",
-          "type": "tool-call",
-        },
-        {
-          "providerMetadata": {
-            "google": {
-              "serverToolCallId": "server-call-1",
-              "serverToolType": "GOOGLE_SEARCH_WEB",
-              "thoughtSignature": "sig-def",
-            },
-          },
-          "result": {
-            "results": [
-              {
-                "title": "Weather in SF",
-              },
-            ],
-          },
-          "toolCallId": "server-call-1",
-          "toolName": "server:GOOGLE_SEARCH_WEB",
-          "type": "tool-result",
-        },
-        {
-          "providerMetadata": undefined,
-          "text": "The weather in San Francisco is sunny.",
-          "type": "text",
-        },
-      ]
-    `);
-
-    expect(finishReason).toMatchInlineSnapshot(`
-      {
-        "raw": "STOP",
-        "unified": "stop",
-      }
-    `);
-  });
-
-  it('should return stop finish reason for server tool calls (provider-executed)', async () => {
-    server.urls[TEST_URL_GEMINI_3_PRO].response = {
-      type: 'json-value',
-      body: {
-        candidates: [
-          {
-            content: {
-              parts: [
-                {
-                  toolCall: {
-                    toolType: 'GOOGLE_SEARCH_WEB',
-                    args: {},
-                    id: 'sc-1',
-                  },
-                },
-                {
-                  toolResponse: {
-                    toolType: 'GOOGLE_SEARCH_WEB',
-                    response: { results: [] },
-                    id: 'sc-1',
-                  },
-                },
-              ],
-              role: 'model',
-            },
-            finishReason: 'STOP',
-          },
-        ],
-        usageMetadata: {
-          promptTokenCount: 5,
-          candidatesTokenCount: 10,
-          totalTokenCount: 15,
-        },
-      },
-    };
-
-    const model = provider.languageModel('gemini-3-pro-preview');
-    const { finishReason } = await model.doGenerate({
-      tools: [
-        {
-          type: 'provider',
-          id: 'google.google_search',
-          name: 'google_search',
-          args: {},
-        },
-      ],
-      prompt: TEST_PROMPT,
-    });
-
-    expect(finishReason).toMatchInlineSnapshot(`
-      {
-        "raw": "STOP",
-        "unified": "stop",
-      }
-    `);
-  });
-
   describe('search tool selection', () => {
     const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
@@ -3209,344 +3136,6 @@ describe('doGenerate', () => {
     });
   });
 
-  describe('top-level reasoning option', () => {
-    const simpleResponseBody = {
-      candidates: [
-        {
-          content: { parts: [{ text: 'response' }], role: 'model' },
-          finishReason: 'STOP',
-          safetyRatings: SAFETY_RATINGS,
-        },
-      ],
-      usageMetadata: {
-        promptTokenCount: 1,
-        candidatesTokenCount: 2,
-        totalTokenCount: 3,
-      },
-    };
-
-    describe('Gemini 3 models (thinkingLevel)', () => {
-      const gemini3Model = provider.chat('gemini-3-pro-preview');
-
-      it('should map reasoning "minimal" to thinkingLevel "minimal"', async () => {
-        server.urls[TEST_URL_GEMINI_3_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini3Model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'minimal',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingLevel: 'minimal' },
-          },
-        });
-      });
-
-      it('should map reasoning "low" to thinkingLevel "low"', async () => {
-        server.urls[TEST_URL_GEMINI_3_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini3Model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'low',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingLevel: 'low' },
-          },
-        });
-      });
-
-      it('should map reasoning "medium" to thinkingLevel "medium"', async () => {
-        server.urls[TEST_URL_GEMINI_3_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini3Model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'medium',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingLevel: 'medium' },
-          },
-        });
-      });
-
-      it('should map reasoning "high" to thinkingLevel "high"', async () => {
-        server.urls[TEST_URL_GEMINI_3_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini3Model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'high',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingLevel: 'high' },
-          },
-        });
-      });
-
-      it('should map reasoning "none" to thinkingLevel "minimal"', async () => {
-        server.urls[TEST_URL_GEMINI_3_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini3Model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'none',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingLevel: 'minimal' },
-          },
-        });
-      });
-
-      it('should coerce reasoning "xhigh" to "high" with compatibility warning', async () => {
-        server.urls[TEST_URL_GEMINI_3_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        const result = await gemini3Model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'xhigh',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingLevel: 'high' },
-          },
-        });
-
-        expect(result.warnings).toContainEqual({
-          type: 'compatibility',
-          feature: 'reasoning',
-          details:
-            'reasoning "xhigh" is not directly supported by this model. mapped to effort "high".',
-        });
-      });
-
-      it('should also detect gemini-3.1 models as Gemini 3', async () => {
-        const gemini31Model = provider.chat('gemini-3.1-pro-preview');
-
-        server.urls[TEST_URL_GEMINI_3_1_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini31Model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'medium',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingLevel: 'medium' },
-          },
-        });
-      });
-    });
-
-    describe('Gemini 2.5 models (thinkingBudget)', () => {
-      const gemini25ProModel = provider.chat('gemini-2.5-pro');
-      const gemini25FlashLiteModel = provider.chat('gemini-2.5-flash-lite');
-
-      it('should map reasoning "none" to thinkingBudget 0', async () => {
-        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini25ProModel.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'none',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingBudget: 0 },
-          },
-        });
-      });
-
-      it('should map reasoning "minimal" to ~2% of maxOutputTokens', async () => {
-        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini25ProModel.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'minimal',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingBudget: Math.round(65536 * 0.02) },
-          },
-        });
-      });
-
-      it('should map reasoning "low" to ~10% of maxOutputTokens', async () => {
-        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini25ProModel.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'low',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingBudget: Math.round(65536 * 0.1) },
-          },
-        });
-      });
-
-      it('should map reasoning "medium" to ~30% of maxOutputTokens', async () => {
-        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini25ProModel.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'medium',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingBudget: Math.round(65536 * 0.3) },
-          },
-        });
-      });
-
-      it('should map reasoning "high" to ~60% of maxOutputTokens', async () => {
-        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini25ProModel.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'high',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingBudget: 32768 },
-          },
-        });
-      });
-
-      it('should map reasoning "xhigh" to ~90% of maxOutputTokens', async () => {
-        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini25ProModel.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'xhigh',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingBudget: 32768 },
-          },
-        });
-      });
-
-      it('should use lower maxOutputTokens for flash-lite models', async () => {
-        server.urls[TEST_URL_GEMINI_2_5_FLASH_LITE].response = {
-          type: 'json-value',
-          body: simpleResponseBody,
-        };
-
-        await gemini25FlashLiteModel.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'medium',
-        });
-
-        expect(await server.calls[0].requestBodyJson).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingBudget: Math.round(65536 * 0.3) },
-          },
-        });
-      });
-    });
-
-    describe('providerOptions precedence', () => {
-      it('should use providerOptions thinkingConfig when both reasoning and providerOptions are set', async () => {
-        prepareJsonFixtureResponse('google-text');
-
-        await model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'high',
-          providerOptions: {
-            google: {
-              thinkingConfig: {
-                thinkingBudget: 999,
-              },
-            },
-          },
-        });
-
-        const body = await server.calls[0].requestBodyJson;
-        expect(body).toMatchObject({
-          generationConfig: {
-            thinkingConfig: { thinkingBudget: 999 },
-          },
-        });
-        expect(
-          body.generationConfig.thinkingConfig.thinkingLevel,
-        ).toBeUndefined();
-      });
-
-      it('should not set thinkingConfig when neither reasoning nor providerOptions are set', async () => {
-        prepareJsonFixtureResponse('google-text');
-
-        await model.doGenerate({
-          prompt: TEST_PROMPT,
-        });
-
-        const body = await server.calls[0].requestBodyJson;
-        expect(body.generationConfig.thinkingConfig).toBeUndefined();
-      });
-
-      it('should not set thinkingConfig when reasoning is "provider-default"', async () => {
-        prepareJsonFixtureResponse('google-text');
-
-        await model.doGenerate({
-          prompt: TEST_PROMPT,
-          reasoning: 'provider-default',
-        });
-
-        const body = await server.calls[0].requestBodyJson;
-        expect(body.generationConfig.thinkingConfig).toBeUndefined();
-      });
-    });
-  });
-
   describe('providerMetadata key based on provider string', () => {
     it('should use "vertex" as providerMetadata key when provider includes "vertex"', async () => {
       server.urls[TEST_URL_GEMINI_PRO].response = {
@@ -3752,16 +3341,12 @@ describe('doStream', () => {
   const TEST_URL_GEMINI_1_5_FLASH =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent';
 
-  const TEST_URL_GEMINI_3_PRO =
-    'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:streamGenerateContent';
-
   const server = createTestServer({
     [TEST_URL_GEMINI_PRO]: {},
     [TEST_URL_GEMINI_2_0_PRO]: {},
     [TEST_URL_GEMINI_2_0_FLASH_EXP]: {},
     [TEST_URL_GEMINI_1_0_PRO]: {},
     [TEST_URL_GEMINI_1_5_FLASH]: {},
-    [TEST_URL_GEMINI_3_PRO]: {},
   });
 
   function prepareChunksFixtureResponse(
@@ -4347,60 +3932,6 @@ describe('doStream', () => {
     ).toBeNull();
   });
 
-  it('should expose serviceTier in provider metadata on finish', async () => {
-    server.urls[TEST_URL_GEMINI_PRO].response = {
-      type: 'stream-chunks',
-      chunks: [
-        `data: ${JSON.stringify({
-          candidates: [
-            {
-              content: {
-                parts: [{ text: 'test response' }],
-                role: 'model',
-              },
-              finishReason: 'STOP',
-              safetyRatings: SAFETY_RATINGS,
-            },
-          ],
-          usageMetadata: {
-            promptTokenCount: 1,
-            candidatesTokenCount: 2,
-            totalTokenCount: 3,
-          },
-          serviceTier: 'flex',
-        })}\n\n`,
-      ],
-    };
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-    });
-
-    const events = await convertReadableStreamToArray(stream);
-    const finishEvent = events.find(event => event.type === 'finish');
-
-    expect(
-      finishEvent?.type === 'finish' &&
-        finishEvent.providerMetadata?.google.serviceTier,
-    ).toBe('flex');
-  });
-
-  it('should expose null serviceTier in provider metadata on finish when not present', async () => {
-    prepareStreamResponse({ content: ['test'] });
-
-    const { stream } = await model.doStream({
-      prompt: TEST_PROMPT,
-    });
-
-    const events = await convertReadableStreamToArray(stream);
-    const finishEvent = events.find(event => event.type === 'finish');
-
-    expect(
-      finishEvent?.type === 'finish' &&
-        finishEvent.providerMetadata?.google.serviceTier,
-    ).toBeNull();
-  });
-
   it('should stream code execution tool calls and results', async () => {
     server.urls[TEST_URL_GEMINI_2_0_PRO].response = {
       type: 'stream-chunks',
@@ -4625,142 +4156,6 @@ describe('doStream', () => {
 
     // Provider-executed tools should not trigger 'tool-calls' finish reason
     // since they don't require SDK iteration - allows structured output to work
-    expect(finishEvent).toMatchObject({
-      type: 'finish',
-      finishReason: {
-        raw: 'STOP',
-        unified: 'stop',
-      },
-    });
-  });
-
-  it('should stream server-side toolCall and toolResponse parts (tool combination)', async () => {
-    server.urls[TEST_URL_GEMINI_3_PRO].response = {
-      type: 'stream-chunks',
-      chunks: [
-        `data: ${JSON.stringify({
-          candidates: [
-            {
-              content: {
-                parts: [
-                  {
-                    toolCall: {
-                      toolType: 'GOOGLE_SEARCH_WEB',
-                      args: { query: 'SF weather' },
-                      id: 'sc-1',
-                    },
-                    thoughtSignature: 'sig-1',
-                  },
-                ],
-              },
-            },
-          ],
-        })}\n\n`,
-        `data: ${JSON.stringify({
-          candidates: [
-            {
-              content: {
-                parts: [
-                  {
-                    toolResponse: {
-                      toolType: 'GOOGLE_SEARCH_WEB',
-                      response: { results: [{ title: 'Weather' }] },
-                      id: 'sc-1',
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        })}\n\n`,
-        `data: ${JSON.stringify({
-          candidates: [
-            {
-              content: {
-                parts: [{ text: 'It is sunny.' }],
-              },
-              finishReason: 'STOP',
-            },
-          ],
-          usageMetadata: {
-            promptTokenCount: 10,
-            candidatesTokenCount: 20,
-            totalTokenCount: 30,
-          },
-        })}\n\n`,
-      ],
-    };
-
-    const model = provider.languageModel('gemini-3-pro-preview');
-    const { stream } = await model.doStream({
-      tools: [
-        {
-          type: 'provider',
-          id: 'google.google_search',
-          name: 'google_search',
-          args: {},
-        },
-      ],
-      prompt: TEST_PROMPT,
-    });
-
-    const events = await convertReadableStreamToArray(stream);
-
-    const toolEvents = events.filter(
-      e => e.type === 'tool-call' || e.type === 'tool-result',
-    );
-
-    expect(toolEvents).toMatchInlineSnapshot(`
-      [
-        {
-          "dynamic": true,
-          "input": "{"query":"SF weather"}",
-          "providerExecuted": true,
-          "providerMetadata": {
-            "google": {
-              "serverToolCallId": "sc-1",
-              "serverToolType": "GOOGLE_SEARCH_WEB",
-              "thoughtSignature": "sig-1",
-            },
-          },
-          "toolCallId": "sc-1",
-          "toolName": "server:GOOGLE_SEARCH_WEB",
-          "type": "tool-call",
-        },
-        {
-          "providerMetadata": {
-            "google": {
-              "serverToolCallId": "sc-1",
-              "serverToolType": "GOOGLE_SEARCH_WEB",
-            },
-          },
-          "result": {
-            "results": [
-              {
-                "title": "Weather",
-              },
-            ],
-          },
-          "toolCallId": "sc-1",
-          "toolName": "server:GOOGLE_SEARCH_WEB",
-          "type": "tool-result",
-        },
-      ]
-    `);
-
-    const textEvents = events.filter(e => e.type === 'text-delta');
-    expect(textEvents).toMatchInlineSnapshot(`
-      [
-        {
-          "delta": "It is sunny.",
-          "id": "0",
-          "providerMetadata": undefined,
-          "type": "text-delta",
-        },
-      ]
-    `);
-
-    const finishEvent = events.find(e => e.type === 'finish');
     expect(finishEvent).toMatchObject({
       type: 'finish',
       finishReason: {
@@ -5146,7 +4541,6 @@ describe('doStream', () => {
                   "probability": "NEGLIGIBLE",
                 },
               ],
-              "serviceTier": null,
               "urlContextMetadata": null,
               "usageMetadata": null,
             },
@@ -5609,7 +5003,6 @@ describe('doStream', () => {
               "groundingMetadata": null,
               "promptFeedback": null,
               "safetyRatings": null,
-              "serviceTier": null,
               "urlContextMetadata": null,
               "usageMetadata": {
                 "candidatesTokenCount": 18,
@@ -5772,7 +5165,6 @@ describe('doStream', () => {
                   "probability": "NEGLIGIBLE",
                 },
               ],
-              "serviceTier": null,
               "urlContextMetadata": null,
               "usageMetadata": null,
             },

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -355,12 +355,32 @@ describe('doGenerate', () => {
   const TEST_URL_GEMINI_1_5_FLASH =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
 
+  const TEST_URL_GEMINI_3_PRO =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent';
+
+  const TEST_URL_GEMINI_3_1_PRO =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent';
+
+  const TEST_URL_GEMINI_2_5_PRO =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent';
+
+  const TEST_URL_GEMINI_2_5_FLASH =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
+
+  const TEST_URL_GEMINI_2_5_FLASH_LITE =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent';
+
   const server = createTestServer({
     [TEST_URL_GEMINI_PRO]: {},
     [TEST_URL_GEMINI_2_0_PRO]: {},
     [TEST_URL_GEMINI_2_0_FLASH_EXP]: {},
     [TEST_URL_GEMINI_1_0_PRO]: {},
     [TEST_URL_GEMINI_1_5_FLASH]: {},
+    [TEST_URL_GEMINI_3_PRO]: {},
+    [TEST_URL_GEMINI_3_1_PRO]: {},
+    [TEST_URL_GEMINI_2_5_PRO]: {},
+    [TEST_URL_GEMINI_2_5_FLASH_LITE]: {},
+    [TEST_URL_GEMINI_2_5_FLASH]: {},
   });
 
   function prepareJsonFixtureResponse(
@@ -553,6 +573,74 @@ describe('doGenerate', () => {
     });
 
     expect(providerMetadata?.google.finishMessage).toBeNull();
+  });
+
+  it('should send serviceTier in request body when specified', async () => {
+    prepareJsonResponse({ content: 'test response' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          serviceTier: 'flex',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      serviceTier: 'flex',
+    });
+  });
+
+  it('should not send serviceTier in request body when not specified', async () => {
+    prepareJsonResponse({ content: 'test response' });
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body).not.toHaveProperty('serviceTier');
+  });
+
+  it('should expose serviceTier in provider metadata', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'test response' }],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: 2,
+          totalTokenCount: 3,
+        },
+        serviceTier: 'flex',
+      },
+    };
+
+    const { providerMetadata } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(providerMetadata?.google.serviceTier).toBe('flex');
+  });
+
+  it('should expose null serviceTier in provider metadata when not present', async () => {
+    prepareJsonResponse({ content: 'test response' });
+
+    const { providerMetadata } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(providerMetadata?.google.serviceTier).toBeNull();
   });
 
   describe('tool-call', () => {
@@ -2258,6 +2346,179 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should handle server-side toolCall and toolResponse parts (tool combination)', async () => {
+    server.urls[TEST_URL_GEMINI_3_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  toolCall: {
+                    toolType: 'GOOGLE_SEARCH_WEB',
+                    args: { query: 'San Francisco weather' },
+                    id: 'server-call-1',
+                  },
+                  thoughtSignature: 'sig-abc',
+                },
+                {
+                  toolResponse: {
+                    toolType: 'GOOGLE_SEARCH_WEB',
+                    response: {
+                      results: [{ title: 'Weather in SF' }],
+                    },
+                    id: 'server-call-1',
+                  },
+                  thoughtSignature: 'sig-def',
+                },
+                {
+                  text: 'The weather in San Francisco is sunny.',
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    const model = provider.languageModel('gemini-3-pro-preview');
+    const { content, finishReason } = await model.doGenerate({
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+        {
+          type: 'function',
+          name: 'weather',
+          inputSchema: {
+            type: 'object',
+            properties: { location: { type: 'string' } },
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "dynamic": true,
+          "input": "{"query":"San Francisco weather"}",
+          "providerExecuted": true,
+          "providerMetadata": {
+            "google": {
+              "serverToolCallId": "server-call-1",
+              "serverToolType": "GOOGLE_SEARCH_WEB",
+              "thoughtSignature": "sig-abc",
+            },
+          },
+          "toolCallId": "server-call-1",
+          "toolName": "server:GOOGLE_SEARCH_WEB",
+          "type": "tool-call",
+        },
+        {
+          "providerMetadata": {
+            "google": {
+              "serverToolCallId": "server-call-1",
+              "serverToolType": "GOOGLE_SEARCH_WEB",
+              "thoughtSignature": "sig-def",
+            },
+          },
+          "result": {
+            "results": [
+              {
+                "title": "Weather in SF",
+              },
+            ],
+          },
+          "toolCallId": "server-call-1",
+          "toolName": "server:GOOGLE_SEARCH_WEB",
+          "type": "tool-result",
+        },
+        {
+          "providerMetadata": undefined,
+          "text": "The weather in San Francisco is sunny.",
+          "type": "text",
+        },
+      ]
+    `);
+
+    expect(finishReason).toMatchInlineSnapshot(`
+      {
+        "raw": "STOP",
+        "unified": "stop",
+      }
+    `);
+  });
+
+  it('should return stop finish reason for server tool calls (provider-executed)', async () => {
+    server.urls[TEST_URL_GEMINI_3_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  toolCall: {
+                    toolType: 'GOOGLE_SEARCH_WEB',
+                    args: {},
+                    id: 'sc-1',
+                  },
+                },
+                {
+                  toolResponse: {
+                    toolType: 'GOOGLE_SEARCH_WEB',
+                    response: { results: [] },
+                    id: 'sc-1',
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 10,
+          totalTokenCount: 15,
+        },
+      },
+    };
+
+    const model = provider.languageModel('gemini-3-pro-preview');
+    const { finishReason } = await model.doGenerate({
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    expect(finishReason).toMatchInlineSnapshot(`
+      {
+        "raw": "STOP",
+        "unified": "stop",
+      }
+    `);
+  });
+
   describe('search tool selection', () => {
     const provider = createGoogleGenerativeAI({
       apiKey: 'test-api-key',
@@ -3136,6 +3397,344 @@ describe('doGenerate', () => {
     });
   });
 
+  describe('top-level reasoning option', () => {
+    const simpleResponseBody = {
+      candidates: [
+        {
+          content: { parts: [{ text: 'response' }], role: 'model' },
+          finishReason: 'STOP',
+          safetyRatings: SAFETY_RATINGS,
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 2,
+        totalTokenCount: 3,
+      },
+    };
+
+    describe('Gemini 3 models (thinkingLevel)', () => {
+      const gemini3Model = provider.chat('gemini-3-pro-preview');
+
+      it('should map reasoning "minimal" to thinkingLevel "minimal"', async () => {
+        server.urls[TEST_URL_GEMINI_3_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini3Model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'minimal',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: 'minimal' },
+          },
+        });
+      });
+
+      it('should map reasoning "low" to thinkingLevel "low"', async () => {
+        server.urls[TEST_URL_GEMINI_3_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini3Model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'low',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: 'low' },
+          },
+        });
+      });
+
+      it('should map reasoning "medium" to thinkingLevel "medium"', async () => {
+        server.urls[TEST_URL_GEMINI_3_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini3Model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'medium',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: 'medium' },
+          },
+        });
+      });
+
+      it('should map reasoning "high" to thinkingLevel "high"', async () => {
+        server.urls[TEST_URL_GEMINI_3_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini3Model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'high',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: 'high' },
+          },
+        });
+      });
+
+      it('should map reasoning "none" to thinkingLevel "minimal"', async () => {
+        server.urls[TEST_URL_GEMINI_3_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini3Model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'none',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: 'minimal' },
+          },
+        });
+      });
+
+      it('should coerce reasoning "xhigh" to "high" with compatibility warning', async () => {
+        server.urls[TEST_URL_GEMINI_3_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        const result = await gemini3Model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'xhigh',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: 'high' },
+          },
+        });
+
+        expect(result.warnings).toContainEqual({
+          type: 'compatibility',
+          feature: 'reasoning',
+          details:
+            'reasoning "xhigh" is not directly supported by this model. mapped to effort "high".',
+        });
+      });
+
+      it('should also detect gemini-3.1 models as Gemini 3', async () => {
+        const gemini31Model = provider.chat('gemini-3.1-pro-preview');
+
+        server.urls[TEST_URL_GEMINI_3_1_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini31Model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'medium',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: 'medium' },
+          },
+        });
+      });
+    });
+
+    describe('Gemini 2.5 models (thinkingBudget)', () => {
+      const gemini25ProModel = provider.chat('gemini-2.5-pro');
+      const gemini25FlashLiteModel = provider.chat('gemini-2.5-flash-lite');
+
+      it('should map reasoning "none" to thinkingBudget 0', async () => {
+        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini25ProModel.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'none',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingBudget: 0 },
+          },
+        });
+      });
+
+      it('should map reasoning "minimal" to ~2% of maxOutputTokens', async () => {
+        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini25ProModel.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'minimal',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingBudget: Math.round(65536 * 0.02) },
+          },
+        });
+      });
+
+      it('should map reasoning "low" to ~10% of maxOutputTokens', async () => {
+        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini25ProModel.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'low',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingBudget: Math.round(65536 * 0.1) },
+          },
+        });
+      });
+
+      it('should map reasoning "medium" to ~30% of maxOutputTokens', async () => {
+        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini25ProModel.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'medium',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingBudget: Math.round(65536 * 0.3) },
+          },
+        });
+      });
+
+      it('should map reasoning "high" to ~60% of maxOutputTokens', async () => {
+        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini25ProModel.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'high',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingBudget: 32768 },
+          },
+        });
+      });
+
+      it('should map reasoning "xhigh" to ~90% of maxOutputTokens', async () => {
+        server.urls[TEST_URL_GEMINI_2_5_PRO].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini25ProModel.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'xhigh',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingBudget: 32768 },
+          },
+        });
+      });
+
+      it('should use lower maxOutputTokens for flash-lite models', async () => {
+        server.urls[TEST_URL_GEMINI_2_5_FLASH_LITE].response = {
+          type: 'json-value',
+          body: simpleResponseBody,
+        };
+
+        await gemini25FlashLiteModel.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'medium',
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingBudget: Math.round(65536 * 0.3) },
+          },
+        });
+      });
+    });
+
+    describe('providerOptions precedence', () => {
+      it('should use providerOptions thinkingConfig when both reasoning and providerOptions are set', async () => {
+        prepareJsonFixtureResponse('google-text');
+
+        await model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'high',
+          providerOptions: {
+            google: {
+              thinkingConfig: {
+                thinkingBudget: 999,
+              },
+            },
+          },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body).toMatchObject({
+          generationConfig: {
+            thinkingConfig: { thinkingBudget: 999 },
+          },
+        });
+        expect(
+          body.generationConfig.thinkingConfig.thinkingLevel,
+        ).toBeUndefined();
+      });
+
+      it('should not set thinkingConfig when neither reasoning nor providerOptions are set', async () => {
+        prepareJsonFixtureResponse('google-text');
+
+        await model.doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.generationConfig.thinkingConfig).toBeUndefined();
+      });
+
+      it('should not set thinkingConfig when reasoning is "provider-default"', async () => {
+        prepareJsonFixtureResponse('google-text');
+
+        await model.doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'provider-default',
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.generationConfig.thinkingConfig).toBeUndefined();
+      });
+    });
+  });
+
   describe('providerMetadata key based on provider string', () => {
     it('should use "vertex" as providerMetadata key when provider includes "vertex"', async () => {
       server.urls[TEST_URL_GEMINI_PRO].response = {
@@ -3341,12 +3940,16 @@ describe('doStream', () => {
   const TEST_URL_GEMINI_1_5_FLASH =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent';
 
+  const TEST_URL_GEMINI_3_PRO =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:streamGenerateContent';
+
   const server = createTestServer({
     [TEST_URL_GEMINI_PRO]: {},
     [TEST_URL_GEMINI_2_0_PRO]: {},
     [TEST_URL_GEMINI_2_0_FLASH_EXP]: {},
     [TEST_URL_GEMINI_1_0_PRO]: {},
     [TEST_URL_GEMINI_1_5_FLASH]: {},
+    [TEST_URL_GEMINI_3_PRO]: {},
   });
 
   function prepareChunksFixtureResponse(
@@ -3932,6 +4535,60 @@ describe('doStream', () => {
     ).toBeNull();
   });
 
+  it('should expose serviceTier in provider metadata on finish', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'test response' }],
+                role: 'model',
+              },
+              finishReason: 'STOP',
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 1,
+            candidatesTokenCount: 2,
+            totalTokenCount: 3,
+          },
+          serviceTier: 'flex',
+        })}\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+    const finishEvent = events.find(event => event.type === 'finish');
+
+    expect(
+      finishEvent?.type === 'finish' &&
+        finishEvent.providerMetadata?.google.serviceTier,
+    ).toBe('flex');
+  });
+
+  it('should expose null serviceTier in provider metadata on finish when not present', async () => {
+    prepareStreamResponse({ content: ['test'] });
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+    const finishEvent = events.find(event => event.type === 'finish');
+
+    expect(
+      finishEvent?.type === 'finish' &&
+        finishEvent.providerMetadata?.google.serviceTier,
+    ).toBeNull();
+  });
+
   it('should stream code execution tool calls and results', async () => {
     server.urls[TEST_URL_GEMINI_2_0_PRO].response = {
       type: 'stream-chunks',
@@ -4156,6 +4813,142 @@ describe('doStream', () => {
 
     // Provider-executed tools should not trigger 'tool-calls' finish reason
     // since they don't require SDK iteration - allows structured output to work
+    expect(finishEvent).toMatchObject({
+      type: 'finish',
+      finishReason: {
+        raw: 'STOP',
+        unified: 'stop',
+      },
+    });
+  });
+
+  it('should stream server-side toolCall and toolResponse parts (tool combination)', async () => {
+    server.urls[TEST_URL_GEMINI_3_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    toolCall: {
+                      toolType: 'GOOGLE_SEARCH_WEB',
+                      args: { query: 'SF weather' },
+                      id: 'sc-1',
+                    },
+                    thoughtSignature: 'sig-1',
+                  },
+                ],
+              },
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    toolResponse: {
+                      toolType: 'GOOGLE_SEARCH_WEB',
+                      response: { results: [{ title: 'Weather' }] },
+                      id: 'sc-1',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'It is sunny.' }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 20,
+            totalTokenCount: 30,
+          },
+        })}\n\n`,
+      ],
+    };
+
+    const model = provider.languageModel('gemini-3-pro-preview');
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.google_search',
+          name: 'google_search',
+          args: {},
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+
+    const toolEvents = events.filter(
+      e => e.type === 'tool-call' || e.type === 'tool-result',
+    );
+
+    expect(toolEvents).toMatchInlineSnapshot(`
+      [
+        {
+          "dynamic": true,
+          "input": "{"query":"SF weather"}",
+          "providerExecuted": true,
+          "providerMetadata": {
+            "google": {
+              "serverToolCallId": "sc-1",
+              "serverToolType": "GOOGLE_SEARCH_WEB",
+              "thoughtSignature": "sig-1",
+            },
+          },
+          "toolCallId": "sc-1",
+          "toolName": "server:GOOGLE_SEARCH_WEB",
+          "type": "tool-call",
+        },
+        {
+          "providerMetadata": {
+            "google": {
+              "serverToolCallId": "sc-1",
+              "serverToolType": "GOOGLE_SEARCH_WEB",
+            },
+          },
+          "result": {
+            "results": [
+              {
+                "title": "Weather",
+              },
+            ],
+          },
+          "toolCallId": "sc-1",
+          "toolName": "server:GOOGLE_SEARCH_WEB",
+          "type": "tool-result",
+        },
+      ]
+    `);
+
+    const textEvents = events.filter(e => e.type === 'text-delta');
+    expect(textEvents).toMatchInlineSnapshot(`
+      [
+        {
+          "delta": "It is sunny.",
+          "id": "0",
+          "providerMetadata": undefined,
+          "type": "text-delta",
+        },
+      ]
+    `);
+
+    const finishEvent = events.find(e => e.type === 'finish');
     expect(finishEvent).toMatchObject({
       type: 'finish',
       finishReason: {
@@ -4541,6 +5334,7 @@ describe('doStream', () => {
                   "probability": "NEGLIGIBLE",
                 },
               ],
+              "serviceTier": null,
               "urlContextMetadata": null,
               "usageMetadata": null,
             },
@@ -5003,6 +5797,7 @@ describe('doStream', () => {
               "groundingMetadata": null,
               "promptFeedback": null,
               "safetyRatings": null,
+              "serviceTier": null,
               "urlContextMetadata": null,
               "usageMetadata": {
                 "candidatesTokenCount": 18,
@@ -5165,6 +5960,7 @@ describe('doStream', () => {
                   "probability": "NEGLIGIBLE",
                 },
               ],
+              "serviceTier": null,
               "urlContextMetadata": null,
               "usageMetadata": null,
             },

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -3,11 +3,11 @@ import {
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
   LanguageModelV4FinishReason,
-  LanguageModelV4FunctionTool,
   LanguageModelV4GenerateResult,
   LanguageModelV4Source,
   LanguageModelV4StreamPart,
   LanguageModelV4StreamResult,
+  JSONObject,
   SharedV4ProviderMetadata,
   SharedV4Warning,
 } from '@ai-sdk/provider';
@@ -18,7 +18,10 @@ import {
   FetchFunction,
   generateId,
   InferSchema,
+  isCustomReasoning,
   lazySchema,
+  mapReasoningToProviderBudget,
+  mapReasoningToProviderEffort,
   parseProviderOptions,
   ParseResult,
   postJsonToApi,
@@ -97,6 +100,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     seed,
     tools,
     toolChoice,
+    reasoning,
     providerOptions,
   }: LanguageModelV4CallOptions) {
     const warnings: SharedV4Warning[] = [];
@@ -136,57 +140,36 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     }
 
     const isGemmaModel = this.modelId.toLowerCase().startsWith('gemma-');
+    const supportsFunctionResponseParts = this.modelId.startsWith('gemini-3');
 
     const { contents, systemInstruction } = convertToGoogleGenerativeAIMessages(
       prompt,
-      { isGemmaModel, providerOptionsName },
+      {
+        isGemmaModel,
+        providerOptionsName,
+        supportsFunctionResponseParts,
+      },
     );
-
-    const { supportsStructuredOutputWithTools } =
-      getGoogleModelCapabilities(this.modelId);
-    const structuredOutputMode =
-      googleOptions?.structuredOutputMode ?? 'auto';
-    const useStructuredOutputWithTools =
-      structuredOutputMode === 'outputFormat' ||
-      (structuredOutputMode === 'auto' && supportsStructuredOutputWithTools);
-
-    const needsJsonToolFallback =
-      responseFormat?.type === 'json' &&
-      responseFormat.schema != null &&
-      tools != null &&
-      tools.length > 0 &&
-      !useStructuredOutputWithTools;
-
-    const jsonResponseToolName = needsJsonToolFallback
-      ? tools.some(
-          tool => tool.type === 'function' && tool.name === 'json',
-        )
-        ? '__ai_sdk_json_response'
-        : 'json'
-      : undefined;
-
-    const jsonResponseTool: LanguageModelV4FunctionTool | undefined =
-      needsJsonToolFallback && jsonResponseToolName != null
-        ? {
-            type: 'function',
-            name: jsonResponseToolName,
-            description: 'Respond with a JSON object.',
-            inputSchema: responseFormat.schema,
-          }
-        : undefined;
 
     const {
       tools: googleTools,
       toolConfig: googleToolConfig,
       toolWarnings,
     } = prepareTools({
-      tools:
-        jsonResponseTool != null
-          ? [...(tools ?? []), jsonResponseTool]
-          : tools,
-      toolChoice: jsonResponseTool != null ? { type: 'required' } : toolChoice,
+      tools,
+      toolChoice,
       modelId: this.modelId,
     });
+
+    const resolvedThinking = resolveThinkingConfig({
+      reasoning,
+      modelId: this.modelId,
+      warnings,
+    });
+    const thinkingConfig =
+      googleOptions?.thinkingConfig || resolvedThinking
+        ? { ...resolvedThinking, ...googleOptions?.thinkingConfig }
+        : undefined;
 
     return {
       args: {
@@ -203,13 +186,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
           // response format:
           responseMimeType:
-            responseFormat?.type === 'json' && jsonResponseTool == null
-              ? 'application/json'
-              : undefined,
+            responseFormat?.type === 'json' ? 'application/json' : undefined,
           responseSchema:
             responseFormat?.type === 'json' &&
             responseFormat.schema != null &&
-            jsonResponseTool == null &&
             // Google GenAI does not support all OpenAPI Schema features,
             // so this is needed as an escape hatch:
             // TODO convert into provider option
@@ -222,7 +202,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
           // provider options:
           responseModalities: googleOptions?.responseModalities,
-          thinkingConfig: googleOptions?.thinkingConfig,
+          thinkingConfig,
           ...(googleOptions?.mediaResolution && {
             mediaResolution: googleOptions.mediaResolution,
           }),
@@ -242,24 +222,17 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
           : googleToolConfig,
         cachedContent: googleOptions?.cachedContent,
         labels: googleOptions?.labels,
+        serviceTier: googleOptions?.serviceTier,
       },
       warnings: [...warnings, ...toolWarnings],
       providerOptionsName,
-      usesJsonResponseTool: jsonResponseTool != null,
-      jsonResponseToolName,
     };
   }
 
   async doGenerate(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4GenerateResult> {
-    const {
-      args,
-      warnings,
-      providerOptionsName,
-      usesJsonResponseTool,
-      jsonResponseToolName,
-    } = await this.getArgs(options);
+    const { args, warnings, providerOptionsName } = await this.getArgs(options);
 
     const mergedHeaders = combineHeaders(
       await resolve(this.config.headers),
@@ -292,6 +265,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
     // Associates a code execution result with its preceding call.
     let lastCodeExecutionToolCallId: string | undefined;
+    // Associates a server-side tool response with its preceding call (tool combination).
+    let lastServerToolCallId: string | undefined;
 
     // Build content array from all parts
     for (const part of parts) {
@@ -320,54 +295,40 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
         // Clear the ID after use to avoid accidental reuse.
         lastCodeExecutionToolCallId = undefined;
       } else if ('text' in part && part.text != null) {
-        if (!usesJsonResponseTool) {
-          const thoughtSignatureMetadata = part.thoughtSignature
+        const thoughtSignatureMetadata = part.thoughtSignature
+          ? {
+              [providerOptionsName]: {
+                thoughtSignature: part.thoughtSignature,
+              },
+            }
+          : undefined;
+
+        if (part.text.length === 0) {
+          if (thoughtSignatureMetadata != null && content.length > 0) {
+            const lastContent = content[content.length - 1];
+            lastContent.providerMetadata = thoughtSignatureMetadata;
+          }
+        } else {
+          content.push({
+            type: part.thought === true ? 'reasoning' : 'text',
+            text: part.text,
+            providerMetadata: thoughtSignatureMetadata,
+          });
+        }
+      } else if ('functionCall' in part) {
+        content.push({
+          type: 'tool-call' as const,
+          toolCallId: this.config.generateId(),
+          toolName: part.functionCall.name,
+          input: JSON.stringify(part.functionCall.args),
+          providerMetadata: part.thoughtSignature
             ? {
                 [providerOptionsName]: {
                   thoughtSignature: part.thoughtSignature,
                 },
               }
-            : undefined;
-
-          if (part.text.length === 0) {
-            if (thoughtSignatureMetadata != null && content.length > 0) {
-              const lastContent = content[content.length - 1];
-              lastContent.providerMetadata = thoughtSignatureMetadata;
-            }
-          } else {
-            content.push({
-              type: part.thought === true ? 'reasoning' : 'text',
-              text: part.text,
-              providerMetadata: thoughtSignatureMetadata,
-            });
-          }
-        }
-      } else if ('functionCall' in part) {
-        const isJsonResponseTool =
-          usesJsonResponseTool &&
-          jsonResponseToolName != null &&
-          part.functionCall.name === jsonResponseToolName;
-
-        if (isJsonResponseTool) {
-          content.push({
-            type: 'text',
-            text: JSON.stringify(part.functionCall.args),
-          });
-        } else {
-          content.push({
-            type: 'tool-call' as const,
-            toolCallId: this.config.generateId(),
-            toolName: part.functionCall.name,
-            input: JSON.stringify(part.functionCall.args),
-            providerMetadata: part.thoughtSignature
-              ? {
-                  [providerOptionsName]: {
-                    thoughtSignature: part.thoughtSignature,
-                  },
-                }
-              : undefined,
-          });
-        }
+            : undefined,
+        });
       } else if ('inlineData' in part) {
         const hasThought = part.thought === true;
         const hasThoughtSignature = !!part.thoughtSignature;
@@ -383,6 +344,57 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
               }
             : undefined,
         });
+      } else if ('toolCall' in part && part.toolCall) {
+        const toolCallId = part.toolCall.id ?? this.config.generateId();
+        lastServerToolCallId = toolCallId;
+        content.push({
+          type: 'tool-call',
+          toolCallId,
+          toolName: `server:${part.toolCall.toolType}`,
+          input: JSON.stringify(part.toolCall.args ?? {}),
+          providerExecuted: true,
+          dynamic: true,
+          providerMetadata: part.thoughtSignature
+            ? {
+                [providerOptionsName]: {
+                  thoughtSignature: part.thoughtSignature,
+                  serverToolCallId: toolCallId,
+                  serverToolType: part.toolCall.toolType,
+                },
+              }
+            : {
+                [providerOptionsName]: {
+                  serverToolCallId: toolCallId,
+                  serverToolType: part.toolCall.toolType,
+                },
+              },
+        });
+      } else if ('toolResponse' in part && part.toolResponse) {
+        const responseToolCallId =
+          lastServerToolCallId ??
+          part.toolResponse.id ??
+          this.config.generateId();
+        content.push({
+          type: 'tool-result',
+          toolCallId: responseToolCallId,
+          toolName: `server:${part.toolResponse.toolType}`,
+          result: (part.toolResponse.response ?? {}) as JSONObject,
+          providerMetadata: part.thoughtSignature
+            ? {
+                [providerOptionsName]: {
+                  thoughtSignature: part.thoughtSignature,
+                  serverToolCallId: responseToolCallId,
+                  serverToolType: part.toolResponse.toolType,
+                },
+              }
+            : {
+                [providerOptionsName]: {
+                  serverToolCallId: responseToolCallId,
+                  serverToolType: part.toolResponse.toolType,
+                },
+              },
+        });
+        lastServerToolCallId = undefined;
       }
     }
 
@@ -417,6 +429,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
           safetyRatings: candidate.safetyRatings ?? null,
           usageMetadata: usageMetadata ?? null,
           finishMessage: candidate.finishMessage ?? null,
+          serviceTier: response.serviceTier ?? null,
         } satisfies GoogleGenerativeAIProviderMetadata,
       },
       request: { body: args },
@@ -431,13 +444,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
   async doStream(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4StreamResult> {
-    const {
-      args,
-      warnings,
-      providerOptionsName,
-      usesJsonResponseTool,
-      jsonResponseToolName,
-    } = await this.getArgs(options);
+    const { args, warnings, providerOptionsName } = await this.getArgs(options);
 
     const headers = combineHeaders(
       await resolve(this.config.headers),
@@ -464,6 +471,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     let providerMetadata: SharedV4ProviderMetadata | undefined = undefined;
     let lastGroundingMetadata: GroundingMetadataSchema | null = null;
     let lastUrlContextMetadata: UrlContextMetadataSchema | null = null;
+    let serviceTier: string | null = null;
 
     const generateId = this.config.generateId;
     let hasToolCalls = false;
@@ -477,6 +485,8 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     const emittedSourceUrls = new Set<string>();
     // Associates a code execution result with its preceding call.
     let lastCodeExecutionToolCallId: string | undefined;
+    // Associates a server-side tool response with its preceding call (tool combination).
+    let lastServerToolCallId: string | undefined;
 
     return {
       stream: response.pipeThrough(
@@ -504,6 +514,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
             if (usageMetadata != null) {
               usage = usageMetadata;
+            }
+
+            if (value.serviceTier != null) {
+              serviceTier = value.serviceTier;
             }
 
             const candidate = value.candidates?.[0];
@@ -575,10 +589,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                     lastCodeExecutionToolCallId = undefined;
                   }
                 } else if ('text' in part && part.text != null) {
-                  if (usesJsonResponseTool) {
-                    continue;
-                  }
-
                   const thoughtSignatureMetadata = part.thoughtSignature
                     ? {
                         [providerOptionsName]: {
@@ -683,6 +693,51 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                     data: part.inlineData.data,
                     providerMetadata: fileMeta,
                   });
+                } else if ('toolCall' in part && part.toolCall) {
+                  const toolCallId = part.toolCall.id ?? generateId();
+                  lastServerToolCallId = toolCallId;
+                  const serverMeta = {
+                    [providerOptionsName]: {
+                      ...(part.thoughtSignature
+                        ? { thoughtSignature: part.thoughtSignature }
+                        : {}),
+                      serverToolCallId: toolCallId,
+                      serverToolType: part.toolCall.toolType,
+                    },
+                  };
+
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId,
+                    toolName: `server:${part.toolCall.toolType}`,
+                    input: JSON.stringify(part.toolCall.args ?? {}),
+                    providerExecuted: true,
+                    dynamic: true,
+                    providerMetadata: serverMeta,
+                  });
+                } else if ('toolResponse' in part && part.toolResponse) {
+                  const responseToolCallId =
+                    lastServerToolCallId ??
+                    part.toolResponse.id ??
+                    generateId();
+                  const serverMeta = {
+                    [providerOptionsName]: {
+                      ...(part.thoughtSignature
+                        ? { thoughtSignature: part.thoughtSignature }
+                        : {}),
+                      serverToolCallId: responseToolCallId,
+                      serverToolType: part.toolResponse.toolType,
+                    },
+                  };
+
+                  controller.enqueue({
+                    type: 'tool-result',
+                    toolCallId: responseToolCallId,
+                    toolName: `server:${part.toolResponse.toolType}`,
+                    result: (part.toolResponse.response ?? {}) as JSONObject,
+                    providerMetadata: serverMeta,
+                  });
+                  lastServerToolCallId = undefined;
                 }
               }
 
@@ -694,56 +749,35 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
               if (toolCallDeltas != null) {
                 for (const toolCall of toolCallDeltas) {
-                  const isJsonResponseTool =
-                    usesJsonResponseTool &&
-                    jsonResponseToolName != null &&
-                    toolCall.toolName === jsonResponseToolName;
+                  controller.enqueue({
+                    type: 'tool-input-start',
+                    id: toolCall.toolCallId,
+                    toolName: toolCall.toolName,
+                    providerMetadata: toolCall.providerMetadata,
+                  });
 
-                  if (isJsonResponseTool) {
-                    if (currentTextBlockId === null) {
-                      currentTextBlockId = String(blockCounter++);
-                      controller.enqueue({
-                        type: 'text-start',
-                        id: currentTextBlockId,
-                      });
-                    }
+                  controller.enqueue({
+                    type: 'tool-input-delta',
+                    id: toolCall.toolCallId,
+                    delta: toolCall.args,
+                    providerMetadata: toolCall.providerMetadata,
+                  });
 
-                    controller.enqueue({
-                      type: 'text-delta',
-                      id: currentTextBlockId,
-                      delta: toolCall.args,
-                    });
-                  } else {
-                    controller.enqueue({
-                      type: 'tool-input-start',
-                      id: toolCall.toolCallId,
-                      toolName: toolCall.toolName,
-                      providerMetadata: toolCall.providerMetadata,
-                    });
+                  controller.enqueue({
+                    type: 'tool-input-end',
+                    id: toolCall.toolCallId,
+                    providerMetadata: toolCall.providerMetadata,
+                  });
 
-                    controller.enqueue({
-                      type: 'tool-input-delta',
-                      id: toolCall.toolCallId,
-                      delta: toolCall.args,
-                      providerMetadata: toolCall.providerMetadata,
-                    });
+                  controller.enqueue({
+                    type: 'tool-call',
+                    toolCallId: toolCall.toolCallId,
+                    toolName: toolCall.toolName,
+                    input: toolCall.args,
+                    providerMetadata: toolCall.providerMetadata,
+                  });
 
-                    controller.enqueue({
-                      type: 'tool-input-end',
-                      id: toolCall.toolCallId,
-                      providerMetadata: toolCall.providerMetadata,
-                    });
-
-                    controller.enqueue({
-                      type: 'tool-call',
-                      toolCallId: toolCall.toolCallId,
-                      toolName: toolCall.toolName,
-                      input: toolCall.args,
-                      providerMetadata: toolCall.providerMetadata,
-                    });
-
-                    hasToolCalls = true;
-                  }
+                  hasToolCalls = true;
                 }
               }
             }
@@ -765,6 +799,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                   safetyRatings: candidate.safetyRatings ?? null,
                   usageMetadata: usageMetadata ?? null,
                   finishMessage: candidate.finishMessage ?? null,
+                  serviceTier,
                 } satisfies GoogleGenerativeAIProviderMetadata,
               };
             }
@@ -799,12 +834,107 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
   }
 }
 
-function getGoogleModelCapabilities(_modelId: string): {
-  supportsStructuredOutputWithTools: boolean;
-} {
-  // No Google model is currently known to accept responseSchema + tools in the same request.
-  // When documented, set to true for those model ids.
-  return { supportsStructuredOutputWithTools: false };
+function isGemini3Model(modelId: string): boolean {
+  return /gemini-3[\.\-]/i.test(modelId) || /gemini-3$/i.test(modelId);
+}
+
+function getMaxOutputTokensForGemini25Model(): number {
+  return 65536;
+}
+
+function getMaxThinkingTokensForGemini25Model(modelId: string): number {
+  const id = modelId.toLowerCase();
+  if (id.includes('2.5-pro') || id.includes('gemini-3-pro-image')) {
+    return 32768;
+  }
+  return 24576;
+}
+
+type GoogleThinkingConfig = NonNullable<
+  InferSchema<typeof googleLanguageModelOptions>['thinkingConfig']
+>;
+
+function resolveThinkingConfig({
+  reasoning,
+  modelId,
+  warnings,
+}: {
+  reasoning: LanguageModelV4CallOptions['reasoning'];
+  modelId: string;
+  warnings: SharedV4Warning[];
+}): Omit<GoogleThinkingConfig, 'includeThoughts'> | undefined {
+  if (!isCustomReasoning(reasoning)) {
+    return undefined;
+  }
+
+  if (isGemini3Model(modelId) && !modelId.includes('gemini-3-pro-image')) {
+    return resolveGemini3ThinkingConfig({ reasoning, warnings });
+  }
+
+  return resolveGemini25ThinkingConfig({ reasoning, modelId, warnings });
+}
+
+function resolveGemini3ThinkingConfig({
+  reasoning,
+  warnings,
+}: {
+  reasoning: Exclude<
+    LanguageModelV4CallOptions['reasoning'],
+    'provider-default' | undefined
+  >;
+  warnings: SharedV4Warning[];
+}): Pick<GoogleThinkingConfig, 'thinkingLevel'> | undefined {
+  if (reasoning === 'none') {
+    // It's not possible to fully disable thinking with Gemini 3.
+    return { thinkingLevel: 'minimal' };
+  }
+
+  const thinkingLevel = mapReasoningToProviderEffort({
+    reasoning,
+    effortMap: {
+      minimal: 'minimal',
+      low: 'low',
+      medium: 'medium',
+      high: 'high',
+      xhigh: 'high',
+    },
+    warnings,
+  });
+
+  if (thinkingLevel == null) {
+    return undefined;
+  }
+
+  return { thinkingLevel };
+}
+
+function resolveGemini25ThinkingConfig({
+  reasoning,
+  modelId,
+  warnings,
+}: {
+  reasoning: Exclude<
+    LanguageModelV4CallOptions['reasoning'],
+    'provider-default' | undefined
+  >;
+  modelId: string;
+  warnings: SharedV4Warning[];
+}): Pick<GoogleThinkingConfig, 'thinkingBudget'> | undefined {
+  if (reasoning === 'none') {
+    return { thinkingBudget: 0 };
+  }
+
+  const thinkingBudget = mapReasoningToProviderBudget({
+    reasoning,
+    maxOutputTokens: getMaxOutputTokensForGemini25Model(),
+    maxReasoningBudget: getMaxThinkingTokensForGemini25Model(modelId),
+    minReasoningBudget: 0,
+    warnings,
+  });
+  if (thinkingBudget == null) {
+    return undefined;
+  }
+  return { thinkingBudget };
 }
 
 function getToolCallsFromParts({
@@ -1041,6 +1171,22 @@ const getContentSchema = () =>
             thoughtSignature: z.string().nullish(),
           }),
           z.object({
+            toolCall: z.object({
+              toolType: z.string(),
+              args: z.unknown().nullish(),
+              id: z.string(),
+            }),
+            thoughtSignature: z.string().nullish(),
+          }),
+          z.object({
+            toolResponse: z.object({
+              toolType: z.string(),
+              response: z.unknown().nullish(),
+              id: z.string(),
+            }),
+            thoughtSignature: z.string().nullish(),
+          }),
+          z.object({
             executableCode: z
               .object({
                 language: z.string(),
@@ -1073,6 +1219,15 @@ const getSafetyRatingSchema = () =>
     blocked: z.boolean().nullish(),
   });
 
+const tokenDetailsSchema = z
+  .array(
+    z.object({
+      modality: z.string(),
+      tokenCount: z.number(),
+    }),
+  )
+  .nullish();
+
 const usageSchema = z.object({
   cachedContentTokenCount: z.number().nullish(),
   thoughtsTokenCount: z.number().nullish(),
@@ -1081,6 +1236,9 @@ const usageSchema = z.object({
   totalTokenCount: z.number().nullish(),
   // https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#TrafficType
   trafficType: z.string().nullish(),
+  // https://ai.google.dev/api/generate-content#Modality
+  promptTokensDetails: tokenDetailsSchema,
+  candidatesTokensDetails: tokenDetailsSchema,
 });
 
 // https://ai.google.dev/api/generate-content#UrlRetrievalMetadata
@@ -1116,6 +1274,7 @@ const responseSchema = lazySchema(() =>
           safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
         })
         .nullish(),
+      serviceTier: z.string().nullish(),
     }),
   ),
 );
@@ -1171,6 +1330,7 @@ const chunkSchema = lazySchema(() =>
           safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
         })
         .nullish(),
+      serviceTier: z.string().nullish(),
     }),
   ),
 );

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -3,6 +3,7 @@ import {
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
   LanguageModelV4FinishReason,
+  LanguageModelV4FunctionTool,
   LanguageModelV4GenerateResult,
   LanguageModelV4Source,
   LanguageModelV4StreamPart,
@@ -151,13 +152,51 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
       },
     );
 
+    const { supportsStructuredOutputWithTools } =
+      getGoogleModelCapabilities(this.modelId);
+    const structuredOutputMode =
+      googleOptions?.structuredOutputMode ?? 'auto';
+    const useStructuredOutputWithTools =
+      structuredOutputMode === 'outputFormat' ||
+      (structuredOutputMode === 'auto' && supportsStructuredOutputWithTools);
+
+    const needsJsonToolFallback =
+      responseFormat?.type === 'json' &&
+      responseFormat.schema != null &&
+      tools != null &&
+      tools.length > 0 &&
+      !useStructuredOutputWithTools;
+
+    const jsonResponseToolName = needsJsonToolFallback
+      ? tools.some(
+          tool => tool.type === 'function' && tool.name === 'json',
+        )
+        ? '__ai_sdk_json_response'
+        : 'json'
+      : undefined;
+
+    const jsonResponseTool: LanguageModelV4FunctionTool | undefined =
+      needsJsonToolFallback &&
+      jsonResponseToolName != null &&
+      responseFormat?.schema != null
+        ? {
+            type: 'function',
+            name: jsonResponseToolName,
+            description: 'Respond with a JSON object.',
+            inputSchema: responseFormat.schema,
+          }
+        : undefined;
+
     const {
       tools: googleTools,
       toolConfig: googleToolConfig,
       toolWarnings,
     } = prepareTools({
-      tools,
-      toolChoice,
+      tools:
+        jsonResponseTool != null
+          ? [...(tools ?? []), jsonResponseTool]
+          : tools,
+      toolChoice: jsonResponseTool != null ? { type: 'required' } : toolChoice,
       modelId: this.modelId,
     });
 
@@ -186,10 +225,13 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
           // response format:
           responseMimeType:
-            responseFormat?.type === 'json' ? 'application/json' : undefined,
+            responseFormat?.type === 'json' && jsonResponseTool == null
+              ? 'application/json'
+              : undefined,
           responseSchema:
             responseFormat?.type === 'json' &&
             responseFormat.schema != null &&
+            jsonResponseTool == null &&
             // Google GenAI does not support all OpenAPI Schema features,
             // so this is needed as an escape hatch:
             // TODO convert into provider option
@@ -226,13 +268,21 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
       },
       warnings: [...warnings, ...toolWarnings],
       providerOptionsName,
+      usesJsonResponseTool: jsonResponseTool != null,
+      jsonResponseToolName,
     };
   }
 
   async doGenerate(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4GenerateResult> {
-    const { args, warnings, providerOptionsName } = await this.getArgs(options);
+    const {
+      args,
+      warnings,
+      providerOptionsName,
+      usesJsonResponseTool,
+      jsonResponseToolName,
+    } = await this.getArgs(options);
 
     const mergedHeaders = combineHeaders(
       await resolve(this.config.headers),
@@ -295,40 +345,54 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
         // Clear the ID after use to avoid accidental reuse.
         lastCodeExecutionToolCallId = undefined;
       } else if ('text' in part && part.text != null) {
-        const thoughtSignatureMetadata = part.thoughtSignature
-          ? {
-              [providerOptionsName]: {
-                thoughtSignature: part.thoughtSignature,
-              },
-            }
-          : undefined;
-
-        if (part.text.length === 0) {
-          if (thoughtSignatureMetadata != null && content.length > 0) {
-            const lastContent = content[content.length - 1];
-            lastContent.providerMetadata = thoughtSignatureMetadata;
-          }
-        } else {
-          content.push({
-            type: part.thought === true ? 'reasoning' : 'text',
-            text: part.text,
-            providerMetadata: thoughtSignatureMetadata,
-          });
-        }
-      } else if ('functionCall' in part) {
-        content.push({
-          type: 'tool-call' as const,
-          toolCallId: this.config.generateId(),
-          toolName: part.functionCall.name,
-          input: JSON.stringify(part.functionCall.args),
-          providerMetadata: part.thoughtSignature
+        if (!usesJsonResponseTool) {
+          const thoughtSignatureMetadata = part.thoughtSignature
             ? {
                 [providerOptionsName]: {
                   thoughtSignature: part.thoughtSignature,
                 },
               }
-            : undefined,
-        });
+            : undefined;
+
+          if (part.text.length === 0) {
+            if (thoughtSignatureMetadata != null && content.length > 0) {
+              const lastContent = content[content.length - 1];
+              lastContent.providerMetadata = thoughtSignatureMetadata;
+            }
+          } else {
+            content.push({
+              type: part.thought === true ? 'reasoning' : 'text',
+              text: part.text,
+              providerMetadata: thoughtSignatureMetadata,
+            });
+          }
+        }
+      } else if ('functionCall' in part) {
+        const isJsonResponseTool =
+          usesJsonResponseTool &&
+          jsonResponseToolName != null &&
+          part.functionCall.name === jsonResponseToolName;
+
+        if (isJsonResponseTool) {
+          content.push({
+            type: 'text',
+            text: JSON.stringify(part.functionCall.args),
+          });
+        } else {
+          content.push({
+            type: 'tool-call' as const,
+            toolCallId: this.config.generateId(),
+            toolName: part.functionCall.name,
+            input: JSON.stringify(part.functionCall.args),
+            providerMetadata: part.thoughtSignature
+              ? {
+                  [providerOptionsName]: {
+                    thoughtSignature: part.thoughtSignature,
+                  },
+                }
+              : undefined,
+          });
+        }
       } else if ('inlineData' in part) {
         const hasThought = part.thought === true;
         const hasThoughtSignature = !!part.thoughtSignature;
@@ -444,7 +508,13 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
   async doStream(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4StreamResult> {
-    const { args, warnings, providerOptionsName } = await this.getArgs(options);
+    const {
+      args,
+      warnings,
+      providerOptionsName,
+      usesJsonResponseTool,
+      jsonResponseToolName,
+    } = await this.getArgs(options);
 
     const headers = combineHeaders(
       await resolve(this.config.headers),
@@ -589,6 +659,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                     lastCodeExecutionToolCallId = undefined;
                   }
                 } else if ('text' in part && part.text != null) {
+                  if (usesJsonResponseTool) {
+                    continue;
+                  }
+
                   const thoughtSignatureMetadata = part.thoughtSignature
                     ? {
                         [providerOptionsName]: {
@@ -749,35 +823,56 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
               if (toolCallDeltas != null) {
                 for (const toolCall of toolCallDeltas) {
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCall.toolCallId,
-                    toolName: toolCall.toolName,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
+                  const isJsonResponseTool =
+                    usesJsonResponseTool &&
+                    jsonResponseToolName != null &&
+                    toolCall.toolName === jsonResponseToolName;
 
-                  controller.enqueue({
-                    type: 'tool-input-delta',
-                    id: toolCall.toolCallId,
-                    delta: toolCall.args,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
+                  if (isJsonResponseTool) {
+                    if (currentTextBlockId === null) {
+                      currentTextBlockId = String(blockCounter++);
+                      controller.enqueue({
+                        type: 'text-start',
+                        id: currentTextBlockId,
+                      });
+                    }
 
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.toolCallId,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: currentTextBlockId,
+                      delta: toolCall.args,
+                    });
+                  } else {
+                    controller.enqueue({
+                      type: 'tool-input-start',
+                      id: toolCall.toolCallId,
+                      toolName: toolCall.toolName,
+                      providerMetadata: toolCall.providerMetadata,
+                    });
 
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.toolCallId,
-                    toolName: toolCall.toolName,
-                    input: toolCall.args,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
+                    controller.enqueue({
+                      type: 'tool-input-delta',
+                      id: toolCall.toolCallId,
+                      delta: toolCall.args,
+                      providerMetadata: toolCall.providerMetadata,
+                    });
 
-                  hasToolCalls = true;
+                    controller.enqueue({
+                      type: 'tool-input-end',
+                      id: toolCall.toolCallId,
+                      providerMetadata: toolCall.providerMetadata,
+                    });
+
+                    controller.enqueue({
+                      type: 'tool-call',
+                      toolCallId: toolCall.toolCallId,
+                      toolName: toolCall.toolName,
+                      input: toolCall.args,
+                      providerMetadata: toolCall.providerMetadata,
+                    });
+
+                    hasToolCalls = true;
+                  }
                 }
               }
             }
@@ -832,6 +927,14 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
       request: { body: args },
     };
   }
+}
+
+function getGoogleModelCapabilities(_modelId: string): {
+  supportsStructuredOutputWithTools: boolean;
+} {
+  // No Google model is currently known to accept responseSchema + tools in the same request.
+  // When documented, set to true for those model ids.
+  return { supportsStructuredOutputWithTools: false };
 }
 
 function isGemini3Model(modelId: string): boolean {

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -3,11 +3,11 @@ import {
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
   LanguageModelV4FinishReason,
+  LanguageModelV4FunctionTool,
   LanguageModelV4GenerateResult,
   LanguageModelV4Source,
   LanguageModelV4StreamPart,
   LanguageModelV4StreamResult,
-  JSONObject,
   SharedV4ProviderMetadata,
   SharedV4Warning,
 } from '@ai-sdk/provider';
@@ -18,10 +18,7 @@ import {
   FetchFunction,
   generateId,
   InferSchema,
-  isCustomReasoning,
   lazySchema,
-  mapReasoningToProviderBudget,
-  mapReasoningToProviderEffort,
   parseProviderOptions,
   ParseResult,
   postJsonToApi,
@@ -100,7 +97,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     seed,
     tools,
     toolChoice,
-    reasoning,
     providerOptions,
   }: LanguageModelV4CallOptions) {
     const warnings: SharedV4Warning[] = [];
@@ -140,36 +136,57 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     }
 
     const isGemmaModel = this.modelId.toLowerCase().startsWith('gemma-');
-    const supportsFunctionResponseParts = this.modelId.startsWith('gemini-3');
 
     const { contents, systemInstruction } = convertToGoogleGenerativeAIMessages(
       prompt,
-      {
-        isGemmaModel,
-        providerOptionsName,
-        supportsFunctionResponseParts,
-      },
+      { isGemmaModel, providerOptionsName },
     );
+
+    const { supportsStructuredOutputWithTools } =
+      getGoogleModelCapabilities(this.modelId);
+    const structuredOutputMode =
+      googleOptions?.structuredOutputMode ?? 'auto';
+    const useStructuredOutputWithTools =
+      structuredOutputMode === 'outputFormat' ||
+      (structuredOutputMode === 'auto' && supportsStructuredOutputWithTools);
+
+    const needsJsonToolFallback =
+      responseFormat?.type === 'json' &&
+      responseFormat.schema != null &&
+      tools != null &&
+      tools.length > 0 &&
+      !useStructuredOutputWithTools;
+
+    const jsonResponseToolName = needsJsonToolFallback
+      ? tools.some(
+          tool => tool.type === 'function' && tool.name === 'json',
+        )
+        ? '__ai_sdk_json_response'
+        : 'json'
+      : undefined;
+
+    const jsonResponseTool: LanguageModelV4FunctionTool | undefined =
+      needsJsonToolFallback && jsonResponseToolName != null
+        ? {
+            type: 'function',
+            name: jsonResponseToolName,
+            description: 'Respond with a JSON object.',
+            inputSchema: responseFormat.schema,
+          }
+        : undefined;
 
     const {
       tools: googleTools,
       toolConfig: googleToolConfig,
       toolWarnings,
     } = prepareTools({
-      tools,
-      toolChoice,
+      tools:
+        jsonResponseTool != null
+          ? [...(tools ?? []), jsonResponseTool]
+          : tools,
+      toolChoice: jsonResponseTool != null ? { type: 'required' } : toolChoice,
       modelId: this.modelId,
     });
-
-    const resolvedThinking = resolveThinkingConfig({
-      reasoning,
-      modelId: this.modelId,
-      warnings,
-    });
-    const thinkingConfig =
-      googleOptions?.thinkingConfig || resolvedThinking
-        ? { ...resolvedThinking, ...googleOptions?.thinkingConfig }
-        : undefined;
 
     return {
       args: {
@@ -186,10 +203,13 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
           // response format:
           responseMimeType:
-            responseFormat?.type === 'json' ? 'application/json' : undefined,
+            responseFormat?.type === 'json' && jsonResponseTool == null
+              ? 'application/json'
+              : undefined,
           responseSchema:
             responseFormat?.type === 'json' &&
             responseFormat.schema != null &&
+            jsonResponseTool == null &&
             // Google GenAI does not support all OpenAPI Schema features,
             // so this is needed as an escape hatch:
             // TODO convert into provider option
@@ -202,7 +222,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
           // provider options:
           responseModalities: googleOptions?.responseModalities,
-          thinkingConfig,
+          thinkingConfig: googleOptions?.thinkingConfig,
           ...(googleOptions?.mediaResolution && {
             mediaResolution: googleOptions.mediaResolution,
           }),
@@ -222,17 +242,24 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
           : googleToolConfig,
         cachedContent: googleOptions?.cachedContent,
         labels: googleOptions?.labels,
-        serviceTier: googleOptions?.serviceTier,
       },
       warnings: [...warnings, ...toolWarnings],
       providerOptionsName,
+      usesJsonResponseTool: jsonResponseTool != null,
+      jsonResponseToolName,
     };
   }
 
   async doGenerate(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4GenerateResult> {
-    const { args, warnings, providerOptionsName } = await this.getArgs(options);
+    const {
+      args,
+      warnings,
+      providerOptionsName,
+      usesJsonResponseTool,
+      jsonResponseToolName,
+    } = await this.getArgs(options);
 
     const mergedHeaders = combineHeaders(
       await resolve(this.config.headers),
@@ -265,8 +292,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
     // Associates a code execution result with its preceding call.
     let lastCodeExecutionToolCallId: string | undefined;
-    // Associates a server-side tool response with its preceding call (tool combination).
-    let lastServerToolCallId: string | undefined;
 
     // Build content array from all parts
     for (const part of parts) {
@@ -295,40 +320,54 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
         // Clear the ID after use to avoid accidental reuse.
         lastCodeExecutionToolCallId = undefined;
       } else if ('text' in part && part.text != null) {
-        const thoughtSignatureMetadata = part.thoughtSignature
-          ? {
-              [providerOptionsName]: {
-                thoughtSignature: part.thoughtSignature,
-              },
-            }
-          : undefined;
-
-        if (part.text.length === 0) {
-          if (thoughtSignatureMetadata != null && content.length > 0) {
-            const lastContent = content[content.length - 1];
-            lastContent.providerMetadata = thoughtSignatureMetadata;
-          }
-        } else {
-          content.push({
-            type: part.thought === true ? 'reasoning' : 'text',
-            text: part.text,
-            providerMetadata: thoughtSignatureMetadata,
-          });
-        }
-      } else if ('functionCall' in part) {
-        content.push({
-          type: 'tool-call' as const,
-          toolCallId: this.config.generateId(),
-          toolName: part.functionCall.name,
-          input: JSON.stringify(part.functionCall.args),
-          providerMetadata: part.thoughtSignature
+        if (!usesJsonResponseTool) {
+          const thoughtSignatureMetadata = part.thoughtSignature
             ? {
                 [providerOptionsName]: {
                   thoughtSignature: part.thoughtSignature,
                 },
               }
-            : undefined,
-        });
+            : undefined;
+
+          if (part.text.length === 0) {
+            if (thoughtSignatureMetadata != null && content.length > 0) {
+              const lastContent = content[content.length - 1];
+              lastContent.providerMetadata = thoughtSignatureMetadata;
+            }
+          } else {
+            content.push({
+              type: part.thought === true ? 'reasoning' : 'text',
+              text: part.text,
+              providerMetadata: thoughtSignatureMetadata,
+            });
+          }
+        }
+      } else if ('functionCall' in part) {
+        const isJsonResponseTool =
+          usesJsonResponseTool &&
+          jsonResponseToolName != null &&
+          part.functionCall.name === jsonResponseToolName;
+
+        if (isJsonResponseTool) {
+          content.push({
+            type: 'text',
+            text: JSON.stringify(part.functionCall.args),
+          });
+        } else {
+          content.push({
+            type: 'tool-call' as const,
+            toolCallId: this.config.generateId(),
+            toolName: part.functionCall.name,
+            input: JSON.stringify(part.functionCall.args),
+            providerMetadata: part.thoughtSignature
+              ? {
+                  [providerOptionsName]: {
+                    thoughtSignature: part.thoughtSignature,
+                  },
+                }
+              : undefined,
+          });
+        }
       } else if ('inlineData' in part) {
         const hasThought = part.thought === true;
         const hasThoughtSignature = !!part.thoughtSignature;
@@ -344,57 +383,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
               }
             : undefined,
         });
-      } else if ('toolCall' in part && part.toolCall) {
-        const toolCallId = part.toolCall.id ?? this.config.generateId();
-        lastServerToolCallId = toolCallId;
-        content.push({
-          type: 'tool-call',
-          toolCallId,
-          toolName: `server:${part.toolCall.toolType}`,
-          input: JSON.stringify(part.toolCall.args ?? {}),
-          providerExecuted: true,
-          dynamic: true,
-          providerMetadata: part.thoughtSignature
-            ? {
-                [providerOptionsName]: {
-                  thoughtSignature: part.thoughtSignature,
-                  serverToolCallId: toolCallId,
-                  serverToolType: part.toolCall.toolType,
-                },
-              }
-            : {
-                [providerOptionsName]: {
-                  serverToolCallId: toolCallId,
-                  serverToolType: part.toolCall.toolType,
-                },
-              },
-        });
-      } else if ('toolResponse' in part && part.toolResponse) {
-        const responseToolCallId =
-          lastServerToolCallId ??
-          part.toolResponse.id ??
-          this.config.generateId();
-        content.push({
-          type: 'tool-result',
-          toolCallId: responseToolCallId,
-          toolName: `server:${part.toolResponse.toolType}`,
-          result: (part.toolResponse.response ?? {}) as JSONObject,
-          providerMetadata: part.thoughtSignature
-            ? {
-                [providerOptionsName]: {
-                  thoughtSignature: part.thoughtSignature,
-                  serverToolCallId: responseToolCallId,
-                  serverToolType: part.toolResponse.toolType,
-                },
-              }
-            : {
-                [providerOptionsName]: {
-                  serverToolCallId: responseToolCallId,
-                  serverToolType: part.toolResponse.toolType,
-                },
-              },
-        });
-        lastServerToolCallId = undefined;
       }
     }
 
@@ -429,7 +417,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
           safetyRatings: candidate.safetyRatings ?? null,
           usageMetadata: usageMetadata ?? null,
           finishMessage: candidate.finishMessage ?? null,
-          serviceTier: response.serviceTier ?? null,
         } satisfies GoogleGenerativeAIProviderMetadata,
       },
       request: { body: args },
@@ -444,7 +431,13 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
   async doStream(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4StreamResult> {
-    const { args, warnings, providerOptionsName } = await this.getArgs(options);
+    const {
+      args,
+      warnings,
+      providerOptionsName,
+      usesJsonResponseTool,
+      jsonResponseToolName,
+    } = await this.getArgs(options);
 
     const headers = combineHeaders(
       await resolve(this.config.headers),
@@ -471,7 +464,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     let providerMetadata: SharedV4ProviderMetadata | undefined = undefined;
     let lastGroundingMetadata: GroundingMetadataSchema | null = null;
     let lastUrlContextMetadata: UrlContextMetadataSchema | null = null;
-    let serviceTier: string | null = null;
 
     const generateId = this.config.generateId;
     let hasToolCalls = false;
@@ -485,8 +477,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
     const emittedSourceUrls = new Set<string>();
     // Associates a code execution result with its preceding call.
     let lastCodeExecutionToolCallId: string | undefined;
-    // Associates a server-side tool response with its preceding call (tool combination).
-    let lastServerToolCallId: string | undefined;
 
     return {
       stream: response.pipeThrough(
@@ -514,10 +504,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
             if (usageMetadata != null) {
               usage = usageMetadata;
-            }
-
-            if (value.serviceTier != null) {
-              serviceTier = value.serviceTier;
             }
 
             const candidate = value.candidates?.[0];
@@ -589,6 +575,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                     lastCodeExecutionToolCallId = undefined;
                   }
                 } else if ('text' in part && part.text != null) {
+                  if (usesJsonResponseTool) {
+                    continue;
+                  }
+
                   const thoughtSignatureMetadata = part.thoughtSignature
                     ? {
                         [providerOptionsName]: {
@@ -693,51 +683,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                     data: part.inlineData.data,
                     providerMetadata: fileMeta,
                   });
-                } else if ('toolCall' in part && part.toolCall) {
-                  const toolCallId = part.toolCall.id ?? generateId();
-                  lastServerToolCallId = toolCallId;
-                  const serverMeta = {
-                    [providerOptionsName]: {
-                      ...(part.thoughtSignature
-                        ? { thoughtSignature: part.thoughtSignature }
-                        : {}),
-                      serverToolCallId: toolCallId,
-                      serverToolType: part.toolCall.toolType,
-                    },
-                  };
-
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId,
-                    toolName: `server:${part.toolCall.toolType}`,
-                    input: JSON.stringify(part.toolCall.args ?? {}),
-                    providerExecuted: true,
-                    dynamic: true,
-                    providerMetadata: serverMeta,
-                  });
-                } else if ('toolResponse' in part && part.toolResponse) {
-                  const responseToolCallId =
-                    lastServerToolCallId ??
-                    part.toolResponse.id ??
-                    generateId();
-                  const serverMeta = {
-                    [providerOptionsName]: {
-                      ...(part.thoughtSignature
-                        ? { thoughtSignature: part.thoughtSignature }
-                        : {}),
-                      serverToolCallId: responseToolCallId,
-                      serverToolType: part.toolResponse.toolType,
-                    },
-                  };
-
-                  controller.enqueue({
-                    type: 'tool-result',
-                    toolCallId: responseToolCallId,
-                    toolName: `server:${part.toolResponse.toolType}`,
-                    result: (part.toolResponse.response ?? {}) as JSONObject,
-                    providerMetadata: serverMeta,
-                  });
-                  lastServerToolCallId = undefined;
                 }
               }
 
@@ -749,35 +694,56 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
 
               if (toolCallDeltas != null) {
                 for (const toolCall of toolCallDeltas) {
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCall.toolCallId,
-                    toolName: toolCall.toolName,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
+                  const isJsonResponseTool =
+                    usesJsonResponseTool &&
+                    jsonResponseToolName != null &&
+                    toolCall.toolName === jsonResponseToolName;
 
-                  controller.enqueue({
-                    type: 'tool-input-delta',
-                    id: toolCall.toolCallId,
-                    delta: toolCall.args,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
+                  if (isJsonResponseTool) {
+                    if (currentTextBlockId === null) {
+                      currentTextBlockId = String(blockCounter++);
+                      controller.enqueue({
+                        type: 'text-start',
+                        id: currentTextBlockId,
+                      });
+                    }
 
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.toolCallId,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: currentTextBlockId,
+                      delta: toolCall.args,
+                    });
+                  } else {
+                    controller.enqueue({
+                      type: 'tool-input-start',
+                      id: toolCall.toolCallId,
+                      toolName: toolCall.toolName,
+                      providerMetadata: toolCall.providerMetadata,
+                    });
 
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.toolCallId,
-                    toolName: toolCall.toolName,
-                    input: toolCall.args,
-                    providerMetadata: toolCall.providerMetadata,
-                  });
+                    controller.enqueue({
+                      type: 'tool-input-delta',
+                      id: toolCall.toolCallId,
+                      delta: toolCall.args,
+                      providerMetadata: toolCall.providerMetadata,
+                    });
 
-                  hasToolCalls = true;
+                    controller.enqueue({
+                      type: 'tool-input-end',
+                      id: toolCall.toolCallId,
+                      providerMetadata: toolCall.providerMetadata,
+                    });
+
+                    controller.enqueue({
+                      type: 'tool-call',
+                      toolCallId: toolCall.toolCallId,
+                      toolName: toolCall.toolName,
+                      input: toolCall.args,
+                      providerMetadata: toolCall.providerMetadata,
+                    });
+
+                    hasToolCalls = true;
+                  }
                 }
               }
             }
@@ -799,7 +765,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
                   safetyRatings: candidate.safetyRatings ?? null,
                   usageMetadata: usageMetadata ?? null,
                   finishMessage: candidate.finishMessage ?? null,
-                  serviceTier,
                 } satisfies GoogleGenerativeAIProviderMetadata,
               };
             }
@@ -834,107 +799,12 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV4 {
   }
 }
 
-function isGemini3Model(modelId: string): boolean {
-  return /gemini-3[\.\-]/i.test(modelId) || /gemini-3$/i.test(modelId);
-}
-
-function getMaxOutputTokensForGemini25Model(): number {
-  return 65536;
-}
-
-function getMaxThinkingTokensForGemini25Model(modelId: string): number {
-  const id = modelId.toLowerCase();
-  if (id.includes('2.5-pro') || id.includes('gemini-3-pro-image')) {
-    return 32768;
-  }
-  return 24576;
-}
-
-type GoogleThinkingConfig = NonNullable<
-  InferSchema<typeof googleLanguageModelOptions>['thinkingConfig']
->;
-
-function resolveThinkingConfig({
-  reasoning,
-  modelId,
-  warnings,
-}: {
-  reasoning: LanguageModelV4CallOptions['reasoning'];
-  modelId: string;
-  warnings: SharedV4Warning[];
-}): Omit<GoogleThinkingConfig, 'includeThoughts'> | undefined {
-  if (!isCustomReasoning(reasoning)) {
-    return undefined;
-  }
-
-  if (isGemini3Model(modelId) && !modelId.includes('gemini-3-pro-image')) {
-    return resolveGemini3ThinkingConfig({ reasoning, warnings });
-  }
-
-  return resolveGemini25ThinkingConfig({ reasoning, modelId, warnings });
-}
-
-function resolveGemini3ThinkingConfig({
-  reasoning,
-  warnings,
-}: {
-  reasoning: Exclude<
-    LanguageModelV4CallOptions['reasoning'],
-    'provider-default' | undefined
-  >;
-  warnings: SharedV4Warning[];
-}): Pick<GoogleThinkingConfig, 'thinkingLevel'> | undefined {
-  if (reasoning === 'none') {
-    // It's not possible to fully disable thinking with Gemini 3.
-    return { thinkingLevel: 'minimal' };
-  }
-
-  const thinkingLevel = mapReasoningToProviderEffort({
-    reasoning,
-    effortMap: {
-      minimal: 'minimal',
-      low: 'low',
-      medium: 'medium',
-      high: 'high',
-      xhigh: 'high',
-    },
-    warnings,
-  });
-
-  if (thinkingLevel == null) {
-    return undefined;
-  }
-
-  return { thinkingLevel };
-}
-
-function resolveGemini25ThinkingConfig({
-  reasoning,
-  modelId,
-  warnings,
-}: {
-  reasoning: Exclude<
-    LanguageModelV4CallOptions['reasoning'],
-    'provider-default' | undefined
-  >;
-  modelId: string;
-  warnings: SharedV4Warning[];
-}): Pick<GoogleThinkingConfig, 'thinkingBudget'> | undefined {
-  if (reasoning === 'none') {
-    return { thinkingBudget: 0 };
-  }
-
-  const thinkingBudget = mapReasoningToProviderBudget({
-    reasoning,
-    maxOutputTokens: getMaxOutputTokensForGemini25Model(),
-    maxReasoningBudget: getMaxThinkingTokensForGemini25Model(modelId),
-    minReasoningBudget: 0,
-    warnings,
-  });
-  if (thinkingBudget == null) {
-    return undefined;
-  }
-  return { thinkingBudget };
+function getGoogleModelCapabilities(_modelId: string): {
+  supportsStructuredOutputWithTools: boolean;
+} {
+  // No Google model is currently known to accept responseSchema + tools in the same request.
+  // When documented, set to true for those model ids.
+  return { supportsStructuredOutputWithTools: false };
 }
 
 function getToolCallsFromParts({
@@ -1171,22 +1041,6 @@ const getContentSchema = () =>
             thoughtSignature: z.string().nullish(),
           }),
           z.object({
-            toolCall: z.object({
-              toolType: z.string(),
-              args: z.unknown().nullish(),
-              id: z.string(),
-            }),
-            thoughtSignature: z.string().nullish(),
-          }),
-          z.object({
-            toolResponse: z.object({
-              toolType: z.string(),
-              response: z.unknown().nullish(),
-              id: z.string(),
-            }),
-            thoughtSignature: z.string().nullish(),
-          }),
-          z.object({
             executableCode: z
               .object({
                 language: z.string(),
@@ -1219,15 +1073,6 @@ const getSafetyRatingSchema = () =>
     blocked: z.boolean().nullish(),
   });
 
-const tokenDetailsSchema = z
-  .array(
-    z.object({
-      modality: z.string(),
-      tokenCount: z.number(),
-    }),
-  )
-  .nullish();
-
 const usageSchema = z.object({
   cachedContentTokenCount: z.number().nullish(),
   thoughtsTokenCount: z.number().nullish(),
@@ -1236,9 +1081,6 @@ const usageSchema = z.object({
   totalTokenCount: z.number().nullish(),
   // https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/GenerateContentResponse#TrafficType
   trafficType: z.string().nullish(),
-  // https://ai.google.dev/api/generate-content#Modality
-  promptTokensDetails: tokenDetailsSchema,
-  candidatesTokensDetails: tokenDetailsSchema,
 });
 
 // https://ai.google.dev/api/generate-content#UrlRetrievalMetadata
@@ -1274,7 +1116,6 @@ const responseSchema = lazySchema(() =>
           safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
         })
         .nullish(),
-      serviceTier: z.string().nullish(),
     }),
   ),
 );
@@ -1330,7 +1171,6 @@ const chunkSchema = lazySchema(() =>
           safetyRatings: z.array(getSafetyRatingSchema()).nullish(),
         })
         .nullish(),
-      serviceTier: z.string().nullish(),
     }),
   ),
 );

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -7,6 +7,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-2.0-flash'
   | 'gemini-2.0-flash-001'
   | 'gemini-2.0-flash-lite'
+  | 'gemini-2.0-flash-exp-image-generation'
   | 'gemini-2.0-flash-lite-001'
   | 'gemini-2.5-pro'
   | 'gemini-2.5-flash'
@@ -77,6 +78,16 @@ export const googleLanguageModelOptions = lazySchema(() =>
        * structured outputs if you need to.
        */
       structuredOutputs: z.boolean().optional(),
+
+      /**
+       * When using both response schema and tools, how to get structured output.
+       * - `outputFormat`: Use native responseSchema (may fail if model rejects schema+tools).
+       * - `jsonTool`: Use a synthetic 'json' tool as fallback.
+       * - `auto`: Use native when the model supports schema+tools, otherwise jsonTool (default).
+       */
+      structuredOutputMode: z
+        .enum(['outputFormat', 'jsonTool', 'auto'])
+        .optional(),
 
       /**
        * Optional. A list of unique safety settings for blocking unsafe content.
@@ -188,11 +199,6 @@ export const googleLanguageModelOptions = lazySchema(() =>
             .optional(),
         })
         .optional(),
-
-      /**
-       * Optional. The service tier to use for the request.
-       */
-      serviceTier: z.enum(['standard', 'flex', 'priority']).optional(),
     }),
   ),
 );

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -199,6 +199,11 @@ export const googleLanguageModelOptions = lazySchema(() =>
             .optional(),
         })
         .optional(),
+
+      /**
+       * Optional. The service tier to use for the request.
+       */
+      serviceTier: z.enum(['standard', 'flex', 'priority']).optional(),
     }),
   ),
 );

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -1669,7 +1669,7 @@ describe('doStream', () => {
           },
           {
             "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+        Error message: SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
             "type": "error",
           },
           {

--- a/packages/groq/src/groq-chat-language-model.test.ts
+++ b/packages/groq/src/groq-chat-language-model.test.ts
@@ -99,70 +99,6 @@ describe('doGenerate', () => {
     });
   });
 
-  describe('top-level reasoning', () => {
-    beforeEach(() => {
-      prepareJsonFixtureResponse('groq-text');
-    });
-
-    it('should map top-level reasoning to reasoning_effort', async () => {
-      await model.doGenerate({
-        prompt: TEST_PROMPT,
-        reasoning: 'high',
-      });
-
-      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
-        'high',
-      );
-    });
-
-    it('should coerce top-level reasoning minimal to low', async () => {
-      await model.doGenerate({
-        prompt: TEST_PROMPT,
-        reasoning: 'minimal',
-      });
-
-      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
-        'low',
-      );
-    });
-
-    it('should coerce top-level reasoning xhigh to high', async () => {
-      await model.doGenerate({
-        prompt: TEST_PROMPT,
-        reasoning: 'xhigh',
-      });
-
-      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
-        'high',
-      );
-    });
-
-    it('should not pass top-level reasoning none as reasoning_effort', async () => {
-      await model.doGenerate({
-        prompt: TEST_PROMPT,
-        reasoning: 'none',
-      });
-
-      expect(
-        (await server.calls[0].requestBodyJson).reasoning_effort,
-      ).toBeUndefined();
-    });
-
-    it('should prefer providerOptions reasoningEffort over top-level reasoning', async () => {
-      await model.doGenerate({
-        prompt: TEST_PROMPT,
-        reasoning: 'medium',
-        providerOptions: {
-          groq: { reasoningEffort: 'high' },
-        },
-      });
-
-      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
-        'high',
-      );
-    });
-  });
-
   it('should extract usage', async () => {
     prepareJsonFixtureResponse('groq-text');
 
@@ -452,32 +388,6 @@ describe('doGenerate', () => {
     `);
   });
 
-  it('should pass performance serviceTier provider option', async () => {
-    prepareJsonFixtureResponse('groq-text');
-
-    await provider('gemma2-9b-it').doGenerate({
-      prompt: TEST_PROMPT,
-      providerOptions: {
-        groq: {
-          serviceTier: 'performance',
-        },
-      },
-    });
-
-    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
-      {
-        "messages": [
-          {
-            "content": "Hello",
-            "role": "user",
-          },
-        ],
-        "model": "gemma2-9b-it",
-        "service_tier": "performance",
-      }
-    `);
-  });
-
   it('should pass tools and toolChoice', async () => {
     prepareJsonFixtureResponse('groq-text');
 
@@ -625,6 +535,203 @@ describe('doGenerate', () => {
         },
       }
     `);
+  });
+
+  it('should use json tool fallback when responseFormat schema and tools are both present (auto)', async () => {
+    prepareJsonFixtureResponse('groq-text');
+
+    const model = provider('gemma2-9b-it');
+
+    await model.doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body.response_format).toBeUndefined();
+    expect(body.tools).toHaveLength(2);
+    const names = body.tools.map(
+      (t: { type: string; function: { name: string } }) => t.function.name,
+    );
+    expect(names.sort()).toEqual(['json', 'test-tool']);
+  });
+
+  it('should use reserved synthetic tool name when user already defines a json tool', async () => {
+    prepareJsonFixtureResponse('groq-text');
+
+    const m = provider('gemma2-9b-it');
+
+    await m.doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'json',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { legacy: { type: 'string' } },
+            required: ['legacy'],
+            additionalProperties: false,
+          },
+        },
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    const names = body.tools.map(
+      (t: { type: string; function: { name: string } }) => t.function.name,
+    );
+    expect(names.sort()).toEqual([
+      '__ai_sdk_json_response',
+      'json',
+      'test-tool',
+    ]);
+  });
+
+  it('should map finish reason to stop when response is only synthetic json tool call', async () => {
+    server.urls[CHAT_COMPLETIONS_URL].response = {
+      type: 'json-value',
+      body: {
+        id: 'chatcmpl-test',
+        object: 'chat.completion',
+        created: 0,
+        model: 'gemma2-9b-it',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_json',
+                  type: 'function',
+                  function: {
+                    name: 'json',
+                    arguments: '{"out":"ok"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+      },
+    };
+
+    const m = provider('gemma2-9b-it');
+    const result = await m.doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.finishReason.unified).toBe('stop');
+    expect(result.content).toEqual([
+      { type: 'text', text: '{"out":"ok"}' },
+    ]);
+  });
+
+  it('should use native response_format when structuredOutputMode is outputFormat with schema and tools', async () => {
+    prepareJsonFixtureResponse('groq-text');
+
+    const model = provider('gemma2-9b-it');
+
+    await model.doGenerate({
+      providerOptions: {
+        groq: { structuredOutputMode: 'outputFormat' },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body.response_format?.type).toBe('json_schema');
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools[0].function.name).toBe('test-tool');
   });
 
   it('should pass response format information as json_object when structuredOutputs explicitly disabled', async () => {
@@ -1066,6 +1173,49 @@ describe('doStream', () => {
         await convertReadableStreamToArray(result.stream),
       ).toMatchSnapshot();
     });
+  });
+
+  it('should map stream finish to stop when only synthetic json tool completes', async () => {
+    server.urls[CHAT_COMPLETIONS_URL].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-json-tool","object":"chat.completion.chunk","created":0,"model":"gemma2-9b-it","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_json","type":"function","function":{"name":"json","arguments":"{\\"out\\":\\"ok\\"}"}}]},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-json-tool","object":"chat.completion.chunk","created":0,"model":"gemma2-9b-it","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { out: { type: 'string' } },
+          required: ['out'],
+          additionalProperties: false,
+        },
+      },
+      tools: [
+        {
+          name: 'test-tool',
+          type: 'function',
+          inputSchema: {
+            type: 'object',
+            properties: { x: { type: 'string' } },
+            required: ['x'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const parts = await convertReadableStreamToArray(stream);
+    const finish = parts.find(p => p.type === 'finish');
+    expect(finish?.type).toBe('finish');
+    if (finish?.type === 'finish') {
+      expect(finish.finishReason.unified).toBe('stop');
+    }
   });
 
   it('should stream tool call deltas when tool call arguments are passed in the first chunk', async () => {
@@ -1519,7 +1669,7 @@ describe('doStream', () => {
           },
           {
             "error": [AI_JSONParseError: JSON parsing failed: Text: {unparsable}.
-        Error message: SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
+        Error message: Expected property name or '}' in JSON at position 1 (line 1 column 2)],
             "type": "error",
           },
           {

--- a/packages/groq/src/groq-chat-language-model.ts
+++ b/packages/groq/src/groq-chat-language-model.ts
@@ -4,6 +4,7 @@ import {
   LanguageModelV4CallOptions,
   LanguageModelV4Content,
   LanguageModelV4FinishReason,
+  LanguageModelV4FunctionTool,
   LanguageModelV4GenerateResult,
   LanguageModelV4StreamPart,
   LanguageModelV4StreamResult,
@@ -17,9 +18,7 @@ import {
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
-  isCustomReasoning,
   isParsableJson,
-  mapReasoningToProviderEffort,
   parseProviderOptions,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
@@ -70,7 +69,6 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
     stopSequences,
     responseFormat,
     seed,
-    reasoning,
     stream,
     tools,
     toolChoice,
@@ -106,11 +104,50 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
       });
     }
 
+    const { supportsStructuredOutputWithTools } =
+      getGroqModelCapabilities(this.modelId);
+    const structuredOutputMode = groqOptions?.structuredOutputMode ?? 'auto';
+    const useStructuredOutputWithTools =
+      structuredOutputMode === 'outputFormat' ||
+      (structuredOutputMode === 'auto' && supportsStructuredOutputWithTools);
+
+    const needsJsonToolFallback =
+      responseFormat?.type === 'json' &&
+      responseFormat.schema != null &&
+      tools != null &&
+      tools.length > 0 &&
+      !useStructuredOutputWithTools;
+
+    const jsonResponseToolName = needsJsonToolFallback
+      ? tools.some(
+          tool => tool.type === 'function' && tool.name === 'json',
+        )
+        ? '__ai_sdk_json_response'
+        : 'json'
+      : undefined;
+
+    const jsonResponseTool: LanguageModelV4FunctionTool | undefined =
+      needsJsonToolFallback && jsonResponseToolName != null
+        ? {
+            type: 'function',
+            name: jsonResponseToolName,
+            description: 'Respond with a JSON object.',
+            inputSchema: responseFormat.schema,
+          }
+        : undefined;
+
     const {
       tools: groqTools,
       toolChoice: groqToolChoice,
       toolWarnings,
-    } = prepareTools({ tools, toolChoice, modelId: this.modelId });
+    } = prepareTools({
+      tools:
+        jsonResponseTool != null
+          ? [...(tools ?? []), jsonResponseTool]
+          : tools,
+      toolChoice: jsonResponseTool != null ? { type: 'required' } : toolChoice,
+      modelId: this.modelId,
+    });
 
     return {
       args: {
@@ -132,7 +169,7 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
 
         // response format:
         response_format:
-          responseFormat?.type === 'json'
+          responseFormat?.type === 'json' && jsonResponseTool == null
             ? structuredOutputs && responseFormat.schema != null
               ? {
                   type: 'json_schema',
@@ -148,21 +185,7 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
 
         // provider options:
         reasoning_format: groqOptions?.reasoningFormat,
-        reasoning_effort:
-          groqOptions?.reasoningEffort ??
-          (isCustomReasoning(reasoning) && reasoning !== 'none'
-            ? mapReasoningToProviderEffort({
-                reasoning,
-                effortMap: {
-                  minimal: 'low',
-                  low: 'low',
-                  medium: 'medium',
-                  high: 'high',
-                  xhigh: 'high',
-                },
-                warnings,
-              })
-            : undefined),
+        reasoning_effort: groqOptions?.reasoningEffort,
         service_tier: groqOptions?.serviceTier,
 
         // messages:
@@ -173,16 +196,19 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
         tool_choice: groqToolChoice,
       },
       warnings: [...warnings, ...toolWarnings],
+      usesJsonResponseTool: jsonResponseTool != null,
+      jsonResponseToolName,
     };
   }
 
   async doGenerate(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4GenerateResult> {
-    const { args, warnings } = await this.getArgs({
-      ...options,
-      stream: false,
-    });
+    const { args, warnings, usesJsonResponseTool, jsonResponseToolName } =
+      await this.getArgs({
+        ...options,
+        stream: false,
+      });
 
     const body = JSON.stringify(args);
 
@@ -210,7 +236,7 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
 
     // text content:
     const text = choice.message.content;
-    if (text != null && text.length > 0) {
+    if (text != null && text.length > 0 && !usesJsonResponseTool) {
       content.push({ type: 'text', text: text });
     }
 
@@ -226,19 +252,42 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
     // tool calls:
     if (choice.message.tool_calls != null) {
       for (const toolCall of choice.message.tool_calls) {
-        content.push({
-          type: 'tool-call',
-          toolCallId: toolCall.id ?? generateId(),
-          toolName: toolCall.function.name,
-          input: toolCall.function.arguments!,
-        });
+        const isJsonResponseTool =
+          usesJsonResponseTool &&
+          jsonResponseToolName != null &&
+          toolCall.function.name === jsonResponseToolName;
+
+        if (isJsonResponseTool) {
+          content.push({
+            type: 'text',
+            text: toolCall.function.arguments!,
+          });
+        } else {
+          content.push({
+            type: 'tool-call',
+            toolCallId: toolCall.id ?? generateId(),
+            toolName: toolCall.function.name,
+            input: toolCall.function.arguments!,
+          });
+        }
       }
     }
+
+    const isJsonResponseFromTool =
+      usesJsonResponseTool &&
+      jsonResponseToolName != null &&
+      choice.message.tool_calls != null &&
+      choice.message.tool_calls.length > 0 &&
+      choice.message.tool_calls.every(
+        tc => tc.function.name === jsonResponseToolName,
+      );
 
     return {
       content,
       finishReason: {
-        unified: mapGroqFinishReason(choice.finish_reason),
+        unified: mapGroqFinishReason(choice.finish_reason, {
+          isJsonResponseFromTool,
+        }),
         raw: choice.finish_reason ?? undefined,
       },
       usage: convertGroqUsage(response.usage),
@@ -255,7 +304,11 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
   async doStream(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4StreamResult> {
-    const { args, warnings } = await this.getArgs({ ...options, stream: true });
+    const { args, warnings, usesJsonResponseTool, jsonResponseToolName } =
+      await this.getArgs({
+        ...options,
+        stream: true,
+      });
 
     const body = JSON.stringify({ ...args, stream: true });
 
@@ -396,25 +449,27 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
             }
 
             if (delta.content != null && delta.content.length > 0) {
-              // end active reasoning block before text starts
-              if (isActiveReasoning) {
+              if (!usesJsonResponseTool) {
+                // end active reasoning block before text starts
+                if (isActiveReasoning) {
+                  controller.enqueue({
+                    type: 'reasoning-end',
+                    id: 'reasoning-0',
+                  });
+                  isActiveReasoning = false;
+                }
+
+                if (!isActiveText) {
+                  controller.enqueue({ type: 'text-start', id: 'txt-0' });
+                  isActiveText = true;
+                }
+
                 controller.enqueue({
-                  type: 'reasoning-end',
-                  id: 'reasoning-0',
+                  type: 'text-delta',
+                  id: 'txt-0',
+                  delta: delta.content,
                 });
-                isActiveReasoning = false;
               }
-
-              if (!isActiveText) {
-                controller.enqueue({ type: 'text-start', id: 'txt-0' });
-                isActiveText = true;
-              }
-
-              controller.enqueue({
-                type: 'text-delta',
-                id: 'txt-0',
-                delta: delta.content,
-              });
             }
 
             if (delta.tool_calls != null) {
@@ -452,11 +507,23 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
                     });
                   }
 
-                  controller.enqueue({
-                    type: 'tool-input-start',
-                    id: toolCallDelta.id,
-                    toolName: toolCallDelta.function.name,
-                  });
+                  const isJsonResponseTool =
+                    usesJsonResponseTool &&
+                    jsonResponseToolName != null &&
+                    toolCallDelta.function.name === jsonResponseToolName;
+
+                  if (!isJsonResponseTool) {
+                    controller.enqueue({
+                      type: 'tool-input-start',
+                      id: toolCallDelta.id,
+                      toolName: toolCallDelta.function.name,
+                    });
+                  } else {
+                    if (!isActiveText) {
+                      controller.enqueue({ type: 'text-start', id: 'txt-0' });
+                      isActiveText = true;
+                    }
+                  }
 
                   toolCalls[index] = {
                     id: toolCallDelta.id,
@@ -476,27 +543,47 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
                   ) {
                     // send delta if the argument text has already started:
                     if (toolCall.function.arguments.length > 0) {
-                      controller.enqueue({
-                        type: 'tool-input-delta',
-                        id: toolCall.id,
-                        delta: toolCall.function.arguments,
-                      });
+                      const isJsonTool =
+                        usesJsonResponseTool &&
+                        jsonResponseToolName != null &&
+                        toolCall.function.name === jsonResponseToolName;
+
+                      if (isJsonTool) {
+                        controller.enqueue({
+                          type: 'text-delta',
+                          id: 'txt-0',
+                          delta: toolCall.function.arguments,
+                        });
+                      } else {
+                        controller.enqueue({
+                          type: 'tool-input-delta',
+                          id: toolCall.id,
+                          delta: toolCall.function.arguments,
+                        });
+                      }
                     }
 
                     // check if tool call is complete
                     // (some providers send the full tool call in one chunk):
                     if (isParsableJson(toolCall.function.arguments)) {
-                      controller.enqueue({
-                        type: 'tool-input-end',
-                        id: toolCall.id,
-                      });
+                      const isJsonTool =
+                        usesJsonResponseTool &&
+                        jsonResponseToolName != null &&
+                        toolCall.function.name === jsonResponseToolName;
 
-                      controller.enqueue({
-                        type: 'tool-call',
-                        toolCallId: toolCall.id ?? generateId(),
-                        toolName: toolCall.function.name,
-                        input: toolCall.function.arguments,
-                      });
+                      if (!isJsonTool) {
+                        controller.enqueue({
+                          type: 'tool-input-end',
+                          id: toolCall.id,
+                        });
+
+                        controller.enqueue({
+                          type: 'tool-call',
+                          toolCallId: toolCall.id ?? generateId(),
+                          toolName: toolCall.function.name,
+                          input: toolCall.function.arguments,
+                        });
+                      }
                       toolCall.hasFinished = true;
                     }
                   }
@@ -516,12 +603,25 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
                     toolCallDelta.function?.arguments ?? '';
                 }
 
+                const isJsonResponseTool =
+                  usesJsonResponseTool &&
+                  jsonResponseToolName != null &&
+                  toolCall.function.name === jsonResponseToolName;
+
                 // send delta
-                controller.enqueue({
-                  type: 'tool-input-delta',
-                  id: toolCall.id,
-                  delta: toolCallDelta.function.arguments ?? '',
-                });
+                if (isJsonResponseTool) {
+                  controller.enqueue({
+                    type: 'text-delta',
+                    id: 'txt-0',
+                    delta: toolCallDelta.function.arguments ?? '',
+                  });
+                } else {
+                  controller.enqueue({
+                    type: 'tool-input-delta',
+                    id: toolCall.id,
+                    delta: toolCallDelta.function.arguments ?? '',
+                  });
+                }
 
                 // check if tool call is complete
                 if (
@@ -529,17 +629,19 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
                   toolCall.function?.arguments != null &&
                   isParsableJson(toolCall.function.arguments)
                 ) {
-                  controller.enqueue({
-                    type: 'tool-input-end',
-                    id: toolCall.id,
-                  });
+                  if (!isJsonResponseTool) {
+                    controller.enqueue({
+                      type: 'tool-input-end',
+                      id: toolCall.id,
+                    });
 
-                  controller.enqueue({
-                    type: 'tool-call',
-                    toolCallId: toolCall.id ?? generateId(),
-                    toolName: toolCall.function.name,
-                    input: toolCall.function.arguments,
-                  });
+                    controller.enqueue({
+                      type: 'tool-call',
+                      toolCallId: toolCall.id ?? generateId(),
+                      toolName: toolCall.function.name,
+                      input: toolCall.function.arguments,
+                    });
+                  }
                   toolCall.hasFinished = true;
                 }
               }
@@ -555,9 +657,25 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
               controller.enqueue({ type: 'text-end', id: 'txt-0' });
             }
 
+            let unifiedFinishReason = finishReason.unified;
+            if (
+              usesJsonResponseTool &&
+              jsonResponseToolName != null &&
+              (finishReason.raw === 'tool_calls' ||
+                finishReason.raw === 'function_call')
+            ) {
+              const finished = toolCalls.filter(t => t.hasFinished);
+              if (
+                finished.length > 0 &&
+                finished.every(t => t.function.name === jsonResponseToolName)
+              ) {
+                unifiedFinishReason = 'stop';
+              }
+            }
+
             controller.enqueue({
               type: 'finish',
-              finishReason,
+              finishReason: { ...finishReason, unified: unifiedFinishReason },
               usage: convertGroqUsage(usage),
               ...(providerMetadata != null ? { providerMetadata } : {}),
             });
@@ -568,6 +686,14 @@ export class GroqChatLanguageModel implements LanguageModelV4 {
       response: { headers: responseHeaders },
     };
   }
+}
+
+function getGroqModelCapabilities(_modelId: string): {
+  supportsStructuredOutputWithTools: boolean;
+} {
+  // No Groq model is currently known to accept response_format schema + tools in the same request.
+  // When documented, set to true for those model ids.
+  return { supportsStructuredOutputWithTools: false };
 }
 
 // limited version of the schema, focussed on what is needed for the implementation

--- a/packages/groq/src/groq-chat-options.ts
+++ b/packages/groq/src/groq-chat-options.ts
@@ -56,6 +56,14 @@ export const groqLanguageModelOptions = z.object({
   structuredOutputs: z.boolean().optional(),
 
   /**
+   * When using both response schema and tools, how to get structured output.
+   * - `outputFormat`: Use native response_format (may fail if model rejects schema+tools).
+   * - `jsonTool`: Use a synthetic 'json' tool as fallback.
+   * - `auto`: Use native when the model supports schema+tools, otherwise jsonTool (default).
+   */
+  structuredOutputMode: z.enum(['outputFormat', 'jsonTool', 'auto']).optional(),
+
+  /**
    * Whether to use strict JSON schema validation.
    * When true, the model uses constrained decoding to guarantee schema compliance.
    * Only used when structured outputs are enabled and a schema is provided.
@@ -67,13 +75,12 @@ export const groqLanguageModelOptions = z.object({
   /**
    * Service tier for the request.
    * - 'on_demand': Default tier with consistent performance and fairness
-   * - 'performance': Prioritized tier for latency-sensitive workloads
    * - 'flex': Higher throughput tier optimized for workloads that can handle occasional request failures
    * - 'auto': Uses on_demand rate limits, then falls back to flex tier if exceeded
    *
    * @default 'on_demand'
    */
-  serviceTier: z.enum(['on_demand', 'performance', 'flex', 'auto']).optional(),
+  serviceTier: z.enum(['on_demand', 'flex', 'auto']).optional(),
 });
 
 export type GroqLanguageModelOptions = z.infer<typeof groqLanguageModelOptions>;

--- a/packages/groq/src/map-groq-finish-reason.test.ts
+++ b/packages/groq/src/map-groq-finish-reason.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { mapGroqFinishReason } from './map-groq-finish-reason';
+
+describe('mapGroqFinishReason', () => {
+  it('maps tool_calls to tool-calls by default', () => {
+    expect(mapGroqFinishReason('tool_calls')).toBe('tool-calls');
+    expect(mapGroqFinishReason('function_call')).toBe('tool-calls');
+  });
+
+  it('maps tool_calls to stop when structured output came from synthetic json tool only', () => {
+    expect(
+      mapGroqFinishReason('tool_calls', { isJsonResponseFromTool: true }),
+    ).toBe('stop');
+    expect(
+      mapGroqFinishReason('function_call', { isJsonResponseFromTool: true }),
+    ).toBe('stop');
+  });
+});

--- a/packages/groq/src/map-groq-finish-reason.ts
+++ b/packages/groq/src/map-groq-finish-reason.ts
@@ -2,6 +2,7 @@ import { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 export function mapGroqFinishReason(
   finishReason: string | null | undefined,
+  options?: { isJsonResponseFromTool?: boolean },
 ): LanguageModelV4FinishReason['unified'] {
   switch (finishReason) {
     case 'stop':
@@ -12,7 +13,7 @@ export function mapGroqFinishReason(
       return 'content-filter';
     case 'function_call':
     case 'tool_calls':
-      return 'tool-calls';
+      return options?.isJsonResponseFromTool ? 'stop' : 'tool-calls';
     default:
       return 'other';
   }


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- What did you change? -->
- add an Anthropic-style JSON-tool fallback so Groq/Google/OpenRouter stop rejecting `generateText` + tools + schema
- make the gateway/agent paths consume the JSON tool output so structured responses succeed instead of looping
- extend tests to cover the reproduction scenarios from https://github.com/gabimoncha/ai-sdk-generate-text-with-schema-issue

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->
- Finalize the provider-level design : keep core mode-less, rely on an anthropic-style synthetic JSON tool whenever a schema and tools are requested together, ensure this covers `generateText`, agents and gateway routing
- Groq/Google fallback scaffolding is done and committed on my branch, next I'll audit them alongside new implementations for OpenRouter and the AI gateway so tool calls actually execute and structured output is returned (matching the repro’s failing cases).
- Add/extend tests mirroring gabimoncha’s scenarios (schema+tools for `generateText/agent` in v5 & v6 paths), then run pnpm test to verify.
- Finish with patch changesets and summary update referencing the repo and confirmed test results.

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
Partially Fixes issue #10023