### PR TITLE
chore: rename ToolCallOptions to ToolExecutionOptions

### DIFF
--- a/.changeset/many-chairs-wonder.md
+++ b/.changeset/many-chairs-wonder.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/mcp': patch
+'ai': patch
+---
+
+chore: rename ToolCallOptions to ToolExecutionOptions

--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -451,7 +451,7 @@ export type HumanInTheLoopUIMessage = UIMessage<
 import {
   convertToModelMessages,
   Tool,
-  ToolCallOptions,
+  ToolExecutionOptions,
   ToolSet,
   UIMessageStreamWriter,
   getToolName,
@@ -501,7 +501,7 @@ export async function processToolCalls<
   executeFunctions: {
     [K in keyof Tools & keyof ExecutableTools]?: (
       args: ExecutableTools[K] extends Tool<infer P> ? P : never,
-      context: ToolCallOptions,
+      context: ToolExecutionOptions,
     ) => Promise<any>;
   },
 ): Promise<HumanInTheLoopUIMessage[]> {

--- a/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
@@ -70,12 +70,12 @@ export const weatherTool = tool({
             {
               name: 'execute',
               isOptional: true,
-              type: 'async (input: INPUT, options: ToolCallOptions) => RESULT | Promise<RESULT> | AsyncIterable<RESULT>',
+              type: 'async (input: INPUT, options: ToolExecutionOptions) => RESULT | Promise<RESULT> | AsyncIterable<RESULT>',
               description:
                 'An async function that is called with the arguments from the tool call and produces a result or a results iterable. If an iterable is provided, all results but the last one are considered preliminary. If not provided, the tool will not be executed automatically.',
               properties: [
                 {
-                  type: 'ToolCallOptions',
+                  type: 'ToolExecutionOptions',
                   parameters: [
                     {
                       name: 'toolCallId',
@@ -124,21 +124,21 @@ export const weatherTool = tool({
             {
               name: 'onInputStart',
               isOptional: true,
-              type: '(options: ToolCallOptions) => void | PromiseLike<void>',
+              type: '(options: ToolExecutionOptions) => void | PromiseLike<void>',
               description:
                 'Optional function that is called when the argument streaming starts. Only called when the tool is used in a streaming context.',
             },
             {
               name: 'onInputDelta',
               isOptional: true,
-              type: '(options: { inputTextDelta: string } & ToolCallOptions) => void | PromiseLike<void>',
+              type: '(options: { inputTextDelta: string } & ToolExecutionOptions) => void | PromiseLike<void>',
               description:
                 'Optional function that is called when an argument streaming delta is available. Only called when the tool is used in a streaming context.',
             },
             {
               name: 'onInputAvailable',
               isOptional: true,
-              type: '(options: { input: INPUT } & ToolCallOptions) => void | PromiseLike<void>',
+              type: '(options: { input: INPUT } & ToolExecutionOptions) => void | PromiseLike<void>',
               description:
                 'Optional function that is called when a tool call can be started, even if the execute function is not provided.',
             },

--- a/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/22-dynamic-tool.mdx
@@ -71,7 +71,7 @@ export const customTool = dynamicTool({
                 'An async function that is called with the arguments from the tool call. The input is typed as unknown and must be validated/cast at runtime.',
                 properties: [
                   {
-                    type: "ToolCallOptions",
+                    type: "ToolExecutionOptions",
                     parameters: [
                       {
                       name: 'toolCallId',

--- a/content/docs/08-migration-guides/27-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/27-migration-guide-6-0.mdx
@@ -60,6 +60,11 @@ const modelMessages = convertToModelMessages(messages); // ModelMessage[]
 They will be removed in a future version.
 You can use `generateText` and `streamText` with an `output` setting instead.
 
+### Renamed `ToolCallOptions` to `ToolExecutionOptions`
+
+The `ToolCallOptions` type has been renamed to `ToolExecutionOptions`
+and is now deprecated.
+
 ## `@ai-sdk/openai` package
 
 ### `strictJsonSchema` defaults to true
@@ -182,10 +187,6 @@ To disable warning logging, set the `AI_SDK_LOG_WARNINGS` environment variable t
 ```bash
 export AI_SDK_LOG_WARNINGS=false
 ```
-
-### V2 Model Compatibility Warning
-
-A warning is displayed when using v2 provider models with AISDK v6 ([PR #10770](https://github.com/vercel/ai/pull/10770)). Update your provider implementations to use v3 models.
 
 ## Tool Changes
 

--- a/examples/next-openai/app/api/use-chat-human-in-the-loop/utils.ts
+++ b/examples/next-openai/app/api/use-chat-human-in-the-loop/utils.ts
@@ -1,7 +1,7 @@
 import {
   convertToModelMessages,
   Tool,
-  ToolCallOptions,
+  ToolExecutionOptions,
   ToolSet,
   UIMessageStreamWriter,
   getToolName,
@@ -51,7 +51,7 @@ export async function processToolCalls<
   executeFunctions: {
     [K in keyof Tools & keyof ExecutableTools]?: (
       args: ExecutableTools[K] extends Tool<infer P> ? P : never,
-      context: ToolCallOptions,
+      context: ToolExecutionOptions,
     ) => Promise<any>;
   },
 ): Promise<HumanInTheLoopUIMessage[]> {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -19,6 +19,7 @@ export {
   type ToolApprovalRequest,
   type ToolApprovalResponse,
   type ToolCallOptions,
+  type ToolExecutionOptions,
   type ToolExecuteFunction,
 } from '@ai-sdk/provider-utils';
 

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -4,7 +4,7 @@ import {
   jsonSchema,
   Tool,
   tool,
-  ToolCallOptions,
+  ToolExecutionOptions,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { MCPClientError } from '../error/mcp-client-error';
@@ -371,7 +371,7 @@ class DefaultMCPClient implements MCPClient {
   }: {
     name: string;
     args: Record<string, unknown>;
-    options?: ToolCallOptions;
+    options?: ToolExecutionOptions;
   }): Promise<CallToolResult> {
     try {
       return this.request({
@@ -513,7 +513,7 @@ class DefaultMCPClient implements MCPClient {
 
         const execute = async (
           args: any,
-          options: ToolCallOptions,
+          options: ToolExecutionOptions,
         ): Promise<CallToolResult> => {
           options?.abortSignal?.throwIfAborted();
           return self.callTool({ name, args, options });

--- a/packages/provider-utils/src/types/execute-tool.ts
+++ b/packages/provider-utils/src/types/execute-tool.ts
@@ -1,5 +1,5 @@
 import { isAsyncIterable } from '../is-async-iterable';
-import { ToolCallOptions, ToolExecuteFunction } from './tool';
+import { ToolExecutionOptions, ToolExecuteFunction } from './tool';
 
 export async function* executeTool<INPUT, OUTPUT>({
   execute,
@@ -8,7 +8,7 @@ export async function* executeTool<INPUT, OUTPUT>({
 }: {
   execute: ToolExecuteFunction<INPUT, OUTPUT>;
   input: INPUT;
-  options: ToolCallOptions;
+  options: ToolExecutionOptions;
 }): AsyncGenerator<
   { type: 'preliminary'; output: OUTPUT } | { type: 'final'; output: OUTPUT }
 > {

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -22,7 +22,7 @@ export {
   type InferToolInput,
   type InferToolOutput,
   type Tool,
-  type ToolCallOptions,
+  type ToolExecutionOptions,
   type ToolExecuteFunction,
   type ToolNeedsApprovalFunction,
 } from './tool';
@@ -32,3 +32,9 @@ export type { ToolCall } from './tool-call';
 export type { ToolContent, ToolModelMessage } from './tool-model-message';
 export type { ToolResult } from './tool-result';
 export type { UserContent, UserModelMessage } from './user-model-message';
+import type { ToolExecutionOptions } from './tool';
+
+/**
+ * @deprecated Use ToolExecutionOptions instead.
+ */
+export type ToolCallOptions = ToolExecutionOptions;

--- a/packages/provider-utils/src/types/tool.ts
+++ b/packages/provider-utils/src/types/tool.ts
@@ -7,8 +7,7 @@ import { ProviderOptions } from './provider-options';
 /**
  * Additional options that are sent into each tool call.
  */
-// TODO AI SDK 6: rename to ToolExecutionOptions
-export interface ToolCallOptions {
+export interface ToolExecutionOptions {
   /**
    * The ID of the tool call. You can use it e.g. when sending tool-call related information with stream data.
    */
@@ -61,7 +60,7 @@ export type ToolNeedsApprovalFunction<INPUT> = (
 
 export type ToolExecuteFunction<INPUT, OUTPUT> = (
   input: INPUT,
-  options: ToolCallOptions,
+  options: ToolExecutionOptions,
 ) => AsyncIterable<OUTPUT> | PromiseLike<OUTPUT> | OUTPUT;
 
 // 0 extends 1 & N checks for any
@@ -149,14 +148,14 @@ Whether the tool needs approval before it can be executed.
    * Optional function that is called when the argument streaming starts.
    * Only called when the tool is used in a streaming context.
    */
-  onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
+  onInputStart?: (options: ToolExecutionOptions) => void | PromiseLike<void>;
 
   /**
    * Optional function that is called when an argument streaming delta is available.
    * Only called when the tool is used in a streaming context.
    */
   onInputDelta?: (
-    options: { inputTextDelta: string } & ToolCallOptions,
+    options: { inputTextDelta: string } & ToolExecutionOptions,
   ) => void | PromiseLike<void>;
 
   /**
@@ -166,7 +165,7 @@ Whether the tool needs approval before it can be executed.
   onInputAvailable?: (
     options: {
       input: [INPUT] extends [never] ? unknown : INPUT;
-    } & ToolCallOptions,
+    } & ToolExecutionOptions,
   ) => void | PromiseLike<void>;
 } & ToolOutputProperties<INPUT, OUTPUT> & {
     /**


### PR DESCRIPTION
## Background
The name `ToolCallOptions` is misleading because the options are used in the tool execution.

## Summary

Rename ToolCallOptions to ToolExecutionOptions.
