### PR TITLE
fix(ai): remove unused mode setting from generateObject and streamObject

### DIFF
--- a/.changeset/thin-jobs-train.md
+++ b/.changeset/thin-jobs-train.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): remove unused mode setting from generateObject and streamObject

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -106,14 +106,6 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
       description: "The type of output to generate. Defaults to 'object'.",
     },
     {
-      name: 'mode',
-      type: "'auto' | 'json' | 'tool'",
-      description:
-        "The mode to use for object generation. Not every model supports all modes. \
-        Defaults to 'auto' for 'object' output and to 'json' for 'no-schema' output. \
-        Must be 'json' for 'no-schema' output.",
-    },
-    {
       name: 'schema',
       type: 'Zod Schema | JSON Schema',
       description:

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -119,14 +119,6 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
       description: "The type of output to generate. Defaults to 'object'.",
     },
     {
-      name: 'mode',
-      type: "'auto' | 'json' | 'tool'",
-      description:
-        "The mode to use for object generation. Not every model supports all modes. \
-        Defaults to 'auto' for 'object' output and to 'json' for 'no-schema' output. \
-        Must be 'json' for 'no-schema' output.",
-    },
-    {
       name: 'schema',
       type: 'Zod Schema | JSON Schema',
       description:

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -130,7 +130,6 @@ export async function generateObject<
 The enum values that the model should use.
         */
           enum: Array<RESULT>;
-          mode?: 'json';
           output: 'enum';
         }
       : OUTPUT extends 'no-schema'

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -154,21 +154,6 @@ Used by some providers for additional LLM guidance, e.g.
 via tool or schema description.
         */
             schemaDescription?: string;
-
-            /**
-The mode to use for object generation.
-
-The schema is converted into a JSON schema and used in one of the following ways
-
-- 'auto': The provider will choose the best mode for the model.
-- 'tool': A tool with the JSON schema as parameters is provided and the provider is instructed to use it.
-- 'json': The JSON schema and an instruction are injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
-
-Please note that most providers do not support all modes.
-
-Default and recommended: 'auto' (best mode for the model).
-        */
-            mode?: 'auto' | 'json' | 'tool';
           }) & {
       output?: OUTPUT;
 

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -211,21 +211,6 @@ Used by some providers for additional LLM guidance, e.g.
 via tool or schema description.
       */
             schemaDescription?: string;
-
-            /**
-The mode to use for object generation.
-
-The schema is converted into a JSON schema and used in one of the following ways
-
-- 'auto': The provider will choose the best mode for the model.
-- 'tool': A tool with the JSON schema as parameters is provided and the provider is instructed to use it.
-- 'json': The JSON schema and an instruction are injected into the prompt. If the provider supports JSON mode, it is enabled. If the provider supports JSON grammars, the grammar is used.
-
-Please note that most providers do not support all modes.
-
-Default and recommended: 'auto' (best mode for the model).
-      */
-            mode?: 'auto' | 'json' | 'tool';
           }) & {
       output?: OUTPUT;
 

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -187,7 +187,6 @@ export function streamObject<
 The enum values that the model should use.
         */
           enum: Array<RESULT>;
-          mode?: 'json';
           output: 'enum';
         }
       : OUTPUT extends 'no-schema'


### PR DESCRIPTION
## Background

The `mode` setting was removed in AI SDK 5.

## Summary

Remove remaining `mode` setting artifacts.

## Related Issues

Fixes #10894