### PR TITLE
chore(ai): export ContentPart type

### DIFF
--- a/.changeset/nine-frogs-exist.md
+++ b/.changeset/nine-frogs-exist.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+chore(ai): export ContentPart type

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -3,6 +3,7 @@ export {
   type GenerateTextOnFinishCallback,
   type GenerateTextOnStepFinishCallback,
 } from './generate-text';
+export type { ContentPart } from './content-part';
 export type { GenerateTextResult } from './generate-text-result';
 export type {
   GeneratedFile as Experimental_GeneratedImage, // Image for backwards compatibility, TODO remove in v5


### PR DESCRIPTION
## Background

`onStepFinish` allows retrieval of `content` which is typed as `ContentPart<ToolSet>[]`, and it was not possible to import the `ContentPart` type from `ai`

## Summary

export `ContentPart`

## Manual Verification

N/A

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

N/A

## Related Issues

N/A