### PR TITLE
fix(devtools): prevent crash when displaying token usage across all models

### DIFF
--- a/.changeset/healthy-jars-sneeze.md
+++ b/.changeset/healthy-jars-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/devtools': patch
+---
+
+Fix crash caused by invalid token usage values in DevTools

--- a/packages/devtools/src/viewer/client/app.tsx
+++ b/packages/devtools/src/viewer/client/app.tsx
@@ -411,9 +411,13 @@ function App() {
     return steps.reduce(
       (acc, s) => {
         const usage = parseJson(s.usage);
+        const inputTokens =
+          typeof usage?.inputTokens === 'number' ? usage.inputTokens : 0;
+        const outputTokens =
+          typeof usage?.outputTokens === 'number' ? usage.outputTokens : 0;
         return {
-          input: acc.input + (usage?.inputTokens ?? 0),
-          output: acc.output + (usage?.outputTokens ?? 0),
+          input: acc.input + inputTokens,
+          output: acc.output + outputTokens,
         };
       },
       { input: 0, output: 0 },
@@ -711,16 +715,26 @@ function App() {
                                   <Tooltip>
                                     <TooltipTrigger asChild>
                                       <span className="text-[11px] font-mono text-muted-foreground">
-                                        {usage.inputTokens ?? 0}{' '}
+                                        {typeof usage.inputTokens === 'number'
+                                          ? usage.inputTokens
+                                          : 0}{' '}
                                         <span className="text-muted-foreground/50">
                                           →
                                         </span>{' '}
-                                        {usage.outputTokens ?? 0}
+                                        {typeof usage.outputTokens === 'number'
+                                          ? usage.outputTokens
+                                          : 0}
                                       </span>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                      Input: {usage.inputTokens ?? 0} · Output:{' '}
-                                      {usage.outputTokens ?? 0}
+                                      Input:{' '}
+                                      {typeof usage.inputTokens === 'number'
+                                        ? usage.inputTokens
+                                        : 0}{' '}
+                                      · Output:{' '}
+                                      {typeof usage.outputTokens === 'number'
+                                        ? usage.outputTokens
+                                        : 0}
                                     </TooltipContent>
                                   </Tooltip>
                                 )}


### PR DESCRIPTION
## Background

The codebase had potential runtime errors when handling usage token calculations. When `usage.inputTokens` or `usage.outputTokens` were non-numeric values (like null, undefined, or strings), the fallback operator ?? would only catch null and undefined, but wouldn't handle other edge cases. This could lead to NaN values being accumulated, breaking token usage tracking, and ultimately breaking the UI.


## Summary

- Replaced unsafe fallback operators with explicit type checking for token usage calculations.
- Changed from using the nullish coalescing operator (??) to properly validating that token values are numbers before using them. 

Now we can:

- Check if the value is actually a number using typeof
- Use 0 as the fallback if it's not
- Store the validated value in a variable for cleaner accumulation

### core fix
```
// Before (unsafe)
input: acc.input + (usage?.inputTokens ?? 0)

// After (type-safe)
const inputTokens = typeof usage?.inputTokens === 'number' ? usage.inputTokens : 0;
input: acc.input + inputTokens

```

## Manual Verification

- Tested with valid numeric token values - accumulation works correctly
- Tested with null/undefined token values - properly defaults to 0
- Tested with string/object token values - properly defaults to 0 instead of producing NaN
- Verified accumulated totals remain accurate across multiple usage objects
- Conducted UI rendering of all 3 types - `error` , `response` , `tool-call` with major providers like `Google` , `Anthropic` and `Openai`

Verified:

- No React runtime errors
- DevTools no longer crashes when viewing usage
- Token usage displays correctly when present
- Missing or non-numeric fields no longer break the UI
- Confirmed production build via pnpm build and pnpm start

## Checklist

- [] Tests have been added / updated (for bug fixes / features)
- [] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

This is more like a simple bug, not much work on this maybe. The token-usage is already in a standardised format 

## Related Issues

Fixes https://github.com/vercel/ai/issues/11096