### PR TITLE
add nano banana example in google vertex ai docs

### DIFF
--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -660,7 +660,7 @@ The following Zod features are known to not work with Google Vertex:
 ### Model Capabilities
 
 | Model                    | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
-| ----------------------   | ------------------- | ------------------- | ------------------- | ------------------- |
+| ------------------------ | ------------------- | ------------------- | ------------------- | ------------------- |
 | `gemini-2.0-flash-001`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-2.0-flash-exp`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-1.5-flash`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -546,6 +546,28 @@ const { text } = await generateText({
 
 See [File Parts](/docs/foundations/prompts#file-parts) for details on how to use files in prompts.
 
+#### Image Outputs
+
+Gemini models with image generation capabilities (`gemini-2.5-flash-image`) support image generation. Images are exposed as files in the response.
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText } from 'ai';
+
+// so far, it seems nano banana only works in "global" region
+const result = await generateText({
+  model: vertex('gemini-2.5-flash-image'),
+  prompt:
+    'Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme',
+});
+
+for (const file of result.files) {
+  if (file.mediaType.startsWith('image/')) {
+    console.log('Generated image:', file);
+  }
+}
+```
+
 ### Safety Ratings
 
 The safety ratings provide insight into the safety of the model's response.
@@ -637,12 +659,13 @@ The following Zod features are known to not work with Google Vertex:
 
 ### Model Capabilities
 
-| Model                  | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
-| ---------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `gemini-2.0-flash-001` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-2.0-flash-exp` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-flash`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `gemini-1.5-pro`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| Model                    | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
+| ----------------------   | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gemini-2.0-flash-001`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-2.0-flash-exp`   | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-flash`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-1.5-pro`         | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `gemini-2.5-flash-image` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 
 <Note>
   The table above lists popular models. Please see the [Google Vertex AI

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -5,6 +5,7 @@ export type GoogleVertexModelId =
   // Stable models
   | 'gemini-2.5-pro'
   | 'gemini-2.5-flash'
+  | 'gemini-2.5-flash-image'
   | 'gemini-2.5-flash-lite'
   | 'gemini-2.0-flash-lite'
   | 'gemini-2.0-flash'
@@ -23,6 +24,7 @@ export type GoogleVertexModelId =
   | 'gemini-2.0-flash-lite-preview-02-05'
   | 'gemini-2.5-flash-lite-preview-09-2025'
   | 'gemini-2.5-flash-preview-09-2025'
+  | 'gemini-2.5-flash-image-preview'
   | 'gemini-3-pro-preview'
   | 'gemini-3-pro-image-preview'
   | 'gemini-3-flash-preview'


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/10516

## Summary

adding a image generation example using nano banana model in google vertex AI. basically I am copying the example from google generative AI to vertex AI. https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai#image-outputs

## Manual Verification

I run the code in the example and it works.

## Checklist

- [ ] n/a ~~Tests have been added / updated (for bug fixes / features)~~
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] n/a ~~A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)~~
- [x] I have reviewed this pull request (self-review)

## Related Issues

closes #10516