### PR TITLE
fix(google): return request as object

### DIFF
--- a/.changeset/twelve-pets-juggle.md
+++ b/.changeset/twelve-pets-juggle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): return request as object

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -189,7 +189,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
     options: Parameters<LanguageModelV3['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV3['doGenerate']>>> {
     const { args, warnings } = await this.getArgs(options);
-    const body = JSON.stringify(args);
 
     const mergedHeaders = combineHeaders(
       await resolve(this.config.headers),
@@ -305,7 +304,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
           usageMetadata: usageMetadata ?? null,
         },
       },
-      request: { body },
+      request: { body: args },
       response: {
         // TODO timestamp, model id, id
         headers: responseHeaders,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -318,7 +318,6 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
   ): Promise<Awaited<ReturnType<LanguageModelV3['doStream']>>> {
     const { args, warnings } = await this.getArgs(options);
 
-    const body = JSON.stringify(args);
     const headers = combineHeaders(
       await resolve(this.config.headers),
       options.headers,
@@ -617,7 +616,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
         }),
       ),
       response: { headers: responseHeaders },
-      request: { body },
+      request: { body: args },
     };
   }
 }


### PR DESCRIPTION
## Background

The Google provider returned the request as stringified JSON. In AI SDK 6 the providers return json objects.

## Summary

Return unchanged args.

## Manual Verification

- [x] Run `examples/ai-core/src/generate-text/google-output-object-zod4.ts`