### PR TITLE
fix(xai): use correct parameter names for maxOutputTokens

### DIFF
--- a/.changeset/yellow-spiders-switch.md
+++ b/.changeset/yellow-spiders-switch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(xai): use correct parameter names for maxOutputTokens

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -207,7 +207,7 @@ describe('XaiResponsesLanguageModel', () => {
                 "role": "user",
               },
             ],
-            "max_tokens": 100,
+            "max_output_tokens": 100,
             "model": "grok-4-fast",
             "temperature": 0.5,
             "top_p": 0.9,

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -114,7 +114,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
     const baseArgs: Record<string, unknown> = {
       model: this.modelId,
       input,
-      max_tokens: maxOutputTokens,
+      max_output_tokens: maxOutputTokens,
       temperature,
       top_p: topP,
       seed,

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -393,7 +393,7 @@ describe('XaiChatLanguageModel', () => {
       expect(request).toMatchInlineSnapshot(`
         {
           "body": {
-            "max_tokens": undefined,
+            "max_completion_tokens": undefined,
             "messages": [
               {
                 "content": "Hello",
@@ -1136,7 +1136,7 @@ describe('XaiChatLanguageModel', () => {
       expect(request).toMatchInlineSnapshot(`
         {
           "body": {
-            "max_tokens": undefined,
+            "max_completion_tokens": undefined,
             "messages": [
               {
                 "content": "Hello",

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -115,7 +115,7 @@ export class XaiChatLanguageModel implements LanguageModelV3 {
       model: this.modelId,
 
       // standard generation settings
-      max_tokens: maxOutputTokens,
+      max_completion_tokens: maxOutputTokens,
       temperature,
       top_p: topP,
       seed,


### PR DESCRIPTION
## Background

the xai provider was not respecting `maxOutputTokens` because it was sending the wrong parameter names to the api, the chat api expects `max_completion_tokens` (not the deprecated `max_tokens`) and the responses api expects `max_output_tokens`

## Summary

- change `max_tokens` to `max_completion_tokens` in xai chat language model
- change `max_tokens` to `max_output_tokens` in xai responses language model

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11180
