### PR TITLE
feat(mcp): preserve MCP tool annotations including readOnlyHint

### DIFF
--- a/.changeset/strange-suits-lick.md
+++ b/.changeset/strange-suits-lick.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/mcp': patch
+---
+
+feat(mcp): preserve MCP tool annotations including readOnlyHint
+
+Preserve all MCP tool annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint) when converting MCP tools to AI SDK tools. These annotations are informational hints that enable clients to make informed decisions about tool behavior.

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -501,12 +501,14 @@ class DefaultMCPClient implements MCPClient {
                   additionalProperties: false,
                 } as JSONSchema7),
                 execute,
+                annotations,
               })
             : tool({
                 description,
                 title,
                 inputSchema: schemas[name].inputSchema,
                 execute,
+                annotations,
               });
 
         tools[name] = toolWithExecute;

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -116,6 +116,33 @@ Not used for provider-defined tools.
   title?: string;
 
   /**
+   * Optional annotations from MCP protocol that provide hints about tool behavior.
+   * These are informational only and should not be used for security decisions.
+   */
+  annotations?: {
+    /**
+     * Human-readable title for the tool.
+     */
+    title?: string;
+    /**
+     * If true, indicates the tool does not modify its environment.
+     */
+    readOnlyHint?: boolean;
+    /**
+     * If true, indicates the tool may perform destructive updates.
+     */
+    destructiveHint?: boolean;
+    /**
+     * If true, indicates repeated calls with same args have no additional effect.
+     */
+    idempotentHint?: boolean;
+    /**
+     * If true, indicates the tool interacts with external entities.
+     */
+    openWorldHint?: boolean;
+  };
+
+  /**
 Additional provider-specific metadata. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
@@ -240,6 +267,13 @@ export function tool(tool: any): any {
 export function dynamicTool(tool: {
   description?: string;
   title?: string;
+  annotations?: {
+    title?: string;
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
   providerOptions?: ProviderOptions;
   inputSchema: FlexibleSchema<unknown>;
   execute: ToolExecuteFunction<unknown, unknown>;


### PR DESCRIPTION
## Summary

Preserve all MCP tool annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint) when converting MCP tools to AI SDK tools.

## Changes

Previously, only the `title` annotation was extracted and preserved from MCP servers. This PR adds support for passing through all five annotation fields defined in the MCP specification (2025-03-26):

- **`title`** - Human-readable tool title
- **`readOnlyHint`** - Tool doesn't modify its environment  
- **`destructiveHint`** - Tool may perform destructive updates
- **`idempotentHint`** - Repeated calls with same args have no additional effect
- **`openWorldHint`** - Tool interacts with external entities

### Implementation

1. Added `annotations` field to `Tool` type definition in `@ai-sdk/provider-utils`
2. Updated `dynamicTool()` function signature to accept annotations parameter
3. Pass annotations from MCP `listTools` response to tool creation in MCP client

### Use Cases

These annotations enable clients to:
- Filter tools by behavior characteristics (e.g., only allow read-only tools in production)
- Show UI warnings before executing destructive operations
- Implement smart retry logic for idempotent tools
- Track/log external system interactions

### Security Note

Per the MCP specification, these annotations are **informational hints only** and should not be used for security-critical decisions. The documentation explicitly states this caveat.

## Testing

- ✅ Existing tests pass
- ✅ TypeScript types are properly defined
- ✅ Backward compatible (all fields are optional)

## Related

- MCP Specification: https://modelcontextprotocol.io/specification/2025-06-18
- Branch follows MCP spec version 2025-03-26 which introduced tool annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>