### PR TITLE
chore(groq): removed deprecated groq-transcription model

### DIFF
--- a/.changeset/big-jobs-lick.md
+++ b/.changeset/big-jobs-lick.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/groq': patch
+---
+
+Removed deprecated distil-whisper-large-v3-en model from groq transcription

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -144,31 +144,30 @@ try {
 
 ## Transcription Models
 
-| Provider                                                                  | Model                        |
-| ------------------------------------------------------------------------- | ---------------------------- |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `whisper-1`                  |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `gpt-4o-transcribe`          |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `gpt-4o-mini-transcribe`     |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models) | `scribe_v1`                  |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models) | `scribe_v1_experimental`     |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)             | `whisper-large-v3-turbo`     |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)             | `distil-whisper-large-v3-en` |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)             | `whisper-large-v3`           |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `whisper-1`                  |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `gpt-4o-transcribe`          |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `gpt-4o-mini-transcribe`     |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `machine`                    |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `low_cost`                   |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `fusion`                     |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `base` (+ variants)          |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `enhanced` (+ variants)      |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova` (+ variants)          |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova-2` (+ variants)        |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova-3` (+ variants)        |
-| [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)         | `default`                    |
-| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models) | `best`                       |
-| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models) | `nano`                       |
-| [Fal](/providers/ai-sdk-providers/fal#transcription-models)               | `whisper`                    |
-| [Fal](/providers/ai-sdk-providers/fal#transcription-models)               | `wizper`                     |
+| Provider                                                                  | Model                    |
+| ------------------------------------------------------------------------- | ------------------------ |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `whisper-1`              |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `gpt-4o-transcribe`      |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)         | `gpt-4o-mini-transcribe` |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models) | `scribe_v1`              |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models) | `scribe_v1_experimental` |
+| [Groq](/providers/ai-sdk-providers/groq#transcription-models)             | `whisper-large-v3-turbo` |
+| [Groq](/providers/ai-sdk-providers/groq#transcription-models)             | `whisper-large-v3`       |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `whisper-1`              |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `gpt-4o-transcribe`      |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)    | `gpt-4o-mini-transcribe` |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `machine`                |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `low_cost`               |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)          | `fusion`                 |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `base` (+ variants)      |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `enhanced` (+ variants)  |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova` (+ variants)      |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova-2` (+ variants)    |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)     | `nova-3` (+ variants)    |
+| [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)         | `default`                |
+| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models) | `best`                   |
+| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models) | `nano`                   |
+| [Fal](/providers/ai-sdk-providers/fal#transcription-models)               | `whisper`                |
+| [Fal](/providers/ai-sdk-providers/fal#transcription-models)               | `wizper`                 |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/09-groq.mdx
+++ b/content/providers/01-ai-sdk-providers/09-groq.mdx
@@ -458,8 +458,7 @@ The following provider options are available:
 
 ### Model Capabilities
 
-| Model                        | Transcription       | Duration            | Segments            | Language            |
-| ---------------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
-| `whisper-large-v3`           | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `whisper-large-v3-turbo`     | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
-| `distil-whisper-large-v3-en` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| Model                    | Transcription       | Duration            | Segments            | Language            |
+| ------------------------ | ------------------- | ------------------- | ------------------- | ------------------- |
+| `whisper-large-v3`       | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
+| `whisper-large-v3-turbo` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/packages/groq/src/groq-transcription-options.ts
+++ b/packages/groq/src/groq-transcription-options.ts
@@ -1,5 +1,4 @@
 export type GroqTranscriptionModelId =
   | 'whisper-large-v3-turbo'
-  | 'distil-whisper-large-v3-en'
   | 'whisper-large-v3'
   | (string & {});


### PR DESCRIPTION


## Background

Support for `distil-whisper-large-v3-en` model is deprecated.

## Summary

Removed `distil-whisper-large-v3-en` model from doc and code.

## Manual Verification

It's just removal of model string from doc and model type definition

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)