### PR TITLE
feat(openai): add compact() utility for conversation compaction [RFC]

### DIFF
--- a/examples/ai-core/package.json
+++ b/examples/ai-core/package.json
@@ -27,7 +27,7 @@
     "@ai-sdk/hume": "workspace:*",
     "@ai-sdk/mcp": "workspace:*",
     "@ai-sdk/mistral": "workspace:*",
-    "@ai-sdk/openai": "3.0.0-beta.103",
+    "@ai-sdk/openai": "workspace:*",
     "@ai-sdk/openai-compatible": "workspace:*",
     "@ai-sdk/perplexity": "workspace:*",
     "@ai-sdk/provider": "workspace:*",

--- a/examples/ai-core/src/generate-text/openai-compact-tool.ts
+++ b/examples/ai-core/src/generate-text/openai-compact-tool.ts
@@ -1,0 +1,35 @@
+import { openai, compact } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  // Step 1: Create a conversation with some context
+  const turn1 = await generateText({
+    model: openai.responses('gpt-4.1-mini'),
+    prompt: 'My name is Alex and I work on AI systems. Remember this.',
+    providerOptions: { openai: { store: true } },
+  });
+  console.log('Turn 1:', turn1.text.slice(0, 100) + '...\n');
+
+  // Step 2: Compact the conversation
+  const compactResult = await compact({
+    model: 'gpt-4.1-mini',
+    previousResponseId: turn1.response.id,
+  });
+
+  console.log('Compaction result:');
+  console.log('  Input tokens:', compactResult.usage.inputTokens);
+  console.log('  Output tokens:', compactResult.usage.outputTokens);
+  console.log('  Output items:', compactResult.output.length);
+  console.log('\nCompacted output (to be used in next request):');
+  console.log(JSON.stringify(compactResult.output, null, 2));
+
+  // TODO: Need guidance on how to convert compactResult.output to CoreMessage[]
+  // so it can be passed to the next generateText call via the messages parameter.
+  //
+  // The compacted output contains:
+  // - User messages (preserved verbatim)
+  // - A single encrypted "compaction" item replacing all assistant messages, tool calls, and reasoning
+  //
+  // Currently there's no way to pass this back into the SDK without a provider-specific extension.
+});

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -2,4 +2,6 @@ export { createOpenAI, openai } from './openai-provider';
 export type { OpenAIProvider, OpenAIProviderSettings } from './openai-provider';
 export type { OpenAIResponsesProviderOptions } from './responses/openai-responses-options';
 export type { OpenAIChatLanguageModelOptions } from './chat/openai-chat-options';
+export { compact } from './tool/compact';
+export type { CompactOptions, CompactResult } from './tool/compact';
 export { VERSION } from './version';

