### PR TITLE
support `name` in OpenAI, xAI, and DeepSeek user and assistant messages via `ModelMessage` `ProviderOptions`

### DIFF
--- a/.changeset/tame-walls-smell.md
+++ b/.changeset/tame-walls-smell.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/deepseek': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/xai': patch
+---
+
+added support for passing `name` in user and asssistant messages for xAI, OpenAI, and DeepSeek

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -130,6 +130,10 @@ The following optional provider options are available for xAI chat models:
 
   The ID of the previous response. You can use it to continue a conversation. Defaults to `undefined`.
 
+- **name** _string_
+
+  A per-message unique identifier representing your end-user, which can help xAI to monitor and detect abuse. Corresponds to `messages` `name` in https://docs.x.ai/docs/api-reference#chat-completions
+
 ## Responses API (Agentic Tools)
 
 You can use the xAI Responses API with the `xai.responses(modelId)` factory method for server-side agentic tool calling. This enables the model to autonomously orchestrate tool calls and research on xAI's servers.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -246,6 +246,9 @@ The following provider options are available:
 - **safetyIdentifier** _string_
   A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies. The IDs should be a string that uniquely identifies each user.
 
+- **name** _string_
+  An optional name for the participant. Provides the model information to differentiate between participants of the same role. Corresponds to `messages` `name` in https://platform.openai.com/docs/api-reference/chat/create#chat_create-messages-user_message-name 
+
 The OpenAI responses provider also returns provider-specific metadata:
 
 ```ts

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -329,4 +329,45 @@ describe('convertToDeepSeekChatMessages', () => {
       `);
     });
   });
+
+  it('passes through openai name on user messages', () => {
+    const { messages, warnings } = convertToDeepSeekChatMessages({
+      prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+        providerOptions: { openai: { name: 'alice' } },
+      },
+    ],
+    responseFormat: undefined,
+  });
+
+    expect(warnings).toEqual([]);
+    expect(messages).toEqual([
+      { role: 'user', content: 'Hello', name: 'alice' },
+    ]);
+  });
+
+  it('passes through openai name on assistant messages', () => {
+    const { messages, warnings } = convertToDeepSeekChatMessages({
+      prompt: [
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi' }],
+        providerOptions: { deepseek: { name: 'deepseek-bot' } },
+      },
+    ],
+    responseFormat: undefined,
+    });
+
+    expect(warnings).toEqual([]);
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: 'Hi',
+        tool_calls: undefined,
+        name: 'deepseek-bot',
+      },
+    ]);
+  });
 });

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -2,8 +2,18 @@ import {
   LanguageModelV3CallOptions,
   LanguageModelV3Prompt,
   SharedV3Warning,
+  SharedV3ProviderOptions,
 } from '@ai-sdk/provider';
 import { DeepSeekChatPrompt } from './deepseek-chat-api-types';
