### PR TITLE
feat(codemod): add remaining codemods for v5 -> v6 migration

### DIFF
--- a/.changeset/eleven-hairs-march.md
+++ b/.changeset/eleven-hairs-march.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/codemod': patch
+---
+
+feat(codemod): add remaining codemods for v5 -> v6 migration

--- a/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
@@ -53,11 +53,13 @@ every file.
 
 ## Codemod Table
 
-| Codemod Name                                         | Description                                                                                        |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `rename-text-embedding-to-embedding`                 | Renames `textEmbeddingModel` to `embeddingModel` and `textEmbedding` to `embedding` on providers   |
-| `rename-mock-v2-to-v3`                               | Renames V2 mock classes from `ai/test` to V3 (e.g., `MockLanguageModelV2` → `MockLanguageModelV3`) |
-| `rename-tool-call-options-to-tool-execution-options` | Renames the `ToolCallOptions` type to `ToolExecutionOptions`                                       |
+| Codemod Name                                             | Description                                                                                        |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `rename-text-embedding-to-embedding`                     | Renames `textEmbeddingModel` to `embeddingModel` and `textEmbedding` to `embedding` on providers   |
+| `rename-mock-v2-to-v3`                                   | Renames V2 mock classes from `ai/test` to V3 (e.g., `MockLanguageModelV2` → `MockLanguageModelV3`) |
+| `rename-tool-call-options-to-tool-execution-options`     | Renames the `ToolCallOptions` type to `ToolExecutionOptions`                                       |
+| `rename-core-message-to-model-message`                   | Renames the `CoreMessage` type to `ModelMessage`                                                   |
+| `rename-converttocoremessages-to-converttomodelmessages` | Renames `convertToCoreMessages` function to `convertToModelMessages`                               |
 
 ## AI SDK Core
 

--- a/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
@@ -53,10 +53,11 @@ every file.
 
 ## Codemod Table
 
-| Codemod Name                         | Description                                                                                        |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| `rename-text-embedding-to-embedding` | Renames `textEmbeddingModel` to `embeddingModel` and `textEmbedding` to `embedding` on providers   |
-| `rename-mock-v2-to-v3`               | Renames V2 mock classes from `ai/test` to V3 (e.g., `MockLanguageModelV2` → `MockLanguageModelV3`) |
+| Codemod Name                                         | Description                                                                                        |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `rename-text-embedding-to-embedding`                 | Renames `textEmbeddingModel` to `embeddingModel` and `textEmbedding` to `embedding` on providers   |
+| `rename-mock-v2-to-v3`                               | Renames V2 mock classes from `ai/test` to V3 (e.g., `MockLanguageModelV2` → `MockLanguageModelV3`) |
+| `rename-tool-call-options-to-tool-execution-options` | Renames the `ToolCallOptions` type to `ToolExecutionOptions`                                       |
 
 ## AI SDK Core
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -139,11 +139,13 @@ npx @ai-sdk/codemod v5/rename-format-stream-part .
 
 ### General Codemods
 
-| Codemod                                                 | Description                                                      |
-| ------------------------------------------------------- | ---------------------------------------------------------------- |
-| `v6/rename-mock-v2-to-v3`                               | Transforms v6/rename mock v2 to v3                               |
-| `v6/rename-text-embedding-to-embedding`                 | Transforms v6/rename text embedding to embedding                 |
-| `v6/rename-tool-call-options-to-tool-execution-options` | Transforms v6/rename tool call options to tool execution options |
+| Codemod                                                     | Description                                                          |
+| ----------------------------------------------------------- | -------------------------------------------------------------------- |
+| `v6/rename-converttocoremessages-to-converttomodelmessages` | Transforms v6/rename converttocoremessages to converttomodelmessages |
+| `v6/rename-core-message-to-model-message`                   | Transforms v6/rename core message to model message                   |
+| `v6/rename-mock-v2-to-v3`                                   | Transforms v6/rename mock v2 to v3                                   |
+| `v6/rename-text-embedding-to-embedding`                     | Transforms v6/rename text embedding to embedding                     |
+| `v6/rename-tool-call-options-to-tool-execution-options`     | Transforms v6/rename tool call options to tool execution options     |
 
 ## CLI Options
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -139,10 +139,11 @@ npx @ai-sdk/codemod v5/rename-format-stream-part .
 
 ### General Codemods
 
-| Codemod                                 | Description                                      |
-| --------------------------------------- | ------------------------------------------------ |
-| `v6/rename-mock-v2-to-v3`               | Transforms v6/rename mock v2 to v3               |
-| `v6/rename-text-embedding-to-embedding` | Transforms v6/rename text embedding to embedding |
+| Codemod                                                 | Description                                                      |
+| ------------------------------------------------------- | ---------------------------------------------------------------- |
+| `v6/rename-mock-v2-to-v3`                               | Transforms v6/rename mock v2 to v3                               |
+| `v6/rename-text-embedding-to-embedding`                 | Transforms v6/rename text embedding to embedding                 |
+| `v6/rename-tool-call-options-to-tool-execution-options` | Transforms v6/rename tool call options to tool execution options |
 
 ## CLI Options
 

