### PR TITLE
feat(agent): support context in onFinish callback

### DIFF
--- a/.changeset/honest-ravens-fix.md
+++ b/.changeset/honest-ravens-fix.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(agent): support context in onFinish callback

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -112,6 +112,13 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         'Callback invoked after each agent step (LLM/tool call) completes.',
     },
     {
+      name: 'onFinish',
+      type: 'ToolLoopAgentOnFinishCallback',
+      isOptional: true,
+      description:
+        'Callback that is called when all agent steps are finished and the response is complete. Receives { steps, result, experimental_context }.',
+    },
+    {
       name: 'experimental_context',
       type: 'unknown',
       isOptional: true,

--- a/packages/ai/src/agent/tool-loop-agent-on-finish-callback.ts
+++ b/packages/ai/src/agent/tool-loop-agent-on-finish-callback.ts
@@ -10,13 +10,22 @@ Callback that is set using the `onFinish` option.
 export type ToolLoopAgentOnFinishCallback<TOOLS extends ToolSet = {}> = (
   event: StepResult<TOOLS> & {
     /**
-Details for all steps.
-   */
+     * Details for all steps.
+     */
     readonly steps: StepResult<TOOLS>[];
 
     /**
-Total usage for all steps. This is the sum of the usage of all steps.
+     * Total usage for all steps. This is the sum of the usage of all steps.
      */
     readonly totalUsage: LanguageModelUsage;
+
+    /**
+     * Context that is passed into tool calls.
+     *
+     * Experimental (can break in patch releases).
+     *
+     * @default undefined
+     */
+    experimental_context?: unknown;
   },
 ) => PromiseLike<void> | void;


### PR DESCRIPTION
## Background

Context needed to be supported in `ToolLoopAgent` `onFinish` as well.

## Summary

Add `experimental_context` to `ToolLoopAgent.onFinish` callback definition.

## Related Issues

Follow up from #11029
Resolves #11017 