### PR TITLE
docs: fix broken formatting of property table in stream-text

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1076,7 +1076,8 @@ To see `streamText` in action, check out [these examples](#examples).
                             {
                               name: 'reasoningTokens',
                               type: 'number | undefined',
-                              description: 'The number of reasoning tokens used.',
+                              description:
+                                'The number of reasoning tokens used.',
                             },
                           ],
                         },
@@ -1331,7 +1332,8 @@ To see `streamText` in action, check out [these examples](#examples).
                             {
                               name: 'reasoningTokens',
                               type: 'number | undefined',
-                              description: 'The number of reasoning tokens used.',
+                              description:
+                                'The number of reasoning tokens used.',
                             },
                           ],
                         },

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -1029,22 +1029,27 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
                       properties: [
                         {
-                          name: 'noCacheTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of non-cached input (prompt) tokens used.',
-                        },
-                        {
-                          name: 'cacheReadTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens read.',
-                        },
-                        {
-                          name: 'cacheWriteTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens written.',
+                          type: 'LanguageModelInputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'noCacheTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of non-cached input (prompt) tokens used.',
+                            },
+                            {
+                              name: 'cacheReadTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens read.',
+                            },
+                            {
+                              name: 'cacheWriteTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens written.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1061,14 +1066,19 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the output (completion) tokens.',
                       properties: [
                         {
-                          name: 'textTokens',
-                          type: 'number | undefined',
-                          description: 'The number of text tokens used.',
-                        },
-                        {
-                          name: 'reasoningTokens',
-                          type: 'number | undefined',
-                          description: 'The number of reasoning tokens used.',
+                          type: 'LanguageModelOutputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'textTokens',
+                              type: 'number | undefined',
+                              description: 'The number of text tokens used.',
+                            },
+                            {
+                              name: 'reasoningTokens',
+                              type: 'number | undefined',
+                              description: 'The number of reasoning tokens used.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1274,22 +1284,27 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
                       properties: [
                         {
-                          name: 'noCacheTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of non-cached input (prompt) tokens used.',
-                        },
-                        {
-                          name: 'cacheReadTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens read.',
-                        },
-                        {
-                          name: 'cacheWriteTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens written.',
+                          type: 'LanguageModelInputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'noCacheTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of non-cached input (prompt) tokens used.',
+                            },
+                            {
+                              name: 'cacheReadTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens read.',
+                            },
+                            {
+                              name: 'cacheWriteTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens written.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1306,14 +1321,19 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the output (completion) tokens.',
                       properties: [
                         {
-                          name: 'textTokens',
-                          type: 'number | undefined',
-                          description: 'The number of text tokens used.',
-                        },
-                        {
-                          name: 'reasoningTokens',
-                          type: 'number | undefined',
-                          description: 'The number of reasoning tokens used.',
+                          type: 'LanguageModelOutputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'textTokens',
+                              type: 'number | undefined',
+                              description: 'The number of text tokens used.',
+                            },
+                            {
+                              name: 'reasoningTokens',
+                              type: 'number | undefined',
+                              description: 'The number of reasoning tokens used.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1672,22 +1692,27 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
                       properties: [
                         {
-                          name: 'noCacheTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of non-cached input (prompt) tokens used.',
-                        },
-                        {
-                          name: 'cacheReadTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens read.',
-                        },
-                        {
-                          name: 'cacheWriteTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens written.',
+                          type: 'LanguageModelInputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'noCacheTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of non-cached input (prompt) tokens used.',
+                            },
+                            {
+                              name: 'cacheReadTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens read.',
+                            },
+                            {
+                              name: 'cacheWriteTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens written.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -1703,14 +1728,19 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the output (completion) tokens.',
                       properties: [
                         {
-                          name: 'textTokens',
-                          type: 'number | undefined',
-                          description: 'The number of text tokens used.',
-                        },
-                        {
-                          name: 'reasoningTokens',
-                          type: 'number | undefined',
-                          description: 'The number of reasoning tokens used.',
+                          type: 'LanguageModelOutputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'textTokens',
+                              type: 'number | undefined',
+                              description: 'The number of text tokens used.',
+                            },
+                            {
+                              name: 'reasoningTokens',
+                              type: 'number | undefined',
+                              description: 'The number of reasoning tokens used.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -2053,22 +2083,27 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
                       properties: [
                         {
-                          name: 'noCacheTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of non-cached input (prompt) tokens used.',
-                        },
-                        {
-                          name: 'cacheReadTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens read.',
-                        },
-                        {
-                          name: 'cacheWriteTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens written.',
+                          type: 'LanguageModelInputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'noCacheTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of non-cached input (prompt) tokens used.',
+                            },
+                            {
+                              name: 'cacheReadTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens read.',
+                            },
+                            {
+                              name: 'cacheWriteTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens written.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -2084,14 +2119,19 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the output (completion) tokens.',
                       properties: [
                         {
-                          name: 'textTokens',
-                          type: 'number | undefined',
-                          description: 'The number of text tokens used.',
-                        },
-                        {
-                          name: 'reasoningTokens',
-                          type: 'number | undefined',
-                          description: 'The number of reasoning tokens used.',
+                          type: 'LanguageModelOutputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'textTokens',
+                              type: 'number | undefined',
+                              description: 'The number of text tokens used.',
+                            },
+                            {
+                              name: 'reasoningTokens',
+                              type: 'number | undefined',
+                              description: 'The number of reasoning tokens used.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -2533,22 +2573,27 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
                       properties: [
                         {
-                          name: 'noCacheTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of non-cached input (prompt) tokens used.',
-                        },
-                        {
-                          name: 'cacheReadTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens read.',
-                        },
-                        {
-                          name: 'cacheWriteTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens written.',
+                          type: 'LanguageModelInputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'noCacheTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of non-cached input (prompt) tokens used.',
+                            },
+                            {
+                              name: 'cacheReadTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens read.',
+                            },
+                            {
+                              name: 'cacheWriteTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens written.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -2564,14 +2609,19 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the output (completion) tokens.',
                       properties: [
                         {
-                          name: 'textTokens',
-                          type: 'number | undefined',
-                          description: 'The number of text tokens used.',
-                        },
-                        {
-                          name: 'reasoningTokens',
-                          type: 'number | undefined',
-                          description: 'The number of reasoning tokens used.',
+                          type: 'LanguageModelOutputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'textTokens',
+                              type: 'number | undefined',
+                              description: 'The number of text tokens used.',
+                            },
+                            {
+                              name: 'reasoningTokens',
+                              type: 'number | undefined',
+                              description: 'The number of reasoning tokens used.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -2647,22 +2697,27 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
                       properties: [
                         {
-                          name: 'noCacheTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of non-cached input (prompt) tokens used.',
-                        },
-                        {
-                          name: 'cacheReadTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens read.',
-                        },
-                        {
-                          name: 'cacheWriteTokens',
-                          type: 'number | undefined',
-                          description:
-                            'The number of cached input (prompt) tokens written.',
+                          type: 'LanguageModelInputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'noCacheTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of non-cached input (prompt) tokens used.',
+                            },
+                            {
+                              name: 'cacheReadTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens read.',
+                            },
+                            {
+                              name: 'cacheWriteTokens',
+                              type: 'number | undefined',
+                              description:
+                                'The number of cached input (prompt) tokens written.',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -2678,14 +2733,19 @@ To see `streamText` in action, check out [these examples](#examples).
                         'Detailed information about the output (completion) tokens.',
                       properties: [
                         {
-                          name: 'textTokens',
-                          type: 'number | undefined',
-                          description: 'The number of text tokens used.',
-                        },
-                        {
-                          name: 'reasoningTokens',
-                          type: 'number | undefined',
-                          description: 'The number of reasoning tokens used.',
+                          type: 'LanguageModelOutputTokenDetails',
+                          parameters: [
+                            {
+                              name: 'textTokens',
+                              type: 'number | undefined',
+                              description: 'The number of text tokens used.',
+                            },
+                            {
+                              name: 'reasoningTokens',
+                              type: 'number | undefined',
+                              description: 'The number of reasoning tokens used.',
+                            },
+                          ],
                         },
                       ],
                     },

--- a/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/03-generate-object.mdx
@@ -604,22 +604,27 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
                 'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
               properties: [
                 {
-                  name: 'noCacheTokens',
-                  type: 'number | undefined',
-                  description:
-                    'The number of non-cached input (prompt) tokens used.',
-                },
-                {
-                  name: 'cacheReadTokens',
-                  type: 'number | undefined',
-                  description:
-                    'The number of cached input (prompt) tokens read.',
-                },
-                {
-                  name: 'cacheWriteTokens',
-                  type: 'number | undefined',
-                  description:
-                    'The number of cached input (prompt) tokens written.',
+                  type: 'LanguageModelInputTokenDetails',
+                  parameters: [
+                    {
+                      name: 'noCacheTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of non-cached input (prompt) tokens used.',
+                    },
+                    {
+                      name: 'cacheReadTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of cached input (prompt) tokens read.',
+                    },
+                    {
+                      name: 'cacheWriteTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of cached input (prompt) tokens written.',
+                    },
+                  ],
                 },
               ],
             },
@@ -636,14 +641,19 @@ To see `generateObject` in action, check out the [additional examples](#more-exa
                 'Detailed information about the output (completion) tokens.',
               properties: [
                 {
-                  name: 'textTokens',
-                  type: 'number | undefined',
-                  description: 'The number of text tokens used.',
-                },
-                {
-                  name: 'reasoningTokens',
-                  type: 'number | undefined',
-                  description: 'The number of reasoning tokens used.',
+                  type: 'LanguageModelOutputTokenDetails',
+                  parameters: [
+                    {
+                      name: 'textTokens',
+                      type: 'number | undefined',
+                      description: 'The number of text tokens used.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      description: 'The number of reasoning tokens used.',
+                    },
+                  ],
                 },
               ],
             },

--- a/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/04-stream-object.mdx
@@ -617,22 +617,27 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
                     'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
                   properties: [
                     {
-                      name: 'noCacheTokens',
-                      type: 'number | undefined',
-                      description:
-                        'The number of non-cached input (prompt) tokens used.',
-                    },
-                    {
-                      name: 'cacheReadTokens',
-                      type: 'number | undefined',
-                      description:
-                        'The number of cached input (prompt) tokens read.',
-                    },
-                    {
-                      name: 'cacheWriteTokens',
-                      type: 'number | undefined',
-                      description:
-                        'The number of cached input (prompt) tokens written.',
+                      type: 'LanguageModelInputTokenDetails',
+                      parameters: [
+                        {
+                          name: 'noCacheTokens',
+                          type: 'number | undefined',
+                          description:
+                            'The number of non-cached input (prompt) tokens used.',
+                        },
+                        {
+                          name: 'cacheReadTokens',
+                          type: 'number | undefined',
+                          description:
+                            'The number of cached input (prompt) tokens read.',
+                        },
+                        {
+                          name: 'cacheWriteTokens',
+                          type: 'number | undefined',
+                          description:
+                            'The number of cached input (prompt) tokens written.',
+                        },
+                      ],
                     },
                   ],
                 },
@@ -649,14 +654,19 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
                     'Detailed information about the output (completion) tokens.',
                   properties: [
                     {
-                      name: 'textTokens',
-                      type: 'number | undefined',
-                      description: 'The number of text tokens used.',
-                    },
-                    {
-                      name: 'reasoningTokens',
-                      type: 'number | undefined',
-                      description: 'The number of reasoning tokens used.',
+                      type: 'LanguageModelOutputTokenDetails',
+                      parameters: [
+                        {
+                          name: 'textTokens',
+                          type: 'number | undefined',
+                          description: 'The number of text tokens used.',
+                        },
+                        {
+                          name: 'reasoningTokens',
+                          type: 'number | undefined',
+                          description: 'The number of reasoning tokens used.',
+                        },
+                      ],
                     },
                   ],
                 },
@@ -767,22 +777,27 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
                 'Detailed information about the input (prompt) tokens. See also: cached tokens and non-cached tokens.',
               properties: [
                 {
-                  name: 'noCacheTokens',
-                  type: 'number | undefined',
-                  description:
-                    'The number of non-cached input (prompt) tokens used.',
-                },
-                {
-                  name: 'cacheReadTokens',
-                  type: 'number | undefined',
-                  description:
-                    'The number of cached input (prompt) tokens read.',
-                },
-                {
-                  name: 'cacheWriteTokens',
-                  type: 'number | undefined',
-                  description:
-                    'The number of cached input (prompt) tokens written.',
+                  type: 'LanguageModelInputTokenDetails',
+                  parameters: [
+                    {
+                      name: 'noCacheTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of non-cached input (prompt) tokens used.',
+                    },
+                    {
+                      name: 'cacheReadTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of cached input (prompt) tokens read.',
+                    },
+                    {
+                      name: 'cacheWriteTokens',
+                      type: 'number | undefined',
+                      description:
+                        'The number of cached input (prompt) tokens written.',
+                    },
+                  ],
                 },
               ],
             },
@@ -799,14 +814,19 @@ To see `streamObject` in action, check out the [additional examples](#more-examp
                 'Detailed information about the output (completion) tokens.',
               properties: [
                 {
-                  name: 'textTokens',
-                  type: 'number | undefined',
-                  description: 'The number of text tokens used.',
-                },
-                {
-                  name: 'reasoningTokens',
-                  type: 'number | undefined',
-                  description: 'The number of reasoning tokens used.',
+                  type: 'LanguageModelOutputTokenDetails',
+                  parameters: [
+                    {
+                      name: 'textTokens',
+                      type: 'number | undefined',
+                      description: 'The number of text tokens used.',
+                    },
+                    {
+                      name: 'reasoningTokens',
+                      type: 'number | undefined',
+                      description: 'The number of reasoning tokens used.',
+                    },
+                  ],
                 },
               ],
             },


### PR DESCRIPTION
Follow up to #11002 