+
+function getDeepSeekMessageName(
+  providerOptions?: SharedV3ProviderOptions,
+): string | undefined {
+  const name = providerOptions?.deepseek?.name;
+  return typeof name === 'string' && name.trim().length > 0
+    ? name
+    : undefined;
+}
 
 export function convertToDeepSeekChatMessages({
   prompt,
@@ -50,9 +60,10 @@ export function convertToDeepSeekChatMessages({
   }
 
   let index = -1;
-  for (const { role, content } of prompt) {
+  for (const { role, content, providerOptions } of prompt) {
     index++;
 
+    const name = getDeepSeekMessageName(providerOptions);
     switch (role) {
       case 'system': {
         messages.push({ role: 'system', content });
@@ -75,6 +86,7 @@ export function convertToDeepSeekChatMessages({
         messages.push({
           role: 'user',
           content: userContent,
+          ...(name ? { name: name } : {}),
         });
 
         break;
@@ -126,6 +138,7 @@ export function convertToDeepSeekChatMessages({
           content: text,
           reasoning_content: reasoning,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+          ...(name ? { name: name } : {}),
         });
 
         break;

--- a/packages/deepseek/src/chat/deepseek-chat-api-types.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-api-types.ts
@@ -17,6 +17,7 @@ export interface DeepSeekSystemMessage {
 export interface DeepSeekUserMessage {
   role: 'user';
   content: string;
+  name?: string;
 }
 
 export interface DeepSeekAssistantMessage {
@@ -24,6 +25,7 @@ export interface DeepSeekAssistantMessage {
   content?: string | null;
   reasoning_content?: string;
   tool_calls?: Array<DeepSeekMessageToolCall>;
+  name?: string;
 }
 
 export interface DeepSeekMessageToolCall {

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.test.ts
@@ -513,4 +513,41 @@ describe('tool calls', () => {
       ]
     `);
   });
+
+  it('passes through openai name on user messages', () => {
+    const { messages, warnings } = convertToOpenAIChatMessages({
+      prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+        providerOptions: { openai: { name: 'alice' } },
+      },
+    ]});
+
+    expect(warnings).toEqual([]);
+    expect(messages).toEqual([
+      { role: 'user', content: 'Hello', name: 'alice' },
+    ]);
+  });
+
+  it('passes through openai name on assistant messages', () => {
+    const { messages, warnings } = convertToOpenAIChatMessages({
+      prompt: [
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi' }],
+        providerOptions: { openai: { name: 'openai-bot' } },
+      },
+    ]});
+
+    expect(warnings).toEqual([]);
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: 'Hi',
+        tool_calls: undefined,
+        name: 'openai-bot',
+      },
+    ]);
+  });
 });

--- a/packages/openai/src/chat/convert-to-openai-chat-messages.ts
+++ b/packages/openai/src/chat/convert-to-openai-chat-messages.ts
@@ -2,9 +2,19 @@ import {
   SharedV3Warning,
   LanguageModelV3Prompt,
   UnsupportedFunctionalityError,
+  SharedV3ProviderOptions,
 } from '@ai-sdk/provider';
 import { OpenAIChatPrompt } from './openai-chat-prompt';
 import { convertToBase64 } from '@ai-sdk/provider-utils';
+
+function getOpenAIMessageName(
+  providerOptions?: SharedV3ProviderOptions,
+): string | undefined {
+  const name = providerOptions?.openai?.name;
+  return typeof name === 'string' && name.trim().length > 0
+    ? name
+    : undefined;
+}
 
 export function convertToOpenAIChatMessages({
   prompt,
@@ -19,7 +29,8 @@ export function convertToOpenAIChatMessages({
   const messages: OpenAIChatPrompt = [];
   const warnings: Array<SharedV3Warning> = [];
 
-  for (const { role, content } of prompt) {
+  for (const { role, content, providerOptions } of prompt) {
+    const name = getOpenAIMessageName(providerOptions);
     switch (role) {
       case 'system': {
         switch (systemMessageMode) {
@@ -140,6 +151,7 @@ export function convertToOpenAIChatMessages({
               }
             }
           }),
+          ...(name ? { name: name } : {}),
         });
 
         break;
@@ -177,6 +189,7 @@ export function convertToOpenAIChatMessages({
           role: 'assistant',
           content: text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+          ...(name ? { name: name } : {}),
         });
 
         break;

--- a/packages/openai/src/chat/openai-chat-prompt.ts
+++ b/packages/openai/src/chat/openai-chat-prompt.ts
@@ -20,6 +20,7 @@ export interface ChatCompletionDeveloperMessage {
 export interface ChatCompletionUserMessage {
   role: 'user';
   content: string | Array<ChatCompletionContentPart>;
+  name?: string;
 }
 
 export type ChatCompletionContentPart =
@@ -52,6 +53,7 @@ export interface ChatCompletionAssistantMessage {
   role: 'assistant';
   content?: string | null;
   tool_calls?: Array<ChatCompletionMessageToolCall>;
+  name?: string;
 }
 
 export interface ChatCompletionMessageToolCall {

--- a/packages/xai/src/convert-to-xai-chat-messages.test.ts
+++ b/packages/xai/src/convert-to-xai-chat-messages.test.ts
@@ -240,4 +240,39 @@ describe('convertToXaiChatMessages', () => {
       },
     ]);
   });
+
+  it('passes through xai name on user messages', () => {
+    const { messages, warnings } = convertToXaiChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+        providerOptions: { xai: { name: 'alice' } },
+      },
+    ]);
+
+    expect(warnings).toEqual([]);
+    expect(messages).toEqual([
+      { role: 'user', content: 'Hello', name: 'alice' },
+    ]);
+  });
+
+  it('passes through xai name on assistant messages', () => {
+    const { messages, warnings } = convertToXaiChatMessages([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi' }],
+        providerOptions: { xai: { name: 'grok-bot' } },
+      },
+    ]);
+
+    expect(warnings).toEqual([]);
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: 'Hi',
+        tool_calls: undefined,
+        name: 'grok-bot',
+      },
+    ]);
+  });
 });

--- a/packages/xai/src/xai-chat-prompt.ts
+++ b/packages/xai/src/xai-chat-prompt.ts
@@ -14,6 +14,7 @@ export interface XaiSystemMessage {
 export interface XaiUserMessage {
   role: 'user';
   content: string | Array<XaiUserMessageContent>;
+  name?: string;
 }
 
 export type XaiUserMessageContent =
@@ -28,6 +29,7 @@ export interface XaiAssistantMessage {
     type: 'function';
     function: { name: string; arguments: string };
   }>;
+  name?: string;
 }
 
 export interface XaiToolMessage {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

 the xAI chat completions API ( https://docs.x.ai/docs/api-reference#chat-completions ),
 openAI chat completions API (`https://platform.openai.com/docs/api-reference/chat/create#chat_create-messages-user_message-name`), and
 DeepSeek chat completions API ( https://api-docs.deepseek.com/api/create-chat-completion#request )
 all  supports user or assistant messages with an optional `name` parameter , but there is no way to pass that via Vercel AI SDK right now

## Summary

adds support for `name` in xAI user and assistant messages via `ModelMessage` `ProviderOptions`

## Manual Verification

added tests

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
Remove the section if it's not needed.
-->
