### PR TITLE
chore(ai): remove UI message reference from model message validation

### DIFF
--- a/.changeset/three-eels-behave.md
+++ b/.changeset/three-eels-behave.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(ai): remove UI message reference from model message validation

--- a/content/docs/07-reference/05-ai-sdk-errors/ai-invalid-prompt-error.mdx
+++ b/content/docs/07-reference/05-ai-sdk-errors/ai-invalid-prompt-error.mdx
@@ -15,6 +15,19 @@ You are passing a `UIMessage[]` as messages into e.g. `streamText`.
 
 You need to first convert them to a `ModelMessage[]` using `convertToModelMessages()`.
 
+```typescript
+import { type UIMessage, generateText, convertToModelMessages } from 'ai';
+
+const messages: UIMessage[] = [
+  /* ... */
+];
+
+const result = await generateText({
+  // ...
+  messages: convertToModelMessages(messages),
+});
+```
+
 ## Properties
 
 - `prompt`: The invalid prompt value

--- a/content/docs/07-reference/05-ai-sdk-errors/ai-invalid-prompt-error.mdx
+++ b/content/docs/07-reference/05-ai-sdk-errors/ai-invalid-prompt-error.mdx
@@ -7,6 +7,14 @@ description: Learn how to fix AI_InvalidPromptError
 
 This error occurs when the prompt provided is invalid.
 
+## Potential Causes
+
+### UI Messages
+
+You are passing a `UIMessage[]` as messages into e.g. `streamText`.
+
+You need to first convert them to a `ModelMessage[]` using `convertToModelMessages()`.
+
 ## Properties
 
 - `prompt`: The invalid prompt value

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -71,9 +71,7 @@ export async function standardizePrompt(
   if (!validationResult.success) {
     throw new InvalidPromptError({
       prompt,
-      message:
-        'The messages must be a ModelMessage[]. ' +
-        'If you have passed a UIMessage[], you can use convertToModelMessages to convert them.',
+      message: 'The messages do not match the ModelMessage[] schema.',
       cause: validationResult.error,
     });
   }


### PR DESCRIPTION
## Background

Users found the message confusing and believed that `UIMessage` is required for persistence and agent use.

## Summary

Move `UIMessage` reference to error documentation page.