### PR TITLE
feat (provider/openai): add gpt-image-1.5 model support

### DIFF
--- a/.changeset/smooth-carrots-sneeze.md
+++ b/.changeset/smooth-carrots-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat (provider/openai): add gpt-image-1.5 model support

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1531,6 +1531,7 @@ const model = openai.image('dall-e-3');
 
 | Model              | Sizes                           |
 | ------------------ | ------------------------------- |
+| `gpt-image-1.5`    | 1024x1024, 1536x1024, 1024x1536 |
 | `gpt-image-1-mini` | 1024x1024, 1536x1024, 1024x1536 |
 | `gpt-image-1`      | 1024x1024, 1536x1024, 1024x1536 |
 | `dall-e-3`         | 1024x1024, 1792x1024, 1024x1792 |
@@ -1540,7 +1541,7 @@ You can pass optional `providerOptions` to the image model. These are prone to c
 
 ```ts
 const { image, providerMetadata } = await generateImage({
-  model: openai.image('gpt-image-1'),
+  model: openai.image('gpt-image-1.5'),
   prompt: 'A salamander at sunrise in a forest pond in the Seychelles.',
   providerOptions: {
     openai: { quality: 'high' },

--- a/examples/ai-core/src/generate-image/openai-gpt-image-1.5.ts
+++ b/examples/ai-core/src/generate-image/openai-gpt-image-1.5.ts
@@ -1,0 +1,18 @@
+import { openai } from '@ai-sdk/openai';
+import { experimental_generateImage as generateImage } from 'ai';
+import { presentImages } from '../lib/present-image';
+import 'dotenv/config';
+
+async function main() {
+  const { image } = await generateImage({
+    model: openai.image('gpt-image-1.5'),
+    prompt: 'A salamander at sunrise in a forest pond in the Seychelles.',
+    providerOptions: {
+      openai: { quality: 'high' },
+    },
+  });
+
+  await presentImages([image]);
+}
+
+main().catch(console.error);

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -16,4 +16,5 @@ export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {
 export const hasDefaultResponseFormat = new Set([
   'gpt-image-1',
   'gpt-image-1-mini',
+  'gpt-image-1.5',
 ]);

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -3,6 +3,8 @@ export type OpenAIImageModelId =
   | 'dall-e-2'
   | 'gpt-image-1'
   | 'gpt-image-1-mini'
+  | 'gpt-image-1.5'
+  | 'gpt-image-1.5-2025-12-16'
   | (string & {});
 
 // https://platform.openai.com/docs/guides/images
@@ -11,10 +13,13 @@ export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {
   'dall-e-2': 10,
   'gpt-image-1': 10,
   'gpt-image-1-mini': 10,
+  'gpt-image-1.5': 10,
+  'gpt-image-1.5-2025-12-16': 10,
 };
 
 export const hasDefaultResponseFormat = new Set([
   'gpt-image-1',
   'gpt-image-1-mini',
   'gpt-image-1.5',
+  'gpt-image-1.5-2025-12-16',
 ]);

--- a/packages/openai/src/image/openai-image-options.ts
+++ b/packages/openai/src/image/openai-image-options.ts
@@ -4,7 +4,6 @@ export type OpenAIImageModelId =
   | 'gpt-image-1'
   | 'gpt-image-1-mini'
   | 'gpt-image-1.5'
-  | 'gpt-image-1.5-2025-12-16'
   | (string & {});
 
 // https://platform.openai.com/docs/guides/images
@@ -14,12 +13,10 @@ export const modelMaxImagesPerCall: Record<OpenAIImageModelId, number> = {
   'gpt-image-1': 10,
   'gpt-image-1-mini': 10,
   'gpt-image-1.5': 10,
-  'gpt-image-1.5-2025-12-16': 10,
 };
 
 export const hasDefaultResponseFormat = new Set([
   'gpt-image-1',
   'gpt-image-1-mini',
   'gpt-image-1.5',
-  'gpt-image-1.5-2025-12-16',
 ]);


### PR DESCRIPTION
## Background

OpenAI is launching their new image model: https://openai.com/index/new-chatgpt-images-is-here/

## Summary

Added `gpt-image-1.5` model id and a new example to validate its operation.

## Manual Verification

Ran new script to validate image generation is functional.

## Checklist

- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
