### PR TITLE
doc: update google-vertex model Id to have gemini-2.5-flash-image-preview

### DIFF
--- a/.changeset/curvy-scissors-drum.md
+++ b/.changeset/curvy-scissors-drum.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+add context_management for anthropic

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -575,12 +575,13 @@ The following Zod features are known to not work with Google Vertex:
 
 ### Model Capabilities
 
-| Model                  | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
-| ---------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `gemini-2.0-flash-001` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-2.0-flash-exp` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-flash`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-pro`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| Model                            | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
+| -------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gemini-2.0-flash-001`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-2.0-flash-exp`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-flash`               | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-pro`                 | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-2.5-flash-image-preview` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   The table above lists popular models. Please see the [Google Vertex AI

--- a/examples/ai-core/src/generate-text/anthropic-context-management.ts
+++ b/examples/ai-core/src/generate-text/anthropic-context-management.ts
@@ -116,7 +116,7 @@ async function main() {
 
     console.log('Context Management:');
     console.log(JSON.stringify(
-        result.providerMetadata?.anthropic?.context_management,
+        result.providerMetadata?.anthropic?.contextManagement,
         null,
         2
     ));

--- a/examples/ai-core/src/generate-text/anthropic-context-management.ts
+++ b/examples/ai-core/src/generate-text/anthropic-context-management.ts
@@ -1,0 +1,129 @@
+import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { generateText, tool } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+    const result = await generateText({
+        model: anthropic('claude-3-7-sonnet-20250219'),
+        messages: [
+            {
+                role: 'user',
+                content: 'What is the weather in San Francisco?'
+            },
+            {
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'tool-call',
+                        toolCallId: 'tool_1',
+                        toolName: 'weather',
+                        input: { location: 'San Francisco' },
+                    }
+                ]
+            },
+            {
+                role: 'tool',
+                content: [
+                    {
+                        type: 'tool-result',
+                        toolCallId: 'tool_1',
+                        toolName: 'weather',
+                        output: {
+                            type: 'json',
+                            value: { temperature: 72, condition: 'sunny' }
+                        }
+                    }
+                ]
+            },
+            {
+                role: 'user',
+                content: 'What about New York?'
+            },
+            {
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'tool-call',
+                        toolCallId: 'tool_2',
+                        toolName: 'weather',
+                        input: { location: 'New York' }
+                    }
+                ]
+            },
+            {
+                role: 'tool',
+                content: [
+                    {
+                        type: 'tool-result',
+                        toolCallId: 'tool_2',
+                        toolName: 'weather',
+                        output: {
+                            type: 'json',
+                            value: { temperature: 65, condition: 'cloudy' }
+                        }
+                    }
+                ]
+            },
+            {
+                role: 'user',
+                content: 'compare the two cities.'
+            }
+        ],
+        tools: {
+            weather: tool({
+                description: 'Get the weather of a location',
+                inputSchema: z.object({
+                    location: z.string().describe('The location to get the weather for')
+                }),
+                execute: async ({ location }) => ({
+                    location,
+                    temperature: 72 + Math.floor(Math.random() * 21) - 10,
+                    condition: 'sunny'
+                })
+            })
+        },
+        providerOptions: {
+            anthropic: {
+                contextManagement: {
+                    edits: [
+                        {
+                            type: 'clear_tool_uses_20250919',
+                            trigger: {
+                                type: 'input_tokens',
+                                value: 1000
+                            },
+                            keep: {
+                                type: 'tool_uses',
+                                value: 1
+                            },
+                            clearAtLeast: {
+                                type: 'input_tokens',
+                                value: 500
+                            },
+                            clearToolInputs: true,
+                            excludeTools: ['important_tool']
+                        }
+                    ]
+                }
+            } satisfies AnthropicProviderOptions
+        }
+    });
+
+    console.log('Text:');
+    console.log(result.text);
+    console.log();
+
+    console.log('Context Management:');
+    console.log(JSON.stringify(
+        result.providerMetadata?.anthropic?.context_management,
+        null,
+        2
+    ));
+    console.log();
+
+    console.log('Usage:');
+    console.log(JSON.stringify(result.usage, null, 2));
+};
+
+main().catch(console.error);

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -15,7 +15,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should exp
         },
       ],
     },
