### PR TITLE
fix(google): use dynamic providerOptionsName for thoughtSignature retrieval

### DIFF
--- a/.changeset/fix-vertex-thought-signature.md
+++ b/.changeset/fix-vertex-thought-signature.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google): use dynamic providerOptionsName when retrieving thoughtSignature in convertToGoogleGenerativeAIMessages
+
+When using @ai-sdk/google-vertex provider with Gemini thinking models, multi-step tool calls would fail with "function call is missing a thought_signature" error. This was because thoughtSignature was stored under providerOptions.vertex but retrieved using hardcoded providerOptions.google. This fix passes providerOptionsName to convertToGoogleGenerativeAIMessages and uses it dynamically.

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -11,12 +11,13 @@ import { convertToBase64 } from '@ai-sdk/provider-utils';
 
 export function convertToGoogleGenerativeAIMessages(
   prompt: LanguageModelV3Prompt,
-  options?: { isGemmaModel?: boolean },
+  options?: { isGemmaModel?: boolean; providerOptionsName?: string },
 ): GoogleGenerativeAIPrompt {
   const systemInstructionParts: Array<{ text: string }> = [];
   const contents: Array<GoogleGenerativeAIContent> = [];
   let systemMessagesAllowed = true;
   const isGemmaModel = options?.isGemmaModel ?? false;
+  const providerOptionsName = options?.providerOptionsName ?? 'google';
 
   for (const { role, content } of prompt) {
     switch (role) {
@@ -81,9 +82,10 @@ export function convertToGoogleGenerativeAIMessages(
           role: 'model',
           parts: content
             .map(part => {
+              const providerOpts = part.providerOptions?.[providerOptionsName];
               const thoughtSignature =
-                part.providerOptions?.google?.thoughtSignature != null
-                  ? String(part.providerOptions.google?.thoughtSignature)
+                providerOpts?.thoughtSignature != null
+                  ? String(providerOpts.thoughtSignature)
                   : undefined;
 
               switch (part.type) {

--- a/packages/google/src/google-generative-ai-language-model.ts
+++ b/packages/google/src/google-generative-ai-language-model.ts
@@ -132,7 +132,7 @@ export class GoogleGenerativeAILanguageModel implements LanguageModelV3 {
 
     const { contents, systemInstruction } = convertToGoogleGenerativeAIMessages(
       prompt,
-      { isGemmaModel },
+      { isGemmaModel, providerOptionsName },
     );
 
     const {


### PR DESCRIPTION
## Summary

When using `@ai-sdk/google-vertex` with Gemini thinking models (e.g. `gemini-3-pro-preview`), multi-step tool calls fail with error:
```
Unable to submit request because function call is missing a `thought_signature`
```

**Root cause:** The SDK stores `thoughtSignature` under `providerOptions.vertex` but retrieves it using hardcoded `providerOptions.google` in `convertToGoogleGenerativeAIMessages`.

**This fix:**
- Adds `providerOptionsName` parameter to `convertToGoogleGenerativeAIMessages`
- Uses dynamic key access `part.providerOptions?.[providerOptionsName]` instead of hardcoded `.google`
- Passes `providerOptionsName` from `getArgs()` to the conversion function

## Test plan

- [x] Tested locally with `gemini-3-pro-preview` via `@ai-sdk/google-vertex`
- [x] Multi-step tool calls now work correctly with thinking models
- [ ] Existing tests should pass (no breaking changes)

Fixes #11181

🤖 Generated with [Claude Code](https://claude.com/claude-code)