### PR TITLE
fix(mcp): pass json header for refreshAuth

### DIFF
--- a/.changeset/chilly-carrots-act.md
+++ b/.changeset/chilly-carrots-act.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): pass json header for refreshAuth

--- a/examples/mcp/src/repro-test.ts
+++ b/examples/mcp/src/repro-test.ts
@@ -1,0 +1,58 @@
+import 'dotenv/config';
+
+const GITHUB_TOKEN_ENDPOINT = 'https://github.com/login/oauth/access_token';
+
+async function testRefreshAuthorization() {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  const refreshToken = process.env.GITHUB_REFRESH_TOKEN;
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    throw new Error(
+      'Missing GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, or GITHUB_REFRESH_TOKEN',
+    );
+  }
+
+  const headers = new Headers({
+    'Content-Type': 'application/x-www-form-urlencoded',
+    // Accept: 'application/json',
+    // UNCOMMENT ABOVE TO FIX
+  });
+
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+
+  const response = await fetch(GITHUB_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers,
+    body: params,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Token refresh failed: ${response.status} ${errorText}`);
+  }
+
+  const tokens = await response.json();
+
+  if (!tokens.access_token || !tokens.token_type) {
+    throw new Error('Invalid token response: missing required fields');
+  }
+
+  return tokens;
+}
+
+testRefreshAuthorization()
+  .then(() => {
+    console.log('====== Test passed ======');
+    process.exit(0);
+  })
+  .catch(error => {
+    console.log('====== Test failed ======');
+    console.error(error.message);
+    process.exit(1);
+  });

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -1144,6 +1144,7 @@ describe('refreshAuthorization', () => {
         method: 'POST',
         headers: new Headers({
           'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
         }),
       }),
     );

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -739,6 +739,7 @@ export async function refreshAuthorization(
 
   const headers = new Headers({
     'Content-Type': 'application/x-www-form-urlencoded',
+    Accept: 'application/json',
   });
   const params = new URLSearchParams({
     grant_type: grantType,


### PR DESCRIPTION
## Background

#10899 

We didn't pass the application/json header while making the request when refreshing auth tokens, which broke the flow (we do it while exchanging auth tokens)

## Summary

Pass the json header

## Manual Verification

- repro code file was created to simulate the flow of that function and the errors caused by it
- verified by first failing the test; the patch then fixed it

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)

## Related Issues

Fixes #10899