### PR TITLE
chore(openai): add JSDoc to responses options

### DIFF
--- a/.changeset/olive-waves-speak.md
+++ b/.changeset/olive-waves-speak.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+chore(openai): add JSDoc to responses options

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -124,7 +124,19 @@ export type OpenAIResponsesModelId =
 export const openaiResponsesProviderOptionsSchema = lazySchema(() =>
   zodSchema(
     z.object({
+      /**
+       * The ID of the OpenAI Conversation to continue.
+       * You must create a conversation first via the OpenAI API.
+       * Cannot be used in conjunction with `previousResponseId`.
+       * Defaults to `undefined`.
+       * @see https://platform.openai.com/docs/api-reference/conversations/create
+       */
       conversation: z.string().nullish(),
+
+      /**
+       * The set of extra fields to include in the response (advanced, usually not needed).
+       * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'message.output_text.logprobs'.
+       */
       include: z
         .array(
           z.enum([
@@ -135,10 +147,17 @@ export const openaiResponsesProviderOptionsSchema = lazySchema(() =>
         )
         .nullish(),
 
+      /**
+       * Instructions for the model.
+       * They can be used to change the system or developer message when continuing a conversation using the `previousResponseId` option.
+       * Defaults to `undefined`.
+       */
       instructions: z.string().nullish(),
 
       /**
-       * Return the log probabilities of the tokens.
+       * Return the log probabilities of the tokens. Including logprobs will increase
+       * the response size and can slow down response times. However, it can
+       * be useful to better understand how the model is behaving.
        *
        * Setting to true will return the log probabilities of the tokens that
        * were generated.
@@ -160,9 +179,25 @@ export const openaiResponsesProviderOptionsSchema = lazySchema(() =>
        */
       maxToolCalls: z.number().nullish(),
 
+      /**
+       * Additional metadata to store with the generation.
+       */
       metadata: z.any().nullish(),
+
+      /**
+       * Whether to use parallel tool calls. Defaults to `true`.
+       */
       parallelToolCalls: z.boolean().nullish(),
+
+      /**
+       * The ID of the previous response. You can use it to continue a conversation.
+       * Defaults to `undefined`.
+       */
       previousResponseId: z.string().nullish(),
+
+      /**
+       * Sets a cache key to tie this prompt to cached prefixes for better caching performance.
+       */
       promptCacheKey: z.string().nullish(),
 
       /**
@@ -174,14 +209,69 @@ export const openaiResponsesProviderOptionsSchema = lazySchema(() =>
        * @default 'in_memory'
        */
       promptCacheRetention: z.enum(['in_memory', '24h']).nullish(),
+
+      /**
+       * Reasoning effort for reasoning models. Defaults to `medium`. If you use
+       * `providerOptions` to set the `reasoningEffort` option, this model setting will be ignored.
+       * Valid values: 'none' | 'minimal' | 'low' | 'medium' | 'high'
+       *
+       * Note: The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
+       * models. Setting `reasoningEffort` to 'none' with other models will result in
+       * an error.
+       */
       reasoningEffort: z.string().nullish(),
+
+      /**
+       * Controls reasoning summary output from the model.
+       * Set to "auto" to automatically receive the richest level available,
+       * or "detailed" for comprehensive summaries.
+       */
       reasoningSummary: z.string().nullish(),
+
+      /**
+       * The identifier for safety monitoring and tracking.
+       */
       safetyIdentifier: z.string().nullish(),
+
+      /**
+       * Service tier for the request.
+       * Set to 'flex' for 50% cheaper processing at the cost of increased latency (available for o3, o4-mini, and gpt-5 models).
+       * Set to 'priority' for faster processing with Enterprise access (available for gpt-4, gpt-5, gpt-5-mini, o3, o4-mini; gpt-5-nano is not supported).
+       *
+       * Defaults to 'auto'.
+       */
       serviceTier: z.enum(['auto', 'flex', 'priority', 'default']).nullish(),
+
+      /**
+       * Whether to store the generation. Defaults to `true`.
+       */
       store: z.boolean().nullish(),
+
+      /**
+       * Whether to use strict JSON schema validation.
+       * Defaults to `true`.
+       */
       strictJsonSchema: z.boolean().nullish(),
+
+      /**
+       * Controls the verbosity of the model's responses. Lower values ('low') will result
+       * in more concise responses, while higher values ('high') will result in more verbose responses.
+       * Valid values: 'low', 'medium', 'high'.
+       */
       textVerbosity: z.enum(['low', 'medium', 'high']).nullish(),
+
+      /**
+       * Controls output truncation. 'auto' (default) performs truncation automatically;
+       * 'disabled' turns truncation off.
+       */
       truncation: z.enum(['auto', 'disabled']).nullish(),
+
+      /**
+       * A unique identifier representing your end-user, which can help OpenAI to
+       * monitor and detect abuse.
+       * Defaults to `undefined`.
+       * @see https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids
+       */
       user: z.string().nullish(),
     }),
   ),


### PR DESCRIPTION
## Background

The JSDoc was missing. It is used to show inline hints in the IDE.

## Summary

Add JSDoc based on our MDX docs page.
