### PR TITLE
chore(ai): deprecate generateObject and streamObject

### DIFF
--- a/.changeset/friendly-crews-battle.md
+++ b/.changeset/friendly-crews-battle.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(ai): deprecate generateObject and streamObject

--- a/content/docs/08-migration-guides/27-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/27-migration-guide-6-0.mdx
@@ -42,6 +42,12 @@ pnpm install ai@beta @ai-sdk/react@beta @ai-sdk/openai@beta
 
 The deprecated `CoreMessage` type and related types, schemas, and functions have been removed.
 
+### `generateObject` and `streamObject` deprecated
+
+`generateObject` and `streamObject` have been deprecated.
+They will be removed in a future version.
+You can use `generateText` and `streamText` with an `output` setting instead.
+
 ## Codemods
 
 The AI SDK **will** provide Codemod transformations to help upgrade your codebase when a

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -108,6 +108,8 @@ functionality that can be fully encapsulated in the provider.
 
 @returns
 A result object that contains the generated object, the finish reason, the token usage, and additional information.
+
+@deprecated Use `generateText` with an `output` setting instead.
  */
 export async function generateObject<
   SCHEMA extends FlexibleSchema<unknown> = FlexibleSchema<JSONValue>,

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -165,6 +165,8 @@ functionality that can be fully encapsulated in the provider.
 
 @returns
 A result object for accessing the partial object stream and additional information.
+
+@deprecated Use `streamText` with an `output` setting instead.
  */
 export function streamObject<
   SCHEMA extends FlexibleSchema<unknown> = FlexibleSchema<JSONValue>,


### PR DESCRIPTION
## Background

For a long time, `generateObject` and `streamObject` had limitations in comparison with `generateText` and `streamText`, e.g. when it comes to tool calling. We have added output generation to `generateText` and `streamText` that should be used going forward.

## Summary

Deprecate `generateObject` and `streamObject`.

## Related Issues

Closes #10025 