### PR TITLE
fix(ai): prune messages properly when toolCalls set to 'before-last-message'

### DIFF
--- a/.changeset/tough-games-pretend.md
+++ b/.changeset/tough-games-pretend.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): prune messages properly when toolCalls set to 'before-last-message'

--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -109,6 +109,111 @@ const messagesFixture2: ModelMessage[] = [
   },
 ];
 
+const multiTurnToolCallMessagesFixture: ModelMessage[] = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'ask me a question',
+      },
+    ],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'text',
+        text: 'What can i help you with',
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_01P9s4havAQSjDmS4eWT1N2V',
+        toolName: 'AskUserQuestion',
+        input: {
+          question: 'What would you like help with today?',
+          options: ['Tool 1 Option 1', 'Tool 1 Option 2', 'Tool 1 Option 3'],
+        },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'toolu_01P9s4havAQSjDmS4eWT1N2V',
+        toolName: 'AskUserQuestion',
+        output: { type: 'text', value: 'Something else' },
+      },
+    ],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_01TMAuwWKLmBoQtx7K88dxsQ',
+        toolName: 'AskUserQuestion',
+        input: {
+          question: 'Ok what else?',
+          options: ['Tool 2 Option 1', 'Tool 2 Option 2', 'Tool 2 Option 3'],
+        },
+      },
+    ],
+  },
+  {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 'toolu_01TMAuwWKLmBoQtx7K88dxsQ',
+        toolName: 'AskUserQuestion',
+        output: {
+          type: 'text',
+          value: "Other - I'll describe it",
+        },
+      },
+    ],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'text',
+        text: 'What would you like to discuss or work on?',
+      },
+    ],
+  },
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'never mind. lets end this conversation',
+      },
+    ],
+  },
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'text',
+        text: 'ok, have a nice day',
+      },
+    ],
+  },
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'thank you',
+      },
+    ],
+  },
+];
+
 describe('pruneMessages', () => {
   describe('reasoning', () => {
     describe('all', () => {
@@ -369,6 +474,72 @@ describe('pruneMessages', () => {
                 },
               ],
               "role": "assistant",
+            },
+          ]
+        `);
+      });
+
+      it('should prune tool calls and results from multi-turn conversation when last message has no tool calls', () => {
+        const result = pruneMessages({
+          messages: multiTurnToolCallMessagesFixture,
+          toolCalls: 'before-last-message',
+        });
+
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "text": "ask me a question",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "content": [
+                {
+                  "text": "What can i help you with",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "text": "What would you like to discuss or work on?",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "text": "never mind. lets end this conversation",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+            {
+              "content": [
+                {
+                  "text": "ok, have a nice day",
+                  "type": "text",
+                },
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "text": "thank you",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
             },
           ]
         `);

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -81,7 +81,7 @@ export function pruneMessages({
     const keptApprovalIds: Set<string> = new Set();
 
     if (keepLastMessagesCount != null) {
-      for (const message of messages.slice(0, -keepLastMessagesCount)) {
+      for (const message of messages.slice(-keepLastMessagesCount)) {
         if (
           (message.role === 'assistant' || message.role === 'tool') &&
           typeof message.content !== 'string'


### PR DESCRIPTION
## Background

`pruneMessages` did not correctly prune when using `before-last-message` (see #10445 ).

## Summary

Changed the inverted logic of the message slice. We now prune all the tool calls `before-last-message` or `before-last-n-messages`.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)

## Related Issues

Fixes #10445