### PR TITLE
feat(provider/openai): add GPT 5.1 Codex Max to OpenAI Responses model IDs list

### DIFF
--- a/.changeset/gold-bees-drum.md
+++ b/.changeset/gold-bees-drum.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(provider/openai): add GPT 5.1 Codex Max to OpenAI Responses model IDs list

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -38,6 +38,7 @@ export const openaiResponsesReasoningModelIds = [
   'gpt-5.1-chat-latest',
   'gpt-5.1-codex-mini',
   'gpt-5.1-codex',
+  'gpt-5.1-codex-max',
 ] as const;
 
 export const openaiResponsesModelIds = [
@@ -102,6 +103,7 @@ export type OpenAIResponsesModelId =
   | 'gpt-5.1-chat-latest'
   | 'gpt-5.1-codex-mini'
   | 'gpt-5.1-codex'
+  | 'gpt-5.1-codex-max'
   | 'gpt-5-2025-08-07'
   | 'gpt-5-chat-latest'
   | 'gpt-5-codex'


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md
-->

## Background
In response to: https://github.com/vercel/ai/pull/11088#pullrequestreview-3568550863

## Summary
Added GPT 5.1 Codex Max to OpenAI Responses model IDs list

## Manual Verification
Ran a modified version of script `examples/ai-core/src/stream-text/openai-reasoning.ts`

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)