### PR TITLE
feat(google): add Google Maps grounding tool support (#9596)

### DIFF
--- a/.changeset/feat-google-maps-grounding.md
+++ b/.changeset/feat-google-maps-grounding.md
@@ -4,4 +4,3 @@
 ---
 
 Add Google Maps grounding tool support for location-aware Gemini responses
-

--- a/.changeset/feat-google-maps-grounding.md
+++ b/.changeset/feat-google-maps-grounding.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google': patch
+'@ai-sdk/google-vertex': patch
+---
+
+Add Google Maps grounding tool support for location-aware Gemini responses
+

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -683,7 +683,8 @@ const { text, sources, providerMetadata } = await generateText({
       },
     },
   },
-  prompt: 'What are the best Italian restaurants within a 15-minute walk from here?',
+  prompt:
+    'What are the best Italian restaurants within a 15-minute walk from here?',
 });
 
 const metadata = providerMetadata?.google as
@@ -712,9 +713,7 @@ When Google Maps grounding is enabled, the model's response will include sources
 }
 ```
 
-<Note>
-  Google Maps grounding is supported on Gemini 2.0 and newer models.
-</Note>
+<Note>Google Maps grounding is supported on Gemini 2.0 and newer models.</Note>
 
 ### RAG Engine Grounding
 

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -557,7 +557,7 @@ File Search responses include citations via the normal `sources` field and expos
 
 Google provides a provider-defined URL context tool.
 
-The URL context tool allows the you to provide specific URLs that you want the model to analyze directly in from the prompt.
+The URL context tool allows you to provide specific URLs that you want the model to analyze directly in from the prompt.
 
 ```ts highlight="9,13-17"
 import { google } from '@ai-sdk/google';
@@ -660,6 +660,61 @@ const metadata = providerMetadata?.google as
 const groundingMetadata = metadata?.groundingMetadata;
 const urlContextMetadata = metadata?.urlContextMetadata;
 ```
+
+### Google Maps Grounding
+
+With [Google Maps grounding](https://ai.google.dev/gemini-api/docs/maps-grounding),
+the model has access to Google Maps data for location-aware responses. This enables providing local data and geospatial context, such as finding nearby restaurants.
+
+```ts highlight="7-16"
+import { google } from '@ai-sdk/google';
+import { GoogleGenerativeAIProviderMetadata } from '@ai-sdk/google';
+import { generateText } from 'ai';
+
+const { text, sources, providerMetadata } = await generateText({
+  model: google('gemini-2.5-flash'),
+  tools: {
+    google_maps: google.tools.googleMaps({}),
+  },
+  providerOptions: {
+    google: {
+      retrievalConfig: {
+        latLng: { latitude: 34.090199, longitude: -117.881081 },
+      },
+    },
+  },
+  prompt: 'What are the best Italian restaurants within a 15-minute walk from here?',
+});
+
+const metadata = providerMetadata?.google as
+  | GoogleGenerativeAIProviderMetadata
+  | undefined;
+const groundingMetadata = metadata?.groundingMetadata;
+```
+
+The optional `retrievalConfig.latLng` provider option provides location context for queries about nearby places. This configuration applies to any grounding tools that support location context, including Google Maps and Google Search.
+
+When Google Maps grounding is enabled, the model's response will include sources pointing to Google Maps URLs. The grounding metadata includes `maps` chunks with place information:
+
+```json
+{
+  "groundingMetadata": {
+    "groundingChunks": [
+      {
+        "maps": {
+          "uri": "https://maps.google.com/?cid=12345",
+          "title": "Restaurant Name",
+          "placeId": "places/ChIJ..."
+        }
+      }
+    ]
+  }
+}
+```
+
+<Note>
+  Google Maps grounding is supported on Gemini 2.0 and newer models.
+</Note>
 
 ### RAG Engine Grounding
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -401,6 +401,32 @@ const result = await generateText({
 });
 ```
 
+#### Google Maps
+
+Google Maps grounding enables Gemini models to access Google Maps data for location-aware responses. Supported models: Gemini 2.5 Flash-Lite, 2.5 Flash, 2.0 Flash, 2.5 Pro, 3.0 Pro.
+
+```ts
+import { vertex } from '@ai-sdk/google-vertex';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: vertex('gemini-2.5-flash'),
+  tools: {
+    google_maps: vertex.tools.googleMaps({}),
+  },
+  providerOptions: {
+    google: {
+      retrievalConfig: {
+        latLng: { latitude: 34.090199, longitude: -117.881081 },
+      },
+    },
+  },
+  prompt: 'What are the best Italian restaurants nearby?',
+});
+```
+
+The optional `retrievalConfig.latLng` provider option provides location context for queries about nearby places. This configuration applies to any grounding tools that support location context.
+
 #### Reasoning (Thinking Tokens)
 
 Google Vertex AI, through its support for Gemini models, can also emit "thinking" tokens, representing the model's reasoning process. The AI SDK exposes these as reasoning information.

