### PR TITLE
add public serverInfo

### DIFF
--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -11,6 +11,7 @@ import {
   GetPromptResult,
   Configuration,
   ElicitationRequestSchema,
+  LATEST_PROTOCOL_VERSION,
 } from './types';
 import { JSONRPCRequest } from './json-rpc-message';
 import {
@@ -419,6 +420,29 @@ describe('MCPClient', () => {
         transport: { type: 'sse', url: 'https://example.com/sse' },
       }),
     ).rejects.toThrowError(MCPClientError);
+  });
+
+  it('should return serverInfo', async () => {
+    const serverInfo = {
+      name: 'mock-mcp-server',
+      version: '1.0.0',
+    };
+    createMockTransport.mockImplementation(
+      () =>
+        new MockMCPTransport({
+          initializeResult: {
+            protocolVersion: LATEST_PROTOCOL_VERSION,
+            serverInfo,
+            capabilities: {},
+          },
+        }),
+    );
+
+    const client = await createMCPClient({
+      transport: { type: 'sse', url: 'https://example.com/sse' },
+    });
+
+    expect(client.serverInfo).toEqual(serverInfo);
   });
 
   it('should throw if server sends invalid protocol version', async () => {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -527,21 +527,21 @@ class DefaultMCPClient implements MCPClient {
         const toolWithExecute =
           schemas === 'automatic'
             ? dynamicTool({
-              description,
-              title,
-              inputSchema: jsonSchema({
-                ...inputSchema,
-                properties: inputSchema.properties ?? {},
-                additionalProperties: false,
-              } as JSONSchema7),
-              execute,
-            })
+                description,
+                title,
+                inputSchema: jsonSchema({
+                  ...inputSchema,
+                  properties: inputSchema.properties ?? {},
+                  additionalProperties: false,
+                } as JSONSchema7),
+                execute,
+              })
             : tool({
-              description,
-              title,
-              inputSchema: schemas[name].inputSchema,
-              execute,
-            });
+                description,
+                title,
+                inputSchema: schemas[name].inputSchema,
+                execute,
+              });
 
         tools[name] = { ...toolWithExecute, _meta };
       }
@@ -729,11 +729,11 @@ class DefaultMCPClient implements MCPClient {
       'result' in response
         ? response
         : new MCPClientError({
-          message: response.error.message,
-          code: response.error.code,
-          data: response.error.data,
-          cause: response.error,
-        }),
+            message: response.error.message,
+            code: response.error.code,
+            data: response.error.data,
+            cause: response.error,
+          }),
     );
   }
 }

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -83,7 +83,7 @@ export async function createMCPClient(
 }
 
 export interface MCPClient {
-  serverInfo: ClientOrServerImplementation;
+  serverInfo?: ClientOrServerImplementation;
 
   tools<TOOL_SCHEMAS extends ToolSchemas = 'automatic'>(options?: {
     schemas?: TOOL_SCHEMAS;
@@ -151,7 +151,7 @@ class DefaultMCPClient implements MCPClient {
     (response: JSONRPCResponse | Error) => void
   > = new Map();
   private serverCapabilities: ServerCapabilities = {};
-  public serverInfo: ClientOrServerImplementation;
+  public serverInfo?: ClientOrServerImplementation;
   private isClosed = true;
   private elicitationRequestHandler?: (
     request: ElicitationRequest,

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -91,6 +91,9 @@ const ServerCapabilitiesSchema = z.looseObject({
 });
 
 export type ServerCapabilities = z.infer<typeof ServerCapabilitiesSchema>;
+export type ClientOrServerImplementation = z.infer<
+  typeof ClientOrServerImplementationSchema
+>;
 export const ClientCapabilitiesSchema = z
   .object({
     elicitation: z.optional(ElicitationCapabilitySchema),


### PR DESCRIPTION
This pull request adds support for exposing server information in the MCP client. At Tabnine, customers use `serverInfo.name` to identify and control their servers, so this property is required.

## Server Information

* Added `ClientOrServerImplementation` and updated `MCPClient` to include a `serverInfo` property.  
* `DefaultMCPClient` now sets `serverInfo` during initialization.  

## Testing

* Added a test to check that `serverInfo` is correctly exposed.  

## Type Imports

* Imported `ClientOrServerImplementation` in the client file to support the new property.
