### PR TITLE
feat(agent): add experimental_download to ToolLoopAgent

### DIFF
--- a/.changeset/stale-moose-marry.md
+++ b/.changeset/stale-moose-marry.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(agent): add experimental_download to ToolLoopAgent

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -285,6 +285,13 @@ for await (const chunk of stream.textStream) {
       isOptional: true,
       description:
         'Optional stream transformation(s). They are applied in the order provided and must maintain the stream structure. See `streamText` docs for details.',
+    },
+  ]}
+/>
+
+#### Returns
+
+The `stream()` method returns a `StreamTextResult` object (see [`streamText`](/docs/reference/ai-sdk-core/stream-text#returns) for details).
 
 ## Types
 

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -124,6 +124,13 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       description: 'Experimental: Optional telemetry configuration.',
     },
     {
+      name: 'experimental_download',
+      type: 'DownloadFunction | undefined',
+      isOptional: true,
+      description:
+        'Experimental: Custom download function for fetching files/URLs for tool or model use. By default, files are downloaded if the model does not support the URL for a given media type.',
+    },
+    {
       name: 'maxOutputTokens',
       type: 'number',
       isOptional: true,
@@ -278,13 +285,6 @@ for await (const chunk of stream.textStream) {
       isOptional: true,
       description:
         'Optional stream transformation(s). They are applied in the order provided and must maintain the stream structure. See `streamText` docs for details.',
-    },
-  ]}
-/>
-
-#### Returns
-
-The `stream()` method returns a `StreamTextResult` object (see [`streamText`](/docs/reference/ai-sdk-core/stream-text#returns) for details).
 
 ## Types
 

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -12,6 +12,7 @@ import { CallSettings } from '../prompt/call-settings';
 import { Prompt } from '../prompt/prompt';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
 import { LanguageModel, ToolChoice } from '../types/language-model';
+import { DownloadFunction } from '../util/download/download-function';
 import { AgentCallParameters } from './agent';
 import { ToolLoopAgentOnFinishCallback } from './tool-loop-agent-on-finish-callback';
 import { ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-finish-callback';
@@ -112,6 +113,13 @@ functionality that can be fully encapsulated in the provider.
   experimental_context?: unknown;
 
   /**
+Custom download function to use for URLs.
+
+By default, files are downloaded if the model does not support the URL for the given media type.
+     */
+  experimental_download?: DownloadFunction | undefined;
+
+  /**
    * The schema for the call options.
    */
   callOptionsSchema?: FlexibleSchema<CALL_OPTIONS>;
@@ -142,6 +150,7 @@ functionality that can be fully encapsulated in the provider.
         | 'activeTools'
         | 'providerOptions'
         | 'experimental_context'
+        | 'experimental_download'
       >,
   ) => MaybePromiseLike<
     Pick<
@@ -163,6 +172,7 @@ functionality that can be fully encapsulated in the provider.
       | 'activeTools'
       | 'providerOptions'
       | 'experimental_context'
+      | 'experimental_download'
     > &
       Omit<Prompt, 'system'>
   >;

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -83,55 +83,53 @@ describe('ToolLoopAgent', () => {
       expect(doGenerateOptions?.abortSignal).toBe(abortController.signal);
     });
 
-    describe('with generateText spy', () => {
-      it('should pass experimental_download to generateText', async () => {
-        const downloadFunction = vi
-          .fn()
-          .mockResolvedValue([
-            { data: new Uint8Array([1, 2, 3]), mediaType: 'image/png' },
-          ]);
-
-        const agent = new ToolLoopAgent({
-          model: new MockLanguageModelV3({
-            doGenerate: async options => {
-              return {
-                finishReason: 'stop' as const,
-                usage: {
-                  inputTokens: 3,
-                  outputTokens: 10,
-                  totalTokens: 13,
-                  reasoningTokens: undefined,
-                  cachedInputTokens: undefined,
-                },
-                warnings: [],
-                content: [{ type: 'text', text: 'reply' }],
-              };
-            },
-          }),
-          experimental_download: downloadFunction,
-        });
-
-        await agent.generate({
-          prompt: [
-            {
-              role: 'user',
-              content: [
-                {
-                  type: 'image',
-                  image: new URL('https://example.com/image.png'),
-                },
-              ],
-            },
-          ],
-        });
-
-        expect(downloadFunction).toHaveBeenCalledWith([
-          {
-            url: new URL('https://example.com/image.png'),
-            isUrlSupportedByModel: false,
-          },
+    it('should pass experimental_download to generateText', async () => {
+      const downloadFunction = vi
+        .fn()
+        .mockResolvedValue([
+          { data: new Uint8Array([1, 2, 3]), mediaType: 'image/png' },
         ]);
+
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV3({
+          doGenerate: async () => {
+            return {
+              finishReason: 'stop' as const,
+              usage: {
+                inputTokens: 3,
+                outputTokens: 10,
+                totalTokens: 13,
+                reasoningTokens: undefined,
+                cachedInputTokens: undefined,
+              },
+              warnings: [],
+              content: [{ type: 'text', text: 'reply' }],
+            };
+          },
+        }),
+        experimental_download: downloadFunction,
       });
+
+      await agent.generate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                image: new URL('https://example.com/image.png'),
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(downloadFunction).toHaveBeenCalledWith([
+        {
+          url: new URL('https://example.com/image.png'),
+          isUrlSupportedByModel: false,
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Background

The `ToolLoopAgent` did not support the `experimental_download` setting from `generateText` and `streamText`.

## Summary

Add `experimental_download` to `ToolLoopAgent`.

## Related Issues

Fixes #10288