--- a/examples/ai-core/src/generate-text/google-tool-maps.ts
+++ b/examples/ai-core/src/generate-text/google-tool-maps.ts
@@ -1,0 +1,32 @@
+import { google, GoogleGenerativeAIProviderMetadata } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const { text, sources, providerMetadata } = await generateText({
+    model: google('gemini-2.5-flash'),
+    tools: {
+      google_maps: google.tools.googleMaps({}),
+    },
+    providerOptions: {
+      google: {
+        retrievalConfig: {
+          latLng: { latitude: 34.09, longitude: -117.88 },
+        },
+      },
+    },
+    prompt:
+      'What are the best Italian restaurants within a 15-minute walk from here?',
+  });
+
+  const metadata = providerMetadata?.google as
+    | GoogleGenerativeAIProviderMetadata
+    | undefined;
+  const groundingMetadata = metadata?.groundingMetadata;
+
+  console.log('Generated Text:', text);
+  console.dir({ sources }, { depth: null });
+  console.dir({ groundingMetadata }, { depth: null });
+}
+
+main().catch(console.error);

--- a/packages/google-vertex/src/google-vertex-tools.ts
+++ b/packages/google-vertex/src/google-vertex-tools.ts
@@ -2,6 +2,7 @@ import { googleTools } from '@ai-sdk/google/internal';
 
 export const googleVertexTools = {
   googleSearch: googleTools.googleSearch,
+  googleMaps: googleTools.googleMaps,
   urlContext: googleTools.urlContext,
   fileSearch: googleTools.fileSearch,
   codeExecution: googleTools.codeExecution,

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -199,6 +199,39 @@ describe('groundingMetadataSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('validates grounding metadata with maps chunks', () => {
+    const metadata = {
+      groundingChunks: [
+        {
+          maps: {
+            uri: 'https://maps.google.com/maps?cid=12345',
+            title: 'Best Italian Restaurant',
+            text: 'A great Italian restaurant',
+            placeId: 'ChIJ12345',
+          },
+        },
+      ],
+    };
+
+    const result = groundingMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(true);
+  });
+
+  it('validates groundingChunks[].maps with missing optional fields', () => {
+    const metadata = {
+      groundingChunks: [
+        {
+          maps: {
+            uri: 'https://maps.google.com/maps?cid=12345',
+          },
+        },
+      ],
+    };
+
+    const result = groundingMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(true);
+  });
+
   it('validates metadata with empty retrievalMetadata', () => {
     const metadata = {
       webSearchQueries: ['sample query'],
@@ -1014,6 +1047,56 @@ describe('doGenerate', () => {
         `);
   });
 
+  it('should extract sources from maps grounding metadata', async () => {
+    prepareJsonResponse({
+      content: 'test response with Maps',
+      groundingMetadata: {
+        groundingChunks: [
+          {
+            maps: {
+              uri: 'https://maps.google.com/maps?cid=12345',
+              title: 'Best Italian Restaurant',
+              placeId: 'ChIJ12345',
+            },
+          },
+          {
+            maps: {
+              uri: 'https://maps.google.com/maps?cid=67890',
+            },
+          },
+        ],
+      },
+    });
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toMatchInlineSnapshot(`
+      [
+        {
+          "providerMetadata": undefined,
+          "text": "test response with Maps",
+          "type": "text",
+        },
+        {
+          "id": "test-id",
+          "sourceType": "url",
+          "title": "Best Italian Restaurant",
+          "type": "source",
+          "url": "https://maps.google.com/maps?cid=12345",
+        },
+        {
+          "id": "test-id",
+          "sourceType": "url",
+          "title": undefined,
+          "type": "source",
+          "url": "https://maps.google.com/maps?cid=67890",
+        },
+      ]
+    `);
+  });
+
   it('should handle mixed source types with correct title defaults', async () => {
     prepareJsonResponse({
       content: 'test response with mixed sources',
@@ -1770,6 +1853,46 @@ describe('doGenerate', () => {
       generationConfig: {
         imageConfig: {
           aspectRatio: '16:9',
+        },
+      },
+    });
+  });
+
+  it('should pass retrievalConfig in provider options', async () => {
+    prepareJsonResponse({ url: TEST_URL_GEMINI_2_0_FLASH_EXP });
+
+    const gemini2Model = provider.chat('gemini-2.0-flash-exp');
+
+    await gemini2Model.doGenerate({
+      prompt: TEST_PROMPT,
+      tools: [
+        {
+          type: 'provider',
+          id: 'google.google_maps',
+          name: 'google_maps',
+          args: {},
+        },
+      ],
+      providerOptions: {
+        google: {
+          retrievalConfig: {
+            latLng: {
+              latitude: 34.090199,
+              longitude: -117.881081,
+            },
+          },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      tools: [{ googleMaps: {} }],
+      toolConfig: {
+        retrievalConfig: {
+          latLng: {
+            latitude: 34.090199,
+            longitude: -117.881081,
+          },
         },
       },
     });

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -189,7 +189,10 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
         safetySettings: googleOptions?.safetySettings,
         tools: googleTools,
         toolConfig: googleOptions?.retrievalConfig
-          ? { ...googleToolConfig, retrievalConfig: googleOptions.retrievalConfig }
+          ? {
+              ...googleToolConfig,
+              retrievalConfig: googleOptions.retrievalConfig,
+            }
           : googleToolConfig,
         cachedContent: googleOptions?.cachedContent,
         labels: googleOptions?.labels,

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -188,7 +188,9 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
         systemInstruction: isGemmaModel ? undefined : systemInstruction,
         safetySettings: googleOptions?.safetySettings,
         tools: googleTools,
-        toolConfig: googleToolConfig,
+        toolConfig: googleOptions?.retrievalConfig
+          ? { ...googleToolConfig, retrievalConfig: googleOptions.retrievalConfig }
+          : googleToolConfig,
         cachedContent: googleOptions?.cachedContent,
         labels: googleOptions?.labels,
       },
@@ -773,6 +775,16 @@ function extractSources({
           filename: fileSearchStore.split('/').pop(),
         });
       }
+    } else if (chunk.maps != null) {
+      if (chunk.maps.uri) {
+        sources.push({
+          type: 'source',
+          sourceType: 'url',
+          id: generateId(),
+          url: chunk.maps.uri,
+          title: chunk.maps.title ?? undefined,
+        });
+      }
     }
   }
 
@@ -796,6 +808,14 @@ export const getGroundingMetadataSchema = () =>
               title: z.string().nullish(),
               text: z.string().nullish(),
               fileSearchStore: z.string().nullish(),
+            })
+            .nullish(),
+          maps: z
+            .object({
+              uri: z.string().nullish(),
+              title: z.string().nullish(),
+              text: z.string().nullish(),
+              placeId: z.string().nullish(),
             })
             .nullish(),
         }),

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -164,6 +164,23 @@ export const googleGenerativeAIProviderOptions = lazySchema(() =>
           imageSize: z.enum(['1K', '2K', '4K']).optional(),
         })
         .optional(),
+
+      /**
+       * Optional. Configuration for grounding retrieval.
+       * Used to provide location context for Google Maps and Google Search grounding.
+       *
+       * https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-maps
+       */
+      retrievalConfig: z
+        .object({
+          latLng: z
+            .object({
+              latitude: z.number(),
+              longitude: z.number(),
+            })
+            .optional(),
+        })
+        .optional(),
     }),
   ),
 );

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -402,3 +402,44 @@ it('should handle url context tool alone', () => {
   expect(result.toolConfig).toBeUndefined();
   expect(result.toolWarnings).toEqual([]);
 });
+
+it('should handle google maps tool', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'provider',
+        id: 'google.google_maps',
+        name: 'google_maps',
+        args: {},
+      },
+    ],
+    modelId: 'gemini-2.5-flash',
+  });
+  expect(result.tools).toEqual([{ googleMaps: {} }]);
+  expect(result.toolConfig).toBeUndefined();
+  expect(result.toolWarnings).toEqual([]);
+});
+
+it('should add warnings for google maps on unsupported models', () => {
+  const result = prepareTools({
+    tools: [
+      {
+        type: 'provider',
+        id: 'google.google_maps',
+        name: 'google_maps',
+        args: {},
+      },
+    ],
+    modelId: 'gemini-1.5-flash',
+  });
+  expect(result.tools).toBeUndefined();
+  expect(result.toolWarnings).toMatchInlineSnapshot(`
+    [
+      {
+        "details": "The Google Maps grounding tool is not supported with Gemini models other than Gemini 2 or newer.",
+        "feature": "provider-defined tool google.google_maps",
+        "type": "unsupported",
+      },
+    ]
+  `);
+});

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -155,6 +155,18 @@ export function prepareTools({
             });
           }
           break;
+        case 'google.google_maps':
+          if (isGemini2orNewer) {
+            googleTools.push({ googleMaps: {} });
+          } else {
+            toolWarnings.push({
+              type: 'unsupported',
+              feature: `provider-defined tool ${tool.id}`,
+              details:
+                'The Google Maps grounding tool is not supported with Gemini models other than Gemini 2 or newer.',
+            });
+          }
+          break;
         default:
           toolWarnings.push({
             type: 'unsupported',

--- a/packages/google/src/google-tools.ts
+++ b/packages/google/src/google-tools.ts
@@ -1,5 +1,6 @@
 import { codeExecution } from './tool/code-execution';
 import { fileSearch } from './tool/file-search';
+import { googleMaps } from './tool/google-maps';
 import { googleSearch } from './tool/google-search';
 import { urlContext } from './tool/url-context';
 import { vertexRagStore } from './tool/vertex-rag-store';
@@ -10,6 +11,15 @@ export const googleTools = {
    * Must have name "google_search".
    */
   googleSearch,
+
+  /**
+   * Creates a Google Maps grounding tool that gives the model access to Google Maps data.
+   * Must have name "google_maps".
+   *
+   * @see https://ai.google.dev/gemini-api/docs/maps-grounding
+   * @see https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-maps
+   */
+  googleMaps,
 
   /**
    * Creates a URL context tool that gives Google direct access to real-time web content.

--- a/packages/google/src/tool/google-maps.ts
+++ b/packages/google/src/tool/google-maps.ts
@@ -1,0 +1,14 @@
+import {
+  createProviderToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+// https://ai.google.dev/gemini-api/docs/maps-grounding
+// https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-maps
+
+export const googleMaps = createProviderToolFactory<{}, {}>({
+  id: 'google.google_maps',
+  inputSchema: lazySchema(() => zodSchema(z.object({}))),
+});


### PR DESCRIPTION
## Background

This PR addresses [#9596](https://github.com/vercel/ai/issues/9596) which requests support for "Grounding with Google Maps" in the Google provider.

Google Maps grounding enables Gemini models to access Google Maps data for location-aware responses, allowing AI applications to provide local data and geospatial context. This is useful for conversational assistants that answer questions about nearby places, personalized location recommendations, and area summaries.

## Summary

Added `googleMaps` tool support to `@ai-sdk/google` and `@ai-sdk/google-vertex` providers:

- `google.tools.googleMaps({})` / `vertex.tools.googleMaps({})` creates a Google Maps grounding tool
- `retrievalConfig.latLng` provides location context via provider options (used by web search and maps grounding)
- Updated source schema to include `maps` chunks with `uri`, `title`, and `placeId` fields

**Usage:**

```ts
import { google } from '@ai-sdk/google';
import { generateText } from 'ai';

const result = await generateText({
  model: google('gemini-2.5-flash'),
  tools: {
    google_maps: google.tools.googleMaps({}),
  },
  providerOptions: {
    google: {
      retrievalConfig: {
        latLng: { latitude: 34.09, longitude: -117.88 },
      },
    },
  },
  prompt: 'What are the best Italian restaurants within a 15-minute walk from here?',
});
```

The `retrievalConfig` is passed via provider options rather than tool parameters because it applies at the `toolConfig` level in the API and could be used by other grounding tools (e.g., Google Search) in the future.

## Manual Verification

Tested with multiple configurations:

- **Gemini API**: `gemini-2.5-flash` with Google Maps + Google Search grounding
- **Vertex AI**: `gemini-2.5-flash` and `gemini-3-pro-preview` (global endpoint)

All cases returned location-aware responses with properly extracted Google Maps sources. Verified that both `maps` and `web` grounding chunks are converted to consistent `LanguageModelV3Source` format.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Add `enableWidget` parameter support for the Google Maps contextual widget (returns `googleMapsWidgetContextToken` in response) once it reaches GA

## Related Issues

Fixes #9596