### PR TITLE
docs: update v6 migration guide to include structured outputs example

### DIFF
--- a/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
@@ -114,7 +114,9 @@ const { output } = await generateText({
     schema: z.object({
       recipe: z.object({
         name: z.string(),
-        ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+        ingredients: z.array(
+          z.object({ name: z.string(), amount: z.string() }),
+        ),
         steps: z.array(z.string()),
       }),
     }),
@@ -158,7 +160,9 @@ const { partialOutputStream } = streamText({
     schema: z.object({
       recipe: z.object({
         name: z.string(),
-        ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+        ingredients: z.array(
+          z.object({ name: z.string(), amount: z.string() }),
+        ),
         steps: z.array(z.string()),
       }),
     }),

--- a/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
+++ b/content/docs/08-migration-guides/24-migration-guide-6-0.mdx
@@ -67,13 +67,13 @@ every file.
 
 The deprecated `CoreMessage` type and related functions have been removed ([PR #10710](https://github.com/vercel/ai/pull/10710)). Replace `convertToCoreMessages` with `convertToModelMessages`.
 
-```tsx filename="Before (V5)"
+```tsx filename="AI SDK 5"
 import { convertToCoreMessages, type CoreMessage } from 'ai';
 
 const coreMessages = convertToCoreMessages(messages); // CoreMessage[]
 ```
 
-```tsx filename="After (V6)"
+```tsx filename="AI SDK 6"
 import { convertToModelMessages, type ModelMessage } from 'ai';
 
 const modelMessages = convertToModelMessages(messages); // ModelMessage[]
@@ -83,7 +83,95 @@ const modelMessages = convertToModelMessages(messages); // ModelMessage[]
 
 `generateObject` and `streamObject` have been deprecated ([PR #10754](https://github.com/vercel/ai/pull/10754)).
 They will be removed in a future version.
-You can use `generateText` and `streamText` with an `output` setting instead.
+Use `generateText` and `streamText` with an `output` setting instead.
+
+```tsx filename="AI SDK 5"
+import { generateObject } from 'ai';
+__PROVIDER_IMPORT__;
+import { z } from 'zod';
+
+const { object } = await generateObject({
+  model: __MODEL__,
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+      steps: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate a lasagna recipe.',
+});
+```
+
+```tsx filename="AI SDK 6"
+import { generateText, Output } from 'ai';
+__PROVIDER_IMPORT__;
+import { z } from 'zod';
+
+const { output } = await generateText({
+  model: __MODEL__,
+  output: Output.object({
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+        steps: z.array(z.string()),
+      }),
+    }),
+  }),
+  prompt: 'Generate a lasagna recipe.',
+});
+```
+
+For streaming structured data, replace `streamObject` with `streamText`:
+
+```tsx filename="AI SDK 5"
+import { streamObject } from 'ai';
+__PROVIDER_IMPORT__;
+import { z } from 'zod';
+
+const { partialObjectStream } = streamObject({
+  model: __MODEL__,
+  schema: z.object({
+    recipe: z.object({
+      name: z.string(),
+      ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+      steps: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Generate a lasagna recipe.',
+});
+
+for await (const partialObject of partialObjectStream) {
+  console.log(partialObject);
+}
+```
+
+```tsx filename="AI SDK 6"
+import { streamText, Output } from 'ai';
+__PROVIDER_IMPORT__;
+import { z } from 'zod';
+
+const { partialOutputStream } = streamText({
+  model: __MODEL__,
+  output: Output.object({
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+        steps: z.array(z.string()),
+      }),
+    }),
+  }),
+  prompt: 'Generate a lasagna recipe.',
+});
+
+for await (const partialObject of partialOutputStream) {
+  console.log(partialObject);
+}
+```
+
+Learn more about [generating structured data](/docs/ai-sdk-core/generating-structured-data).
 
 ### `cachedInputTokens` and `reasoningTokens` in `LanguageModelUsage` Deprecation
 
@@ -101,14 +189,14 @@ and is now deprecated.
 
 Strict mode for tools is now controlled by setting `strict` on each tool ([PR #10817](https://github.com/vercel/ai/pull/10817)). This enables fine-grained control over strict tool calls, which is important since strict mode depends on the specific tool input schema.
 
-```tsx filename="AI SDK 5.0"
-import { openai } from '@ai-sdk/openai';
+```tsx filename="AI SDK 5"
+__PROVIDER_IMPORT__;
 import { streamText, tool } from 'ai';
 import { z } from 'zod';
 
 // Tool strict mode was controlled by strictJsonSchema
 const result = streamText({
-  model: openai('gpt-4o'),
+  model: __MODEL__,
   tools: {
     calculator: tool({
       description: 'A simple calculator',
@@ -129,13 +217,13 @@ const result = streamText({
 });
 ```
 
-```tsx filename="AI SDK 6.0"
-import { openai } from '@ai-sdk/openai';
+```tsx filename="AI SDK 6"
+__PROVIDER_IMPORT__;
 import { streamText, tool } from 'ai';
 import { z } from 'zod';
 
 const result = streamText({
-  model: openai('gpt-4o'),
+  model: __MODEL__,
   tools: {
     calculator: tool({
       description: 'A simple calculator',
@@ -160,7 +248,7 @@ AI SDK 6 introduces more flexible tool output and result content support ([PR #9
 
 The `system` parameter in the `ToolCallRepairFunction` type now accepts `SystemModelMessage` in addition to `string` ([PR #10635](https://github.com/vercel/ai/pull/10635)). This allows for more flexible system message configuration, including provider-specific options like caching.
 
-```tsx filename="AI SDK 5.0"
+```tsx filename="AI SDK 5"
 import type { ToolCallRepairFunction } from 'ai';
 
 const repairToolCall: ToolCallRepairFunction<MyTools> = async ({
@@ -175,7 +263,7 @@ const repairToolCall: ToolCallRepairFunction<MyTools> = async ({
 };
 ```
 
-```tsx filename="AI SDK 6.0"
+```tsx filename="AI SDK 6"
 import type { ToolCallRepairFunction, SystemModelMessage } from 'ai';
 
 const repairToolCall: ToolCallRepairFunction<MyTools> = async ({
@@ -196,7 +284,7 @@ const repairToolCall: ToolCallRepairFunction<MyTools> = async ({
 
 The `textEmbeddingModel` and `textEmbedding` methods on providers have been renamed to `embeddingModel` and `embedding` respectively. Additionally, generics have been removed from `EmbeddingModel`, `embed`, and `embedMany` ([PR #10592](https://github.com/vercel/ai/pull/10592)).
 
-```tsx filename="AI SDK 5.0"
+```tsx filename="AI SDK 5"
 import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
@@ -212,7 +300,7 @@ const { embedding } = await embed({
 });
 ```
 
-```tsx filename="AI SDK 6.0"
+```tsx filename="AI SDK 6"
 import { openai } from '@ai-sdk/openai';
 import { embed } from 'ai';
 
@@ -242,7 +330,7 @@ export AI_SDK_LOG_WARNINGS=false
 
 Separate warning types for each generation function have been consolidated into a single `Warning` type exported from the `ai` package ([PR #10631](https://github.com/vercel/ai/pull/10631)).
 
-```tsx filename="AI SDK 5.0"
+```tsx filename="AI SDK 5"
 // Separate warning types for each generation function
 import type {
   CallWarning,
@@ -252,7 +340,7 @@ import type {
 } from 'ai';
 ```
 
-```tsx filename="AI SDK 6.0"
+```tsx filename="AI SDK 6"
 // Single Warning type for all generation functions
 import type { Warning } from 'ai';
 ```
@@ -267,14 +355,14 @@ The `strictJsonSchema` setting for JSON outputs and tool calls is enabled by def
 
 However, strict mode is stricter about schema requirements. If you receive schema rejection errors, adjust your schema (for example, use `null` instead of `undefined`) or disable strict mode.
 
-```tsx filename="AI SDK 5.0"
+```tsx filename="AI SDK 5"
 import { openai } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 
 // strictJsonSchema was false by default
 const result = await generateObject({
-  model: openai('gpt-4o'),
+  model: openai('gpt-5.1'),
   schema: z.object({
     name: z.string(),
   }),
@@ -282,14 +370,14 @@ const result = await generateObject({
 });
 ```
 
-```tsx filename="AI SDK 6.0"
+```tsx filename="AI SDK 6"
 import { openai } from '@ai-sdk/openai';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 
 // strictJsonSchema is true by default
 const result = await generateObject({
-  model: openai('gpt-4o'),
+  model: openai('gpt-5.1'),
   schema: z.object({
     name: z.string(),
   }),
@@ -298,7 +386,7 @@ const result = await generateObject({
 
 // Disable strict mode if needed
 const resultNoStrict = await generateObject({
-  model: openai('gpt-4o'),
+  model: openai('gpt-5.1'),
   schema: z.object({
     name: z.string(),
   }),
@@ -327,14 +415,14 @@ This change impacts users who configure `@ai-sdk/openai` with a custom `baseUrl`
 
 The `@ai-sdk/azure` provider now uses the Responses API by default when calling `azure()` ([PR #9868](https://github.com/vercel/ai/pull/9868)). To use the previous Chat Completions API behavior, use `azure.chat()` instead.
 
-```tsx filename="AI SDK 5.0"
+```tsx filename="AI SDK 5"
 import { azure } from '@ai-sdk/azure';
 
 // Used Chat Completions API
 const model = azure('gpt-4o');
 ```
 
-```tsx filename="AI SDK 6.0"
+```tsx filename="AI SDK 6"
 import { azure } from '@ai-sdk/azure';
 
 // Now uses Responses API by default
@@ -365,7 +453,7 @@ The available modes are:
 - `'jsonTool'`: Use a special JSON tool to specify the structured output format
 - `'auto'` (default): Use `'outputFormat'` when supported by the model, otherwise fall back to `'jsonTool'`
 
-```tsx filename="AI SDK 6.0"
+```tsx filename="AI SDK 6"
 import { anthropic } from '@ai-sdk/anthropic';
 import { generateObject } from 'ai';
 import { z } from 'zod';
@@ -392,7 +480,7 @@ const result = await generateObject({
 
 V2 mock classes have been removed from the `ai/test` module. Use the new V3 mock classes instead for testing.
 
-```tsx filename="AI SDK 5.0"
+```tsx filename="AI SDK 5"
 import {
   MockEmbeddingModelV2,
   MockImageModelV2,
@@ -403,7 +491,7 @@ import {
 } from 'ai/test';
 ```
 
-```tsx filename="AI SDK 6.0"
+```tsx filename="AI SDK 6"
 import {
   MockEmbeddingModelV3,
   MockImageModelV3,


### PR DESCRIPTION
Structured outputs section was missing example and link.