### PR TITLE
docs: add note on tools, stopWhen and structured outputs

### DIFF
--- a/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
+++ b/content/docs/03-ai-sdk-core/10-generating-structured-data.mdx
@@ -308,6 +308,8 @@ You can generate structured data with `generateText` and `streamText` by using t
 <Note>
   Some models, e.g. those by OpenAI, support structured outputs and tool calling
   at the same time. This is only possible with `generateText` and `streamText`.
+  You need to specify a `stopCondition` with that allows more than a single
+  stepCount if you want to use tools and structured outputs together.
 </Note>
 
 ### `generateText`


### PR DESCRIPTION
## Background

It was unclear that a `stopCondition` needs to be set when using structured outputs with tools (see https://github.com/vercel/ai/issues/9798#issuecomment-3589289717 ).

## Summary

Clarify that a max steps stop condition is needed.