### PR TITLE
feat(agent): export AgentCallParameters and AgentStreamParameters types

### DIFF
--- a/.changeset/flat-toes-clean.md
+++ b/.changeset/flat-toes-clean.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(agent): export AgentCallParameters and AgentStreamParameters types

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -1,4 +1,8 @@
-export { type Agent } from './agent';
+export {
+  type Agent,
+  type AgentCallParameters,
+  type AgentStreamParameters,
+} from './agent';
 export { type ToolLoopAgentOnFinishCallback } from './tool-loop-agent-on-finish-callback';
 export { type ToolLoopAgentOnStepFinishCallback } from './tool-loop-agent-on-step-finish-callback';
 export {


### PR DESCRIPTION
## Background

`AgentCallParameters` and `AgentStreamParameters` are needed for building custom `Agent` implementations.

## Summary

Export `AgentCallParameters` and `AgentStreamParameters` types.