### PR TITLE
feat (provider/gateway): add support for zero data retention filtering in the AI Gateway provider

### DIFF
--- a/.changeset/lovely-pans-wash.md
+++ b/.changeset/lovely-pans-wash.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add zdr provider option for zero data retention

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -382,11 +382,11 @@ The following gateway provider options are available:
 
   Example: `only: ['anthropic', 'vertex']` will only allow routing to Anthropic or Vertex AI.
 
-- **zdr** _boolean_
+- **zeroDataRetention** _boolean_
 
   Restricts routing to providers with zero data retention guarantees.
 
-  Example: `zdr: true`
+  Example: `zeroDataRetention: true`
 
 - **models** _string[]_
 
@@ -451,7 +451,7 @@ const { text } = await generateText({
 
 #### Zero Data Retention Example
 
-Use the `zdr` option for sensitive data that requires privacy guarantees:
+Use the `zeroDataRetention` option for sensitive data that requires privacy guarantees:
 
 ```ts
 import type { GatewayProviderOptions } from '@ai-sdk/gateway';
@@ -462,7 +462,7 @@ const { text } = await generateText({
   prompt: 'Analyze this sensitive document...',
   providerOptions: {
     gateway: {
-      zdr: true,
+      zeroDataRetention: true,
     } satisfies GatewayProviderOptions,
   },
 });

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -384,9 +384,9 @@ The following gateway provider options are available:
 
 - **zdr** _boolean_
 
-  When enabled, filters routing to only providers that guarantee zero data retention. This ensures that your requests are only sent to providers that do not store or retain any of your data.
+  Restricts routing to providers with zero data retention guarantees.
 
-  Example: `zdr: true` will only allow routing to providers with zero data retention guarantees.
+  Example: `zdr: true`
 
 - **models** _string[]_
 
@@ -451,7 +451,7 @@ const { text } = await generateText({
 
 #### Zero Data Retention Example
 
-The `zdr` option ensures requests are only routed to providers with zero data retention guarantees:
+Use the `zdr` option for sensitive data that requires privacy guarantees:
 
 ```ts
 import type { GatewayProviderOptions } from '@ai-sdk/gateway';
@@ -462,13 +462,10 @@ const { text } = await generateText({
   prompt: 'Analyze this sensitive document...',
   providerOptions: {
     gateway: {
-      zdr: true, // Only use providers with zero data retention
+      zdr: true,
     } satisfies GatewayProviderOptions,
   },
 });
-
-// The gateway will only route to providers that guarantee
-// they do not store or retain any of your request data
 ```
 
 ### Provider-Specific Options

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -384,7 +384,7 @@ The following gateway provider options are available:
 
 - **zeroDataRetention** _boolean_
 
-  Restricts routing to providers with zero data retention guarantees.
+  Restricts routing to providers with zero data retention policies.
 
   Example: `zeroDataRetention: true`
 
@@ -451,7 +451,7 @@ const { text } = await generateText({
 
 #### Zero Data Retention Example
 
-Use the `zeroDataRetention` option for sensitive data that requires privacy guarantees:
+Use the `zeroDataRetention` option for sensitive data that requires privacy assurances:
 
 ```ts
 import type { GatewayProviderOptions } from '@ai-sdk/gateway';

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -382,6 +382,12 @@ The following gateway provider options are available:
 
   Example: `only: ['anthropic', 'vertex']` will only allow routing to Anthropic or Vertex AI.
 
+- **zdr** _boolean_
+
+  When enabled, filters routing to only providers that guarantee zero data retention. This ensures that your requests are only sent to providers that do not store or retain any of your data.
+
+  Example: `zdr: true` will only allow routing to providers with zero data retention guarantees.
+
 - **models** _string[]_
 
   Specifies fallback models to use when the primary model fails or is unavailable. The gateway will try the primary model first (specified in the `model` parameter), then try each model in this array in order until one succeeds.
@@ -441,6 +447,28 @@ const { text } = await generateText({
 // 2. If it fails, try openai/gpt-5-nano
 // 3. If that fails, try gemini-2.0-flash
 // 4. Return the result from the first model that succeeds
+```
+
+#### Zero Data Retention Example
+
+The `zdr` option ensures requests are only routed to providers with zero data retention guarantees:
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4',
+  prompt: 'Analyze this sensitive document...',
+  providerOptions: {
+    gateway: {
+      zdr: true, // Only use providers with zero data retention
+    } satisfies GatewayProviderOptions,
+  },
+});
+
+// The gateway will only route to providers that guarantee
+// they do not store or retain any of your request data
 ```
 
 ### Provider-Specific Options

--- a/examples/ai-core/src/stream-text/gateway-provider-options-zdr.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-zdr.ts
@@ -8,7 +8,7 @@ async function main() {
     prompt: 'Analyze this sensitive business data and provide insights.',
     providerOptions: {
       gateway: {
-        zdr: true, // Only use providers with zero data retention
+        zeroDataRetention: true, // Only use providers with zero data retention
       } satisfies GatewayProviderOptions,
     },
   });

--- a/examples/ai-core/src/stream-text/gateway-provider-options-zdr.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-zdr.ts
@@ -1,0 +1,29 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'anthropic/claude-sonnet-4',
+    prompt: 'Analyze this sensitive business data and provide insights.',
+    providerOptions: {
+      gateway: {
+        zdr: true, // Only use providers with zero data retention
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -42,7 +42,7 @@ const gatewayProviderOptions = lazySchema(() =>
        *
        * When enabled, only providers that guarantee zero data retention will be used.
        */
-      zdr: z.boolean().optional(),
+      zeroDataRetention: z.boolean().optional(),
     }),
   ),
 );

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -37,6 +37,12 @@ const gatewayProviderOptions = lazySchema(() =>
        * Example: `['openai/gpt-5-nano', 'zai/glm-4.6']` will try `openai/gpt-5-nano` first, then `zai/glm-4.6` as fallback.
        */
       models: z.array(z.string()).optional(),
+      /**
+       * Whether to filter by only providers with zero data retention.
+       *
+       * When enabled, only providers that guarantee zero data retention will be used.
+       */
+      zdr: z.boolean().optional(),
     }),
   ),
 );


### PR DESCRIPTION

## Background

  Added support for zero data retention filtering in the AI Gateway provider, allowing users to ensure
  their requests are only routed to providers that guarantee zero data retention.

## Summary

  This PR adds a new `zdr` (zero data retention) option to the Gateway provider options, which accepts a
   boolean value. When enabled, the gateway will filter and route requests only to providers that
  guarantee they do not store or retain any request data.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

It is possible that in the future ZDR could be an enum with different levels of retention. 

