### PR TITLE
fix(gateway): convert execution-denied tool results to text

### DIFF
--- a/.changeset/three-panthers-notice.md
+++ b/.changeset/three-panthers-notice.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): convert execution-denied tool results to text


### PR DESCRIPTION
## Background

When a user denies a tool execution approval (answers "n" to an approval prompt), the SDK creates a tool result with `output: { type: 'execution-denied' }`. The Gateway API doesn't recognize this type, returning `GatewayInvalidRequestError: Invalid input` at `"prompt",3,"content",0,"output"`.

Other providers (OpenAI, Anthropic, Mistral, etc.) handle this by converting `execution-denied` to plain text in their message converters before sending to their APIs.

## Summary

- Renamed `maybeEncodeFileParts()` → `preparePrompt()` to reflect its broader responsibility
- Added conversion of `execution-denied` tool results to `{ type: 'text', value: reason }` before sending to Gateway API
- Added tests for the conversion

## Manual Verification

1. Run `examples/ai-core/src/stream-text/openai-tool-approval.ts`
2. Change provider/model to use gateway
3. Ask for weather somewhere, then reject the execution approval
4. Verify no error is thrown and the model responds appropriately

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues
Fixes #10663 