### PR TITLE
fix(amazon-bedrock): move anthropic_beta to request body

### DIFF
--- a/.changeset/unlucky-birds-hug.md
+++ b/.changeset/unlucky-birds-hug.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): move anthropic_beta to request body

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -442,6 +442,27 @@ console.log(text); // text response
 See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details
 on how to integrate reasoning into your chatbot.
 
+## Extended Context Window
+
+Claude Sonnet 4 models on Amazon Bedrock support an extended context window of up to 1 million tokens when using the `context-1m-2025-08-07` beta feature.
+
+```ts
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: bedrock('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+  prompt: 'analyze this large document...',
+  providerOptions: {
+    bedrock: {
+      additionalModelRequestFields: {
+        anthropic_beta: ['context-1m-2025-08-07'],
+      },
+    },
+  },
+});
+```
+
 ## Computer Use
 
 Via Anthropic, Amazon Bedrock provides three provider-defined tools that can be used to interact with external systems:

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -455,9 +455,7 @@ const result = await generateText({
   prompt: 'analyze this large document...',
   providerOptions: {
     bedrock: {
-      additionalModelRequestFields: {
-        anthropic_beta: ['context-1m-2025-08-07'],
-      },
+      anthropicBeta: ['context-1m-2025-08-07'],
     },
   },
 });

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2014,9 +2014,7 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
       providerOptions: {
         bedrock: {
-          additionalModelRequestFields: {
-            anthropic_beta: ['context-1m-2025-08-07'],
-          },
+          anthropicBeta: ['context-1m-2025-08-07'],
         },
       },
     });
@@ -2106,9 +2104,7 @@ describe('doGenerate', () => {
       ],
       providerOptions: {
         bedrock: {
-          additionalModelRequestFields: {
-            anthropic_beta: ['context-1m-2025-08-07'],
-          },
+          anthropicBeta: ['context-1m-2025-08-07'],
         },
       },
     });

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -156,6 +156,13 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       };
     }
 
+    if (betas.size > 0) {
+      bedrockOptions.additionalModelRequestFields = {
+        ...bedrockOptions.additionalModelRequestFields,
+        anthropic_beta: Array.from(betas),
+      };
+    }
+
     const isThinking = bedrockOptions.reasoningConfig?.type === 'enabled';
     const thinkingBudget = bedrockOptions.reasoningConfig?.budgetTokens;
 
@@ -289,17 +296,11 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
   };
 
   private async getHeaders({
-    betas,
     headers,
   }: {
-    betas: Set<string>;
     headers: Record<string, string | undefined> | undefined;
   }) {
-    return combineHeaders(
-      await resolve(this.config.headers),
-      betas.size > 0 ? { 'anthropic-beta': Array.from(betas).join(',') } : {},
-      headers,
-    );
+    return combineHeaders(await resolve(this.config.headers), headers);
   }
 
   async doGenerate(
@@ -309,13 +310,12 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       command: args,
       warnings,
       usesJsonResponseTool,
-      betas,
     } = await this.getArgs(options);
 
     const url = `${this.getUrl(this.modelId)}/converse`;
     const { value: response, responseHeaders } = await postJsonToApi({
       url,
-      headers: await this.getHeaders({ betas, headers: options.headers }),
+      headers: await this.getHeaders({ headers: options.headers }),
       body: args,
       failedResponseHandler: createJsonErrorResponseHandler({
         errorSchema: BedrockErrorSchema,
@@ -437,13 +437,12 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       command: args,
       warnings,
       usesJsonResponseTool,
-      betas,
     } = await this.getArgs(options);
     const url = `${this.getUrl(this.modelId)}/converse-stream`;
 
     const { value: response, responseHeaders } = await postJsonToApi({
       url,
-      headers: await this.getHeaders({ betas, headers: options.headers }),
+      headers: await this.getHeaders({ headers: options.headers }),
       body: args,
       failedResponseHandler: createJsonErrorResponseHandler({
         errorSchema: BedrockErrorSchema,

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -157,9 +157,15 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
     }
 
     if (betas.size > 0) {
+      const existingBetas =
+        bedrockOptions.additionalModelRequestFields?.anthropic_beta ?? [];
+      const mergedBetas = Array.isArray(existingBetas)
+        ? [...existingBetas, ...Array.from(betas)]
+        : Array.from(betas);
+
       bedrockOptions.additionalModelRequestFields = {
         ...bedrockOptions.additionalModelRequestFields,
-        anthropic_beta: Array.from(betas),
+        anthropic_beta: mergedBetas,
       };
     }
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -156,12 +156,12 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       };
     }
 
-    if (betas.size > 0) {
-      const existingBetas =
-        bedrockOptions.additionalModelRequestFields?.anthropic_beta ?? [];
-      const mergedBetas = Array.isArray(existingBetas)
-        ? [...existingBetas, ...Array.from(betas)]
-        : Array.from(betas);
+    if (betas.size > 0 || bedrockOptions.anthropicBeta) {
+      const existingBetas = bedrockOptions.anthropicBeta ?? [];
+      const mergedBetas =
+        betas.size > 0
+          ? [...existingBetas, ...Array.from(betas)]
+          : existingBetas;
 
       bedrockOptions.additionalModelRequestFields = {
         ...bedrockOptions.additionalModelRequestFields,

--- a/packages/amazon-bedrock/src/bedrock-chat-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.ts
@@ -104,6 +104,10 @@ export const bedrockProviderOptions = z.object({
       budgetTokens: z.number().optional(),
     })
     .optional(),
+  /**
+   * Anthropic beta features to enable
+   */
+  anthropicBeta: z.array(z.string()).optional(),
 });
 
 export type BedrockProviderOptions = z.infer<typeof bedrockProviderOptions>;


### PR DESCRIPTION
## Background

aws bedrock requires `anthropic_beta` parameters in the request body under `additionalModelRequestFields`, not in http headers. this was preventing the 1m token context window feature from working

## Summary

- moved `anthropic_beta` from HTTP headers to request body `additionalModelRequestFields`
- updated `getHeaders` method to no longer include beta parameters
- updated tests to verify beta parameters in request body instead of headers
- added test for 1M context window functionality
- added documentation for extended context window feature

## Manual Verification

tested with mock bedrock api calls verifying:
- beta parameters appear in request body `additionalModelRequestFields`
- computer-use tools still work with their beta headers
- 1M context window can be enabled via `providerOptions.bedrock.additionalModelRequestFields`
- all tests pass

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes 1M context window support for AWS Bedrock Anthropic models

## Reference
https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html
