### PR TITLE
fix(ai-sdk/react): Fix subscribeToMessages callback dependency in useChat

### DIFF
--- a/.changeset/big-buses-complain.md
+++ b/.changeset/big-buses-complain.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+Fix subscribeToMessages callback dependency in useChat

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -72,14 +72,12 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     chatRef.current = 'chat' in options ? options.chat : new Chat(options);
   }
 
-  const optionsId = 'id' in options ? options.id : null;
-
   const subscribeToMessages = useCallback(
     (update: () => void) =>
       chatRef.current['~registerMessagesCallback'](update, throttleWaitMs),
-    // optionsId is required to trigger re-subscription when the chat ID changes
+    // `chatRef.current.id` is required to trigger re-subscription when the chat ID changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [throttleWaitMs, optionsId],
+    [throttleWaitMs, chatRef.current.id],
   );
 
   const messages = useSyncExternalStore(


### PR DESCRIPTION
## Background

Follow-up to:
- #7387

That PR fixed stale subscriptions when the chat ID changes. However, it was incomplete since it only handled the case where the new ID was passed in the options. It's also possible for you to pass in a `chat` instance directly which could have a new ID.

## Summary

Tweak the logic there to use the `chatRef.current.id` in the dependency array, so no matter how the ID changes we'll refresh the subscription callbacks.

## Manual Verification

Didn't do manually testing since the unit tests for this specific case (plus the one I added) seemed sufficient.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
