### PR TITLE
feat: export GatewayModelId and use to type LanguageModel

### DIFF
--- a/.changeset/pretty-beers-share.md
+++ b/.changeset/pretty-beers-share.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat: export GatewayModelId and use to type LanguageModel

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,5 +1,5 @@
 // re-exports:
-export { createGateway, gateway } from '@ai-sdk/gateway';
+export { createGateway, gateway, type GatewayModelId } from '@ai-sdk/gateway';
 export {
   asSchema,
   createIdGenerator,

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -10,13 +10,29 @@ import {
 declare global {
   /**
    * Global interface that can be augmented by third-party packages to register custom model IDs.
-   *
+   * 
+   * You can register model IDs in two ways:
+   * 
+   * 1. Register baesd on Model IDs from a provider package:
+   * @example
+   * ```typescript
+   * import { openai } from '@ai-sdk/openai';
+   * type OpenAIResponsesModelId = Parameters<typeof openai>[0];
+   * 
+   * declare global {
+   *   interface RegisteredProviderModels {
+   *     openai: OpenAIResponsesModelId;
+   *   }
+   * }
+   * ```
+   * 
+   * 2. Register individual model IDs directly as keys:
    * @example
    * ```typescript
    * declare global {
    *   interface RegisteredProviderModels {
-   *     'my-provider:my-model': true;
-   *     'my-provider:another-model': true;
+   *     'my-provider:my-model': any;
+   *     'my-provider:another-model': any;
    *   }
    * }
    * ```
@@ -32,7 +48,7 @@ export type GlobalProviderModelId = [keyof RegisteredProviderModels] extends [
   never,
 ]
   ? GatewayModelId
-  : keyof RegisteredProviderModels;
+  : keyof RegisteredProviderModels | RegisteredProviderModels[keyof RegisteredProviderModels];
 
 /**
 Language model that is used by the AI SDK Core functions.

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -7,10 +7,40 @@ import {
   LanguageModelV3Source,
 } from '@ai-sdk/provider';
 
+declare global {
+  /**
+   * Global interface that can be augmented by third-party packages to register custom model IDs.
+   *
+   * @example
+   * ```typescript
+   * declare global {
+   *   interface RegisteredProviderModels {
+   *     'my-provider:my-model': true;
+   *     'my-provider:another-model': true;
+   *   }
+   * }
+   * ```
+   */
+  interface RegisteredProviderModels {}
+}
+
+/**
+ * Global provider model ID type that defaults to GatewayModelId but can be augmented
+ * by third-party packages via declaration merging.
+ */
+export type GlobalProviderModelId = [keyof RegisteredProviderModels] extends [
+  never,
+]
+  ? GatewayModelId
+  : keyof RegisteredProviderModels;
+
 /**
 Language model that is used by the AI SDK Core functions.
 */
-export type LanguageModel = GatewayModelId | LanguageModelV3 | LanguageModelV2;
+export type LanguageModel =
+  | GlobalProviderModelId
+  | LanguageModelV3
+  | LanguageModelV2;
 
 /**
 Reason why a language model finished generating a response.

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -10,22 +10,22 @@ import {
 declare global {
   /**
    * Global interface that can be augmented by third-party packages to register custom model IDs.
-   * 
+   *
    * You can register model IDs in two ways:
-   * 
+   *
    * 1. Register baesd on Model IDs from a provider package:
    * @example
    * ```typescript
    * import { openai } from '@ai-sdk/openai';
    * type OpenAIResponsesModelId = Parameters<typeof openai>[0];
-   * 
+   *
    * declare global {
    *   interface RegisteredProviderModels {
    *     openai: OpenAIResponsesModelId;
    *   }
    * }
    * ```
-   * 
+   *
    * 2. Register individual model IDs directly as keys:
    * @example
    * ```typescript
@@ -48,7 +48,9 @@ export type GlobalProviderModelId = [keyof RegisteredProviderModels] extends [
   never,
 ]
   ? GatewayModelId
-  : keyof RegisteredProviderModels | RegisteredProviderModels[keyof RegisteredProviderModels];
+  :
+      | keyof RegisteredProviderModels
+      | RegisteredProviderModels[keyof RegisteredProviderModels];
 
 /**
 Language model that is used by the AI SDK Core functions.

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -1,3 +1,4 @@
+import { GatewayModelId } from '@ai-sdk/gateway';
 import {
   LanguageModelV2,
   LanguageModelV3,
@@ -9,7 +10,7 @@ import {
 /**
 Language model that is used by the AI SDK Core functions.
 */
-export type LanguageModel = string | LanguageModelV3 | LanguageModelV2;
+export type LanguageModel = GatewayModelId | LanguageModelV3 | LanguageModelV2;
 
 /**
 Reason why a language model finished generating a response.


### PR DESCRIPTION
## Background

GatewayModelId was not exported from AI packages. Additionally, LanguageModel was only typed as a string. 

## Summary

Export GatewayModelId. Use it to type LanguageModel (replaces plain string).

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
