### PR TITLE
chore(ai): remove rejected todos

### DIFF
--- a/packages/ai/src/generate-text/content-part.ts
+++ b/packages/ai/src/generate-text/content-part.ts
@@ -8,7 +8,6 @@ import { TypedToolError } from './tool-error';
 import { TypedToolResult } from './tool-result';
 import { ToolSet } from './tool-set';
 
-// TODO AI SDK 5.1 / AI SDK 6: revisit naming, e.g. rename to Output
 export type ContentPart<TOOLS extends ToolSet> =
   | { type: 'text'; text: string; providerMetadata?: ProviderMetadata }
   | ReasoningOutput

--- a/packages/ai/src/generate-text/generate-text-result.ts
+++ b/packages/ai/src/generate-text/generate-text-result.ts
@@ -29,7 +29,6 @@ export interface GenerateTextResult<
   /**
 The content that was generated in the last step.
    */
-  // TODO AI SDK 5.1 / AI SDK 6: consider renaming to output
   readonly content: Array<ContentPart<TOOLS>>;
 
   /**

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -940,7 +940,6 @@ function asToolCalls(content: Array<LanguageModelV3Content>) {
   }));
 }
 
-// TODO AI SDK 5.1 / AI SDK 6: rename to asOutput
 function asContent<TOOLS extends ToolSet>({
   content,
   toolCalls,

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -350,7 +350,6 @@ Converts the result to a streamed response object with a stream data part stream
   toTextStreamResponse(init?: ResponseInit): Response;
 }
 
-// TODO AI SDK 5.1 rename
 export type TextStreamPart<TOOLS extends ToolSet> =
   | {
       type: 'text-start';


### PR DESCRIPTION
## Background

We considered renaming `content` to `output` (see #8599 ). However, `output` is now used for structured outputs.

## Summary

Remove outdated TODOs.

## Related Issues

Closes #8599