### PR TITLE
fix(openai): skip unpaired reasoning item_reference in Responses API

### DIFF
--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -1163,7 +1163,15 @@ describe('convertToOpenAIResponsesInput', () => {
                       },
                     },
                   },
-                  { type: 'text', text: 'First response' },
+                  {
+                    type: 'text',
+                    text: 'First response',
+                    providerOptions: {
+                      openai: {
+                        itemId: 'msg_001',
+                      },
+                    },
+                  },
                 ],
               },
               {
@@ -1182,7 +1190,15 @@ describe('convertToOpenAIResponsesInput', () => {
                       },
                     },
                   },
-                  { type: 'text', text: 'Second response' },
+                  {
+                    type: 'text',
+                    text: 'Second response',
+                    providerOptions: {
+                      openai: {
+                        itemId: 'msg_002',
+                      },
+                    },
+                  },
                 ],
               },
             ],
@@ -1206,14 +1222,8 @@ describe('convertToOpenAIResponsesInput', () => {
                 "type": "item_reference",
               },
               {
-                "content": [
-                  {
-                    "text": "First response",
-                    "type": "output_text",
-                  },
-                ],
-                "id": undefined,
-                "role": "assistant",
+                "id": "msg_001",
+                "type": "item_reference",
               },
               {
                 "content": [
@@ -1229,14 +1239,8 @@ describe('convertToOpenAIResponsesInput', () => {
                 "type": "item_reference",
               },
               {
-                "content": [
-                  {
-                    "text": "Second response",
-                    "type": "output_text",
-                  },
-                ],
-                "id": undefined,
-                "role": "assistant",
+                "id": "msg_002",
+                "type": "item_reference",
               },
             ]
           `);
@@ -1619,6 +1623,176 @@ describe('convertToOpenAIResponsesInput', () => {
             ]
           `);
         });
+      });
+    });
+
+    describe('reasoning item_reference pairing (store: true)', () => {
+      it('should include reasoning item_reference when followed by text', async () => {
+        const result = await convertToOpenAIResponsesInput({
+          toolNameMapping: testToolNameMapping,
+          prompt: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'reasoning',
+                  text: 'Analyzing the problem',
+                  providerOptions: {
+                    openai: {
+                      itemId: 'rs_001',
+                    },
+                  },
+                },
+                {
+                  type: 'text',
+                  text: 'Here is my response',
+                  providerOptions: {
+                    openai: {
+                      itemId: 'msg_001',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          systemMessageMode: 'system',
+          store: true,
+        });
+
+        expect(result.input).toMatchInlineSnapshot(`
+          [
+            {
+              "id": "rs_001",
+              "type": "item_reference",
+            },
+            {
+              "id": "msg_001",
+              "type": "item_reference",
+            },
+          ]
+        `);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should include reasoning item_reference when followed by tool-call', async () => {
+        const result = await convertToOpenAIResponsesInput({
+          toolNameMapping: testToolNameMapping,
+          prompt: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'reasoning',
+                  text: 'I need to call a tool',
+                  providerOptions: {
+                    openai: {
+                      itemId: 'rs_001',
+                    },
+                  },
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_001',
+                  toolName: 'search',
+                  input: { query: 'test' },
+                  providerOptions: {
+                    openai: {
+                      itemId: 'fc_001',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          systemMessageMode: 'system',
+          store: true,
+        });
+
+        expect(result.input).toMatchInlineSnapshot(`
+          [
+            {
+              "id": "rs_001",
+              "type": "item_reference",
+            },
+            {
+              "id": "fc_001",
+              "type": "item_reference",
+            },
+          ]
+        `);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should skip reasoning item_reference when followed by tool-call without itemId', async () => {
+        const result = await convertToOpenAIResponsesInput({
+          toolNameMapping: testToolNameMapping,
+          prompt: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'reasoning',
+                  text: 'I need to call a tool',
+                  providerOptions: {
+                    openai: {
+                      itemId: 'rs_001',
+                    },
+                  },
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_001',
+                  toolName: 'search',
+                  input: { query: 'test' },
+                  // No itemId - this tool-call will emit function_call, not item_reference
+                },
+              ],
+            },
+          ],
+          systemMessageMode: 'system',
+          store: true,
+        });
+
+        // reasoning is skipped because the tool-call won't emit an item_reference
+        expect(result.input).toMatchInlineSnapshot(`
+          [
+            {
+              "arguments": "{"query":"test"}",
+              "call_id": "call_001",
+              "id": undefined,
+              "name": "search",
+              "type": "function_call",
+            },
+          ]
+        `);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should skip reasoning item_reference when not followed by any part', async () => {
+        const result = await convertToOpenAIResponsesInput({
+          toolNameMapping: testToolNameMapping,
+          prompt: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'reasoning',
+                  text: 'Reasoning with no following message',
+                  providerOptions: {
+                    openai: {
+                      itemId: 'rs_001',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          systemMessageMode: 'system',
+          store: true,
+        });
+
+        expect(result.input).toHaveLength(0);
+        expect(result.warnings).toHaveLength(0);
       });
     });
   });

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -262,10 +262,13 @@ export async function convertToOpenAIResponsesInput({
                     }
 
                     // Check if the following part will emit an item_reference
+                    // either by having an itemId or being a tool-result
                     const followingPartHasItemId =
                       followingPart?.providerOptions?.openai?.itemId != null;
+                    const followingPartIsToolResult =
+                      followingPart?.type === 'tool-result';
 
-                    if (followingPartHasItemId) {
+                    if (followingPartHasItemId || followingPartIsToolResult) {
                       input.push({ type: 'item_reference', id: reasoningId });
                     }
 


### PR DESCRIPTION
## Background

When using the OpenAI Responses API with `store: true` and reasoning models (e.g., o3, o4-mini), the API returns errors when `item_reference` items are unpaired:

- `Item 'rs_xxx' of type 'reasoning' was provided without its required following item`
- `Item 'fc_xxx' of type 'function_call' was provided without its required 'reasoning' item`

This occurs in multi-turn conversations when:

- A reasoning item is followed by a tool call that lacks an itemId (i.e., the tool call wasn't stored by the API)
- The tool call emits a full function_call object instead of an item_reference
- The reasoning item_reference is now "unpaired" because OpenAI expects both reasoning and its following item to either both use item_reference or both use full objects

The typical scenario is the agent reasons, calls a tool, the tool returns an error (e.g., validation failure), and on retry the SDK rebuilds the conversation context. The reasoning has an itemId from the previous turn, but the failed tool call does not, causing the mismatch.

## Summary

Added look-ahead logic when processing reasoning parts with `store: true`. Before including a reasoning `item_reference`, the code now scans past consecutive reasoning parts to find the first non-reasoning part. The reference is only included if that part has a valid itemId that it will then include in it's iteration. Failed tool calls do not have the `itemId` and thus do not include the `item_reference`, causing the issue.

## Manual Verification

Tested with a reasoning model that calls a custom tool with invalid input. Previously this caused the API error; now the reasoning `item_reference` is correctly skipped and the conversation continues.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Related Issues

https://github.com/vercel/ai/issues/8379

v5 PR: https://github.com/vercel/ai/pull/10827