### PR TITLE
fix(package/ai): fix Gateway image cost reporting bug

### DIFF
--- a/.changeset/rich-chicken-walk.md
+++ b/.changeset/rich-chicken-walk.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(package/ai): fix Gateway image cost reporting bug

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -204,24 +204,25 @@ Only applicable for HTTP-based providers.
               ...(currentEntry as object),
               ...metadata,
             } as Record<string, unknown>;
-
-            for (const key of ['cost', 'marketCost']) {
-              const previousValue = (currentEntry as Record<string, unknown>)[
-                key
-              ];
-              const newValue = (metadata as Record<string, unknown>)[key];
-              const sum = addDecimal(
-                typeof previousValue === 'string' ? previousValue : undefined,
-                typeof newValue === 'string' ? newValue : undefined,
-              );
-              if (sum) merged[key] = sum;
-            }
-
+                const existingCalls =
+                  (currentEntry as Record<string, unknown>)['calls'];
+                const callsArray = Array.isArray(existingCalls)
+                  ? (existingCalls as unknown[])
+                  : [];
+                (merged as Record<string, unknown>)['allCalls'] = [
+                  ...callsArray,
+                  metadata,
+                ];
             providerMetadata[providerName] =
               merged as ImageModelV3ProviderMetadata[string];
           } else {
-            providerMetadata[providerName] =
-              metadata as ImageModelV3ProviderMetadata[string];
+                const first = { ...(metadata as object) } as Record<
+                  string,
+                  unknown
+                >;
+                (first as Record<string, unknown>)['allCalls'] = [metadata];
+                providerMetadata[providerName] =
+                  first as ImageModelV3ProviderMetadata[string];
           }
           const imagesValue = (
             providerMetadata[providerName] as { images?: unknown }
@@ -293,22 +294,4 @@ async function invokeModelMaxImagesPerCall(model: ImageModelV3) {
   return model.maxImagesPerCall({
     modelId: model.modelId,
   });
-}
-
-/**
- * Adds two non-negative decimal numbers represented as strings.
- */
-function addDecimal(value1?: string, value2?: string): string | undefined {
-  if (!value1 || !value2) return value1 || value2;
-  const [integer1, fraction1 = ''] = value1.split('.');
-  const [integer2, fraction2 = ''] = value2.split('.');
-  const precision = Math.max(fraction1.length, fraction2.length);
-  const sum =
-    BigInt(integer1 + fraction1.padEnd(precision, '0')) +
-    BigInt(integer2 + fraction2.padEnd(precision, '0'));
-  const sumString = sum.toString().padStart(precision + 1, '0');
-  return `${sumString.slice(0, -precision)}.${sumString.slice(-precision)}`.replace(
-    /\.?0+$/,
-    '',
-  );
 }

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -205,7 +205,7 @@ Only applicable for HTTP-based providers.
               ...metadata,
             } as Record<string, unknown>;
                 const existingCalls =
-                  (currentEntry as Record<string, unknown>)['calls'];
+                  (currentEntry as Record<string, unknown>)['allCalls'];
                 const callsArray = Array.isArray(existingCalls)
                   ? (existingCalls as unknown[])
                   : [];


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
I discovered a bug in the cost reporting for images generated via Gateway. If n > 1, the cost in the provider metadata would be reported as if n = 1 (but the correct amount would be debited). This is because the cost fields in the provider metadata were being merged without being summed across requests (since maxImagesPerCall = 1)

## Summary
Merged with summation

## Manual Verification
Ran Gateway requests and cost is now reported accurately

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)