### PR TITLE
docs(tools): add ToolSDK MCP Registry to tools list

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -162,6 +162,7 @@ These packages provide pre-built tools you can install and use immediately:
 
 These are pre-built tools available as MCP servers:
 
+- **[ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry)** - A privately deployable MCP Registry with one-line AI SDK integration via **toolsdk.ai**. (See: [AI SDK Integration](https://toolsdk.ai/docs/tutorials/getting-started#ai-sdk))
 - **[Smithery](https://smithery.ai/docs/integrations/vercel_ai_sdk)** - An open marketplace of 6,000+ MCPs, including [Browserbase](https://browserbase.com/) and [Exa](https://exa.ai/).
 - **[Pipedream](https://pipedream.com/docs/connect/mcp/ai-frameworks/vercel-ai-sdk)** - Developer toolkit that lets you easily add 3,000+ integrations to your app or AI agent.
 - **[Apify](https://docs.apify.com/platform/integrations/vercel-ai-sdk)** - Apify provides a [marketplace](https://apify.com/store) of thousands of tools for web scraping, data extraction, and browser automation.


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The *MCP Tools* section aims to provide developers with a clear overview of publicly available MCP servers.  
Before this change, the list did not include the ToolSDK MCP Registry, which is a privately deployable registry with seamless one-line integration via toolsdk.ai.  
Adding it improves discoverability for developers who want to manage their MCP tools in self-hosted or enterprise environments.

## Summary

Added the **ToolSDK MCP Registry** entry to the *MCP Tools* list in the documentation:

```markdown
- **[ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry)** - A privately deployable MCP Registry with one-line AI SDK integration via **toolsdk.ai**. (See: [AI SDK Integration](https://toolsdk.ai/docs/tutorials/getting-started#ai-sdk))
````

No functional changes; documentation update only.

## Manual Verification

Not applicable — documentation-only change.

## Checklist

* [ ] Tests have been added / updated (for bug fixes / features)
* [x] Documentation has been added / updated (for bug fixes / features)
* [ ] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
* [x] I have reviewed this pull request (self-review)

## Future Work

Potentially add more usage examples or guidance on integrating third-party MCP registries with the AI SDK.

## Related Issues

None.