### PR TITLE
feat(provider/bedrock): Support Nova 2 extended reasoning `maxReasoningEffort` field

### DIFF
--- a/.changeset/violet-otters-compete.md
+++ b/.changeset/violet-otters-compete.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+feat(provider/bedrock): Support Nova 2 extended reasoning `maxReasoningEffort` field

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -416,20 +416,37 @@ console.log(
 
 ## Reasoning
 
-Amazon Bedrock has reasoning support for the `claude-3-7-sonnet-20250219` model.
+Amazon Bedrock supports model creator-specific reasoning features:
 
-You can enable it using the `reasoningConfig` provider option and specifying a thinking budget in tokens (minimum: `1024`, maximum: `64000`).
+- Anthropic (e.g. `claude-3-7-sonnet-20250219`): enable via the `reasoningConfig` provider option and specifying a thinking budget in tokens (minimum: `1024`, maximum: `64000`).
+- Amazon (e.g. `us.amazon.nova-2-lite-v1:0`): enable via the `reasoningConfig` provider option and specifying a maximum reasoning effort level (`'low' | 'medium' | 'high'`).
 
 ```ts
 import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { generateText } from 'ai';
 
+// Anthropic example
 const { text, reasoning, reasoningDetails } = await generateText({
   model: bedrock('us.anthropic.claude-3-7-sonnet-20250219-v1:0'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
     bedrock: {
       reasoningConfig: { type: 'enabled', budgetTokens: 1024 },
+    },
+  },
+});
+
+console.log(reasoning); // reasoning text
+console.log(reasoningDetails); // reasoning details including redacted reasoning
+console.log(text); // text response
+
+// Nova 2 example
+const { text, reasoning, reasoningDetails } = await generateText({
+  model: bedrock('us.amazon.nova-2-lite-v1:0'),
+  prompt: 'How many people will live in the world in 2040?',
+  providerOptions: {
+    bedrock: {
+      reasoningConfig: { type: 'enabled', maxReasoningEffort: 'medium' },
     },
   },
 });

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -426,7 +426,7 @@ import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { generateText } from 'ai';
 
 // Anthropic example
-const { text, reasoning } = await generateText({
+const anthropicResult = await generateText({
   model: bedrock('us.anthropclaude-3-7-sonnet-20250219-v1:0'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
@@ -436,11 +436,11 @@ const { text, reasoning } = await generateText({
   },
 });
 
-console.log(reasoning); // reasoning text
-console.log(text); // text response
+console.log(anthropicResult.reasoning); // reasoning text
+console.log(anthropicResult.text); // text response
 
 // Nova 2 example
-const { text, reasoning } = await generateText({
+const amazonResult = await generateText({
   model: bedrock('us.amazon.nova-2-lite-v1:0'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
@@ -450,8 +450,8 @@ const { text, reasoning } = await generateText({
   },
 });
 
-console.log(reasoning); // reasoning text
-console.log(text); // text response
+console.log(amazonResult.reasoning); // reasoning text
+console.log(amazonResult.text); // text response
 ```
 
 See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -426,8 +426,8 @@ import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { generateText } from 'ai';
 
 // Anthropic example
-const { text, reasoning, reasoningDetails } = await generateText({
-  model: bedrock('us.anthropic.claude-3-7-sonnet-20250219-v1:0'),
+const { text, reasoning } = await generateText({
+  model: bedrock('us.anthropclaude-3-7-sonnet-20250219-v1:0'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
     bedrock: {
@@ -437,11 +437,10 @@ const { text, reasoning, reasoningDetails } = await generateText({
 });
 
 console.log(reasoning); // reasoning text
-console.log(reasoningDetails); // reasoning details including redacted reasoning
 console.log(text); // text response
 
 // Nova 2 example
-const { text, reasoning, reasoningDetails } = await generateText({
+const { text, reasoning } = await generateText({
   model: bedrock('us.amazon.nova-2-lite-v1:0'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
@@ -452,7 +451,6 @@ const { text, reasoning, reasoningDetails } = await generateText({
 });
 
 console.log(reasoning); // reasoning text
-console.log(reasoningDetails); // reasoning details including redacted reasoning
 console.log(text); // text response
 ```
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2175,6 +2175,38 @@ describe('doStream', () => {
       ]
     `);
   });
+
+  it('should warn when Anthropic model receives maxReasoningEffort in stream', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          messageStop: {
+            stopReason: 'stop_sequence',
+          },
+        }) + '\n',
+      ],
+    };
+
+    const result = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      providerOptions: {
+        bedrock: {
+          reasoningConfig: {
+            type: 'enabled',
+            maxReasoningEffort: 'medium',
+          },
+        },
+      },
+    });
+
+    await convertReadableStreamToArray(result.stream);
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.additionalModelRequestFields?.reasoningConfig).toBeUndefined();
+  });
 });
 
 describe('doGenerate', () => {
@@ -2965,6 +2997,32 @@ describe('doGenerate', () => {
       },
     });
     expect(requestBody.additionalModelRequestFields?.thinking).toBeUndefined();
+  });
+
+  it('should warn when Anthropic model receives maxReasoningEffort (generate)', async () => {
+    prepareJsonResponse({});
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        bedrock: {
+          reasoningConfig: {
+            type: 'enabled',
+            maxReasoningEffort: 'medium',
+          },
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.additionalModelRequestFields?.reasoningConfig).toBeUndefined();
+
+    expect(result.warnings).toContainEqual({
+      type: 'unsupported',
+      feature: 'maxReasoningEffort',
+      details:
+        'maxReasoningEffort applies only to Amazon Nova models on Bedrock and will be ignored for this model.',
+    });
   });
 
   it('should extract reasoning text with signature', async () => {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2205,7 +2205,9 @@ describe('doStream', () => {
     await convertReadableStreamToArray(result.stream);
 
     const requestBody = await server.calls[0].requestBodyJson;
-    expect(requestBody.additionalModelRequestFields?.reasoningConfig).toBeUndefined();
+    expect(
+      requestBody.additionalModelRequestFields?.reasoningConfig,
+    ).toBeUndefined();
   });
 });
 
