### PR TITLE
chore(specification): rename v3 provider defined tool to provider tool

### DIFF
--- a/.changeset/four-dogs-add.md
+++ b/.changeset/four-dogs-add.md
@@ -1,0 +1,19 @@
+---
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/huggingface': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/xai': patch
+'ai': patch
+---
+
+chore(specification): rename v3 provider defined tool to provider tool

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -3,7 +3,7 @@ import {
   LanguageModelV3CallOptions,
   LanguageModelV3FunctionTool,
   LanguageModelV3Prompt,
-  LanguageModelV3ProviderDefinedTool,
+  LanguageModelV3ProviderTool,
 } from '@ai-sdk/provider';
 import {
   dynamicTool,
@@ -2077,7 +2077,7 @@ describe('generateText', () => {
   describe('options.activeTools', () => {
     it('should filter available tools to only the ones in activeTools', async () => {
       let tools:
-        | (LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool)[]
+        | (LanguageModelV3FunctionTool | LanguageModelV3ProviderTool)[]
         | undefined;
 
       await generateText({
@@ -2619,7 +2619,7 @@ describe('generateText', () => {
           }),
           tools: {
             web_search: {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'test.web_search',
               inputSchema: z.object({ value: z.string() }),
               outputSchema: z.object({ value: z.string() }),

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -4,7 +4,7 @@ import {
   SharedV3Warning,
   LanguageModelV3FunctionTool,
   LanguageModelV3Prompt,
-  LanguageModelV3ProviderDefinedTool,
+  LanguageModelV3ProviderTool,
   LanguageModelV3StreamPart,
   SharedV3ProviderMetadata,
 } from '@ai-sdk/provider';
@@ -8737,7 +8737,7 @@ describe('streamText', () => {
           }),
           tools: {
             web_search: {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'test.web_search',
               inputSchema: z.object({ value: z.string() }),
               outputSchema: z.object({ value: z.string() }),
@@ -12281,7 +12281,7 @@ describe('streamText', () => {
   describe('options.activeTools', () => {
     it('should filter available tools to only the ones in activeTools', async () => {
       let tools:
-        | (LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool)[]
+        | (LanguageModelV3FunctionTool | LanguageModelV3ProviderTool)[]
         | undefined;
 
       const result = streamText({

--- a/packages/ai/src/generate-text/to-response-messages.test.ts
+++ b/packages/ai/src/generate-text/to-response-messages.test.ts
@@ -706,7 +706,7 @@ describe('toResponseMessages', () => {
         ],
         tools: {
           web_search: tool({
-            type: 'provider-defined',
+            type: 'provider',
             id: 'test.web_search',
             inputSchema: z.object({
               query: z.string(),

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
@@ -14,8 +14,8 @@ const mockTools = {
   }),
 };
 
-const mockProviderDefinedTool: Tool = {
-  type: 'provider-defined',
+const mockProviderTool: Tool = {
+  type: 'provider',
   id: 'provider.tool-id',
   args: { key: 'value' },
   inputSchema: z.object({}),
@@ -23,7 +23,7 @@ const mockProviderDefinedTool: Tool = {
 
 const mockToolsWithProviderDefined = {
   ...mockTools,
-  providerTool: mockProviderDefinedTool,
+  providerTool: mockProviderTool,
 };
 
 describe('prepareToolsAndToolChoice', () => {

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.test.ts
@@ -319,7 +319,7 @@ describe('prepareToolsAndToolChoice', () => {
             },
             "id": "provider.tool-id",
             "name": "providerTool",
-            "type": "provider-defined",
+            "type": "provider",
           },
         ],
       }

--- a/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
+++ b/packages/ai/src/prompt/prepare-tools-and-tool-choice.ts
@@ -1,6 +1,6 @@
 import {
   LanguageModelV3FunctionTool,
-  LanguageModelV3ProviderDefinedTool,
+  LanguageModelV3ProviderTool,
   LanguageModelV3ToolChoice,
 } from '@ai-sdk/provider';
 import { asSchema } from '@ai-sdk/provider-utils';
@@ -18,7 +18,7 @@ export async function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
   activeTools: Array<keyof TOOLS> | undefined;
 }): Promise<{
   tools:
-    | Array<LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool>
+    | Array<LanguageModelV3FunctionTool | LanguageModelV3ProviderTool>
     | undefined;
   toolChoice: LanguageModelV3ToolChoice | undefined;
 }> {
@@ -38,7 +38,7 @@ export async function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
       : Object.entries(tools);
 
   const languageModelTools: Array<
-    LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool
+    LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
   > = [];
   for (const [name, tool] of filteredTools) {
     const toolType = tool.type;
@@ -55,9 +55,9 @@ export async function prepareToolsAndToolChoice<TOOLS extends ToolSet>({
           providerOptions: tool.providerOptions,
         });
         break;
-      case 'provider-defined':
+      case 'provider':
         languageModelTools.push({
-          type: 'provider-defined' as const,
+          type: 'provider' as const,
           name,
           id: tool.id,
           args: tool.args,

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -23,7 +23,7 @@ vi.mock('@ai-sdk/anthropic/internal', async importOriginal => {
     anthropicTools: {
       ...original.anthropicTools,
       bash_20241022: (args: any) => ({
-        type: 'provider-defined',
+        type: 'provider',
         id: 'anthropic.bash_20241022',
         name: 'bash',
         args,
@@ -2552,7 +2552,7 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
       tools: [
         {
-          type: 'provider-defined',
+          type: 'provider',
           id: 'anthropic.bash_20241022',
           name: 'bash',
           args: {},
@@ -2657,7 +2657,7 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
       tools: [
         {
-          type: 'provider-defined',
+          type: 'provider',
           id: 'anthropic.bash_20241022',
           name: 'bash',
           args: {},
@@ -2702,7 +2702,7 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
       tools: [
         {
-          type: 'provider-defined',
+          type: 'provider',
           id: 'anthropic.bash_20241022',
           name: 'bash',
           args: {},

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -40,7 +40,7 @@ export async function prepareTools({
   // Filter out unsupported web_search tool and add a warning
   const supportedTools = tools.filter(tool => {
     if (
-      tool.type === 'provider-defined' &&
+      tool.type === 'provider' &&
       tool.id === 'anthropic.web_search_20250305'
     ) {
       toolWarnings.push({
@@ -64,16 +64,13 @@ export async function prepareTools({
   }
 
   const isAnthropicModel = modelId.includes('anthropic.');
-  const providerDefinedTools = supportedTools.filter(
-    t => t.type === 'provider-defined',
-  );
+  const ProviderTools = supportedTools.filter(t => t.type === 'provider');
   const functionTools = supportedTools.filter(t => t.type === 'function');
 
   let additionalTools: Record<string, unknown> | undefined = undefined;
   const bedrockTools: BedrockTool[] = [];
 
-  const usingAnthropicTools =
-    isAnthropicModel && providerDefinedTools.length > 0;
+  const usingAnthropicTools = isAnthropicModel && ProviderTools.length > 0;
 
   // Handle Anthropic provider-defined tools for Anthropic models on Bedrock
   if (usingAnthropicTools) {
@@ -92,7 +89,7 @@ export async function prepareTools({
       toolWarnings: anthropicToolWarnings,
       betas: anthropicBetas,
     } = await prepareAnthropicTools({
-      tools: providerDefinedTools,
+      tools: ProviderTools,
       toolChoice,
     });
 
@@ -108,7 +105,7 @@ export async function prepareTools({
     }
 
     // Create a standard Bedrock tool representation for validation purposes
-    for (const tool of providerDefinedTools) {
+    for (const tool of ProviderTools) {
       const toolFactory = Object.values(anthropicTools).find(factory => {
         const instance = (factory as (args: any) => any)({});
         return instance.id === tool.id;
@@ -131,7 +128,7 @@ export async function prepareTools({
     }
   } else {
     // Report unsupported provider-defined tools for non-anthropic models
-    for (const tool of providerDefinedTools) {
+    for (const tool of ProviderTools) {
       toolWarnings.push({ type: 'unsupported', feature: `tool ${tool.id}` });
     }
   }

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -1536,7 +1536,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'anthropic.web_search_20250305',
                 name: 'web_search',
                 args: {
@@ -1621,7 +1621,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.web_search_20250305',
               name: 'web_search',
               args: {
@@ -1658,7 +1658,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.web_search_20250305',
               name: 'web_search',
               args: {
@@ -1693,7 +1693,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.web_search_20250305',
               name: 'web_search',
               args: {
@@ -1740,7 +1740,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.web_search_20250305',
               name: 'web_search',
               args: {
@@ -1783,7 +1783,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.web_search_20250305',
               name: 'web_search',
               args: {
@@ -1857,7 +1857,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.web_search_20250305',
               name: 'web_search',
               args: {
@@ -1936,7 +1936,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.web_search_20250305',
               name: 'web_search',
               args: {
@@ -1985,7 +1985,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               inputSchema: { type: 'object', properties: {} },
             },
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.web_search_20250305',
               name: 'web_search',
               args: {
@@ -2023,7 +2023,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'anthropic.web_fetch_20250910',
                 name: 'web_fetch',
                 args: { maxUses: 1 },
@@ -2074,7 +2074,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'anthropic.web_fetch_20250910',
                 name: 'web_fetch',
                 args: { maxUses: 1 },
@@ -2098,7 +2098,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'anthropic.web_fetch_20250910',
                 name: 'web_fetch',
                 args: { maxUses: 1 },
@@ -2199,7 +2199,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250825',
               name: 'code_execution',
               args: {},
@@ -2348,7 +2348,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250825',
               name: 'code_execution',
               args: {},
@@ -2388,7 +2388,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250825',
               name: 'code_execution',
               args: {},
@@ -2421,7 +2421,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.memory_20250818',
               name: 'memory',
               args: {},
@@ -2470,7 +2470,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.memory_20250818',
               name: 'memory',
               args: {},
@@ -2490,7 +2490,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250825',
               name: 'code_execution',
               args: {},
@@ -2539,7 +2539,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250825',
               name: 'code_execution',
               args: {},
@@ -2557,7 +2557,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250825',
               name: 'code_execution',
               args: {},
@@ -2575,7 +2575,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250825',
               name: 'code_execution',
               args: {},
@@ -2625,7 +2625,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250522',
               name: 'code_execution',
               args: {},
@@ -2705,7 +2705,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250522',
               name: 'code_execution',
               args: {},
@@ -2768,7 +2768,7 @@ describe('AnthropicMessagesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250522',
               name: 'code_execution',
               args: {},
@@ -2817,7 +2817,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               inputSchema: { type: 'object', properties: {} },
             },
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.code_execution_20250522',
               name: 'code_execution',
               args: {},
@@ -4732,7 +4732,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'anthropic.code_execution_20250825',
                 name: 'code_execution',
                 args: {},
@@ -4761,7 +4761,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'anthropic.code_execution_20250825',
                 name: 'code_execution',
                 args: {},
@@ -4780,7 +4780,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'anthropic.code_execution_20250825',
                 name: 'code_execution',
                 args: {},
@@ -4805,7 +4805,7 @@ describe('AnthropicMessagesLanguageModel', () => {
               prompt: TEST_PROMPT,
               tools: [
                 {
-                  type: 'provider-defined',
+                  type: 'provider',
                   id: 'anthropic.web_fetch_20250910',
                   name: 'web_fetch',
                   args: { maxUses: 1 },
@@ -4832,7 +4832,7 @@ describe('AnthropicMessagesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'anthropic.web_search_20250305',
                 name: 'web_search',
                 args: {

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -372,7 +372,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       if (
         !tools?.some(
           tool =>
-            tool.type === 'provider-defined' &&
+            tool.type === 'provider' &&
             tool.id === 'anthropic.code_execution_20250825',
         )
       ) {

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -51,7 +51,7 @@ describe('prepareTools', () => {
         const result = await prepareTools({
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.computer_20241022',
               name: 'computer',
               args: {
@@ -90,7 +90,7 @@ describe('prepareTools', () => {
         const result = await prepareTools({
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'anthropic.text_editor_20241022',
               name: 'text_editor',
               args: {},
@@ -120,7 +120,7 @@ describe('prepareTools', () => {
       const result = await prepareTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'anthropic.bash_20241022',
             name: 'bash',
             args: {},
@@ -150,7 +150,7 @@ describe('prepareTools', () => {
       const result = await prepareTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'anthropic.text_editor_20250728',
             name: 'str_replace_based_edit_tool',
             args: { maxCharacters: 10000 },
@@ -178,7 +178,7 @@ describe('prepareTools', () => {
       const result = await prepareTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'anthropic.text_editor_20250728',
             name: 'str_replace_based_edit_tool',
             args: {},
@@ -206,7 +206,7 @@ describe('prepareTools', () => {
       const result = await prepareTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'anthropic.web_search_20250305',
             name: 'web_search',
             args: {
@@ -246,7 +246,7 @@ describe('prepareTools', () => {
       const result = await prepareTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'anthropic.web_fetch_20250910',
             name: 'web_fetch',
             args: {
@@ -291,7 +291,7 @@ describe('prepareTools', () => {
     const result = await prepareTools({
       tools: [
         {
-          type: 'provider-defined',
+          type: 'provider',
           id: 'unsupported.tool',
           name: 'unsupported_tool',
           args: {},

--- a/packages/anthropic/src/anthropic-prepare-tools.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.ts
@@ -56,7 +56,7 @@ export async function prepareTools({
         break;
       }
 
-      case 'provider-defined': {
+      case 'provider': {
         // Note: Provider-defined tools don't currently support providerOptions in the SDK,
         // so cache_control cannot be set on them. The Anthropic API supports caching all tools,
         // but the SDK would need to be updated to expose providerOptions on provider-defined tools.

--- a/packages/anthropic/src/tool/bash_20241022.ts
+++ b/packages/anthropic/src/tool/bash_20241022.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -14,7 +14,7 @@ const bash_20241022InputSchema = lazySchema(() =>
   ),
 );
 
-export const bash_20241022 = createProviderDefinedToolFactory<
+export const bash_20241022 = createProviderToolFactory<
   {
     /**
      * The bash command to run. Required unless the tool is being restarted.

--- a/packages/anthropic/src/tool/bash_20250124.ts
+++ b/packages/anthropic/src/tool/bash_20250124.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -14,7 +14,7 @@ const bash_20250124InputSchema = lazySchema(() =>
   ),
 );
 
-export const bash_20250124 = createProviderDefinedToolFactory<
+export const bash_20250124 = createProviderToolFactory<
   {
     /**
      * The bash command to run. Required unless the tool is being restarted.

--- a/packages/anthropic/src/tool/code-execution_20250522.ts
+++ b/packages/anthropic/src/tool/code-execution_20250522.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -24,7 +24,7 @@ const codeExecution_20250522InputSchema = lazySchema(() =>
   ),
 );
 
-const factory = createProviderDefinedToolFactoryWithOutputSchema<
+const factory = createProviderToolFactoryWithOutputSchema<
   {
     /**
      * The Python code to execute.

--- a/packages/anthropic/src/tool/code-execution_20250825.ts
+++ b/packages/anthropic/src/tool/code-execution_20250825.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -83,7 +83,7 @@ export const codeExecution_20250825InputSchema = lazySchema(() =>
   ),
 );
 
-const factory = createProviderDefinedToolFactoryWithOutputSchema<
+const factory = createProviderToolFactoryWithOutputSchema<
   | {
       type: 'bash_code_execution';
 

--- a/packages/anthropic/src/tool/computer_20241022.ts
+++ b/packages/anthropic/src/tool/computer_20241022.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -26,7 +26,7 @@ const computer_20241022InputSchema = lazySchema(() =>
   ),
 );
 
-export const computer_20241022 = createProviderDefinedToolFactory<
+export const computer_20241022 = createProviderToolFactory<
   {
     /**
      * The action to perform. The available actions are:

--- a/packages/anthropic/src/tool/computer_20250124.ts
+++ b/packages/anthropic/src/tool/computer_20250124.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -38,7 +38,7 @@ const computer_20250124InputSchema = lazySchema(() =>
   ),
 );
 
-export const computer_20250124 = createProviderDefinedToolFactory<
+export const computer_20250124 = createProviderToolFactory<
   {
     /**
      * - `key`: Press a key or key-combination on the keyboard.

--- a/packages/anthropic/src/tool/memory_20250818.ts
+++ b/packages/anthropic/src/tool/memory_20250818.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -43,7 +43,7 @@ const memory_20250818InputSchema = lazySchema(() =>
   ),
 );
 
-export const memory_20250818 = createProviderDefinedToolFactory<
+export const memory_20250818 = createProviderToolFactory<
   | { command: 'view'; path: string; view_range?: [number, number] }
   | { command: 'create'; path: string; file_text: string }
   | { command: 'str_replace'; path: string; old_str: string; new_str: string }

--- a/packages/anthropic/src/tool/text-editor_20241022.ts
+++ b/packages/anthropic/src/tool/text-editor_20241022.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -19,7 +19,7 @@ const textEditor_20241022InputSchema = lazySchema(() =>
   ),
 );
 
-export const textEditor_20241022 = createProviderDefinedToolFactory<
+export const textEditor_20241022 = createProviderToolFactory<
   {
     /**
      * The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.

--- a/packages/anthropic/src/tool/text-editor_20250124.ts
+++ b/packages/anthropic/src/tool/text-editor_20250124.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -19,7 +19,7 @@ const textEditor_20250124InputSchema = lazySchema(() =>
   ),
 );
 
-export const textEditor_20250124 = createProviderDefinedToolFactory<
+export const textEditor_20250124 = createProviderToolFactory<
   {
     /**
      * The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.

--- a/packages/anthropic/src/tool/text-editor_20250429.ts
+++ b/packages/anthropic/src/tool/text-editor_20250429.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -19,7 +19,7 @@ const textEditor_20250429InputSchema = lazySchema(() =>
   ),
 );
 
-export const textEditor_20250429 = createProviderDefinedToolFactory<
+export const textEditor_20250429 = createProviderToolFactory<
   {
     /**
      * The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`.

--- a/packages/anthropic/src/tool/text-editor_20250728.ts
+++ b/packages/anthropic/src/tool/text-editor_20250728.ts
@@ -1,4 +1,4 @@
-import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
+import { createProviderToolFactory } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 
@@ -24,7 +24,7 @@ const textEditor_20250728InputSchema = lazySchema(() =>
   ),
 );
 
-const factory = createProviderDefinedToolFactory<
+const factory = createProviderToolFactory<
   {
     /**
      * The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`.

--- a/packages/anthropic/src/tool/web-fetch-20250910.ts
+++ b/packages/anthropic/src/tool/web-fetch-20250910.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -52,7 +52,7 @@ const webFetch_20250910InputSchema = lazySchema(() =>
   ),
 );
 
-const factory = createProviderDefinedToolFactoryWithOutputSchema<
+const factory = createProviderToolFactoryWithOutputSchema<
   {
     /**
      * The URL to fetch.

--- a/packages/anthropic/src/tool/web-search_20250305.ts
+++ b/packages/anthropic/src/tool/web-search_20250305.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -46,7 +46,7 @@ const webSearch_20250305InputSchema = lazySchema(() =>
   ),
 );
 
-const factory = createProviderDefinedToolFactoryWithOutputSchema<
+const factory = createProviderToolFactoryWithOutputSchema<
   {
     /**
      * The search query to execute.

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -931,7 +931,7 @@ describe('responses', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.file_search',
               name: 'file_search',
               args: {
@@ -1013,7 +1013,7 @@ describe('responses', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.code_interpreter',
               name: 'code_interpreter',
               args: {},
@@ -1068,7 +1068,7 @@ describe('responses', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'openai.file_search',
                 name: 'file_search',
                 args: {
@@ -1139,7 +1139,7 @@ describe('responses', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'openai.file_search',
                 name: 'file_search',
                 args: {
@@ -1221,7 +1221,7 @@ describe('responses', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.web_search_preview',
               name: 'web_search_preview',
               args: {},
@@ -1245,7 +1245,7 @@ describe('responses', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.image_generation',
             name: 'image_generation',
             args: {
@@ -1612,7 +1612,7 @@ describe('responses', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.code_interpreter',
             name: 'code_interpreter',
             args: {},
@@ -1633,7 +1633,7 @@ describe('responses', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.file_search',
             name: 'file_search',
             args: {
@@ -1655,7 +1655,7 @@ describe('responses', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.file_search',
             name: 'file_search',
             args: {
@@ -1682,7 +1682,7 @@ describe('responses', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.web_search_preview',
             name: 'web_search_preview',
             args: {},

--- a/packages/cohere/src/cohere-prepare-tools.test.ts
+++ b/packages/cohere/src/cohere-prepare-tools.test.ts
@@ -45,7 +45,7 @@ it('should add warnings for provider-defined tools', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined' as const,
+        type: 'provider' as const,
         id: 'provider.tool',
         name: 'tool',
         args: {},

--- a/packages/cohere/src/cohere-prepare-tools.ts
+++ b/packages/cohere/src/cohere-prepare-tools.ts
@@ -44,7 +44,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider') {
       toolWarnings.push({
         type: 'unsupported',
         feature: `provider-defined tool ${tool.id}`,

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.test.ts
@@ -13,8 +13,8 @@ vi.mock('@ai-sdk/provider-utils', () => ({
     .mockImplementation(({ settingValue }) => settingValue),
   withoutTrailingSlash: vi.fn().mockImplementation(url => url),
   createJsonErrorResponseHandler: vi.fn(),
-  createProviderDefinedToolFactory: vi.fn(),
-  createProviderDefinedToolFactoryWithOutputSchema: vi.fn(),
+  createProviderToolFactory: vi.fn(),
+  createProviderToolFactoryWithOutputSchema: vi.fn(),
   lazySchema: vi.fn(),
   zodSchema: vi.fn(),
 }));

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1,6 +1,6 @@
 import {
   LanguageModelV3Prompt,
-  LanguageModelV3ProviderDefinedTool,
+  LanguageModelV3ProviderTool,
 } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -1367,7 +1367,7 @@ describe('doGenerate', () => {
     const { content } = await model.doGenerate({
       tools: [
         {
-          type: 'provider-defined',
+          type: 'provider',
           id: 'google.code_execution',
           name: 'code_execution',
           args: {},
@@ -1417,7 +1417,7 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.google_search',
             name: 'google_search',
             args: {},
@@ -1440,7 +1440,7 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.google_search',
             name: 'google_search',
             args: {},
@@ -1463,7 +1463,7 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.google_search',
             name: 'google_search',
             args: {},
@@ -1487,7 +1487,7 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.google_search',
             name: 'google_search',
             args: {
@@ -1521,7 +1521,7 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.url_context',
             name: 'url_context',
             args: {},
@@ -1543,7 +1543,7 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.vertex_rag_store',
             name: 'vertex_rag_store',
             args: {
@@ -2470,7 +2470,7 @@ describe('doStream', () => {
     const { stream } = await model.doStream({
       tools: [
         {
-          type: 'provider-defined',
+          type: 'provider',
           id: 'google.code_execution',
           name: 'code_execution',
           args: {},
@@ -2526,7 +2526,7 @@ describe('doStream', () => {
         includeRawChunks: false,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.google_search',
             name: 'google_search',
             args: {},
@@ -2552,7 +2552,7 @@ describe('doStream', () => {
         includeRawChunks: false,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.google_search',
             name: 'google_search',
             args: {},
@@ -2577,7 +2577,7 @@ describe('doStream', () => {
         includeRawChunks: false,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.google_search',
             name: 'google_search',
             args: {},
@@ -2603,7 +2603,7 @@ describe('doStream', () => {
         includeRawChunks: false,
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'google.google_search',
             name: 'google_search',
             args: {

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -101,8 +101,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
     if (
       tools?.some(
         tool =>
-          tool.type === 'provider-defined' &&
-          tool.id === 'google.vertex_rag_store',
+          tool.type === 'provider' && tool.id === 'google.vertex_rag_store',
       ) &&
       !this.config.provider.startsWith('google.vertex.')
     ) {

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV3ProviderDefinedTool } from '@ai-sdk/provider';
+import { LanguageModelV3ProviderTool } from '@ai-sdk/provider';
 import { expect, it } from 'vitest';
 import { prepareTools } from './google-prepare-tools';
 
@@ -54,19 +54,19 @@ it('should correctly prepare provider-defined tools as array', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.google_search',
         name: 'google_search',
         args: {},
       },
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.url_context',
         name: 'url_context',
         args: {},
       },
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.file_search',
         name: 'file_search',
         args: { fileSearchStoreNames: ['projects/foo/fileSearchStores/bar'] },
@@ -91,7 +91,7 @@ it('should correctly prepare single provider-defined tool', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.google_search',
         name: 'google_search',
         args: {},
@@ -108,7 +108,7 @@ it('should add warnings for unsupported tools', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'unsupported.tool',
         name: 'unsupported_tool',
         args: {},
@@ -129,8 +129,8 @@ it('should add warnings for unsupported tools', () => {
 });
 
 it('should add warnings for file search on unsupported models', () => {
-  const tool: LanguageModelV3ProviderDefinedTool = {
-    type: 'provider-defined' as const,
+  const tool: LanguageModelV3ProviderTool = {
+    type: 'provider' as const,
     id: 'google.file_search',
     name: 'file_search',
     args: { fileSearchStoreNames: ['projects/foo/fileSearchStores/bar'] },
@@ -157,7 +157,7 @@ it('should correctly prepare file search tool', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.file_search',
         name: 'file_search',
         args: {
@@ -278,7 +278,7 @@ it('should warn when mixing function and provider-defined tools', () => {
         inputSchema: { type: 'object', properties: {} },
       },
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.google_search',
         name: 'google_search',
         args: {},
@@ -311,7 +311,7 @@ it('should handle tool choice with mixed tools (provider-defined tools only)', (
         inputSchema: { type: 'object', properties: {} },
       },
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.google_search',
         name: 'google_search',
         args: {},
@@ -339,7 +339,7 @@ it('should handle latest modelId for provider-defined tools correctly', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.google_search',
         name: 'google_search',
         args: {},
@@ -356,7 +356,7 @@ it('should handle gemini-3 modelId for provider-defined tools correctly', () => 
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.google_search',
         name: 'google_search',
         args: {},
@@ -373,7 +373,7 @@ it('should handle code execution tool', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.code_execution',
         name: 'code_execution',
         args: {},
@@ -390,7 +390,7 @@ it('should handle url context tool alone', () => {
   const result = prepareTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'google.url_context',
         name: 'url_context',
         args: {},

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -61,24 +61,20 @@ export function prepareTools({
 
   // Check for mixed tool types and add warnings
   const hasFunctionTools = tools.some(tool => tool.type === 'function');
-  const hasProviderDefinedTools = tools.some(
-    tool => tool.type === 'provider-defined',
-  );
+  const hasProviderTools = tools.some(tool => tool.type === 'provider');
 
-  if (hasFunctionTools && hasProviderDefinedTools) {
+  if (hasFunctionTools && hasProviderTools) {
     toolWarnings.push({
       type: 'unsupported',
       feature: `combination of function and provider-defined tools`,
     });
   }
 
-  if (hasProviderDefinedTools) {
+  if (hasProviderTools) {
     const googleTools: any[] = [];
 
-    const providerDefinedTools = tools.filter(
-      tool => tool.type === 'provider-defined',
-    );
-    providerDefinedTools.forEach(tool => {
+    const ProviderTools = tools.filter(tool => tool.type === 'provider');
+    ProviderTools.forEach(tool => {
       switch (tool.id) {
         case 'google.google_search':
           if (isGemini2orNewer) {

--- a/packages/google/src/tool/code-execution.ts
+++ b/packages/google/src/tool/code-execution.ts
@@ -1,4 +1,4 @@
-import { createProviderDefinedToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
+import { createProviderToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 /**
@@ -10,7 +10,7 @@ import { z } from 'zod/v4';
  * @see https://ai.google.dev/gemini-api/docs/code-execution (Google AI)
  * @see https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/code-execution-api (Vertex AI)
  */
-export const codeExecution = createProviderDefinedToolFactoryWithOutputSchema<
+export const codeExecution = createProviderToolFactoryWithOutputSchema<
   {
     language: string;
     code: string;

--- a/packages/google/src/tool/file-search.ts
+++ b/packages/google/src/tool/file-search.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -42,7 +42,7 @@ const fileSearchArgsSchema = lazySchema(() =>
   zodSchema(fileSearchArgsBaseSchema),
 );
 
-export const fileSearch = createProviderDefinedToolFactory<
+export const fileSearch = createProviderToolFactory<
   {},
   GoogleFileSearchToolArgs
 >({

--- a/packages/google/src/tool/google-search.ts
+++ b/packages/google/src/tool/google-search.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -9,7 +9,7 @@ import { z } from 'zod/v4';
 // https://ai.google.dev/api/generate-content#GroundingSupport
 // https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-search
 
-export const googleSearch = createProviderDefinedToolFactory<
+export const googleSearch = createProviderToolFactory<
   {},
   {
     /**

--- a/packages/google/src/tool/url-context.ts
+++ b/packages/google/src/tool/url-context.ts
@@ -1,11 +1,11 @@
 import {
-  createProviderDefinedToolFactory,
+  createProviderToolFactory,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
-export const urlContext = createProviderDefinedToolFactory<
+export const urlContext = createProviderToolFactory<
   {
     // Url context does not have any input schema, it will directly use the url from the prompt
   },

--- a/packages/google/src/tool/vertex-rag-store.ts
+++ b/packages/google/src/tool/vertex-rag-store.ts
@@ -1,4 +1,4 @@
-import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
+import { createProviderToolFactory } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 // https://cloud.google.com/vertex-ai/generative-ai/docs/rag-engine/use-vertexai-search#generate-content-using-gemini-api
@@ -9,7 +9,7 @@ import { z } from 'zod/v4';
  *
  * @note Only works with Vertex Gemini models.
  */
-export const vertexRagStore = createProviderDefinedToolFactory<
+export const vertexRagStore = createProviderToolFactory<
   {},
   {
     /**

--- a/packages/groq/src/groq-prepare-tools.test.ts
+++ b/packages/groq/src/groq-prepare-tools.test.ts
@@ -59,7 +59,7 @@ describe('prepareTools', () => {
     const result = prepareTools({
       tools: [
         {
-          type: 'provider-defined',
+          type: 'provider',
           id: 'some.unsupported_tool',
           name: 'unsupported_tool',
           args: {},
@@ -152,7 +152,7 @@ describe('prepareTools', () => {
       const result = prepareTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'groq.browser_search',
             name: 'browser_search',
             args: {},
@@ -173,7 +173,7 @@ describe('prepareTools', () => {
       const result = prepareTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'groq.browser_search',
             name: 'browser_search',
             args: {},
@@ -204,7 +204,7 @@ describe('prepareTools', () => {
             inputSchema: { type: 'object', properties: {} },
           },
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'groq.browser_search',
             name: 'browser_search',
             args: {},
@@ -236,7 +236,7 @@ describe('prepareTools', () => {
         const result = prepareTools({
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'groq.browser_search',
               name: 'browser_search',
               args: {},
@@ -254,7 +254,7 @@ describe('prepareTools', () => {
       const result = prepareTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'groq.browser_search',
             name: 'browser_search',
             args: {},

--- a/packages/groq/src/groq-prepare-tools.ts
+++ b/packages/groq/src/groq-prepare-tools.ts
@@ -65,7 +65,7 @@ export function prepareTools({
   > = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider') {
       if (tool.id === 'groq.browser_search') {
         if (!isBrowserSearchSupportedModel(modelId)) {
           toolWarnings.push({

--- a/packages/groq/src/tool/browser-search.ts
+++ b/packages/groq/src/tool/browser-search.ts
@@ -1,4 +1,4 @@
-import { createProviderDefinedToolFactory } from '@ai-sdk/provider-utils';
+import { createProviderToolFactory } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 /**
@@ -13,7 +13,7 @@ import { z } from 'zod/v4';
  *
  * @see https://console.groq.com/docs/browser-search
  */
-export const browserSearch = createProviderDefinedToolFactory<
+export const browserSearch = createProviderToolFactory<
   {
     // Browser search doesn't take input parameters - it's controlled by the prompt
     // The tool is activated automatically when included in the tools array

--- a/packages/huggingface/src/responses/huggingface-responses-prepare-tools.ts
+++ b/packages/huggingface/src/responses/huggingface-responses-prepare-tools.ts
@@ -44,7 +44,7 @@ export function prepareResponsesTools({
           parameters: tool.inputSchema,
         });
         break;
-      case 'provider-defined':
+      case 'provider':
         toolWarnings.push({
           type: 'unsupported',
           feature: `provider-defined tool ${tool.id}`,

--- a/packages/mistral/src/mistral-prepare-tools.ts
+++ b/packages/mistral/src/mistral-prepare-tools.ts
@@ -44,7 +44,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider') {
       toolWarnings.push({
         type: 'unsupported',
         feature: `provider-defined tool ${tool.id}`,

--- a/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-prepare-tools.ts
@@ -48,7 +48,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider') {
       toolWarnings.push({
         type: 'unsupported',
         feature: `provider-defined tool ${tool.id}`,

--- a/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
@@ -62,7 +62,7 @@ it('should add warnings for unsupported tools', () => {
   const result = prepareChatTools({
     tools: [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'openai.unsupported_tool',
         name: 'unsupported_tool',
         args: {},

--- a/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
@@ -77,7 +77,7 @@ it('should add warnings for unsupported tools', () => {
   expect(result.toolWarnings).toMatchInlineSnapshot(`
     [
       {
-        "feature": "tool type: provider-defined",
+        "feature": "tool type: provider",
         "type": "unsupported",
       },
     ]

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2159,7 +2159,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.code_interpreter',
               name: 'codeExecution',
               args: {},
@@ -2236,7 +2236,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.image_generation',
               name: 'generateImage',
               args: {
@@ -2293,7 +2293,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.local_shell',
               name: 'shell',
               args: {},
@@ -2340,7 +2340,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         result = await createModel('gpt-5-nano').doGenerate({
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.web_search',
               name: 'webSearch',
               args: {},
@@ -2451,7 +2451,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.web_search',
               name: 'webSearch',
               args: {},
@@ -2473,7 +2473,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.mcp',
               name: 'MCP',
               args: {
@@ -2530,7 +2530,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'openai.file_search',
                 name: 'fileSearch',
                 args: {
@@ -2601,7 +2601,7 @@ describe('OpenAIResponsesLanguageModel', () => {
             prompt: TEST_PROMPT,
             tools: [
               {
-                type: 'provider-defined',
+                type: 'provider',
                 id: 'openai.file_search',
                 name: 'fileSearch',
                 args: {
@@ -2727,7 +2727,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         ],
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.computer_use',
             name: 'computerUse',
             args: {},
@@ -3809,7 +3809,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         const { stream } = await createModel('gpt-5-nano').doStream({
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.web_search',
               name: 'webSearch',
               args: {},
@@ -3845,7 +3845,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         const { stream } = await createModel('gpt-5-nano').doStream({
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.web_search',
               name: 'webSearch',
               args: {},
@@ -3866,7 +3866,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.file_search',
               name: 'fileSearch',
               args: {
@@ -3888,7 +3888,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.file_search',
               name: 'fileSearch',
               args: {
@@ -3917,7 +3917,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.code_interpreter',
               name: 'codeExecution',
               args: {},
@@ -3965,7 +3965,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.image_generation',
               name: 'generateImage',
               args: {},
@@ -3987,7 +3987,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.local_shell',
               name: 'shell',
               args: {},
@@ -4008,7 +4008,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         const { stream } = await createModel('gpt-5-mini').doStream({
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'openai.mcp',
               name: 'MCP',
               args: {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -4,7 +4,7 @@ import {
   SharedV3Warning,
   LanguageModelV3Content,
   LanguageModelV3FinishReason,
-  LanguageModelV3ProviderDefinedTool,
+  LanguageModelV3ProviderTool,
   LanguageModelV3StreamPart,
   LanguageModelV3Usage,
   SharedV3ProviderMetadata,
@@ -163,9 +163,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
     function hasOpenAITool(id: string) {
       return (
-        tools?.find(
-          tool => tool.type === 'provider-defined' && tool.id === id,
-        ) != null
+        tools?.find(tool => tool.type === 'provider' && tool.id === id) != null
       );
     }
 
@@ -185,10 +183,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
     const webSearchToolName = (
       tools?.find(
         tool =>
-          tool.type === 'provider-defined' &&
+          tool.type === 'provider' &&
           (tool.id === 'openai.web_search' ||
             tool.id === 'openai.web_search_preview'),
-      ) as LanguageModelV3ProviderDefinedTool | undefined
+      ) as LanguageModelV3ProviderTool | undefined
     )?.name;
 
     if (webSearchToolName) {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -8,7 +8,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.code_interpreter',
             name: 'code_interpreter',
             args: {},
@@ -39,7 +39,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.code_interpreter',
             name: 'code_interpreter',
             args: {
@@ -69,7 +69,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.code_interpreter',
             name: 'code_interpreter',
             args: {
@@ -108,7 +108,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.code_interpreter',
             name: 'code_interpreter',
             args: {
@@ -143,7 +143,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.code_interpreter',
             name: 'code_interpreter',
             args: {
@@ -178,7 +178,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.code_interpreter',
             name: 'code_interpreter',
             args: {},
@@ -225,7 +225,7 @@ describe('prepareResponsesTools', () => {
             },
           },
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.code_interpreter',
             name: 'code_interpreter',
             args: {
@@ -271,7 +271,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.image_generation',
             name: 'image_generation',
             args: {
@@ -315,7 +315,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.image_generation',
             name: 'image_generation',
             args: {},
@@ -350,7 +350,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.local_shell',
             name: 'local_shell',
             args: {},
@@ -379,7 +379,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.web_search',
             name: 'web_search',
             args: {},
@@ -410,7 +410,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.web_search',
             name: 'web_search',
             args: {
@@ -443,7 +443,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.web_search',
             name: 'web_search',
             args: {
@@ -476,7 +476,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.web_search',
             name: 'web_search',
             args: {
@@ -531,7 +531,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.web_search',
             name: 'web_search',
             args: {
@@ -570,7 +570,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.web_search',
             name: 'web_search',
             args: {
@@ -619,7 +619,7 @@ describe('prepareResponsesTools', () => {
             },
           },
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'openai.web_search',
             name: 'web_search',
             args: {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -57,7 +57,7 @@ export async function prepareResponsesTools({
           strict: strictJsonSchema,
         });
         break;
-      case 'provider-defined': {
+      case 'provider': {
         switch (tool.id) {
           case 'openai.file_search': {
             const args = await validateTypes({

--- a/packages/openai/src/tool/code-interpreter.ts
+++ b/packages/openai/src/tool/code-interpreter.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -54,7 +54,7 @@ type CodeInterpreterArgs = {
 };
 
 export const codeInterpreterToolFactory =
-  createProviderDefinedToolFactoryWithOutputSchema<
+  createProviderToolFactoryWithOutputSchema<
     {
       /**
        * The code to run, or null if not available.

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -59,7 +59,7 @@ export const fileSearchOutputSchema = lazySchema(() =>
   ),
 );
 
-export const fileSearch = createProviderDefinedToolFactoryWithOutputSchema<
+export const fileSearch = createProviderToolFactoryWithOutputSchema<
   {},
   {
     /**

--- a/packages/openai/src/tool/image-generation.ts
+++ b/packages/openai/src/tool/image-generation.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -104,21 +104,20 @@ type ImageGenerationArgs = {
   size?: 'auto' | '1024x1024' | '1024x1536' | '1536x1024';
 };
 
-const imageGenerationToolFactory =
-  createProviderDefinedToolFactoryWithOutputSchema<
-    {},
-    {
-      /**
-       * The generated image encoded in base64.
-       */
-      result: string;
-    },
-    ImageGenerationArgs
-  >({
-    id: 'openai.image_generation',
-    inputSchema: imageGenerationInputSchema,
-    outputSchema: imageGenerationOutputSchema,
-  });
+const imageGenerationToolFactory = createProviderToolFactoryWithOutputSchema<
+  {},
+  {
+    /**
+     * The generated image encoded in base64.
+     */
+    result: string;
+  },
+  ImageGenerationArgs
+>({
+  id: 'openai.image_generation',
+  inputSchema: imageGenerationInputSchema,
+  outputSchema: imageGenerationOutputSchema,
+});
 
 export const imageGeneration = (
   args: ImageGenerationArgs = {}, // default

--- a/packages/openai/src/tool/local-shell.ts
+++ b/packages/openai/src/tool/local-shell.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -24,7 +24,7 @@ export const localShellOutputSchema = lazySchema(() =>
   zodSchema(z.object({ output: z.string() })),
 );
 
-export const localShell = createProviderDefinedToolFactoryWithOutputSchema<
+export const localShell = createProviderToolFactoryWithOutputSchema<
   {
     /**
      * Execute a shell command on the server.

--- a/packages/openai/src/tool/mcp.ts
+++ b/packages/openai/src/tool/mcp.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -122,7 +122,7 @@ type McpArgs = {
   serverUrl?: string;
 };
 
-export const mcpToolFactory = createProviderDefinedToolFactoryWithOutputSchema<
+export const mcpToolFactory = createProviderToolFactoryWithOutputSchema<
   {},
   | {
       type: 'call';

--- a/packages/openai/src/tool/web-search-preview.ts
+++ b/packages/openai/src/tool/web-search-preview.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -48,93 +48,92 @@ const webSearchPreviewOutputSchema = lazySchema(() =>
   ),
 );
 
-export const webSearchPreview =
-  createProviderDefinedToolFactoryWithOutputSchema<
-    {
-      // Web search preview doesn't take input parameters - it's controlled by the prompt
-    },
-    {
+export const webSearchPreview = createProviderToolFactoryWithOutputSchema<
+  {
+    // Web search preview doesn't take input parameters - it's controlled by the prompt
+  },
+  {
+    /**
+     * An object describing the specific action taken in this web search call.
+     * Includes details on how the model used the web (search, open_page, find).
+     */
+    action:
+      | {
+          /**
+           * Action type "search" - Performs a web search query.
+           */
+          type: 'search';
+
+          /**
+           * The search query.
+           */
+          query?: string;
+        }
+      | {
+          /**
+           * Action type "openPage" - Opens a specific URL from search results.
+           */
+          type: 'openPage';
+
+          /**
+           * The URL opened by the model.
+           */
+          url: string;
+        }
+      | {
+          /**
+           * Action type "find": Searches for a pattern within a loaded page.
+           */
+          type: 'find';
+
+          /**
+           * The URL of the page searched for the pattern.
+           */
+          url: string;
+
+          /**
+           * The pattern or text to search for within the page.
+           */
+          pattern: string;
+        };
+  },
+  {
+    /**
+     * Search context size to use for the web search.
+     * - high: Most comprehensive context, highest cost, slower response
+     * - medium: Balanced context, cost, and latency (default)
+     * - low: Least context, lowest cost, fastest response
+     */
+    searchContextSize?: 'low' | 'medium' | 'high';
+
+    /**
+     * User location information to provide geographically relevant search results.
+     */
+    userLocation?: {
       /**
-       * An object describing the specific action taken in this web search call.
-       * Includes details on how the model used the web (search, open_page, find).
+       * Type of location (always 'approximate')
        */
-      action:
-        | {
-            /**
-             * Action type "search" - Performs a web search query.
-             */
-            type: 'search';
-
-            /**
-             * The search query.
-             */
-            query?: string;
-          }
-        | {
-            /**
-             * Action type "openPage" - Opens a specific URL from search results.
-             */
-            type: 'openPage';
-
-            /**
-             * The URL opened by the model.
-             */
-            url: string;
-          }
-        | {
-            /**
-             * Action type "find": Searches for a pattern within a loaded page.
-             */
-            type: 'find';
-
-            /**
-             * The URL of the page searched for the pattern.
-             */
-            url: string;
-
-            /**
-             * The pattern or text to search for within the page.
-             */
-            pattern: string;
-          };
-    },
-    {
+      type: 'approximate';
       /**
-       * Search context size to use for the web search.
-       * - high: Most comprehensive context, highest cost, slower response
-       * - medium: Balanced context, cost, and latency (default)
-       * - low: Least context, lowest cost, fastest response
+       * Two-letter ISO country code (e.g., 'US', 'GB')
        */
-      searchContextSize?: 'low' | 'medium' | 'high';
-
+      country?: string;
       /**
-       * User location information to provide geographically relevant search results.
+       * City name (free text, e.g., 'Minneapolis')
        */
-      userLocation?: {
-        /**
-         * Type of location (always 'approximate')
-         */
-        type: 'approximate';
-        /**
-         * Two-letter ISO country code (e.g., 'US', 'GB')
-         */
-        country?: string;
-        /**
-         * City name (free text, e.g., 'Minneapolis')
-         */
-        city?: string;
-        /**
-         * Region name (free text, e.g., 'Minnesota')
-         */
-        region?: string;
-        /**
-         * IANA timezone (e.g., 'America/Chicago')
-         */
-        timezone?: string;
-      };
-    }
-  >({
-    id: 'openai.web_search_preview',
-    inputSchema: webSearchPreviewInputSchema,
-    outputSchema: webSearchPreviewOutputSchema,
-  });
+      city?: string;
+      /**
+       * Region name (free text, e.g., 'Minnesota')
+       */
+      region?: string;
+      /**
+       * IANA timezone (e.g., 'America/Chicago')
+       */
+      timezone?: string;
+    };
+  }
+>({
+  id: 'openai.web_search_preview',
+  inputSchema: webSearchPreviewInputSchema,
+  outputSchema: webSearchPreviewOutputSchema,
+});

--- a/packages/openai/src/tool/web-search.ts
+++ b/packages/openai/src/tool/web-search.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -58,122 +58,121 @@ export const webSearchOutputSchema = lazySchema(() =>
   ),
 );
 
-export const webSearchToolFactory =
-  createProviderDefinedToolFactoryWithOutputSchema<
-    {
-      // Web search doesn't take input parameters - it's controlled by the prompt
-    },
-    {
+export const webSearchToolFactory = createProviderToolFactoryWithOutputSchema<
+  {
+    // Web search doesn't take input parameters - it's controlled by the prompt
+  },
+  {
+    /**
+     * An object describing the specific action taken in this web search call.
+     * Includes details on how the model used the web (search, open_page, find).
+     */
+    action:
+      | {
+          /**
+           * Action type "search" - Performs a web search query.
+           */
+          type: 'search';
+
+          /**
+           * The search query.
+           */
+          query?: string;
+        }
+      | {
+          /**
+           * Action type "openPage" - Opens a specific URL from search results.
+           */
+          type: 'openPage';
+
+          /**
+           * The URL opened by the model.
+           */
+          url: string;
+        }
+      | {
+          /**
+           * Action type "find": Searches for a pattern within a loaded page.
+           */
+          type: 'find';
+
+          /**
+           * The URL of the page searched for the pattern.
+           */
+          url: string;
+
+          /**
+           * The pattern or text to search for within the page.
+           */
+          pattern: string;
+        };
+
+    /**
+     * Optional sources cited by the model for the web search call.
+     */
+    sources?: Array<
+      { type: 'url'; url: string } | { type: 'api'; name: string }
+    >;
+  },
+  {
+    /**
+     * Whether to use external web access for fetching live content.
+     * - true: Fetch live web content (default)
+     * - false: Use cached/indexed results
+     */
+    externalWebAccess?: boolean;
+
+    /**
+     * Filters for the search.
+     */
+    filters?: {
       /**
-       * An object describing the specific action taken in this web search call.
-       * Includes details on how the model used the web (search, open_page, find).
+       * Allowed domains for the search.
+       * If not provided, all domains are allowed.
+       * Subdomains of the provided domains are allowed as well.
        */
-      action:
-        | {
-            /**
-             * Action type "search" - Performs a web search query.
-             */
-            type: 'search';
+      allowedDomains?: string[];
+    };
 
-            /**
-             * The search query.
-             */
-            query?: string;
-          }
-        | {
-            /**
-             * Action type "openPage" - Opens a specific URL from search results.
-             */
-            type: 'openPage';
+    /**
+     * Search context size to use for the web search.
+     * - high: Most comprehensive context, highest cost, slower response
+     * - medium: Balanced context, cost, and latency (default)
+     * - low: Least context, lowest cost, fastest response
+     */
+    searchContextSize?: 'low' | 'medium' | 'high';
 
-            /**
-             * The URL opened by the model.
-             */
-            url: string;
-          }
-        | {
-            /**
-             * Action type "find": Searches for a pattern within a loaded page.
-             */
-            type: 'find';
-
-            /**
-             * The URL of the page searched for the pattern.
-             */
-            url: string;
-
-            /**
-             * The pattern or text to search for within the page.
-             */
-            pattern: string;
-          };
-
+    /**
+     * User location information to provide geographically relevant search results.
+     */
+    userLocation?: {
       /**
-       * Optional sources cited by the model for the web search call.
+       * Type of location (always 'approximate')
        */
-      sources?: Array<
-        { type: 'url'; url: string } | { type: 'api'; name: string }
-      >;
-    },
-    {
+      type: 'approximate';
       /**
-       * Whether to use external web access for fetching live content.
-       * - true: Fetch live web content (default)
-       * - false: Use cached/indexed results
+       * Two-letter ISO country code (e.g., 'US', 'GB')
        */
-      externalWebAccess?: boolean;
-
+      country?: string;
       /**
-       * Filters for the search.
+       * City name (free text, e.g., 'Minneapolis')
        */
-      filters?: {
-        /**
-         * Allowed domains for the search.
-         * If not provided, all domains are allowed.
-         * Subdomains of the provided domains are allowed as well.
-         */
-        allowedDomains?: string[];
-      };
-
+      city?: string;
       /**
-       * Search context size to use for the web search.
-       * - high: Most comprehensive context, highest cost, slower response
-       * - medium: Balanced context, cost, and latency (default)
-       * - low: Least context, lowest cost, fastest response
+       * Region name (free text, e.g., 'Minnesota')
        */
-      searchContextSize?: 'low' | 'medium' | 'high';
-
+      region?: string;
       /**
-       * User location information to provide geographically relevant search results.
+       * IANA timezone (e.g., 'America/Chicago')
        */
-      userLocation?: {
-        /**
-         * Type of location (always 'approximate')
-         */
-        type: 'approximate';
-        /**
-         * Two-letter ISO country code (e.g., 'US', 'GB')
-         */
-        country?: string;
-        /**
-         * City name (free text, e.g., 'Minneapolis')
-         */
-        city?: string;
-        /**
-         * Region name (free text, e.g., 'Minnesota')
-         */
-        region?: string;
-        /**
-         * IANA timezone (e.g., 'America/Chicago')
-         */
-        timezone?: string;
-      };
-    }
-  >({
-    id: 'openai.web_search',
-    inputSchema: webSearchInputSchema,
-    outputSchema: webSearchOutputSchema,
-  });
+      timezone?: string;
+    };
+  }
+>({
+  id: 'openai.web_search',
+  inputSchema: webSearchInputSchema,
+  outputSchema: webSearchOutputSchema,
+});
 
 export const webSearch = (
   args: Parameters<typeof webSearchToolFactory>[0] = {}, // default

--- a/packages/provider-utils/src/create-tool-name-mapping.test.ts
+++ b/packages/provider-utils/src/create-tool-name-mapping.test.ts
@@ -1,6 +1,6 @@
 import {
   LanguageModelV3FunctionTool,
-  LanguageModelV3ProviderDefinedTool,
+  LanguageModelV3ProviderTool,
 } from '@ai-sdk/provider';
 import { describe, expect, it } from 'vitest';
 import { createToolNameMapping } from './create-tool-name-mapping';
@@ -8,16 +8,16 @@ import { createToolNameMapping } from './create-tool-name-mapping';
 describe('createToolNameMapping', () => {
   it('should create mappings for provider-defined tools', () => {
     const tools: Array<
-      LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool
+      LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
     > = [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'anthropic.computer-use',
         name: 'custom-computer-tool',
         args: {},
       },
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'openai.code-interpreter',
         name: 'custom-code-tool',
         args: {},
@@ -47,7 +47,7 @@ describe('createToolNameMapping', () => {
 
   it('should ignore function tools', () => {
     const tools: Array<
-      LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool
+      LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
     > = [
       {
         type: 'function',
@@ -71,10 +71,10 @@ describe('createToolNameMapping', () => {
 
   it('should return input name when tool is not in providerToolNames', () => {
     const tools: Array<
-      LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool
+      LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
     > = [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'unknown.tool',
         name: 'custom-tool',
         args: {},
@@ -91,10 +91,10 @@ describe('createToolNameMapping', () => {
 
   it('should return input name when mapping does not exist', () => {
     const tools: Array<
-      LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool
+      LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
     > = [
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'anthropic.computer-use',
         name: 'custom-computer-tool',
         args: {},
@@ -117,7 +117,7 @@ describe('createToolNameMapping', () => {
 
   it('should handle empty tools array', () => {
     const tools: Array<
-      LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool
+      LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
     > = [];
 
     const providerToolNames: Record<`${string}.${string}`, string> = {};
@@ -130,7 +130,7 @@ describe('createToolNameMapping', () => {
 
   it('should handle mixed function and provider-defined tools', () => {
     const tools: Array<
-      LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool
+      LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
     > = [
       {
         type: 'function',
@@ -139,7 +139,7 @@ describe('createToolNameMapping', () => {
         inputSchema: { type: 'object' },
       },
       {
-        type: 'provider-defined',
+        type: 'provider',
         id: 'anthropic.computer-use',
         name: 'provider-tool',
         args: {},

--- a/packages/provider-utils/src/create-tool-name-mapping.ts
+++ b/packages/provider-utils/src/create-tool-name-mapping.ts
@@ -1,6 +1,6 @@
 import {
   LanguageModelV3FunctionTool,
-  LanguageModelV3ProviderDefinedTool,
+  LanguageModelV3ProviderTool,
 } from '@ai-sdk/provider';
 
 /**
@@ -38,7 +38,7 @@ export function createToolNameMapping({
    * Tools that were passed to the language model.
    */
   tools:
-    | Array<LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool>
+    | Array<LanguageModelV3FunctionTool | LanguageModelV3ProviderTool>
     | undefined;
 
   /**
@@ -50,7 +50,7 @@ export function createToolNameMapping({
   const providerToolNameToCustomToolName: Record<string, string> = {};
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined' && tool.id in providerToolNames) {
+    if (tool.type === 'provider' && tool.id in providerToolNames) {
       const providerToolName = providerToolNames[tool.id];
       customToolNameToProviderToolName[tool.name] = providerToolName;
       providerToolNameToCustomToolName[providerToolName] = tool.name;

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -27,11 +27,11 @@ export { parseJsonEventStream } from './parse-json-event-stream';
 export { parseProviderOptions } from './parse-provider-options';
 export * from './post-to-api';
 export {
-  createProviderDefinedToolFactory,
-  createProviderDefinedToolFactoryWithOutputSchema,
-  type ProviderDefinedToolFactory,
-  type ProviderDefinedToolFactoryWithOutputSchema,
-} from './provider-defined-tool-factory';
+  createProviderToolFactory,
+  createProviderToolFactoryWithOutputSchema,
+  type ProviderToolFactory,
+  type ProviderToolFactoryWithOutputSchema,
+} from './provider-tool-factory';
 export * from './remove-undefined-entries';
 export * from './resolve';
 export * from './response-handler';

--- a/packages/provider-utils/src/provider-tool-factory.ts
+++ b/packages/provider-utils/src/provider-tool-factory.ts
@@ -1,7 +1,7 @@
 import { tool, Tool, ToolExecuteFunction } from './types/tool';
 import { FlexibleSchema } from './schema';
 
-export type ProviderDefinedToolFactory<INPUT, ARGS extends object> = <OUTPUT>(
+export type ProviderToolFactory<INPUT, ARGS extends object> = <OUTPUT>(
   options: ARGS & {
     execute?: ToolExecuteFunction<INPUT, OUTPUT>;
     needsApproval?: Tool<INPUT, OUTPUT>['needsApproval'];
@@ -12,13 +12,13 @@ export type ProviderDefinedToolFactory<INPUT, ARGS extends object> = <OUTPUT>(
   },
 ) => Tool<INPUT, OUTPUT>;
 
-export function createProviderDefinedToolFactory<INPUT, ARGS extends object>({
+export function createProviderToolFactory<INPUT, ARGS extends object>({
   id,
   inputSchema,
 }: {
   id: `${string}.${string}`;
   inputSchema: FlexibleSchema<INPUT>;
-}): ProviderDefinedToolFactory<INPUT, ARGS> {
+}): ProviderToolFactory<INPUT, ARGS> {
   return <OUTPUT>({
     execute,
     outputSchema,
@@ -38,7 +38,7 @@ export function createProviderDefinedToolFactory<INPUT, ARGS extends object>({
     onInputAvailable?: Tool<INPUT, OUTPUT>['onInputAvailable'];
   }): Tool<INPUT, OUTPUT> =>
     tool({
-      type: 'provider-defined',
+      type: 'provider',
       id,
       args,
       inputSchema,
@@ -52,7 +52,7 @@ export function createProviderDefinedToolFactory<INPUT, ARGS extends object>({
     });
 }
 
-export type ProviderDefinedToolFactoryWithOutputSchema<
+export type ProviderToolFactoryWithOutputSchema<
   INPUT,
   OUTPUT,
   ARGS extends object,
@@ -67,7 +67,7 @@ export type ProviderDefinedToolFactoryWithOutputSchema<
   },
 ) => Tool<INPUT, OUTPUT>;
 
-export function createProviderDefinedToolFactoryWithOutputSchema<
+export function createProviderToolFactoryWithOutputSchema<
   INPUT,
   OUTPUT,
   ARGS extends object,
@@ -79,7 +79,7 @@ export function createProviderDefinedToolFactoryWithOutputSchema<
   id: `${string}.${string}`;
   inputSchema: FlexibleSchema<INPUT>;
   outputSchema: FlexibleSchema<OUTPUT>;
-}): ProviderDefinedToolFactoryWithOutputSchema<INPUT, OUTPUT, ARGS> {
+}): ProviderToolFactoryWithOutputSchema<INPUT, OUTPUT, ARGS> {
   return ({
     execute,
     needsApproval,
@@ -97,7 +97,7 @@ export function createProviderDefinedToolFactoryWithOutputSchema<
     onInputAvailable?: Tool<INPUT, OUTPUT>['onInputAvailable'];
   }): Tool<INPUT, OUTPUT> =>
     tool({
-      type: 'provider-defined',
+      type: 'provider',
       id,
       args,
       inputSchema,

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -189,7 +189,7 @@ The types of input and output are not known at development time.
         /**
 Tool with provider-defined input and output schemas.
      */
-        type: 'provider-defined';
+        type: 'provider';
 
         /**
 The ID of the tool. Must follow the format `<provider-name>.<unique-tool-name>`.

--- a/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-options.ts
@@ -2,7 +2,7 @@ import { JSONSchema7 } from 'json-schema';
 import { SharedV2ProviderOptions } from '../../shared/v2/shared-v2-provider-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
 import { LanguageModelV2Prompt } from './language-model-v2-prompt';
-import { LanguageModelV2ProviderDefinedTool } from './language-model-v2-provider-defined-tool';
+import { LanguageModelV2ProviderTool } from './language-model-v2-provider-defined-tool';
 import { LanguageModelV2ToolChoice } from './language-model-v2-tool-choice';
 
 export type LanguageModelV2CallOptions = {
@@ -93,9 +93,7 @@ by the model, calls will generate deterministic results.
   /**
 The tools that are available for the model.
   */
-  tools?: Array<
-    LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool
-  >;
+  tools?: Array<LanguageModelV2FunctionTool | LanguageModelV2ProviderTool>;
 
   /**
 Specifies how the tool should be selected. Defaults to 'auto'.

--- a/packages/provider/src/language-model/v2/language-model-v2-call-warning.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-call-warning.ts
@@ -1,6 +1,6 @@
 import { LanguageModelV2CallOptions } from './language-model-v2-call-options';
 import { LanguageModelV2FunctionTool } from './language-model-v2-function-tool';
-import { LanguageModelV2ProviderDefinedTool } from './language-model-v2-provider-defined-tool';
+import { LanguageModelV2ProviderTool } from './language-model-v2-provider-defined-tool';
 
 /**
 Warning from the model provider for this call. The call will proceed, but e.g.
@@ -14,7 +14,7 @@ export type LanguageModelV2CallWarning =
     }
   | {
       type: 'unsupported-tool';
-      tool: LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool;
+      tool: LanguageModelV2FunctionTool | LanguageModelV2ProviderTool;
       details?: string;
     }
   | {

--- a/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts
+++ b/packages/provider/src/language-model/v2/language-model-v2-provider-defined-tool.ts
@@ -1,11 +1,11 @@
 /**
 The configuration of a tool that is defined by the provider.
  */
-export type LanguageModelV2ProviderDefinedTool = {
+export type LanguageModelV2ProviderTool = {
   /**
-The type of the tool (always 'provider-defined').
+The type of the tool (always 'provider').
    */
-  type: 'provider-defined';
+  type: 'provider';
 
   /**
 The ID of the tool. Should follow the format `<provider-name>.<unique-tool-name>`.

--- a/packages/provider/src/language-model/v3/index.ts
+++ b/packages/provider/src/language-model/v3/index.ts
@@ -6,7 +6,7 @@ export * from './language-model-v3-file';
 export * from './language-model-v3-finish-reason';
 export * from './language-model-v3-function-tool';
 export * from './language-model-v3-prompt';
-export * from './language-model-v3-provider-defined-tool';
+export * from './language-model-v3-provider-tool';
 export * from './language-model-v3-reasoning';
 export * from './language-model-v3-response-metadata';
 export * from './language-model-v3-source';

--- a/packages/provider/src/language-model/v3/language-model-v3-call-options.ts
+++ b/packages/provider/src/language-model/v3/language-model-v3-call-options.ts
@@ -2,7 +2,7 @@ import { JSONSchema7 } from 'json-schema';
 import { SharedV3ProviderOptions } from '../../shared/v3/shared-v3-provider-options';
 import { LanguageModelV3FunctionTool } from './language-model-v3-function-tool';
 import { LanguageModelV3Prompt } from './language-model-v3-prompt';
-import { LanguageModelV3ProviderDefinedTool } from './language-model-v3-provider-defined-tool';
+import { LanguageModelV3ProviderTool } from './language-model-v3-provider-tool';
 import { LanguageModelV3ToolChoice } from './language-model-v3-tool-choice';
 
 export type LanguageModelV3CallOptions = {
@@ -93,9 +93,7 @@ by the model, calls will generate deterministic results.
   /**
 The tools that are available for the model.
   */
-  tools?: Array<
-    LanguageModelV3FunctionTool | LanguageModelV3ProviderDefinedTool
-  >;
+  tools?: Array<LanguageModelV3FunctionTool | LanguageModelV3ProviderTool>;
 
   /**
 Specifies how the tool should be selected. Defaults to 'auto'.

--- a/packages/provider/src/language-model/v3/language-model-v3-provider-tool.ts
+++ b/packages/provider/src/language-model/v3/language-model-v3-provider-tool.ts
@@ -1,11 +1,15 @@
 /**
- * The configuration of a tool that is defined by the provider.
+ * The configuration of a provider tool.
+ *
+ * Provider tools are tools that are specific to a certain provider.
+ * The input and output schemas are defined be the provider, and
+ * some of the tools are also executed on the provider systems.
  */
-export type LanguageModelV3ProviderDefinedTool = {
+export type LanguageModelV3ProviderTool = {
   /**
-   * The type of the tool (always 'provider-defined').
+   * The type of the tool (always 'provider').
    */
-  type: 'provider-defined';
+  type: 'provider';
 
   /**
    * The ID of the tool. Should follow the format `<provider-id>.<unique-tool-name>`.

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -336,7 +336,7 @@ describe('XaiResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'xai.web_search',
               name: 'web_search',
               args: {},
@@ -363,7 +363,7 @@ describe('XaiResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'xai.web_search',
               name: 'web_search',
               args: {
@@ -401,7 +401,7 @@ describe('XaiResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'xai.x_search',
               name: 'x_search',
               args: {},
@@ -421,7 +421,7 @@ describe('XaiResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'xai.code_execution',
               name: 'code_execution',
               args: {},
@@ -576,13 +576,13 @@ describe('XaiResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'xai.web_search',
               name: 'web_search',
               args: {},
             },
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'xai.code_execution',
               name: 'code_execution',
               args: {},
@@ -606,7 +606,7 @@ describe('XaiResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'xai.web_search',
               name: 'web_search',
               args: {},
@@ -699,7 +699,7 @@ describe('XaiResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           tools: [
             {
-              type: 'provider-defined',
+              type: 'provider',
               id: 'xai.web_search',
               name: 'web_search',
               args: {},

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -83,16 +83,15 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
     }
 
     const webSearchToolName = tools?.find(
-      tool => tool.type === 'provider-defined' && tool.id === 'xai.web_search',
+      tool => tool.type === 'provider' && tool.id === 'xai.web_search',
     )?.name;
 
     const xSearchToolName = tools?.find(
-      tool => tool.type === 'provider-defined' && tool.id === 'xai.x_search',
+      tool => tool.type === 'provider' && tool.id === 'xai.x_search',
     )?.name;
 
     const codeExecutionToolName = tools?.find(
-      tool =>
-        tool.type === 'provider-defined' && tool.id === 'xai.code_execution',
+      tool => tool.type === 'provider' && tool.id === 'xai.code_execution',
     )?.name;
 
     const { input, inputWarnings } = await convertToXaiResponsesInput({

--- a/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.test.ts
@@ -7,7 +7,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {},
@@ -35,7 +35,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {
@@ -64,7 +64,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {
@@ -92,7 +92,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {
@@ -120,7 +120,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.x_search',
             name: 'x_search',
             args: {},
@@ -147,7 +147,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.x_search',
             name: 'x_search',
             args: {
@@ -179,7 +179,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.x_search',
             name: 'x_search',
             args: {
@@ -209,7 +209,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.x_search',
             name: 'x_search',
             args: {
@@ -241,7 +241,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.code_execution',
             name: 'code_execution',
             args: {},
@@ -264,7 +264,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.view_image',
             name: 'view_image',
             args: {},
@@ -281,7 +281,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.view_x_video',
             name: 'view_x_video',
             args: {},
@@ -342,7 +342,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {},
@@ -358,7 +358,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {},
@@ -374,7 +374,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {},
@@ -409,7 +409,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {},
@@ -433,13 +433,13 @@ describe('prepareResponsesTools', () => {
             inputSchema: { type: 'object', properties: {} },
           },
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.web_search',
             name: 'web_search',
             args: {},
           },
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'xai.x_search',
             name: 'x_search',
             args: {},
@@ -478,7 +478,7 @@ describe('prepareResponsesTools', () => {
       const result = await prepareResponsesTools({
         tools: [
           {
-            type: 'provider-defined',
+            type: 'provider',
             id: 'unsupported.tool',
             name: 'unsupported',
             args: {},

--- a/packages/xai/src/responses/xai-responses-prepare-tools.ts
+++ b/packages/xai/src/responses/xai-responses-prepare-tools.ts
@@ -46,7 +46,7 @@ export async function prepareResponsesTools({
   for (const tool of normalizedTools) {
     toolByName.set(tool.name, tool);
 
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider') {
       switch (tool.id) {
         case 'xai.web_search': {
           const args = await validateTypes({
@@ -159,7 +159,7 @@ export async function prepareResponsesTools({
         };
       }
 
-      if (selectedTool.type === 'provider-defined') {
+      if (selectedTool.type === 'provider') {
         switch (selectedTool.id) {
           case 'xai.web_search':
             return {

--- a/packages/xai/src/tool/code-execution.ts
+++ b/packages/xai/src/tool/code-execution.ts
@@ -1,4 +1,4 @@
-import { createProviderDefinedToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
+import { createProviderToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 const codeExecutionOutputSchema = z.object({
@@ -6,12 +6,11 @@ const codeExecutionOutputSchema = z.object({
   error: z.string().optional().describe('any error that occurred'),
 });
 
-const codeExecutionToolFactory =
-  createProviderDefinedToolFactoryWithOutputSchema({
-    id: 'xai.code_execution',
-    inputSchema: z.object({}).describe('no input parameters'),
-    outputSchema: codeExecutionOutputSchema,
-  });
+const codeExecutionToolFactory = createProviderToolFactoryWithOutputSchema({
+  id: 'xai.code_execution',
+  inputSchema: z.object({}).describe('no input parameters'),
+  outputSchema: codeExecutionOutputSchema,
+});
 
 export const codeExecution = (
   args: Parameters<typeof codeExecutionToolFactory>[0] = {},

--- a/packages/xai/src/tool/view-image.ts
+++ b/packages/xai/src/tool/view-image.ts
@@ -1,4 +1,4 @@
-import { createProviderDefinedToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
+import { createProviderToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 const viewImageOutputSchema = z.object({
@@ -9,7 +9,7 @@ const viewImageOutputSchema = z.object({
     .describe('objects detected in the image'),
 });
 
-const viewImageToolFactory = createProviderDefinedToolFactoryWithOutputSchema({
+const viewImageToolFactory = createProviderToolFactoryWithOutputSchema({
   id: 'xai.view_image',
   inputSchema: z.object({}).describe('no input parameters'),
   outputSchema: viewImageOutputSchema,

--- a/packages/xai/src/tool/view-x-video.ts
+++ b/packages/xai/src/tool/view-x-video.ts
@@ -1,4 +1,4 @@
-import { createProviderDefinedToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
+import { createProviderToolFactoryWithOutputSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 const viewXVideoOutputSchema = z.object({
@@ -7,7 +7,7 @@ const viewXVideoOutputSchema = z.object({
   duration: z.number().optional().describe('duration in seconds'),
 });
 
-const viewXVideoToolFactory = createProviderDefinedToolFactoryWithOutputSchema({
+const viewXVideoToolFactory = createProviderToolFactoryWithOutputSchema({
   id: 'xai.view_x_video',
   inputSchema: z.object({}).describe('no input parameters'),
   outputSchema: viewXVideoOutputSchema,

--- a/packages/xai/src/tool/web-search.ts
+++ b/packages/xai/src/tool/web-search.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -30,7 +30,7 @@ const webSearchOutputSchema = lazySchema(() =>
   ),
 );
 
-const webSearchToolFactory = createProviderDefinedToolFactoryWithOutputSchema<
+const webSearchToolFactory = createProviderToolFactoryWithOutputSchema<
   Record<string, never>,
   {
     query: string;

--- a/packages/xai/src/tool/x-search.ts
+++ b/packages/xai/src/tool/x-search.ts
@@ -1,5 +1,5 @@
 import {
-  createProviderDefinedToolFactoryWithOutputSchema,
+  createProviderToolFactoryWithOutputSchema,
   lazySchema,
   zodSchema,
 } from '@ai-sdk/provider-utils';
@@ -34,7 +34,7 @@ const xSearchOutputSchema = lazySchema(() =>
   ),
 );
 
-const xSearchToolFactory = createProviderDefinedToolFactoryWithOutputSchema<
+const xSearchToolFactory = createProviderToolFactoryWithOutputSchema<
   Record<string, never>,
   {
     query: string;

--- a/packages/xai/src/xai-prepare-tools.ts
+++ b/packages/xai/src/xai-prepare-tools.ts
@@ -45,7 +45,7 @@ export function prepareTools({
   }> = [];
 
   for (const tool of tools) {
-    if (tool.type === 'provider-defined') {
+    if (tool.type === 'provider') {
       toolWarnings.push({
         type: 'unsupported',
         feature: `provider-defined tool ${tool.name}`,


### PR DESCRIPTION
## Background

The term `provider-defined` is overly complex. `provider` is sufficient and increases code readability.

## Summary

Rename provider defined tool to provider tool.

**breaking change**: provider tools from ai sdk v5 providers will not work with ai sdk 6. however, there are no community providers with provider defined tools that we are aware of, and all 1st party providers will be updated.