### PR TITLE
chore(anthropic): update test case to include event: error

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -4920,7 +4920,9 @@ describe('AnthropicMessagesLanguageModel', () => {
       server.urls['https://api.anthropic.com/v1/messages'].response = {
         type: 'stream-chunks',
         chunks: [
-          `data: {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}\n\n`,
+          `event: error\n`,
+          `data: {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}\n`,
+          `\n`,
         ],
       };
 

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -4988,6 +4988,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           `data: {"type":"message_start","message":{"id":"msg_01KfpJoAEabmH2iHRRFjQMAG","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
           `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`,
           `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n`,
+          `event: error\n`,
           `data: {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}\n\n`,
         ],
       };


### PR DESCRIPTION
## Background

The test case was not fully matching the API behavior.

See https://github.com/anthropics/anthropic-sdk-typescript/blob/3852b086203f9d7795c5c9e288fba992fc17b61b/tests/streaming.test.ts#L222-L245 for the Anthropic SDK unit test.

## Summary

Add `event: error` chunks to test fixtures.