### PR TITLE
feat(provider/gateway): Change default maxImagesPerCall per-provider

### DIFF
--- a/.changeset/little-tomatoes-attack.md
+++ b/.changeset/little-tomatoes-attack.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): Change default maxImagesPerCall per-provider

--- a/packages/gateway/src/gateway-image-model-settings.ts
+++ b/packages/gateway/src/gateway-image-model-settings.ts
@@ -6,3 +6,19 @@ export type GatewayImageModelId =
   | 'bfl/flux-pro-1.1'
   | 'bfl/flux-pro-1.1-ultra'
   | (string & {});
+
+/**
+  Default number of images a provider can return per single request.
+  Only include providers that deviate from the default of 4 (e.g. Vertex
+  Imagen is 4).
+*/
+export const DEFAULT_MAX_IMAGES_PER_CALL_BY_PROVIDER: Record<string, number> = {
+  bfl: 1,
+};
+
+export function getDefaultMaxImagesPerCallForModel(
+  modelId: GatewayImageModelId,
+): number | undefined {
+  const providerPrefix = typeof modelId === 'string' ? modelId.split('/')[0] : '';
+  return DEFAULT_MAX_IMAGES_PER_CALL_BY_PROVIDER[providerPrefix];
+}

--- a/packages/gateway/src/gateway-image-model-settings.ts
+++ b/packages/gateway/src/gateway-image-model-settings.ts
@@ -19,6 +19,7 @@ export const DEFAULT_MAX_IMAGES_PER_CALL_BY_PROVIDER: Record<string, number> = {
 export function getDefaultMaxImagesPerCallForModel(
   modelId: GatewayImageModelId,
 ): number | undefined {
-  const providerPrefix = typeof modelId === 'string' ? modelId.split('/')[0] : '';
+  const providerPrefix =
+    typeof modelId === 'string' ? modelId.split('/')[0] : '';
   return DEFAULT_MAX_IMAGES_PER_CALL_BY_PROVIDER[providerPrefix];
 }

--- a/packages/gateway/src/gateway-image-model.test.ts
+++ b/packages/gateway/src/gateway-image-model.test.ts
@@ -38,6 +38,18 @@ describe('GatewayImageModel', () => {
       expect(model.maxImagesPerCall).toBe(4);
     });
 
+    it('should use provider default maxImagesPerCall for BFL models (1)', () => {
+      const model = new GatewayImageModel('bfl/flux-pro-1.1', {
+        provider: 'gateway',
+        baseURL: 'https://api.test.com',
+        headers: async () => ({}),
+        fetch: globalThis.fetch,
+        o11yHeaders: {},
+      });
+
+      expect(model.maxImagesPerCall).toBe(1);
+    });
+
     it('should accept custom provider name', () => {
       const model = new GatewayImageModel(TEST_MODEL_ID, {
         provider: 'custom-gateway',

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -14,10 +14,13 @@ import { z } from 'zod/v4';
 import type { GatewayConfig } from './gateway-config';
 import { asGatewayError } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
+import { getDefaultMaxImagesPerCallForModel } from './gateway-image-model-settings';
 
 export class GatewayImageModel implements ImageModelV3 {
   readonly specificationVersion = 'v3' as const;
-  readonly maxImagesPerCall = 4;
+  get maxImagesPerCall() {
+    return getDefaultMaxImagesPerCallForModel(this.modelId) ?? 4;
+  }
 
   constructor(
     readonly modelId: string,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
I discovered that passing in `n` to set the number of images to `generateImage` doesn't work with Black Forest Labs unless `maxImagesPerCall` is explicitly set to 1, because that's the max number of images BFL returns per request. It would return 1 image every time regardless of `n`. Users could solve this by explicitly setting `maxImagesPerCall: 1` themselves but the behavior is confusing. We previously defaulted to 4 because that's the value for Vertex Imagen. We need a new default for other providers.

## Summary
Added a mapping of provider to default `maxImagesPerCall` and adjust the default based on the model slug

## Manual Verification
`n` now works

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)