### PR TITLE
fix (provider/black-forest-labs): allow null for cost and megapixel in provider response

### DIFF
--- a/.changeset/six-birds-burn.md
+++ b/.changeset/six-birds-burn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/black-forest-labs': patch
+---
+
+fix (provider/black-forest-labs): allow null for cost and megapixel in provider response

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.test.ts
@@ -168,6 +168,35 @@ describe('BlackForestLabsImageModel', () => {
       expect(metadata).not.toHaveProperty('outputMegapixels');
     });
 
+    it('handles null cost and megapixel fields from submit API', async () => {
+      server.urls['https://api.example.com/v1/test-model'].response = {
+        type: 'json-value',
+        body: {
+          id: 'req-123',
+          polling_url: 'https://api.example.com/poll',
+          cost: null,
+          input_mp: null,
+          output_mp: null,
+        },
+      };
+
+      const model = createBasicModel();
+      const result = await model.doGenerate({
+        prompt,
+        n: 1,
+        size: undefined,
+        seed: undefined,
+        aspectRatio: '1:1',
+        providerOptions: {},
+      });
+
+      const metadata = result.providerMetadata?.blackForestLabs.images[0];
+      expect(metadata).toBeDefined();
+      expect(metadata).not.toHaveProperty('cost');
+      expect(metadata).not.toHaveProperty('inputMegapixels');
+      expect(metadata).not.toHaveProperty('outputMegapixels');
+    });
+
     it('calls the expected URLs in sequence', async () => {
       const model = createBasicModel();
 

--- a/packages/black-forest-labs/src/black-forest-labs-image-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-image-model.ts
@@ -338,9 +338,9 @@ function gcd(a: number, b: number): number {
 const bflSubmitSchema = z.object({
   id: z.string(),
   polling_url: z.url(),
-  cost: z.number().optional(),
-  input_mp: z.number().optional(),
-  output_mp: z.number().optional(),
+  cost: z.number().nullish(),
+  input_mp: z.number().nullish(),
+  output_mp: z.number().nullish(),
 });
 
 const bflStatus = z.union([


### PR DESCRIPTION
## Background

In https://github.com/vercel/ai/pull/10571/ we added logic to pull additional detail from the provider response to make available in provider metadata. For some models the provider returns `null` for these fields, breaking the provider response parsing.

## Summary

Move to `nullish` from `optional` in the zod schema. Add a test that would have caught the issue.

## Manual Verification

Ran example script manually against models that passed previously and broke previously and observed both passing.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
