### PR TITLE
fix(docs): update reasoning property names to match API 5.0

### DIFF
--- a/content/cookbook/00-guides/20-sonnet-3-7.mdx
+++ b/content/cookbook/00-guides/20-sonnet-3-7.mdx
@@ -26,7 +26,7 @@ At the center of the AI SDK is [AI SDK Core](/docs/ai-sdk-core/overview), which 
 import { anthropic } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 
-const { text, reasoning, reasoningDetails } = await generateText({
+const { text, reasoningText, reasoning } = await generateText({
   model: anthropic('claude-3-7-sonnet-20250219'),
   prompt: 'How many people will live in the world in 2040?',
 });
@@ -53,7 +53,7 @@ Claude 3.7 Sonnet introduces a new extended thinking—the ability to solve comp
 import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 
-const { text, reasoning, reasoningDetails } = await generateText({
+const { text, reasoningText, reasoning } = await generateText({
   model: anthropic('claude-3-7-sonnet-20250219'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
@@ -63,8 +63,8 @@ const { text, reasoning, reasoningDetails } = await generateText({
   },
 });
 
-console.log(reasoning); // reasoning text
-console.log(reasoningDetails); // reasoning details including redacted reasoning
+console.log(reasoningText); // reasoning text
+console.log(reasoning); // reasoning details including redacted reasoning
 console.log(text); // text response
 ```
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -983,13 +983,13 @@ To see `generateText` in action, check out [these examples](#examples).
               description: 'The full text that has been generated.',
             },
             {
-              name: 'reasoning',
+              name: 'reasoningText',
               type: 'string | undefined',
               description:
                 'The reasoning text of the model (only available for some models).',
             },
             {
-              name: 'reasoningDetails',
+              name: 'reasoning',
               type: 'Array<ReasoningDetail>',
               description:
                 'The reasoning details of the model (only available for some models).',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1055,7 +1055,7 @@ To see `streamText` in action, check out [these examples](#examples).
               description: 'The full text that has been generated.',
             },
             {
-              name: 'reasoning',
+              name: 'reasoningText',
               type: 'string | undefined',
               description:
                 'The reasoning text of the model (only available for some models).',
@@ -1314,7 +1314,7 @@ To see `streamText` in action, check out [these examples](#examples).
                 'The reasoning text of the model (only available for some models).',
             },
             {
-              name: 'reasoningDetails',
+              name: 'reasoning',
               type: 'Array<ReasoningDetail>',
               description:
                 'The reasoning details of the model (only available for some models).',

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -190,7 +190,7 @@ and specifying a thinking budget in tokens.
 import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { generateText } from 'ai';
 
-const { text, reasoning, reasoningDetails } = await generateText({
+const { text, reasoningText, reasoning } = await generateText({
   model: anthropic('claude-opus-4-20250514'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
@@ -200,8 +200,8 @@ const { text, reasoning, reasoningDetails } = await generateText({
   },
 });
 
-console.log(reasoning); // reasoning text
-console.log(reasoningDetails); // reasoning details including redacted reasoning
+console.log(reasoningText); // reasoning text
+console.log(reasoning); // reasoning details including redacted reasoning
 console.log(text); // text response
 ```
 

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -436,7 +436,7 @@ const anthropicResult = await generateText({
   },
 });
 
-console.log(anthropicResult.reasoning); // reasoning text
+console.log(anthropicResult.reasoningText); // reasoning text
 console.log(anthropicResult.text); // text response
 
 // Nova 2 example
@@ -450,7 +450,7 @@ const amazonResult = await generateText({
   },
 });
 
-console.log(amazonResult.reasoning); // reasoning text
+console.log(amazonResult.reasoningText); // reasoning text
 console.log(amazonResult.text); // text response
 ```
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -394,7 +394,7 @@ import { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google'; // Note: imp
 import { generateText, streamText } from 'ai';
 
 // For generateText:
-const { text, reasoning, reasoningDetails } = await generateText({
+const { text, reasoningText, reasoning } = await generateText({
   model: vertex('gemini-2.0-flash-001'), // Or other supported model via Vertex
   providerOptions: {
     google: {
@@ -408,8 +408,8 @@ const { text, reasoning, reasoningDetails } = await generateText({
   prompt: 'Explain quantum computing in simple terms.',
 });
 
-console.log('Reasoning:', reasoning);
-console.log('Reasoning Details:', reasoningDetails);
+console.log('Reasoning:', reasoningText);
+console.log('Reasoning Details:', reasoning);
 console.log('Final Text:', text);
 
 // For streamText:
@@ -438,7 +438,7 @@ for await (const part of result.fullStream) {
 
 When `includeThoughts` is true, parts of the API response marked with `thought: true` will be processed as reasoning.
 
-- In `generateText`, these contribute to the `reasoning` (string) and `reasoningDetails` (array) fields.
+- In `generateText`, these contribute to the `reasoningText` (string) and `reasoning` (array) fields.
 - In `streamText`, these are emitted as `reasoning` stream parts.
 
 <Note>
@@ -970,7 +970,7 @@ and specifying a thinking budget in tokens.
 import { vertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
 import { generateText } from 'ai';
 
-const { text, reasoning, reasoningDetails } = await generateText({
+const { text, reasoningText, reasoning } = await generateText({
   model: vertexAnthropic('claude-3-7-sonnet@20250219'),
   prompt: 'How many people will live in the world in 2040?',
   providerOptions: {
@@ -980,8 +980,8 @@ const { text, reasoning, reasoningDetails } = await generateText({
   },
 });
 
-console.log(reasoning); // reasoning text
-console.log(reasoningDetails); // reasoning details including redacted reasoning
+console.log(reasoningText); // reasoning text
+console.log(reasoning); // reasoning details including redacted reasoning
 console.log(text); // text response
 ```
 


### PR DESCRIPTION
## Background
The AI SDK 5.0 introduced breaking changes to the reasoning property names in `generateText()` and `streamText()` responses. The migration guide documents these changes, but several documentation files and examples were still using the old property names, which would confuse developers trying to use the latest API version.

## Summary
Replace deprecated `reasoning` and `reasoningDetails` properties with new `reasoningText` and `reasoning` properties across all documentation and examples to align with AI SDK 5.0 migration guide.

## Manual Verification

✅ Verified all occurrences of old property names have been 
✅ Confirmed changes match the [migration guide](https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0#generate-text-reasoning-property-changes)

## Checklist

  - [ ] Tests have been added / updated (for bug fixes / features) - N/A (documentation only)
  - [x] Documentation has been added / updated (for bug fixes / features)
  - [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
  - [x] I have reviewed this pull request (self-review)

## Related Issues
Fixes #10842
