### PR TITLE
chore(openai): enable strict json by default

### DIFF
--- a/.changeset/fuzzy-buckets-deny.md
+++ b/.changeset/fuzzy-buckets-deny.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+chore(openai): enable strict json by default

--- a/content/docs/08-migration-guides/27-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/27-migration-guide-6-0.mdx
@@ -42,6 +42,21 @@ pnpm install ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta
 
 The deprecated `CoreMessage` type and related types, schemas, and functions have been removed.
 
+## `@ai-sdk/openai` package
+
+### `strictJsonSchema` defaults to true
+
+The `strictJsonSchema` setting for JSON outputs and tool calls is enabled by default.
+
+This can lead to schemas getting rejected by the OpenAI API.
+In those cases, you can adjust the schema (e.g. producing `null` instead of `undefined`),
+or turn of `strictJsonSchema`.
+
+### `structuredOutputs` option removed from chat model
+
+The `structuredOutputs` provider option has been removed from chat models.
+You can use `strictJsonSchema` instead.
+
 ## Codemods
 
 The AI SDK **will** provide Codemod transformations to help upgrade your codebase when a

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -202,7 +202,7 @@ The following provider options are available:
   Controls whether the model returns its reasoning process. Set to `'auto'` for a condensed summary, `'detailed'` for more comprehensive reasoning. Defaults to `undefined` (no reasoning summaries). When enabled, reasoning summaries appear in the stream as events with type `'reasoning'` and in non-streaming responses within the `reasoning` field.
 
 - **strictJsonSchema** _boolean_
-  Whether to use strict JSON schema validation. Defaults to `false`.
+  Whether to use strict JSON schema validation. Defaults to `true`.
 
 - **serviceTier** _'auto' | 'flex' | 'priority' | 'default'_
   Service tier for the request. Set to 'flex' for 50% cheaper processing
@@ -802,13 +802,6 @@ The following optional provider options are available for OpenAI chat models:
   `providerOptions` to set the `reasoningEffort` option, this
   model setting will be ignored.
 
-- **structuredOutputs** _boolean_
-
-  Whether to use structured outputs.
-  Defaults to `true`.
-
-  When enabled, tool calls and object generation will be strict and follow the provided schema.
-
 - **maxCompletionTokens** _number_
 
   Maximum number of completion tokens to generate. Useful for reasoning models.
@@ -836,7 +829,7 @@ The following optional provider options are available for OpenAI chat models:
 - **strictJsonSchema** _boolean_
 
   Whether to use strict JSON schema validation.
-  Defaults to `false`.
+  Defaults to `true`.
 
 - **textVerbosity** _'low' | 'medium' | 'high'_
 

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -204,7 +204,7 @@ The following provider options are available:
 - **strictJsonSchema** _boolean_
   Whether to use strict JSON schema validation. Defaults to `true`.
 
