### PR TITLE
fix(google-vertex): remove duplicate gemini-1.0-pro-001 model ID

### DIFF
--- a/.changeset/chatty-donuts-wait.md
+++ b/.changeset/chatty-donuts-wait.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+Remove duplicate gemini-1.0-pro-001 model ID

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -18,7 +18,6 @@ export type GoogleVertexModelId =
   | 'gemini-1.0-pro-001'
   | 'gemini-1.0-pro-vision-001'
   | 'gemini-1.0-pro'
-  | 'gemini-1.0-pro-001'
   | 'gemini-1.0-pro-002'
   // Preview models
   | 'gemini-2.0-flash-lite-preview-02-05'


### PR DESCRIPTION
### Summary
Removes a duplicate `gemini-1.0-pro-001` entry from the `GoogleVertexModelId` union type.

### Context
The model ID `gemini-1.0-pro-001` was listed twice in the **stable models** section of
`google-vertex-options.ts`. This PR removes the duplicate to ensure the union contains
only unique model IDs.

### Changes
- Deduplicated the `GoogleVertexModelId` union by removing the extra
  `gemini-1.0-pro-001` entry
- Added a patch changeset (`chatty-donuts-wait.md`) for `@ai-sdk/google-vertex`

### Impact
- **Non-breaking** type-level fix
- No runtime behavior changes

### Verification
- Built packages locally using `pnpm build`
- Type-checked successfully
- Focused diff: only `google-vertex-options.ts` and the changeset file were modified