-    "context_management": null,
+    "contextManagement": null,
     "stopSequence": null,
     "usage": {
       "cache_creation": {
@@ -45,7 +45,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 >
       "id": "container_011CU6rVteVhydYXRyNs6G1M",
       "skills": null,
     },
-    "context_management": null,
+    "contextManagement": null,
     "stopSequence": null,
     "usage": {
       "cache_creation": {
@@ -292,7 +292,7 @@ Both files have been exported and are ready for download!",
         "id": "container_011CUJar2mdkMcv7daEVAQw2",
         "skills": null,
       },
-      "context_management": null,
+      "contextManagement": null,
       "stopSequence": null,
       "usage": {
         "cache_creation": {
@@ -1734,626 +1734,7 @@ exports[`AnthropicMessagesLanguageModel > doStream > json schema response format
       "anthropic": {
         "cacheCreationInputTokens": 0,
         "container": null,
-        "stopSequence": null,
-        "usage": {
-          "cache_creation": {
-            "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 0,
-          },
-          "cache_creation_input_tokens": 0,
-          "cache_read_input_tokens": 0,
-          "input_tokens": 313,
-          "output_tokens": 305,
-          "service_tier": "standard",
-        },
-      },
-    },
-    "type": "finish",
-    "usage": {
-      "cachedInputTokens": 0,
-      "inputTokens": 313,
-      "outputTokens": 305,
-      "totalTokens": 618,
-    },
-  },
-]
-`;
-
-exports[`AnthropicMessagesLanguageModel > doStream > json schema response format(supported model) > should stream the text output 1`] = `
-[
-  {
-    "type": "stream-start",
-    "warnings": [],
-  },
-  {
-    "id": "msg_01KbeodbKEyjf2fLb2Jnkr5s",
-    "modelId": "claude-sonnet-4-5-20250929",
-    "type": "response-metadata",
-  },
-  {
-    "id": "0",
-    "type": "text-start",
-  },
-  {
-    "delta": "{"",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "characters"",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": ":[{"name":"Th",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "eron",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " Iron",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "heart","class":"warrior","description",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "":"A battle",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "-scar",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "red veteran",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " with",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " steel",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "-",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "gray hair and a",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " prominent",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " scar across his left eye.",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " Wiel",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ding a massive two",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "-handed sword passe",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "d down through his family for",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " generations,",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " Theron fights",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " with discipl",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ined precision h",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "oned through decades",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " of combat. Despite",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " his gruff exterior, he harb",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ors a deep sense of honor and prot",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ects the weak",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " without",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " hesitation.",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": ""},{"name":"Lyra",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " Star",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "weaver","class":"mage","",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "description":"A young",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " pro",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "digy in",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " the",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " arcane arts with",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " flowing",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " silver ro",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "bes ador",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ned with celest",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ial patterns",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": ". Her",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " eyes",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " g",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "low f",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "aintly blue",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " when",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " chann",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "eling powerful",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " sp",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ells.",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " Lyra special",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "izes in ele",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "mental magic an",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "d ast",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ral div",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ination, having",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " studie",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "d at",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " the Gran",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "d Academy since",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " childhoo",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "d. She is",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " curious",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " and ide",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "alistic, often getting",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " into",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " trouble",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " while",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " pursuing",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " forbidden",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " knowledge."},{"name":"R",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ook",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " Shadow",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "st",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ep",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "","class":"thief","description":"",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "A nim",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ble and cun",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ning r",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ogue who",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " moves through",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " shadows",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " like",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " a whis",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "per in",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " the night. With",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " jet",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "-black hair,",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " leather",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " armor,",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " and an array of lock",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "picks an",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "d daggers hidden on",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " his person, Rook makes his",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " living liber",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ating treas",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ures from those",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " he",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " deems unworthy of",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " them",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": ". Behin",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "d his coc",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "ky smile",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " lies a trouble",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "d past and a strict",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " personal",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " code about",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " who",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " deserves to be",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": " rob",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "delta": "bed."}]}",
-    "id": "0",
-    "type": "text-delta",
-  },
-  {
-    "id": "0",
-    "type": "text-end",
-  },
-  {
-    "finishReason": "stop",
-    "providerMetadata": {
-      "anthropic": {
-        "cacheCreationInputTokens": 0,
-        "container": null,
+        "contextManagement": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -6058,7 +5439,7 @@ The presentation has",
             },
           ],
         },
-        "context_management": null,
+        "contextManagement": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -11102,7 +10483,7 @@ Both",
           "id": "container_011CUJb5Pk4kFWskBpuCjwXj",
           "skills": null,
         },
-        "context_management": null,
+        "contextManagement": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -12400,7 +11781,7 @@ The Fibonacci sequence starts with 0, ",
           "id": "container_011CU6pTr2hLT47seQ5Xs4yj",
           "skills": null,
         },
-        "context_management": null,
+        "contextManagement": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -12505,7 +11886,7 @@ It simply echoed back",
       "anthropic": {
         "cacheCreationInputTokens": 0,
         "container": null,
-        "context_management": null,
+        "contextManagement": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -12905,7 +12286,7 @@ The page also discusses",
       "anthropic": {
         "cacheCreationInputTokens": 0,
         "container": null,
-        "context_management": null,
+        "contextManagement": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -13640,7 +13021,7 @@ The main tech story today appears to be Apple's significant",
       "anthropic": {
         "cacheCreationInputTokens": 0,
         "container": null,
-        "context_management": null,
+        "contextManagement": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {

--- a/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-messages-language-model.test.ts.snap
@@ -15,6 +15,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > agent skills > should exp
         },
       ],
     },
+    "context_management": null,
     "stopSequence": null,
     "usage": {
       "cache_creation": {
@@ -44,6 +45,7 @@ exports[`AnthropicMessagesLanguageModel > doGenerate > code execution 20250825 >
       "id": "container_011CU6rVteVhydYXRyNs6G1M",
       "skills": null,
     },
+    "context_management": null,
     "stopSequence": null,
     "usage": {
       "cache_creation": {
@@ -290,6 +292,7 @@ Both files have been exported and are ready for download!",
         "id": "container_011CUJar2mdkMcv7daEVAQw2",
         "skills": null,
       },
+      "context_management": null,
       "stopSequence": null,
       "usage": {
         "cache_creation": {
@@ -6055,6 +6058,7 @@ The presentation has",
             },
           ],
         },
+        "context_management": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -11098,6 +11102,7 @@ Both",
           "id": "container_011CUJb5Pk4kFWskBpuCjwXj",
           "skills": null,
         },
+        "context_management": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -12395,6 +12400,7 @@ The Fibonacci sequence starts with 0, ",
           "id": "container_011CU6pTr2hLT47seQ5Xs4yj",
           "skills": null,
         },
+        "context_management": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -12499,6 +12505,7 @@ It simply echoed back",
       "anthropic": {
         "cacheCreationInputTokens": 0,
         "container": null,
+        "context_management": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -12898,6 +12905,7 @@ The page also discusses",
       "anthropic": {
         "cacheCreationInputTokens": 0,
         "container": null,
+        "context_management": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {
@@ -13632,6 +13640,7 @@ The main tech story today appears to be Apple's significant",
       "anthropic": {
         "cacheCreationInputTokens": 0,
         "container": null,
+        "context_management": null,
         "stopSequence": null,
         "usage": {
           "cache_creation": {

--- a/packages/anthropic/src/anthropic-message-metadata.ts
+++ b/packages/anthropic/src/anthropic-message-metadata.ts
@@ -44,4 +44,19 @@ export interface AnthropicMessageMetadata {
       version: string;
     }> | null;
   } | null;
+
+  context_management: {
+    appliedEdits: Array<
+      | {
+          type: 'clear_tool_uses_20250919';
+          clearedToolUses: number;
+          clearedInputTokens: number;
+        }
+      | {
+          type: 'clear_thinking_20251015';
+          clearedThinkingTurns: number;
+          clearedInputTokens: number;
+        }
+    >;
+  } | null;
 }

--- a/packages/anthropic/src/anthropic-message-metadata.ts
+++ b/packages/anthropic/src/anthropic-message-metadata.ts
@@ -45,18 +45,18 @@ export interface AnthropicMessageMetadata {
     }> | null;
   } | null;
 
-  context_management: {
+  contextManagement: {
     appliedEdits: Array<
       | {
-          type: 'clear_tool_uses_20250919';
-          clearedToolUses: number;
-          clearedInputTokens: number;
-        }
+        type: 'clear_tool_uses_20250919';
+        clearedToolUses: number;
+        clearedInputTokens: number;
+      }
       | {
-          type: 'clear_thinking_20251015';
-          clearedThinkingTurns: number;
-          clearedInputTokens: number;
-        }
+        type: 'clear_thinking_20251015';
+        clearedThinkingTurns: number;
+        clearedInputTokens: number;
+      }
     >;
   } | null;
 }

--- a/packages/anthropic/src/anthropic-messages-api.ts
+++ b/packages/anthropic/src/anthropic-messages-api.ts
@@ -358,6 +358,68 @@ export type AnthropicContainer = {
   }> | null;
 };
 
+export type AnthropicInputTokensTrigger = {
+  type: 'input_tokens';
+  value: number;
+};
+
+export type AnthropicToolUsesTrigger = {
+  type: 'tool_uses';
+  value: number;
+};
+
+export type AnthropicContextManagementTrigger =
+  | AnthropicInputTokensTrigger
+  | AnthropicToolUsesTrigger;
+
+export type AnthropicClearToolUsesEdit = {
+  type: 'clear_tool_uses_20250919';
+  trigger?: AnthropicContextManagementTrigger;
+  keep?: {
+    type: 'tool_uses';
+    value: number;
+  };
+  clear_at_least?: {
+    type: 'input_tokens';
+    value: number;
+  };
+  clear_tool_inputs?: boolean;
+  exclude_tools?: string[];
+};
+
+export type AnthropicClearThinkingBlockEdit = {
+  type: 'clear_thinking_20251015';
+  keep?: 'all' | { type: 'thinking_turns'; value: number };
+};
+
+export type AnthropicContextManagementEdit =
+  | AnthropicClearToolUsesEdit
+  | AnthropicClearThinkingBlockEdit;
+
+export type AnthropicContextManagementConfig = {
+  edits: AnthropicContextManagementEdit[];
+};
+
+export type AnthropicResponseClearToolUsesEdit = {
+  type: 'clear_tool_uses_20250919';
+  cleared_tool_uses: number;
+  cleared_input_tokens: number;
+};
+
+export type AnthropicResponseClearThinkingBlockEdit = {
+  type: 'clear_thinking_20251015';
+  cleared_thinking_turns: number;
+  cleared_input_tokens: number;
+};
+
+export type AnthropicResponseContextManagementEdit =
+  | AnthropicResponseClearToolUsesEdit
+  | AnthropicResponseClearThinkingBlockEdit;
+
+export type AnthropicResponseContextManagement = {
+  applied_edits: AnthropicResponseContextManagementEdit[];
+};
+
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
 export const anthropicMessagesResponseSchema = lazySchema(() =>
@@ -580,6 +642,24 @@ export const anthropicMessagesResponseSchema = lazySchema(() =>
               }),
             )
             .nullish(),
+        })
+        .nullish(),
+      context_management: z
+        .object({
+          applied_edits: z.array(
+            z.discriminatedUnion('type', [
+              z.object({
+                type: z.literal('clear_tool_uses_20250919'),
+                cleared_tool_uses: z.number(),
+                cleared_input_tokens: z.number(),
+              }),
+              z.object({
+                type: z.literal('clear_thinking_20251015'),
+                cleared_thinking_turns: z.number(),
+                cleared_input_tokens: z.number(),
+              }),
+            ]),
+          ),
         })
         .nullish(),
     }),
