### PR TITLE
feat (provider/black-forest-labs): include cost and megapixels in metadata

### DIFF
--- a/.changeset/lucky-rivers-begin.md
+++ b/.changeset/lucky-rivers-begin.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/black-forest-labs': patch
+---
+
+feat (provider/black-forest-labs): include cost and megapixels in metadata

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -113,6 +113,61 @@ describe('BlackForestLabsImageModel', () => {
       });
     });
 
+    it('includes all cost and megapixel fields when provided by submit API', async () => {
+      server.urls['https://api.example.com/v1/test-model'].response = {
+        type: 'json-value',
+        body: {
+          id: 'req-123',
+          polling_url: 'https://api.example.com/poll',
+          cost: 0.08,
+          input_mp: 1.5,
+          output_mp: 2.0,
+        },
+      };
+
+      const model = createBasicModel();
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        seed: undefined,
+        aspectRatio: '1:1',
+        providerOptions: {},
+      });
+
+      expect(result.providerMetadata?.blackForestLabs.images[0]).toMatchObject({
+        cost: 0.08,
+        inputMegapixels: 1.5,
+        outputMegapixels: 2.0,
+      });
+    });
+
+    it('omits cost and megapixel fields from providerMetadata when not provided by submit API', async () => {
+      server.urls['https://api.example.com/v1/test-model'].response = {
+        type: 'json-value',
+        body: {
+          id: 'req-123',
+          polling_url: 'https://api.example.com/poll',
+        },
+      };
+
+      const model = createBasicModel();
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        seed: undefined,
+        aspectRatio: '1:1',
+        providerOptions: {},
+      });
+
+      const metadata = result.providerMetadata?.blackForestLabs.images[0];
+      expect(metadata).toBeDefined();
+      expect(metadata).not.toHaveProperty('cost');
+      expect(metadata).not.toHaveProperty('inputMegapixels');
+      expect(metadata).not.toHaveProperty('outputMegapixels');
+    });
+
     it('calls the expected URLs in sequence', async () => {
       const model = createBasicModel();
 

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -190,6 +190,13 @@ export class BlackForestLabsImageModel implements ImageModelV3 {
               ...(resultStartTime != null && { start_time: resultStartTime }),
               ...(resultEndTime != null && { end_time: resultEndTime }),
               ...(resultDuration != null && { duration: resultDuration }),
+              ...(submit.value.cost != null && { cost: submit.value.cost }),
+              ...(submit.value.input_mp != null && {
+                inputMegapixels: submit.value.input_mp,
+              }),
+              ...(submit.value.output_mp != null && {
+                outputMegapixels: submit.value.output_mp,
+              }),
             },
           ],
         },
@@ -331,6 +338,9 @@ function gcd(a: number, b: number): number {
 const bflSubmitSchema = z.object({
   id: z.string(),
   polling_url: z.url(),
+  cost: z.number().optional(),
+  input_mp: z.number().optional(),
+  output_mp: z.number().optional(),
 });
 
 const bflStatus = z.union([


### PR DESCRIPTION
## Background

Black Forest Labs reports cost and image megapixels in the initial image post response. Customers may want this information for tracking and reporting purposes.

## Summary

Added parsing of cost and megapixel data and inclusion in provider metadata.

## Manual Verification

Ran example script and observed data present in provider metadata.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
