### PR TITLE
feat(ai): print model warnings in embed and embedMany

### DIFF
--- a/.changeset/strong-turkeys-push.md
+++ b/.changeset/strong-turkeys-push.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): print model warnings in embed and embedMany

--- a/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/05-embed.mdx
@@ -149,6 +149,12 @@ const { embedding } = await embed({
       ],
     },
     {
+      name: 'warnings',
+      type: 'Warning[]',
+      description:
+        'Warnings from the model provider (e.g. unsupported settings).',
+    },
+    {
       name: 'response',
       type: 'Response',
       isOptional: true,

--- a/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/06-embed-many.mdx
@@ -150,15 +150,15 @@ const { embeddings } = await embedMany({
               type: 'number',
               description: 'The total number of input tokens.',
             },
-            {
-              name: 'body',
-              type: 'unknown',
-              isOptional: true,
-              description: 'The response body.',
-            },
           ],
         },
       ],
+    },
+    {
+      name: 'warnings',
+      type: 'Warning[]',
+      description:
+        'Warnings from the model provider (e.g. unsupported settings).',
     },
     {
       name: 'providerMetadata',

--- a/examples/ai-core/src/embed-many/amazon-bedrock.ts
+++ b/examples/ai-core/src/embed-many/amazon-bedrock.ts
@@ -3,7 +3,7 @@ import { embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model: bedrock.embedding('amazon.titan-embed-text-v2:0'),
     values: [
       'sunny day at the beach',
@@ -14,6 +14,7 @@ async function main() {
 
   console.log(embeddings);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/azure.ts
+++ b/examples/ai-core/src/embed-many/azure.ts
@@ -3,7 +3,7 @@ import { embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model: azure.embedding('text-embedding-3-large'), // use your own deployment
     values: [
       'sunny day at the beach',
@@ -14,6 +14,7 @@ async function main() {
 
   console.log(embeddings);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/baseten.ts
+++ b/examples/ai-core/src/embed-many/baseten.ts
@@ -12,7 +12,7 @@ async function main() {
     modelURL: EMBEDDING_MODEL_URL,
   });
 
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model: baseten.embeddingModel(),
     values: [
       'sunny day at the beach',
@@ -26,6 +26,7 @@ async function main() {
   console.log('Embedding dimension:', embeddings[0].length);
   console.log('First embedding (first 5 values):', embeddings[0].slice(0, 5));
   console.log('Usage:', usage);
+  console.log('Warnings:', warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/cohere.ts
+++ b/examples/ai-core/src/embed-many/cohere.ts
@@ -3,7 +3,7 @@ import { embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model: cohere.embedding('embed-multilingual-v3.0'),
     values: [
       'sunny day at the beach',
@@ -14,6 +14,7 @@ async function main() {
 
   console.log(embeddings);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/gateway.ts
+++ b/examples/ai-core/src/embed-many/gateway.ts
@@ -13,6 +13,7 @@ async function main() {
 
   console.log('Embeddings:', result.embeddings);
   console.log('Usage:', result.usage);
+  console.log('Warnings:', result.warnings);
 
   if (result.providerMetadata) {
     console.log('\nProvider Metadata:');

--- a/examples/ai-core/src/embed-many/google-vertex.ts
+++ b/examples/ai-core/src/embed-many/google-vertex.ts
@@ -3,7 +3,7 @@ import { embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model: vertex.embeddingModel('text-embedding-004'),
     values: [
       'sunny day at the beach',
@@ -14,6 +14,7 @@ async function main() {
 
   console.log(embeddings);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/google.ts
+++ b/examples/ai-core/src/embed-many/google.ts
@@ -3,7 +3,7 @@ import { embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model: google.embeddingModel('gemini-embedding-001'),
     values: [
       'sunny day at the beach',
@@ -14,6 +14,7 @@ async function main() {
 
   console.log(embeddings);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/mistral.ts
+++ b/examples/ai-core/src/embed-many/mistral.ts
@@ -3,7 +3,7 @@ import { embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model: mistral.embedding('mistral-embed'),
     values: [
       'sunny day at the beach',
@@ -14,6 +14,7 @@ async function main() {
 
   console.log(embeddings);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/openai-compatible-togetherai.ts
+++ b/examples/ai-core/src/embed-many/openai-compatible-togetherai.ts
@@ -11,7 +11,7 @@ async function main() {
     },
   });
   const model = togetherai.embeddingModel('BAAI/bge-large-en-v1.5');
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model,
     values: [
       'sunny day at the beach',
@@ -22,6 +22,7 @@ async function main() {
 
   console.log(embeddings);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/openai-cosine-similarity.ts
+++ b/examples/ai-core/src/embed-many/openai-cosine-similarity.ts
@@ -3,7 +3,7 @@ import { cosineSimilarity, embedMany } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embeddings } = await embedMany({
+  const { embeddings, warnings } = await embedMany({
     model: openai.embedding('text-embedding-3-small'),
     values: ['sunny day at the beach', 'rainy afternoon in the city'],
   });
@@ -11,6 +11,7 @@ async function main() {
   console.log(
     `cosine similarity: ${cosineSimilarity(embeddings[0], embeddings[1])}`,
   );
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed-many/openai.ts
+++ b/examples/ai-core/src/embed-many/openai.ts
@@ -3,7 +3,7 @@ import { embedMany } from 'ai';
 import { run } from '../lib/run';
 
 run(async () => {
-  const { embeddings, usage } = await embedMany({
+  const { embeddings, usage, warnings } = await embedMany({
     model: openai.embedding('text-embedding-3-small'),
     values: [
       'sunny day at the beach',
@@ -14,4 +14,5 @@ run(async () => {
 
   console.log(embeddings);
   console.log(usage);
+  console.log(warnings);
 });

--- a/examples/ai-core/src/embed/amazon-bedrock.ts
+++ b/examples/ai-core/src/embed/amazon-bedrock.ts
@@ -3,13 +3,14 @@ import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: bedrock.embedding('amazon.titan-embed-text-v2:0'),
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/azure.ts
+++ b/examples/ai-core/src/embed/azure.ts
@@ -3,13 +3,14 @@ import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: azure.embedding('text-embedding-3-large'), // use your own deployment
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/baseten.ts
+++ b/examples/ai-core/src/embed/baseten.ts
@@ -12,7 +12,7 @@ async function main() {
     modelURL: EMBEDDING_MODEL_URL,
   });
 
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: baseten.embeddingModel(),
     value: 'sunny day at the beach',
   });
@@ -20,6 +20,7 @@ async function main() {
   console.log('Embedding dimension:', embedding.length);
   console.log('First 5 values:', embedding.slice(0, 5));
   console.log('Usage:', usage);
+  console.log('Warnings:', warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/cohere.ts
+++ b/examples/ai-core/src/embed/cohere.ts
@@ -3,13 +3,14 @@ import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: cohere.embedding('embed-multilingual-v3.0'),
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/gateway.ts
+++ b/examples/ai-core/src/embed/gateway.ts
@@ -9,6 +9,7 @@ async function main() {
 
   console.log('Embedding:', result.embedding);
   console.log('Usage:', result.usage);
+  console.log('Warnings:', result.warnings);
 
   if (result.providerMetadata) {
     console.log('\nProvider Metadata:');

--- a/examples/ai-core/src/embed/google-vertex.ts
+++ b/examples/ai-core/src/embed/google-vertex.ts
@@ -3,13 +3,14 @@ import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: vertex.embeddingModel('text-embedding-004'),
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/google.ts
+++ b/examples/ai-core/src/embed/google.ts
@@ -3,13 +3,14 @@ import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: google.embeddingModel('gemini-embedding-001'),
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/mistral.ts
+++ b/examples/ai-core/src/embed/mistral.ts
@@ -3,13 +3,14 @@ import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: mistral.embedding('mistral-embed'),
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/openai-compatible-togetherai.ts
+++ b/examples/ai-core/src/embed/openai-compatible-togetherai.ts
@@ -11,13 +11,14 @@ async function main() {
     },
   });
   const model = togetherai.embeddingModel('BAAI/bge-large-en-v1.5');
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model,
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/examples/ai-core/src/embed/openai.ts
+++ b/examples/ai-core/src/embed/openai.ts
@@ -3,11 +3,12 @@ import { embed } from 'ai';
 import { run } from '../lib/run';
 
 run(async () => {
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: openai.embedding('text-embedding-3-small'),
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 });

--- a/examples/ai-core/src/embed/togetherai.ts
+++ b/examples/ai-core/src/embed/togetherai.ts
@@ -3,13 +3,14 @@ import { embed } from 'ai';
 import 'dotenv/config';
 
 async function main() {
-  const { embedding, usage } = await embed({
+  const { embedding, usage, warnings } = await embed({
     model: togetherai.embeddingModel('BAAI/bge-base-en-v1.5'),
     value: 'sunny day at the beach',
   });
 
   console.log(embedding);
   console.log(usage);
+  console.log(warnings);
 }
 
 main().catch(console.error);

--- a/packages/ai/src/embed/embed-many-result.ts
+++ b/packages/ai/src/embed/embed-many-result.ts
@@ -1,6 +1,7 @@
 import { Embedding } from '../types';
 import { EmbeddingModelUsage } from '../types/usage';
 import { ProviderMetadata } from '../types';
+import { Warning } from '../types/warning';
 
 /**
 The result of a `embedMany` call.
@@ -21,6 +22,11 @@ export interface EmbedManyResult {
   The embedding token usage.
     */
   readonly usage: EmbeddingModelUsage;
+
+  /**
+  Warnings for the call, e.g. unsupported settings.
+    */
+  readonly warnings: Array<Warning>;
 
   /**
   Optional provider-specific metadata.

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -1,9 +1,10 @@
 import { EmbeddingModelV3 } from '@ai-sdk/provider';
 import assert from 'node:assert';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
+import * as logWarningsModule from '../logger/log-warnings';
 import { MockEmbeddingModelV3 } from '../test/mock-embedding-model-v3';
 import { MockTracer } from '../test/mock-tracer';
-import { Embedding, EmbeddingModelUsage } from '../types';
+import { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { createResolvablePromise } from '../util/create-resolvable-promise';
 import { embedMany } from './embed-many';
 
@@ -490,6 +491,146 @@ describe('result.providerMetadata', () => {
     });
 
     expect(result.providerMetadata).toStrictEqual(providerMetadata);
+  });
+});
+
+describe('result.warnings', () => {
+  it('should include warnings in the result (single call path)', async () => {
+    const expectedWarnings: Warning[] = [
+      {
+        type: 'other',
+        message: 'Setting is not supported',
+      },
+    ];
+
+    const result = await embedMany({
+      model: new MockEmbeddingModelV3({
+        maxEmbeddingsPerCall: null,
+        doEmbed: async () => ({
+          embeddings: dummyEmbeddings,
+          warnings: expectedWarnings,
+        }),
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual(expectedWarnings);
+  });
+
+  it('should aggregate warnings from multiple calls', async () => {
+    const warning1: Warning = {
+      type: 'other',
+      message: 'Warning from call 1',
+    };
+    const warning2: Warning = {
+      type: 'unsupported',
+      feature: 'dimensions',
+    };
+
+    let callCount = 0;
+
+    const result = await embedMany({
+      model: new MockEmbeddingModelV3({
+        maxEmbeddingsPerCall: 2,
+        doEmbed: async () => {
+          switch (callCount++) {
+            case 0:
+              return {
+                embeddings: dummyEmbeddings.slice(0, 2),
+                warnings: [warning1],
+              };
+            case 1:
+              return {
+                embeddings: dummyEmbeddings.slice(2),
+                warnings: [warning2],
+              };
+            default:
+              throw new Error('Unexpected call');
+          }
+        },
+      }),
+      values: testValues,
+    });
+
+    expect(result.warnings).toStrictEqual([warning1, warning2]);
+  });
+});
+
+describe('logWarnings', () => {
+  let logWarningsSpy: ReturnType<typeof vitest.spyOn>;
+
+  beforeEach(() => {
+    logWarningsSpy = vitest.spyOn(logWarningsModule, 'logWarnings');
+  });
+
+  it('should call logWarnings with the correct warnings (single call path)', async () => {
+    const expectedWarnings: Warning[] = [
+      {
+        type: 'other',
+        message: 'Setting is not supported',
+      },
+    ];
+
+    await embedMany({
+      model: new MockEmbeddingModelV3({
+        maxEmbeddingsPerCall: null,
+        doEmbed: async () => ({
+          embeddings: dummyEmbeddings,
+          warnings: expectedWarnings,
+        }),
+      }),
+      values: testValues,
+    });
+
+    expect(logWarningsSpy).toHaveBeenCalledOnce();
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: expectedWarnings,
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
+  });
+
+  it('should call logWarnings with aggregated warnings from multiple calls', async () => {
+    const warning1: Warning = {
+      type: 'other',
+      message: 'Warning from call 1',
+    };
+    const warning2: Warning = {
+      type: 'unsupported',
+      feature: 'dimensions',
+    };
+
+    let callCount = 0;
+
+    await embedMany({
+      model: new MockEmbeddingModelV3({
+        maxEmbeddingsPerCall: 2,
+        doEmbed: async () => {
+          switch (callCount++) {
+            case 0:
+              return {
+                embeddings: dummyEmbeddings.slice(0, 2),
+                warnings: [warning1],
+              };
+            case 1:
+              return {
+                embeddings: dummyEmbeddings.slice(2),
+                warnings: [warning2],
+              };
+            default:
+              throw new Error('Unexpected call');
+          }
+        },
+      }),
+      values: testValues,
+    });
+
+    expect(logWarningsSpy).toHaveBeenCalledOnce();
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: [warning1, warning2],
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 });
 

--- a/packages/ai/src/embed/embed-result.ts
+++ b/packages/ai/src/embed/embed-result.ts
@@ -1,6 +1,7 @@
 import { Embedding } from '../types';
 import { EmbeddingModelUsage } from '../types/usage';
 import { ProviderMetadata } from '../types';
+import { Warning } from '../types/warning';
 
 /**
 The result of an `embed` call.
@@ -21,6 +22,11 @@ export interface EmbedResult {
   The embedding token usage.
     */
   readonly usage: EmbeddingModelUsage;
+
+  /**
+  Warnings for the call, e.g. unsupported settings.
+    */
+  readonly warnings: Array<Warning>;
 
   /**
   Optional provider-specific metadata.

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -1,9 +1,10 @@
 import { EmbeddingModelV3 } from '@ai-sdk/provider';
 import assert from 'node:assert';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
+import * as logWarningsModule from '../logger/log-warnings';
 import { MockEmbeddingModelV3 } from '../test/mock-embedding-model-v3';
 import { MockTracer } from '../test/mock-tracer';
-import { Embedding, EmbeddingModelUsage } from '../types';
+import { Embedding, EmbeddingModelUsage, Warning } from '../types';
 import { embed } from './embed';
 
 const dummyEmbedding = [0.1, 0.2, 0.3];
@@ -151,6 +152,73 @@ describe('options.providerOptions', () => {
     });
 
     expect(result.embedding).toStrictEqual([1, 2, 3]);
+  });
+});
+
+describe('result.warnings', () => {
+  it('should include warnings in the result', async () => {
+    const expectedWarnings: Warning[] = [
+      {
+        type: 'other',
+        message: 'Setting is not supported',
+      },
+      {
+        type: 'unsupported',
+        feature: 'dimensions',
+        details: 'Dimensions parameter not supported',
+      },
+    ];
+
+    const result = await embed({
+      model: new MockEmbeddingModelV3({
+        doEmbed: async () => ({
+          embeddings: [dummyEmbedding],
+          warnings: expectedWarnings,
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(result.warnings).toStrictEqual(expectedWarnings);
+  });
+});
+
+describe('logWarnings', () => {
+  let logWarningsSpy: ReturnType<typeof vitest.spyOn>;
+
+  beforeEach(() => {
+    logWarningsSpy = vitest.spyOn(logWarningsModule, 'logWarnings');
+  });
+
+  it('should call logWarnings with the correct warnings', async () => {
+    const expectedWarnings: Warning[] = [
+      {
+        type: 'other',
+        message: 'Setting is not supported',
+      },
+      {
+        type: 'unsupported',
+        feature: 'dimensions',
+        details: 'Dimensions parameter not supported',
+      },
+    ];
+
+    await embed({
+      model: new MockEmbeddingModelV3({
+        doEmbed: async () => ({
+          embeddings: [dummyEmbedding],
+          warnings: expectedWarnings,
+        }),
+      }),
+      value: testValue,
+    });
+
+    expect(logWarningsSpy).toHaveBeenCalledOnce();
+    expect(logWarningsSpy).toHaveBeenCalledWith({
+      warnings: expectedWarnings,
+      provider: 'mock-provider',
+      model: 'mock-model-id',
+    });
   });
 });
 

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -1,4 +1,5 @@
 import { ProviderOptions, withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { logWarnings } from '../logger/log-warnings';
 import { resolveEmbeddingModel } from '../model/resolve-model';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
@@ -105,7 +106,8 @@ Only applicable for HTTP-based providers.
     }),
     tracer,
     fn: async span => {
-      const { embedding, usage, response, providerMetadata } = await retry(() =>
+      const { embedding, usage, warnings, response, providerMetadata } =
+        await retry(() =>
         // nested spans to align with the embedMany telemetry data:
         recordSpan({
           name: 'ai.embed.doEmbed',
@@ -151,6 +153,7 @@ Only applicable for HTTP-based providers.
             return {
               embedding,
               usage,
+              warnings: modelResponse.warnings,
               providerMetadata: modelResponse.providerMetadata,
               response: modelResponse.response,
             };
@@ -168,10 +171,13 @@ Only applicable for HTTP-based providers.
         }),
       );
 
+      logWarnings({ warnings, provider: model.provider, model: model.modelId });
+
       return new DefaultEmbedResult({
         value,
         embedding,
         usage,
+        warnings,
         providerMetadata,
         response,
       });
@@ -183,6 +189,7 @@ class DefaultEmbedResult implements EmbedResult {
   readonly value: EmbedResult['value'];
   readonly embedding: EmbedResult['embedding'];
   readonly usage: EmbedResult['usage'];
+  readonly warnings: EmbedResult['warnings'];
   readonly providerMetadata: EmbedResult['providerMetadata'];
   readonly response: EmbedResult['response'];
 
@@ -190,12 +197,14 @@ class DefaultEmbedResult implements EmbedResult {
     value: EmbedResult['value'];
     embedding: EmbedResult['embedding'];
     usage: EmbedResult['usage'];
+    warnings: EmbedResult['warnings'];
     providerMetadata?: EmbedResult['providerMetadata'];
     response?: EmbedResult['response'];
   }) {
     this.value = options.value;
     this.embedding = options.embedding;
     this.usage = options.usage;
+    this.warnings = options.warnings;
     this.providerMetadata = options.providerMetadata;
     this.response = options.response;
   }


### PR DESCRIPTION
## Background

embedding models support warnings in the v3 specification (added in #10711), but needed to log these warnings

## Summary

- add `warnings` property to `EmbedResult` and `EmbedManyResult` interfaces
- call `logWarnings` in both `embed` and `embedMany` functions
- aggregate warnings from multiple api calls in `embedMany`

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #10952