--- a/packages/codemod/src/codemods/v6/rename-converttocoremessages-to-converttomodelmessages.ts
+++ b/packages/codemod/src/codemods/v6/rename-converttocoremessages-to-converttomodelmessages.ts
@@ -1,0 +1,60 @@
+import { createTransformer } from '../lib/create-transformer';
+
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  // Replace import specifiers from 'ai' package
+  root
+    .find(j.ImportDeclaration)
+    .filter(path => {
+      return (
+        path.node.source.type === 'StringLiteral' &&
+        path.node.source.value === 'ai'
+      );
+    })
+    .forEach(path => {
+      path.node.specifiers?.forEach(specifier => {
+        if (
+          specifier.type === 'ImportSpecifier' &&
+          specifier.imported.type === 'Identifier' &&
+          specifier.imported.name === 'convertToCoreMessages'
+        ) {
+          specifier.imported.name = 'convertToModelMessages';
+          // Also update the local name if it matches the original imported name
+          if (
+            specifier.local &&
+            specifier.local.type === 'Identifier' &&
+            specifier.local.name === 'convertToCoreMessages'
+          ) {
+            specifier.local.name = 'convertToModelMessages';
+          }
+          context.hasChanges = true;
+        }
+      });
+    });
+
+  // Replace function calls and identifiers
+  root
+    .find(j.Identifier)
+    .filter(path => {
+      // Only replace identifiers that are not part of import declarations
+      // (those are handled above) and are not property keys
+      const parent = path.parent;
+      return (
+        path.node.name === 'convertToCoreMessages' &&
+        parent.node.type !== 'ImportSpecifier' &&
+        !(
+          parent.node.type === 'MemberExpression' &&
+          parent.node.property === path.node
+        ) &&
+        !(parent.node.type === 'Property' && parent.node.key === path.node) &&
+        !(
+          parent.node.type === 'ObjectProperty' && parent.node.key === path.node
+        )
+      );
+    })
+    .forEach(path => {
+      path.node.name = 'convertToModelMessages';
+      context.hasChanges = true;
+    });
+});

--- a/packages/codemod/src/codemods/v6/rename-core-message-to-model-message.ts
+++ b/packages/codemod/src/codemods/v6/rename-core-message-to-model-message.ts
@@ -1,0 +1,76 @@
+import { createTransformer } from '../lib/create-transformer';
+
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  // Replace import specifiers from 'ai' package
+  root
+    .find(j.ImportDeclaration)
+    .filter(path => {
+      return (
+        path.node.source.type === 'StringLiteral' &&
+        path.node.source.value === 'ai'
+      );
+    })
+    .forEach(path => {
+      path.node.specifiers?.forEach(specifier => {
+        if (
+          specifier.type === 'ImportSpecifier' &&
+          specifier.imported.type === 'Identifier' &&
+          specifier.imported.name === 'CoreMessage'
+        ) {
+          specifier.imported.name = 'ModelMessage';
+          // Also update the local name if it matches the original imported name
+          if (
+            specifier.local &&
+            specifier.local.type === 'Identifier' &&
+            specifier.local.name === 'CoreMessage'
+          ) {
+            specifier.local.name = 'ModelMessage';
+          }
+          context.hasChanges = true;
+        }
+      });
+    });
+
+  // Replace type references and identifiers
+  root
+    .find(j.Identifier)
+    .filter(path => {
+      // Only replace identifiers that are not part of import declarations
+      // (those are handled above) and are not property keys
+      const parent = path.parent;
+      return (
+        path.node.name === 'CoreMessage' &&
+        parent.node.type !== 'ImportSpecifier' &&
+        !(
+          parent.node.type === 'MemberExpression' &&
+          parent.node.property === path.node
+        ) &&
+        !(parent.node.type === 'Property' && parent.node.key === path.node) &&
+        !(
+          parent.node.type === 'ObjectProperty' && parent.node.key === path.node
+        )
+      );
+    })
+    .forEach(path => {
+      path.node.name = 'ModelMessage';
+      context.hasChanges = true;
+    });
+
+  // Replace TypeScript type annotations
+  root
+    .find(j.TSTypeReference)
+    .filter(path => {
+      return (
+        path.node.typeName.type === 'Identifier' &&
+        path.node.typeName.name === 'CoreMessage'
+      );
+    })
+    .forEach(path => {
+      if (path.node.typeName.type === 'Identifier') {
+        path.node.typeName.name = 'ModelMessage';
+        context.hasChanges = true;
+      }
+    });
+});

