### PR TITLE
fix: docs unescaped characters in mcp sampling provider page

### DIFF
--- a/content/providers/03-community-providers/100-mcp-sampling.mdx
+++ b/content/providers/03-community-providers/100-mcp-sampling.mdx
@@ -101,7 +101,7 @@ const model = provider.languageModel({
 
 The `languageModel()` method accepts optional model preferences:
 
-- **hints** _Array<{ name: string }>_
+- **hints** _Array\<\{ name: string \}\>_
 
   Array of model name hints (e.g., `[{ name: "gpt-5-mini" }]`). These suggest preferred models to the MCP client.
 


### PR DESCRIPTION
Docs are not building because of unescaped character.