### PR TITLE
feat(openai): additional settings for file search tool

### DIFF
--- a/.changeset/brave-schools-speak.md
+++ b/.changeset/brave-schools-speak.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): additional settings for file search tool

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -173,14 +173,14 @@ export type OpenAIResponsesFileSearchToolComparisonFilter = {
   key: string;
 
   /**
-   * Specifies the comparison operator: eq, ne, gt, gte, lt, lte.
+   * Specifies the comparison operator: eq, ne, gt, gte, lt, lte, in, nin.
    */
-  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
+  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'nin';
 
   /**
-   * The value to compare against the attribute key; supports string, number, or boolean types.
+   * The value to compare against the attribute key; supports string, number, boolean, or array of string types.
    */
-  value: string | number | boolean;
+  value: string | number | boolean | string[];
 };
 
 /**

--- a/packages/openai/src/tool/file-search.ts
+++ b/packages/openai/src/tool/file-search.ts
@@ -11,8 +11,8 @@ import {
 
 const comparisonFilterSchema = z.object({
   key: z.string(),
-  type: z.enum(['eq', 'ne', 'gt', 'gte', 'lt', 'lte']),
-  value: z.union([z.string(), z.number(), z.boolean()]),
+  type: z.enum(['eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'nin']),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]),
 });
 
 const compoundFilterSchema: z.ZodType<any> = z.object({


### PR DESCRIPTION
## Background

OpenAI added more parameters to the file search tool (see #10958 ).

## Summary

- add `in` and `nin` type
- support `string[]` as value

## Related Issues

Resolves #10958 