### PR TITLE
docs(chatbot): update reload to regenerate in useChat examples

### DIFF
--- a/content/docs/04-ai-sdk-ui/02-chatbot.mdx
+++ b/content/docs/04-ai-sdk-ui/02-chatbot.mdx
@@ -200,7 +200,7 @@ import { DefaultChatTransport } from 'ai';
 import { useState } from 'react';
 
 export default function Chat() {
-  const { messages, sendMessage, error, reload } = useChat({
+  const { messages, sendMessage, error, regenerate } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/chat',
     }),
@@ -221,7 +221,7 @@ export default function Chat() {
       {error && (
         <>
           <div>An error occurred.</div>
-          <button type="button" onClick={() => reload()}>
+          <button type="button" onClick={() => regenerate()}>
             Retry
           </button>
         </>


### PR DESCRIPTION
## Background

  The `reload` function was renamed to `regenerate` in #6773 to better reflect its purpose. The name "reload" was slightly
  misleading, as the function actually regenerates assistant messages rather than reloading the entire chat.

  ## Summary

  Updated the chatbot documentation (`content/docs/04-ai-sdk-ui/02-chatbot.mdx`) to reflect the API change from `reload` to
  `regenerate` in the `useChat` hook examples:
  - Changed destructured property from `reload` to `regenerate`
  - Updated button onClick handler from `reload()` to `regenerate()`

  ## Checklist

  - [ ] Tests have been added / updated (for bug fixes / features)
  - [x] Documentation has been added / updated (for bug fixes / features)
  - [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project
  root)
  - [ ] I have reviewed this pull request (self-review)

  ## Related Issues

  Related to #6773