### PR TITLE
Add 'effect' dependency to package.json

### DIFF
--- a/examples/next-openai/package.json
+++ b/examples/next-openai/package.json
@@ -35,6 +35,7 @@
     "ai": "6.0.0-beta.99",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "effect": "^3.19.4",
     "lucide-react": "^0.545.0",
     "next": "^15.5.4",
     "react": "^18",


### PR DESCRIPTION
## Background
`@ai-sdk/provider-utils` (used transitively by `@ai-sdk/react`) imports the `effect` runtime but doesn’t list it as a dependency. Because `effect` wasn’t in our `package.json`, the Next.js build failed with `Module not found: Can't resolve 'effect'`.

## Summary
Added `effect` (`^3.19.4`) to the app’s dependencies so `@ai-sdk/provider-utils` can resolve its runtime at build time.

## Manual Verification
- `npm install`
- `npm run dev` (verified the app now compiles without the missing-module error)

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work
n/a

## Related Issues
n/a