### PR TITLE
fix(google): add support for gemini-3-pro-preview model tools

### DIFF
--- a/.changeset/shiny-dingos-refuse.md
+++ b/.changeset/shiny-dingos-refuse.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Prepare search tool for gemini-3-pro-preview

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -1,6 +1,6 @@
+import { LanguageModelV3ProviderDefinedTool } from '@ai-sdk/provider';
 import { expect, it } from 'vitest';
 import { prepareTools } from './google-prepare-tools';
-import { LanguageModelV3ProviderDefinedTool } from '@ai-sdk/provider';
 
 it('should return undefined tools and tool_choice when tools are null', () => {
   const result = prepareTools({
@@ -371,6 +371,23 @@ it('should handle latest modelId for provider-defined tools correctly', () => {
       },
     ],
     modelId: 'gemini-flash-latest',
+  });
+  expect(result.tools).toEqual([{ googleSearch: {} }]);
+  expect(result.toolConfig).toBeUndefined();
+  expect(result.toolWarnings).toEqual([]);
+});
+
+it('should handle gemini-3 modelId for provider-defined tools correctly', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'google.google_search',
+        name: 'google_search',
+        args: {},
+      },
+    ],
+    modelId: 'gemini-3-pro-preview',
   });
   expect(result.tools).toEqual([{ googleSearch: {} }]);
   expect(result.toolConfig).toBeUndefined();

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -47,7 +47,7 @@ export function prepareTools({
       'gemini-pro-latest',
     ] as const satisfies GoogleGenerativeAIModelId[]
   ).some(id => id === modelId);
-  const isAfterGemini2 =
+  const isGemini2orNewer =
     modelId.includes('gemini-2') || modelId.includes('gemini-3') || isLatest;
   const supportsDynamicRetrieval =
     modelId.includes('gemini-1.5-flash') && !modelId.includes('-8b');
@@ -81,7 +81,7 @@ export function prepareTools({
     providerDefinedTools.forEach(tool => {
       switch (tool.id) {
         case 'google.google_search':
-          if (isAfterGemini2) {
+          if (isGemini2orNewer) {
             googleTools.push({ googleSearch: {} });
           } else if (supportsDynamicRetrieval) {
             // For non-Gemini-2 models that don't support dynamic retrieval, use basic googleSearchRetrieval
@@ -103,7 +103,7 @@ export function prepareTools({
           }
           break;
         case 'google.url_context':
-          if (isAfterGemini2) {
+          if (isGemini2orNewer) {
             googleTools.push({ urlContext: {} });
           } else {
             toolWarnings.push({
@@ -115,7 +115,7 @@ export function prepareTools({
           }
           break;
         case 'google.code_execution':
-          if (isAfterGemini2) {
+          if (isGemini2orNewer) {
             googleTools.push({ codeExecution: {} });
           } else {
             toolWarnings.push({
@@ -139,7 +139,7 @@ export function prepareTools({
           }
           break;
         case 'google.vertex_rag_store':
-          if (isAfterGemini2) {
+          if (isGemini2orNewer) {
             googleTools.push({
               retrieval: {
                 vertex_rag_store: {

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -47,7 +47,8 @@ export function prepareTools({
       'gemini-pro-latest',
     ] as const satisfies GoogleGenerativeAIModelId[]
   ).some(id => id === modelId);
-  const isGemini2 = modelId.includes('gemini-2') || isLatest;
+  const isAfterGemini2 =
+    modelId.includes('gemini-2') || modelId.includes('gemini-3') || isLatest;
   const supportsDynamicRetrieval =
     modelId.includes('gemini-1.5-flash') && !modelId.includes('-8b');
   const supportsFileSearch = modelId.includes('gemini-2.5');
@@ -80,7 +81,7 @@ export function prepareTools({
     providerDefinedTools.forEach(tool => {
       switch (tool.id) {
         case 'google.google_search':
-          if (isGemini2) {
+          if (isAfterGemini2) {
             googleTools.push({ googleSearch: {} });
           } else if (supportsDynamicRetrieval) {
             // For non-Gemini-2 models that don't support dynamic retrieval, use basic googleSearchRetrieval
@@ -102,7 +103,7 @@ export function prepareTools({
           }
           break;
         case 'google.url_context':
-          if (isGemini2) {
+          if (isAfterGemini2) {
             googleTools.push({ urlContext: {} });
           } else {
             toolWarnings.push({
@@ -114,7 +115,7 @@ export function prepareTools({
           }
           break;
         case 'google.code_execution':
-          if (isGemini2) {
+          if (isAfterGemini2) {
             googleTools.push({ codeExecution: {} });
           } else {
             toolWarnings.push({
@@ -138,7 +139,7 @@ export function prepareTools({
           }
           break;
         case 'google.vertex_rag_store':
-          if (isGemini2) {
+          if (isAfterGemini2) {
             googleTools.push({
               retrieval: {
                 vertex_rag_store: {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->



https://github.com/CherryHQ/cherry-studio/issues/11354

## Summary

Update tool preparation logic to handle gemini-3 modelId and rename isGemini2 flag to isAfterGemini2 to better reflect its purpose

## Manual Verification

```ts
import { google } from '@ai-sdk/google';
import { generateText } from 'ai';
import 'dotenv/config';

async function main() {
  const result = await generateText({
    model: google('gemini-3-pro-preview'),
    maxOutputTokens: 512,
    tools: {
      google_search: google.tools.googleSearch({}),
    },
    prompt: 'What is the weather in San Francisco today?',
  });

  console.log(JSON.stringify(result, null, 2));
}

main().catch(console.error);
```

~~I have already tried using the script above to test the functionality, but for some reason, I keep getting the error "Cannot connect to API: Connect Timeout Error." It might be due to Cloudflare's service not yet being fully restored.~~

~~If possible, please help me with the testing.~~

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The current implementation is patch. Instead of manually checking for gemini versions 2 or 3, we should default behavior to support native google search

## Related Issues

Fixes #10348 
