### PR TITLE
fix(ai): prevent header loss when statusText is undefined in writeHead

### DIFF
--- a/.changeset/light-donkeys-beg.md
+++ b/.changeset/light-donkeys-beg.md
@@ -1,0 +1,5 @@
+---
+'ai': major
+---
+
+fix header loss when statusText is undefined in writeHead

--- a/.changeset/light-donkeys-beg.md
+++ b/.changeset/light-donkeys-beg.md
@@ -1,5 +1,5 @@
 ---
-'ai': major
+'ai': patch
 ---
 
 fix header loss when statusText is undefined in writeHead

--- a/packages/ai/src/util/write-to-server-response.test.ts
+++ b/packages/ai/src/util/write-to-server-response.test.ts
@@ -194,7 +194,7 @@ class SimpleMockResponse extends EventEmitter {
   writtenChunks: any[] = [];
   statusCode = 0;
   statusMessage = '';
-  headers: Record<string, string | number | string[]> = {};
+  headers: Record<string, string | number | string[]> | undefined;
   ended = false;
 
   write(chunk: any): boolean {
@@ -215,10 +215,10 @@ class SimpleMockResponse extends EventEmitter {
 
     if (typeof statusMessage === 'string') {
       this.statusMessage = statusMessage;
-      this.headers = headers || {};
+      this.headers = headers;
     } else {
       this.statusMessage = '';
-      this.headers = statusMessage || {};
+      this.headers = statusMessage;
     }
   }
 
@@ -241,7 +241,7 @@ class BackpressureMockResponse extends EventEmitter {
   writeCallCount = 0;
   statusCode = 0;
   statusMessage = '';
-  headers: Record<string, string | number | string[]> = {};
+  headers: Record<string, string | number | string[]> | undefined;
   ended = false;
   private shouldApplyBackpressure = false;
 
@@ -283,10 +283,10 @@ class BackpressureMockResponse extends EventEmitter {
 
     if (typeof statusMessage === 'string') {
       this.statusMessage = statusMessage;
-      this.headers = headers || {};
+      this.headers = headers;
     } else {
       this.statusMessage = '';
-      this.headers = statusMessage || {};
+      this.headers = statusMessage;
     }
   }
 

--- a/packages/ai/src/util/write-to-server-response.ts
+++ b/packages/ai/src/util/write-to-server-response.ts
@@ -1,4 +1,4 @@
-import { ServerResponse } from 'node:http';
+import { ServerResponse, OutgoingHttpHeaders } from 'node:http';
 
 /**
  * Writes the content of a stream to a server response.
@@ -16,14 +16,7 @@ export function writeToServerResponse({
   headers?: Record<string, string | number | string[]>;
   stream: ReadableStream<Uint8Array>;
 }): void {
-  const code = status ?? 200;
-  if (statusText) {
-    response.writeHead(code, statusText, headers);
-  } else if (headers !== undefined) {
-    response.writeHead(code, headers);
-  } else {
-    response.writeHead(code);
-  }
+  response.writeHead(status ?? 200, ...[statusText, headers].filter(arg => arg !== undefined) as [string?, OutgoingHttpHeaders?]);
 
   const reader = stream.getReader();
   const read = async () => {

--- a/packages/ai/src/util/write-to-server-response.ts
+++ b/packages/ai/src/util/write-to-server-response.ts
@@ -16,7 +16,14 @@ export function writeToServerResponse({
   headers?: Record<string, string | number | string[]>;
   stream: ReadableStream<Uint8Array>;
 }): void {
-  response.writeHead(status ?? 200, statusText, headers);
+  const code = status ?? 200;
+  if (statusText) {
+    response.writeHead(code, statusText, headers);
+  } else if (headers !== undefined) {
+    response.writeHead(code, headers);
+  } else {
+    response.writeHead(code);
+  }
 
   const reader = stream.getReader();
   const read = async () => {

--- a/packages/ai/src/util/write-to-server-response.ts
+++ b/packages/ai/src/util/write-to-server-response.ts
@@ -1,4 +1,4 @@
-import { ServerResponse, OutgoingHttpHeaders } from 'node:http';
+import { ServerResponse } from 'node:http';
 
 /**
  * Writes the content of a stream to a server response.

--- a/packages/ai/src/util/write-to-server-response.ts
+++ b/packages/ai/src/util/write-to-server-response.ts
@@ -16,7 +16,12 @@ export function writeToServerResponse({
   headers?: Record<string, string | number | string[]>;
   stream: ReadableStream<Uint8Array>;
 }): void {
-  response.writeHead(status ?? 200, ...[statusText, headers].filter(arg => arg !== undefined) as [string?, OutgoingHttpHeaders?]);
+  const statusCode = status ?? 200;
+  if (statusText !== undefined) {
+    response.writeHead(statusCode, statusText, headers);
+  } else {
+    response.writeHead(statusCode, headers);
+  }
 
   const reader = stream.getReader();
   const read = async () => {


### PR DESCRIPTION
## Problem

In `pipeAgentUIStreamToResponse`, when `statusText` is not set, all headers are lost.

The issue occurs in `writeToServerResponse`, which calls `response.writeHead(status != null ? status : 200, statusText, headers);` 

This always passes `statusText` in `arguments[1]`, even when it's `undefined`.

According to Node.js's `writeHead` implementation ([reference](https://github.com/jshttp/on-headers/blob/master/index.js#L121)), the function determines where to read headers based on whether `arguments[1]` is a string or not

```jsx
var headerIndex = length > 1 && typeof arguments[1] === 'string'
    ? 2
    : 1
```

Headers should be read from `arguments[2]` when `arguments[1]` is a string, otherwise from `arguments[1]`.

When `statusText` is `undefined`, `arguments[1]` is treated as non-string, so `headerIndex` becomes `1`, causing the code to read headers from `arguments[1]` and ignore the actual headers in `arguments[2]`.

**Result:** No headers are applied—neither developer-provided headers (from `headers` parameter) nor default UI message stream headers (`UI_MESSAGE_STREAM_HEADERS`).

## Solution

Only pass `statusText` when it has a value. According to the [Node.js v25.2.1 documentation](https://nodejs.org/api/http.html#responsewriteheadstatuscode-statusmessage-headers), this ensures Node.js correctly identifies which argument contains the headers.