### PR TITLE
Emit OTel spans for non-executing tool calls

### DIFF
--- a/.changeset/cool-badgers-mate.md
+++ b/.changeset/cool-badgers-mate.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+emit OTel spans for tool calls that have no `execute`

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -32,10 +32,6 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   const { toolName, toolCallId, input } = toolCall;
   const tool = tools?.[toolName];
 
-  if (tool?.execute == null) {
-    return undefined;
-  }
-
   return recordSpan({
     name: 'ai.toolCall',
     attributes: selectTelemetryAttributes({
@@ -54,11 +50,15 @@ export async function executeToolCall<TOOLS extends ToolSet>({
     }),
     tracer,
     fn: async span => {
+      if (tool?.execute == null) {
+        return undefined;
+      }
+
       let output: unknown;
 
       try {
         const stream = executeTool({
-          execute: tool.execute!.bind(tool),
+          execute: tool.execute.bind(tool),
           input,
           options: {
             toolCallId,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

<!-- Why was this change necessary? -->

Right now, tool call spans are only created if they have a defined execute function. This means that tool calls that don't have an execute function aren't picked up in tracing. Thus, the only way to tell which tool calls were picked is to manually parse + look at the ai.response.toolCalls attribute of a doGenerate/doStream span.

See #10498 

## Summary

<!-- What did you change? -->

We now emit tool calls spans even if they don't have a defined `execute` function.

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

Ran AI SDK with these changes on a new app and defined a tool call without an `execute` function. Made sure the OTel spans were emitted. 

Example:
```
{
  _spanContext: {
    traceId: 'e58b6aa4a3529d7d66443c41c13f4e08',
    spanId: 'e1a3b36e0d2b6af9',
    traceFlags: 1,
    traceState: undefined
  },
  kind: 0,
  parentSpanContext: {
    traceId: 'e58b6aa4a3529d7d66443c41c13f4e08',
    spanId: '368d8f9a9c4e8748',
    traceFlags: 1,
    traceState: undefined
  },
  attributes: {
    'operation.name': 'ai.toolCall',
    'ai.operationId': 'ai.toolCall',
    'ai.toolCall.name': 'noop',
    'ai.toolCall.id': 'call_THXOT8HgcOkQpeJYZZj55Yy5',
    'ai.toolCall.args': '{"reason":"User requested to call the noop tool."}'
  },
  links: [],
  events: [],
  startTime: [ 1763855474, 148000000 ],
  resource: r {
    _rawAttributes: [ [Array], [Array], [Array] ],
    _asyncAttributesPending: false,
    _schemaUrl: undefined,
    _memoizedAttributes: undefined
  },
  instrumentationScope: { name: 'ai', version: undefined, schemaUrl: undefined },
  _droppedAttributesCount: 0,
  _droppedEventsCount: 0,
  _droppedLinksCount: 0,
  name: 'ai.toolCall',
  status: { code: 0 },
  endTime: [ 1763855474, 148702750 ],
  _ended: true,
  _duration: [ 0, 702750 ],
  _spanProcessor: Ga { _spanProcessors: [ [Ni] ] },
  _spanLimits: {
    attributeValueLengthLimit: Infinity,
    attributeCountLimit: 128,
    linkCountLimit: 128,
    eventCountLimit: 128,
    attributePerEventCountLimit: 128,
    attributePerLinkCountLimit: 128
  },
  _attributeValueLengthLimit: Infinity,
  _performanceStartTime: 9343.804209,
  _performanceOffset: -0.605224609375,
  _startTimeProvided: false
}
```

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
This is a draft of proposed changes for #10498.