### PR TITLE
docs(gateway): add OIDC authentication reference to getting started

### DIFF
--- a/content/docs/02-getting-started/00-choosing-a-provider.mdx
+++ b/content/docs/02-getting-started/00-choosing-a-provider.mdx
@@ -39,6 +39,12 @@ Add your API key to your environment:
 AI_GATEWAY_API_KEY=your_api_key_here
 ```
 
+<Note>
+  When deployed to Vercel, you can also use [OIDC
+  authentication](/providers/ai-sdk-providers/ai-gateway#oidc-authentication-vercel-deployments)
+  without API keys.
+</Note>
+
 The AI Gateway is the default [global provider](/docs/ai-sdk-core/provider-management#global-provider-configuration), so you can access models using a simple string:
 
 ```ts

--- a/content/docs/02-getting-started/00-choosing-a-provider.mdx
+++ b/content/docs/02-getting-started/00-choosing-a-provider.mdx
@@ -19,7 +19,7 @@ const { text } = await generateText({
 
 ## AI Gateway
 
-The [Vercel AI Gateway](/providers/ai-sdk-providers/ai-gateway) is the fastest way to get started with the AI SDK. Access models from OpenAI, Anthropic, Google, and other providers with a single API key.
+The [Vercel AI Gateway](/providers/ai-sdk-providers/ai-gateway) is the fastest way to get started with the AI SDK. Access models from OpenAI, Anthropic, Google, and other providers. Authenticate with [OIDC](https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway#oidc-authentication-vercel-deployments) or a gateway API key
 
 <div className="max-w-[40%] mx-auto">
   <ButtonLink

--- a/content/docs/02-getting-started/00-choosing-a-provider.mdx
+++ b/content/docs/02-getting-started/00-choosing-a-provider.mdx
@@ -19,7 +19,7 @@ const { text } = await generateText({
 
 ## AI Gateway
 
-The [Vercel AI Gateway](/providers/ai-sdk-providers/ai-gateway) is the fastest way to get started with the AI SDK. Access models from OpenAI, Anthropic, Google, and other providers. Authenticate with [OIDC](https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway#oidc-authentication-vercel-deployments) or a gateway API key
+The [Vercel AI Gateway](/providers/ai-sdk-providers/ai-gateway) is the fastest way to get started with the AI SDK. Access models from OpenAI, Anthropic, Google, and other providers. Authenticate with [OIDC](https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway#oidc-authentication-vercel-deployments) or an AI Gateway API key
 
 <div className="max-w-[40%] mx-auto">
   <ButtonLink

--- a/content/docs/02-getting-started/00-choosing-a-provider.mdx
+++ b/content/docs/02-getting-started/00-choosing-a-provider.mdx
@@ -39,12 +39,6 @@ Add your API key to your environment:
 AI_GATEWAY_API_KEY=your_api_key_here
 ```
 
-<Note>
-  When deployed to Vercel, you can also use [OIDC
-  authentication](/providers/ai-sdk-providers/ai-gateway#oidc-authentication-vercel-deployments)
-  without API keys.
-</Note>
-
 The AI Gateway is the default [global provider](/docs/ai-sdk-core/provider-management#global-provider-configuration), so you can access models using a simple string:
 
 ```ts


### PR DESCRIPTION
## Background

the ai gateway section in the "choosing a provider" getting started page didn't mention oidc authentication, which is an important feature for vercel deployments.

## Summary

- add note about oidc authentication with link to detailed docs in the ai gateway section

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #11117
