### PR TITLE
fix(openai): v5 - skip unpaired reasoning item_reference in Responses API

### DIFF
--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -139,7 +139,8 @@ export async function convertToOpenAIResponsesInput({
         const reasoningMessages: Record<string, OpenAIResponsesReasoning> = {};
         const toolCallParts: Record<string, LanguageModelV2ToolCallPart> = {};
 
-        for (const part of content) {
+        for (const partIndex in content) {
+          const part = content[partIndex];
           switch (part.type) {
             case 'text': {
               const id = part.providerOptions?.openai?.itemId as
@@ -240,9 +241,28 @@ export async function convertToOpenAIResponsesInput({
                   // use item references to refer to reasoning (single reference)
                   // when the first part is encountered
                   if (reasoningMessage === undefined) {
-                    input.push({ type: 'item_reference', id: reasoningId });
+                    // Only include reasoning item_reference if eventually followed by
+                    // text or tool-call that will also emit an item_reference.
+                    // Reasoning parts can be followed by more reasoning (same ID),
+                    // but the sequence must end with a paired item. If the following
+                    // part won't emit an item_reference (e.g., tool-call without itemId,
+                    // tool-result, or nothing), skip the reasoning to prevent API errors.
+                    let lookAheadIndex = Number(partIndex) + 1;
+                    let followingPart = content[lookAheadIndex];
+                    while (followingPart?.type === 'reasoning') {
+                      lookAheadIndex++;
+                      followingPart = content[lookAheadIndex];
+                    }
 
-                    // store unused reasoning message to mark id as used
+                    // Check if the following part will emit an item_reference
+                    const followingPartHasItemId =
+                      followingPart?.providerOptions?.openai?.itemId != null;
+
+                    if (followingPartHasItemId) {
+                      input.push({ type: 'item_reference', id: reasoningId });
+                    }
+
+                    // store reasoning message to mark id as used
                     reasoningMessages[reasoningId] = {
                       type: 'reasoning',
                       id: reasoningId,

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -255,10 +255,13 @@ export async function convertToOpenAIResponsesInput({
                     }
 
                     // Check if the following part will emit an item_reference
+                    // either by having an itemId or being a tool-result
                     const followingPartHasItemId =
                       followingPart?.providerOptions?.openai?.itemId != null;
+                    const followingPartIsToolResult =
+                      followingPart?.type === 'tool-result';
 
-                    if (followingPartHasItemId) {
+                    if (followingPartHasItemId || followingPartIsToolResult) {
                       input.push({ type: 'item_reference', id: reasoningId });
                     }
 


### PR DESCRIPTION
## Background

When using the OpenAI Responses API with `store: true` and reasoning models (e.g., o3, o4-mini), the API returns errors when `item_reference` items are unpaired:

- `Item 'rs_xxx' of type 'reasoning' was provided without its required following item`
- `Item 'fc_xxx' of type 'function_call' was provided without its required 'reasoning' item`

This occurs in multi-turn conversations when:

- A reasoning item is followed by a tool call that lacks an itemId (i.e., the tool call wasn't stored by the API)
- The tool call emits a full function_call object instead of an item_reference
- The reasoning item_reference is now "unpaired" because OpenAI expects both reasoning and its following item to either both use item_reference or both use full objects

The typical scenario is that the agent reasons, calls a tool, the tool returns an error (e.g., validation failure), and on retry the SDK rebuilds the conversation context. The reasoning has an `itemId` from the previous turn, but the failed tool call does not, causing the mismatch.

## Summary

Added look-ahead logic when processing reasoning parts with `store: true`. Before including a reasoning `item_reference`, the code now scans past consecutive reasoning parts to find the first non-reasoning part. The reference is only included if that part has a valid itemId that it will then include in it's iteration. Failed tool calls do not have the `itemId` and thus do not include the `item_reference`, causing the issue.

## Manual Verification

Tested with a reasoning model that calls a custom tool with invalid input. Previously this caused the API error; now the reasoning `item_reference` is correctly skipped and the conversation continues.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

Port into v6 main branch. https://github.com/vercel/ai/pull/10829

## Related Issues

https://github.com/vercel/ai/issues/8379