### PR TITLE
fix(bedrock): send {} as tool input when streaming tool calls without arguments

### DIFF
--- a/.changeset/angry-wasps-raise.md
+++ b/.changeset/angry-wasps-raise.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(bedrock): send {} as tool input when streaming tool calls without arguments

--- a/examples/ai-core/src/generate-text/amazon-bedrock-tool-call-no-args.ts
+++ b/examples/ai-core/src/generate-text/amazon-bedrock-tool-call-no-args.ts
@@ -1,0 +1,19 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+import { print } from '../lib/print';
+
+run(async () => {
+  const result = await generateText({
+    model: bedrock('anthropic.claude-3-5-sonnet-20241022-v2:0'),
+    tools: {
+      updateIssueList: tool({
+        inputSchema: z.object({}), // empty input schema
+      }),
+    },
+    prompt: 'Update the issue list',
+  });
+
+  print('Content:', result.content);
+});

--- a/examples/ai-core/src/stream-text/amazon-bedrock-tool-call-no-args.ts
+++ b/examples/ai-core/src/stream-text/amazon-bedrock-tool-call-no-args.ts
@@ -1,0 +1,19 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+import { printFullStream } from '../lib/print-full-stream';
+
+run(async () => {
+  const result = streamText({
+    model: bedrock('anthropic.claude-3-5-sonnet-20241022-v2:0'),
+    tools: {
+      updateIssueList: tool({
+        inputSchema: z.object({}),
+      }),
+    },
+    prompt: 'Update the issue list',
+  });
+
+  await printFullStream({ result });
+});

--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-tool-no-args.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-tool-no-args.chunks.txt
@@ -1,0 +1,8 @@
+{"contentBlockStart":{"contentBlockIndex":0,"start":{}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"I'll update the issue list for you."}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"contentBlockStart":{"contentBlockIndex":1,"start":{"toolUse":{"toolUseId":"tool-use-id","name":"updateIssueList"}}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"toolUse":{"input":""}}}}
+{"contentBlockStop":{"contentBlockIndex":1}}
+{"metadata":{"usage":{"inputTokens":100,"outputTokens":25,"totalTokens":125},"metrics":{"latencyMs":150}}}
+{"messageStop":{"stopReason":"tool_use"}}

--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-tool-no-args.json
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-tool-no-args.json
@@ -1,0 +1,25 @@
+{
+  "output": {
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "text": "I'll update the issue list for you."
+        },
+        {
+          "toolUse": {
+            "toolUseId": "tool-use-id",
+            "name": "updateIssueList",
+            "input": {}
+          }
+        }
+      ]
+    }
+  },
+  "usage": {
+    "inputTokens": 100,
+    "outputTokens": 25,
+    "totalTokens": 125
+  },
+  "stopReason": "tool_use"
+}

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -423,7 +423,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
             type: 'tool-call' as const,
             toolCallId: part.toolUse?.toolUseId ?? this.config.generateId(),
             toolName: part.toolUse?.name ?? `tool-${this.config.generateId()}`,
-            input: JSON.stringify(part.toolUse?.input ?? ''),
+            input: JSON.stringify(part.toolUse?.input ?? {}),
           });
         }
       }
@@ -680,7 +680,10 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
                       type: 'tool-call',
                       toolCallId: contentBlock.toolCallId,
                       toolName: contentBlock.toolName,
-                      input: contentBlock.jsonText,
+                      input:
+                        contentBlock.jsonText === ''
+                          ? '{}'
+                          : contentBlock.jsonText,
                     });
                   }
                 }


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

I faced the same issue on bedrock calls, similar to #10747. Converting to {} instead of empty string for tool call

## Summary

<!-- What did you change? -->

## Manual Verification

<!--
For features & bugfixes.
Please explain how you *manually* verified that the change works end-to-end as expected (excluding automated tests).
Remove the section if it's not needed (e.g. for docs).
-->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
