### PR TITLE
chore(provider): add deprecated textEmbeddingModel and textEmbedding aliases

### DIFF
--- a/.changeset/sharp-ants-camp.md
+++ b/.changeset/sharp-ants-camp.md
@@ -1,0 +1,35 @@
+---
+'@ai-sdk/black-forest-labs': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/huggingface': patch
+'@ai-sdk/assemblyai': patch
+'@ai-sdk/elevenlabs': patch
+'@ai-sdk/perplexity': patch
+'@ai-sdk/togetherai': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/deepinfra': patch
+'@ai-sdk/fireworks': patch
+'@ai-sdk/replicate': patch
+'@ai-sdk/cerebras': patch
+'@ai-sdk/deepgram': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/baseten': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+'@ai-sdk/gladia': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/vercel': patch
+'@ai-sdk/azure': patch
+'@ai-sdk/revai': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/luma': patch
+'@ai-sdk/fal': patch
+'@ai-sdk/xai': patch
+---
+
+chore(provider): add deprecated textEmbeddingModel and textEmbedding aliases

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -112,8 +112,14 @@ export interface AmazonBedrockProvider extends ProviderV3 {
 
   languageModel(modelId: BedrockChatModelId): LanguageModelV3;
 
+  /**
+   * Creates a model for text embeddings.
+   */
   embedding(modelId: BedrockEmbeddingModelId): EmbeddingModelV3;
 
+  /**
+   * Creates a model for text embeddings.
+   */
   embeddingModel(modelId: BedrockEmbeddingModelId): EmbeddingModelV3;
 
   /**

--- a/packages/amazon-bedrock/src/bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.ts
@@ -117,6 +117,16 @@ export interface AmazonBedrockProvider extends ProviderV3 {
   embeddingModel(modelId: BedrockEmbeddingModelId): EmbeddingModelV3;
 
   /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(modelId: BedrockEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: BedrockEmbeddingModelId): EmbeddingModelV3;
+
+  /**
 Creates a model for image generation.
    */
   image(modelId: BedrockImageModelId): ImageModelV3;
@@ -318,6 +328,8 @@ export function createAmazonBedrock(
   provider.languageModel = createChatModel;
   provider.embedding = createEmbeddingModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
   provider.reranking = createRerankingModel;

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -130,6 +130,7 @@ export function createAnthropic(
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/anthropic/src/anthropic-provider.ts
+++ b/packages/anthropic/src/anthropic-provider.ts
@@ -32,6 +32,11 @@ Creates a model for text generation.
   messages(modelId: AnthropicMessagesModelId): LanguageModelV3;
 
   /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+
+  /**
 Anthropic-specific computer use tool.
    */
   tools: typeof anthropicTools;

--- a/packages/assemblyai/src/assemblyai-provider.ts
+++ b/packages/assemblyai/src/assemblyai-provider.ts
@@ -24,6 +24,11 @@ export interface AssemblyAIProvider extends ProviderV3 {
 Creates a model for transcription.
    */
   transcription(modelId: AssemblyAITranscriptionModelId): TranscriptionModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface AssemblyAIProviderSettings {

--- a/packages/assemblyai/src/assemblyai-provider.ts
+++ b/packages/assemblyai/src/assemblyai-provider.ts
@@ -92,6 +92,7 @@ export function createAssemblyAI(
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -47,8 +47,14 @@ Creates an Azure OpenAI completion model for text generation.
    */
   completion(deploymentId: string): LanguageModelV3;
 
+  /**
+   * Creates an Azure OpenAI model for text embeddings.
+   */
   embedding(deploymentId: string): EmbeddingModelV3;
 
+  /**
+   * Creates an Azure OpenAI model for text embeddings.
+   */
   embeddingModel(deploymentId: string): EmbeddingModelV3;
 
   /**

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -49,6 +49,18 @@ Creates an Azure OpenAI completion model for text generation.
 
   embedding(deploymentId: string): EmbeddingModelV3;
 
+  embeddingModel(deploymentId: string): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(deploymentId: string): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(deploymentId: string): EmbeddingModelV3;
+
   /**
    * Creates an Azure OpenAI DALL-E model for image generation.
    */
@@ -58,11 +70,6 @@ Creates an Azure OpenAI completion model for text generation.
    * Creates an Azure OpenAI DALL-E model for image generation.
    */
   imageModel(deploymentId: string): ImageModelV3;
-
-  /**
-Creates an Azure OpenAI model for text embeddings.
-   */
-  embeddingModel(deploymentId: string): EmbeddingModelV3;
 
   /**
    * Creates an Azure OpenAI model for audio transcription.
@@ -243,6 +250,8 @@ export function createAzure(
   provider.completion = createCompletionModel;
   provider.embedding = createEmbeddingModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
   provider.responses = createResponsesModel;

--- a/packages/baseten/src/baseten-provider.ts
+++ b/packages/baseten/src/baseten-provider.ts
@@ -81,6 +81,11 @@ Creates a language model for text generation. Alias for chatModel.
 Creates a embedding model for text generation.
 */
   embeddingModel(modelId?: BasetenEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId?: BasetenEmbeddingModelId): EmbeddingModelV3;
 }
 
 // by default, we use the Model APIs
@@ -235,6 +240,7 @@ export function createBaseten(
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   return provider;
 }
 

--- a/packages/black-forest-labs/src/black-forest-labs-provider.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-provider.ts
@@ -83,6 +83,13 @@ export function createBlackForestLabs(
       pollTimeoutMillis: options.pollTimeoutMillis,
     });
 
+  const embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'embeddingModel',
+    });
+  };
+
   return {
     specificationVersion: 'v3',
     imageModel: createImageModel,
@@ -93,12 +100,8 @@ export function createBlackForestLabs(
         modelType: 'languageModel',
       });
     },
