### PR TITLE
fix(ai): prevent error-prone manual tool retrieval

### DIFF
--- a/.changeset/dry-years-look.md
+++ b/.changeset/dry-years-look.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+Introduce getTool utility function which improves tool retrieval by also checking name property in tool definition

--- a/packages/ai/src/generate-text/execute-tool-call.ts
+++ b/packages/ai/src/generate-text/execute-tool-call.ts
@@ -9,6 +9,7 @@ import { ToolOutput } from './tool-output';
 import { ToolSet } from './tool-set';
 import { TypedToolResult } from './tool-result';
 import { TypedToolError } from './tool-error';
+import { getTool } from '../util/get-tool';
 
 export async function executeToolCall<TOOLS extends ToolSet>({
   toolCall,
@@ -30,7 +31,8 @@ export async function executeToolCall<TOOLS extends ToolSet>({
   onPreliminaryToolResult?: (result: TypedToolResult<TOOLS>) => void;
 }): Promise<ToolOutput<TOOLS> | undefined> {
   const { toolName, toolCallId, input } = toolCall;
-  const tool = tools?.[toolName];
+
+  const tool = getTool(toolName, tools) as TOOLS[keyof TOOLS & string];
 
   if (tool?.execute == null) {
     return undefined;

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -62,6 +62,7 @@ import { ToolOutput } from './tool-output';
 import { TypedToolResult } from './tool-result';
 import { ToolSet } from './tool-set';
 import { NoOutputGeneratedError } from '../error';
+import { getTool } from '../util/get-tool';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -565,7 +566,10 @@ A function that attempts to repair a tool call that failed to parse.
               continue; // ignore invalid tool calls
             }
 
-            const tool = tools?.[toolCall.toolName];
+            const tool = getTool(
+              toolCall.toolName,
+              tools,
+            ) as TOOLS[keyof TOOLS & string];
 
             if (tool == null) {
               // ignore tool calls for tools that are not available,

--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -11,6 +11,7 @@ import { ToolCallRepairError } from '../error/tool-call-repair-error';
 import { DynamicToolCall, TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { ToolSet } from './tool-set';
+import { getTool } from '../util/get-tool';
 
 export async function parseToolCall<TOOLS extends ToolSet>({
   toolCall,
@@ -131,7 +132,7 @@ async function doParseToolCall<TOOLS extends ToolSet>({
 }): Promise<TypedToolCall<TOOLS>> {
   const toolName = toolCall.toolName as keyof TOOLS & string;
 
-  const tool = tools[toolName];
+  const tool = getTool(toolName, tools) as TOOLS[keyof TOOLS & string];
 
   if (tool == null) {
     // provider-executed dynamic tools are not part of our list of tools:

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -91,6 +91,7 @@ import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { ToolOutput } from './tool-output';
 import { StaticToolOutputDenied } from './tool-output-denied';
 import { ToolSet } from './tool-set';
+import { getTool } from '../util/get-tool';
 
 const originalGenerateId = createIdGenerator({
   prefix: 'aitxt',
@@ -1475,7 +1476,11 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
 
                     case 'tool-input-delta': {
                       const toolName = activeToolCallToolNames[chunk.id];
-                      const tool = tools?.[toolName];
+
+                      const tool = getTool(
+                        toolName,
+                        tools,
+                      ) as TOOLS[keyof TOOLS & string];
 
                       if (tool?.onInputDelta != null) {
                         await tool.onInputDelta({

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -27,6 +27,7 @@ import {
   ToolUIPart,
   UIMessage,
 } from './ui-messages';
+import { getTool } from '../util/get-tool';
 
 /**
 Converts an array of UI messages from useChat into an array of ModelMessages that can be used
@@ -210,7 +211,10 @@ export function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                           part.state === 'output-error'
                             ? part.errorText
                             : part.output,
-                        tool: options?.tools?.[toolName],
+                        tool: getTool(
+                          toolName,
+                          options?.tools,
+                        ) as ToolSet[keyof ToolSet & string],
                         errorMode:
                           part.state === 'output-error' ? 'json' : 'none',
                       }),
@@ -298,7 +302,10 @@ export function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                               toolPart.state === 'output-error'
                                 ? toolPart.errorText
                                 : toolPart.output,
-                            tool: options?.tools?.[toolName],
+                            tool: getTool(
+                              toolName,
+                              options?.tools,
+                            ) as ToolSet[keyof ToolSet & string],
                             errorMode:
                               toolPart.state === 'output-error'
                                 ? 'text'

--- a/packages/ai/src/util/get-tool.test.ts
+++ b/packages/ai/src/util/get-tool.test.ts
@@ -1,0 +1,38 @@
+import { tool } from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+import z from 'zod';
+import { getTool } from './get-tool';
+
+describe('getTool', () => {
+  it('gets tool by name attribute', () => {
+    const tools = {
+      weatherTool: tool({ name: 'weather', inputSchema: z.object({}) }),
+      bashTool: tool({ name: 'bash', inputSchema: z.object({}) }),
+    };
+
+    const weather = getTool('weather', tools);
+    expect(weather).toBeDefined();
+
+    const bash = getTool('bash', tools);
+    expect(bash).toBeDefined();
+
+    const weatherTool = getTool('weatherTool', tools);
+    expect(weatherTool).toBeDefined();
+  });
+
+  it('gets tool by key value when name is undefined', () => {
+    const tools = {
+      weatherTool: tool({ inputSchema: z.object({}) }),
+      bashTool: tool({ inputSchema: z.object({}) }),
+    };
+
+    const weather = getTool('weatherTool', tools);
+    expect(weather).toBeDefined();
+
+    const bash = getTool('bashTool', tools);
+    expect(bash).toBeDefined();
+
+    const errorTool = getTool('error-tool', tools);
+    expect(errorTool).toBeUndefined();
+  });
+});

--- a/packages/ai/src/util/get-tool.ts
+++ b/packages/ai/src/util/get-tool.ts
@@ -1,0 +1,15 @@
+import type { ToolSet } from 'ai';
+
+/**
+This function gets tool from tools object based on the either:
+- name property in tool definition
+- the key value in the object itself
+ * */
+export function getTool(toolName: string, tools: ToolSet | undefined) {
+  if (!tools) return undefined;
+
+  return (
+    Object.entries(tools).find(([_, tool]) => tool?.name === toolName) ??
+    tools[toolName]
+  );
+}

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -104,6 +104,12 @@ export type Tool<
   OUTPUT extends JSONValue | unknown | never = any,
 > = {
   /**
+An optional name for the tool
+This is usually used by provider-defined tools
+   */
+  name?: string;
+
+  /**
 An optional description of what the tool does.
 Will be used by the language model to decide whether to use the tool.
 Not used for provider-defined tools.


### PR DESCRIPTION
Introduced `getTools(toolName, tools)` utility for getting tool out of tools object

The previous way uses the user-defined key from tools object, some tools (provider-defined tools) will not work if user has set key that does not match the one on name property in tool. With `getTools` it will look for tools based on name property, if not found it will fallback to the default bahaviour (looking tool name from tools object)

<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Some tools like `openai.web_search` require the tool to be defined in key `web_search` for LLM to be able to call it and work, if it is defined on `webSearch` or `Web_search` it will not work

## Summary

I've added a utility function `getTool` to replace `tools?.[toolName]` which works by finding tool based on the `name` property in tool definition, otherwise fallback to default key lookup

## Manual Verification

On the current version the following code would not work because code execution tool requires the key to  be `code_execution`:

```typescript
  const content = await generateText({
    model: google("gemini-2.5-flash"),
    prompt: "use python to calclate the 20th fibonacci number",
    tools: {
      codeExecution,
    },
  });

```

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes  #10472
