### PR TITLE
feat (ai): propagate all metadata in generate-image

### DIFF
--- a/examples/ai-core/src/generate-image/openai.ts
+++ b/examples/ai-core/src/generate-image/openai.ts
@@ -19,7 +19,13 @@ async function main() {
     usage: result.usage,
   });
 
-  await presentImages([result.image]);
+  await presentImages(result.images);
+
+  console.log('Generated', result.images.length, 'image(s)');
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(result.providerMetadata, null, 2),
+  );
 }
 
 main().catch(console.error);

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -197,29 +197,26 @@ Only applicable for HTTP-based providers.
       for (const [providerName, metadata] of Object.entries<{
         images: unknown;
       }>(result.providerMetadata)) {
-        if (providerName === 'gateway') {
-          const currentEntry = providerMetadata[providerName];
-          if (currentEntry != null && typeof currentEntry === 'object') {
-            providerMetadata[providerName] = {
-              ...(currentEntry as object),
-              ...metadata,
-            } as ImageModelV3ProviderMetadata[string];
-          } else {
-            providerMetadata[providerName] =
-              metadata as ImageModelV3ProviderMetadata[string];
-          }
-          const imagesValue = (
-            providerMetadata[providerName] as { images?: unknown }
-          ).images;
-          if (Array.isArray(imagesValue) && imagesValue.length === 0) {
-            delete (providerMetadata[providerName] as { images?: unknown })
-              .images;
+        const existingMetadata = providerMetadata[providerName];
+        if (existingMetadata != null && typeof existingMetadata === 'object') {
+          providerMetadata[providerName] = {
+            ...(existingMetadata as object),
+            ...metadata,
+          } as ImageModelV3ProviderMetadata[string];
+
+          if (
+            'images' in existingMetadata &&
+            Array.isArray(existingMetadata.images) &&
+            Array.isArray(metadata.images)
+          ) {
+            (providerMetadata[providerName] as { images: unknown[] }).images = [
+              ...existingMetadata.images,
+              ...metadata.images,
+            ];
           }
         } else {
-          providerMetadata[providerName] ??= { images: [] };
-          providerMetadata[providerName].images.push(
-            ...result.providerMetadata[providerName].images,
-          );
+          providerMetadata[providerName] =
+            metadata as ImageModelV3ProviderMetadata[string];
         }
       }
     }

--- a/packages/openai/src/image/openai-image-model.ts
+++ b/packages/openai/src/image/openai-image-model.ts
@@ -112,6 +112,7 @@ export class OpenAIImageModel implements ImageModelV3 {
                 }
               : null,
           ),
+          foo: 'bar',
         },
       },
     };

--- a/packages/openai/src/image/openai-image-model.ts
+++ b/packages/openai/src/image/openai-image-model.ts
@@ -112,7 +112,6 @@ export class OpenAIImageModel implements ImageModelV3 {
                 }
               : null,
           ),
-          foo: 'bar',
         },
       },
     };


### PR DESCRIPTION
## Background

The `generateImage` function throws away provider metadata other than data in the `images` field. Providers may include metadata the developer would like to reference outside of any `images` field.

## Summary

Generalize `gateway`-specific logic to preserve metadata to apply to all providers. Remove logic to "clean" empty `images` arrays as unnecessary complexity for a too-small win.

## Manual Verification

Ran example scripts with and without `foo: 'bar'` example top level output in OpenAI image model provider metadata and observe its presence with the change and absence without.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)