### PR TITLE
feat(ui): add UIMessage part helper functions

### DIFF
--- a/.changeset/feat-ui-message-helpers.md
+++ b/.changeset/feat-ui-message-helpers.md
@@ -1,0 +1,14 @@
+---
+'ai': patch
+---
+
+feat(ui): add UIMessage part helper functions
+
+Add convenience functions to extract and aggregate UIMessage parts:
+
+- `getTextParts(message)` - get all text parts as array
+- `getTextContent(message)` - get joined text string
+- `getReasoningParts(message)` - get all reasoning parts as array
+- `getReasoningContent(message)` - get joined reasoning string
+- `isReasoningStreaming(message)` - check if reasoning is currently streaming
+- `isTextStreaming(message)` - check if text is currently streaming

--- a/content/docs/07-reference/02-ai-sdk-ui/48-ui-message-helpers.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/48-ui-message-helpers.mdx
@@ -1,0 +1,245 @@
+---
+title: UIMessage Helpers
+description: API Reference for UIMessage helper functions.
+---
+
+# UIMessage Helpers
+
+Helper functions to extract and aggregate parts from `UIMessage` objects. Useful when working with reasoning models (DeepSeek, Claude, etc.) that stream content as multiple parts.
+
+## getTextParts
+
+Get all text parts from a message.
+
+```ts
+import { getTextParts } from 'ai';
+
+const textParts = getTextParts(message);
+// => TextUIPart[]
+```
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'message',
+      type: 'UIMessage',
+      description: 'The UIMessage to extract text parts from.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'TextUIPart[]',
+      type: 'Array',
+      description: 'Array of text parts from the message.',
+    },
+  ]}
+/>
+
+## getTextContent
+
+Get joined text content from a message.
+
+```ts
+import { getTextContent } from 'ai';
+
+const text = getTextContent(message);
+// => "Hello, how can I help you?"
+```
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'message',
+      type: 'UIMessage',
+      description: 'The UIMessage to extract text content from.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'string',
+      type: 'string',
+      description: 'Concatenated text from all text parts.',
+    },
+  ]}
+/>
+
+## getReasoningParts
+
+Get all reasoning parts from a message.
+
+```ts
+import { getReasoningParts } from 'ai';
+
+const reasoningParts = getReasoningParts(message);
+// => ReasoningUIPart[]
+```
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'message',
+      type: 'UIMessage',
+      description: 'The UIMessage to extract reasoning parts from.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'ReasoningUIPart[]',
+      type: 'Array',
+      description: 'Array of reasoning parts from the message.',
+    },
+  ]}
+/>
+
+## getReasoningContent
+
+Get joined reasoning text from a message.
+
+```ts
+import { getReasoningContent } from 'ai';
+
+const reasoning = getReasoningContent(message);
+// => "Let me think about this step by step..."
+```
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'message',
+      type: 'UIMessage',
+      description: 'The UIMessage to extract reasoning content from.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'string',
+      type: 'string',
+      description: 'Concatenated text from all reasoning parts.',
+    },
+  ]}
+/>
+
+## isTextStreaming
+
+Check if text is currently streaming in a message.
+
+```ts
+import { isTextStreaming } from 'ai';
+
+if (isTextStreaming(message)) {
+  // Show typing indicator
+}
+```
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'message',
+      type: 'UIMessage',
+      description: 'The UIMessage to check for streaming text.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'boolean',
+      type: 'boolean',
+      description: 'True if any text part has state "streaming".',
+    },
+  ]}
+/>
+
+## isReasoningStreaming
+
+Check if reasoning is currently streaming in a message.
+
+```ts
+import { isReasoningStreaming } from 'ai';
+
+if (isReasoningStreaming(message)) {
+  // Show "thinking..." indicator
+}
+```
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'message',
+      type: 'UIMessage',
+      description: 'The UIMessage to check for streaming reasoning.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'boolean',
+      type: 'boolean',
+      description: 'True if any reasoning part has state "streaming".',
+    },
+  ]}
+/>
+
+## Example: Displaying Reasoning
+
+```tsx
+import { getReasoningContent, isReasoningStreaming } from 'ai';
+
+function Message({ message }) {
+  const reasoning = getReasoningContent(message);
+  const isThinking = isReasoningStreaming(message);
+
+  return (
+    <div>
+      {reasoning && (
+        <details>
+          <summary>
+            {isThinking ? 'Thinking...' : 'View reasoning'}
+          </summary>
+          <p>{reasoning}</p>
+        </details>
+      )}
+      <p>{getTextContent(message)}</p>
+    </div>
+  );
+}
+```

