### PR TITLE
docs: remove unnecessary provider imports

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -10,7 +10,6 @@ Streams text generations from a language model.
 You can use the streamText function for interactive use cases such as chat bots and other real-time applications. You can also generate UI components with tools.
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { streamText } from 'ai';
 
 const { textStream } = streamText({

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -12,7 +12,6 @@ It can be used to force the language model to return structured data, e.g. for i
 #### Example: generate an object using a schema
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 
@@ -36,7 +35,6 @@ console.log(JSON.stringify(object, null, 2));
 For arrays, you specify the schema of the array items.
 
 ```ts highlight="7"
-import { openai } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 
@@ -76,7 +74,6 @@ const { object } = await generateObject({
 #### Example: generate JSON without a schema
 
 ```ts highlight="6"
-import { openai } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 
 const { object } = await generateObject({

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -12,7 +12,6 @@ It can be used to force the language model to return structured data, e.g. for i
 #### Example: stream an object using a schema
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
@@ -40,7 +39,6 @@ For arrays, you specify the schema of the array items.
 You can use `elementStream` to get the stream of complete array elements.
 
 ```ts highlight="7,18"
-import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 import { z } from 'zod';
 
@@ -65,7 +63,6 @@ for await (const hero of elementStream) {
 #### Example: generate JSON without a schema
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { streamObject } from 'ai';
 
 const { partialObjectStream } = streamObject({

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -10,7 +10,6 @@ Generate an embedding for a single value using an embedding model.
 This is ideal for use cases where you need to embed a single value to e.g. retrieve similar items or to use the embedding in a downstream task.
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
 const { embedding } = await embed({

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -12,7 +12,6 @@ by the embedding model.
 has a limit on how many embeddings can be generated in a single call.
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { embedMany } from 'ai';
 
 const { embeddings } = await embedMany({

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -351,7 +351,6 @@ import {
   generateText,
 } from '@ai-sdk/mcp';
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
-import { openai } from '@ai-sdk/openai';
 
 let client;
 

--- a/content/docs/07-reference/01-ai-sdk-core/50-cosine-similarity.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/50-cosine-similarity.mdx
@@ -12,7 +12,6 @@ like cosine similarity are often used.
 A high value (close to 1) indicates that the vectors are very similar, while a low value (close to -1) indicates that they are different.
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { cosineSimilarity, embedMany } from 'ai';
 
 const { embeddings } = await embedMany({

--- a/content/docs/07-reference/01-ai-sdk-core/60-wrap-language-model.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/60-wrap-language-model.mdx
@@ -10,10 +10,10 @@ by wrapping them with middleware.
 See [Language Model Middleware](/docs/ai-sdk-core/middleware) for more information on middleware.
 
 ```ts
-import { wrapLanguageModel } from 'ai';
+import { wrapLanguageModel, gateway } from 'ai';
 
 const wrappedLanguageModel = wrapLanguageModel({
-  model: 'openai/gpt-4.1',
+  model: gateway('openai/gpt-4.1'),
   middleware: yourLanguageModelMiddleware,
 });
 ```

--- a/content/docs/07-reference/01-ai-sdk-core/70-step-count-is.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/70-step-count-is.mdx
@@ -10,7 +10,6 @@ Creates a stop condition that stops when the number of steps reaches a specified
 This function is used with `stopWhen` in `generateText` and `streamText` to control when a tool-calling loop should stop based on the number of steps executed.
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { generateText, stepCountIs } from 'ai';
 
 const result = await generateText({

--- a/content/docs/07-reference/01-ai-sdk-core/71-has-tool-call.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/71-has-tool-call.mdx
@@ -10,7 +10,6 @@ Creates a stop condition that stops when a specific tool is called.
 This function is used with `stopWhen` in `generateText` and `streamText` to control when a tool-calling loop should stop based on whether a particular tool has been invoked.
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { generateText, hasToolCall } from 'ai';
 
 const result = await generateText({

--- a/content/docs/07-reference/02-ai-sdk-ui/31-convert-to-model-messages.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/31-convert-to-model-messages.mdx
@@ -8,7 +8,6 @@ description: Convert useChat messages to ModelMessages for AI functions (API Ref
 The `convertToModelMessages` function is used to transform an array of UI messages from the `useChat` hook into an array of `ModelMessage` objects. These `ModelMessage` objects are compatible with AI core functions like `streamText`.
 
 ```ts filename="app/api/chat/route.ts"
-import { openai } from '@ai-sdk/openai';
 import { convertToModelMessages, streamText } from 'ai';
 
 export async function POST(req: Request) {
@@ -71,13 +70,13 @@ import { tool } from 'ai';
 import { z } from 'zod';
 
 const screenshotTool = tool({
-  parameters: z.object({}),
+  inputSchema: z.object({}),
   execute: async () => 'imgbase64',
   toModelOutput: result => [{ type: 'image', data: result }],
 });
 
 const result = streamText({
-  model: openai('gpt-4'),
+  model: 'anthropic/claude-sonnet-4.5',
   messages: convertToModelMessages(messages, {
     tools: {
       screenshot: screenshotTool,
@@ -97,7 +96,6 @@ The `convertToModelMessages` function supports converting custom data parts atta
 By default, data parts in user messages are filtered out during conversion. To include them, provide a `convertDataPart` callback that transforms data parts into text or file parts that the model can understand:
 
 ```ts filename="app/api/chat/route.ts"
-import { openai } from '@ai-sdk/openai';
 import { convertToModelMessages, streamText } from 'ai';
 
 type CustomUIMessage = UIMessage<

--- a/content/docs/07-reference/04-stream-helpers/05-stream-to-response.mdx
+++ b/content/docs/07-reference/04-stream-helpers/05-stream-to-response.mdx
@@ -27,7 +27,6 @@ By default, the status code is set to 200 and the Content-Type header is set to 
 You can e.g. use `streamToResponse` to pipe a data stream to a Node.js HTTP server response:
 
 ```ts
-import { openai } from '@ai-sdk/openai';
 import { StreamData, streamText, streamToResponse } from 'ai';
 import { createServer } from 'http';
 


### PR DESCRIPTION
Moved to gateway/global provider, but some remaining imports that are not necessary.