-    embeddingModel: (modelId: string) => {
-      throw new NoSuchModelError({
-        modelId,
-        modelType: 'embeddingModel',
-      });
-    },
+    embeddingModel,
+    textEmbeddingModel: embeddingModel,
   };
 }
 

--- a/packages/black-forest-labs/src/black-forest-labs-provider.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-provider.ts
@@ -52,6 +52,11 @@ Creates a model for image generation.
 Creates a model for image generation.
    */
   imageModel(modelId: BlackForestLabsImageModelId): ImageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 const defaultBaseURL = 'https://api.bfl.ai/v1';

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -65,6 +65,11 @@ Creates a Cerebras model for text generation.
 Creates a Cerebras chat model for text generation.
 */
   chat(modelId: CerebrasChatModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export function createCerebras(

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -107,6 +107,7 @@ export function createCerebras(
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/cohere/src/cohere-provider.ts
+++ b/packages/cohere/src/cohere-provider.ts
@@ -29,8 +29,14 @@ Creates a model for text generation.
 */
   languageModel(modelId: CohereChatModelId): LanguageModelV3;
 
+  /**
+   * Creates a model for text embeddings.
+   */
   embedding(modelId: CohereEmbeddingModelId): EmbeddingModelV3;
 
+  /**
+   * Creates a model for text embeddings.
+   */
   embeddingModel(modelId: CohereEmbeddingModelId): EmbeddingModelV3;
 
   /**

--- a/packages/cohere/src/cohere-provider.ts
+++ b/packages/cohere/src/cohere-provider.ts
@@ -34,6 +34,16 @@ Creates a model for text generation.
   embeddingModel(modelId: CohereEmbeddingModelId): EmbeddingModelV3;
 
   /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(modelId: CohereEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: CohereEmbeddingModelId): EmbeddingModelV3;
+
+  /**
    * Creates a model for reranking.
    */
   reranking(modelId: CohereRerankingModelId): RerankingModelV3;
@@ -135,6 +145,8 @@ export function createCohere(
   provider.languageModel = createChatModel;
   provider.embedding = createEmbeddingModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   provider.reranking = createRerankingModel;
   provider.rerankingModel = createRerankingModel;
 

--- a/packages/deepgram/src/deepgram-provider.ts
+++ b/packages/deepgram/src/deepgram-provider.ts
@@ -115,6 +115,7 @@ export function createDeepgram(
       message: 'Deepgram does not provide text embedding models',
     });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({

--- a/packages/deepgram/src/deepgram-provider.ts
+++ b/packages/deepgram/src/deepgram-provider.ts
@@ -32,6 +32,11 @@ Creates a model for transcription.
 Creates a model for speech generation.
    */
   speech(modelId: DeepgramSpeechModelId): SpeechModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface DeepgramProviderSettings {

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -77,6 +77,11 @@ Creates a completion model for text generation.
 Creates a embedding model for text generation.
 */
   embeddingModel(modelId: DeepInfraEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: DeepInfraEmbeddingModelId): EmbeddingModelV3;
 }
 
 export function createDeepInfra(
@@ -148,6 +153,7 @@ export function createDeepInfra(
   provider.imageModel = createImageModel;
   provider.languageModel = createChatModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
 
   return provider;
 }

--- a/packages/deepseek/src/deepseek-provider.ts
+++ b/packages/deepseek/src/deepseek-provider.ts
@@ -51,6 +51,11 @@ Creates a DeepSeek model for text generation.
 Creates a DeepSeek chat model for text generation.
 */
   chat(modelId: DeepSeekChatModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export function createDeepSeek(

--- a/packages/deepseek/src/deepseek-provider.ts
+++ b/packages/deepseek/src/deepseek-provider.ts
@@ -92,6 +92,7 @@ export function createDeepSeek(
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -114,6 +114,7 @@ export function createElevenLabs(
       message: 'ElevenLabs does not provide embedding models',
     });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({

--- a/packages/elevenlabs/src/elevenlabs-provider.ts
+++ b/packages/elevenlabs/src/elevenlabs-provider.ts
@@ -32,6 +32,11 @@ Creates a model for transcription.
 Creates a model for speech generation.
    */
   speech(modelId: ElevenLabsSpeechModelId): SpeechModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface ElevenLabsProviderSettings {

--- a/packages/fal/src/fal-provider.ts
+++ b/packages/fal/src/fal-provider.ts
@@ -63,6 +63,11 @@ Creates a model for transcription.
 Creates a model for speech generation.
    */
   speech(modelId: FalSpeechModelId): SpeechModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 const defaultBaseURL = 'https://fal.run';

--- a/packages/fal/src/fal-provider.ts
+++ b/packages/fal/src/fal-provider.ts
@@ -148,6 +148,13 @@ export function createFal(options: FalProviderSettings = {}): FalProvider {
       fetch: options.fetch,
     });
 
+  const embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'embeddingModel',
+    });
+  };
+
   return {
     specificationVersion: 'v3' as const,
     imageModel: createImageModel,
@@ -159,12 +166,8 @@ export function createFal(options: FalProviderSettings = {}): FalProvider {
       });
     },
     speech: createSpeechModel,
-    embeddingModel: (modelId: string) => {
-      throw new NoSuchModelError({
-        modelId,
-        modelType: 'embeddingModel',
-      });
-    },
+    embeddingModel,
+    textEmbeddingModel: embeddingModel,
     transcription: createTranscriptionModel,
   };
 }

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -83,6 +83,11 @@ Creates a text embedding model for text generation.
   embeddingModel(modelId: FireworksEmbeddingModelId): EmbeddingModelV3;
 
   /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: FireworksEmbeddingModelId): EmbeddingModelV3;
+
+  /**
 Creates a model for image generation.
 */
   image(modelId: FireworksImageModelId): ImageModelV3;
@@ -158,6 +163,7 @@ export function createFireworks(
   provider.chatModel = createChatModel;
   provider.languageModel = createChatModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
   return provider;

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -53,6 +53,11 @@ Creates a model for generating text embeddings.
   embeddingModel(modelId: GatewayEmbeddingModelId): EmbeddingModelV3;
 
   /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: GatewayEmbeddingModelId): EmbeddingModelV3;
+
+  /**
 Creates a model for generating images.
 */
   imageModel(modelId: GatewayImageModelId): ImageModelV3;
@@ -231,7 +236,7 @@ export function createGatewayProvider(
     });
   };
   provider.languageModel = createLanguageModel;
-  provider.embeddingModel = (modelId: GatewayEmbeddingModelId) => {
+  const createEmbeddingModel = (modelId: GatewayEmbeddingModelId) => {
     return new GatewayEmbeddingModel(modelId, {
       provider: 'gateway',
       baseURL,
@@ -240,6 +245,8 @@ export function createGatewayProvider(
       o11yHeaders: createO11yHeaders(),
     });
   };
+  provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
 
   return provider;
 }

--- a/packages/gladia/src/gladia-provider.ts
+++ b/packages/gladia/src/gladia-provider.ts
@@ -93,6 +93,7 @@ export function createGladia(
       message: 'Gladia does not provide embedding models',
     });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({

--- a/packages/gladia/src/gladia-provider.ts
+++ b/packages/gladia/src/gladia-provider.ts
@@ -20,6 +20,11 @@ export interface GladiaProvider extends ProviderV3 {
 Creates a model for transcription.
    */
   transcription(): TranscriptionModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface GladiaProviderSettings {

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -29,6 +29,11 @@ Creates a model for text generation.
 Anthropic-specific computer use tool.
    */
   tools: typeof anthropicTools;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface GoogleVertexAnthropicProviderSettings {

--- a/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
+++ b/packages/google-vertex/src/anthropic/google-vertex-anthropic-provider.ts
@@ -120,6 +120,7 @@ export function createVertexAnthropic(
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -52,6 +52,13 @@ Creates a model for image generation.
   imageModel(modelId: GoogleVertexImageModelId): ImageModelV3;
 
   tools: typeof googleVertexTools;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(
+    modelId: GoogleVertexEmbeddingModelId,
+  ): GoogleVertexEmbeddingModel;
 }
 
 export interface GoogleVertexProviderSettings {

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -194,6 +194,7 @@ export function createVertex(
   provider.specificationVersion = 'v3' as const;
   provider.languageModel = createChatModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
   provider.tools = googleVertexTools;

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -44,8 +44,14 @@ Creates a model for image generation.
    */
   generativeAI(modelId: GoogleGenerativeAIModelId): LanguageModelV3;
 
+  /**
+   * Creates a model for text embeddings.
+   */
   embedding(modelId: GoogleGenerativeAIEmbeddingModelId): EmbeddingModelV3;
 
+  /**
+   * Creates a model for text embeddings.
+   */
   embeddingModel(modelId: GoogleGenerativeAIEmbeddingModelId): EmbeddingModelV3;
 
   /**

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -48,6 +48,18 @@ Creates a model for image generation.
 
   embeddingModel(modelId: GoogleGenerativeAIEmbeddingModelId): EmbeddingModelV3;
 
+  /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(modelId: GoogleGenerativeAIEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(
+    modelId: GoogleGenerativeAIEmbeddingModelId,
+  ): EmbeddingModelV3;
+
   tools: typeof googleTools;
 }
 
@@ -168,6 +180,8 @@ export function createGoogleGenerativeAI(
   provider.generativeAI = createChatModel;
   provider.embedding = createEmbeddingModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
   provider.tools = googleTools;

--- a/packages/groq/src/groq-provider.ts
+++ b/packages/groq/src/groq-provider.ts
@@ -37,6 +37,11 @@ Creates a model for transcription.
    * Tools provided by Groq.
    */
   tools: typeof groqTools;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface GroqProviderSettings {

--- a/packages/groq/src/groq-provider.ts
+++ b/packages/groq/src/groq-provider.ts
@@ -120,6 +120,7 @@ export function createGroq(options: GroqProviderSettings = {}): GroqProvider {
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/huggingface/src/huggingface-provider.ts
+++ b/packages/huggingface/src/huggingface-provider.ts
@@ -49,6 +49,11 @@ Creates a Hugging Face responses model for text generation.
 Creates a Hugging Face responses model for text generation.
 */
   responses(modelId: HuggingFaceResponsesModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 /**

--- a/packages/huggingface/src/huggingface-provider.ts
+++ b/packages/huggingface/src/huggingface-provider.ts
@@ -94,6 +94,7 @@ export function createHuggingFace(
         'Hugging Face Responses API does not support text embeddings. Use the Hugging Face Inference API directly for embeddings.',
     });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({

--- a/packages/luma/src/luma-provider.ts
+++ b/packages/luma/src/luma-provider.ts
@@ -67,6 +67,13 @@ export function createLuma(options: LumaProviderSettings = {}): LumaProvider {
       fetch: options.fetch,
     });
 
+  const embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'embeddingModel',
+    });
+  };
+
   return {
     specificationVersion: 'v3' as const,
     image: createImageModel,
@@ -77,12 +84,8 @@ export function createLuma(options: LumaProviderSettings = {}): LumaProvider {
         modelType: 'languageModel',
       });
     },
-    embeddingModel: (modelId: string) => {
-      throw new NoSuchModelError({
-        modelId,
-        modelType: 'embeddingModel',
-      });
-    },
+    embeddingModel,
+    textEmbeddingModel: embeddingModel,
   };
 }
 

--- a/packages/luma/src/luma-provider.ts
+++ b/packages/luma/src/luma-provider.ts
@@ -40,6 +40,11 @@ Creates a model for image generation.
 Creates a model for image generation.
    */
   imageModel(modelId: LumaImageModelId): ImageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 const defaultBaseURL = 'https://api.lumalabs.ai';

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -29,8 +29,14 @@ Creates a model for text generation.
 */
   chat(modelId: MistralChatModelId): LanguageModelV3;
 
+  /**
+   * Creates a model for text embeddings.
+   */
   embedding(modelId: MistralEmbeddingModelId): EmbeddingModelV3;
 
+  /**
+   * Creates a model for text embeddings.
+   */
   embeddingModel: (modelId: MistralEmbeddingModelId) => EmbeddingModelV3;
 
   /**

--- a/packages/mistral/src/mistral-provider.ts
+++ b/packages/mistral/src/mistral-provider.ts
@@ -32,6 +32,16 @@ Creates a model for text generation.
   embedding(modelId: MistralEmbeddingModelId): EmbeddingModelV3;
 
   embeddingModel: (modelId: MistralEmbeddingModelId) => EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(modelId: MistralEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: MistralEmbeddingModelId): EmbeddingModelV3;
 }
 
 export interface MistralProviderSettings {
@@ -115,6 +125,8 @@ export function createMistral(
   provider.chat = createChatModel;
   provider.embedding = createEmbeddingModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
 
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });

--- a/packages/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/openai-compatible/src/openai-compatible-provider.ts
@@ -37,6 +37,11 @@ export interface OpenAICompatibleProvider<
 
   embeddingModel(modelId: EMBEDDING_MODEL_IDS): EmbeddingModelV3;
 
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: EMBEDDING_MODEL_IDS): EmbeddingModelV3;
+
   imageModel(modelId: IMAGE_MODEL_IDS): ImageModelV3;
 }
 
@@ -164,6 +169,7 @@ export function createOpenAICompatible<
   provider.chatModel = createChatModel;
   provider.completionModel = createCompletionModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   provider.imageModel = createImageModel;
 
   return provider as OpenAICompatibleProvider<

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -64,6 +64,16 @@ Creates a model for text embeddings.
   embeddingModel(modelId: OpenAIEmbeddingModelId): EmbeddingModelV3;
 
   /**
+   * @deprecated Use `embedding` instead.
+   */
+  textEmbedding(modelId: OpenAIEmbeddingModelId): EmbeddingModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: OpenAIEmbeddingModelId): EmbeddingModelV3;
+
+  /**
 Creates a model for image generation.
    */
   image(modelId: OpenAIImageModelId): ImageModelV3;
@@ -237,6 +247,8 @@ export function createOpenAI(
   provider.responses = createResponsesModel;
   provider.embedding = createEmbeddingModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbedding = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
 
   provider.image = createImageModel;
   provider.imageModel = createImageModel;

--- a/packages/perplexity/src/perplexity-provider.ts
+++ b/packages/perplexity/src/perplexity-provider.ts
@@ -24,6 +24,11 @@ Creates an Perplexity chat model for text generation.
 Creates an Perplexity language model for text generation.
    */
   languageModel(modelId: PerplexityLanguageModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface PerplexityProviderSettings {

--- a/packages/perplexity/src/perplexity-provider.ts
+++ b/packages/perplexity/src/perplexity-provider.ts
@@ -85,6 +85,7 @@ export function createPerplexity(
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/provider/src/provider/v3/provider-v3.ts
+++ b/packages/provider/src/provider/v3/provider-v3.ts
@@ -36,6 +36,20 @@ The model id is then passed to the provider function to get the model.
   embeddingModel(modelId: string): EmbeddingModelV3;
 
   /**
+Returns the text embedding model with the given id.
+The model id is then passed to the provider function to get the model.
+
+@param {string} modelId - The id of the model to return.
+
+@returns {EmbeddingModel} The embedding model associated with the id
+
+@throws {NoSuchModelError} If no such model exists.
+
+@deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel?(modelId: string): EmbeddingModelV3;
+
+  /**
 Returns the image model with the given id.
 The model id is then passed to the provider function to get the model.
 

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -66,6 +66,13 @@ export function createReplicate(
       fetch: options.fetch,
     });
 
+  const embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({
+      modelId,
+      modelType: 'embeddingModel',
+    });
+  };
+
   return {
     specificationVersion: 'v3' as const,
     image: createImageModel,
@@ -76,12 +83,8 @@ export function createReplicate(
         modelType: 'languageModel',
       });
     },
-    embeddingModel: (modelId: string) => {
-      throw new NoSuchModelError({
-        modelId,
-        modelType: 'embeddingModel',
-      });
-    },
+    embeddingModel,
+    textEmbeddingModel: embeddingModel,
   };
 }
 

--- a/packages/replicate/src/replicate-provider.ts
+++ b/packages/replicate/src/replicate-provider.ts
@@ -40,6 +40,11 @@ export interface ReplicateProvider extends ProviderV3 {
    * Creates a Replicate image generation model.
    */
   imageModel(modelId: ReplicateImageModelId): ReplicateImageModel;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 /**

--- a/packages/revai/src/revai-provider.ts
+++ b/packages/revai/src/revai-provider.ts
@@ -96,6 +96,7 @@ export function createRevai(
       message: 'Rev.ai does not provide text embedding models',
     });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
 
   provider.imageModel = () => {
     throw new NoSuchModelError({

--- a/packages/revai/src/revai-provider.ts
+++ b/packages/revai/src/revai-provider.ts
@@ -24,6 +24,11 @@ export interface RevaiProvider extends ProviderV3 {
 Creates a model for transcription.
    */
   transcription(modelId: RevaiTranscriptionModelId): TranscriptionModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface RevaiProviderSettings {

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -72,6 +72,11 @@ Creates a text embedding model for text generation.
   embeddingModel(modelId: TogetherAIEmbeddingModelId): EmbeddingModelV3;
 
   /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: TogetherAIEmbeddingModelId): EmbeddingModelV3;
+
+  /**
 Creates a model for image generation.
 */
   image(modelId: TogetherAIImageModelId): ImageModelV3;
@@ -163,6 +168,7 @@ export function createTogetherAI(
   provider.languageModel = createChatModel;
   provider.chatModel = createChatModel;
   provider.embeddingModel = createEmbeddingModel;
+  provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
   provider.reranking = createRerankingModel;

--- a/packages/vercel/src/vercel-provider.ts
+++ b/packages/vercel/src/vercel-provider.ts
@@ -91,6 +91,7 @@ export function createVercel(
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
   provider.imageModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
   };

--- a/packages/vercel/src/vercel-provider.ts
+++ b/packages/vercel/src/vercel-provider.ts
@@ -43,6 +43,11 @@ Creates a model for text generation.
 Creates a language model for text generation.
 */
   languageModel(modelId: VercelChatModelId): LanguageModelV3;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export function createVercel(

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -64,6 +64,11 @@ Creates an Xai image model for image generation.
 Server-side agentic tools for use with the responses API.
    */
   tools: typeof xaiTools;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
 }
 
 export interface XaiProviderSettings {

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -146,6 +146,7 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.textEmbeddingModel = provider.embeddingModel;
   provider.imageModel = createImageModel;
   provider.image = createImageModel;
   provider.tools = xaiTools;


### PR DESCRIPTION
## Background

pr #10592 renamed `textEmbeddingModel` to `embeddingModel` and `textEmbedding` to `embedding` across all provider packages this was a breaking change for users who were using the old method names

## Summary

- add back `textEmbeddingModel` as deprecated alias to `embeddingModel` in all 30 provider packages
- add back `textEmbedding` as deprecated alias to `embedding` in providers that had this shorthand (openai, mistral, google, cohere, azure, amazon-bedrock)
- add optional deprecated `textEmbeddingModel` to `ProviderV3` interface in `@ai-sdk/provider`

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #10624
