### PR TITLE
feat(ai): add OpenTelemetry metrics for generateText and streamText

### DIFF
--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -73,6 +73,110 @@ const result = await generateText({
 });
 ```
 
+## Metrics
+
+The AI SDK supports OpenTelemetry metrics for monitoring and alerting on AI operations.
+Metrics are automatically recorded when telemetry is enabled, providing aggregated statistics
+like request counts, token usage, and latency distributions.
+
+### Enabling Metrics
+
+Metrics are enabled by default when telemetry is enabled. You can explicitly control metrics recording:
+
+```ts highlight="6"
+const result = await generateText({
+  model: __MODEL__,
+  prompt: 'Write a short story about a cat.',
+  experimental_telemetry: {
+    isEnabled: true,
+    recordMetrics: true, // enabled by default when telemetry is enabled
+  },
+});
+```
+
+To disable metrics while keeping traces enabled:
+
+```ts highlight="6"
+const result = await generateText({
+  model: __MODEL__,
+  prompt: 'Write a short story about a cat.',
+  experimental_telemetry: {
+    isEnabled: true,
+    recordMetrics: false,
+  },
+});
+```
+
+### Custom Meter
+
+You may provide a custom `meter` to use a `MeterProvider` other than the global one:
+
+```ts highlight="7"
+const meterProvider = new MeterProvider();
+const result = await generateText({
+  model: __MODEL__,
+  prompt: 'Write a short story about a cat.',
+  experimental_telemetry: {
+    isEnabled: true,
+    meter: meterProvider.getMeter('ai'),
+  },
+});
+```
+
+### Available Metrics
+
+The following metrics are recorded for AI operations:
+
+| Metric Name | Type | Unit | Description |
+|-------------|------|------|-------------|
+| `ai.requests.total` | Counter | `{request}` | Total number of AI requests |
+| `ai.tokens.total` | Counter | `{token}` | Total number of tokens used (with `ai.token.type` attribute: `prompt` or `completion`) |
+| `ai.errors.total` | Counter | `{error}` | Total number of errors |
+| `ai.tool_calls.total` | Counter | `{call}` | Total number of tool calls |
+| `ai.request.duration` | Histogram | `ms` | Request duration in milliseconds |
+| `ai.time_to_first_token` | Histogram | `ms` | Time to first token in milliseconds (streaming only) |
+| `ai.requests.active` | UpDownCounter | `{request}` | Number of currently active requests |
+
+### Metric Attributes
+
+All metrics include the following attributes:
+
+- `ai.model.provider`: The provider of the model (e.g., `openai`)
+- `ai.model.id`: The ID of the model (e.g., `gpt-4`)
+- `ai.telemetry.functionId`: The function ID if set via `telemetry.functionId`
+- `ai.operationId`: The operation type (`ai.generateText` or `ai.streamText`)
+- `ai.request.success`: Whether the request was successful (`true` or `false`)
+- `ai.response.finish_reason`: The finish reason from the model (when available)
+
+Token metrics additionally include:
+- `ai.token.type`: The type of token (`prompt` or `completion`)
+
+Tool call metrics additionally include:
+- `ai.tool_call.name`: The name of the tool
+- `ai.tool_call.success`: Whether the tool call was successful
+
+### Example: Monitoring with Prometheus
+
+```ts
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
+import { MeterProvider } from '@opentelemetry/sdk-metrics';
+
+const exporter = new PrometheusExporter({ port: 9464 });
+const meterProvider = new MeterProvider();
+meterProvider.addMetricReader(exporter);
+
+const result = await generateText({
+  model: openai('gpt-4'),
+  prompt: 'Hello, world!',
+  experimental_telemetry: {
+    isEnabled: true,
+    meter: meterProvider.getMeter('ai'),
+  },
+});
+
+// Metrics available at http://localhost:9464/metrics
+```
+
 ## Collected Data
 
 ### generateText function

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -25,7 +25,15 @@ import { standardizePrompt } from '../prompt/standardize-prompt';
 import { wrapGatewayError } from '../prompt/wrap-gateway-error';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
+import { getMeter } from '../telemetry/get-meter';
 import { getTracer } from '../telemetry/get-tracer';
+import {
+  AIMetrics,
+  createAIMetrics,
+  decrementActiveRequests,
+  incrementActiveRequests,
+  recordStreamMetrics,
+} from '../telemetry/record-metrics';
 import { recordSpan } from '../telemetry/record-span';
 import { selectTelemetryAttributes } from '../telemetry/select-telemetry-attributes';
 import { stringifyForTelemetry } from '../telemetry/stringify-for-telemetry';
@@ -644,6 +652,27 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
     this.includeRawChunks = includeRawChunks;
     this.tools = tools;
 
+    // Initialize metrics early so they can be used in eventProcessor
+    const should_record_metrics =
+      telemetry?.isEnabled === true && telemetry?.recordMetrics !== false;
+    const meter = getMeter({
+      isEnabled: should_record_metrics,
+      meter: telemetry?.meter,
+    });
+    const ai_metrics = createAIMetrics(meter);
+    const metrics_attributes = {
+      'ai.model.provider': model.provider,
+      'ai.model.id': model.modelId,
+      'ai.telemetry.functionId': telemetry?.functionId,
+      'ai.operationId': 'ai.streamText',
+    };
+    const metrics_start_time = Date.now();
+    let metrics_first_token_time: number | undefined;
+    let metrics_has_error = false;
+
+    // Track active requests
+    incrementActiveRequests(ai_metrics, metrics_attributes);
+
     // promise to ensure that the step has been fully processed by the event processor
     // before a new step is started. This is required because the continuation condition
     // needs the updated steps to determine if another step is needed.
@@ -700,6 +729,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
         }
 
         if (part.type === 'error') {
+          metrics_has_error = true;
           await onError({ error: wrapGatewayError(part.error) });
         }
 
@@ -714,6 +744,11 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
         }
 
         if (part.type === 'text-delta') {
+          // Record time to first token for metrics
+          if (metrics_first_token_time === undefined) {
+            metrics_first_token_time = Date.now();
+          }
+
           const activeText = activeTextContent[part.id];
 
           if (activeText == null) {
@@ -957,9 +992,33 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT extends Output>
               },
             }),
           );
+          // Record success metrics
+          const time_to_first_token_ms =
+            metrics_first_token_time !== undefined
+              ? metrics_first_token_time - metrics_start_time
+              : undefined;
+
+          recordStreamMetrics(ai_metrics, metrics_attributes, {
+            duration_ms: Date.now() - metrics_start_time,
+            prompt_tokens: totalUsage.inputTokens ?? 0,
+            completion_tokens: totalUsage.outputTokens ?? 0,
+            success: !metrics_has_error,
+            finish_reason: finishReason,
+            time_to_first_token_ms,
+          });
         } catch (error) {
+          // Record error metrics
+          recordStreamMetrics(ai_metrics, metrics_attributes, {
+            duration_ms: Date.now() - metrics_start_time,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            success: false,
+          });
+
           controller.error(error);
         } finally {
+          // Always decrement active requests
+          decrementActiveRequests(ai_metrics, metrics_attributes);
           rootSpan.end();
         }
       },

--- a/packages/ai/src/telemetry/get-meter.test.ts
+++ b/packages/ai/src/telemetry/get-meter.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getMeter } from './get-meter';
+import { noopMeter } from './noop-meter';
+
+describe('getMeter', () => {
+  it('should return noopMeter when isEnabled is false', () => {
+    const meter = getMeter({ isEnabled: false });
+    expect(meter).toBe(noopMeter);
+  });
+
+  it('should return noopMeter when isEnabled is undefined', () => {
+    const meter = getMeter({});
+    expect(meter).toBe(noopMeter);
+  });
+
+  it('should return noopMeter when called with no options', () => {
+    const meter = getMeter();
+    expect(meter).toBe(noopMeter);
+  });
+
+  it('should return custom meter when provided and isEnabled is true', () => {
+    const custom_meter = {
+      createCounter: vi.fn(),
+      createHistogram: vi.fn(),
+      createUpDownCounter: vi.fn(),
+      createGauge: vi.fn(),
+      createObservableGauge: vi.fn(),
+      createObservableCounter: vi.fn(),
+      createObservableUpDownCounter: vi.fn(),
+      addBatchObservableCallback: vi.fn(),
+      removeBatchObservableCallback: vi.fn(),
+    } as any;
+
+    const meter = getMeter({ isEnabled: true, meter: custom_meter });
+    expect(meter).toBe(custom_meter);
+  });
+
+  it('should return noopMeter when isEnabled is false even with custom meter', () => {
+    const custom_meter = {
+      createCounter: vi.fn(),
+    } as any;
+
+    const meter = getMeter({ isEnabled: false, meter: custom_meter });
+    expect(meter).toBe(noopMeter);
+  });
+});

--- a/packages/ai/src/telemetry/get-meter.ts
+++ b/packages/ai/src/telemetry/get-meter.ts
@@ -1,0 +1,28 @@
+import { Meter, metrics } from '@opentelemetry/api';
+import { noopMeter } from './noop-meter';
+
+/**
+ * Get a meter for recording metrics.
+ *
+ * @param options - Options for getting the meter.
+ * @param options.isEnabled - Whether telemetry is enabled. If false, returns a noop meter.
+ * @param options.meter - A custom meter to use. If not provided, uses the global meter provider.
+ * @returns A meter instance for recording metrics.
+ */
+export function getMeter({
+  isEnabled = false,
+  meter,
+}: {
+  isEnabled?: boolean;
+  meter?: Meter;
+} = {}): Meter {
+  if (!isEnabled) {
+    return noopMeter;
+  }
+
+  if (meter) {
+    return meter;
+  }
+
+  return metrics.getMeter('ai');
+}

--- a/packages/ai/src/telemetry/noop-meter.test.ts
+++ b/packages/ai/src/telemetry/noop-meter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { noopMeter } from './noop-meter';
+
+describe('noopMeter', () => {
+  it('should create a counter that does nothing', () => {
+    const counter = noopMeter.createCounter('test.counter');
+    expect(() => counter.add(1)).not.toThrow();
+    expect(() => counter.add(10, { key: 'value' })).not.toThrow();
+  });
+
+  it('should create a histogram that does nothing', () => {
+    const histogram = noopMeter.createHistogram('test.histogram');
+    expect(() => histogram.record(100)).not.toThrow();
+    expect(() => histogram.record(200, { key: 'value' })).not.toThrow();
+  });
+
+  it('should create an up-down counter that does nothing', () => {
+    const up_down_counter = noopMeter.createUpDownCounter('test.updown');
+    expect(() => up_down_counter.add(1)).not.toThrow();
+    expect(() => up_down_counter.add(-1, { key: 'value' })).not.toThrow();
+  });
+
+  it('should create a gauge that does nothing', () => {
+    const gauge = noopMeter.createGauge('test.gauge');
+    expect(() => gauge.record(42)).not.toThrow();
+    expect(() => gauge.record(100, { key: 'value' })).not.toThrow();
+  });
+
+  it('should create observable instruments that do nothing', () => {
+    const observable_gauge = noopMeter.createObservableGauge('test.observable_gauge');
+    const observable_counter = noopMeter.createObservableCounter('test.observable_counter');
+    const observable_updown = noopMeter.createObservableUpDownCounter('test.observable_updown');
+
+    expect(() => observable_gauge.addCallback(() => {})).not.toThrow();
+    expect(() => observable_gauge.removeCallback(() => {})).not.toThrow();
+    expect(() => observable_counter.addCallback(() => {})).not.toThrow();
+    expect(() => observable_updown.removeCallback(() => {})).not.toThrow();
+  });
+
+  it('should handle batch observable callbacks', () => {
+    const callback = () => {};
+    expect(() => noopMeter.addBatchObservableCallback(callback, [])).not.toThrow();
+    expect(() => noopMeter.removeBatchObservableCallback(callback)).not.toThrow();
+  });
+});

--- a/packages/ai/src/telemetry/noop-meter.ts
+++ b/packages/ai/src/telemetry/noop-meter.ts
@@ -1,0 +1,102 @@
+import {
+  Meter,
+  Counter,
+  Histogram,
+  UpDownCounter,
+  Gauge,
+  ObservableGauge,
+  ObservableCounter,
+  ObservableUpDownCounter,
+  MetricOptions,
+  BatchObservableCallback,
+  Observable,
+} from '@opentelemetry/api';
+
+/**
+ * Counter implementation that does nothing (null object).
+ */
+const noopCounter: Counter = {
+  add(_value: number, _attributes?: unknown): void {},
+};
+
+/**
+ * Histogram implementation that does nothing (null object).
+ */
+const noopHistogram: Histogram = {
+  record(_value: number, _attributes?: unknown): void {},
+};
+
+/**
+ * UpDownCounter implementation that does nothing (null object).
+ */
+const noopUpDownCounter: UpDownCounter = {
+  add(_value: number, _attributes?: unknown): void {},
+};
+
+/**
+ * Gauge implementation that does nothing (null object).
+ */
+const noopGauge: Gauge = {
+  record(_value: number, _attributes?: unknown): void {},
+};
+
+/**
+ * Observable implementation that does nothing (null object).
+ */
+const noopObservable: Observable = {
+  addCallback(_callback: unknown): void {},
+  removeCallback(_callback: unknown): void {},
+};
+
+/**
+ * Meter implementation that does nothing (null object).
+ * Used when telemetry is disabled to avoid performance overhead.
+ */
+export const noopMeter: Meter = {
+  createCounter(_name: string, _options?: MetricOptions): Counter {
+    return noopCounter;
+  },
+
+  createHistogram(_name: string, _options?: MetricOptions): Histogram {
+    return noopHistogram;
+  },
+
+  createUpDownCounter(
+    _name: string,
+    _options?: MetricOptions,
+  ): UpDownCounter {
+    return noopUpDownCounter;
+  },
+
+  createGauge(_name: string, _options?: MetricOptions): Gauge {
+    return noopGauge;
+  },
+
+  createObservableGauge(
+    _name: string,
+    _options?: MetricOptions,
+  ): ObservableGauge {
+    return noopObservable as ObservableGauge;
+  },
+
+  createObservableCounter(
+    _name: string,
+    _options?: MetricOptions,
+  ): ObservableCounter {
+    return noopObservable as ObservableCounter;
+  },
+
+  createObservableUpDownCounter(
+    _name: string,
+    _options?: MetricOptions,
+  ): ObservableUpDownCounter {
+    return noopObservable as ObservableUpDownCounter;
+  },
+
+  addBatchObservableCallback(
+    _callback: BatchObservableCallback,
+    _observables: Observable[],
+  ): void {},
+
+  removeBatchObservableCallback(_callback: BatchObservableCallback): void {},
+};

--- a/packages/ai/src/telemetry/record-metrics.test.ts
+++ b/packages/ai/src/telemetry/record-metrics.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createAIMetrics,
+  recordRequestMetrics,
+  recordStreamMetrics,
+  recordToolCallMetrics,
+  incrementActiveRequests,
+  decrementActiveRequests,
+} from './record-metrics';
+import { noopMeter } from './noop-meter';
+
+describe('createAIMetrics', () => {
+  it('should create all metric instruments', () => {
+    const ai_metrics = createAIMetrics(noopMeter);
+
+    expect(ai_metrics.request_counter).toBeDefined();
+    expect(ai_metrics.token_counter).toBeDefined();
+    expect(ai_metrics.error_counter).toBeDefined();
+    expect(ai_metrics.tool_call_counter).toBeDefined();
+    expect(ai_metrics.duration_histogram).toBeDefined();
+    expect(ai_metrics.time_to_first_token_histogram).toBeDefined();
+    expect(ai_metrics.active_requests).toBeDefined();
+  });
+});
+
+describe('recordRequestMetrics', () => {
+  let mock_metrics: ReturnType<typeof createMockMetrics>;
+
+  function createMockMetrics() {
+    return {
+      request_counter: { add: vi.fn() },
+      token_counter: { add: vi.fn() },
+      error_counter: { add: vi.fn() },
+      tool_call_counter: { add: vi.fn() },
+      duration_histogram: { record: vi.fn() },
+      time_to_first_token_histogram: { record: vi.fn() },
+      active_requests: { add: vi.fn() },
+    };
+  }
+
+  beforeEach(() => {
+    mock_metrics = createMockMetrics();
+  });
+
+  it('should record success metrics correctly', () => {
+    const attributes = { 'ai.model.id': 'gpt-4' };
+
+    recordRequestMetrics(mock_metrics as any, attributes, {
+      duration_ms: 1000,
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      success: true,
+      finish_reason: 'stop',
+    });
+
+    expect(mock_metrics.request_counter.add).toHaveBeenCalledWith(1, {
+      'ai.model.id': 'gpt-4',
+      'ai.request.success': true,
+      'ai.response.finish_reason': 'stop',
+    });
+
+    expect(mock_metrics.duration_histogram.record).toHaveBeenCalledWith(1000, {
+      'ai.model.id': 'gpt-4',
+      'ai.request.success': true,
+      'ai.response.finish_reason': 'stop',
+    });
+
+    expect(mock_metrics.token_counter.add).toHaveBeenCalledWith(100, {
+      'ai.model.id': 'gpt-4',
+      'ai.request.success': true,
+      'ai.response.finish_reason': 'stop',
+      'ai.token.type': 'prompt',
+    });
+
+    expect(mock_metrics.token_counter.add).toHaveBeenCalledWith(50, {
+      'ai.model.id': 'gpt-4',
+      'ai.request.success': true,
+      'ai.response.finish_reason': 'stop',
+      'ai.token.type': 'completion',
+    });
+
+    expect(mock_metrics.error_counter.add).not.toHaveBeenCalled();
+  });
+
+  it('should record error metrics correctly', () => {
+    const attributes = { 'ai.model.id': 'gpt-4' };
+
+    recordRequestMetrics(mock_metrics as any, attributes, {
+      duration_ms: 500,
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      success: false,
+    });
+
+    expect(mock_metrics.request_counter.add).toHaveBeenCalledWith(1, {
+      'ai.model.id': 'gpt-4',
+      'ai.request.success': false,
+    });
+
+    expect(mock_metrics.error_counter.add).toHaveBeenCalledWith(1, {
+      'ai.model.id': 'gpt-4',
+      'ai.request.success': false,
+    });
+  });
+
+  it('should not record tokens when count is zero', () => {
+    recordRequestMetrics(mock_metrics as any, {}, {
+      duration_ms: 100,
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      success: true,
+    });
+
+    expect(mock_metrics.token_counter.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordStreamMetrics', () => {
+  let mock_metrics: ReturnType<typeof createMockMetrics>;
+
+  function createMockMetrics() {
+    return {
+      request_counter: { add: vi.fn() },
+      token_counter: { add: vi.fn() },
+      error_counter: { add: vi.fn() },
+      tool_call_counter: { add: vi.fn() },
+      duration_histogram: { record: vi.fn() },
+      time_to_first_token_histogram: { record: vi.fn() },
+      active_requests: { add: vi.fn() },
+    };
+  }
+
+  beforeEach(() => {
+    mock_metrics = createMockMetrics();
+  });
+
+  it('should record time to first token when provided', () => {
+    const attributes = { 'ai.model.id': 'gpt-4' };
+
+    recordStreamMetrics(mock_metrics as any, attributes, {
+      duration_ms: 2000,
+      prompt_tokens: 100,
+      completion_tokens: 200,
+      success: true,
+      finish_reason: 'stop',
+      time_to_first_token_ms: 150,
+    });
+
+    expect(mock_metrics.time_to_first_token_histogram.record).toHaveBeenCalledWith(150, {
+      'ai.model.id': 'gpt-4',
+      'ai.request.success': true,
+    });
+
+    // Also verify base metrics are recorded
+    expect(mock_metrics.request_counter.add).toHaveBeenCalled();
+    expect(mock_metrics.duration_histogram.record).toHaveBeenCalled();
+  });
+
+  it('should not record time to first token when undefined', () => {
+    recordStreamMetrics(mock_metrics as any, {}, {
+      duration_ms: 1000,
+      prompt_tokens: 50,
+      completion_tokens: 100,
+      success: true,
+    });
+
+    expect(mock_metrics.time_to_first_token_histogram.record).not.toHaveBeenCalled();
+  });
+
+  it('should not record time to first token when zero', () => {
+    recordStreamMetrics(mock_metrics as any, {}, {
+      duration_ms: 1000,
+      prompt_tokens: 50,
+      completion_tokens: 100,
+      success: true,
+      time_to_first_token_ms: 0,
+    });
+
+    expect(mock_metrics.time_to_first_token_histogram.record).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordToolCallMetrics', () => {
+  let mock_metrics: ReturnType<typeof createMockMetrics>;
+
+  function createMockMetrics() {
+    return {
+      request_counter: { add: vi.fn() },
+      token_counter: { add: vi.fn() },
+      error_counter: { add: vi.fn() },
+      tool_call_counter: { add: vi.fn() },
+      duration_histogram: { record: vi.fn() },
+      time_to_first_token_histogram: { record: vi.fn() },
+      active_requests: { add: vi.fn() },
+    };
+  }
+
+  beforeEach(() => {
+    mock_metrics = createMockMetrics();
+  });
+
+  it('should record successful tool call', () => {
+    const attributes = { 'ai.model.id': 'gpt-4' };
+
+    recordToolCallMetrics(mock_metrics as any, attributes, {
+      tool_name: 'search',
+      success: true,
+    });
+
+    expect(mock_metrics.tool_call_counter.add).toHaveBeenCalledWith(1, {
+      'ai.model.id': 'gpt-4',
+      'ai.tool_call.name': 'search',
+      'ai.tool_call.success': true,
+    });
+
+    expect(mock_metrics.error_counter.add).not.toHaveBeenCalled();
+  });
+
+  it('should record failed tool call with error', () => {
+    const attributes = { 'ai.model.id': 'gpt-4' };
+
+    recordToolCallMetrics(mock_metrics as any, attributes, {
+      tool_name: 'calculator',
+      success: false,
+    });
+
+    expect(mock_metrics.tool_call_counter.add).toHaveBeenCalledWith(1, {
+      'ai.model.id': 'gpt-4',
+      'ai.tool_call.name': 'calculator',
+      'ai.tool_call.success': false,
+    });
+
+    expect(mock_metrics.error_counter.add).toHaveBeenCalledWith(1, {
+      'ai.model.id': 'gpt-4',
+      'ai.tool_call.name': 'calculator',
+      'ai.tool_call.success': false,
+      'ai.error.type': 'tool_call',
+    });
+  });
+});
+
+describe('active requests tracking', () => {
+  let mock_metrics: ReturnType<typeof createMockMetrics>;
+
+  function createMockMetrics() {
+    return {
+      request_counter: { add: vi.fn() },
+      token_counter: { add: vi.fn() },
+      error_counter: { add: vi.fn() },
+      tool_call_counter: { add: vi.fn() },
+      duration_histogram: { record: vi.fn() },
+      time_to_first_token_histogram: { record: vi.fn() },
+      active_requests: { add: vi.fn() },
+    };
+  }
+
+  beforeEach(() => {
+    mock_metrics = createMockMetrics();
+  });
+
+  it('should increment active requests', () => {
+    const attributes = { 'ai.model.id': 'gpt-4' };
+
+    incrementActiveRequests(mock_metrics as any, attributes);
+
+    expect(mock_metrics.active_requests.add).toHaveBeenCalledWith(1, attributes);
+  });
+
+  it('should decrement active requests', () => {
+    const attributes = { 'ai.model.id': 'gpt-4' };
+
+    decrementActiveRequests(mock_metrics as any, attributes);
+
+    expect(mock_metrics.active_requests.add).toHaveBeenCalledWith(-1, attributes);
+  });
+});

--- a/packages/ai/src/telemetry/record-metrics.ts
+++ b/packages/ai/src/telemetry/record-metrics.ts
@@ -1,0 +1,220 @@
+import { Attributes, Counter, Histogram, Meter, UpDownCounter } from '@opentelemetry/api';
+
+/**
+ * AI SDK metrics instruments.
+ */
+export interface AIMetrics {
+  /** Counter for total number of requests */
+  request_counter: Counter;
+  /** Counter for total tokens used (with type attribute for prompt/completion) */
+  token_counter: Counter;
+  /** Counter for total errors */
+  error_counter: Counter;
+  /** Counter for tool calls */
+  tool_call_counter: Counter;
+  /** Histogram for request duration in milliseconds */
+  duration_histogram: Histogram;
+  /** Histogram for time to first token in milliseconds (streaming only) */
+  time_to_first_token_histogram: Histogram;
+  /** UpDownCounter for active requests */
+  active_requests: UpDownCounter;
+}
+
+/**
+ * Create AI SDK metrics instruments from a meter.
+ *
+ * @param meter - OpenTelemetry Meter instance.
+ * @returns AIMetrics object containing all metric instruments.
+ */
+export function createAIMetrics(meter: Meter): AIMetrics {
+  return {
+    request_counter: meter.createCounter('ai.requests.total', {
+      description: 'Total number of AI requests',
+      unit: '{request}',
+    }),
+
+    token_counter: meter.createCounter('ai.tokens.total', {
+      description: 'Total number of tokens used',
+      unit: '{token}',
+    }),
+
+    error_counter: meter.createCounter('ai.errors.total', {
+      description: 'Total number of errors',
+      unit: '{error}',
+    }),
+
+    tool_call_counter: meter.createCounter('ai.tool_calls.total', {
+      description: 'Total number of tool calls',
+      unit: '{call}',
+    }),
+
+    duration_histogram: meter.createHistogram('ai.request.duration', {
+      description: 'Request duration in milliseconds',
+      unit: 'ms',
+    }),
+
+    time_to_first_token_histogram: meter.createHistogram('ai.time_to_first_token', {
+      description: 'Time to first token in milliseconds',
+      unit: 'ms',
+    }),
+
+    active_requests: meter.createUpDownCounter('ai.requests.active', {
+      description: 'Number of currently active requests',
+      unit: '{request}',
+    }),
+  };
+}
+
+/**
+ * Data for recording request completion metrics.
+ */
+export interface RequestMetricsData {
+  /** Request duration in milliseconds */
+  duration_ms: number;
+  /** Number of prompt tokens used */
+  prompt_tokens: number;
+  /** Number of completion tokens used */
+  completion_tokens: number;
+  /** Whether the request was successful */
+  success: boolean;
+  /** Finish reason from the model */
+  finish_reason?: string;
+}
+
+/**
+ * Record metrics for a completed request.
+ *
+ * @param ai_metrics - AIMetrics instance.
+ * @param attributes - Common attributes for all metrics.
+ * @param data - Request completion data.
+ */
+export function recordRequestMetrics(
+  ai_metrics: AIMetrics,
+  attributes: Attributes,
+  data: RequestMetricsData,
+): void {
+  const base_labels: Attributes = {
+    ...attributes,
+    'ai.request.success': data.success,
+  };
+
+  if (data.finish_reason) {
+    base_labels['ai.response.finish_reason'] = data.finish_reason;
+  }
+
+  // Record request count
+  ai_metrics.request_counter.add(1, base_labels);
+
+  // Record duration
+  ai_metrics.duration_histogram.record(data.duration_ms, base_labels);
+
+  // Record tokens with type attribute
+  if (data.prompt_tokens > 0) {
+    ai_metrics.token_counter.add(data.prompt_tokens, {
+      ...base_labels,
+      'ai.token.type': 'prompt',
+    });
+  }
+
+  if (data.completion_tokens > 0) {
+    ai_metrics.token_counter.add(data.completion_tokens, {
+      ...base_labels,
+      'ai.token.type': 'completion',
+    });
+  }
+
+  // Record error if not successful
+  if (!data.success) {
+    ai_metrics.error_counter.add(1, base_labels);
+  }
+}
+
+/**
+ * Data for recording streaming metrics.
+ */
+export interface StreamMetricsData extends RequestMetricsData {
+  /** Time to first token in milliseconds */
+  time_to_first_token_ms?: number;
+}
+
+/**
+ * Record metrics for a completed streaming request.
+ *
+ * @param ai_metrics - AIMetrics instance.
+ * @param attributes - Common attributes for all metrics.
+ * @param data - Stream completion data.
+ */
+export function recordStreamMetrics(
+  ai_metrics: AIMetrics,
+  attributes: Attributes,
+  data: StreamMetricsData,
+): void {
+  // Record base request metrics
+  recordRequestMetrics(ai_metrics, attributes, data);
+
+  // Record time to first token if available
+  if (data.time_to_first_token_ms !== undefined && data.time_to_first_token_ms > 0) {
+    ai_metrics.time_to_first_token_histogram.record(data.time_to_first_token_ms, {
+      ...attributes,
+      'ai.request.success': data.success,
+    });
+  }
+}
+
+/**
+ * Record metrics for a tool call.
+ *
+ * @param ai_metrics - AIMetrics instance.
+ * @param attributes - Common attributes for all metrics.
+ * @param data - Tool call data.
+ */
+export function recordToolCallMetrics(
+  ai_metrics: AIMetrics,
+  attributes: Attributes,
+  data: {
+    tool_name: string;
+    success: boolean;
+    duration_ms?: number;
+  },
+): void {
+  const labels: Attributes = {
+    ...attributes,
+    'ai.tool_call.name': data.tool_name,
+    'ai.tool_call.success': data.success,
+  };
+
+  ai_metrics.tool_call_counter.add(1, labels);
+
+  if (!data.success) {
+    ai_metrics.error_counter.add(1, {
+      ...labels,
+      'ai.error.type': 'tool_call',
+    });
+  }
+}
+
+/**
+ * Helper to increment active requests counter.
+ *
+ * @param ai_metrics - AIMetrics instance.
+ * @param attributes - Common attributes.
+ */
+export function incrementActiveRequests(
+  ai_metrics: AIMetrics,
+  attributes: Attributes,
+): void {
+  ai_metrics.active_requests.add(1, attributes);
+}
+
+/**
+ * Helper to decrement active requests counter.
+ *
+ * @param ai_metrics - AIMetrics instance.
+ * @param attributes - Common attributes.
+ */
+export function decrementActiveRequests(
+  ai_metrics: AIMetrics,
+  attributes: Attributes,
+): void {
+  ai_metrics.active_requests.add(-1, attributes);
+}

--- a/packages/ai/src/telemetry/telemetry-settings.ts
+++ b/packages/ai/src/telemetry/telemetry-settings.ts
@@ -1,4 +1,4 @@
-import { AttributeValue, Tracer } from '@opentelemetry/api';
+import { AttributeValue, Meter, Tracer } from '@opentelemetry/api';
 
 /**
  * Telemetry configuration.
@@ -41,4 +41,20 @@ export type TelemetrySettings = {
    * A custom tracer to use for the telemetry data.
    */
   tracer?: Tracer;
+
+  /**
+   * Enable or disable metrics recording. Enabled by default when telemetry is enabled.
+   *
+   * Metrics provide aggregated statistics like request counts, token usage,
+   * and latency distributions that are useful for monitoring and alerting.
+   */
+  recordMetrics?: boolean;
+
+  /**
+   * A custom meter to use for recording metrics.
+   *
+   * If not provided and metrics are enabled, uses the global meter provider
+   * with the meter name 'ai'.
+   */
+  meter?: Meter;
 };


### PR DESCRIPTION
## Background

  The AI SDK currently supports OpenTelemetry tracing for observability, but
   lacks metrics support. Metrics provide aggregated statistics (request
  counts, token usage, latency distributions) that are essential for
  monitoring, alerting, and capacity planning in production environments.

  ## Summary

  This PR adds OpenTelemetry metrics support to the AI SDK:

  **New telemetry modules:**
  - `get-meter.ts` - Meter instance retrieval with noop fallback
  - `noop-meter.ts` - No-op meter implementation for disabled telemetry
  - `record-metrics.ts` - Core metrics recording logic

  **Metrics instruments:**
  - `ai.requests.total` (Counter) - Total request count
  - `ai.tokens.total` (Counter) - Token usage with prompt/completion type
  - `ai.errors.total` (Counter) - Error count
  - `ai.tool_calls.total` (Counter) - Tool call count
  - `ai.request.duration` (Histogram) - Request latency
  - `ai.time_to_first_token` (Histogram) - TTFT for streaming
  - `ai.requests.active` (UpDownCounter) - Active request gauge

  **Integration:**
  - Integrated metrics into `generateText` and `streamText`
  - Added `recordMetrics` and `meter` options to `TelemetrySettings`

  **Documentation:**
  - Added metrics section to telemetry docs with usage examples and
  Prometheus integration

  ## Checklist

  - [x] Tests have been added / updated (for bug fixes / features)
  - [x] Documentation has been added / updated (for bug fixes / features)
  - [ ] A _patch_ changeset for relevant packages has been added (for bug
  fixes / features - run `pnpm changeset` in the project root)
  - [x] I have reviewed this pull request (self-review)

  ## Future Work

  - Add metrics support to `generateObject` and `streamObject`
  - Add metrics support to `embed` and `embedMany`
  - Add tool call metrics recording in tool execution flow