### PR TITLE
fix(docs): Update deprecated Cohere model ID in README

### DIFF
--- a/.changeset/eighty-eyes-develop.md
+++ b/.changeset/eighty-eyes-develop.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cohere': patch
+---
+
+fix(docs): Update deprecated Cohere model ID in README

--- a/packages/cohere/README.md
+++ b/packages/cohere/README.md
@@ -25,7 +25,7 @@ import { cohere } from '@ai-sdk/cohere';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: cohere('command-r-plus'),
+  model: cohere('command-nightly'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background

The README for the `@ai-sdk/cohere` package references the model ID `command-r-plus`, which has been deprecated by Cohere. Developers following the documentation would encounter issues using this outdated model.

## Summary

Updated the README to replace the deprecated `command-r-plus` model ID with the currently active and supported model: `command-nightly`.

This ensures that the usage examples remain accurate and functional for developers integrating Cohere models through the AI SDK.

## Manual Verification

Not applicable — this is a documentation-only update.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

None at this time.

## Related Issues

N/A