-  <Note type="warning">
+    <Note type="warning">
 OpenAI structured outputs have several
 [limitations](https://openai.com/index/introducing-structured-outputs-in-the-api),
 in particular around the [supported schemas](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas),

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -204,6 +204,17 @@ The following provider options are available:
 - **strictJsonSchema** _boolean_
   Whether to use strict JSON schema validation. Defaults to `true`.
 
+  <Note type="warning">
+OpenAI structured outputs have several
+[limitations](https://openai.com/index/introducing-structured-outputs-in-the-api),
+in particular around the [supported schemas](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas),
+and are therefore opt-in.
+
+For example, optional schema properties are not supported.
+You need to change Zod `.nullish()` and `.optional()` to `.nullable()`.
+
+</Note>
+
 - **serviceTier** _'auto' | 'flex' | 'priority' | 'default'_
   Service tier for the request. Set to 'flex' for 50% cheaper processing
   at the cost of increased latency (available for o3, o4-mini, and gpt-5 models).
@@ -900,13 +911,13 @@ console.log('Usage:', {
   reasoning models.
 </Note>
 
-#### Structured Outputs
+#### Strict Structured Outputs
 
-Structured outputs are enabled by default.
-You can disable them by setting the `structuredOutputs` option to `false`.
+Strict structured outputs are enabled by default.
+You can disable them by setting the `strictJsonSchema` option to `false`.
 
 ```ts highlight="7"
-import { openai } from '@ai-sdk/openai';
+import { openai, OpenAIChatLanguageModelOptions } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 
@@ -914,8 +925,8 @@ const result = await generateObject({
   model: openai.chat('gpt-4o-2024-08-06'),
   providerOptions: {
     openai: {
-      structuredOutputs: false,
-    },
+      strictJsonSchema: false,
+    } satisfies OpenAIChatLanguageModelOptions,
   },
   schemaName: 'recipe',
   schemaDescription: 'A recipe for lasagna.',

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -204,11 +204,12 @@ The following provider options are available:
 - **strictJsonSchema** _boolean_
   Whether to use strict JSON schema validation. Defaults to `true`.
 
-    <Note type="warning">
-OpenAI structured outputs have several
-[limitations](https://openai.com/index/introducing-structured-outputs-in-the-api),
-in particular around the [supported schemas](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas),
-and are therefore opt-in.
+      <Note type="warning">
+
+  OpenAI structured outputs have several
+  [limitations](https://openai.com/index/introducing-structured-outputs-in-the-api),
+  in particular around the [supported schemas](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas),
+  and are therefore opt-in.
 
 For example, optional schema properties are not supported.
 You need to change Zod `.nullish()` and `.optional()` to `.nullable()`.

--- a/examples/ai-core/src/generate-text/openai-provider-options.ts
+++ b/examples/ai-core/src/generate-text/openai-provider-options.ts
@@ -13,7 +13,6 @@ async function main() {
         user: '<user_id>',
         maxCompletionTokens: 100,
         store: false,
-        structuredOutputs: false,
         serviceTier: 'auto',
         strictJsonSchema: false,
         textVerbosity: 'medium',

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -597,7 +597,7 @@ describe('doGenerate', () => {
                 ],
                 "type": "object",
               },
-              "strict": false,
+              "strict": true,
             },
             "type": "function",
           },
@@ -752,57 +752,7 @@ describe('doGenerate', () => {
       });
     });
 
-    it('should forward json response format as "json_object" and omit schema when structuredOutputs are disabled', async () => {
-      prepareJsonResponse({ content: '{"value":"Spark"}' });
-
-      const model = provider.chat('gpt-4o-2024-08-06');
-
-      const { warnings } = await model.doGenerate({
-        prompt: TEST_PROMPT,
-        providerOptions: {
-          openai: {
-            structuredOutputs: false,
-          },
-        },
-        responseFormat: {
-          type: 'json',
-          schema: {
-            type: 'object',
-            properties: { value: { type: 'string' } },
-            required: ['value'],
-            additionalProperties: false,
-            $schema: 'http://json-schema.org/draft-07/schema#',
-          },
-        },
-      });
-
-      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
-        {
-          "messages": [
-            {
-              "content": "Hello",
-              "role": "user",
-            },
-          ],
-          "model": "gpt-4o-2024-08-06",
-          "response_format": {
-            "type": "json_object",
-          },
-        }
-      `);
-
-      expect(warnings).toMatchInlineSnapshot(`
-        [
-          {
-            "details": "JSON response format schema is only supported with structuredOutputs",
-            "feature": "responseFormat",
-            "type": "unsupported",
-          },
-        ]
-      `);
-    });
-
-    it('should forward json response format as "json_object" and include schema when structuredOutputs are enabled', async () => {
+    it('should forward json response format as "json_object" and include schema', async () => {
       prepareJsonResponse({ content: '{"value":"Spark"}' });
 
       const model = provider.chat('gpt-4o-2024-08-06');
@@ -846,7 +796,7 @@ describe('doGenerate', () => {
                 ],
                 "type": "object",
               },
-              "strict": false,
+              "strict": true,
             },
             "type": "json_schema",
           },
@@ -856,7 +806,7 @@ describe('doGenerate', () => {
       expect(warnings).toEqual([]);
     });
 
-    it('should use json_schema & strict with responseFormat json when structuredOutputs are enabled', async () => {
+    it('should use json_schema & strict with responseFormat json', async () => {
       prepareJsonResponse({ content: '{"value":"Spark"}' });
 
       const model = provider.chat('gpt-4o-2024-08-06');
@@ -900,7 +850,7 @@ describe('doGenerate', () => {
                 ],
                 "type": "object",
               },
-              "strict": false,
+              "strict": true,
             },
             "type": "json_schema",
           },
@@ -908,7 +858,7 @@ describe('doGenerate', () => {
       `);
     });
 
-    it('should set name & description with responseFormat json when structuredOutputs are enabled', async () => {
+    it('should set name & description with responseFormat json', async () => {
       prepareJsonResponse({ content: '{"value":"Spark"}' });
 
       const model = provider.chat('gpt-4o-2024-08-06');
@@ -955,7 +905,7 @@ describe('doGenerate', () => {
                 ],
                 "type": "object",
               },
-              "strict": false,
+              "strict": true,
             },
             "type": "json_schema",
           },
@@ -986,7 +936,7 @@ describe('doGenerate', () => {
       });
     });
 
-    it('should set strict with tool calls when structuredOutputs are enabled', async () => {
+    it('should set strict with tool call', async () => {
       prepareJsonResponse({
         tool_calls: [
           {
@@ -1049,7 +999,7 @@ describe('doGenerate', () => {
                   ],
                   "type": "object",
                 },
-                "strict": false,
+                "strict": true,
               },
               "type": "function",
             },
@@ -1070,7 +1020,7 @@ describe('doGenerate', () => {
     });
   });
 
-  it('should set strict for tool usage when structuredOutputs are enabled', async () => {
+  it('should set strict for tool usage', async () => {
     prepareJsonResponse({
       tool_calls: [
         {
@@ -1139,7 +1089,7 @@ describe('doGenerate', () => {
                 ],
                 "type": "object",
               },
-              "strict": false,
+              "strict": true,
             },
             "type": "function",
           },

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -88,23 +88,8 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
         schema: openaiChatLanguageModelOptions,
       })) ?? {};
 
-    const structuredOutputs = openaiOptions.structuredOutputs ?? true;
-
     if (topK != null) {
       warnings.push({ type: 'unsupported', feature: 'topK' });
-    }
-
-    if (
-      responseFormat?.type === 'json' &&
-      responseFormat.schema != null &&
-      !structuredOutputs
-    ) {
-      warnings.push({
-        type: 'unsupported',
-        feature: 'responseFormat',
-        details:
-          'JSON response format schema is only supported with structuredOutputs',
-      });
     }
 
     const { messages, warnings: messageWarnings } = convertToOpenAIChatMessages(
@@ -116,7 +101,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
 
     warnings.push(...messageWarnings);
 
-    const strictJsonSchema = openaiOptions.strictJsonSchema ?? false;
+    const strictJsonSchema = openaiOptions.strictJsonSchema ?? true;
 
     const baseArgs = {
       // model id:
@@ -148,7 +133,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
       presence_penalty: presencePenalty,
       response_format:
         responseFormat?.type === 'json'
-          ? structuredOutputs && responseFormat.schema != null
+          ? responseFormat.schema != null
             ? {
                 type: 'json_schema',
                 json_schema: {
@@ -294,7 +279,6 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
     } = prepareChatTools({
       tools,
       toolChoice,
-      structuredOutputs,
       strictJsonSchema,
     });
 

--- a/packages/openai/src/chat/openai-chat-options.ts
+++ b/packages/openai/src/chat/openai-chat-options.ts
@@ -103,13 +103,6 @@ export const openaiChatLanguageModelOptions = lazySchema(() =>
       prediction: z.record(z.string(), z.any()).optional(),
 
       /**
-       * Whether to use structured outputs.
-       *
-       * @default true
-       */
-      structuredOutputs: z.boolean().optional(),
-
-      /**
        * Service tier for the request.
        * - 'auto': Default service tier. The request will be processed with the service tier configured in the
        *           Project settings. Unless otherwise configured, the Project will use 'default'.
@@ -124,7 +117,7 @@ export const openaiChatLanguageModelOptions = lazySchema(() =>
       /**
        * Whether to use strict JSON schema validation.
        *
-       * @default false
+       * @default true
        */
       strictJsonSchema: z.boolean().optional(),
 

--- a/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
@@ -4,7 +4,6 @@ import { it, expect } from 'vitest';
 it('should return undefined tools and toolChoice when tools are null', () => {
   const result = prepareChatTools({
     tools: undefined,
-    structuredOutputs: false,
     strictJsonSchema: false,
   });
 
@@ -18,7 +17,6 @@ it('should return undefined tools and toolChoice when tools are null', () => {
 it('should return undefined tools and toolChoice when tools are empty', () => {
   const result = prepareChatTools({
     tools: [],
-    structuredOutputs: false,
     strictJsonSchema: false,
   });
 
@@ -39,7 +37,6 @@ it('should correctly prepare function tools', () => {
         inputSchema: { type: 'object', properties: {} },
       },
     ],
-    structuredOutputs: false,
     strictJsonSchema: false,
   });
 
@@ -50,7 +47,7 @@ it('should correctly prepare function tools', () => {
         name: 'testFunction',
         description: 'A test function',
         parameters: { type: 'object', properties: {} },
-        strict: undefined,
+        strict: false,
       },
     },
   ]);
@@ -68,7 +65,6 @@ it('should add warnings for unsupported tools', () => {
         args: {},
       },
     ],
-    structuredOutputs: false,
     strictJsonSchema: false,
   });
 
@@ -95,7 +91,6 @@ it('should handle tool choice "auto"', () => {
       },
     ],
     toolChoice: { type: 'auto' },
-    structuredOutputs: false,
     strictJsonSchema: false,
   });
   expect(result.toolChoice).toEqual('auto');
@@ -112,7 +107,6 @@ it('should handle tool choice "required"', () => {
       },
     ],
     toolChoice: { type: 'required' },
-    structuredOutputs: false,
     strictJsonSchema: false,
   });
   expect(result.toolChoice).toEqual('required');
@@ -129,7 +123,6 @@ it('should handle tool choice "none"', () => {
       },
     ],
     toolChoice: { type: 'none' },
-    structuredOutputs: false,
     strictJsonSchema: false,
   });
   expect(result.toolChoice).toEqual('none');
@@ -146,7 +139,6 @@ it('should handle tool choice "tool"', () => {
       },
     ],
     toolChoice: { type: 'tool', toolName: 'testFunction' },
-    structuredOutputs: false,
     strictJsonSchema: false,
   });
   expect(result.toolChoice).toEqual({

--- a/packages/openai/src/chat/openai-chat-prepare-tools.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.ts
@@ -11,12 +11,10 @@ import {
 export function prepareChatTools({
   tools,
   toolChoice,
-  structuredOutputs,
   strictJsonSchema,
 }: {
   tools: LanguageModelV3CallOptions['tools'];
   toolChoice?: LanguageModelV3CallOptions['toolChoice'];
-  structuredOutputs: boolean;
   strictJsonSchema: boolean;
 }): {
   tools?: OpenAIChatFunctionTool[];
@@ -43,7 +41,7 @@ export function prepareChatTools({
             name: tool.name,
             description: tool.description,
             parameters: tool.inputSchema,
-            strict: structuredOutputs ? strictJsonSchema : undefined,
+            strict: strictJsonSchema,
           },
         });
         break;

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -373,7 +373,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                   ],
                   "type": "object",
                 },
-                "strict": false,
+                "strict": true,
                 "type": "json_schema",
               },
             },
@@ -1103,7 +1103,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                   ],
                   "type": "object",
                 },
-                "strict": false,
+                "strict": true,
                 "type": "json_schema",
               },
             },
@@ -1113,7 +1113,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
-      it('should send responseFormat json_schema format with strictSchemas false', async () => {
+      it('should send responseFormat json_schema format with strictJsonSchema false', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           responseFormat: {
             type: 'json',
@@ -1130,8 +1130,8 @@ describe('OpenAIResponsesLanguageModel', () => {
           prompt: TEST_PROMPT,
           providerOptions: {
             openai: {
-              strictSchemas: false,
-            },
+              strictJsonSchema: false,
+            } satisfies OpenAIResponsesProviderOptions,
           },
         });
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -152,7 +152,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
     warnings.push(...inputWarnings);
 
-    const strictJsonSchema = openaiOptions?.strictJsonSchema ?? false;
+    const strictJsonSchema = openaiOptions?.strictJsonSchema ?? true;
 
     let include: OpenAIResponsesIncludeOptions = openaiOptions?.include;
 

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -134,6 +134,7 @@ export const openaiResponsesProviderOptionsSchema = lazySchema(() =>
           ]),
         )
         .nullish(),
+
       instructions: z.string().nullish(),
 
       /**


### PR DESCRIPTION
## Background

OpenAI strict JSON ensures that valid, parseable JSON that matches a schema is produced. However, it limits the supported JSON schemas. In AI SDK 5 we turned off the strict JSON mode because of that. Unfortunately it led to increased production stability issues (some schema generation requests fail in production). To have increased stability in production, we revert to enabling strict mode by default.

## Summary

* Turn on strict JSON schema generation by default for OpenAI responses and chat models
* Remove `structuredOutputs` option from OpenAI chat models

## Related Issues
#8868