--- a/packages/ai/src/ui/index.ts
+++ b/packages/ai/src/ui/index.ts
@@ -28,11 +28,17 @@ export { lastAssistantMessageIsCompleteWithApprovalResponses } from './last-assi
 export { lastAssistantMessageIsCompleteWithToolCalls } from './last-assistant-message-is-complete-with-tool-calls';
 export { TextStreamChatTransport } from './text-stream-chat-transport';
 export {
+  getReasoningContent,
+  getReasoningParts,
+  getTextContent,
+  getTextParts,
   getToolName,
   getToolOrDynamicToolName,
   isDataUIPart,
   isFileUIPart,
+  isReasoningStreaming,
   isReasoningUIPart,
+  isTextStreaming,
   isTextUIPart,
   isToolOrDynamicToolUIPart,
   isToolUIPart,

--- a/packages/ai/src/ui/ui-messages.test.ts
+++ b/packages/ai/src/ui/ui-messages.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { getToolName, isDataUIPart } from './ui-messages';
+import {
+  getToolName,
+  isDataUIPart,
+  getTextParts,
+  getTextContent,
+  getReasoningParts,
+  getReasoningContent,
+  isReasoningStreaming,
+  isTextStreaming,
+  UIMessage,
+} from './ui-messages';
 
 describe('getToolName', () => {
   it('should return the tool name after the "tool-" prefix', () => {
@@ -44,5 +54,140 @@ describe('isDataUIPart', () => {
         text: 'some text',
       }),
     ).toBe(false);
+  });
+});
+
+// helper to create test messages
+const createMessage = (parts: UIMessage['parts']): UIMessage => ({
+  id: 'test-id',
+  role: 'assistant',
+  parts,
+});
+
+describe('getTextParts', () => {
+  it('should return all text parts', () => {
+    const message = createMessage([
+      { type: 'text', text: 'Hello' },
+      { type: 'reasoning', text: 'thinking...' },
+      { type: 'text', text: 'World' },
+    ]);
+
+    const result = getTextParts(message);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe('Hello');
+    expect(result[1].text).toBe('World');
+  });
+
+  it('should return empty array when no text parts', () => {
+    const message = createMessage([{ type: 'reasoning', text: 'thinking...' }]);
+
+    expect(getTextParts(message)).toHaveLength(0);
+  });
+});
+
+describe('getTextContent', () => {
+  it('should join all text parts', () => {
+    const message = createMessage([
+      { type: 'text', text: 'Hello ' },
+      { type: 'reasoning', text: 'thinking...' },
+      { type: 'text', text: 'World' },
+    ]);
+
+    expect(getTextContent(message)).toBe('Hello World');
+  });
+
+  it('should return empty string when no text parts', () => {
+    const message = createMessage([{ type: 'reasoning', text: 'thinking...' }]);
+
+    expect(getTextContent(message)).toBe('');
+  });
+});
+
+describe('getReasoningParts', () => {
+  it('should return all reasoning parts', () => {
+    const message = createMessage([
+      { type: 'reasoning', text: 'first thought' },
+      { type: 'text', text: 'Hello' },
+      { type: 'reasoning', text: 'second thought' },
+    ]);
+
+    const result = getReasoningParts(message);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe('first thought');
+    expect(result[1].text).toBe('second thought');
+  });
+
+  it('should return empty array when no reasoning parts', () => {
+    const message = createMessage([{ type: 'text', text: 'Hello' }]);
+
+    expect(getReasoningParts(message)).toHaveLength(0);
+  });
+});
+
+describe('getReasoningContent', () => {
+  it('should join all reasoning parts', () => {
+    const message = createMessage([
+      { type: 'reasoning', text: 'first ' },
+      { type: 'text', text: 'Hello' },
+      { type: 'reasoning', text: 'second' },
+    ]);
+
+    expect(getReasoningContent(message)).toBe('first second');
+  });
+
+  it('should return empty string when no reasoning parts', () => {
+    const message = createMessage([{ type: 'text', text: 'Hello' }]);
+
+    expect(getReasoningContent(message)).toBe('');
+  });
+});
+
+describe('isReasoningStreaming', () => {
+  it('should return true when reasoning is streaming', () => {
+    const message = createMessage([
+      { type: 'reasoning', text: 'thinking...', state: 'streaming' },
+    ]);
+
+    expect(isReasoningStreaming(message)).toBe(true);
+  });
+
+  it('should return false when reasoning is done', () => {
+    const message = createMessage([
+      { type: 'reasoning', text: 'thought', state: 'done' },
+    ]);
+
+    expect(isReasoningStreaming(message)).toBe(false);
+  });
+
+  it('should return false when no reasoning parts', () => {
+    const message = createMessage([{ type: 'text', text: 'Hello' }]);
+
+    expect(isReasoningStreaming(message)).toBe(false);
+  });
+});
+
+describe('isTextStreaming', () => {
+  it('should return true when text is streaming', () => {
+    const message = createMessage([
+      { type: 'text', text: 'Hello...', state: 'streaming' },
+    ]);
+
+    expect(isTextStreaming(message)).toBe(true);
+  });
+
+  it('should return false when text is done', () => {
+    const message = createMessage([
+      { type: 'text', text: 'Hello', state: 'done' },
+    ]);
+
+    expect(isTextStreaming(message)).toBe(false);
+  });
+
+  it('should return false when no text parts', () => {
+    const message = createMessage([{ type: 'reasoning', text: 'thinking' }]);
+
+    expect(isTextStreaming(message)).toBe(false);
   });
 });

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -498,3 +498,53 @@ export type InferUIMessagePart<UI_MESSAGE extends UIMessage> = UIMessagePart<
   InferUIMessageData<UI_MESSAGE>,
   InferUIMessageTools<UI_MESSAGE>
 >;
