### PR TITLE
fix(packages/provider): fix 'CallWarning' and allow strings as type

### DIFF
--- a/.changeset/unlucky-bobcats-sing.md
+++ b/.changeset/unlucky-bobcats-sing.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider': patch
+---
+
+fix(packages/provider): fix CallWarning and allow strings as type

--- a/packages/provider/src/language-model/v3/language-model-v3-call-warning.ts
+++ b/packages/provider/src/language-model/v3/language-model-v3-call-warning.ts
@@ -10,7 +10,9 @@ some settings might not be supported, which can lead to suboptimal results.
 export type LanguageModelV3CallWarning =
   | {
       type: 'unsupported-setting';
-      setting: Omit<keyof LanguageModelV3CallOptions, 'prompt'>; // TODO allow string
+      setting:
+        | Exclude<keyof LanguageModelV3CallOptions, 'prompt'>
+        | (string & {});
       details?: string;
     }
   | {


### PR DESCRIPTION
## Background

#7906

`Omit` removes keys from objects, but `keyof` produces a union of strings ans hence there was type mismatch

## Summary

- `Exlcude` was used as the correct utility to remove the 'prompt'
- string types are now allowed

## Manual Verification

Type safety can be checked from the following code snippet:
```
function testV3Warning(warning: LanguageModelV3CallWarning | undefined) {
  if (warning?.type === 'unsupported-setting') {
    
    const what: string = warning.setting;
//          ^- this will be an error:
//      Type 'Omit<keyof LanguageModelV3CallOptions, "prompt">' is not assignable to type 'string'.
  }
}

const mockV3Warning: LanguageModelV3CallWarning = {
  type: 'unsupported-setting',
  setting: 'maxOutputTokens',
  details: 'maxOutputTokens not supported',
};

testV3Warning(mockV3Warning);
```

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] ~~Documentation has been added / updated (for bug fixes / features)~~
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)

## Related Issues

Fixes #7906