### PR TITLE
chore(provider): add jsdoc

### DIFF
--- a/packages/provider/src/language-model/v3/language-model-v3-file.ts
+++ b/packages/provider/src/language-model/v3/language-model-v3-file.ts
@@ -25,5 +25,8 @@ be returned as binary data.
  */
   data: string | Uint8Array;
 
+  /**
+   * Optional provider-specific metadata for the file part.
+   */
   providerMetadata?: SharedV3ProviderMetadata;
 };


### PR DESCRIPTION
## Background

JsDoc was missing on `LanguageModelV3File.providerMetadata`

## Summary

Add JsDoc