### PR TITLE
feat(google): `thinking_level` option for Gemini 3

### DIFF
--- a/.changeset/clever-glasses-learn.md
+++ b/.changeset/clever-glasses-learn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(google): `thinking_level` option for Gemini 3

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1847,6 +1847,29 @@ describe('doGenerate', () => {
       }
     `);
   });
+
+  it('should pass thinkingLevel in provider options', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          thinkingConfig: {
+            thinkingLevel: 'high',
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      generationConfig: {
+        thinkingConfig: {
+          thinkingLevel: 'high',
+        },
+      },
+    });
+  });
 });
 
 describe('doStream', () => {

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -52,6 +52,8 @@ export const googleGenerativeAIProviderOptions = lazySchema(() =>
         .object({
           thinkingBudget: z.number().optional(),
           includeThoughts: z.boolean().optional(),
+          // https://ai.google.dev/gemini-api/docs/gemini-3?thinking=high#thinking_level
+          thinkingLevel: z.enum(['low', 'medium', 'high']).optional(),
         })
         .optional(),
 


### PR DESCRIPTION
## Background

https://ai.google.dev/gemini-api/docs/gemini-3?thinking=high#thinking_level

## Summary

Added `providerOptions.google.thinkingConfig.thinkingLevel`

## Manual Verification

```ts
await generateText({
  model: google('gemini-3-pro-preview'),
  prompt:
    "Describe the most unusual or striking architectural feature you've ever seen in a building or structure.",
  providerOptions: {
    google: {
      thinkingConfig: {
        // fails when uncommented, only one of thinking budget or thinking level allowed to be set
        // thinkingBudget: 2048,
        includeThoughts: true,
        thinkingLevel: 'high',
      },
    },
  },
});
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Document the new parameter, I wasn't quite sure where but didn't want the PR to be blocked longer than necessary.

## Related Issues

closes #10352