### PR TITLE
chore(ai): remove deprecated CodeMessage type and related types and functions

### DIFF
--- a/.changeset/ninety-rivers-explain.md
+++ b/.changeset/ninety-rivers-explain.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(ai): remove deprecated CodeMessage type and related types and functions

--- a/content/docs/08-migration-guides/27-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/27-migration-guide-6-0.mdx
@@ -36,6 +36,12 @@ An example upgrade command would be:
 pnpm install ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta
 ```
 
+## `ai` package
+
+### `CoreMessage` removed
+
+The deprecated `CoreMessage` type and related types, schemas, and functions have been removed.
+
 ## Codemods
 
 The AI SDK **will** provide Codemod transformations to help upgrade your codebase when a

--- a/packages/ai/src/prompt/index.ts
+++ b/packages/ai/src/prompt/index.ts
@@ -1,22 +1,10 @@
 export type { CallSettings } from './call-settings';
 export {
   assistantModelMessageSchema,
-  coreAssistantMessageSchema,
-  coreMessageSchema,
-  coreSystemMessageSchema,
-  coreToolMessageSchema,
-  coreUserMessageSchema,
   modelMessageSchema,
   systemModelMessageSchema,
   toolModelMessageSchema,
   userModelMessageSchema,
-} from './message';
-export type {
-  CoreAssistantMessage,
-  CoreMessage,
-  CoreSystemMessage,
-  CoreToolMessage,
-  CoreUserMessage,
 } from './message';
 export type { Prompt } from './prompt';
 

--- a/packages/ai/src/prompt/message.ts
+++ b/packages/ai/src/prompt/message.ts
@@ -18,12 +18,6 @@ import {
   toolResultPartSchema,
 } from './content-part';
 
-/**
-@deprecated Use `SystemModelMessage` instead.
- */
-// TODO remove in AI SDK 6
-export type CoreSystemMessage = SystemModelMessage;
-
 export const systemModelMessageSchema: z.ZodType<SystemModelMessage> = z.object(
   {
     role: z.literal('system'),
@@ -31,18 +25,6 @@ export const systemModelMessageSchema: z.ZodType<SystemModelMessage> = z.object(
     providerOptions: providerMetadataSchema.optional(),
   },
 );
-
-/**
-@deprecated Use `systemModelMessageSchema` instead.
- */
-// TODO remove in AI SDK 6
-export const coreSystemMessageSchema = systemModelMessageSchema;
-
-/**
-@deprecated Use `UserModelMessage` instead.
- */
-// TODO remove in AI SDK 6
-export type CoreUserMessage = UserModelMessage;
 
 export const userModelMessageSchema: z.ZodType<UserModelMessage> = z.object({
   role: z.literal('user'),
@@ -52,18 +34,6 @@ export const userModelMessageSchema: z.ZodType<UserModelMessage> = z.object({
   ]),
   providerOptions: providerMetadataSchema.optional(),
 });
-
-/**
-@deprecated Use `userModelMessageSchema` instead.
- */
-// TODO remove in AI SDK 6
-export const coreUserMessageSchema = userModelMessageSchema;
-
-/**
-@deprecated Use `AssistantModelMessage` instead.
- */
-// TODO remove in AI SDK 6
-export type CoreAssistantMessage = AssistantModelMessage;
 
 export const assistantModelMessageSchema: z.ZodType<AssistantModelMessage> =
   z.object({
@@ -84,35 +54,11 @@ export const assistantModelMessageSchema: z.ZodType<AssistantModelMessage> =
     providerOptions: providerMetadataSchema.optional(),
   });
 
-/**
-@deprecated Use `assistantModelMessageSchema` instead.
- */
-// TODO remove in AI SDK 6
-export const coreAssistantMessageSchema = assistantModelMessageSchema;
-
-/**
-@deprecated Use `ToolModelMessage` instead.
- */
-// TODO remove in AI SDK 6
-export type CoreToolMessage = ToolModelMessage;
-
 export const toolModelMessageSchema: z.ZodType<ToolModelMessage> = z.object({
   role: z.literal('tool'),
   content: z.array(z.union([toolResultPartSchema, toolApprovalResponseSchema])),
   providerOptions: providerMetadataSchema.optional(),
 });
-
-/**
-@deprecated Use `toolModelMessageSchema` instead.
- */
-// TODO remove in AI SDK 6
-export const coreToolMessageSchema = toolModelMessageSchema;
-
-/**
-@deprecated Use `ModelMessage` instead.
-   */
-// TODO remove in AI SDK 6
-export type CoreMessage = ModelMessage;
 
 export const modelMessageSchema: z.ZodType<ModelMessage> = z.union([
   systemModelMessageSchema,
@@ -120,9 +66,3 @@ export const modelMessageSchema: z.ZodType<ModelMessage> = z.union([
   assistantModelMessageSchema,
   toolModelMessageSchema,
 ]);
-
-/**
-@deprecated Use `modelMessageSchema` instead.
- */
-// TODO remove in AI SDK 6
-export const coreMessageSchema: z.ZodType<CoreMessage> = modelMessageSchema;

--- a/packages/ai/src/types/embedding-model.ts
+++ b/packages/ai/src/types/embedding-model.ts
@@ -5,7 +5,7 @@ import {
 } from '@ai-sdk/provider';
 
 /**
-Embedding model that is used by the AI SDK Core functions.
+Embedding model that is used by the AI SDK.
 */
 export type EmbeddingModel =
   | string

--- a/packages/ai/src/types/image-model.ts
+++ b/packages/ai/src/types/image-model.ts
@@ -6,7 +6,7 @@ import {
 } from '@ai-sdk/provider';
 
 /**
-Image model that is used by the AI SDK Core functions.
+Image model that is used by the AI SDK.
   */
 export type ImageModel = string | ImageModelV3 | ImageModelV2;
 

--- a/packages/ai/src/types/language-model.ts
+++ b/packages/ai/src/types/language-model.ts
@@ -53,7 +53,7 @@ export type GlobalProviderModelId = [keyof RegisteredProviderModels] extends [
       | RegisteredProviderModels[keyof RegisteredProviderModels];
 
 /**
-Language model that is used by the AI SDK Core functions.
+Language model that is used by the AI SDK.
 */
 export type LanguageModel =
   | GlobalProviderModelId

--- a/packages/ai/src/types/reranking-model.ts
+++ b/packages/ai/src/types/reranking-model.ts
@@ -1,6 +1,6 @@
 import { RerankingModelV3 } from '@ai-sdk/provider';
 
 /**
- * Reranking model that is used by the AI SDK Core functions.
+ * Reranking model that is used by the AI SDK.
  */
 export type RerankingModel = RerankingModelV3;

--- a/packages/ai/src/types/speech-model.ts
+++ b/packages/ai/src/types/speech-model.ts
@@ -1,6 +1,6 @@
 import { SpeechModelV2, SpeechModelV3 } from '@ai-sdk/provider';
 
 /**
-Speech model that is used by the AI SDK Core functions.
+Speech model that is used by the AI SDK.
   */
 export type SpeechModel = string | SpeechModelV3 | SpeechModelV2;

--- a/packages/ai/src/types/transcription-model.ts
+++ b/packages/ai/src/types/transcription-model.ts
@@ -1,7 +1,7 @@
 import { TranscriptionModelV2, TranscriptionModelV3 } from '@ai-sdk/provider';
 
 /**
-Transcription model that is used by the AI SDK Core functions.
+Transcription model that is used by the AI SDK.
   */
 export type TranscriptionModel =
   | string

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -356,9 +356,3 @@ export function convertToModelMessages<UI_MESSAGE extends UIMessage>(
 
   return modelMessages;
 }
-
-/**
-@deprecated Use `convertToModelMessages` instead.
- */
-// TODO remove in AI SDK 6
-export const convertToCoreMessages = convertToModelMessages;

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -16,10 +16,7 @@ export {
 } from './chat';
 export { type ChatTransport } from './chat-transport';
 export { convertFileListToFileUIParts } from './convert-file-list-to-file-ui-parts';
-export {
-  convertToCoreMessages,
-  convertToModelMessages,
-} from './convert-to-model-messages';
+export { convertToModelMessages } from './convert-to-model-messages';
 export { DefaultChatTransport } from './default-chat-transport';
 export {
   HttpChatTransport,


### PR DESCRIPTION
## Background

`CoreMessage` and related types have been deprecated in AI SDK 5.

## Summary

Remove the deprecated `CoreMessage` type and related types, schemas, and functions.