### PR TITLE
fix(amazon-bedrock): clamp temperature to valid 0-1 range with warnings

### DIFF
--- a/.changeset/hip-berries-nail.md
+++ b/.changeset/hip-berries-nail.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): clamp temperature to valid 0-1 range with warnings

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2611,11 +2611,14 @@ describe('doGenerate', () => {
     const requestBody = await server.calls[0].requestBodyJson;
 
     expect(requestBody.inferenceConfig.temperature).toBe(1);
-    expect(result.warnings).toContainEqual({
-      type: 'other',
-      message:
-        'temperature value 1.5 exceeds bedrock maximum of 1.0. clamped to 1.0',
-    });
+    expect(result.warnings).toMatchInlineSnapshot(`
+      [
+        {
+          "message": "temperature value 1.5 exceeds bedrock maximum of 1.0. clamped to 1.0",
+          "type": "other",
+        },
+      ]
+    `);
   });
 
   it('should clamp temperature below 0 to 0 and add warning', async () => {
@@ -2629,11 +2632,14 @@ describe('doGenerate', () => {
     const requestBody = await server.calls[0].requestBodyJson;
 
     expect(requestBody.inferenceConfig.temperature).toBe(0);
-    expect(result.warnings).toContainEqual({
-      type: 'other',
-      message:
-        'temperature value -0.5 is below bedrock minimum of 0. clamped to 0',
-    });
+    expect(result.warnings).toMatchInlineSnapshot(`
+      [
+        {
+          "message": "temperature value -0.5 is below bedrock minimum of 0. clamped to 0",
+          "type": "other",
+        },
+      ]
+    `);
   });
 
   it('should not clamp valid temperature between 0 and 1', async () => {
@@ -2647,6 +2653,6 @@ describe('doGenerate', () => {
     const requestBody = await server.calls[0].requestBodyJson;
 
     expect(requestBody.inferenceConfig.temperature).toBe(0.7);
-    expect(result.warnings).toEqual([]);
+    expect(result.warnings).toMatchInlineSnapshot(`[]`);
   });
 });

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2614,7 +2614,7 @@ describe('doGenerate', () => {
     expect(result.warnings).toMatchInlineSnapshot(`
       [
         {
-          "details": "temperature value 1.5 exceeds bedrock maximum of 1.0. clamped to 1.0",
+          "details": "1.5 exceeds bedrock maximum of 1.0. clamped to 1.0",
           "setting": "temperature",
           "type": "unsupported-setting",
         },
@@ -2636,7 +2636,7 @@ describe('doGenerate', () => {
     expect(result.warnings).toMatchInlineSnapshot(`
       [
         {
-          "details": "temperature value -0.5 is below bedrock minimum of 0. clamped to 0",
+          "details": "-0.5 is below bedrock minimum of 0. clamped to 0",
           "setting": "temperature",
           "type": "unsupported-setting",
         },

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2614,8 +2614,9 @@ describe('doGenerate', () => {
     expect(result.warnings).toMatchInlineSnapshot(`
       [
         {
-          "message": "temperature value 1.5 exceeds bedrock maximum of 1.0. clamped to 1.0",
-          "type": "other",
+          "details": "temperature value 1.5 exceeds bedrock maximum of 1.0. clamped to 1.0",
+          "setting": "temperature",
+          "type": "unsupported-setting",
         },
       ]
     `);
@@ -2635,8 +2636,9 @@ describe('doGenerate', () => {
     expect(result.warnings).toMatchInlineSnapshot(`
       [
         {
-          "message": "temperature value -0.5 is below bedrock minimum of 0. clamped to 0",
-          "type": "other",
+          "details": "temperature value -0.5 is below bedrock minimum of 0. clamped to 0",
+          "setting": "temperature",
+          "type": "unsupported-setting",
         },
       ]
     `);

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -104,6 +104,20 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       });
     }
 
+    if (temperature != null && temperature > 1) {
+      warnings.push({
+        type: 'other',
+        message: `temperature value ${temperature} exceeds bedrock maximum of 1.0. clamped to 1.0`,
+      });
+      temperature = 1;
+    } else if (temperature != null && temperature < 0) {
+      warnings.push({
+        type: 'other',
+        message: `temperature value ${temperature} is below bedrock minimum of 0. clamped to 0`,
+      });
+      temperature = 0;
+    }
+
     if (
       responseFormat != null &&
       responseFormat.type !== 'text' &&

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -108,14 +108,14 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'temperature',
-        details: `temperature value ${temperature} exceeds bedrock maximum of 1.0. clamped to 1.0`,
+        details: `${temperature} exceeds bedrock maximum of 1.0. clamped to 1.0`,
       });
       temperature = 1;
     } else if (temperature != null && temperature < 0) {
       warnings.push({
         type: 'unsupported-setting',
         setting: 'temperature',
-        details: `temperature value ${temperature} is below bedrock minimum of 0. clamped to 0`,
+        details: `${temperature} is below bedrock minimum of 0. clamped to 0`,
       });
       temperature = 0;
     }

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -106,14 +106,16 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
 
     if (temperature != null && temperature > 1) {
       warnings.push({
-        type: 'other',
-        message: `temperature value ${temperature} exceeds bedrock maximum of 1.0. clamped to 1.0`,
+        type: 'unsupported-setting',
+        setting: 'temperature',
+        details: `temperature value ${temperature} exceeds bedrock maximum of 1.0. clamped to 1.0`,
       });
       temperature = 1;
     } else if (temperature != null && temperature < 0) {
       warnings.push({
-        type: 'other',
-        message: `temperature value ${temperature} is below bedrock minimum of 0. clamped to 0`,
+        type: 'unsupported-setting',
+        setting: 'temperature',
+        details: `temperature value ${temperature} is below bedrock minimum of 0. clamped to 0`,
       });
       temperature = 0;
     }


### PR DESCRIPTION
## Background

aws bedrock requires temperature values between 0 and 1. users passing values outside this range receive 400 errors from the bedrock api

## Summary

- clamp temperature values to bedrock's valid range (0-1)
- add warnings when temperature is clamped
- add tests for clamping behavior

## Manual Verification

tested with temperature values above 1, below 0, and within valid range. confirmed:
- values > 1 are clamped to 1 with warning
- values < 0 are clamped to 0 with warning
- valid values pass through unchanged
- all tests pass

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
