### PR TITLE
fix(ai): skip validation for provider-executed dynamic tools in v5

### DIFF
--- a/packages/ai/src/generate-text/parse-tool-call.ts
+++ b/packages/ai/src/generate-text/parse-tool-call.ts
@@ -8,7 +8,7 @@ import {
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { NoSuchToolError } from '../error/no-such-tool-error';
 import { ToolCallRepairError } from '../error/tool-call-repair-error';
-import { TypedToolCall } from './tool-call';
+import { DynamicToolCall, TypedToolCall } from './tool-call';
 import { ToolCallRepairFunction } from './tool-call-repair-function';
 import { ToolSet } from './tool-set';
 
@@ -27,6 +27,11 @@ export async function parseToolCall<TOOLS extends ToolSet>({
 }): Promise<TypedToolCall<TOOLS>> {
   try {
     if (tools == null) {
+      // provider-executed dynamic tools are not part of our list of tools:
+      if (toolCall.providerExecuted && toolCall.dynamic) {
+        return await parseProviderExecutedDynamicToolCall(toolCall);
+      }
+
       throw new NoSuchToolError({ toolName: toolCall.toolName });
     }
 
@@ -90,6 +95,33 @@ export async function parseToolCall<TOOLS extends ToolSet>({
   }
 }
 
+async function parseProviderExecutedDynamicToolCall(
+  toolCall: LanguageModelV2ToolCall,
+): Promise<DynamicToolCall> {
+  const parseResult =
+    toolCall.input.trim() === ''
+      ? { success: true as const, value: {} }
+      : await safeParseJSON({ text: toolCall.input });
+
+  if (parseResult.success === false) {
+    throw new InvalidToolInputError({
+      toolName: toolCall.toolName,
+      toolInput: toolCall.input,
+      cause: parseResult.error,
+    });
+  }
+
+  return {
+    type: 'tool-call',
+    toolCallId: toolCall.toolCallId,
+    toolName: toolCall.toolName,
+    input: parseResult.value,
+    providerExecuted: true,
+    dynamic: true,
+    providerMetadata: toolCall.providerMetadata,
+  };
+}
+
 async function doParseToolCall<TOOLS extends ToolSet>({
   toolCall,
   tools,
@@ -102,6 +134,11 @@ async function doParseToolCall<TOOLS extends ToolSet>({
   const tool = tools[toolName];
 
   if (tool == null) {
+    // provider-executed dynamic tools are not part of our list of tools:
+    if (toolCall.providerExecuted && toolCall.dynamic) {
+      return await parseProviderExecutedDynamicToolCall(toolCall);
+    }
+
     throw new NoSuchToolError({
       toolName: toolCall.toolName,
       availableTools: Object.keys(tools),


### PR DESCRIPTION
## Description

Backport of #10734 to the v5.0 release branch.

## Problem

Provider-executed dynamic tools (like Claude Code's built-in Bash tool) are being incorrectly validated in `parseToolCall`, causing them to be marked as `invalid: true` even though they execute successfully on the provider side.

This results in error messages being sent back to the model:
```
Model tried to call unavailable tool 'Bash'. No tools are available.
```

The model then gets confused and apologizes for tools it just successfully used.

## Root Cause

The `parseToolCall` function validates ALL tool calls against the user's tools map, without checking if the tool has `providerExecuted: true`. Provider-executed tools aren't in the user's tools map because they're managed by the provider, not the application.

## Solution

Add checks for `toolCall.providerExecuted && toolCall.dynamic` before attempting validation in two places:
1. When `tools == null` (line 31-33)
2. When tool is not found in tools map (line 111-113)

If both flags are true, call `parseProviderExecutedDynamicToolCall` to handle the tool call without validation.

## Testing

Tested with ai-sdk-provider-claude-code v2.2.3. Before fix:
- Tool calls marked as `invalid: true`
- Error messages sent to model
- Model apologizes for successfully used tools

After fix:
- Tool calls properly recognized with `providerExecuted: true`
- No validation errors
- Model responds normally

## Related Issues

- Fixes #10888
- Backport of #10734

## Checklist

- [x] Added logic to skip validation for provider-executed dynamic tools
- [x] Added `parseProviderExecutedDynamicToolCall` helper function
- [x] Imported `DynamicToolCall` type
- [x] Tested with real-world provider (ai-sdk-provider-claude-code)
- [x] No breaking changes to existing behavior