### PR TITLE
chore(openai): update tests for apply-patch tool to use snapshots

### DIFF
--- a/.changeset/tame-tools-turn.md
+++ b/.changeset/tame-tools-turn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+chore(openai): update tests for apply-patch tool to use snapshots

--- a/packages/openai/src/responses/__snapshots__/openai-responses-language-model.test.ts.snap
+++ b/packages/openai/src/responses/__snapshots__/openai-responses-language-model.test.ts.snap
@@ -774,6 +774,49 @@ An analysis by Climate Central revealed that San Francisco, along with most U.S.
 ]
 `;
 
+exports[`OpenAIResponsesLanguageModel > doStream > apply_patch tool streaming > should handle apply_patch tool calls in streaming mode 1`] = `
+[
+  {
+    "type": "stream-start",
+    "warnings": [],
+  },
+  {
+    "id": "resp_0372d86dfc1762fe00692741f339a08190bce9b78ee2079295",
+    "modelId": "gpt-5.1-2025-11-13",
+    "timestamp": 2025-11-26T18:07:47.000Z,
+    "type": "response-metadata",
+  },
+  {
+    "input": "{"callId":"call_kA46f91ZwocQyMCKyyZqRyC5","operation":{"type":"create_file","path":"shopping-checklist.md","diff":"+## Shopping Checklist\\n+\\n+- [ ] Milk\\n+- [ ] Bread\\n+- [ ] Eggs\\n+- [ ] Fresh fruit\\n+- [ ] Coffee\\n"}}",
+    "providerMetadata": {
+      "openai": {
+        "itemId": "apc_0372d86dfc1762fe00692741f3f3dc8190879cba489ff2fc8b",
+      },
+    },
+    "toolCallId": "call_kA46f91ZwocQyMCKyyZqRyC5",
+    "toolName": "apply_patch",
+    "type": "tool-call",
+  },
+  {
+    "finishReason": "stop",
+    "providerMetadata": {
+      "openai": {
+        "responseId": "resp_0372d86dfc1762fe00692741f339a08190bce9b78ee2079295",
+        "serviceTier": "default",
+      },
+    },
+    "type": "finish",
+    "usage": {
+      "cachedInputTokens": 0,
+      "inputTokens": 642,
+      "outputTokens": 67,
+      "reasoningTokens": 0,
+      "totalTokens": 709,
+    },
+  },
+]
+`;
+
 exports[`OpenAIResponsesLanguageModel > doStream > code interpreter tool > should stream code interpreter results with annotations 1`] = `
 [
   {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2720,25 +2720,6 @@ describe('OpenAIResponsesLanguageModel', () => {
         it('should include apply_patch tool call and result in content', async () => {
           expect(result.content).toMatchSnapshot();
         });
-
-        it('should parse create_file operation correctly', () => {
-          const toolCall = result.content.find(
-            item =>
-              item.type === 'tool-call' && item.toolName === 'apply_patch',
-          );
-          expect(toolCall).toBeDefined();
-          if (toolCall && toolCall.type === 'tool-call') {
-            const input = JSON.parse(toolCall.input);
-            expect(input).toMatchObject({
-              callId: 'call_CdXiGtcRl49Q6Ek20tG9lYOr',
-              operation: {
-                type: 'create_file',
-                path: 'shopping-checklist.md',
-                diff: expect.stringContaining('Shopping Checklist'),
-              },
-            });
-          }
-        });
       });
     });
 
@@ -5043,24 +5024,7 @@ describe('OpenAIResponsesLanguageModel', () => {
           ],
         });
 
-        const parts = await convertReadableStreamToArray(stream);
-        const toolCallParts = parts.filter(
-          part => part.type === 'tool-call' && part.toolName === 'apply_patch',
-        );
-
-        expect(toolCallParts.length).toBeGreaterThan(0);
-        const toolCall = toolCallParts[0];
-        if (toolCall && toolCall.type === 'tool-call') {
-          const input = JSON.parse(toolCall.input);
-          expect(input).toMatchObject({
-            callId: 'call_kA46f91ZwocQyMCKyyZqRyC5',
-            operation: {
-              type: 'create_file',
-              path: 'shopping-checklist.md',
-              diff: expect.stringContaining('Shopping Checklist'),
-            },
-          });
-        }
+        expect(await convertReadableStreamToArray(stream)).toMatchSnapshot();
       });
     });
   });


### PR DESCRIPTION
## Background

Follow up for comment https://github.com/vercel/ai/pull/10623/files/91f375482d701ace2febcc4467375e8edfd20515#r2572931432

## Summary

Used the standard convention of testing via snapshots, instead of manual logic

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