@@ -3015,7 +3017,9 @@ describe('doGenerate', () => {
     });
 
     const requestBody = await server.calls[0].requestBodyJson;
-    expect(requestBody.additionalModelRequestFields?.reasoningConfig).toBeUndefined();
+    expect(
+      requestBody.additionalModelRequestFields?.reasoningConfig,
+    ).toBeUndefined();
 
     expect(result.warnings).toContainEqual({
       type: 'unsupported',

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2964,9 +2964,7 @@ describe('doGenerate', () => {
         },
       },
     });
-    expect(
-      requestBody.additionalModelRequestFields?.thinking,
-    ).toBeUndefined();
+    expect(requestBody.additionalModelRequestFields?.thinking).toBeUndefined();
   });
 
   it('should extract reasoning text with signature', async () => {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -204,7 +204,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
     } else if (!isAnthropicModel && thinkingBudget != null) {
       warnings.push({
         type: 'unsupported',
-        setting: 'budgetTokens',
+        feature: 'budgetTokens',
         details:
           'budgetTokens applies only to Anthropic models on Bedrock and will be ignored for this model.',
       });
@@ -212,7 +212,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
 
     const maxReasoningEffort =
       bedrockOptions.reasoningConfig?.maxReasoningEffort;
-    if (maxReasoningEffort != null) {
+    if (maxReasoningEffort != null && !isAnthropicModel) {
       bedrockOptions.additionalModelRequestFields = {
         ...bedrockOptions.additionalModelRequestFields,
         reasoningConfig: {
@@ -222,6 +222,13 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
           maxReasoningEffort,
         },
       };
+    } else if (maxReasoningEffort != null && isAnthropicModel) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'maxReasoningEffort',
+        details:
+          'maxReasoningEffort applies only to Amazon Nova models on Bedrock and will be ignored for this model.',
+      });
     }
 
     if (isAnthropicThinkingEnabled && inferenceConfig.temperature != null) {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -176,8 +176,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
     const isThinkingRequested =
       bedrockOptions.reasoningConfig?.type === 'enabled';
     const thinkingBudget = bedrockOptions.reasoningConfig?.budgetTokens;
-    const isAnthropicThinkingEnabled =
-      isAnthropicModel && isThinkingRequested;
+    const isAnthropicThinkingEnabled = isAnthropicModel && isThinkingRequested;
 
     const inferenceConfig = {
       ...(maxOutputTokens != null && { maxTokens: maxOutputTokens }),

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -203,7 +203,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       };
     } else if (!isAnthropicModel && thinkingBudget != null) {
       warnings.push({
-        type: 'unsupported-setting',
+        type: 'unsupported',
         setting: 'budgetTokens',
         details:
           'budgetTokens applies only to Anthropic models on Bedrock and will be ignored for this model.',

--- a/packages/amazon-bedrock/src/bedrock-chat-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.ts
@@ -102,6 +102,7 @@ export const bedrockProviderOptions = z.object({
     .object({
       type: z.union([z.literal('enabled'), z.literal('disabled')]).optional(),
       budgetTokens: z.number().optional(),
+      maxReasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
     })
     .optional(),
   /**


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
Amazon's new Nova 2 models support reasoning but need the `maxReasoningEffort` to enable it. We currently don't support it.

## Summary

- Added support for `reasoningConfig.maxReasoningEffort` ('low' | 'medium' | 'high')
- Mapped `maxReasoningEffort` to `additionalModelRequestFields.reasoningConfig` for Bedrock requests
- Scoped thinking/budgetTokens mapping to Anthropic models only, ignored (with warning) for Nova to avoid ValidationException (was rejected by the model)
- Kept temperature/topP/topK gating only when Anthropic thinking is enabled

## Manual Verification
Reasoning works and appears as [REDACTED], as expected according to: https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)