### PR TITLE
fix(anthropic): Fix streaming deadlock in Cloudflare Workers

### DIFF
--- a/.changeset/fix-cloudflare-workers-streaming.md
+++ b/.changeset/fix-cloudflare-workers-streaming.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+fix(anthropic): Fix streaming deadlock in Cloudflare Workers
+
+The previous `tee()` + async IIFE pattern in `doStream()` caused a deadlock in Cloudflare Workers' pull-based stream model. The `returnPromise` is now resolved immediately after creating the transform stream. Error handling for 200 responses with error payloads is still handled in the `transform()` function and will emit error events that consumers can handle when reading from the stream.


### PR DESCRIPTION
## Summary

Fixes streaming deadlock in Cloudflare Workers caused by the `tee()` + async IIFE pattern in `doStream()`.

## Problem

`streamText()` with the Anthropic provider hangs indefinitely when deployed to Cloudflare Workers. The root cause is in `anthropic-messages-language-model.ts`:

```typescript
const [streamForFirstChunk, streamForConsumer] = transformedStream.tee();
stream = streamForConsumer;
const reader = streamForFirstChunk.getReader();
(async () => {
  const { done } = await reader.read();  // Hangs here in CF Workers!
  // ...
})();
return returnPromise.promise;
```

This creates a deadlock in CF Workers' pull-based stream model:
1. `returnPromise.promise` waits for the promise to be resolved
2. The promise is resolved inside `transform()` when data flows
3. Data flows when someone reads from the stream
4. But nobody reads from `streamForConsumer` because `doStream()` hasn't returned
5. The async IIFE calls `reader.read()` which waits for data
6. In CF Workers, tee'd streams don't propagate backpressure correctly → deadlock

## Solution

Resolve `returnPromise` immediately after creating the transform stream. Error handling for 200 responses with error payloads is still handled in `transform()` and will emit error events that consumers can handle.

```typescript
stream = transformedStream;
returnPromise.resolve({
  stream,
  request: { body },
  response: { headers: responseHeaders },
});
return returnPromise.promise;
```

## Test plan

- [x] Tested streaming works in Cloudflare Workers with direct Anthropic API
- [x] Tested streaming works in Cloudflare Workers with proxy configuration
- [x] All three streaming methods work: `textStream`, `fullStream`, `for-await-of`

Fixes #10725