### PR TITLE
fix(anthropic): use default thinking budget when unspecified

### DIFF
--- a/.changeset/modern-students-peel.md
+++ b/.changeset/modern-students-peel.md
@@ -2,4 +2,4 @@
 '@ai-sdk/anthropic': patch
 ---
 
-add a warning instead of throwing an error when thinking is enabled but thinking budget is not given
+fix(anthropic): use default thinking budget when unspecified

--- a/.changeset/modern-students-peel.md
+++ b/.changeset/modern-students-peel.md
@@ -2,4 +2,4 @@
 '@ai-sdk/anthropic': patch
 ---
 
-improve error message when thinking is enabled but thinking budget is not given
+add a warning instead of throwing an error when thinking is enabled but thinking budget is not given

--- a/.changeset/modern-students-peel.md
+++ b/.changeset/modern-students-peel.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+improve error message when thinking is enabled but thinking budget is not given

--- a/examples/ai-core/src/generate-text/anthropic-reasoning-without-budget.ts
+++ b/examples/ai-core/src/generate-text/anthropic-reasoning-without-budget.ts
@@ -1,0 +1,26 @@
+import { anthropic, AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
+    providerOptions: {
+      anthropic: {
+        thinking: { type: 'enabled' },
+      } satisfies AnthropicProviderOptions,
+    },
+    maxRetries: 0,
+  });
+
+  console.log('Reasoning:');
+  console.log(result.reasoning);
+  console.log();
+
+  console.log('Text:');
+  console.log(result.text);
+  console.log();
+
+  console.log('Warnings:', result.warnings);
+});

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -905,6 +905,51 @@ describe('AnthropicMessagesLanguageModel', () => {
       expect(warnings).toMatchInlineSnapshot(`[]`);
     });
 
+    it('should use default thinking budget when it is not set', async () => {
+      prepareJsonResponse({});
+
+      const { warnings } = await provider('claude-haiku-4-5').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          anthropic: {
+            thinking: { type: 'enabled' },
+          } satisfies AnthropicProviderOptions,
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+        {
+          "max_tokens": 64000,
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "model": "claude-haiku-4-5",
+          "thinking": {
+            "budget_tokens": 1024,
+            "type": "enabled",
+          },
+        }
+      `);
+
+      expect(warnings).toMatchInlineSnapshot(`
+        [
+          {
+            "details": "thinking budget is required when thinking is enabled. using default budget of 1024 tokens.",
+            "feature": "extended thinking",
+            "type": "compatibility",
+          },
+        ]
+      `);
+    });
+
     it('should pass tools and toolChoice', async () => {
       prepareJsonResponse({});
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -12,7 +12,6 @@ import {
   LanguageModelV3Usage,
   SharedV3ProviderMetadata,
   SharedV3Warning,
-  UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -369,9 +368,10 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
 
     if (isThinking) {
       if (thinkingBudget == null) {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'extended thinking',
-          message: 'Extended thinking requires a thinking budget',
+        warnings.push({
+          type: 'unsupported',
+          feature: 'extended thinking',
+          details: 'thinking budget is required when thinking is enabled.',
         });
       }
 
@@ -403,7 +403,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       }
 
       // adjust max tokens to account for thinking:
-      baseArgs.max_tokens = maxTokens + thinkingBudget;
+      baseArgs.max_tokens = maxTokens + (thinkingBudget ?? 0);
     }
 
     // limit to max output tokens for known models to enable model switching without breaking it:

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -31,13 +31,12 @@ import {
 import { anthropicFailedResponseHandler } from './anthropic-error';
 import { AnthropicMessageMetadata } from './anthropic-message-metadata';
 import {
-  AnthropicContextManagementConfig,
   AnthropicContainer,
   anthropicMessagesChunkSchema,
   anthropicMessagesResponseSchema,
   AnthropicReasoningMetadata,
-  Citation,
   AnthropicResponseContextManagement,
+  Citation,
 } from './anthropic-messages-api';
 import {
   AnthropicMessagesModelId,
@@ -371,7 +370,8 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     if (isThinking) {
       if (thinkingBudget == null) {
         throw new UnsupportedFunctionalityError({
-          functionality: 'thinking requires a budget',
+          functionality: 'extended thinking',
+          message: 'thinking requires a budget',
         });
       }
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -371,7 +371,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       if (thinkingBudget == null) {
         throw new UnsupportedFunctionalityError({
           functionality: 'extended thinking',
-          message: 'thinking requires a budget',
+          message: 'Extended thinking requires a thinking budget',
         });
       }
 

--- a/packages/anthropic/src/anthropic-messages-language-model.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.ts
@@ -257,7 +257,7 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
       });
 
     const isThinking = anthropicOptions?.thinking?.type === 'enabled';
-    const thinkingBudget = anthropicOptions?.thinking?.budgetTokens;
+    let thinkingBudget = anthropicOptions?.thinking?.budgetTokens;
 
     const maxTokens = maxOutputTokens ?? maxOutputTokensForModel;
 
@@ -369,10 +369,18 @@ export class AnthropicMessagesLanguageModel implements LanguageModelV3 {
     if (isThinking) {
       if (thinkingBudget == null) {
         warnings.push({
-          type: 'unsupported',
+          type: 'compatibility',
           feature: 'extended thinking',
-          details: 'thinking budget is required when thinking is enabled.',
+          details:
+            'thinking budget is required when thinking is enabled. using default budget of 1024 tokens.',
         });
+
+        baseArgs.thinking = {
+          type: 'enabled',
+          budget_tokens: 1024,
+        };
+
+        thinkingBudget = 1024;
       }
 
       if (baseArgs.temperature != null) {


### PR DESCRIPTION
## Background

When users attempt to use extended thinking with Anthropic models without giving `thinkingBudget`, they receive a weird error message `'thinking requires a budget' functionality not supported`.

## Summary

- use a default thinking budget of 1024 tokens
- return compatibility warning

## Manual Verification

- [x] ran `examples/ai-core/src/generate-text/anthropic-reasoning-without-budget.ts`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)