### PR TITLE
chore(mcp) - use aliases for all mcp examples and docs examples

### DIFF
--- a/content/cookbook/01-next/73-mcp-tools.mdx
+++ b/content/cookbook/01-next/73-mcp-tools.mdx
@@ -17,7 +17,10 @@ If you prefer to use the official transports (optional), install the official Ty
 <Snippet text="pnpm install @modelcontextprotocol/sdk" />
 
 ```ts filename="app/api/completion/route.ts"
-import { experimental_createMCPClient, streamText } from '@ai-sdk/mcp';
+import {
+  experimental_createMCPClient as createMCPClient,
+  streamText,
+} from '@ai-sdk/mcp';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { openai } from '@ai-sdk/openai';
 // Optional: Official transports if you prefer them
@@ -35,12 +38,12 @@ export async function POST(req: Request) {
       args: ['src/stdio/dist/server.js'],
     });
 
-    const stdioClient = await experimental_createMCPClient({
+    const stdioClient = await createMCPClient({
       transport,
     });
 
     // Connect to an HTTP MCP server directly via the client transport config
-    const httpClient = await experimental_createMCPClient({
+    const httpClient = await createMCPClient({
       transport: {
         type: 'http',
         url: 'http://localhost:3000/mcp',
@@ -54,7 +57,7 @@ export async function POST(req: Request) {
     });
 
     // Connect to a Server-Sent Events (SSE) MCP server directly via the client transport config
-    const sseClient = await experimental_createMCPClient({
+    const sseClient = await createMCPClient({
       transport: {
         type: 'sse',
         url: 'http://localhost:3000/sse',
@@ -69,9 +72,9 @@ export async function POST(req: Request) {
 
     // Alternatively, you can create transports with the official SDKs instead of direct config:
     // const httpTransport = new StreamableHTTPClientTransport(new URL('http://localhost:3000/mcp'));
-    // const httpClient = await experimental_createMCPClient({ transport: httpTransport });
+    // const httpClient = await createMCPClient({ transport: httpTransport });
     // const sseTransport = new SSEClientTransport(new URL('http://localhost:3000/sse'));
-    // const sseClient = await experimental_createMCPClient({ transport: sseTransport });
+    // const sseClient = await createMCPClient({ transport: sseTransport });
 
     const toolSetOne = await stdioClient.tools();
     const toolSetTwo = await httpClient.tools();

--- a/content/cookbook/05-node/54-mcp-tools.mdx
+++ b/content/cookbook/05-node/54-mcp-tools.mdx
@@ -14,7 +14,7 @@ If you prefer to use the official transports (optional), install the official Mo
 
 ```ts
 import {
-  experimental_createMCPClient,
+  experimental_createMCPClient as createMCPClient,
   generateText,
   stepCountIs,
 } from '@ai-sdk/mcp';
@@ -36,12 +36,12 @@ try {
     args: ['src/stdio/dist/server.js'],
   });
 
