### PR TITLE
fix(anthropic): Fix streaming deadlock in Cloudflare Workers

### DIFF
--- a/.changeset/fix-cloudflare-workers-streaming.md
+++ b/.changeset/fix-cloudflare-workers-streaming.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+fix(anthropic): Fix streaming deadlock in Cloudflare Workers
+
+Removed the `tee()` + first chunk read pattern that causes a deadlock in Cloudflare Workers. The original pattern used `tee()` to split the stream and read the first chunk to trigger the transform, but this causes issues with pull-based streams in CF Workers where the stream doesn't flow until `doStream()` returns.
+
+The fix resolves the promise immediately with the stream. Error handling for HTTP 200 responses with error payloads is still done in the transform function.


### PR DESCRIPTION
## Summary

This PR fixes a streaming deadlock issue when using `@ai-sdk/anthropic` with `streamText()` in Cloudflare Workers.

### Problem

The `doStream()` method uses a `tee()` + async first-chunk read pattern to trigger the transform stream:

```typescript
const [streamForFirstChunk, streamForConsumer] = transformedStream.tee();
stream = streamForConsumer;
const reader = streamForFirstChunk.getReader();
(async () => {
  const { done } = await reader.read();
  // ...
})();
return returnPromise.promise;
```

This causes a deadlock in Cloudflare Workers because:
1. The stream doesn't flow until `doStream()` returns
2. But `doStream()` returns a promise that waits for the transform to process a chunk
3. The transform won't process a chunk until the stream flows
4. **Deadlock**

This works in Node.js but fails in CF Workers due to differences in how pull-based streams are handled.

### Solution

Remove the `tee()` pattern and resolve the promise immediately with the stream:

```typescript
stream = transformedStream;
returnPromise.resolve({
  stream,
  request: { body },
  response: { headers: responseHeaders },
});
return returnPromise.promise;
```

Error handling for HTTP 200 responses with error payloads is still done in the transform function via the `isFirstChunk` check.

## Test Plan

- [x] Tested with `streamText()` in Cloudflare Workers
- [x] Verified streaming works with direct Anthropic API
- [x] Verified streaming works through proxy configurations

## Related

This is a simpler alternative to #10726 that focuses only on the minimal fix needed.