### PR TITLE
docs(sap-ai): update documentation for v2.0 breaking changes

### DIFF
--- a/content/providers/03-community-providers/20-sap-ai.mdx
+++ b/content/providers/03-community-providers/20-sap-ai.mdx
@@ -7,12 +7,14 @@ description: SAP AI Core Provider for the AI SDK
 
 ## Important Note
 
-> **Third-Party Provider**: This SAP AI Core provider (`@mymediset/sap-ai-provider`) is developed and maintained by Mymediset, not by SAP SE. While it integrates with official SAP AI Core services, it is not an official SAP product. For official SAP AI solutions, please refer to the [SAP AI Core Documentation](https://help.sap.com/docs/ai-core).
+> **Third-Party Provider**: This SAP AI Core provider (`@mymediset/sap-ai-provider`) is developed and maintained by Mymediset, not by SAP SE. While it uses the official SAP AI SDK and integrates with SAP AI Core services, it is not an official SAP product. For official SAP AI solutions, please refer to the [SAP AI Core Documentation](https://help.sap.com/docs/ai-core).
 
 [SAP AI Core](https://help.sap.com/docs/ai-core) is SAP's enterprise-grade AI platform that provides access to leading AI models from OpenAI, Anthropic, Google, Amazon, and more through a unified, secure, and scalable infrastructure. The SAP AI Core provider for the AI SDK enables seamless integration with enterprise AI capabilities while offering unique advantages:
 
 - **Multi-Model Access**: Support for 40+ models including GPT-4, Claude, Gemini, and Amazon Nova
-- **OAuth Integration**: Automatic authentication handling with SAP BTP
+- **Automatic Authentication**: Built-in credential handling via SAP AI SDK
+- **Data Masking**: Built-in SAP Data Privacy Integration (DPI) for privacy
+- **Content Filtering**: Azure Content Safety and Llama Guard support
 - **Cost Management**: Enterprise billing and usage tracking through SAP BTP
 - **High Availability**: Enterprise-grade infrastructure with SLA guarantees
 - **Hybrid Deployment**: Support for both cloud and on-premise deployments
@@ -27,48 +29,47 @@ The SAP AI Core provider is available in the `@mymediset/sap-ai-provider` module
 
 <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
   <Tab>
-    <Snippet text="pnpm add @mymediset/sap-ai-provider" dark />
+    <Snippet text="pnpm add @mymediset/sap-ai-provider ai" dark />
   </Tab>
   <Tab>
-    <Snippet text="npm install @mymediset/sap-ai-provider" dark />
+    <Snippet text="npm install @mymediset/sap-ai-provider ai" dark />
   </Tab>
   <Tab>
-    <Snippet text="yarn add @mymediset/sap-ai-provider" dark />
+    <Snippet text="yarn add @mymediset/sap-ai-provider ai" dark />
   </Tab>
   <Tab>
-    <Snippet text="bun add @mymediset/sap-ai-provider" dark />
+    <Snippet text="bun add @mymediset/sap-ai-provider ai" dark />
   </Tab>
 </Tabs>
 
 ## Provider Instance
 
-To create an SAP AI Core provider instance, use the `createSAPAIProvider` function:
+To create an SAP AI Core provider instance, use the `createSAPAIProvider` function. The provider is now **synchronous** and authentication is handled automatically via the SAP AI SDK:
 
 ```typescript
 import { createSAPAIProvider } from '@mymediset/sap-ai-provider';
 
-const sapai = await createSAPAIProvider({
-  serviceKey: 'YOUR_SAP_AI_CORE_SERVICE_KEY',
-});
+// Authentication via AICORE_SERVICE_KEY environment variable
+const sapai = createSAPAIProvider();
 ```
 
-You can obtain your SAP AI Core service key from your SAP BTP Cockpit by creating a service key for your AI Core instance.
+You can obtain your SAP AI Core service key from your SAP BTP Cockpit by creating a service key for your AI Core instance, then set it as the `AICORE_SERVICE_KEY` environment variable.
 
 ## Language Models
 
 You can create SAP AI Core models using the provider instance and model name:
 
 ```typescript
-// OpenAI models
+// Azure OpenAI models
 const gpt4Model = sapai('gpt-4o');
 
-// Anthropic models
-const claudeModel = sapai('anthropic--claude-3-sonnet');
+// Anthropic models (via AWS Bedrock)
+const claudeModel = sapai('anthropic--claude-3.5-sonnet');
 
-// Google models
-const geminiModel = sapai('gemini-1.5-pro');
+// Google Vertex AI models
+const geminiModel = sapai('gemini-2.5-flash');
 
-// Amazon models
+// Amazon Nova models (via AWS Bedrock)
 const novaModel = sapai('amazon--nova-pro');
 ```
 
@@ -76,29 +77,31 @@ const novaModel = sapai('amazon--nova-pro');
 
 The provider supports a wide range of models available in your SAP AI Core deployment:
 
-### OpenAI Models
+### Azure OpenAI Models
 
-- `gpt-4`, `gpt-4o`, `gpt-4o-mini`
-- `o1`
+- `gpt-4o`, `gpt-4o-mini`
+- `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
+- `o1`, `o3`, `o3-mini`, `o4-mini`
 
-### Anthropic Models
+### Anthropic Models (AWS Bedrock)
 
 - `anthropic--claude-3-haiku`, `anthropic--claude-3-sonnet`, `anthropic--claude-3-opus`
-- `anthropic--claude-3.5-sonnet`
+- `anthropic--claude-3.5-sonnet`, `anthropic--claude-3.7-sonnet`
+- `anthropic--claude-4-sonnet`, `anthropic--claude-4-opus`
 
-### Google Models
+### Google Vertex AI Models
 
-- `gemini-1.5-pro`, `gemini-1.5-flash`
-- `gemini-2.0-pro`, `gemini-2.0-flash`
+- `gemini-2.0-flash`, `gemini-2.0-flash-lite`
+- `gemini-2.5-flash`, `gemini-2.5-pro`
 
-### Amazon Models
+### Amazon Nova Models (AWS Bedrock)
 
 - `amazon--nova-premier`, `amazon--nova-pro`, `amazon--nova-lite`, `amazon--nova-micro`
 
-### Other Models
+### AI Core Open Source Models
 
-- `mistralai--mistral-large-instruct`
-- `meta--llama3-70b-instruct`, `meta--llama3.1-70b-instruct`
+- `mistralai--mistral-large-instruct`, `mistralai--mistral-medium-instruct`, `mistralai--mistral-small-instruct`
+- `cohere--command-a-reasoning`
 
 Note: Model availability may vary based on your SAP AI Core subscription and region. Some models may require additional configuration or permissions.
 
@@ -112,9 +115,8 @@ Here are examples of using SAP AI Core with the AI SDK:
 import { createSAPAIProvider } from '@mymediset/sap-ai-provider';
 import { generateText } from 'ai';
 
-const sapai = await createSAPAIProvider({
-  serviceKey: process.env.SAP_AI_SERVICE_KEY,
-});
+// Authentication via AICORE_SERVICE_KEY environment variable
+const sapai = createSAPAIProvider();
 
 const { text } = await generateText({
   model: sapai('gpt-4o'),
@@ -130,17 +132,15 @@ console.log(text);
 import { createSAPAIProvider } from '@mymediset/sap-ai-provider';
 import { streamText } from 'ai';
 
-const sapai = await createSAPAIProvider({
-  serviceKey: process.env.SAP_AI_SERVICE_KEY,
-});
+const sapai = createSAPAIProvider();
 
-const result = streamText({
-  model: sapai('anthropic--claude-3-sonnet'),
+const result = await streamText({
+  model: sapai('anthropic--claude-3.5-sonnet'),
   prompt: 'Write a short story about AI.',
 });
 
 for await (const textPart of result.textStream) {
-  console.log(textPart);
+  process.stdout.write(textPart);
 }
 ```
 
@@ -151,9 +151,7 @@ import { createSAPAIProvider } from '@mymediset/sap-ai-provider';
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 
-const sapai = await createSAPAIProvider({
-  serviceKey: process.env.SAP_AI_SERVICE_KEY,
-});
+const sapai = createSAPAIProvider();
 
 const result = await generateText({
   model: sapai('gpt-4o'),
@@ -161,7 +159,7 @@ const result = await generateText({
   tools: {
     checkInventory: tool({
       description: 'Check current inventory levels',
-      inputSchema: z.object({
+      parameters: z.object({
         item: z.string().describe('Item to check'),
         location: z.string().describe('Warehouse location'),
       }),
@@ -171,6 +169,7 @@ const result = await generateText({
       },
     }),
   },
+  maxSteps: 3,
 });
 
 console.log(result.text);
@@ -182,9 +181,7 @@ console.log(result.text);
 import { createSAPAIProvider } from '@mymediset/sap-ai-provider';
 import { generateText } from 'ai';
 
-const sapai = await createSAPAIProvider({
-  serviceKey: process.env.SAP_AI_SERVICE_KEY,
-});
+const sapai = createSAPAIProvider();
 
 const result = await generateText({
   model: sapai('gpt-4o'),
@@ -195,7 +192,7 @@ const result = await generateText({
         { type: 'text', text: 'Analyze this business process diagram.' },
         {
           type: 'image',
-          image: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ...',
+          image: new URL('https://example.com/diagram.jpg'),
         },
       ],
     },
@@ -205,57 +202,118 @@ const result = await generateText({
 console.log(result.text);
 ```
 
+### Data Masking (SAP DPI)
+
+Use SAP's Data Privacy Integration to automatically mask sensitive data:
+
+```typescript
+import {
+  createSAPAIProvider,
+  buildDpiMaskingProvider,
+} from '@mymediset/sap-ai-provider';
+import { generateText } from 'ai';
+
+const dpiConfig = buildDpiMaskingProvider({
+  method: 'anonymization',
+  entities: [
+    'profile-email',
+    'profile-person',
+    { type: 'profile-phone', replacement_strategy: { method: 'constant', value: 'REDACTED' } },
+  ],
+});
+
+const sapai = createSAPAIProvider({
+  defaultSettings: {
+    masking: {
+      masking_providers: [dpiConfig],
+    },
+  },
+});
+
+const result = await generateText({
+  model: sapai('gpt-4o'),
+  prompt: 'Email john@example.com about the meeting.',
+});
+
+console.log(result.text);
+```
+
+### Content Filtering
+
+```typescript
+import {
+  createSAPAIProvider,
+  buildAzureContentSafetyFilter,
+} from '@mymediset/sap-ai-provider';
+
+const sapai = createSAPAIProvider({
+  defaultSettings: {
+    filtering: {
+      input: {
+        filters: [
+          buildAzureContentSafetyFilter('input', {
+            hate: 'ALLOW_SAFE',
+            violence: 'ALLOW_SAFE_LOW_MEDIUM',
+          }),
+        ],
+      },
+    },
+  },
+});
+```
+
 ## Configuration
 
 ### Provider Settings
 
 ```typescript
 interface SAPAIProviderSettings {
-  serviceKey?: string; // SAP AI Core service key JSON
-  token?: string; // Direct access token (alternative to serviceKey)
-  baseURL?: string; // Custom base URL for API calls
+  resourceGroup?: string; // SAP AI Core resource group (default: 'default')
+  deploymentId?: string; // Specific deployment ID (auto-resolved if not set)
+  destination?: HttpDestinationOrFetchOptions; // Custom destination
+  defaultSettings?: SAPAISettings; // Default settings for all models
 }
 ```
 
 ### Model Settings
 
 ```typescript
-interface SAPAIModelSettings {
+interface SAPAISettings {
+  modelVersion?: string; // Model version (default: 'latest')
   modelParams?: {
     maxTokens?: number; // Maximum tokens to generate
     temperature?: number; // Sampling temperature (0-2)
     topP?: number; // Nucleus sampling parameter
     frequencyPenalty?: number; // Frequency penalty (-2 to 2)
     presencePenalty?: number; // Presence penalty (-2 to 2)
+    n?: number; // Number of completions
+    parallel_tool_calls?: boolean; // Enable parallel tool calls
   };
-  safePrompt?: boolean; // Enable safe prompt filtering
-  structuredOutputs?: boolean; // Enable structured outputs
+  masking?: MaskingModule; // Data masking configuration
+  filtering?: FilteringModule; // Content filtering configuration
 }
 ```
 
 ## Environment Variables
 
-### Required
+### On SAP BTP (Recommended)
 
-Your SAP AI Core service key:
+When running on SAP BTP, bind an AI Core service instance to your application. The SDK will automatically detect the service binding from `VCAP_SERVICES`.
 
-```bash
-SAP_AI_SERVICE_KEY='{"serviceurls":{"AI_API_URL":"..."},"clientid":"...","clientsecret":"..."}'
-```
+### Local Development
 
-### Optional
-
-Direct access token (alternative to service key):
+Set the `AICORE_SERVICE_KEY` environment variable with your service key JSON:
 
 ```bash
-SAP_AI_TOKEN='your-access-token'
+AICORE_SERVICE_KEY='{"serviceurls":{"AI_API_URL":"https://..."},"clientid":"...","clientsecret":"...","url":"..."}'
 ```
 
-Custom base URL:
+Get your service key from SAP BTP:
 
-```bash
-SAP_AI_BASE_URL='https://api.ai.prod.eu-central-1.aws.ml.hana.ondemand.com'
-```
+1. Go to your SAP BTP Cockpit
+2. Navigate to your AI Core instance
+3. Create a service key
+4. Copy the JSON and set it as the environment variable
 
 ## Enterprise Features
 
@@ -268,6 +326,64 @@ SAP AI Core offers several enterprise-grade features:
 - **Integration Ready**: Native integration with SAP S/4HANA, SuccessFactors, and other SAP solutions
 
 For more information about these features and advanced configuration options, visit the [SAP AI Core Documentation](https://help.sap.com/docs/ai-core).
+
+## Migration from v1
+
+Version 2.0 is a complete rewrite using the official SAP AI SDK. Here are the key changes:
+
+### Authentication
+
+**Before (v1):**
+
+```typescript
+const provider = await createSAPAIProvider({
+  serviceKey: process.env.SAP_AI_SERVICE_KEY,
+});
+```
+
+**After (v2):**
+
+```typescript
+// Set AICORE_SERVICE_KEY env var instead
+const provider = createSAPAIProvider();
+```
+
+### Provider is now synchronous
+
+**Before (v1):**
+
+```typescript
+const provider = await createSAPAIProvider({ serviceKey });
+```
+
+**After (v2):**
+
+```typescript
+const provider = createSAPAIProvider();
+```
+
+### Data Masking Configuration
+
+**Before (v1):**
+
+```typescript
+const dpiMasking = {
+  type: 'sap_data_privacy_integration',
+  method: 'anonymization',
+  entities: [{ type: 'profile-email' }],
+};
+```
+
+**After (v2):**
+
+```typescript
+import { buildDpiMaskingProvider } from '@mymediset/sap-ai-provider';
+
+const dpiMasking = buildDpiMaskingProvider({
+  method: 'anonymization',
+  entities: ['profile-email'],
+});
+```
 
 ## Additional Resources
 

--- a/content/providers/03-community-providers/20-sap-ai.mdx
+++ b/content/providers/03-community-providers/20-sap-ai.mdx
@@ -218,7 +218,10 @@ const dpiConfig = buildDpiMaskingProvider({
   entities: [
     'profile-email',
     'profile-person',
-    { type: 'profile-phone', replacement_strategy: { method: 'constant', value: 'REDACTED' } },
+    {
+      type: 'profile-phone',
+      replacement_strategy: { method: 'constant', value: 'REDACTED' },
+    },
   ],
 });
 


### PR DESCRIPTION
## Summary

Updates the SAP AI Core community provider documentation for v2.0 breaking changes.

## Breaking Changes in @mymediset/sap-ai-provider v2.0

- **Authentication**: Now uses `AICORE_SERVICE_KEY` environment variable (SAP AI SDK standard)
- **Provider creation**: Now synchronous - `createSAPAIProvider()` instead of `await createSAPAIProvider()`
- **No more `serviceKey` option**: Authentication is handled automatically by the SAP AI SDK

## New Features Documented

- Data masking with SAP DPI (`buildDpiMaskingProvider()`)
- Content filtering (`buildAzureContentSafetyFilter()`)
- Updated model list with latest offerings
- Added migration guide from v1 to v2

## Checklist

- [x] Documentation only change
- [x] No changeset needed (docs only)