-  const clientOne = await experimental_createMCPClient({
+  const clientOne = await createMCPClient({
     transport,
   });
 
   // Connect to an HTTP MCP server directly via the client transport config
-  const clientTwo = await experimental_createMCPClient({
+  const clientTwo = await createMCPClient({
     transport: {
       type: 'http',
       url: 'http://localhost:3000/mcp',
@@ -55,7 +55,7 @@ try {
   });
 
   // Connect to a Server-Sent Events (SSE) MCP server directly via the client transport config
-  const clientThree = await experimental_createMCPClient({
+  const clientThree = await createMCPClient({
     transport: {
       type: 'sse',
       url: 'http://localhost:3000/sse',
@@ -70,9 +70,9 @@ try {
 
   // Alternatively, you can create transports with the official SDKs instead of direct config:
   // const httpTransport = new StreamableHTTPClientTransport(new URL('http://localhost:3000/mcp'));
-  // clientTwo = await experimental_createMCPClient({ transport: httpTransport });
+  // clientTwo = await createMCPClient({ transport: httpTransport });
   // const sseTransport = new SSEClientTransport(new URL('http://localhost:3000/sse'));
-  // clientThree = await experimental_createMCPClient({ transport: sseTransport });
+  // clientThree = await createMCPClient({ transport: sseTransport });
 
   const toolSetOne = await clientOne.tools();
   const toolSetTwo = await clientTwo.tools();

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -310,14 +310,17 @@ Returns a Promise that resolves to an `MCPClient` with the following methods:
 ## Example
 
 ```typescript
-import { experimental_createMCPClient, generateText } from '@ai-sdk/mcp';
+import {
+  experimental_createMCPClient as createMCPClient,
+  generateText,
+} from '@ai-sdk/mcp';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { openai } from '@ai-sdk/openai';
 
 let client;
 
 try {
-  client = await experimental_createMCPClient({
+  client = await createMCPClient({
     transport: new Experimental_StdioMCPTransport({
       command: 'node server.js',
     }),

--- a/examples/mcp/src/mcp-prompts/client.ts
+++ b/examples/mcp/src/mcp-prompts/client.ts
@@ -1,7 +1,7 @@
-import { experimental_createMCPClient } from '@ai-sdk/mcp';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 
 async function main() {
-  const mcpClient = await experimental_createMCPClient({
+  const mcpClient = await createMCPClient({
     transport: {
       type: 'sse',
       url: 'http://localhost:8083/sse',

--- a/examples/mcp/src/mcp-resources/client.ts
+++ b/examples/mcp/src/mcp-resources/client.ts
@@ -1,9 +1,9 @@
-import { experimental_createMCPClient } from '@ai-sdk/mcp';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 import { openai } from '@ai-sdk/openai';
 import { generateText, stepCountIs } from 'ai';
 
 async function main() {
-  const mcpClient = await experimental_createMCPClient({
+  const mcpClient = await createMCPClient({
     transport: {
       type: 'sse',
       url: 'http://localhost:8082/sse',

--- a/examples/mcp/src/mcp-with-auth/client.ts
+++ b/examples/mcp/src/mcp-with-auth/client.ts
@@ -13,7 +13,10 @@ import type {
 } from 'ai';
 */
 
-import { experimental_createMCPClient, auth } from '@ai-sdk/mcp';
+import {
+  experimental_createMCPClient as createMCPClient,
+  auth,
+} from '@ai-sdk/mcp';
 import 'dotenv/config';
 import type {
   OAuthClientProvider,
@@ -188,7 +191,7 @@ async function main() {
     waitForAuthorizationCode(Number(8090)),
   );
 
-  const mcpClient = await experimental_createMCPClient({
+  const mcpClient = await createMCPClient({
     transport: { type: 'http', url: serverUrl, authProvider },
   });
   const tools = await mcpClient.tools();

--- a/examples/mcp/src/sse/client.ts
+++ b/examples/mcp/src/sse/client.ts
@@ -1,11 +1,11 @@
 import { openai } from '@ai-sdk/openai';
 import { generateText, stepCountIs } from 'ai';
-import { experimental_createMCPClient } from '@ai-sdk/mcp';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 
 import 'dotenv/config';
 
 async function main() {
-  const mcpClient = await experimental_createMCPClient({
+  const mcpClient = await createMCPClient({
     transport: {
       type: 'sse',
       url: 'http://localhost:8080/sse',

--- a/examples/mcp/src/stdio/client.ts
+++ b/examples/mcp/src/stdio/client.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { generateText, stepCountIs } from 'ai';
-import { experimental_createMCPClient } from '@ai-sdk/mcp';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 import 'dotenv/config';
 import { z } from 'zod';
 
@@ -19,7 +19,7 @@ async function main() {
       },
     });
 
-    mcpClient = await experimental_createMCPClient({
+    mcpClient = await createMCPClient({
       transport: stdioTransport,
     });
 

--- a/examples/next-openai/app/api/mcp-with-auth/route.ts
+++ b/examples/next-openai/app/api/mcp-with-auth/route.ts
@@ -7,7 +7,7 @@ import {
   createUIMessageStreamResponse,
 } from 'ai';
 import {
-  experimental_createMCPClient,
+  experimental_createMCPClient as createMCPClient,
   auth,
   type OAuthClientInformation,
   type OAuthClientMetadata,
@@ -230,7 +230,7 @@ export async function POST(req: Request) {
           });
         }
 
-        const mcpClient = await experimental_createMCPClient({
+        const mcpClient = await createMCPClient({
           transport: { type: 'http', url: serverUrl, authProvider },
         });
 

--- a/examples/next-openai/app/api/mcp-zapier/route.ts
+++ b/examples/next-openai/app/api/mcp-zapier/route.ts
@@ -1,13 +1,13 @@
 import { openai } from '@ai-sdk/openai';
 import { convertToModelMessages, stepCountIs, streamText } from 'ai';
-import { experimental_createMCPClient } from '@ai-sdk/mcp';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
-  const mcpClient = await experimental_createMCPClient({
+  const mcpClient = await createMCPClient({
     transport: {
       type: 'http',
       url: 'https://mcp.zapier.com/api/mcp/s/[YOUR_SERVER_ID]/mcp',

--- a/examples/next-openai/app/mcp/chat/route.ts
+++ b/examples/next-openai/app/mcp/chat/route.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { convertToModelMessages, stepCountIs, streamText } from 'ai';
-import { experimental_createMCPClient } from '@ai-sdk/mcp';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 
 export async function POST(req: Request) {
   const requestUrl = new URL(req.url);
@@ -9,7 +9,7 @@ export async function POST(req: Request) {
   const transport = new StreamableHTTPClientTransport(url);
 
   const [client, { messages }] = await Promise.all([
-    experimental_createMCPClient({
+    createMCPClient({
       transport,
     }),
     req.json(),


### PR DESCRIPTION
## Background

to maintain consistency when dealing with `experimental` features

## Summary

used aliases for imports of `experimental_createMCPClient`

## Checklist

- [ ] ~~Tests have been added / updated (for bug fixes / features)~~
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] ~~A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)~~