--- a/packages/openai/src/tool/compact.ts
+++ b/packages/openai/src/tool/compact.ts
@@ -1,0 +1,205 @@
+import {
+  FetchFunction,
+  combineHeaders,
+  createJsonResponseHandler,
+  lazySchema,
+  loadApiKey,
+  loadOptionalSetting,
+  postJsonToApi,
+  withoutTrailingSlash,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { openaiFailedResponseHandler } from '../openai-error';
+
+/**
+ * Options for the compact function.
+ */
+export interface CompactOptions {
+  /**
+   * Model ID to use for compaction (e.g., 'gpt-5', 'gpt-5.2').
+   */
+  model: string;
+
+  /**
+   * The conversation input to compact. Can be a string or array of input items.
+   * Either `input` or `previousResponseId` must be provided.
+   */
+  input?: string | Array<Record<string, unknown>>;
+
+  /**
+   * The ID of a previous response to compact.
+   * Either `input` or `previousResponseId` must be provided.
+   */
+  previousResponseId?: string;
+
+  /**
+   * Optional system message for the compaction request.
+   * Should match instructions used in responses for best results.
+   */
+  instructions?: string;
+
+  /**
+   * OpenAI API key. Defaults to OPENAI_API_KEY environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * Base URL for the OpenAI API. Defaults to https://api.openai.com/v1.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the request.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation.
+   */
+  fetch?: FetchFunction;
+
+  /**
+   * Abort signal for cancelling the request.
+   */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Result of a compact operation.
+ */
+export interface CompactResult {
+  /**
+   * The unique identifier for the compacted response.
+   */
+  id: string;
+
+  /**
+   * Unix timestamp (in seconds) when the compacted conversation was created.
+   */
+  createdAt: number;
+
+  /**
+   * The compacted output items to use as input for the next request.
+   */
+  output: Array<Record<string, unknown>>;
+
+  /**
+   * Token usage details for the compaction.
+   */
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+const compactResponseSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      id: z.string(),
+      object: z.literal('response.compaction'),
+      created_at: z.number(),
+      output: z.array(z.record(z.string(), z.unknown())),
+      usage: z.object({
+        input_tokens: z.number(),
+        output_tokens: z.number(),
+      }),
+    }),
+  ),
+);
+
+/**
+ * Compacts a conversation to reduce context size while preserving the model's understanding.
+ *
+ * Compaction replaces prior assistant messages, tool calls, tool results, and encrypted
+ * reasoning with a single encrypted compaction item. User messages are kept verbatim.
+ *
+ * @example
+ * ```ts
+ * import { compact } from '@ai-sdk/openai';
+ *
+ * const result = await compact({
+ *   model: 'gpt-5',
+ *   previousResponseId: 'resp_abc123',
+ * });
+ *
+ * // Use result.output as input for the next request
+ * ```
+ */
+export async function compact(options: CompactOptions): Promise<CompactResult> {
+  const {
+    model,
+    input,
+    previousResponseId,
+    instructions,
+    apiKey,
+    baseURL: baseURLOption,
+    headers: customHeaders,
+    fetch: customFetch,
+    abortSignal,
+  } = options;
+
+  if (!input && !previousResponseId) {
+    throw new Error(
+      'Either `input` or `previousResponseId` must be provided for compaction.',
+    );
+  }
+
+  const baseURL =
+    withoutTrailingSlash(
+      loadOptionalSetting({
+        settingValue: baseURLOption,
+        environmentVariableName: 'OPENAI_BASE_URL',
+      }),
+    ) ?? 'https://api.openai.com/v1';
+
+  const resolvedApiKey = loadApiKey({
+    apiKey,
+    environmentVariableName: 'OPENAI_API_KEY',
+    description: 'OpenAI',
+  });
+
+  const headers = combineHeaders(
+    {
+      Authorization: `Bearer ${resolvedApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    customHeaders,
+  );
+
+  const body: Record<string, unknown> = {
+    model,
+  };
+
+  if (input) {
+    body.input = input;
+  }
+
+  if (previousResponseId) {
+    body.previous_response_id = previousResponseId;
+  }
+
+  if (instructions) {
+    body.instructions = instructions;
+  }
+
+  const { value: response } = await postJsonToApi({
+    url: `${baseURL}/responses/compact`,
+    headers,
+    body,
+    failedResponseHandler: openaiFailedResponseHandler,
+    successfulResponseHandler: createJsonResponseHandler(compactResponseSchema),
+    abortSignal,
+    fetch: customFetch,
+  });
+
+  return {
+    id: response.id,
+    createdAt: response.created_at,
+    output: response.output,
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/mistral
       '@ai-sdk/openai':
-        specifier: 3.0.0-beta.103
+        specifier: workspace:*
         version: link:../../packages/openai
       '@ai-sdk/openai-compatible':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Add a standalone utility function to call OpenAI's `/v1/responses/compact` endpoint for reducing conversation context size.

## Changes

- Add `compact()` utility function in `packages/openai/src/tool/compact.ts`
- Export `compact`, `CompactOptions`, `CompactResult` from `@ai-sdk/openai`
- Add example demonstrating the compact API

## How it works

The `compact()` function compresses prior assistant messages, tool calls, and reasoning into a single encrypted compaction item while preserving user messages verbatim. This enables long-running conversations to stay within context limits.

```ts
import { compact } from '@ai-sdk/openai';

const result = await compact({
  model: 'gpt-4.1-mini',
  previousResponseId: 'resp_xxx',
});

// result.output contains the compacted conversation items
// result.usage shows token reduction (e.g., 9594 -> 1136 tokens)
```

## Open Question

**How should `compactResult.output` be passed to the next `generateText` call?**

The compact endpoint returns an array of OpenAI-format input items:
- User messages (preserved verbatim)
- A single encrypted `compaction` item replacing all assistant messages, tool calls, and reasoning

These need to flow into the next request, but there's no current way to do this without a provider-specific extension. Looking for guidance on the right abstraction—should this convert to `CoreMessage[]`, or is there another pattern?

## Testing

- All 496 existing tests pass
- Verified with live API calls that compaction works