### PR TITLE
feat(ai): support SystemModelMessage in system and instructions properties

### DIFF
--- a/.changeset/wild-hornets-punch.md
+++ b/.changeset/wild-hornets-punch.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): support SystemModelMessage in system and instructions properties

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -40,7 +40,7 @@ To see `generateText` in action, check out [these examples](#examples).
     },
     {
       name: 'system',
-      type: 'string',
+      type: 'string | SystemModelMessage',
       description:
         'The system prompt to use that specifies the behavior of the model.',
     },
@@ -581,7 +581,7 @@ To see `generateText` in action, check out [these examples](#examples).
               description: 'Change which tools are active for this step.',
             },
             {
-              name: 'system',
+              name: 'system | SystemModelMessage',
               type: 'string',
               isOptional: true,
               description: 'Change the system prompt for this step.',
@@ -622,7 +622,7 @@ To see `generateText` in action, check out [these examples](#examples).
           parameters: [
             {
               name: 'system',
-              type: 'string | undefined',
+              type: 'string | SystemModelMessage | undefined',
               description: 'The system prompt.',
             },
             {

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -42,7 +42,7 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'system',
-      type: 'string',
+      type: 'string | SystemModelMessage',
       description:
         'The system prompt to use that specifies the behavior of the model.',
     },
@@ -633,7 +633,7 @@ To see `streamText` in action, check out [these examples](#examples).
             },
             {
               name: 'system',
-              type: 'string',
+              type: 'string | SystemModelMessage',
               isOptional: true,
               description: 'Change the system prompt for this step.',
             },
@@ -673,7 +673,7 @@ To see `streamText` in action, check out [these examples](#examples).
           parameters: [
             {
               name: 'system',
-              type: 'string | undefined',
+              type: 'string | SystemModelMessage | undefined',
               description: 'The system prompt.',
             },
             {

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -151,7 +151,7 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
     },
     {
       name: 'system',
-      type: 'string',
+      type: 'string | SystemModelMessage',
       description:
         'The system prompt to use that specifies the behavior of the model.',
     },

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -156,7 +156,7 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
         Not available with 'no-schema' or 'enum' output.",
     },
     {
-      name: 'system',
+      name: 'system | SystemModelMessage',
       type: 'string',
       description:
         'The system prompt to use that specifies the behavior of the model.',

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -49,7 +49,7 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
     },
     {
       name: 'instructions',
-      type: 'string',
+      type: 'string | SystemModelMessage',
       isOptional: true,
       description:
         'Instructions for the agent, usually used for system prompt/context.',

--- a/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
+++ b/content/docs/07-reference/03-ai-sdk-rsc/01-stream-ui.mdx
@@ -36,7 +36,7 @@ To see `streamUI` in action, check out [these examples](#examples).
     },
     {
       name: 'system',
-      type: 'string',
+      type: 'string | SystemModelMessage',
       description:
         'The system prompt to use that specifies the behavior of the model.',
     },

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -331,8 +331,10 @@ const result = await generateText({
 
 The minimum cacheable prompt length is:
 
-- 1024 tokens for Claude 3.7 Sonnet, Claude 3.5 Sonnet and Claude 3 Opus
-- 2048 tokens for Claude 3.5 Haiku and Claude 3 Haiku
+- 4096 tokens for Claude Opus 4.5
+- 1024 tokens for Claude Opus 4.1, Claude Opus 4, Claude Sonnet 4.5, Claude Sonnet 4, Claude Sonnet 3.7, and Claude Opus 3
+- 4096 tokens for Claude Haiku 4.5
+- 2048 tokens for Claude Haiku 3.5 and Claude Haiku 3
 
 Shorter prompts cannot be cached, even if marked with `cacheControl`. Any requests to cache fewer than this number of tokens will be processed without caching.
 

--- a/examples/ai-core/src/agent/anthropic-cache-instruction.ts
+++ b/examples/ai-core/src/agent/anthropic-cache-instruction.ts
@@ -1,0 +1,29 @@
+import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { ToolLoopAgent } from 'ai';
+import fs from 'node:fs';
+import { print } from '../lib/print';
+import { run } from '../lib/run';
+
+const errorMessage = fs.readFileSync('data/error-message.txt', 'utf8');
+
+const agent = new ToolLoopAgent({
+  model: anthropic('claude-sonnet-4-5'),
+  instructions: {
+    role: 'system',
+    content: `You are a JavaScript expert that knows everything about the following error message: ${errorMessage}`,
+    providerOptions: {
+      anthropic: {
+        cacheControl: { type: 'ephemeral' },
+      } satisfies AnthropicProviderOptions,
+    },
+  },
+});
+
+run(async () => {
+  const result = await agent.generate({
+    prompt: 'Explain the error message.',
+  });
+
+  print('Result:', result.content);
+  print('Metadata:', result.providerMetadata?.anthropic);
+});

--- a/examples/ai-core/src/generate-text/anthropic-cache-control.ts
+++ b/examples/ai-core/src/generate-text/anthropic-cache-control.ts
@@ -1,4 +1,4 @@
-import { anthropic } from '@ai-sdk/anthropic';
+import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 import 'dotenv/config';
 import fs from 'node:fs';
@@ -21,8 +21,8 @@ async function main() {
             text: `Error message: ${errorMessage}`,
             providerOptions: {
               anthropic: {
-                cacheControl: { type: 'ephemeral' },
-              },
+                cacheControl: { type: 'ephemeral', ttl: '1h' },
+              } satisfies AnthropicProviderOptions,
             },
           },
           {

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -2,6 +2,7 @@ import {
   FlexibleSchema,
   MaybePromiseLike,
   ProviderOptions,
+  SystemModelMessage,
 } from '@ai-sdk/provider-utils';
 import { Output } from '../generate-text/output';
 import { PrepareStepFunction } from '../generate-text/prepare-step';
@@ -32,8 +33,10 @@ export type ToolLoopAgentSettings<
 
   /**
    * The instructions for the agent.
+   *
+   * It can be a string, or, if you need to pass additional provider options (e.g. for caching), a `SystemModelMessage`.
    */
-  instructions?: string;
+  instructions?: string | SystemModelMessage;
 
   /**
 The language model to use.

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -154,6 +154,11 @@ describe('ToolLoopAgent', () => {
         [
           {
             "content": "INSTRUCTIONS",
+            "providerOptions": {
+              "test": {
+                "value": "test",
+              },
+            },
             "role": "system",
           },
           {

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -134,23 +134,22 @@ describe('ToolLoopAgent', () => {
           ]
         `);
       });
-    });
 
-    it('should pass system message instructions', async () => {
-      const agent = new ToolLoopAgent({
-        model: mockModel,
-        instructions: {
-          role: 'system',
-          content: 'INSTRUCTIONS',
-          providerOptions: { test: { value: 'test' } },
-        },
-      });
+      it('should pass system message instructions', async () => {
+        const agent = new ToolLoopAgent({
+          model: mockModel,
+          instructions: {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+            providerOptions: { test: { value: 'test' } },
+          },
+        });
 
-      await agent.generate({
-        prompt: 'Hello, world!',
-      });
+        await agent.generate({
+          prompt: 'Hello, world!',
+        });
 
-      expect(doGenerateOptions?.prompt).toMatchInlineSnapshot(`
+        expect(doGenerateOptions?.prompt).toMatchInlineSnapshot(`
         [
           {
             "content": "INSTRUCTIONS",
@@ -173,6 +172,7 @@ describe('ToolLoopAgent', () => {
           },
         ]
       `);
+      });
     });
   });
 
@@ -268,6 +268,79 @@ describe('ToolLoopAgent', () => {
       await result.consumeStream();
 
       expect(doStreamOptions?.abortSignal).toBe(abortController.signal);
+    });
+
+    it('should pass string instructions', async () => {
+      const agent = new ToolLoopAgent({
+        model: mockModel,
+        instructions: 'INSTRUCTIONS',
+      });
+
+      const result = await agent.stream({
+        prompt: 'Hello, world!',
+      });
+
+      await result.consumeStream();
+
+      expect(doStreamOptions?.prompt).toMatchInlineSnapshot(`
+        [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "providerOptions": undefined,
+            "role": "user",
+          },
+        ]
+      `);
+    });
+
+    it('should pass system message instructions', async () => {
+      const agent = new ToolLoopAgent({
+        model: mockModel,
+        instructions: {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+          providerOptions: { test: { value: 'test' } },
+        },
+      });
+
+      const result = await agent.stream({
+        prompt: 'Hello, world!',
+      });
+
+      await result.consumeStream();
+
+      expect(doStreamOptions?.prompt).toMatchInlineSnapshot(`
+      [
+        {
+          "content": "INSTRUCTIONS",
+          "providerOptions": {
+            "test": {
+              "value": "test",
+            },
+          },
+          "role": "system",
+        },
+        {
+          "content": [
+            {
+              "text": "Hello, world!",
+              "type": "text",
+            },
+          ],
+          "providerOptions": undefined,
+          "role": "user",
+        },
+      ]
+    `);
     });
   });
 });

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -135,6 +135,40 @@ describe('ToolLoopAgent', () => {
         `);
       });
     });
+
+    it('should pass system message instructions', async () => {
+      const agent = new ToolLoopAgent({
+        model: mockModel,
+        instructions: {
+          role: 'system',
+          content: 'INSTRUCTIONS',
+          providerOptions: { test: { value: 'test' } },
+        },
+      });
+
+      await agent.generate({
+        prompt: 'Hello, world!',
+      });
+
+      expect(doGenerateOptions?.prompt).toMatchInlineSnapshot(`
+        [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "providerOptions": undefined,
+            "role": "user",
+          },
+        ]
+      `);
+    });
   });
 
   describe('stream', () => {

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -68,6 +68,8 @@ export class ToolLoopAgent<
 
     const { instructions, messages, prompt, ...callArgs } = preparedCallArgs;
 
+    // TODO figure out how to handle different instruction types
+
     return {
       ...callArgs,
 

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -68,8 +68,6 @@ export class ToolLoopAgent<
 
     const { instructions, messages, prompt, ...callArgs } = preparedCallArgs;
 
-    // TODO figure out how to handle different instruction types
-
     return {
       ...callArgs,
 

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -4,6 +4,7 @@ import {
   ModelMessage,
   safeParseJSON,
   safeValidateTypes,
+  SystemModelMessage,
 } from '@ai-sdk/provider-utils';
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
@@ -22,7 +23,7 @@ export async function parseToolCall<TOOLS extends ToolSet>({
   toolCall: LanguageModelV3ToolCall;
   tools: TOOLS | undefined;
   repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;
-  system: string | undefined;
+  system: string | SystemModelMessage | undefined;
   messages: ModelMessage[];
 }): Promise<TypedToolCall<TOOLS>> {
   try {

--- a/packages/ai/src/generate-text/prepare-step.ts
+++ b/packages/ai/src/generate-text/prepare-step.ts
@@ -1,4 +1,4 @@
-import { ModelMessage, Tool } from '@ai-sdk/provider-utils';
+import { ModelMessage, SystemModelMessage, Tool } from '@ai-sdk/provider-utils';
 import { LanguageModel, ToolChoice } from '../types/language-model';
 import { StepResult } from './step-result';
 
@@ -29,7 +29,7 @@ export type PrepareStepResult<
       model?: LanguageModel;
       toolChoice?: ToolChoice<NoInfer<TOOLS>>;
       activeTools?: Array<keyof NoInfer<TOOLS>>;
-      system?: string;
+      system?: string | SystemModelMessage;
       messages?: Array<ModelMessage>;
     }
   | undefined;

--- a/packages/ai/src/generate-text/run-tools-transformation.ts
+++ b/packages/ai/src/generate-text/run-tools-transformation.ts
@@ -6,6 +6,7 @@ import {
   getErrorMessage,
   IdGenerator,
   ModelMessage,
+  SystemModelMessage,
 } from '@ai-sdk/provider-utils';
 import { Tracer } from '@opentelemetry/api';
 import { TelemetrySettings } from '../telemetry/telemetry-settings';
@@ -120,7 +121,7 @@ export function runToolsTransformation<TOOLS extends ToolSet>({
   generatorStream: ReadableStream<LanguageModelV3StreamPart>;
   tracer: Tracer;
   telemetry: TelemetrySettings | undefined;
-  system: string | undefined;
+  system: string | SystemModelMessage | undefined;
   messages: ModelMessage[];
   abortSignal: AbortSignal | undefined;
   repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;

--- a/packages/ai/src/generate-text/tool-call-repair-function.ts
+++ b/packages/ai/src/generate-text/tool-call-repair-function.ts
@@ -1,7 +1,7 @@
 import { JSONSchema7, LanguageModelV3ToolCall } from '@ai-sdk/provider';
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
-import { ModelMessage } from '../prompt';
+import { ModelMessage, SystemModelMessage } from '../prompt';
 import { ToolSet } from './tool-set';
 
 /**
@@ -18,7 +18,7 @@ import { ToolSet } from './tool-set';
  * @param options.error - The error that occurred while parsing the tool call.
  */
 export type ToolCallRepairFunction<TOOLS extends ToolSet> = (options: {
-  system: string | undefined;
+  system: string | SystemModelMessage | undefined;
   messages: ModelMessage[];
   toolCall: LanguageModelV3ToolCall;
   tools: TOOLS;

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -6,6 +6,77 @@ import {
 } from './convert-to-language-model-prompt';
 
 describe('convertToLanguageModelPrompt', () => {
+  describe('system message', () => {
+    it('should convert a string system message', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          system: 'INSTRUCTIONS',
+          messages: [{ role: 'user', content: 'Hello, world!' }],
+        },
+        supportedUrls: {},
+        download: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": "INSTRUCTIONS",
+            "role": "system",
+          },
+          {
+            "content": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "providerOptions": undefined,
+            "role": "user",
+          },
+        ]
+      `);
+    });
+
+    it('should convert a SystemModelMessage system message', async () => {
+      const result = await convertToLanguageModelPrompt({
+        prompt: {
+          system: {
+            role: 'system',
+            content: 'INSTRUCTIONS',
+            providerOptions: { test: { value: 'test' } },
+          },
+          messages: [{ role: 'user', content: 'Hello, world!' }],
+        },
+        supportedUrls: {},
+        download: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "content": "INSTRUCTIONS",
+            "providerOptions": {
+              "test": {
+                "value": "test",
+              },
+            },
+            "role": "system",
+          },
+          {
+            "content": [
+              {
+                "text": "Hello, world!",
+                "type": "text",
+              },
+            ],
+            "providerOptions": undefined,
+            "role": "user",
+          },
+        ]
+      `);
+    });
+  });
+
   describe('user message', () => {
     describe('image parts', () => {
       it('should download images for user image parts with URLs when model does not support image URLs', async () => {

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -46,7 +46,15 @@ export async function convertToLanguageModelPrompt({
 
   const messages = [
     ...(prompt.system != null
-      ? [{ role: 'system' as const, content: prompt.system }]
+      ? typeof prompt.system === 'string'
+        ? [{ role: 'system' as const, content: prompt.system }]
+        : [
+            {
+              role: 'system' as const,
+              content: prompt.system.content,
+              providerOptions: prompt.system.providerOptions,
+            },
+          ]
       : []),
     ...prompt.messages.map(message =>
       convertToLanguageModelMessage({ message, downloadedAssets }),

--- a/packages/ai/src/prompt/prompt.ts
+++ b/packages/ai/src/prompt/prompt.ts
@@ -1,4 +1,4 @@
-import { ModelMessage } from '@ai-sdk/provider-utils';
+import { ModelMessage, SystemModelMessage } from '@ai-sdk/provider-utils';
 
 /**
 Prompt part of the AI function options.
@@ -8,7 +8,7 @@ export type Prompt = {
   /**
 System message to include in the prompt. Can be used with `prompt` or `messages`.
    */
-  system?: string;
+  system?: string | SystemModelMessage;
 } & (
   | {
       /**

--- a/packages/ai/src/prompt/standardize-prompt.test.ts
+++ b/packages/ai/src/prompt/standardize-prompt.test.ts
@@ -2,7 +2,7 @@ import { InvalidPromptError } from '@ai-sdk/provider';
 import { standardizePrompt } from './standardize-prompt';
 import { describe, it, expect } from 'vitest';
 
-describe('message prompt', () => {
+describe('standardizePrompt', () => {
   it('should throw InvalidPromptError when system message has parts', async () => {
     await expect(async () => {
       await standardizePrompt({
@@ -22,5 +22,30 @@ describe('message prompt', () => {
         messages: [],
       });
     }).rejects.toThrow(InvalidPromptError);
+  });
+
+  it('should support SystemModelMessage system message', async () => {
+    const result = await standardizePrompt({
+      system: {
+        role: 'system',
+        content: 'INSTRUCTIONS',
+      },
+      prompt: 'Hello, world!',
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello, world!",
+            "role": "user",
+          },
+        ],
+        "system": {
+          "content": "INSTRUCTIONS",
+          "role": "system",
+        },
+      }
+    `);
   });
 });

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -1,5 +1,9 @@
 import { InvalidPromptError } from '@ai-sdk/provider';
-import { ModelMessage, safeValidateTypes } from '@ai-sdk/provider-utils';
+import {
+  ModelMessage,
+  safeValidateTypes,
+  SystemModelMessage,
+} from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { modelMessageSchema } from './message';
 import { Prompt } from './prompt';
@@ -8,7 +12,7 @@ export type StandardizedPrompt = {
   /**
    * System message.
    */
-  system?: string;
+  system?: string | SystemModelMessage;
 
   /**
    * Messages.
@@ -33,8 +37,13 @@ export async function standardizePrompt(
     });
   }
 
-  // validate that system is a string
-  if (prompt.system != null && typeof prompt.system !== 'string') {
+  // validate that system is a string or a SystemModelMessage
+  if (
+    prompt.system != null &&
+    typeof prompt.system !== 'string' &&
+    'type' in prompt.system &&
+    prompt.system.type !== 'system'
+  ) {
     throw new InvalidPromptError({
       prompt,
       message: 'system must be a string',

--- a/packages/ai/src/prompt/standardize-prompt.ts
+++ b/packages/ai/src/prompt/standardize-prompt.ts
@@ -41,8 +41,8 @@ export async function standardizePrompt(
   if (
     prompt.system != null &&
     typeof prompt.system !== 'string' &&
-    'type' in prompt.system &&
-    prompt.system.type !== 'system'
+    'role' in prompt.system &&
+    prompt.system.role !== 'system'
   ) {
     throw new InvalidPromptError({
       prompt,


### PR DESCRIPTION
## Background

Agent instructions may need provider options, e.g. for caching (see #10329 ).

## Summary

* allow `SystemModelMessage` in `system` property on `Prompt` (**breaking change** on tool call repair functions)
* allow `SystemModelMessage` in agent instructions

## Manual Verification

- [x] run `examples/ai-core/src/agent/anthropic-cache-instruction.ts` twice and check caching stats

## Tasks

- [x] add to settings
- [x] refactor generate test
- [x] add 2 cases to generate test
- [x] update and test convert to language model prompt
- [x] update and test standardizePrompt
- [x] refactor stream test
- [x] add 2 cases to stream test
- [x] implement tool loop agent changes
- [x] docs: reference for streamText etc
- [x] docs: agent
- [x] changeset

## Related Issues

Resolves #10329