--- a/packages/codemod/src/codemods/v6/rename-tool-call-options-to-tool-execution-options.ts
+++ b/packages/codemod/src/codemods/v6/rename-tool-call-options-to-tool-execution-options.ts
@@ -1,0 +1,74 @@
+import { createTransformer } from '../lib/create-transformer';
+
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  // Replace import specifiers from 'ai' package
+  root
+    .find(j.ImportDeclaration)
+    .filter(path => {
+      return (
+        path.node.source.type === 'StringLiteral' &&
+        path.node.source.value === 'ai'
+      );
+    })
+    .forEach(path => {
+      path.node.specifiers?.forEach(specifier => {
+        if (
+          specifier.type === 'ImportSpecifier' &&
+          specifier.imported.type === 'Identifier' &&
+          specifier.imported.name === 'ToolCallOptions'
+        ) {
+          specifier.imported.name = 'ToolExecutionOptions';
+          // Also update the local name if it matches the original imported name
+          if (
+            specifier.local &&
+            specifier.local.type === 'Identifier' &&
+            specifier.local.name === 'ToolCallOptions'
+          ) {
+            specifier.local.name = 'ToolExecutionOptions';
+          }
+          context.hasChanges = true;
+        }
+      });
+    });
+
+  // Replace identifiers (variable names, function arguments, etc.)
+  root
+    .find(j.Identifier)
+    .filter(path => {
+      const parent = path.parent;
+      return (
+        path.node.name === 'ToolCallOptions' &&
+        parent.node.type !== 'ImportSpecifier' &&
+        !(
+          parent.node.type === 'MemberExpression' &&
+          parent.node.property === path.node
+        ) &&
+        !(parent.node.type === 'Property' && parent.node.key === path.node) &&
+        !(
+          parent.node.type === 'ObjectProperty' && parent.node.key === path.node
+        )
+      );
+    })
+    .forEach(path => {
+      path.node.name = 'ToolExecutionOptions';
+      context.hasChanges = true;
+    });
+
+  // Replace TypeScript type references
+  root
+    .find(j.TSTypeReference)
+    .filter(path => {
+      return (
+        path.node.typeName.type === 'Identifier' &&
+        path.node.typeName.name === 'ToolCallOptions'
+      );
+    })
+    .forEach(path => {
+      if (path.node.typeName.type === 'Identifier') {
+        path.node.typeName.name = 'ToolExecutionOptions';
+        context.hasChanges = true;
+      }
+    });
+});

--- a/packages/codemod/src/lib/upgrade.ts
+++ b/packages/codemod/src/lib/upgrade.ts
@@ -82,6 +82,7 @@ const bundle = [
   'v5/rename-addtoolresult-to-addtooloutput',
   'v6/rename-text-embedding-to-embedding',
   'v6/rename-mock-v2-to-v3',
+  'v6/rename-tool-call-options-to-tool-execution-options',
 ];
 
 const log = debug('codemod:upgrade');

--- a/packages/codemod/src/lib/upgrade.ts
+++ b/packages/codemod/src/lib/upgrade.ts
@@ -83,6 +83,8 @@ const bundle = [
   'v6/rename-text-embedding-to-embedding',
   'v6/rename-mock-v2-to-v3',
   'v6/rename-tool-call-options-to-tool-execution-options',
+  'v6/rename-core-message-to-model-message',
+  'v6/rename-converttocoremessages-to-converttomodelmessages',
 ];
 
 const log = debug('codemod:upgrade');

--- a/packages/codemod/src/test/__testfixtures__/rename-core-message-to-model-message.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/rename-core-message-to-model-message.input.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import { CoreMessage, streamText } from 'ai';
+
+// Type annotation in variable declaration
+const messages: CoreMessage[] = [];
+
+// Type annotation in function parameter
+function processMessages(msgs: CoreMessage[]) {
+  return msgs;
+}
+
+// Function return type
+function getMessages(): CoreMessage[] {
+  return [];
+}
+
+// In interface
+interface ChatState {
+  messages: CoreMessage[];
+  history: CoreMessage[];
+}
+
+// In type alias
+type MessageStore = {
+  items: CoreMessage[];
+};
+
+// Generic constraint
+function filterMessages<T extends CoreMessage>(msgs: T[]): T[] {
+  return msgs;
+}
+
+// Type assertion
+const msg = {} as CoreMessage;
+

