### PR TITLE
fix(openai): expose execute function of apply-patch tool

### DIFF
--- a/.changeset/smooth-readers-lay.md
+++ b/.changeset/smooth-readers-lay.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): refactor apply-patch tool

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -639,6 +639,36 @@ Your execute function must return an output array with results for each command:
 - **stderr** _string_ - Standard error from the command
 - **outcome** - Either `{ type: 'timeout' }` or `{ type: 'exit', exitCode: number }`
 
+#### Apply Patch Tool
+
+The OpenAI Responses API supports the apply patch tool for GPT-5.1 models through the `openai.tools.applyPatch` tool.
+The apply patch tool lets the model create, update, and delete files in your codebase using structured diffs.
+Instead of just suggesting edits, the model emits patch operations that your application applies and reports back on,
+enabling iterative, multi-step code editing workflows.
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { generateText, stepCountIs } from 'ai';
+
+const result = await generateText({
+  model: openai('gpt-5.1'),
+  tools: {
+    apply_patch: openai.tools.applyPatch({
+      execute: async ({ callId, operation }) => {
+        // ... your implementation for applying the diffs.
+      },
+    }),
+  },
+  prompt: 'Create a python file that calculates the factorial of a number',
+  stopWhen: stepCountIs(5),
+});
+```
+
+Your execute function must return:
+
+- **status** _'completed' | 'failed'_ - Whether the patch was applied successfully
+- **output** _string_ (optional) - Human-readable log text (e.g., results or error messages)
+
 #### Image Inputs
 
 The OpenAI Responses API supports Image inputs for appropriate models.

--- a/examples/ai-core/src/generate-text/openai-responses-apply-patch.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-apply-patch.ts
@@ -1,166 +1,35 @@
-import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
-import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { generateText, stepCountIs } from 'ai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import {
-  ApplyPatchOperation,
-  WorkspaceEditor,
-} from '../lib/apply-patch-file-editor';
+import { createApplyPatchExecutor } from '../lib/apply-patch-file-editor';
 import { run } from '../lib/run';
 
 run(async () => {
   const workspaceRoot = path.join(__dirname, '../output');
   await fs.mkdir(workspaceRoot, { recursive: true });
 
-  const editor = new WorkspaceEditor(workspaceRoot);
+  const result = await generateText({
+    model: openai.responses('gpt-5.1'),
+    tools: {
+      apply_patch: openai.tools.applyPatch({
+        execute: createApplyPatchExecutor(workspaceRoot),
+      }),
+    },
+    prompt: `Create a markdown file with a shopping checklist of 5 entries.`,
+    stopWhen: stepCountIs(5),
+  });
 
-  try {
-    const result1 = await generateText({
-      model: openai.responses('gpt-5.1'),
-      prompt: `Create a markdown file with a shopping checklist of 5 entries.`,
-      tools: {
-        apply_patch: openai.tools.applyPatch(),
-      },
-    });
+  console.log('\n=== Result ===');
+  console.log('Text:', result.text);
+  console.log('\nFiles saved in:', workspaceRoot);
 
-    console.log('\n=== Model Response ===');
-    console.dir(result1, { depth: Infinity });
-
-    // Extract and apply patch operations
-    const patchResults: Array<{
-      toolCallId: string;
-      result: { status: 'completed' | 'failed'; output?: string };
-    }> = [];
-    let createdFilePath: string | null = null;
-
-    for (const toolCall of result1.toolCalls) {
-      if (toolCall.toolName === 'apply_patch') {
-        const input = toolCall.input as {
-          callId: string;
-          operation: ApplyPatchOperation;
-        };
-
-        let result: { status: 'completed' | 'failed'; output?: string };
-        switch (input.operation.type) {
-          case 'create_file':
-            result = await editor.createFile(input.operation);
-            // Track the created file path
-            if (result.status === 'completed') {
-              createdFilePath = input.operation.path;
-            }
-            break;
-          case 'update_file':
-            result = await editor.updateFile(input.operation);
-            break;
-          case 'delete_file':
-            result = await editor.deleteFile(input.operation);
-            break;
-        }
-
-        patchResults.push({
-          toolCallId: toolCall.toolCallId,
-          result,
-        });
-
-        console.log(
-          `Applied ${input.operation.type} to ${input.operation.path}: ${result.status}`,
-        );
-      }
-    }
-
-    // Step 2: Send results back and ask for an update
-    if (patchResults.length > 0 && createdFilePath) {
-      // Read the created file using the actual path from the patch operation
-      const fileContent = await fs.readFile(
-        path.join(workspaceRoot, createdFilePath),
-        'utf8',
-      );
-      console.log(`Current ${createdFilePath} content:`);
-      console.log(fileContent);
-
-      console.log('\n=== Step 2: Reading file and updating it ===\n');
-      // Send patch results back and ask for update
-      // We use previousResponseId to pass previous message context and append the tool results object
-      const result2 = await generateText({
-        model: openai.responses('gpt-5.1'),
-        messages: [
-          {
-            role: 'tool' as const,
-            content: patchResults.map(pr => ({
-              type: 'tool-result' as const,
-              toolCallId: pr.toolCallId,
-              toolName: 'apply_patch' as const,
-              output: {
-                type: 'json' as const,
-                value: pr.result,
-              },
-            })),
-          },
-          {
-            role: 'user' as const,
-            content: `The user has the following file:\n\n<BEGIN_FILES>\n===== ${createdFilePath}\n${fileContent}\n<END_FILES>\n\nCheck off the last two items from the file.`,
-          },
-        ],
-        tools: {
-          apply_patch: openai.tools.applyPatch(),
-        },
-        providerOptions: {
-          openai: {
-            previousResponseId: result1.providerMetadata?.openai
-              .responseId as string,
-          } satisfies OpenAIResponsesProviderOptions,
-        },
-      });
-
-      console.log('\n=== Model Response ===');
-      console.dir(result2, { depth: Infinity });
-
-      // Apply new patch operations
-      const patchResults2: Array<{
-        toolCallId: string;
-        result: { status: 'completed' | 'failed'; output?: string };
-      }> = [];
-
-      for (const toolCall of result2.toolCalls) {
-        if (toolCall.toolName === 'apply_patch') {
-          const input = toolCall.input as {
-            callId: string;
-            operation: ApplyPatchOperation;
-          };
-
-          let result: { status: 'completed' | 'failed'; output?: string };
-          switch (input.operation.type) {
-            case 'create_file':
-              result = await editor.createFile(input.operation);
-              break;
-            case 'update_file':
-              result = await editor.updateFile(input.operation);
-              break;
-            case 'delete_file':
-              result = await editor.deleteFile(input.operation);
-              break;
-          }
-
-          patchResults2.push({
-            toolCallId: toolCall.toolCallId,
-            result,
-          });
-
-          console.log(
-            `Applied ${input.operation.type} to ${input.operation.path}: ${result.status}`,
-          );
-        }
-      }
-
-      console.log(`\n=== Final ${createdFilePath} content ===\n`);
-      const finalContent = await fs.readFile(
-        path.join(workspaceRoot, createdFilePath),
-        'utf8',
-      );
-      console.log(finalContent);
-    }
-  } catch (error) {
-    console.error('Error:', error);
+  // List created files
+  const files = await fs.readdir(workspaceRoot);
+  for (const file of files) {
+    const filePath = path.join(workspaceRoot, file);
+    const content = await fs.readFile(filePath, 'utf8');
+    console.log(`\n=== ${file} ===`);
+    console.log(content);
   }
-  console.log(`\nFiles saved in: ${workspaceRoot}`);
 });

--- a/examples/ai-core/src/lib/apply-patch-file-editor.ts
+++ b/examples/ai-core/src/lib/apply-patch-file-editor.ts
@@ -18,6 +18,35 @@ export type ApplyPatchOperation =
       diff: string;
     };
 
+/**
+ * Creates an execute function for the applyPatch tool that operates within a workspace root.
+ *
+ * @param workspaceRoot - The root directory for file operations
+ * @returns An execute function compatible with openai.tools.applyPatch()
+ */
+export function createApplyPatchExecutor(workspaceRoot: string) {
+  const editor = new WorkspaceEditor(workspaceRoot);
+
+  return async ({
+    callId,
+    operation,
+  }: {
+    callId: string;
+    operation: ApplyPatchOperation;
+  }): Promise<{ status: 'completed' | 'failed'; output?: string }> => {
+    console.log(`[${callId}] Applying ${operation.type} to ${operation.path}`);
+
+    switch (operation.type) {
+      case 'create_file':
+        return editor.createFile(operation);
+      case 'update_file':
+        return editor.updateFile(operation);
+      case 'delete_file':
+        return editor.deleteFile(operation);
+    }
+  };
+}
+
 export class WorkspaceEditor {
   constructor(private readonly root: string) {}
 

--- a/examples/ai-core/src/lib/apply-patch-file-editor.ts
+++ b/examples/ai-core/src/lib/apply-patch-file-editor.ts
@@ -18,12 +18,6 @@ export type ApplyPatchOperation =
       diff: string;
     };
 
-/**
- * Creates an execute function for the applyPatch tool that operates within a workspace root.
- *
- * @param workspaceRoot - The root directory for file operations
- * @returns An execute function compatible with openai.tools.applyPatch()
- */
 export function createApplyPatchExecutor(workspaceRoot: string) {
   const editor = new WorkspaceEditor(workspaceRoot);
 

--- a/examples/ai-core/src/stream-text/openai-responses-apply-patch.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-apply-patch.ts
@@ -1,201 +1,59 @@
-import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { openai } from '@ai-sdk/openai';
 import { streamText } from 'ai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import {
-  ApplyPatchOperation,
-  WorkspaceEditor,
-} from '../lib/apply-patch-file-editor';
+import { createApplyPatchExecutor } from '../lib/apply-patch-file-editor';
 import { run } from '../lib/run';
 
 run(async () => {
   const workspaceRoot = path.join(__dirname, '../output');
   await fs.mkdir(workspaceRoot, { recursive: true });
 
-  const editor = new WorkspaceEditor(workspaceRoot);
+  const result = await streamText({
+    model: openai.responses('gpt-5.1'),
+    prompt: `Create a markdown file with a shopping checklist of 5 entries.`,
+    tools: {
+      apply_patch: openai.tools.applyPatch({
+        execute: createApplyPatchExecutor(workspaceRoot),
+      }),
+    },
+  });
 
-  try {
-    const result1 = await streamText({
-      model: openai.responses('gpt-5.1'),
-      prompt: `Create a markdown file with a shopping checklist of 5 entries.`,
-      tools: {
-        apply_patch: openai.tools.applyPatch(),
-      },
-    });
-
-    process.stdout.write('\n=== Model Response (Streaming) ===\n');
-    for await (const part of result1.fullStream) {
-      switch (part.type) {
-        case 'text-delta': {
-          process.stdout.write(part.text);
-          break;
-        }
-
-        case 'tool-call': {
-          process.stdout.write(
-            `\n\nTool call: '${part.toolName}'\nInput: ${JSON.stringify(part.input, null, 2)}\n`,
-          );
-          break;
-        }
-
-        case 'tool-result': {
-          process.stdout.write(
-            `\nTool result: '${part.toolName}'\nOutput: ${JSON.stringify(part.output, null, 2)}\n`,
-          );
-          break;
-        }
-
-        case 'error': {
-          console.error('\n\nCode execution error:', part.error);
-          break;
-        }
+  process.stdout.write('\n=== Model Response (Streaming) ===\n');
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'text-delta': {
+        process.stdout.write(part.text);
+        break;
       }
-    }
-    process.stdout.write('\n\n');
-
-    // Get tool calls and provider metadata (these automatically consume the stream)
-    const toolCalls1 = await result1.toolCalls;
-    const providerMetadata1 = await result1.providerMetadata;
-
-    // Extract and apply patch operations
-    const patchResults: Array<{
-      toolCallId: string;
-      result: { status: 'completed' | 'failed'; output?: string };
-    }> = [];
-    let createdFilePath: string | null = null;
-
-    for (const toolCall of toolCalls1) {
-      if (toolCall.toolName === 'apply_patch') {
-        const input = toolCall.input as {
-          callId: string;
-          operation: ApplyPatchOperation;
-        };
-
-        let result: { status: 'completed' | 'failed'; output?: string };
-        switch (input.operation.type) {
-          case 'create_file':
-            result = await editor.createFile(input.operation);
-            if (result.status === 'completed') {
-              createdFilePath = input.operation.path;
-            }
-            break;
-          case 'update_file':
-            result = await editor.updateFile(input.operation);
-            break;
-          case 'delete_file':
-            result = await editor.deleteFile(input.operation);
-            break;
-        }
-
-        patchResults.push({
-          toolCallId: toolCall.toolCallId,
-          result,
-        });
-
-        console.log(
-          `Applied ${input.operation.type} to ${input.operation.path}: ${result.status}`,
+      case 'tool-call': {
+        process.stdout.write(
+          `\n\nTool call: '${part.toolName}'\nInput: ${JSON.stringify(part.input, null, 2)}\n`,
         );
+        break;
+      }
+      case 'tool-result': {
+        process.stdout.write(
+          `\nTool result: '${part.toolName}'\nOutput: ${JSON.stringify(part.output, null, 2)}\n`,
+        );
+        break;
+      }
+      case 'error': {
+        console.error('\n\nError:', part.error);
+        break;
       }
     }
-
-    // Step 2: Send results back and ask for an update
-    if (patchResults.length > 0 && createdFilePath) {
-      // Read the created file using the actual path from the patch operation
-      const fileContent = await fs.readFile(
-        path.join(workspaceRoot, createdFilePath),
-        'utf8',
-      );
-      console.log(`\nCurrent ${createdFilePath} content:`);
-      console.log(fileContent);
-
-      console.log('\n=== Step 2: Reading file and updating it ===\n');
-
-      const result2 = streamText({
-        model: openai.responses('gpt-5.1'),
-        messages: [
-          {
-            role: 'tool' as const,
-            content: patchResults.map(pr => ({
-              type: 'tool-result' as const,
-              toolCallId: pr.toolCallId,
-              toolName: 'apply_patch' as const,
-              output: {
-                type: 'json' as const,
-                value: pr.result,
-              },
-            })),
-          },
-          {
-            role: 'user' as const,
-            content: `The user has the following file:\n\n<BEGIN_FILES>\n===== ${createdFilePath}\n${fileContent}\n<END_FILES>\n\nCheck off the last two items from the file.`,
-          },
-        ],
-        tools: {
-          apply_patch: openai.tools.applyPatch(),
-        },
-        providerOptions: {
-          openai: {
-            previousResponseId: providerMetadata1?.openai.responseId as string,
-          } satisfies OpenAIResponsesProviderOptions,
-        },
-      });
-
-      // Stream the text response
-      process.stdout.write('=== Model Response (Streaming) ===\n');
-      for await (const textPart of result2.textStream) {
-        process.stdout.write(textPart);
-      }
-      process.stdout.write('\n\n');
-
-      // Get tool calls (automatically consumes the stream)
-      const toolCalls2 = await result2.toolCalls;
-
-      // Apply new patch operations
-      const patchResults2: Array<{
-        toolCallId: string;
-        result: { status: 'completed' | 'failed'; output?: string };
-      }> = [];
-
-      for (const toolCall of toolCalls2) {
-        if (toolCall.toolName === 'apply_patch') {
-          const input = toolCall.input as {
-            callId: string;
-            operation: ApplyPatchOperation;
-          };
-
-          let result: { status: 'completed' | 'failed'; output?: string };
-          switch (input.operation.type) {
-            case 'create_file':
-              result = await editor.createFile(input.operation);
-              break;
-            case 'update_file':
-              result = await editor.updateFile(input.operation);
-              break;
-            case 'delete_file':
-              result = await editor.deleteFile(input.operation);
-              break;
-          }
-
-          patchResults2.push({
-            toolCallId: toolCall.toolCallId,
-            result,
-          });
-
-          console.log(
-            `Applied ${input.operation.type} to ${input.operation.path}: ${result.status}`,
-          );
-        }
-      }
-
-      console.log(`\n=== Final ${createdFilePath} content ===\n`);
-      const finalContent = await fs.readFile(
-        path.join(workspaceRoot, createdFilePath),
-        'utf8',
-      );
-      console.log(finalContent);
-    }
-  } catch (error) {
-    console.error('Error:', error);
   }
-  console.log(`\nFiles saved in: ${workspaceRoot}`);
+  process.stdout.write('\n\n');
+
+  console.log('Files saved in:', workspaceRoot);
+
+  // List created files
+  const files = await fs.readdir(workspaceRoot);
+  for (const file of files) {
+    const filePath = path.join(workspaceRoot, file);
+    const content = await fs.readFile(filePath, 'utf8');
+    console.log(`\n=== ${file} ===`);
+    console.log(content);
+  }
 });

--- a/examples/next-openai/agent/openai-apply-patch-agent.ts
+++ b/examples/next-openai/agent/openai-apply-patch-agent.ts
@@ -1,13 +1,10 @@
 import { openai, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
-import { ToolLoopAgent, InferAgentUIMessage, tool } from 'ai';
+import { ToolLoopAgent, InferAgentUIMessage } from 'ai';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import {
-  WorkspaceEditor,
-  ApplyPatchOperation,
-} from '@/lib/apply-patch-file-editor';
+import { createApplyPatchExecutor } from '@/lib/apply-patch-file-editor';
 
-// Create a workspace editor instance for the agent
+// Create workspace directory
 const workspaceRoot = path.join(process.cwd(), 'workspace');
 
 // Ensure workspace directory exists
@@ -19,30 +16,11 @@ async function ensureWorkspaceExists() {
 
 ensureWorkspaceExists();
 
-const editor = new WorkspaceEditor(workspaceRoot);
-
-const baseApplyPatchTool = openai.tools.applyPatch();
-
 export const openaiApplyPatchAgent = new ToolLoopAgent({
   model: openai.responses('gpt-5.1'),
   tools: {
-    apply_patch: tool({
-      ...baseApplyPatchTool,
-      async execute(input: { callId: string; operation: ApplyPatchOperation }) {
-        let result: { status: 'completed' | 'failed'; output?: string };
-        switch (input.operation.type) {
-          case 'create_file':
-            result = await editor.createFile(input.operation);
-            break;
-          case 'update_file':
-            result = await editor.updateFile(input.operation);
-            break;
-          case 'delete_file':
-            result = await editor.deleteFile(input.operation);
-            break;
-        }
-        return result;
-      },
+    apply_patch: openai.tools.applyPatch({
+      execute: createApplyPatchExecutor(workspaceRoot),
     }),
   },
   providerOptions: {

--- a/examples/next-openai/lib/apply-patch-file-editor.ts
+++ b/examples/next-openai/lib/apply-patch-file-editor.ts
@@ -18,6 +18,29 @@ export type ApplyPatchOperation =
       diff: string;
     };
 
+export function createApplyPatchExecutor(workspaceRoot: string) {
+  const editor = new WorkspaceEditor(workspaceRoot);
+
+  return async ({
+    callId,
+    operation,
+  }: {
+    callId: string;
+    operation: ApplyPatchOperation;
+  }): Promise<{ status: 'completed' | 'failed'; output?: string }> => {
+    console.log(`[${callId}] Applying ${operation.type} to ${operation.path}`);
+
+    switch (operation.type) {
+      case 'create_file':
+        return editor.createFile(operation);
+      case 'update_file':
+        return editor.updateFile(operation);
+      case 'delete_file':
+        return editor.deleteFile(operation);
+    }
+  };
+}
+
 export class WorkspaceEditor {
   constructor(private readonly root: string) {}
 

--- a/packages/openai/src/tool/apply-patch.ts
+++ b/packages/openai/src/tool/apply-patch.ts
@@ -133,11 +133,9 @@ export const applyPatchToolFactory = createProviderToolFactoryWithOutputSchema<
 });
 
 /**
- * Creates an apply_patch tool instance.
- *
  * The apply_patch tool lets GPT-5.1 create, update, and delete files in your
- * codebase using structured diffs.
- *
- * @returns A provider-defined tool for applying patches.
+ * codebase using structured diffs. Instead of just suggesting edits, the model
+ * emits patch operations that your application applies and then reports back on,
+ * enabling iterative, multi-step code editing workflows.
  */
-export const applyPatch = () => applyPatchToolFactory({});
+export const applyPatch = applyPatchToolFactory;


### PR DESCRIPTION
## Background

the dx of using apply-patch tool wasn't convenient.

users would have to manually pass in a `tool-result` object but a simpler way to do this would be using the `execute` function while defining tools



## Summary

expose `execute` callback in the tool since this tool isn't provider executed

## Manual Verification

tested the change in example `http://localhost:3000/chat-openai-apply-patch`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)

**NOTE: this is a breaking change for the tool so please update to the latest beta to continue using it**