### PR TITLE
chore(provider): remove todo

### DIFF
--- a/packages/provider/src/errors/json-parse-error.ts
+++ b/packages/provider/src/errors/json-parse-error.ts
@@ -5,7 +5,6 @@ const name = 'AI_JSONParseError';
 const marker = `vercel.ai.error.${name}`;
 const symbol = Symbol.for(marker);
 
-// TODO v5: rename to ParseError
 export class JSONParseError extends AISDKError {
   private readonly [symbol] = true; // used in isInstance
 


### PR DESCRIPTION
## Background

We have no other parse errors and changing the error would impact error pages, client error handling code, and make the error less specific. It is good to know that JSON was attempted.

## Summary

Remove TODO.

## Future Work

- revisit when we start supporting different formats