--- a/packages/codemod/src/test/__testfixtures__/rename-core-message-to-model-message.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/rename-core-message-to-model-message.output.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import { ModelMessage, streamText } from 'ai';
+
+// Type annotation in variable declaration
+const messages: ModelMessage[] = [];
+
+// Type annotation in function parameter
+function processMessages(msgs: ModelMessage[]) {
+  return msgs;
+}
+
+// Function return type
+function getMessages(): ModelMessage[] {
+  return [];
+}
+
+// In interface
+interface ChatState {
+  messages: ModelMessage[];
+  history: ModelMessage[];
+}
+
+// In type alias
+type MessageStore = {
+  items: ModelMessage[];
+};
+
+// Generic constraint
+function filterMessages<T extends ModelMessage>(msgs: T[]): T[] {
+  return msgs;
+}
+
+// Type assertion
+const msg = {} as ModelMessage;
+

--- a/packages/codemod/src/test/__testfixtures__/rename-tool-call-options-to-tool-execution-options.input.ts
+++ b/packages/codemod/src/test/__testfixtures__/rename-tool-call-options-to-tool-execution-options.input.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+import { ToolCallOptions } from 'ai';
+
+// Type annotation in function parameter
+function executeWithOptions(options: ToolCallOptions) {
+  return options;
+}
+
+// Type annotation in variable declaration
+const myOptions: ToolCallOptions = {
+  toolCallId: '123',
+  messages: [],
+};
+
+// Using as type parameter
+const optionsList: ToolCallOptions[] = [];
+
+// Function return type
+function getOptions(): ToolCallOptions {
+  return {} as ToolCallOptions;
+}
+
+// In interface
+interface MyToolConfig {
+  options: ToolCallOptions;
+}
+
+// In type alias
+type ToolOptionsWrapper = {
+  inner: ToolCallOptions;
+};
+
+// Generic constraint
+function processOptions<T extends ToolCallOptions>(opts: T): T {
+  return opts;
+}
+

--- a/packages/codemod/src/test/__testfixtures__/rename-tool-call-options-to-tool-execution-options.output.ts
+++ b/packages/codemod/src/test/__testfixtures__/rename-tool-call-options-to-tool-execution-options.output.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+import { ToolExecutionOptions } from 'ai';
+
+// Type annotation in function parameter
+function executeWithOptions(options: ToolExecutionOptions) {
+  return options;
+}
+
+// Type annotation in variable declaration
+const myOptions: ToolExecutionOptions = {
+  toolCallId: '123',
+  messages: [],
+};
+
+// Using as type parameter
+const optionsList: ToolExecutionOptions[] = [];
+
+// Function return type
+function getOptions(): ToolExecutionOptions {
+  return {} as ToolExecutionOptions;
+}
+
+// In interface
+interface MyToolConfig {
+  options: ToolExecutionOptions;
+}
+
+// In type alias
+type ToolOptionsWrapper = {
+  inner: ToolExecutionOptions;
+};
+
+// Generic constraint
+function processOptions<T extends ToolExecutionOptions>(opts: T): T {
+  return opts;
+}
+

--- a/packages/codemod/src/test/rename-converttocoremessages-to-converttomodelmessages-v6.test.ts
+++ b/packages/codemod/src/test/rename-converttocoremessages-to-converttomodelmessages-v6.test.ts
@@ -1,0 +1,12 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v6/rename-converttocoremessages-to-converttomodelmessages';
+import { testTransform } from './test-utils';
+
+describe('rename-converttocoremessages-to-converttomodelmessages (v6)', () => {
+  it('transforms correctly', () => {
+    testTransform(
+      transformer,
+      'rename-converttocoremessages-to-converttomodelmessages',
+    );
+  });
+});

--- a/packages/codemod/src/test/rename-core-message-to-model-message.test.ts
+++ b/packages/codemod/src/test/rename-core-message-to-model-message.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v6/rename-core-message-to-model-message';
+import { testTransform } from './test-utils';
+
+describe('rename-core-message-to-model-message', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'rename-core-message-to-model-message');
+  });
+});

--- a/packages/codemod/src/test/rename-tool-call-options-to-tool-execution-options.test.ts
+++ b/packages/codemod/src/test/rename-tool-call-options-to-tool-execution-options.test.ts
@@ -1,0 +1,12 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v6/rename-tool-call-options-to-tool-execution-options';
+import { testTransform } from './test-utils';
+
+describe('rename-tool-call-options-to-tool-execution-options', () => {
+  it('transforms correctly', () => {
+    testTransform(
+      transformer,
+      'rename-tool-call-options-to-tool-execution-options',
+    );
+  });
+});


### PR DESCRIPTION
## Background

As per the [migration guide](https://github.com/vercel/ai/blob/main/content/docs/08-migration-guides/24-migration-guide-6-0.mdx), all breaking changes need respective codemods to allow seamless migration to v6 of the AI SDK.

## Summary

- Codemod, tests and test fixtures added for renaming `CoreMessage` type to `ModelMessage`
- Codemod, tests and test fixtures added for renaming `convertToCoreMessages` function to `convertToModelMessages`

## Manual Verification

Unit tests added

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)

## Future Work

If more breaking changes remain