### PR TITLE
Add reproduction for anthropic invalid request error

### DIFF
--- a/examples/next-openai/app/chat-anthropic-tools/page.tsx
+++ b/examples/next-openai/app/chat-anthropic-tools/page.tsx
@@ -43,7 +43,7 @@ const initialMessages = [
       {
         type: 'tool-weather',
         state: 'output-available',
-        toolCallId: 'toolu_0194MoeeJGJDTGfNPZB7Ciay',
+        toolCallId: 'toolu_0194MoeeJGJDTGfNPZB7Ciae',
         input: {
           city: 'london',
         },

--- a/examples/next-openai/app/chat-anthropic-tools/page.tsx
+++ b/examples/next-openai/app/chat-anthropic-tools/page.tsx
@@ -39,12 +39,12 @@ const initialMessages = [
         },
       },
       {
+        type: 'step-start',
+      },
+      {
         type: 'text',
         text: 'The weather in Paris is currently **cloudy** with a temperature of **72°F** (about 22°C).',
         state: 'done',
-      },
-      {
-        type: 'step-start',
       },
       {
         type: 'tool-weather',
@@ -58,6 +58,9 @@ const initialMessages = [
           temperature: 72,
           weather: 'cloudy',
         },
+      },
+      {
+        type: 'step-start',
       },
       {
         type: 'text',

--- a/examples/next-openai/app/chat-anthropic-tools/page.tsx
+++ b/examples/next-openai/app/chat-anthropic-tools/page.tsx
@@ -7,12 +7,68 @@ import WeatherView from '@/components/tool/weather-view';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 
+const initialMessages = [
+  {
+    id: crypto.randomUUID(),
+    role: 'user',
+    parts: [
+      {
+        type: 'text',
+        text: "hey what's the weather in paris?",
+      },
+    ],
+  },
+  {
+    id: crypto.randomUUID(),
+    role: 'assistant',
+    parts: [
+      {
+        type: 'tool-weather',
+        state: 'output-available',
+        toolCallId: 'toolu_0194MoeeJGJDTGfNPZB7Ciay',
+        input: {
+          city: 'paris',
+        },
+        output: {
+          state: 'ready',
+          temperature: 72,
+          weather: 'cloudy',
+        },
+      },
+      {
+        type: 'text',
+        text: 'The weather in Paris is currently **cloudy** with a temperature of **72°F** (about 22°C).',
+        state: 'done',
+      },
+      {
+        type: 'tool-weather',
+        state: 'output-available',
+        toolCallId: 'toolu_0194MoeeJGJDTGfNPZB7Ciay',
+        input: {
+          city: 'london',
+        },
+        output: {
+          state: 'ready',
+          temperature: 72,
+          weather: 'cloudy',
+        },
+      },
+      {
+        type: 'text',
+        text: 'The weather in London is currently **cloudy** with a temperature of **72°F** (about 22°C).',
+        state: 'done',
+      },
+    ],
+  },
+] satisfies AnthropicToolsAgentMessage[];
+
 export default function TestAnthropicCodeExecution() {
   const { error, status, sendMessage, messages, regenerate } =
     useChat<AnthropicToolsAgentMessage>({
       transport: new DefaultChatTransport({
         api: '/api/chat-anthropic-tools',
       }),
+      messages: initialMessages,
     });
 
   return (

--- a/examples/next-openai/app/chat-anthropic-tools/page.tsx
+++ b/examples/next-openai/app/chat-anthropic-tools/page.tsx
@@ -23,6 +23,9 @@ const initialMessages = [
     role: 'assistant',
     parts: [
       {
+        type: 'step-start',
+      },
+      {
         type: 'tool-weather',
         state: 'output-available',
         toolCallId: 'toolu_0194MoeeJGJDTGfNPZB7Ciay',
@@ -39,6 +42,9 @@ const initialMessages = [
         type: 'text',
         text: 'The weather in Paris is currently **cloudy** with a temperature of **72°F** (about 22°C).',
         state: 'done',
+      },
+      {
+        type: 'step-start',
       },
       {
         type: 'tool-weather',


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

Adding a reproduction case for this issue -> https://github.com/vercel/ai/issues/8516

As requested by https://github.com/vercel/ai/issues/8516#issuecomment-3582532426

## Summary

Added a reproduction case for 

```
anthropic api error: tool_use ids were found without tool_result blocks immediately after
```

## Manual Verification

Got the following error
```json
{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "messages.1: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_0194MoeeJGJDTGfNPZB7Ciay. Each `tool_use` block must have a corresponding `tool_result` block in the next message."
  },
  "request_id": "req_011CVfmtLZ6T89V3waBnGker"
}
```

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

https://github.com/vercel/ai/issues/8516
