### PR TITLE
fix(provider/anthropic): clamp temperature to valid 0-1 range with warnings

### DIFF
--- a/.changeset/tricky-grapes-rush.md
+++ b/.changeset/tricky-grapes-rush.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(provider/anthropic): clamp temperature to valid 0-1 range with warnings

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -2636,6 +2636,64 @@ describe('AnthropicMessagesLanguageModel', () => {
         }),
       ).rejects.toThrow('Overloaded');
     });
+
+    describe('temperature clamping', () => {
+      it('should clamp temperature above 1 to 1 and add warning', async () => {
+        prepareJsonResponse({});
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: 1.5,
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+
+        expect(requestBody.temperature).toBe(1);
+        expect(result.warnings).toMatchInlineSnapshot(`
+          [
+            {
+              "message": "temperature value 1.5 exceeds anthropic maximum of 1.0. clamped to 1.0",
+              "type": "other",
+            },
+          ]
+        `);
+      });
+
+      it('should clamp temperature below 0 to 0 and add warning', async () => {
+        prepareJsonResponse({});
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: -0.5,
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+
+        expect(requestBody.temperature).toBe(0);
+        expect(result.warnings).toMatchInlineSnapshot(`
+          [
+            {
+              "message": "temperature value -0.5 is below anthropic minimum of 0. clamped to 0",
+              "type": "other",
+            },
+          ]
+        `);
+      });
+
+      it('should not clamp valid temperature between 0 and 1', async () => {
+        prepareJsonResponse({});
+
+        const result = await model.doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: 0.7,
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+
+        expect(requestBody.temperature).toBe(0.7);
+        expect(result.warnings).toMatchInlineSnapshot(`[]`);
+      });
+    });
   });
 
   describe('doStream', () => {

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -2652,8 +2652,9 @@ describe('AnthropicMessagesLanguageModel', () => {
         expect(result.warnings).toMatchInlineSnapshot(`
           [
             {
-              "message": "temperature value 1.5 exceeds anthropic maximum of 1.0. clamped to 1.0",
-              "type": "other",
+              "details": "1.5 exceeds anthropic maximum of 1.0. clamped to 1.0",
+              "setting": "temperature",
+              "type": "unsupported-setting",
             },
           ]
         `);
@@ -2673,8 +2674,9 @@ describe('AnthropicMessagesLanguageModel', () => {
         expect(result.warnings).toMatchInlineSnapshot(`
           [
             {
-              "message": "temperature value -0.5 is below anthropic minimum of 0. clamped to 0",
-              "type": "other",
+              "details": "-0.5 is below anthropic minimum of 0. clamped to 0",
+              "setting": "temperature",
+              "type": "unsupported-setting",
             },
           ]
         `);

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -166,6 +166,20 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       });
     }
 
+    if (temperature != null && temperature > 1) {
+      warnings.push({
+        type: 'other',
+        message: `temperature value ${temperature} exceeds anthropic maximum of 1.0. clamped to 1.0`,
+      });
+      temperature = 1;
+    } else if (temperature != null && temperature < 0) {
+      warnings.push({
+        type: 'other',
+        message: `temperature value ${temperature} is below anthropic minimum of 0. clamped to 0`,
+      });
+      temperature = 0;
+    }
+
     if (responseFormat?.type === 'json') {
       if (responseFormat.schema == null) {
         warnings.push({

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -168,14 +168,16 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
     if (temperature != null && temperature > 1) {
       warnings.push({
-        type: 'other',
-        message: `temperature value ${temperature} exceeds anthropic maximum of 1.0. clamped to 1.0`,
+        type: 'unsupported-setting',
+        setting: 'temperature',
+        details: `${temperature} exceeds anthropic maximum of 1.0. clamped to 1.0`,
       });
       temperature = 1;
     } else if (temperature != null && temperature < 0) {
       warnings.push({
-        type: 'other',
-        message: `temperature value ${temperature} is below anthropic minimum of 0. clamped to 0`,
+        type: 'unsupported-setting',
+        setting: 'temperature',
+        details: `${temperature} is below anthropic minimum of 0. clamped to 0`,
       });
       temperature = 0;
     }


### PR DESCRIPTION
## Background

anthropic api requires temperature values between 0 and 1. users passing values outside this range receive 400 errors from the anthropic api

## Summary

- clamp temperature values to valid range (0-1) for anthropic provider
- add warnings when temperature is clamped
- add tests for clamping behavior with inline snapshots

## Manual Verification

tested with temperature values above 1, below 0, and within valid range. confirmed:
- values > 1 are clamped to 1 with warning
- values < 0 are clamped to 0 with warning
- valid values pass through unchanged
- all tests pass (3 new tests added)

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