@@ -849,6 +929,24 @@ export const anthropicMessagesChunkSchema = lazySchema(() =>
                   }),
                 )
                 .nullish(),
+            })
+            .nullish(),
+          context_management: z
+            .object({
+              applied_edits: z.array(
+                z.discriminatedUnion('type', [
+                  z.object({
+                    type: z.literal('clear_tool_uses_20250919'),
+                    cleared_tool_uses: z.number(),
+                    cleared_input_tokens: z.number(),
+                  }),
+                  z.object({
+                    type: z.literal('clear_thinking_20251015'),
+                    cleared_thinking_turns: z.number(),
+                    cleared_input_tokens: z.number(),
+                  }),
+                ]),
+              ),
             })
             .nullish(),
         }),

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -803,7 +803,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           "anthropic": {
             "cacheCreationInputTokens": null,
             "container": null,
-            "context_management": null,
+            "contextManagement": null,
             "stopSequence": "STOP",
             "usage": {
               "input_tokens": 4,
@@ -1118,7 +1118,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "anthropic": {
               "cacheCreationInputTokens": 10,
               "container": null,
-              "context_management": null,
+              "contextManagement": null,
               "stopSequence": null,
               "usage": {
                 "cache_creation_input_tokens": 10,
@@ -1255,7 +1255,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             "anthropic": {
               "cacheCreationInputTokens": 10,
               "container": null,
-              "context_management": null,
+              "contextManagement": null,
               "stopSequence": null,
               "usage": {
                 "cache_creation": {
@@ -3051,7 +3051,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT
         });
 
-        expect(result.providerMetadata?.anthropic?.context_management).toEqual({
+        expect(result.providerMetadata?.anthropic?.contextManagement).toEqual({
           appliedEdits: [{
             type: 'clear_tool_uses_20250919',
             clearedToolUses: 5,
@@ -3168,7 +3168,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 "anthropic": {
                   "cacheCreationInputTokens": 0,
                   "container": null,
-                  "context_management": null,
+                  "contextManagement": null,
                   "stopSequence": null,
                   "usage": {
                     "cache_creation": {
@@ -3301,7 +3301,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 "anthropic": {
                   "cacheCreationInputTokens": 0,
                   "container": null,
-                  "context_management": null,
+                  "contextManagement": null,
                   "stopSequence": null,
                   "usage": {
                     "cache_creation": {
@@ -3479,7 +3479,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                   "anthropic": {
                     "cacheCreationInputTokens": 0,
                     "container": null,
-                    "context_management": null,
+                    "contextManagement": null,
                     "stopSequence": null,
                     "usage": {
                       "cache_creation": {
@@ -3665,7 +3665,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "anthropic": {
                 "cacheCreationInputTokens": null,
                 "container": null,
-                "context_management": null,
+                "contextManagement": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 17,
@@ -3765,7 +3765,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "anthropic": {
                 "cacheCreationInputTokens": null,
                 "container": null,
-                "context_management": null,
+                "contextManagement": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 17,
@@ -3847,7 +3847,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "anthropic": {
                 "cacheCreationInputTokens": null,
                 "container": null,
-                "context_management": null,
+                "contextManagement": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 17,
@@ -3915,7 +3915,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "anthropic": {
                 "cacheCreationInputTokens": null,
                 "container": null,
-                "context_management": null,
+                "contextManagement": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 17,
@@ -4051,7 +4051,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "anthropic": {
                 "cacheCreationInputTokens": null,
                 "container": null,
-                "context_management": null,
+                "contextManagement": null,
                 "stopSequence": null,
                 "usage": {
                   "input_tokens": 441,
@@ -4262,7 +4262,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "anthropic": {
                 "cacheCreationInputTokens": 10,
                 "container": null,
-                "context_management": null,
+                "contextManagement": null,
                 "stopSequence": null,
                 "usage": {
                   "cache_creation_input_tokens": 10,
@@ -4337,7 +4337,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               "anthropic": {
                 "cacheCreationInputTokens": 10,
                 "container": null,
-                "context_management": null,
+                "contextManagement": null,
                 "stopSequence": null,
                 "usage": {
                   "cache_creation": {
@@ -4442,7 +4442,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 "anthropic": {
                   "cacheCreationInputTokens": null,
                   "container": null,
-                  "context_management": null,
+                  "contextManagement": null,
                   "stopSequence": null,
                   "usage": {
                     "input_tokens": 17,
@@ -4491,7 +4491,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 "anthropic": {
                   "cacheCreationInputTokens": null,
                   "container": null,
-                  "context_management": null,
+                  "contextManagement": null,
                   "stopSequence": "STOP",
                   "usage": {
                     "input_tokens": 17,
@@ -4727,7 +4727,7 @@ describe('AnthropicMessagesLanguageModel', () => {
                 "anthropic": {
                   "cacheCreationInputTokens": null,
                   "container": null,
-                  "context_management": null,
+                  "contextManagement": null,
                   "stopSequence": null,
                   "usage": {
                     "input_tokens": 17,

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -2994,7 +2994,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           providerOptions: {
             anthropic: {
-              context_management: {
+              contextManagement: {
                 edits: [{ type: 'clear_tool_uses_20250919' }]
               }
             }
@@ -3015,7 +3015,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           providerOptions: {
             anthropic: {
-              context_management: {
+              contextManagement: {
                 edits: [{ type: 'clear_tool_uses_20250919' }]
               }
             }

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -29,11 +29,13 @@ import {
 import { anthropicFailedResponseHandler } from './anthropic-error';
 import { AnthropicMessageMetadata } from './anthropic-message-metadata';
 import {
+  AnthropicContextManagementConfig,
   AnthropicContainer,
   anthropicMessagesChunkSchema,
   anthropicMessagesResponseSchema,
   AnthropicReasoningMetadata,
   Citation,
+  AnthropicResponseContextManagement,
 } from './anthropic-messages-api';
 import {
   AnthropicMessagesModelId,
@@ -74,15 +76,15 @@ function createCitationSource(
       anthropic:
         citation.type === 'page_location'
           ? {
-              citedText: citation.cited_text,
-              startPageNumber: citation.start_page_number,
-              endPageNumber: citation.end_page_number,
-            }
+            citedText: citation.cited_text,
+            startPageNumber: citation.start_page_number,
+            endPageNumber: citation.end_page_number,
+          }
           : {
-              citedText: citation.cited_text,
-              startCharIndex: citation.start_char_index,
-              endCharIndex: citation.end_char_index,
-            },
+            citedText: citation.cited_text,
+            startCharIndex: citation.start_char_index,
+            endCharIndex: citation.end_char_index,
+          },
     } satisfies SharedV3ProviderMetadata,
   };
 }
@@ -214,15 +216,17 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
     const jsonResponseTool: LanguageModelV3FunctionTool | undefined =
       responseFormat?.type === 'json' &&
-      responseFormat.schema != null &&
-      !useStructuredOutput
+        responseFormat.schema != null &&
+        !useStructuredOutput
         ? {
-            type: 'function',
-            name: 'json',
-            description: 'Respond with a JSON object.',
-            inputSchema: responseFormat.schema,
-          }
+          type: 'function',
+          name: 'json',
+          description: 'Respond with a JSON object.',
+          inputSchema: responseFormat.schema,
+        }
         : undefined;
+
+    const contextManagement = anthropicOptions?.context_management;
 
     // Create a shared cache control validator to track breakpoints across tools and messages
     const cacheControlValidator = new CacheControlValidator();
@@ -263,28 +267,28 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       ...(useStructuredOutput &&
         responseFormat?.type === 'json' &&
         responseFormat.schema != null && {
-          output_format: {
-            type: 'json_schema',
-            schema: responseFormat.schema,
-          },
-        }),
+        output_format: {
+          type: 'json_schema',
+          schema: responseFormat.schema,
+        },
+      }),
 
       // mcp servers:
       ...(anthropicOptions?.mcpServers &&
         anthropicOptions.mcpServers.length > 0 && {
-          mcp_servers: anthropicOptions.mcpServers.map(server => ({
-            type: server.type,
-            name: server.name,
-            url: server.url,
-            authorization_token: server.authorizationToken,
-            tool_configuration: server.toolConfiguration
-              ? {
-                  allowed_tools: server.toolConfiguration.allowedTools,
-                  enabled: server.toolConfiguration.enabled,
-                }
-              : undefined,
-          })),
-        }),
+        mcp_servers: anthropicOptions.mcpServers.map(server => ({
+          type: server.type,
+          name: server.name,
+          url: server.url,
+          authorization_token: server.authorizationToken,
+          tool_configuration: server.toolConfiguration
+            ? {
+              allowed_tools: server.toolConfiguration.allowedTools,
+              enabled: server.toolConfiguration.enabled,
+            }
+            : undefined,
+        })),
+      }),
 
       // container with agent skills:
       ...(anthropicOptions?.container && {
@@ -301,6 +305,34 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       // prompt:
       system: messagesPrompt.system,
       messages: messagesPrompt.messages,
+
+      ...(contextManagement && {
+        context_management: {
+          edits: contextManagement.edits.map(edit => {
+            if (edit.type === 'clear_tool_uses_20250919') {
+              return {
+                type: edit.type,
+                ...(edit.trigger !== undefined && { trigger: edit.trigger }),
+                ...(edit.keep !== undefined && { keep: edit.keep }),
+                ...(edit.clear_at_least !== undefined && {
+                  clear_at_least: edit.clear_at_least,
+                }),
+                ...(edit.clear_tool_inputs !== undefined && {
+                  clear_tool_inputs: edit.clear_tool_inputs,
+                }),
+                ...(edit.exclude_tools !== undefined && {
+                  exclude_tools: edit.exclude_tools,
+                }),
+              };
+            } else {
+              return {
+                type: edit.type,
+                ...(edit.keep !== undefined && { keep: edit.keep }),
+              };
+            }
+          }),
+        },
+      }),
     };
 
     if (isThinking) {
@@ -363,6 +395,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       betas.add('mcp-client-2025-04-04');
     }
 
+    if (contextManagement) {
+      betas.add('context-management-2025-06-27');
+    }
+
     if (
       anthropicOptions?.container &&
       anthropicOptions.container.skills &&
@@ -408,17 +444,17 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     } = await prepareTools(
       jsonResponseTool != null
         ? {
-            tools: [...(tools ?? []), jsonResponseTool],
-            toolChoice: { type: 'required' },
-            disableParallelToolUse: true,
-            cacheControlValidator,
-          }
+          tools: [...(tools ?? []), jsonResponseTool],
+          toolChoice: { type: 'required' },
+          disableParallelToolUse: true,
+          cacheControlValidator,
+        }
         : {
-            tools: tools ?? [],
-            toolChoice,
-            disableParallelToolUse: anthropicOptions?.disableParallelToolUse,
-            cacheControlValidator,
-          },
+          tools: tools ?? [],
+          toolChoice,
+          disableParallelToolUse: anthropicOptions?.disableParallelToolUse,
+          cacheControlValidator,
+        },
     );
 
     // Extract cache control warnings once at the end
@@ -817,15 +853,36 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
           stopSequence: response.stop_sequence ?? null,
           container: response.container
             ? {
-                expiresAt: response.container.expires_at,
-                id: response.container.id,
-                skills:
-                  response.container.skills?.map(skill => ({
-                    type: skill.type,
-                    skillId: skill.skill_id,
-                    version: skill.version,
-                  })) ?? null,
-              }
+              expiresAt: response.container.expires_at,
+              id: response.container.id,
+              skills:
+                response.container.skills?.map(skill => ({
+                  type: skill.type,
+                  skillId: skill.skill_id,
+                  version: skill.version,
+                })) ?? null,
+            }
+            : null,
+          context_management: response.context_management
+            ? {
+              appliedEdits: response.context_management.applied_edits.map(
+                edit => {
+                  if (edit.type === 'clear_tool_uses_20250919') {
+                    return {
+                      type: edit.type,
+                      clearedToolUses: edit.cleared_tool_uses,
+                      clearedInputTokens: edit.cleared_input_tokens,
+                    };
+                  } else {
+                    return {
+                      type: edit.type,
+                      clearedThinkingTurns: edit.cleared_thinking_turns,
+                      clearedInputTokens: edit.cleared_input_tokens,
+                    };
+                  }
+                },
+              ),
+            }
             : null,
         } satisfies AnthropicMessageMetadata,
       },
@@ -847,6 +904,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
     // Extract citation documents for response processing
     const citationDocuments = this.extractCitationDocuments(options.prompt);
+
+    let contextManagement: AnthropicResponseContextManagement | null = null;
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: this.buildRequestUrl(true),
@@ -870,13 +929,13 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     const contentBlocks: Record<
       number,
       | {
-          type: 'tool-call';
-          toolCallId: string;
-          toolName: string;
-          input: string;
-          providerExecuted?: boolean;
-          firstDelta: boolean;
-        }
+        type: 'tool-call';
+        toolCallId: string;
+        toolName: string;
+        input: string;
+        providerExecuted?: boolean;
+        firstDelta: boolean;
+      }
       | { type: 'text' | 'reasoning' }
     > = {};
     const mcpToolCalls: Record<string, LanguageModelV3ToolCall> = {};
@@ -1031,7 +1090,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                       // map tool names for the code execution 20250825 tool:
                       const mappedToolName =
                         part.name === 'text_editor_code_execution' ||
-                        part.name === 'bash_code_execution'
+                          part.name === 'bash_code_execution'
                           ? 'code_execution'
                           : part.name;
 
@@ -1255,7 +1314,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                         const toolName =
                           contentBlock.toolName ===
                             'text_editor_code_execution' ||
-                          contentBlock.toolName === 'bash_code_execution'
+                            contentBlock.toolName === 'bash_code_execution'
                             ? 'code_execution'
                             : contentBlock.toolName;
 
@@ -1357,7 +1416,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                         contentBlock.firstDelta &&
                         (contentBlock.toolName === 'bash_code_execution' ||
                           contentBlock.toolName ===
-                            'text_editor_code_execution')
+                          'text_editor_code_execution')
                       ) {
                         delta = `{"type": "${contentBlock.toolName}",${delta.substring(1)}`;
                       }
@@ -1434,16 +1493,20 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                 container =
                   value.delta.container != null
                     ? {
-                        expiresAt: value.delta.container.expires_at,
-                        id: value.delta.container.id,
-                        skills:
-                          value.delta.container.skills?.map(skill => ({
-                            type: skill.type,
-                            skillId: skill.skill_id,
-                            version: skill.version,
-                          })) ?? null,
-                      }
+                      expiresAt: value.delta.container.expires_at,
+                      id: value.delta.container.id,
+                      skills:
+                        value.delta.container.skills?.map(skill => ({
+                          type: skill.type,
+                          skillId: skill.skill_id,
+                          version: skill.version,
+                        })) ?? null,
+                    }
                     : null;
+
+                if (value.delta.context_management) {
+                  contextManagement = value.delta.context_management;
+                }
 
                 rawUsage = {
                   ...rawUsage,
@@ -1464,6 +1527,30 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                       cacheCreationInputTokens,
                       stopSequence,
                       container,
+                      context_management: contextManagement
+                        ? {
+                          appliedEdits: contextManagement.applied_edits.map(
+                            edit => {
+                              if (edit.type === 'clear_tool_uses_20250919') {
+                                return {
+                                  type: edit.type,
+                                  clearedToolUses: edit.cleared_tool_uses,
+                                  clearedInputTokens:
+                                    edit.cleared_input_tokens,
+                                };
+                              } else {
+                                return {
+                                  type: edit.type,
+                                  clearedThinkingTurns:
+                                    edit.cleared_thinking_turns,
+                                  clearedInputTokens:
+                                    edit.cleared_input_tokens,
+                                };
+                              }
+                            },
+                          ),
+                        }
+                        : null,
                     } satisfies AnthropicMessageMetadata,
                   },
                 });

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -226,7 +226,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
         }
         : undefined;
 
-    const contextManagement = anthropicOptions?.context_management;
+    const contextManagement = anthropicOptions?.contextManagement;
 
     // Create a shared cache control validator to track breakpoints across tools and messages
     const cacheControlValidator = new CacheControlValidator();
@@ -863,7 +863,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                 })) ?? null,
             }
             : null,
-          context_management: response.context_management
+          contextManagement: response.context_management
             ? {
               appliedEdits: response.context_management.applied_edits.map(
                 edit => {
@@ -1527,7 +1527,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                       cacheCreationInputTokens,
                       stopSequence,
                       container,
-                      context_management: contextManagement
+                      contextManagement: contextManagement
                         ? {
                           appliedEdits: contextManagement.applied_edits.map(
                             edit => {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -314,14 +314,14 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
                 type: edit.type,
                 ...(edit.trigger !== undefined && { trigger: edit.trigger }),
                 ...(edit.keep !== undefined && { keep: edit.keep }),
-                ...(edit.clear_at_least !== undefined && {
-                  clear_at_least: edit.clear_at_least,
+                ...(edit.clearAtLeast !== undefined && {
+                  clear_at_least: edit.clearAtLeast,
                 }),
-                ...(edit.clear_tool_inputs !== undefined && {
-                  clear_tool_inputs: edit.clear_tool_inputs,
+                ...(edit.clearToolInputs !== undefined && {
+                  clear_tool_inputs: edit.clearToolInputs,
                 }),
-                ...(edit.exclude_tools !== undefined && {
-                  exclude_tools: edit.exclude_tools,
+                ...(edit.excludeTools !== undefined && {
+                  exclude_tools: edit.excludeTools,
                 }),
               };
             } else {

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -159,7 +159,7 @@ export const anthropicProviderOptions = z.object({
    */
   effort: z.enum(['low', 'medium', 'high']).optional(),
 
-  context_management: z
+  contextManagement: z
     .object({
       edits: z.array(
         z.discriminatedUnion('type', [

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -158,6 +158,56 @@ export const anthropicProviderOptions = z.object({
    * @default 'high'
    */
   effort: z.enum(['low', 'medium', 'high']).optional(),
+
+  context_management: z
+    .object({
+      edits: z.array(
+        z.discriminatedUnion('type', [
+          z.object({
+            type: z.literal('clear_tool_uses_20250919'),
+            trigger: z
+              .discriminatedUnion('type', [
+                z.object({
+                  type: z.literal('input_tokens'),
+                  value: z.number(),
+                }),
+                z.object({
+                  type: z.literal('tool_uses'),
+                  value: z.number(),
+                }),
+              ])
+              .optional(),
+            keep: z
+              .object({
+                type: z.literal('tool_uses'),
+                value: z.number(),
+              })
+              .optional(),
+            clear_at_least: z
+              .object({
+                type: z.literal('input_tokens'),
+                value: z.number(),
+              })
+              .optional(),
+            clear_tool_inputs: z.boolean().optional(),
+            exclude_tools: z.array(z.string()).optional(),
+          }),
+          z.object({
+            type: z.literal('clear_thinking_20251015'),
+            keep: z
+              .union([
+                z.literal('all'),
+                z.object({
+                  type: z.literal('thinking_turns'),
+                  value: z.number(),
+                }),
+              ])
+              .optional(),
+          }),
+        ]),
+      ),
+    })
+    .optional(),
 });
 
 export type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;

--- a/packages/anthropic/src/anthropic-messages-options.ts
+++ b/packages/anthropic/src/anthropic-messages-options.ts
@@ -183,14 +183,14 @@ export const anthropicProviderOptions = z.object({
                 value: z.number(),
               })
               .optional(),
-            clear_at_least: z
+            clearAtLeast: z
               .object({
                 type: z.literal('input_tokens'),
                 value: z.number(),
               })
               .optional(),
-            clear_tool_inputs: z.boolean().optional(),
-            exclude_tools: z.array(z.string()).optional(),
+            clearToolInputs: z.boolean().optional(),
+            excludeTools: z.array(z.string()).optional(),
           }),
           z.object({
             type: z.literal('clear_thinking_20251015'),

--- a/packages/anthropic/src/map-anthropic-stop-reason.ts
+++ b/packages/anthropic/src/map-anthropic-stop-reason.ts
@@ -21,6 +21,8 @@ export function mapAnthropicStopReason({
       return isJsonResponseFromTool ? 'stop' : 'tool-calls';
     case 'max_tokens':
       return 'length';
+    case 'model_context_window_exceeded':
+      return 'length';
     default:
       return 'unknown';
   }

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -24,6 +24,7 @@ export type GoogleVertexModelId =
   | 'gemini-2.0-flash-lite-preview-02-05'
   | 'gemini-2.5-flash-lite-preview-09-2025'
   | 'gemini-2.5-flash-preview-09-2025'
+  | 'gemini-2.5-flash-image-preview'
   | 'gemini-3-pro-preview'
   | 'gemini-3-pro-image-preview'
   // Experimental models


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

Fixes : #10516 

## Background

The Vertex provider already supports gemini-2.5-flash-image-preview internally, but the docs and model-ID list didn’t reflect that. This made it look as if the model was only usable through the generative-AI provider. The maintainer confirmed that it should work in Vertex and that the docs and model IDs just needed an update. This PR adds the missing model entry and updates the documentation so users can actually see and use the model through the Vertex provider.

## Summary

This PR adds the Gemini 2.5 Flash Image model to the Google Vertex AI provider.
- Added model `gemini-2.5-flash-image-preview` to `GoogleVertexModelId` in `packages/google-vertex/src/google-vertex-options.ts`
- Updated the model capabilities table in the documentation of vertex

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