+
+/**
+ * Get all text parts from a message.
+ */
+export function getTextParts(message: UIMessage): TextUIPart[] {
+  return message.parts.filter(isTextUIPart);
+}
+
+/**
+ * Get joined text content from a message.
+ */
+export function getTextContent(message: UIMessage): string {
+  return getTextParts(message)
+    .map(part => part.text)
+    .join('');
+}
+
+/**
+ * Get all reasoning parts from a message.
+ */
+export function getReasoningParts(message: UIMessage): ReasoningUIPart[] {
+  return message.parts.filter(isReasoningUIPart);
+}
+
+/**
+ * Get joined reasoning text from a message.
+ */
+export function getReasoningContent(message: UIMessage): string {
+  return getReasoningParts(message)
+    .map(part => part.text)
+    .join('');
+}
+
+/**
+ * Check if reasoning is currently streaming in a message.
+ */
+export function isReasoningStreaming(message: UIMessage): boolean {
+  return message.parts.some(
+    part => isReasoningUIPart(part) && part.state === 'streaming',
+  );
+}
+
+/**
+ * Check if text is currently streaming in a message.
+ */
+export function isTextStreaming(message: UIMessage): boolean {
+  return message.parts.some(
+    part => isTextUIPart(part) && part.state === 'streaming',
+  );
+}


### PR DESCRIPTION
## Summary

Add convenience functions to extract and aggregate UIMessage parts:

- `getTextParts(message)` - get all text parts as array
- `getTextContent(message)` - get joined text string  
- `getReasoningParts(message)` - get all reasoning parts as array
- `getReasoningContent(message)` - get joined reasoning string
- `isReasoningStreaming(message)` - check if reasoning is currently streaming
- `isTextStreaming(message)` - check if text is currently streaming

## Motivation

When working with reasoning models (DeepSeek, Claude, etc.), the SDK streams reasoning as multiple parts that need to be aggregated for display. Currently, users must manually filter and join parts:

```tsx
// Before: manual filtering/joining
const reasoningText = message.parts
  .filter((p) => p.type === 'reasoning')
  .map((p) => p.text)
  .join('');
```

```tsx
// After: one-liner
import { getReasoningContent } from 'ai';
const reasoningText = getReasoningContent(message);
```

This pattern is common enough that built-in helpers reduce boilerplate and improve DX.

## Changes

- Added 6 helper functions to `packages/ai/src/ui/ui-messages.ts`
- Added comprehensive tests for all helpers
- Exported functions from `packages/ai/src/ui/index.ts`

## Test plan

- [x] All existing tests pass
- [x] New tests cover all helper functions
- [x] Tests cover edge cases (empty parts, no matching parts)