### PR TITLE
feat(provider/openai): add support for OpenAI xhigh reasoning effort

### DIFF
--- a/.changeset/wise-bags-return.md
+++ b/.changeset/wise-bags-return.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add support for OpenAI xhigh reasoning effort

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -189,13 +189,14 @@ The following provider options are available:
 - **user** _string_
   A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. Defaults to `undefined`.
 
-- **reasoningEffort** _'none' | 'minimal' | 'low' | 'medium' | 'high'_
+- **reasoningEffort** _'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'_
   Reasoning effort for reasoning models. Defaults to `medium`. If you use `providerOptions` to set the `reasoningEffort` option, this model setting will be ignored.
 
 <Note>
   The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
   models. Setting `reasoningEffort` to 'none' with other models will result in
-  an error.
+  an error. Also, the 'none' type for `reasoningEffort` is only available for 
+  OpenAI's GPT-5.1-Codex-Max model.
 </Note>
 
 - **reasoningSummary** _'auto' | 'detailed'_
@@ -875,7 +876,7 @@ The following optional provider options are available for OpenAI chat models:
   A unique identifier representing your end-user, which can help OpenAI to
   monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
 
-- **reasoningEffort** _'minimal' | 'low' | 'medium' | 'high'_
+- **reasoningEffort** _'minimal' | 'low' | 'medium' | 'high' | 'xhigh'_
 
   Reasoning effort for reasoning models. Defaults to `medium`. If you use
   `providerOptions` to set the `reasoningEffort` option, this

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -194,9 +194,9 @@ The following provider options are available:
 
 <Note>
   The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
-  models. Also, the 'xhigh' type for `reasoningEffort` is only available for 
-  OpenAI's GPT-5.1-Codex-Max model. Setting `reasoningEffort` to 'none' or 'xhigh' with unsupported models will result in
-  an error.
+  models. Also, the 'xhigh' type for `reasoningEffort` is only available for
+  OpenAI's GPT-5.1-Codex-Max model. Setting `reasoningEffort` to 'none' or
+  'xhigh' with unsupported models will result in an error.
 </Note>
 
 - **reasoningSummary** _'auto' | 'detailed'_

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -194,9 +194,9 @@ The following provider options are available:
 
 <Note>
   The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
-  models. Setting `reasoningEffort` to 'none' with other models will result in
-  an error. Also, the 'none' type for `reasoningEffort` is only available for 
-  OpenAI's GPT-5.1-Codex-Max model.
+  models. Also, the 'xhigh' type for `reasoningEffort` is only available for 
+  OpenAI's GPT-5.1-Codex-Max model. Setting `reasoningEffort` to 'none' or 'xhigh' with unsupported models will result in
+  an error.
 </Note>
 
 - **reasoningSummary** _'auto' | 'detailed'_

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -543,6 +543,25 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should pass reasoningEffort xhigh setting', async () => {
+    prepareJsonResponse({ content: '' });
+
+    const model = provider.chat('gpt-5.1-codex-max');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: { reasoningEffort: 'xhigh' },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-5.1-codex-max',
+      messages: [{ role: 'user', content: 'Hello' }],
+      reasoning_effort: 'xhigh',
+    });
+  });
+
   it('should pass textVerbosity setting from provider options', async () => {
     prepareJsonResponse({ content: '' });
 

--- a/packages/openai/src/chat/openai-chat-options.ts
+++ b/packages/openai/src/chat/openai-chat-options.ts
@@ -79,7 +79,7 @@ export const openaiChatLanguageModelOptions = lazySchema(() =>
        * Reasoning effort for reasoning models. Defaults to `medium`.
        */
       reasoningEffort: z
-        .enum(['none', 'minimal', 'low', 'medium', 'high'])
+        .enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
         .optional(),
 
       /**

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -751,6 +751,32 @@ describe('OpenAIResponsesLanguageModel', () => {
         },
       );
 
+      it('should send xhigh reasoningEffort for codex-max model', async () => {
+        const { warnings } = await createModel('gpt-5.1-codex-max').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              reasoningEffort: 'xhigh',
+            } satisfies OpenAIResponsesProviderOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5.1-codex-max',
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+          reasoning: {
+            effort: 'xhigh',
+          },
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
       it.each(nonReasoningModelIds)(
         'should not send and warn about unsupported reasoningEffort and reasoningSummary provider options for %s',
         async modelId => {

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -215,11 +215,10 @@ export const openaiResponsesProviderOptionsSchema = lazySchema(() =>
        * `providerOptions` to set the `reasoningEffort` option, this model setting will be ignored.
        * Valid values: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
        *
-       * Note: The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
-       * models. Setting `reasoningEffort` to 'none' with other models will result in
+       * The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
+       * models. Also, the 'xhigh' type for `reasoningEffort` is only available for
+       * OpenAI's GPT-5.1-Codex-Max model. Setting `reasoningEffort` to 'none' or 'xhigh' with unsupported models will result in
        * an error.
-       * 
-       * Note: The 'xhigh' type for `reasoningEffort` is only available for OpenAI's GPT-5.1-Codex-Max model.
        */
       reasoningEffort: z.string().nullish(),
 

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -213,11 +213,13 @@ export const openaiResponsesProviderOptionsSchema = lazySchema(() =>
       /**
        * Reasoning effort for reasoning models. Defaults to `medium`. If you use
        * `providerOptions` to set the `reasoningEffort` option, this model setting will be ignored.
-       * Valid values: 'none' | 'minimal' | 'low' | 'medium' | 'high'
+       * Valid values: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
        *
        * Note: The 'none' type for `reasoningEffort` is only available for OpenAI's GPT-5.1
        * models. Setting `reasoningEffort` to 'none' with other models will result in
        * an error.
+       * 
+       * Note: The 'xhigh' type for `reasoningEffort` is only available for OpenAI's GPT-5.1-Codex-Max model.
        */
       reasoningEffort: z.string().nullish(),
 


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
GPT-5.1-Codex-Max now supports the `xhigh` reasoningEffort value

## Summary
Added support for it

## Manual Verification
Verified that for both the chat completions API and the responses API, requests with xhigh work for gpt-5.1-codex-max and fail for other models.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [X]  Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)